### PR TITLE
Metabox refresh

### DIFF
--- a/metabox/configs/testing-ppa-config.py
+++ b/metabox/configs/testing-ppa-config.py
@@ -2,7 +2,7 @@ configuration = {
     'local': {
         'origin': 'ppa',
         'uri': 'ppa:checkbox-dev/testing',
-        'releases': ['bionic', 'focal'],
+        'releases': ['focal', 'jammy'],
     },
     'remote': {
         'origin': 'ppa',
@@ -12,6 +12,6 @@ configuration = {
     'service': {
         'origin': 'ppa',
         'uri': 'ppa:checkbox-dev/testing',
-        'releases': ['bionic', 'focal'],
+        'releases': ['focal', 'jammy'],
     },
 }

--- a/metabox/metabox/core/lxd_execute.py
+++ b/metabox/metabox/core/lxd_execute.py
@@ -72,7 +72,11 @@ class InteractiveWebsocket(WebSocketClient):
                 check = data.encode('utf-8') in self.stdout_data
             if check:
                 with self.stdout_lock:
-                    self.stdout_data = bytearray()
+                    if type(data) != str:
+                        self.stdout_data = data.split(self.stdout_data)
+                    else:
+                        self.stdout_data = self.stdout_data.split(
+                            data.encode('utf-8'), maxsplit=1)[-1]
                 not_found = False
             if timeout and time.time() > start_time + timeout:
                 logger.warning(

--- a/metabox/metabox/core/lxd_execute.py
+++ b/metabox/metabox/core/lxd_execute.py
@@ -80,7 +80,7 @@ class InteractiveWebsocket(WebSocketClient):
                 not_found = False
             if timeout and time.time() > start_time + timeout:
                 logger.warning(
-                    "{} not found! Timeout is reached (set to {})",
+                    "'{}' not found! Timeout is reached (set to {})",
                     data, timeout)
                 raise TimeoutError
         return not_found is False
@@ -119,6 +119,7 @@ class InteractiveWebsocket(WebSocketClient):
                 time.sleep(0.1)
                 attempt += 1
         if not_found:
+            logger.warning("test plan {} not found!", data)
             return False
         data = '(X) ' + data
         attempt = 0

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -73,11 +73,16 @@ class LxdMachineProvider():
 
     def _get_existing_machines(self):
         for container in self.client.containers.all():
+            if not container.name.startswith('metabox'):
+                continue
             try:
+                container.start(wait=True)
                 content = container.files.get(self.LXD_INTERNAL_CONFIG_PATH)
+                container.stop(wait=True)
                 config_dict = json.loads(content)
                 config = MachineConfig(config_dict['role'], config_dict)
-            except (KeyError, LXDAPIException):
+            except Exception as e:
+                print(container.name, e)
                 continue
             if config in self._machine_config:
                 self._owned_containers.append(

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -157,7 +157,7 @@ class ContainerBaseMachine():
         return []
 
     def start_remote(self, host, launcher, interactive=False, timeout=0):
-        assert(self.config.role == 'remote')
+        assert (self.config.role == 'remote')
 
         if interactive:
             # Return a PTS object to interact with
@@ -171,7 +171,7 @@ class ContainerBaseMachine():
                 timeout=timeout)
 
     def start(self, cmd=None, env={}, interactive=False, timeout=0):
-        assert(self.config.role == 'local')
+        assert (self.config.role == 'local')
         if interactive:
             # Return a PTS object to interact with
             return self.interactive_execute(
@@ -216,7 +216,7 @@ class ContainerBaseMachine():
         pass
 
     def start_user_session(self):
-        assert(self.config.role in ('service', 'local'))
+        assert (self.config.role in ('service', 'local'))
         # Start a set of ubuntu-user-owned processes to fake an active GDM user
         # session (A virtual framebuffer and a pulseaudio server with a dummy
         # output)
@@ -275,12 +275,12 @@ class ContainerVenvMachine(ContainerBaseMachine):
         ]
 
     def start_service(self, force=False):
-        assert(self.config.role == 'service')
+        assert (self.config.role == 'service')
         self._pts = self.interactive_execute('service', verbose=True)
         return self._pts
 
     def stop_service(self):
-        assert(self.config.role == 'service')
+        assert (self.config.role == 'service')
         return self._pts.send_signal(signal.SIGINT.value)
 
     def reboot_service(self):
@@ -291,7 +291,7 @@ class ContainerVenvMachine(ContainerBaseMachine):
         raise RuntimeError
 
     def is_service_active(self):
-        assert(self.config.role == 'service')
+        assert (self.config.role == 'service')
         return run_or_raise(
             self._container, 'pgrep -f "python3.*checkbox-cli service"')
 
@@ -319,18 +319,18 @@ class ContainerPPAMachine(ContainerBaseMachine):
         ]
 
     def start_service(self, force=False):
-        assert(self.config.role == 'service')
+        assert (self.config.role == 'service')
         if force:
             return run_or_raise(
                 self._container, "sudo systemctl start checkbox-ng.service")
 
     def stop_service(self):
-        assert(self.config.role == 'service')
+        assert (self.config.role == 'service')
         return run_or_raise(
             self._container, "sudo systemctl stop checkbox-ng.service")
 
     def is_service_active(self):
-        assert(self.config.role == 'service')
+        assert (self.config.role == 'service')
         return run_or_raise(
             self._container,
             "systemctl is-active checkbox-ng.service").stdout == 'active'
@@ -403,7 +403,7 @@ class ContainerSnapMachine(ContainerBaseMachine):
         return cmds
 
     def start_service(self, force=False):
-        assert(self.config.role == 'service')
+        assert (self.config.role == 'service')
         if force:
             return run_or_raise(
                 self._container,
@@ -411,14 +411,14 @@ class ContainerSnapMachine(ContainerBaseMachine):
                     self._snap_name))
 
     def stop_service(self):
-        assert(self.config.role == 'service')
+        assert (self.config.role == 'service')
         return run_or_raise(
             self._container,
             "sudo systemctl stop snap.{}.service.service".format(
                 self._snap_name))
 
     def is_service_active(self):
-        assert(self.config.role == 'service')
+        assert (self.config.role == 'service')
         return run_or_raise(
             self._container,
             "systemctl is-active snap.{}.service.service".format(
@@ -428,8 +428,8 @@ class ContainerSnapMachine(ContainerBaseMachine):
 
 def machine_selector(config, container):
     if config.origin in ('snap', 'classic_snap'):
-        return(ContainerSnapMachine(config, container))
+        return (ContainerSnapMachine(config, container))
     elif config.origin == 'ppa':
-        return(ContainerPPAMachine(config, container))
+        return (ContainerPPAMachine(config, container))
     elif config.origin == 'source':
-        return(ContainerVenvMachine(config, container))
+        return (ContainerVenvMachine(config, container))

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -221,7 +221,9 @@ class ContainerBaseMachine():
         # session (A virtual framebuffer and a pulseaudio server with a dummy
         # output)
         interactive_execute(
-            self._container, "/usr/bin/Xvfb -screen 0 1280x1024x24")
+            self._container,
+            "DISPLAY=:0 XAUTHORITY=/run/user/1000/gdm/Xauthority "
+            "XDG_SESSION_TYPE=x11 /usr/bin/Xvfb -screen 0 1280x1024x24")
         # Note: running the following commands as part of standard setup does
         # not make them persistent as after restoring snapshots user/1000
         # is gone from /run

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -182,7 +182,8 @@ class Runner:
             scn.run()
             if not scn.has_passed():
                 self.failed = True
-                logger.error("{} scenario has failed.".format(scn.name))
+                logger.error("[{}][{}] {} scenario has failed.".format(
+                    scn.mode, scn.releases, scn.name))
                 if self.hold_on_fail:
                     if scn.mode == "remote":
                         msg = (
@@ -200,7 +201,8 @@ class Runner:
                     print(msg)
                     input()
             else:
-                logger.success("{} scenario has passed.".format(scn.name))
+                logger.success("[{}][{}] {} scenario has passed.".format(
+                    scn.mode, scn.releases, scn.name))
             self.machine_provider.cleanup()
         del self.machine_provider
         stopTime = time.perf_counter()

--- a/metabox/metabox/core/utils.py
+++ b/metabox/metabox/core/utils.py
@@ -47,3 +47,6 @@ class _re:
 
     def search(self, data):
         return bool(self._pattern.search(data))
+
+    def split(self, data):
+        return re.split(self._pattern, data, maxsplit=1)[-1]

--- a/metabox/metabox/main.py
+++ b/metabox/metabox/main.py
@@ -21,11 +21,18 @@
 Entry point to the Metabox program.
 """
 import argparse
+import logging
 import warnings
 from pathlib import Path
 
 from loguru._logger import Core
 from metabox.core.runner import Runner
+
+
+class InterceptHandler(logging.Handler):
+    def emit(self, record):
+        # Mute all ws4py ConnectionResetError
+        return
 
 
 def main():
@@ -61,6 +68,7 @@ def main():
         '--debug-machine-setup', action='store_true',
         help="Turn on verbosity during machine setup. "
              "Only works with --log TRACE")
+    logging.basicConfig(handlers=[InterceptHandler()], level=0, force=True)
     # Ignore warnings issued by pylxd/models/operation.py
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/metabox/metabox/scenarios/basic/run-invocation.py
+++ b/metabox/metabox/scenarios/basic/run-invocation.py
@@ -58,16 +58,6 @@ class RunTestplanWithEnvvar(Scenario):
     ]
 
 
-class RunTestplanWithTimeout(Scenario):
-
-    mode = ['local']
-    steps = [
-        Start('run 2021.com.canonical.certification::'
-              'basic-automated-passing', timeout='0.1s'),
-        AssertRetCode(0)
-    ]
-
-
 class RunManualplan(Scenario):
 
     mode = ['local']

--- a/metabox/metabox/scenarios/desktop_env/launcher.py
+++ b/metabox/metabox/scenarios/desktop_env/launcher.py
@@ -69,7 +69,7 @@ class AudioPlayback(Scenario):
         Expect('Pick an action'),
         Send(keys.KEY_ENTER),
         Expect('Pipeline initialized, now starting playback.'),
-        Expect('Pick an action'),
+        Expect('Pick an action', timeout=10),
         Send('p' + keys.KEY_ENTER),
         AssertNotPrinted('Connection failure: Connection refused'),
         Expect(_re('(☑|job passed).*audio/playback_auto'), timeout=10),

--- a/metabox/metabox/scenarios/urwid/testplan.py
+++ b/metabox/metabox/scenarios/urwid/testplan.py
@@ -33,14 +33,15 @@ class UrwidTestPlanSelection(Scenario):
         SelectTestPlan(
             'com.canonical.certification::'
             'after-suspend-graphics-discrete-gpu-cert-automated'),
-        SelectTestPlan('com.canonical.certification::client-cert-18-04'),
+        SelectTestPlan(
+            'com.canonical.certification::client-cert-desktop-18-04'),
         Send(keys.KEY_ENTER),
         Expect('Choose tests to run on your system:'),
         Send('d' + keys.KEY_ENTER),
         Expect('Choose tests to run on your system:'),
         Send(keys.KEY_DOWN * 18 + keys.KEY_SPACE + 't'),
         Expect('System Manifest:'),
-        Send('y' * 9 + 't'),
+        Send('y' * 11 + 't'),
         Expect('Pick an action'),
         Send('s' + keys.KEY_ENTER),
         Expect('Finish'),


### PR DESCRIPTION
## Description

Set of patches to get metabox working 

## Resolved issues

- Resume from LXD snapshots (metabox config are saved in the container but file operations now require a running container)
- Random issues with the expect command (on success the stdout buffer was totally consumed/reset)
- Tests requiring a desktop user session were failing since more env var are now required (in addition of just $DISPLAY)
- Failing scenarios (outdated test plan names, dummy timeouts)
- Noisy logging from ws4py

## Tests

tested using:

`$ metabox metabox/configs/testing-ppa-config.py --do-not-dispose`
