### PR TITLE
New workflows to get daily builds of checkbox and checkbox core snaps

### DIFF
--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -1,0 +1,53 @@
+name: checkbox core snap daily build
+
+on:
+  schedule:
+    - cron: '00 04 * * *'
+  workflow_dispatch:
+
+jobs:
+  snap:
+    strategy:
+      matrix:
+        releases: [16, 18, 20, 22]
+    runs-on: ubuntu-latest
+    env:
+      SERIES: series${{ matrix.releases }}
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
+    name: Checkbox Core snap for series ${{ matrix.releases }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check for checkbox projects new commits
+        run: |
+          git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap
+          [[ ! -z $(git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap) ]]
+      - name: Copy over the common files for series ${{ matrix.releases }}
+        run: |
+          cd checkbox-core-snap/
+          ./prepare.sh $SERIES
+      - name: add LP credentials
+        run: |
+          mkdir -p ~/.local/share/snapcraft/provider/launchpad/
+          echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
+          git config --global user.email "robot@lists.canonical.com"
+          git config --global user.name "Certification bot"
+      - uses: snapcore/action-build@v1
+        id: snapcraft
+        with:
+          path: checkbox-core-snap/series${{ matrix.releases }}
+          snapcraft-channel: 7.x/stable
+          snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
+      - uses: actions/upload-artifact@v3
+        with:
+          name: series${{ matrix.releases }}
+          path: checkbox-core-snap/series${{ matrix.releases }}/*.snap
+      - name: Upload checkbox core snaps to the store
+        run: |
+          for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap
+          do
+            echo "Uploading $snap..."
+            snapcraft upload $snap --release edge
+          done

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -1,0 +1,62 @@
+name: checkbox snap daily build
+
+on:
+  schedule:
+    - cron: '00 04 * * *'
+  workflow_dispatch:
+
+jobs:
+  snap:
+    strategy:
+      matrix:
+        type: [classic, uc]
+        releases: [16, 18, 20, 22]
+    runs-on: ubuntu-latest
+    env:
+      SERIES: series_${{ matrix.type }}${{ matrix.releases }}
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
+    name: Checkbox snap for series ${{ matrix.type }}${{ matrix.releases }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check for checkbox snap new commits
+        run: |
+          git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-snap
+          [[ ! -z $(git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-snap) ]]
+      - name: Copy over the common files for series ${{ matrix.type }}${{ matrix.releases }}
+        run: |
+          cd checkbox-snap/
+          ./prepare_${{ matrix.type }}.sh $SERIES
+      - name: add LP credentials
+        run: |
+          mkdir -p ~/.local/share/snapcraft/provider/launchpad/
+          echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
+          git config --global user.email "robot@lists.canonical.com"
+          git config --global user.name "Certification bot"
+      - uses: snapcore/action-build@v1
+        id: snapcraft
+        with:
+          path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}
+          snapcraft-channel: 7.x/stable
+          snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
+      - uses: actions/upload-artifact@v3
+        with:
+          name: series_${{ matrix.type }}${{ matrix.releases }}
+          path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
+      - name: Upload checkbox snaps to the store
+        run: |
+          for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
+          do
+            echo "Uploading $snap..."
+            if [[ ${{ matrix.type }} == 'classic' ]]; then
+              if [[ ${{ matrix.releases }} == '22' ]]; then
+                snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge
+              else
+                snapcraft upload $snap --release ${{ matrix.releases }}.04/edge
+              fi
+            else
+              snapcraft upload $snap --release ${{ matrix.type }}${{ matrix.releases }}/edge
+            fi
+          done


### PR DESCRIPTION
## Description

The workflow itself runs daily but the builds are actually triggered only if new commits were created for:

- the checkbox snap: only in checkbox-snap/
- the checkbox core snap: checkbox-ng/, checkbox-support/, providers/ and checkbox-core-snap/

## Tests

Tested using the staging repo:

- checkbox core snap: https://github.com/canonical/checkbox-staging/actions/runs/3546758036
- checkbox snap: https://github.com/canonical/checkbox-staging/actions/runs/3546748981

Note that the checkbox snap for 22.04 is uploaded to both **22.04/edge** and **latest/edge**
