### PR TITLE
Fix: remove unnecessary script out of conditions

### DIFF
--- a/providers/base/units/suspend/suspend-graphics.pxu
+++ b/providers/base/units/suspend/suspend-graphics.pxu
@@ -212,7 +212,6 @@ depends:
 command:
  # shellcheck disable=SC1091
  source graphics_env.sh {{ driver }} {{ index }}
- graphics_driver.py
  if [[ $XDG_SESSION_TYPE == "wayland" ]]
  then
    inxi_snapshot -Gazy


### PR DESCRIPTION
## Description

Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
  - This PR solves the problem that the crash report dialog be shown caused by the graphics_driver.py script under Wayland windowing system.

## Resolved issues

#29 Crash report dialog be shown caused by graphics_driver.py 

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [x] Steps to follow for reviewer to run & manually test are provided.

1. Cold boot into OS
2. Run `checkbox-cli`
3. Choose and execute `com.canonical.certification::client-cert-desktop-22-04-automated` test plan
4. Execute `suspend/1_driver_version_after_suspend_xxx_auto` case in Suspend tests set

- [ ] A list of what tests were run and on what platform/configuration is provided.
