### PR TITLE
Create deb_release.yml

### DIFF
--- a/.github/workflows/deb_release.yml
+++ b/.github/workflows/deb_release.yml
@@ -1,0 +1,65 @@
+name: Debian packages release
+
+on:
+  workflow_dispatch:
+    inputs:
+      config:
+        description: JSON of options
+        type: string
+        default: '{}'
+        required: true
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt update -qq
+          sudo apt install -qq -y bumpversion devscripts python3-launchpadlib
+      - name: Checkout checkbox monorepo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check for new commits
+        run: |
+          echo '${{ inputs.config }}' | jq > config.json
+          tools/release/release_deb_monorepo.py check --config config.json
+          rm -f config.json
+      - name: Bump versions
+        run: |
+          git config --global user.email "robot@canonical.com"
+          git config --global user.name "Devices Certification Bot"
+          tools/release/release_deb_monorepo.py bump --part major
+      - name: Create changelog
+        run: |
+          tools/release/release_deb_monorepo.py changelog
+      - name: Archive changelog
+        uses: actions/upload-artifact@v3
+        with:
+          name: Changelog
+          path: changelog
+      - name: Push release tags
+        run: |
+          tools/release/release_deb_monorepo.py push
+      - name: Update the PPA recipe and kick-off the builds
+        env:
+          LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
+          CHECKBOX_REPO: ${{ github.repository }}
+        run: |
+          tools/release/release_deb_monorepo.py build
+      - name: Open a new release for development
+        if: fromJson(inputs.config).mode == 'stable'
+        env:
+          DEBEMAIL: robot@canonical.com
+          DEBFULLNAME: Devices Certification Bot
+        run: |
+          tools/release/release_deb_monorepo.py open
+      - name: Create pull request
+        if: |
+          (fromJson(inputs.config).mode == 'stable' &&
+           fromJson(inputs.config).dry_run != true)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create -H release --title 'Open a new release for development' --body 'Created by Github action'

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -1,0 +1,168 @@
+# Checkbox release process (Debian packages)
+
+## PPA/Repositories
+
+* [Stable](https://launchpad.net/~hardware-certification/+archive/ubuntu/public): The official release of Checkbox.
+* [Testing](https://code.launchpad.net/~checkbox-dev/+archive/ubuntu/testing): Release candidates of Checkbox before it becomes the official release.
+* [Development](https://code.launchpad.net/~checkbox-dev/+archive/ubuntu/ppa): Daily builds (that may contain experimental features).
+
+## Projects released as Debian packages
+
+* [checkbox-ng](https://github.com/canonical/checkbox/tree/main/checkbox-ng)
+* [checkbox-support](https://github.com/canonical/checkbox/tree/main/checkbox-support)
+* [providers/base](https://github.com/canonical/checkbox/tree/main/providers/base)
+* [providers/resource](https://github.com/canonical/checkbox/tree/main/providers/resource)
+* [providers/certification-client](https://github.com/canonical/checkbox/tree/main/providers/certification-client)
+* [providers/certification-server](https://github.com/canonical/checkbox/tree/main/providers/certification-server)
+* [providers/sru](https://github.com/canonical/checkbox/tree/main/providers/sru)
+* [providers/tpm2](https://github.com/canonical/checkbox/tree/main/providers/tpm2)
+* [providers/ipdt](https://github.com/canonical/checkbox/tree/main/providers/ipdt)
+* [providers/phoronix](https://github.com/canonical/checkbox/tree/main/providers/phoronix)
+* [providers/gpgpu](https://github.com/canonical/checkbox/tree/main/providers/gpgpu)
+
+## Release steps summary
+
+Steps | Release candidate(s) (RC) | Stable release | Dry mode
+:--- | :---: | :---: | :---:
+Parse each project and check for new commits | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:
+Bump and tag versions | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:
+Create release changelog (since the latest stable tag) | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:
+Push release tags to Github | :heavy_check_mark: | :heavy_check_mark: | :x:[^1]
+Update the PPA recipes and kick-off the builds | :heavy_check_mark: | :heavy_check_mark: | :x:
+Open a new release for development | :x: | :heavy_check_mark: | :x:
+Create a pull request including the new [SemVer](https://semver.org/spec/v2.0.0.html) | :x: | :heavy_check_mark: | :x:
+
+## How to trigger the GitHub Actions release workflow
+
+All the release steps above are fully automated but initiating a release is a manual
+process requiring some user input.
+
+The same workflow support two types of release, **testing** and **stable**.
+Additionally, the release manager can perform a **dry run** to:
+* Identify which projects are going to be released 
+* Review the release changelog
+
+Since `workflow_dispatch` only supports a maximum of 10 user inputs[^2], all config options are grouped into a single JSON parameter.
+For all the release scenarios below, just copy-paste the JSON snippet into the workflow input field (pre-filled with `{}`)
+
+```
+╭-----------------------------------^----╮
+|  Use workflow from                     |
+|  ╭----------------╮                    |
+|  | Branch: main v |                    |
+|  ╰----------------╯                    |
+|                                        |
+|  JSON of options *                     |
+|  ╭--------------------------------╮    |
+|  | {}                             |    |
+|  ╰--------------------------------╯    |
+|                                        |
+|  ╭--------------╮                      |
+|  | Run workflow |                      |
+|  ╰--------------╯                      |
+╰----------------------------------------╯
+```
+
+### Triggering the first release candidate
+
+Before applying RC tags, it's recommended to first perform a **dry run** of the **testing** mode and select all the projects:
+
+```
+{
+    "mode": "testing",
+    "dry_run": true,
+    "checkbox-ng": true,
+    "checkbox-support": true,
+    "provider-base": true,
+    "provider-resource": true,
+    "provider-tpm2": true,
+    "provider-sru": true,
+    "provider-certification-server": true,
+    "provider-certification-client": true,
+    "provider-gpgpu": true,
+    "provider-ipdt": true,
+    "provider-phoronix": true
+}
+```
+
+After reviewing the changelog, **dry run** can be set to false:
+
+```
+{
+    "mode": "testing",
+    "dry_run": false,
+    "checkbox-ng": true,
+    "checkbox-support": true,
+    "provider-base": true,
+    "provider-resource": true,
+    "provider-tpm2": true,
+    "provider-sru": true,
+    "provider-certification-server": true,
+    "provider-certification-client": true,
+    "provider-gpgpu": true,
+    "provider-ipdt": true,
+    "provider-phoronix": true
+}
+```
+
+### Requesting another release candidate for a subset of projects
+
+If the validation of the release candidates identifies issues or regressions, running the workflow again will create new RC tags (project-vX.Y.Zrc**N+1**).
+
+In the example below, new RC are required for `checkbox-support` and the `base` provider: 
+
+```
+{
+    "mode": "testing",
+    "dry_run": false,
+    "checkbox-support": true,
+    "provider-base": true
+}
+```
+
+The same workflow can run using the JSON config below of course:
+
+```
+{
+    "mode": "testing",
+    "dry_run": false,
+    "checkbox-ng": false,
+    "checkbox-support": true,
+    "provider-base": true,
+    "provider-resource": false,
+    "provider-tpm2": false,
+    "provider-sru": false,
+    "provider-certification-server": false,
+    "provider-certification-client": false,
+    "provider-gpgpu": false,
+    "provider-ipdt": false,
+    "provider-phoronix": false
+}
+```
+
+### Triggering a stable release
+
+Stable releases **MUST** follow release candidates, it's not possible to jump
+from a stable tag to an other stable tag. The next JSON config will apply the
+stable release tag to the same commit the latest RC tag was applied to.
+
+```
+{
+    "mode": "stable",
+    "dry_run": false,
+    "checkbox-ng": true,
+    "checkbox-support": true,
+    "provider-base": true,
+    "provider-resource": true,
+    "provider-tpm2": true,
+    "provider-sru": true,
+    "provider-certification-server": true,
+    "provider-certification-client": true,
+    "provider-gpgpu": true,
+    "provider-ipdt": true,
+    "provider-phoronix": true
+}
+```
+
+[^1]:Actually a `git push --dry-run` is executed
+[^2]:https://github.com/community/community/discussions/8774

--- a/tools/release/lp-recipe-update-build.py
+++ b/tools/release/lp-recipe-update-build.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+# This file is part of Checkbox.
+#
+# Copyright 2016 Canonical Ltd.
+# Written by:
+#   Sylvain Pineau <sylvain.pineau@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Kicks off a recipe build for a branch in Launchpad which has an associated
+recipe.
+Meant to be used as part of a checkbox release to the Hardware Certification
+public PPA and the ~checkbox-dev testing PPA.
+"""
+
+import os
+import re
+import sys
+
+from launchpadlib.credentials import Credentials
+from launchpadlib.launchpad import Launchpad
+from lazr.restfulclient.errors import BadRequest
+from argparse import ArgumentParser
+
+
+def main():
+    parser = ArgumentParser('Invoke a recipe build on specified branch')
+    parser.add_argument('project',
+                        help="Unique name of the project")
+    parser.add_argument('--recipe', '-r',
+                        help="Recipe name to build with. If there is only one "
+                             "then that will be used by default, if not then "
+                             "this must be specified.")
+    parser.add_argument('--new-version', '-n',
+                        help="New version to use in the recipe "
+                             "(for debian changelog) and bzr tags.")
+    args = parser.parse_args()
+
+    credentials = Credentials.from_string(os.getenv("LP_CREDENTIALS"))
+    lp = Launchpad(
+        credentials, None, None, service_root='production', version='devel')
+    try:
+        project = lp.projects[args.project]
+    except KeyError:
+        parser.error("{} was not found in Launchpad.".format(args.project))
+
+    if project.recipes.total_size == 0:
+        parser.error("{} does not have any recipes.".format(args.project))
+    else:
+        build_recipe = None
+
+        if project.recipes.total_size == 1:
+            build_recipe = project.recipes[0]
+        elif args.recipe:
+            for recipe in project.recipes:
+                if recipe.name == args.recipe:
+                    build_recipe = recipe
+        else:
+            all_recipe_names = [recipe.name for recipe in project.recipes]
+            parser.error(
+                "I don't know which recipe from "
+                "{project} you want to use, specify "
+                "one of '{recipes}' using --recipe".format(
+                    project=args.project,
+                    recipes=', '.join(all_recipe_names)))
+
+        text = build_recipe.recipe_text
+        # 0.28.0rc1 → 0.28.0~rc1
+        deb_version = re.sub(r"(rc\d+)$", "~\g<0>", args.new_version)
+        # 0.28.0rc1 → 0.28.0_rc1
+        deb_tag = re.sub(r"(rc\d+)$", "_\g<0>", args.new_version)
+        text = re.sub(r"deb-version .*?~ppa", "deb-version {}~ppa".format(
+            deb_version), text)
+        # v0.27.0 → v0.28.0rc1
+        text = re.sub(r"v\d\S+", "v{}".format(args.new_version), text)
+        # debian-0.27.0-1 → debian-0.28.0_rc1-1
+        text = re.sub(r"debian-(.*)$", "debian-{}-1".format(deb_tag), text)
+        build_recipe.recipe_text = text
+        build_recipe.lp_save()
+        if build_recipe:
+            for series in build_recipe.distroseries:
+                try:
+                    build_recipe.requestBuild(
+                        pocket="Release",
+                        distroseries=series,
+                        archive=build_recipe.daily_build_archive_link)
+                except BadRequest:
+                    print("An identical build of this recipe is "
+                          "already pending")
+        print("Check builds status: " + build_recipe.web_link)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/release/lp-request-import.py
+++ b/tools/release/lp-request-import.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python3
+# This file is part of Checkbox.
+#
+# Copyright 2022 Canonical Ltd.
+# Written by:
+#   Sylvain Pineau <sylvain.pineau@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Script that forces a code import from Github in Launchpad.
+It's a blocking call, usually code is imported in less than a minute.
+Timeout set to 2 minutes
+
+References:
+- https://help.launchpad.net/Code/Imports
+- https://launchpad.net/+apidoc/devel.html#code_import
+"""
+
+import os
+import sys
+import time
+
+from argparse import ArgumentParser
+from datetime import datetime, timedelta
+
+from launchpadlib.credentials import Credentials
+from launchpadlib.launchpad import Launchpad
+
+
+def main():
+    parser = ArgumentParser("A script to force code import in Launchpad.")
+    parser.add_argument('repo',
+                        help="Unique name of the repository")
+    args = parser.parse_args()
+    credentials = Credentials.from_string(os.getenv("LP_CREDENTIALS"))
+    lp = Launchpad(
+        credentials, None, None, service_root='production', version='devel')
+    repo = lp.git_repositories.getByPath(path=args.repo)
+    if not repo:
+        parser.error("{} repo was not found in Launchpad.".format(args.repo))
+    start = datetime.utcnow()
+    try:
+        repo.code_import.requestImport()
+    except Exception as e:
+        if 'This code import is already running' not in e:
+            return 1
+    while (repo.code_import.date_last_successful.replace(tzinfo=None) < start):
+        if datetime.utcnow() - start > timedelta(seconds=120):
+            return 1
+        time.sleep(5)
+    print("Code import completed ({})".format(repo.web_link))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/release/release_deb_monorepo.py
+++ b/tools/release/release_deb_monorepo.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2022-2023 Canonical Ltd.
+# Written by:
+#   Sylvain Pineau <sylvain.pineau@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+
+from pathlib import Path
+
+
+class ConsoleFormatter(logging.Formatter):
+
+    """Custom Logging Formatter to ease copy paste of commands."""
+
+    def format(self, record):
+        fmt = '%(message)s'
+        if record.levelno == logging.ERROR:
+            fmt = "%(levelname)-8s %(message)s"
+        result = logging.Formatter(fmt).format(record)
+        return result
+
+
+# create logger
+logger = logging.getLogger('release')
+logger.setLevel(logging.DEBUG)
+# create file handler which logs even debug messages
+fh = logging.FileHandler('release.log')
+fh.setLevel(logging.DEBUG)
+# create console handler with a higher log level
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+# create formatter and add it to the handlers
+fh_formatter = logging.Formatter('%(asctime)-15s %(levelname)-8s %(message)s')
+fh.setFormatter(fh_formatter)
+ch.setFormatter(ConsoleFormatter())
+# add the handlers to the logger
+logger.addHandler(fh)
+logger.addHandler(ch)
+
+
+def run(*args, **kwargs):
+    """wrapper for subprocess.run."""
+    try:
+        return subprocess.run(
+            *args, **kwargs,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        logger.error('{}\n{}'.format(e, e.output.decode()))
+        raise SystemExit(1)
+
+
+class Release:
+
+    def __init__(self, args) -> None:
+        self.args = args
+        self._checkpoint = Path('.checkpoint.json')
+
+    def _save_checkpoint(self, settings):
+        with open(self._checkpoint, "w") as f:
+            json.dump(settings, f, indent=4, sort_keys=True)
+
+    def _load_checkpoint(self):
+        return json.load(open(self._checkpoint))
+
+    def _find_tag(self, project_name, pattern='*[^c][0-9]'):
+        cmd = run([
+            'git', 'for-each-ref', '--sort=-taggerdate', '--count=1',
+            'refs/tags/{}-v{}'.format(project_name, pattern),
+            '--format=%(refname:short)'])
+        return cmd.stdout.decode().rstrip()
+
+    def _is_release_required(self, mode, project_name, project_path, tag):
+        # Ignore the release bump commit when looking for code changes
+        bump_commit = 1
+        if 'rc' in tag:
+            bump_commit = 0
+        cmd = ['git', 'rev-list', '--count', '--no-merges',
+               '{}..'.format(tag), '--',
+               "':{}'".format(project_path)]
+        # TODO remove the exclude pathspec on debian after
+        # the next release
+        cmd += ["':(exclude){}/debian'".format(project_path)]
+        count = int(run(' '.join(cmd), shell=True).stdout.decode().rstrip())
+        is_release_required = False
+        if mode == 'stable' and (count > bump_commit):
+            is_release_required = True
+        if mode == 'testing' and (count > bump_commit):
+            is_release_required = True
+        if is_release_required:
+            logger.info(
+                "+ Release required: {} (since {})".format(
+                    project_name, tag))
+        else:
+            logger.info(
+                "- No release required: {}".format(project_name))
+        return is_release_required
+
+    def check(self):
+        """Check project folders for new commits since the latest tag."""
+        config = json.load(open(self.args.config))
+        settings = {
+            "dry_run": bool(config['dry_run']),
+            "mode": config['mode'],
+            "projects": {}
+        }
+        mode = settings["mode"]
+        logger.info("".center(80, '#'))
+        logger.info("# Check the Checkbox monorepo for new commits...")
+        logger.info("".center(80, '#'))
+        for path, dirs, files in os.walk('.'):
+            if "debian" in dirs:
+                project_path = str(Path(*Path(path).parts))
+                project_name = str(project_path).replace('s/', '-')
+                if (project_name not in config) or (not config[project_name]):
+                    settings["projects"][project_name] = {
+                        "path": path,
+                        "release_required": False,
+                        "last_tag": None,
+                        "last_stable_tag": None,
+                    }
+                    logger.info(
+                        "- No release requested: {}".format(project_name))
+                    continue
+                # Find the latest stable tag
+                if not (last_stable_tag := self._find_tag(project_name)):
+                    logger.warning("No tag found for {}".format(project_name))
+                    continue
+                # Find the latest tag
+                if not (last_tag := self._find_tag(project_name, '*')):
+                    logger.warning("No tag found for {}".format(project_name))
+                    continue
+                settings["projects"][project_name] = {
+                    "path": path,
+                    "release_required": self._is_release_required(
+                        mode, project_name, project_path,
+                        last_stable_tag if mode == 'stable' else last_tag),
+                    "last_tag": last_tag,
+                    "last_stable_tag": last_stable_tag,
+                }
+        self._save_checkpoint(settings)
+
+    def bump(self):
+        """Bump project version and tag according to release mode."""
+        settings = self._load_checkpoint()
+        logger.info("".center(80, '#'))
+        if settings["mode"] == 'stable':
+            logger.info("# Bump versions and add stable tags...")
+        else:
+            logger.info("# Bump versions and add release candidate tags...")
+        logger.info("".center(80, '#'))
+        for project_name, project_info in settings["projects"].items():
+            if not project_info["release_required"]:
+                continue
+            last_tag = project_info["last_tag"].split('-v')[1]
+            project_path = project_info["path"]
+            if settings["mode"] == 'stable':
+                if "rc" in last_tag:
+                    # Dry run to record the next stable version
+                    bumpversion_output = run(
+                        ['bumpversion', '--list', '--dry-run', '--allow-dirty',
+                         '--current-version', last_tag, '--no-commit',
+                         'release'],
+                        cwd=project_path, check=True).stdout.decode()
+                    stable_version = \
+                        bumpversion_output.splitlines()[-1].replace(
+                            'new_version=', '')
+                    message = "Bump {} version: {} → {}".format(
+                        project_name, last_tag, stable_version)
+                    stable_sha1 = run(
+                        'git rev-list -n 1 '+project_info["last_tag"],
+                        shell=True, check=True).stdout.decode().rstrip()
+                    run(['git', 'tag', project_name+'-v'+stable_version,
+                         stable_sha1, '-m', message],
+                        check=True)
+                else:
+                    continue
+                    # FIXME Releasing to stable from an old stable tag w/o any
+                    # RC in between must not be allowed, as it means silently
+                    # relasing unverified commits.
+                    # TODO log a warning
+                    # run(['bumpversion', '--current-version', last_tag,
+                    #         '--tag', '--no-commit', self.args.bump,
+                    #         '--serialize',
+                    #         '{major}.{minor}.{patch}'],
+                    #     cwd=project_path, check=True)
+            elif settings["mode"] == 'testing':
+                if "rc" in last_tag:
+                    # bump to jump to rc+1
+                    run(['bumpversion', '--current-version', last_tag,
+                         '--allow-dirty', '--tag', '--no-commit', 'N'],
+                        cwd=project_path, check=True)
+                else:
+                    # bump to jump to rc1
+                    run(['bumpversion', '--current-version',
+                         # FIXME Using 1.99.0 here ensures all packages will
+                         # get the same version number for the next RC.
+                         # There a mix of 1.x and 0.x packages and a major bump
+                         # is required because of the new native packaging.
+                         # After the first release, let's use `last_tag`
+                         # instead
+                         '1.99.0',
+                         '--allow-dirty',
+                         '--tag', '--no-commit', self.args.part],
+                        cwd=project_path, check=True)
+            # Only keep the tags, discard .bumpversion file updates
+            run('git checkout .',
+                cwd=project_path, check=True, shell=True)
+            run('git clean -dff', check=True, shell=True)
+            last_tag = self._find_tag(project_name, '*')
+            settings["projects"][project_name]["last_tag"] = last_tag
+            logger.info("Bump {} to {}".format(project_name, last_tag))
+        self._save_checkpoint(settings)
+
+    def push(self):
+        """Push release tags to origin."""
+        settings = self._load_checkpoint()
+        logger.info("".center(80, '#'))
+        logger.info("# Push release tags to origin...")
+        logger.info("".center(80, '#'))
+        if settings["dry_run"]:
+            run(['git', 'push', '--dry-run', 'origin', '--tags'], check=True)
+        else:
+            run(['git', 'push', 'origin', '--tags'], check=True)
+
+    def build(self):
+        """Update the PPA recipe and kick-off the builds."""
+        settings = self._load_checkpoint()
+        logger.info("".center(80, '#'))
+        logger.info("# Update PPA recipes and kick-off the builds")
+        logger.info("".center(80, '#'))
+        if settings["dry_run"]:
+            logger.info('# Dry run: Skipping the build step')
+            return
+        # Request code import
+        staging = ""
+        if os.getenv("CHECKBOX_REPO", "").endswith("staging"):
+            staging = "-staging"
+        logger.info("Requesting code import...")
+        output = run(
+            "./tools/release/lp-request-import.py {}".format(
+                "~checkbox-dev/checkbox/+git/checkbox"+staging),
+            shell=True, check=True).stdout.decode().rstrip()
+        logger.info(output)
+        for project_name, project_info in settings["projects"].items():
+            package_name = project_name
+            if project_name.startswith('provider'):
+                package_name = "checkbox-"+package_name
+            if os.getenv("CHECKBOX_REPO", "").endswith("staging"):
+                package_name = "staging-"+package_name
+            if not project_info["release_required"]:
+                continue
+            logger.info("Request {} build ({})".format(
+                package_name, project_info["last_tag"]))
+            new_version = project_info["last_tag"].split('-v')[1]
+            if settings["mode"] == 'testing':
+                output = run(
+                    "./tools/release/lp-recipe-update-build.py checkbox "
+                    "--recipe {} -n {}".format(
+                        package_name+'-testing', new_version),
+                    shell=True, check=True).stdout.decode().rstrip()
+            else:
+                output = run(
+                    "./tools/release/lp-recipe-update-build.py checkbox "
+                    "--recipe {} -n {}".format(
+                        package_name+'-stable', new_version),
+                    shell=True, check=True).stdout.decode().rstrip()
+            logger.info(output)
+
+    def changelog(self):
+        """Create the changelog for released projects."""
+        settings = self._load_checkpoint()
+        logger.info("".center(80, '#'))
+        logger.info("# Create the changelog...")
+        logger.info("".center(80, '#'))
+        for project_name, project_info in settings["projects"].items():
+            if not project_info["release_required"]:
+                continue
+            project_path = str(Path(*Path(project_info["path"]).parts[2:]))
+            cmd = ['git', 'log', '--no-merges', "--pretty='format:+ %s'",
+                   '{}...{}'.format(
+                       project_info["last_stable_tag"],
+                       project_info["last_tag"]),
+                   '--', "':{}'".format(project_path)]
+            # TODO remove the exclude pathspec on debian after
+            # the next release
+            cmd += ["':(exclude){}/debian'".format(project_path)]
+            log = run(
+                ' '.join(cmd), check=True, shell=True).stdout.decode()
+            if log:
+                logger.debug("# {}: {}".format(project_name, cmd))
+                with open('changelog', 'a') as f:
+                    f.write('\n{} ({}):\n'.format(
+                        project_name, project_info["last_tag"]))
+                    f.write(log)
+                    f.write("\n")
+
+    def open(self):
+        """Bump the project version to open a new release for development."""
+        settings = self._load_checkpoint()
+        logger.info("".center(80, '#'))
+        logger.info("# Open next versions for development...")
+        logger.info("".center(80, '#'))
+        self._checkpoint.unlink()
+        if settings["mode"] == 'testing':
+            logger.info(
+                '# Impossible to open a new version for development'
+                ', skipping...')
+            return
+        run('git clean -dff', check=True, shell=True)
+        run(['git', 'checkout', '-b', 'release'], check=True)
+        for project_name, project_info in settings["projects"].items():
+            if not project_info["release_required"]:
+                continue
+            project_path = project_info["path"]
+            # Dry run to record the next version number
+            bumpversion_output = run(
+                ['bumpversion', '--list', '--dry-run',
+                 self.args.part, '--serialize',
+                 '{major}.{minor}.{patch}'],
+                cwd=project_path, check=True).stdout.decode()
+            new_dev_version = bumpversion_output.splitlines()[-1].replace(
+                'new_version=', '')
+            logger.info("Bump {} to version {}".format(
+                project_name, new_dev_version))
+            run(['dch', '-v', new_dev_version, '-D', 'unstable',
+                 '"new upstream version"'],
+                cwd=project_path, check=True)
+            run('git add --update',
+                cwd=project_path, check=True, shell=True)
+            files = [
+                'setup.py', 'plainbox/__init__.py', 'checkbox_ng/__init__.py']
+            if project_name == 'checkbox-support':
+                files = ['setup.py']
+            elif 'provider' in project_name:
+                files = ['manage.py']
+            message = "Bump {} version: ".format(
+                project_name) + "{current_version} → {new_version}"
+            run(['bumpversion', '--serialize', '{major}.{minor}.{patch}',
+                 '--message', message,
+                 self.args.part, '--allow-dirty', '--commit'] + files,
+                cwd=project_path, check=True)
+        if settings["dry_run"]:
+            run(['git', 'push', '-n', '-f', 'origin', 'release'], check=True)
+        else:
+            run(['git', 'push', '-f', 'origin', 'release'], check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Release Debian packages from checkbox monorepo")
+    subparsers = parser.add_subparsers(
+        dest='step', help='release step to run')
+    parser_check = subparsers.add_parser(
+        'check', help='Check for new commits since the latest project tags')
+    parser_check.add_argument(
+        "--config", required=True,
+        help="Release settings (json file)", metavar="CONFIG")
+    parser_bump = subparsers.add_parser(
+        'bump', help='Bump packages version')
+    parser_bump.add_argument("--part", default='minor', help='bump part name')
+    subparsers.add_parser(
+        'push', help='Push release tags to origin')
+    subparsers.add_parser(
+        'build', help='Start Launchpad build recipes')
+    subparsers.add_parser(
+        'changelog', help='Generate release changelog')
+    parser_open = subparsers.add_parser(
+        'open', help='Open next version for development')
+    parser_open.add_argument("--part", default='minor', help='bump part name')
+    args = parser.parse_args()
+
+    # Run the release step command
+    getattr(Release(args), args.step)()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
New deb release workflow

Manage RC and stable releases (with an option for dry mode)

Since workflow_dispatch only support a maximum of 10 user inputs, all config options are grouped into a single json parameter.

A typical json config looks like this:

```
{
    "mode": "testing",
    "dry_run": true,
    "checkbox-ng": true,
    "checkbox-support": true,
    "provider-base": true,
    "provider-resource": true,
    "provider-tpm2": true,
    "provider-sru": true,
    "provider-certification-server": true,
    "provider-certification-client": true,
    "provider-gpgpu": true,
    "provider-ipdt": true,
    "provider-phoronix": true
}
```
Successfully tested using the staging repo: 
https://github.com/canonical/checkbox-staging/actions/workflows/deb_release.yml