### PR TITLE
Fix: MIPI camera can use gstreamer when fswebcam can't take photo

### DIFF
--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -308,6 +308,8 @@ class CameraTest:
 
         try:
             check_call(command, stdout=open(os.devnull, 'w'), stderr=STDOUT)
+            if os.path.getsize(filename) == 0:
+                use_camerabin = True
         except (CalledProcessError, OSError):
             use_camerabin = True
         if use_camerabin:


### PR DESCRIPTION
## Description
Describe your changes here:

- Fix MIPI camera can't use the `camerabin`(`gstreamer`), cos it will not error in `fswebcam` (return code is 0)
- Judge the `filename` size, if it is zero will use the `camerabin` to capture the photo
## Resolved issues
Fixes: [issues/260](https://github.com/canonical/checkbox/issues/260)

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
       Method 1: camera_test.py still /dev/video{number}
       Method 2: checkbox-cli to run "camera/still"

- [ ] A list of what tests were run and on what platform/configuration is provided.
      platform: Tributo RPL (TRBR-DVT1-C2)  [C3 test report](https://certification.canonical.com/hardware/202211-30877/submission/292140/),  Oasis 13 (OAS3-DVT1-C5) [C3 test report](https://certification.canonical.com/hardware/202210-30708/submission/292141/)
```
../src/intel/isl/isl.c:2220: FINISHME: ../src/intel/isl/isl.c:isl_surf_supports_ccs: CCS for 3D textures is disabled, but a workaround is available.
/tmp/nest-3sfmnklq.9eab1a240788a625825ffa3d6d363cf91c78e33c579726dc4d2cb249f23932f4/camera_test.py:326: DeprecationWarning: Clutter.Texture.new_from_file is deprecated
  still_texture = Clutter.Texture.new_from_file(filename)
/tmp/nest-3sfmnklq.9eab1a240788a625825ffa3d6d363cf91c78e33c579726dc4d2cb249f23932f4/camera_test.py:327: DeprecationWarning: Clutter.Container.add_actor is deprecated
  stage.add_actor(still_texture)
```



                     
