### PR TITLE
Fix build error

### DIFF
--- a/checkbox-ng/debian/rules
+++ b/checkbox-ng/debian/rules
@@ -3,7 +3,7 @@ export PYBUILD_NAME=checkbox-ng
 export LANG=
 export LANGUAGE=
 export NO_PNG_PKG_MANGLE=1
-export SRCTOP=checkbox-ng
+export SRCTOP=../checkbox-ng
 
 %:
 	dh $@ --sourcedirectory=$(SRCTOP) --with=python3,sphinxdoc --buildsystem=pybuild


### PR DESCRIPTION
## Description

Describe your changes here:

Failed to use debuild in checkbox-ng

## Resolved issues

checkbox-ng (main)$ debuild -b
 dpkg-buildpackage -us -uc -ui -b
dpkg-buildpackage: info: source package checkbox-ng
dpkg-buildpackage: info: source version 2.0.0
dpkg-buildpackage: info: source distribution unstable
dpkg-buildpackage: info: source changed by Sylvain Pineau <sylvain.pineau@canonical.com>
 dpkg-source --before-build .
dpkg-buildpackage: info: host architecture amd64
 fakeroot debian/rules clean
dh clean --sourcedirectory=checkbox-ng --with=python3,sphinxdoc --buildsystem=pybuild
   dh_auto_clean -O--sourcedirectory=checkbox-ng -O--buildsystem=pybuild
dh_auto_clean: error: invalid or non-existing path to the source directory: checkbox-ng
make: *** [debian/rules:9: clean] Error 25
dpkg-buildpackage: error: fakeroot debian/rules clean subprocess returned exit status 2
debuild: fatal error at line 1182:
dpkg-buildpackage -us -uc -ui -b failed

## Tests

- debuild -S 
- debuild -b
