### PR TITLE
Add Bluetooth microphone recording test with HSP/HFP profile

### DIFF
--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -416,3 +416,40 @@ flags: also-after-suspend
 _summary: Bluetooth OBEX send
 _description:
  This is an automated Bluetooth file transfer test. It sends an image to the device specified by the BTDEVADDR environment variable
+
+ plugin: user-interact-verify
+category_id: com.canonical.plainbox::bluetooth
+id: bluetooth/audio_record_playback
+depends: bluetooth/detect-output
+estimated_duration: 120.0
+flags: also-after-suspend
+command:
+  audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  idx=$(pactl list cards short | awk '/bluez/{print $1}')
+  if [ "$idx" = "" ]; then
+    echo "Please enable and pair the bluetooth headset device"
+    exit 1
+  fi
+  bt_sink=$(pactl list sinks short | awk '/bluez/{print $2}')
+  bt_profile=$(pactl list cards | awk -v RS='' '/bluez/' | awk -F':' '{print $1}' | awk '/head_unit/{print $1}')
+  pactl set-card-profile "$idx" "$bt_profile"
+  pactl set-default-sink "$bt_sink"
+  bt_source=$(pactl list sources short | awk '/bluez_source/{print $2}')
+  if [ "$bt_source" = "" ]; then
+    echo "Please check your bluetooth support HSP/HFP profile"
+    exit 1
+  fi
+  pactl set-default-source "$bt_source"
+  alsa_record_playback.sh
+  EXIT_CODE=$?
+  audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  exit $EXIT_CODE
+_purpose:
+     This test will check the Headset Head Unit (HSP/HFP) capability of your Bluetooth device,
+     to check if you can recording sounds
+_steps:
+     1. Enable and pair the bluetooth headset
+     2. Click "Test", then speak into your Bluetooth microphone.
+     3. After a few seconds, your speech will be played back to you.
+_verification:
+     Did you hear your speech played back?

--- a/providers/base/units/bluetooth/test-plan.pxu
+++ b/providers/base/units/bluetooth/test-plan.pxu
@@ -17,6 +17,7 @@ include:
  bluetooth/audio-a2dp                           certification-status=blocker
  bluetooth4/HOGP-mouse                          certification-status=blocker
  bluetooth4/HOGP-keyboard                       certification-status=blocker
+ bluetooth/audio_record_playback                certification-status=blocker
 
 id: bluetooth-cert-automated
 unit: test plan
@@ -37,6 +38,7 @@ include:
  bluetooth4/HOGP-mouse                          certification-status=blocker
  bluetooth4/HOGP-keyboard                       certification-status=blocker
  bluetooth/audio-a2dp                           certification-status=blocker
+ bluetooth/audio_record_playback                certification-status=blocker
 
 id: bluetooth-full
 unit: test plan
@@ -173,6 +175,7 @@ include:
  after-suspend-bluetooth/audio-a2dp                           certification-status=blocker
  after-suspend-bluetooth4/HOGP-mouse                          certification-status=blocker
  after-suspend-bluetooth4/HOGP-keyboard                       certification-status=blocker
+ after-suspend-bluetooth/audio_record_playback                certification-status=blocker
 
 id: after-suspend-bluetooth-cert-automated
 unit: test plan


### PR DESCRIPTION
The Bluetooth test case only has a2dp profile test for now, we need to make sure the input function on bluetooth headset device and this also covers the HSP/HFP profile test.

Origin MR is from: [launchpad merge 429954](https://code.launchpad.net/~clairlin/plainbox-provider-checkbox/+git/plainbox-provider-checkbox/+merge/429954)
