### PR TITLE
Add RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+sphinx:
+   configuration: checkbox-ng/docs/conf.py
+
+# Python requirements to build the docs
+# See: <https://docs.readthedocs.io/en/stable/faq.html#can-i-document-a-python-
+# package-that-is-not-at-the-root-of-my-repository>
+python:
+   install:
+   - requirements: checkbox-ng/docs/requirements.txt

--- a/checkbox-ng/docs/requirements.txt
+++ b/checkbox-ng/docs/requirements.txt
@@ -1,0 +1,1 @@
+checkbox-ng


### PR DESCRIPTION
After gathering everything into a monorepo, RTD complains about building the documentation that lives in checkbox-ng/docs. Using a .readthedocs.yaml config and specifying a requirements.txt file to fix the issue.