### PR TITLE
New workflow to trigger debian packages daily builds

### DIFF
--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -1,0 +1,25 @@
+name: Debian packages daily build
+
+on:
+  schedule:
+    - cron: '00 04 * * *'
+  workflow_dispatch:
+
+jobs:
+  deb_daily_builds:
+    name: Debian packages daily build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt update -qq
+          sudo apt install -qq -y python3-launchpadlib
+      - name: Checkout checkbox monorepo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check for checkbox projects new commits
+        env:
+          LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
+        run: |
+          tools/daily-builds/deb_daily_builds.py

--- a/tools/daily-builds/deb_daily_builds.py
+++ b/tools/daily-builds/deb_daily_builds.py
@@ -20,8 +20,6 @@
 import os
 import subprocess
 
-from pathlib import Path
-
 
 def run(*args, **kwargs):
     """wrapper for subprocess.run."""
@@ -45,8 +43,10 @@ def main():
     projects = {}
     for path, dirs, files in os.walk('.'):
         if "debian" in dirs:
-            project_path = str(Path(*Path(path).parts))
-            project_name = str(project_path).replace('s/', '-')
+            project_path = os.path.relpath(path)
+            # Tweak the provider paths to get names in the following form:
+            # providers/base -> checkbox-provider-base
+            project_name = project_path.replace('s/', '-')
             if project_name.startswith('provider'):
                 project_name = "checkbox-"+project_name
             projects[project_name] = project_path

--- a/tools/daily-builds/deb_daily_builds.py
+++ b/tools/daily-builds/deb_daily_builds.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2022-2023 Canonical Ltd.
+# Written by:
+#   Sylvain Pineau <sylvain.pineau@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess
+
+from pathlib import Path
+
+
+def run(*args, **kwargs):
+    """wrapper for subprocess.run."""
+    try:
+        return subprocess.run(
+            *args, **kwargs,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        print('{}\n{}'.format(e, e.output.decode()))
+        raise SystemExit(1)
+
+
+def main():
+    """Parse the checkbox monorepo to trigger deb daily builds in Launchpad."""
+    # First request code import (GitHub -> Launchpad)
+    run(
+       "./tools/release/lp-request-import.py "
+       "~checkbox-dev/checkbox/+git/checkbox",
+       shell=True, check=True)
+    projects = {}
+    for path, dirs, files in os.walk('.'):
+        if "debian" in dirs:
+            project_path = str(Path(*Path(path).parts))
+            project_name = str(project_path).replace('s/', '-')
+            if project_name.startswith('provider'):
+                project_name = "checkbox-"+project_name
+            projects[project_name] = project_path
+    # Find projects new commits from the last 24 hours
+    for name, path in sorted(projects.items(), key=lambda i: i[1]):
+        new_commits = int(run(
+            'git rev-list --count HEAD --not '
+            '$(git rev-list -n1 --before="24 hours" '
+            '--first-parent HEAD) -- :{}'.format(path),
+            shell=True, check=True).stdout.decode().rstrip())
+        # Kick off daily builds if the new commits got merged into main
+        if new_commits:
+            output = run(
+                "./tools/daily-builds/lp-recipe-build.py checkbox "
+                "--recipe {}".format(name+'-daily'),
+                shell=True, check=True).stdout.decode().rstrip()
+            print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/daily-builds/lp-recipe-build.py
+++ b/tools/daily-builds/lp-recipe-build.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python3
+# This file is part of Checkbox.
+#
+# Copyright 2022-2023 Canonical Ltd.
+# Written by:
+#   Sylvain Pineau <sylvain.pineau@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Kicks off a deb recipe build in Launchpad.
+"""
+
+import os
+import sys
+
+from launchpadlib.credentials import Credentials
+from launchpadlib.launchpad import Launchpad
+from lazr.restfulclient.errors import BadRequest
+from argparse import ArgumentParser
+
+
+def main():
+    parser = ArgumentParser('Invoke a recipe build on specified branch')
+    parser.add_argument('project',
+                        help="Unique name of the project")
+    parser.add_argument('--recipe', '-r',
+                        help="Recipe name to build with. If there is only one "
+                             "then that will be used by default, if not then "
+                             "this must be specified.")
+    args = parser.parse_args()
+
+    credentials = Credentials.from_string(os.getenv("LP_CREDENTIALS"))
+    lp = Launchpad(
+        credentials, None, None, service_root='production', version='devel')
+    try:
+        project = lp.projects[args.project]
+    except KeyError:
+        parser.error("{} was not found in Launchpad.".format(args.project))
+
+    if project.recipes.total_size == 0:
+        parser.error("{} does not have any recipes.".format(args.project))
+    else:
+        build_recipe = None
+
+        if project.recipes.total_size == 1:
+            build_recipe = project.recipes[0]
+        elif args.recipe:
+            for recipe in project.recipes:
+                if recipe.name == args.recipe:
+                    build_recipe = recipe
+        else:
+            all_recipe_names = [recipe.name for recipe in project.recipes]
+            parser.error(
+                "I don't know which recipe from "
+                "{project} you want to use, specify "
+                "one of '{recipes}' using --recipe".format(
+                    project=args.project,
+                    recipes=', '.join(all_recipe_names)))
+
+        if build_recipe:
+            for series in build_recipe.distroseries:
+                try:
+                    build_recipe.requestBuild(
+                        pocket="Release",
+                        distroseries=series,
+                        archive=build_recipe.daily_build_archive_link)
+                except BadRequest:
+                    print("An identical build of this recipe is "
+                          "already pending")
+        print("Check builds status: " + build_recipe.web_link)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Describe your changes here:

New workflow to replicate the Launchpad daily builds for chekbox debian packages
Implemented using a dedicated python script rather than a job matrix for the following reason:
- All jobs would have to checkout the repo

## Resolved issues

Fixes [CHECKBOX-175](https://warthogs.atlassian.net/browse/CHECKBOX-175)

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [ ] A list of what tests were run and on what platform/configuration is provided.
