### PR TITLE
bin:audio_test.py: use pactl get-default-source and get-default-sink

### DIFF
--- a/providers/base/bin/audio_test.py
+++ b/providers/base/bin/audio_test.py
@@ -128,10 +128,12 @@ class PAVolumeController(object):
             return False
         if not self.identifier:
             return False
-        command = ['pactl',
-                   'set-%s-volume' % (self.pa_types[self.type]),
-                   str(self.identifier[0]),
-                   str(int(volume)) + "%"]
+        command = [
+            "pactl",
+            "set-%s-volume" % (self.pa_types[self.type]),
+            self.identifier,
+            str(int(volume)) + "%",
+        ]
         self._pactl_output(command)
         self._volume = volume
         return True
@@ -145,10 +147,12 @@ class PAVolumeController(object):
         mute = str(int(mute))
         if not self.identifier:
             return False
-        command = ['pactl',
-                   'set-%s-mute' % (self.pa_types[self.type]),
-                   str(self.identifier[0]),
-                   mute]
+        command = [
+            "pactl",
+            "set-%s-mute" % (self.pa_types[self.type]),
+            self.identifier,
+            mute,
+        ]
         self._pactl_output(command)
         return True
 
@@ -156,46 +160,38 @@ class PAVolumeController(object):
         if self.type:
             self.identifier = self._get_identifier_for(self.type)
             if self.identifier and self.logger:
-                message = "Using PulseAudio identifier %s (%s) for %s" %\
-                       (self.identifier + (self.type,))
+                message = "Using PulseAudio identifier %s for %s" % (
+                    self.identifier,
+                    self.type,
+                )
                 self.logger.info(message)
             return self.identifier
 
     def _get_identifier_for(self, type):
         """Gets default PulseAudio identifier for given type.
 
-           Arguments:
-           type: either input or output
+        Arguments:
+        type: either input or output
 
-           Returns:
-           A tuple: (pa_id, pa_description)
+        Returns:
+        A string: device_name
 
         """
 
         if type not in self.pa_types:
             return None
-        command = ['pactl', 'list', self.pa_types[type] + "s", 'short']
 
-        # Expect lines of this form (field separator is tab):
-        # <ID>\t<NAME>\t<MODULE>\t<SAMPLE_SPEC_WITH_SPACES>\t<STATE>
-        # What we need to return is the ID for the first element on this list
-        # that does not contain auto_null or monitor.
-        pa_info = self._pactl_output(command)
-        valid_elements = None
-
-        if pa_info:
-            reject_regex = '.*(monitor|auto_null).*'
-            valid_elements = [element for element in pa_info.splitlines()
-                              if not re.match(reject_regex, element)]
-        if not valid_elements:
+        command = ["pactl", "get-default-" + self.pa_types[type]]
+        name = self._pactl_output(command).strip()
+        if name.startswith("auto_null") or name.endswith(".monitor"):
             if self.logger:
-                self.logger.error("No valid PulseAudio elements"
-                                  " for %s" % (self.type))
+                self.logger.error(
+                    "Default PulseAudio element for %s is invalid (%s)"
+                    % (self.type, name)
+                )
             return None
-        # We only need the pulseaudio numeric ID and long name for each element
-        valid_elements = [(int(e.split()[0]), e.split()[1])
-                          for e in valid_elements]
-        return valid_elements[0]
+
+        return name
 
     def _pactl_output(self, command):
         # This method mainly calls pactl (hence the name). Since pactl may


### PR DESCRIPTION
Get default source/sink directly instead of manually filtering through the list.

## Description

Describe your changes here:

- The original implementation of getting current default source/sink is by filtering through the list of sources/sinks and get the first item.  However, this wouldn't work if the default source/sink is not the first one.
- This fixes the issue by using the command `pactl get-default-(source|sink)` to get the identifier string of the device.
- Note that the other commands `pactl set-{source,sink}-volume` and `pactl set-{source,sink}-mute` can be used with identifier string instead of numeric id to control the device.

To test this issue:
1. Find a device with multiple audio outputs (laptop with HDMI audio out, for example), or multiple audio inputs.
2. Set the pactl default device sink (using `pactl set-default-sink`) to the second one of `pactl list sinks short | grep -v monitor | grep -v autonull` (or replace sink with source for inputs)
3. Run `audio_test.py` and it should use the device assigned above.

This test script didn't have an automated test before.  If a test script is required along with this PR, I can attempt to make one.

## Resolved issues

This PR is a migration of the Launchpad MP: https://code.launchpad.net/~checkbox-dev/plainbox-provider-checkbox/+git/plainbox-provider-checkbox/+merge/431179

Has no public LP bug / Jira issue opened.

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [X] Steps to follow for reviewer to run & manually test are provided.
- [ ] A list of what tests were run and on what platform/configuration is provided.
