### PR TITLE
Fix the deb release changelog step to get the correct pathspec

### DIFF
--- a/tools/release/release_deb_monorepo.py
+++ b/tools/release/release_deb_monorepo.py
@@ -294,15 +294,14 @@ class Release:
         for project_name, project_info in settings["projects"].items():
             if not project_info["release_required"]:
                 continue
-            project_path = str(Path(*Path(project_info["path"]).parts[2:]))
             cmd = ['git', 'log', '--no-merges', "--pretty='format:+ %s'",
                    '{}...{}'.format(
                        project_info["last_stable_tag"],
                        project_info["last_tag"]),
-                   '--', "':{}'".format(project_path)]
+                   '--', "':{}'".format(project_info["path"])]
             # TODO remove the exclude pathspec on debian after
             # the next release
-            cmd += ["':(exclude){}/debian'".format(project_path)]
+            cmd += ["':(exclude){}/debian'".format(project_info["path"])]
             log = run(
                 ' '.join(cmd), check=True, shell=True).stdout.decode()
             if log:


### PR DESCRIPTION
## Description

Fix a small bug affecting the deb release changelog step.
The `git log` call was not getting the correct pathspec.
As a result logs for a given subproject are actually listing the whole repo commit history between two tags, w/o any filters by path.

## Documentation

N/A

## Tests

Tested using this patch on a fresh clone:
```
$  ./tools/release/release_deb_monorepo.py check --config ~/config.json 
$  ./tools/release/release_deb_monorepo.py bump --part major
$  ./tools/release/release_deb_monorepo.py changelog
```
config.json:
```
{
    "mode": "testing",
    "dry_run": true,
    "checkbox-ng": true,
    "checkbox-support": true,
    "provider-base": true,
    "provider-resource": true,
    "provider-tpm2": true,
    "provider-sru": true,
    "provider-certification-server": true,
    "provider-certification-client": true,
    "provider-gpgpu": true,
    "provider-ipdt": true,
    "provider-phoronix": true
}
```