### PR TITLE
Fix typo in Bluetooth jobs

### DIFF
--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -417,7 +417,7 @@ _summary: Bluetooth OBEX send
 _description:
  This is an automated Bluetooth file transfer test. It sends an image to the device specified by the BTDEVADDR environment variable
 
- plugin: user-interact-verify
+plugin: user-interact-verify
 category_id: com.canonical.plainbox::bluetooth
 id: bluetooth/audio_record_playback
 depends: bluetooth/detect-output


### PR DESCRIPTION
After fixing this, running

```
./manage.py validate
```

works. Before that, it would complain with:

```
error: ???: Cannot load job definitions from
'/<<PKGBUILDDIR>>/providers/base/units/bluetooth/jobs.pxu': Unexpected multi-line value (jobs.pxu, line 420)
```


## Resolved issues

Because of this typo, Debian packages cannot be built. See for instance:

https://launchpadlibrarian.net/633100725/buildlog_ubuntu-bionic-amd64.checkbox-provider-base_2.0.0~rc2~ppa~ubuntu18.04.1_BUILDING.txt.gz