### PR TITLE
fix: make USB insertion not miss events in journal

### DIFF
--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -16,6 +16,7 @@ import re
 import select
 import signal
 import sys
+import time
 from systemd import journal
 
 from checkbox_support.scripts.zapper_proxy import ControlVersionDecider
@@ -58,7 +59,7 @@ class USBWatcher:
 
     def run(self):
         j = journal.Reader()
-        j.seek_tail()
+        j.seek_realtime(time.time())
         p = select.poll()
         p.register(j, j.get_events())
         if self.args.zapper_usb_address:


### PR DESCRIPTION
## Description

This patch fixes a problem where the watcher responsible for picking up usb insertion events may have missed the message.

The previously used `seek_tail` method moved the journal cursor beyond the point where messages could go, so when the "mass storage inserted" message came, it may have gone unnoticed.

This patch uses `seek_realtime` function that moves the cursor to particular time ("realtime" here is a misnomer). In this case it
moves the cursor to the current time, so all journal messages from that time on are beiing checked.

## Resolved issues
Fixes: LP #1991207 https://bugs.launchpad.net/plainbox-provider-checkbox/+bug/1991207

## Documentation
Tests confirming it fixes the problem were performed on a device that was affected by the bug.