### PR TITLE
Add: Archive the session-share folder to tarball

### DIFF
--- a/checkbox-ng/plainbox/impl/exporter/tar.py
+++ b/checkbox-ng/plainbox/impl/exporter/tar.py
@@ -34,7 +34,7 @@ from plainbox.impl.exporter import SessionStateExporterBase
 from plainbox.impl.exporter.jinja2 import Jinja2SessionStateExporter
 from plainbox.impl.providers import get_providers
 from plainbox.impl.unit.exporter import ExporterUnitSupport
-
+from plainbox.impl.session.storage import WellKnownDirsHelper
 
 class TARSessionStateExporter(SessionStateExporterBase):
     """Session state exporter creating Tar archives."""
@@ -93,6 +93,7 @@ class TARSessionStateExporter(SessionStateExporterBase):
                             arcname = os.path.splitext(arcname)[0]
                         tar.add(filename, os.path.join(folder, arcname),
                                 recursive=False)
+            tar.add(WellKnownDirsHelper.session_share(manager.storage.id), 'session-share')
 
     def dump(self, session, stream):
         pass


### PR DESCRIPTION
## Description

Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).

  - Because the session-share directory are not be archived into the tarball after finishing testing and there are lots of cases' log file be generated to session-share directory. Therefore, this commit is aim to archive the whole logs to tarball.

- Introduce your implementation approach in a way that helps reviewing it well.
  - Add the session-share folder to tarball

## Tests

- My test result is [https://certification.canonical.com/hardware/201712-26032/submission/286522/](https://certification.canonical.com/hardware/201712-26032/submission/286522/)
  - You can download the submission tarball and extract it, the session-share folder is included in it.

