### PR TITLE
remote_assistant: incrementally build list of extra environment variables

### DIFF
--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -233,6 +233,7 @@ class RemoteSessionAssistant():
         }
 
     def prepare_extra_env(self):
+        extra_env = {}
         # If possible also set the DISPLAY env var
         # i.e when a user desktop session is running
         for p in psutil.pids():
@@ -255,16 +256,15 @@ class RemoteSessionAssistant():
                 p_user != 'gdm'
             ):  # gdm uses :1024
                 uid = pwd.getpwnam(self._normal_user).pw_uid
-                return {
-                    'DISPLAY': p_environ['DISPLAY'],
-                    'WAYLAND_DISPLAY': p_environ['WAYLAND_DISPLAY'],
-                    'XAUTHORITY': p_environ['XAUTHORITY'],
-                    'XDG_SESSION_TYPE': p_environ['XDG_SESSION_TYPE'],
-                    'XDG_RUNTIME_DIR': '/run/user/{}'.format(uid),
-                    'DBUS_SESSION_BUS_ADDRESS':
-                        'unix:path=/run/user/{}/bus'.format(uid)
-                }
-        return {}
+                extra_env['DISPLAY'] = p_environ['DISPLAY']
+                extra_env['XAUTHORITY'] = p_environ['XAUTHORITY']
+                extra_env['XDG_SESSION_TYPE'] = p_environ['XDG_SESSION_TYPE']
+                extra_env['XDG_RUNTIME_DIR'] = '/run/user/{}'.format(uid)
+                extra_env['DBUS_SESSION_BUS_ADDRESS'] = 'unix:path=/run/user/{}/bus'.format(uid)
+            if "WAYLAND_DISPLAY" in p_environ:
+                extra_env['WAYLAND_DISPLAY'] = p_environ['WAYLAND_DISPLAY']
+
+        return extra_env
 
     @allowed_when(Idle)
     def start_session(self, configuration):


### PR DESCRIPTION

## Description

`prepare_extra_env()` method updated to build a list of extra environment variables required for desktop testing.

`WAYLAND_DISPLAY` is handled separately as there are cases where it is not present, yet the other environment variables are required (e.g. when running Xorg instead of Wayland).

## Resolved issues

Note the Jira/Launchpad issue(s) resolved by this PR (`Fixes|Resolves ...`).

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why: remote assistant currently doesn't have unit tests. We are waiting for Metabox to work on some.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too)

## Tests

- [X] Steps to follow for reviewer to run & manually test are provided.
- [X] A list of what tests were run and on what platform/configuration is provided:

After applying the patch:

1. Using checkbox remote to execute a job while observing `journalctl -f -u checkbox-ng.service` to make sure the expected environment variables are being forwarded (`DISPLAY`, `WAYLAND_DISPLAY`, `XDG_SESSION_TYPE`, etc.).
2. Repeat step 1 on both Xorg and Wayland on Ubuntu 22.04.