### PR TITLE
Fix: Include submission-resources in ISO install test

### DIFF
--- a/providers/certification-server/units/iso-install.pxu
+++ b/providers/certification-server/units/iso-install.pxu
@@ -15,6 +15,7 @@ include:
     miscellanea/klog_results.log
     miscellanea/sosreport                      certification-status=non-blocker
     miscellanea/sosreport_attachment           certification-status=non-blocker
+    miscellanea/submission-resources           certification-status=non-blocker
     miscellanea/test_iso_install               certification-status=non-blocker
 bootstrap_include:
     device


### PR DESCRIPTION
## Description

Add the miscellanea/submission-resources job to the iso-install test. This fixes a problem in which C3 was not showing the version used to run the test-iso-install test plan.


## Resolved issues

Resolves https://warthogs.atlassian.net/browse/SERVCERT-615.

See 1 December, 2022 test run on brennan (on my personal network) for sample run:

https://certification.canonical.com/hardware/201508-19150/

Note the "Release" column correctly shows the Ubuntu version, which it did not before.

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [ ] A list of what tests were run and on what platform/configuration is provided.
