### PR TITLE
support: update pactl parser to be compatible with pyparsing 2.x and 3.x

### DIFF
--- a/checkbox-support/checkbox_support/parsers/pactl.py
+++ b/checkbox-support/checkbox_support/parsers/pactl.py
@@ -54,10 +54,6 @@ from collections import OrderedDict
 from inspect import isroutine
 
 import pyparsing as p
-try:
-    p.__compat__.collect_all_And_tokens = False
-except AttributeError:
-    pass
 
 # Enable packrat paring.
 #
@@ -214,7 +210,9 @@ class Port(Node):
         'name': 'port-name',
         'label': 'port-label',
         'priority': 'port-priority',
-        'availability': 'port-availability'
+        'availability': lambda t: t["port-availability"][0]
+        if isinstance(t["port-availability"], p.ParseResults)
+        else t["port-availability"],
     }
 
     __syntax__ = (
@@ -283,10 +281,16 @@ class PortWithProfile(Node):
         'name': 'port-name',
         'label': 'port-label',
         'priority': 'port-priority',
-        'latency_offset': 'port-latency-offset',
-        'availability': 'port-availability',
-        'properties': lambda t: t['port-properties'].asList(),
-        'profile_list': lambda t: t['port-profile-list'].asList(),
+        'latency_offset': lambda t: t["port-latency-offset"][0]
+        if isinstance(t["port-latency-offset"], p.ParseResults)
+        else t["port-latency-offset"],
+        'availability': lambda t: t["port-availability"][0]
+        if isinstance(t["port-availability"], p.ParseResults)
+        else t["port-availability"],
+        'properties': lambda t: t["port-properties"].asList()[0]
+        if any(isinstance(i, list) for i in t["port-properties"].asList())
+        else t["port-properties"].asList(),
+        'profile_list': lambda t: t["port-profile-list"].asList(),
     }
 
     __syntax__ = (


### PR DESCRIPTION
## Description

pyparsing 3.x, introduced in Ubuntu 22.10 repositories, removes support for [`__compat__.collect_all_And_tokens` setting](https://pyparsing-docs.readthedocs.io/en/latest/whats_new_in_3_0_0.html#other-discontinued-features). As a result, `MatchFirst` expressions return a list, even if it only has one item in it.

Since Ubuntu 16.04 (which ships pyparsing 2.0) still has to be supported, this commits makes use of lambda for some expression fragments to work on 22.10 while being retrocompatible with 16.04.

## Resolved issues

Fixes https://warthogs.atlassian.net/browse/CHECKBOX-173

## Documentation

- [X] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [X] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [X] Steps to follow for reviewer to run & manually test are provided.
- [X] A list of what tests were run and on what platform/configuration is provided.

Unit tests (previously failing on Kinetic) were run on checkbox-support after applying the patch on both a Xenial and a Kinetic LXC containers:

```
# ./setup.py test -s checkbox_support.parsers.tests.test_pactl
running test
running egg_info
writing entry points to checkbox_support.egg-info/entry_points.txt
writing top-level names to checkbox_support.egg-info/top_level.txt
writing requirements to checkbox_support.egg-info/requires.txt
writing dependency_links to checkbox_support.egg-info/dependency_links.txt
writing checkbox_support.egg-info/PKG-INFO
reading manifest file 'checkbox_support.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'checkbox_support.egg-info/SOURCES.txt'
running build_ext
test_SPDIF_in_port_label (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_active_port_with_prefix (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_base_volume (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_chinese_ports (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_empty_value (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_format (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_inf_volume (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_leading_space (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_many_ports (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_one_port (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_profiles (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_properties (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_simple (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_volume (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_volume_variant1 (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_volume_with_tabs (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_with_ports_properties (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_with_profile_association (checkbox_support.parsers.tests.test_pactl.AttributeTests) ... ok
test_DMIC_pactl_list_cards_x13 (checkbox_support.parsers.tests.test_pactl.DocumentTests) ... ok
test_pactl_list (checkbox_support.parsers.tests.test_pactl.DocumentTests) ... ok
test_pactl_list_bt_volume_trusty (checkbox_support.parsers.tests.test_pactl.DocumentTests) ... ok
test_pactl_list_cards (checkbox_support.parsers.tests.test_pactl.DocumentTests) ... ok
test_pactl_list_cards_p16gen1 (checkbox_support.parsers.tests.test_pactl.DocumentTests) ... ok
test_pactl_list_cards_xps1340 (checkbox_support.parsers.tests.test_pactl.DocumentTests) ... ok
test_pactl_list_clients_bionic (checkbox_support.parsers.tests.test_pactl.DocumentTests) ... ok
test_pactl_list_modules (checkbox_support.parsers.tests.test_pactl.DocumentTests) ... ok
test_pactl_list_negative_balance_focal (checkbox_support.parsers.tests.test_pactl.DocumentTests) ... ok
test_pactl_list_ports_with_pretag (checkbox_support.parsers.tests.test_pactl.DocumentTests) ... ok
test_pactl_list_sinks (checkbox_support.parsers.tests.test_pactl.DocumentTests) ... ok
test_pactl_list_sinks_p16gen1 (checkbox_support.parsers.tests.test_pactl.DocumentTests) ... ok
test_DMIC_port_with_blank_space (checkbox_support.parsers.tests.test_pactl.PortTests) ... ok
test_chinese_label (checkbox_support.parsers.tests.test_pactl.PortTests) ... ok
test_port (checkbox_support.parsers.tests.test_pactl.PortTests) ... ok
test_port_no_availability_info (checkbox_support.parsers.tests.test_pactl.PortTests) ... ok
test_port_not_available (checkbox_support.parsers.tests.test_pactl.PortTests) ... ok
test_port_with_ (checkbox_support.parsers.tests.test_pactl.PortTests) ... ok
test_HDMI_in_label (checkbox_support.parsers.tests.test_pactl.ProfileTests) ... ok
test_IEC985_in_label (checkbox_support.parsers.tests.test_pactl.ProfileTests) ... ok
test_colon_after_priority (checkbox_support.parsers.tests.test_pactl.ProfileTests) ... ok
test_smoke (checkbox_support.parsers.tests.test_pactl.ProfileTests) ... ok
test_dash (checkbox_support.parsers.tests.test_pactl.PropertyTests) ... ok
test_smoke (checkbox_support.parsers.tests.test_pactl.PropertyTests) ... ok
test_underscore (checkbox_support.parsers.tests.test_pactl.PropertyTests) ... ok
test_DMIC_sinks (checkbox_support.parsers.tests.test_pactl.RecordTests) ... ok
test_modules (checkbox_support.parsers.tests.test_pactl.RecordTests) ... ok
test_sinks (checkbox_support.parsers.tests.test_pactl.RecordTests) ... ok
test_sinks_p16gen1 (checkbox_support.parsers.tests.test_pactl.RecordTests) ... ok

----------------------------------------------------------------------
Ran 47 tests in 8.439s

OK

# ./setup.py test -s checkbox_support.scripts.tests.test_audio_settings
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
/usr/lib/python3/dist-packages/setuptools/installer.py:27: SetuptoolsDeprecationWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
  warnings.warn(
running egg_info
writing checkbox_support.egg-info/PKG-INFO
writing dependency_links to checkbox_support.egg-info/dependency_links.txt
writing entry points to checkbox_support.egg-info/entry_points.txt
writing requirements to checkbox_support.egg-info/requires.txt
writing top-level names to checkbox_support.egg-info/top_level.txt
reading manifest file 'checkbox_support.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'COPYING'
writing manifest file 'checkbox_support.egg-info/SOURCES.txt'
running build_ext
test_volume_regex_trusty (checkbox_support.scripts.tests.test_audio_settings.RegexTest)
Testing pactl 4.0 output ... ok
test_volume_regex_xenial (checkbox_support.scripts.tests.test_audio_settings.RegexTest)
Testing pactl 8.0 output ... ok
test_desktop_bionic_x13 (checkbox_support.scripts.tests.test_audio_settings.SetProfileTest)
Bionic system with a Intel UHD Graphics chipset, it's DMIC system. ... ok
test_desktop_precise_radeon_available (checkbox_support.scripts.tests.test_audio_settings.SetProfileTest)
Home-made system running Precise with a Radeon card. ... ok
test_desktop_precise_radeon_not_available (checkbox_support.scripts.tests.test_audio_settings.SetProfileTest)
Home-made system running Precise with a Radeon card. ... ok
test_desktop_precise_xps1340 (checkbox_support.scripts.tests.test_audio_settings.SetProfileTest)
Precise system with a Nvidia chipset. ... ok
test_desktop_raring_t430s_available (checkbox_support.scripts.tests.test_audio_settings.SetProfileTest)
Raring system with a Mini-DisplayPort. ... ok
test_desktop_raring_t430s_not_available (checkbox_support.scripts.tests.test_audio_settings.SetProfileTest)
Raring system with a Mini-DisplayPort. ... ok
test_displayport_monitor_hifi (checkbox_support.scripts.tests.test_audio_settings.SetProfileTest)
Displayport profiles can be exposed using Hifi ... ok

----------------------------------------------------------------------
Ran 9 tests in 14.277s

OK
```
