### PR TITLE
Updated EDID script

### DIFF
--- a/checkbox-support/checkbox_support/scripts/zapper_proxy.py
+++ b/checkbox-support/checkbox_support/scripts/zapper_proxy.py
@@ -59,6 +59,17 @@ class IZapperControl:
         """
 
     @abstractmethod
+    def change_edid(self, edid_file=None):
+        """
+        Set EDID on HDMI output. If input is None, clear EDID.
+        Note that the argument is used as-is without any checks done on
+        this side. Any validation and use of it will be done on the
+        remote end.
+
+        :param bytes edid_file: EDID binary file
+        """
+
+    @abstractmethod
     def get_capabilities(self):
         """Get Zapper's setup capabilities in checkbox resource form."""
 
@@ -79,6 +90,9 @@ class ZapperControlV1(IZapperControl):
     def usb_set_state(self, address, state):
         self._conn.root.zombiemux_set_state(address, state)
         print("State '{}' set for the address {}.".format(state, address))
+
+    def change_edid(self, edid_file=None):
+        self._conn.root.change_edid(edid_file)
 
     def get_capabilities(self):
         capabilities = self._conn.root.get_capabilities()

--- a/providers/base/bin/edid_cycle.py
+++ b/providers/base/bin/edid_cycle.py
@@ -14,6 +14,8 @@ import subprocess
 import sys
 import time
 
+from checkbox_support.scripts.zapper_proxy import (             # noqa: E402
+    ControlVersionDecider)
 
 def check_resolution():
     output = subprocess.check_output('xdpyinfo')
@@ -25,10 +27,10 @@ def check_resolution():
 
 
 def change_edid(host, edid_file):
+    zapper_control = ControlVersionDecider().decide(host)
+
     with open(edid_file, 'rb') as f:
-        cmd = ['ssh', host, 'v4l2-ctl --set-edid=file=-,'
-               'format=raw --fix-edid-checksums']
-        subprocess.check_output(cmd, input=f.read())
+        zapper_control.change_edid(f.read())
 
 
 def main():


### PR DESCRIPTION
## Description

Some changes were made for controlling EDID directly using Control. With this PR we make use of that new API instead of relying on direct SSH calls (which is also no more valid since v4l2-utils is not available system wide).

## Resolved issues

- Resolves [ZAP-280](https://warthogs.atlassian.net/browse/ZAP-280)
- Needed for [ZAP-283](https://warthogs.atlassian.net/browse/ZAP-283)

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [X] A list of what tests were run and on what platform/configuration is provided.


[ZAP-280]: https://warthogs.atlassian.net/browse/ZAP-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ZAP-283]: https://warthogs.atlassian.net/browse/ZAP-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ