### PR TITLE
Adding an additional CPUID for Ice Lake in the CPUID script

### DIFF
--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -118,7 +118,7 @@ CPUIDS = {
         "Comet Lake":       ['0x806ec', '0xa065'],
         "Cooper Lake":      ['0x5065a', '0x5065b'],
         "Haswell":          ['0x306c', '0x4065', '0x4066', '0x306f'],
-        "Ice Lake":         ['0x606e6', '0x606a6', '0x706e6'],
+        "Ice Lake":         ['0x606e6', '0x606a6', '0x706e6', '0x606c1'],
         "Ivy Bridge":       ['0x306a', '0x306e'],
         "Kaby Lake":        ['0x806e9', '0x906e9'],
         "Knights Landing":  ['0x5067'],


### PR DESCRIPTION
## Description
Recently when reviewing a certification for the Dell XR4520C and the XR4510C a new CPUID for Ice Lake was Identified. 
CPUID: 0x606c1
 
XR4510C
https://certification.canonical.com/hardware/202209-30651/submission/290331/test/82097/result/29979890/

XR4520C
https://certification.canonical.com/hardware/202209-30647/submission/290366/test/82097/result/29983220/

Describe your changes here:
I added 0x606c1 as an additional option for Ice Lake

## Resolved issues
Resolved https://warthogs.atlassian.net/browse/SERVCERT-635


## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [ ] A list of what tests were run and on what platform/configuration is provided.
