### PR TITLE
collect mac to submission

### DIFF
--- a/providers/base/units/miscellanea/jobs.pxu
+++ b/providers/base/units/miscellanea/jobs.pxu
@@ -15,6 +15,7 @@ depends:
  snap
  requirements
  uname
+ device
  dmi_attachment
  lsblk_attachment
  sysfs_attachment


### PR DESCRIPTION
## Description
adding a device job into the depends field of miscellanea/submission-resources job. So we could capture all hardware components while we submit a submission to C3.

## Resolved issues
N/A

## Documentation
N/A

## Tests
N/A
