### PR TITLE
Fix checkbox-ng tox.ini (compatibility with tox 4.0.0rc1)

### DIFF
--- a/checkbox-ng/tox.ini
+++ b/checkbox-ng/tox.ini
@@ -3,6 +3,10 @@ envlist = py35,py36,py38,py310
 skip_missing_interpreters = true
 
 [testenv]
+allowlist_externals =
+    {envsitepackagesdir}/plainbox/impl/providers/categories/manage.py
+    {envsitepackagesdir}/plainbox/impl/providers/exporters/manage.py
+    {envsitepackagesdir}/plainbox/impl/providers/manifest/manage.py
 commands =
     sphinx-build docs html
     {envbindir}/python3 setup.py develop --quiet


### PR DESCRIPTION
## Description

checkbox-ng tox tests are the only one currently failing w/ tox 4 rc1.
This patch works with both tox 3.27.1 or tox 4.0.0rc1.
