### PR TITLE
New workflow to trigger a checkbox.readthedocs.io build

### DIFF
--- a/.github/workflows/trigger-rtd-build.yml
+++ b/.github/workflows/trigger-rtd-build.yml
@@ -1,0 +1,15 @@
+name: Trigger a new checkbox.readthedocs.io build
+on:
+  pull_request:
+    types:
+      - closed
+    paths:
+      - 'checkbox-ng/docs/**'
+
+jobs:
+  if_merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        curl -X POST -d "branches=latest" -d "token=${{ secrets.RTD_TOKEN }}" https://readthedocs.org/api/v2/webhook/checkbox/137367/


### PR DESCRIPTION
## Description

Describe your changes here:

- Trigger a new build of the checkbox documentation when pull request merges including `checkbox-ng/docs` commits
- It relies on the same RTD V2 token previously in use in the [pmr hook](https://git.launchpad.net/checkbox-ng/tree/.pmr-merge-hook#n11)

## Resolved issues

Fixes https://warthogs.atlassian.net/browse/CHECKBOX-176

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [ ] A list of what tests were run and on what platform/configuration is provided.
