### PR TITLE
Edid resources

### DIFF
--- a/providers/base/units/zapper/jobs.pxu
+++ b/providers/base/units/zapper/jobs.pxu
@@ -2,7 +2,7 @@ unit: template
 template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'
 id: monitor/{index}_zapper_hdmi_{product_slug}
-requires: display.hdmi == 'supported'
+requires: display.hdmi == 'supported' and zapper_capabilities.capability == 'HDMI' and zapper_capabilities.hotplug == 'True'
 plugin: shell
 estimated_duration: 20
 _summary: Check if the system recognizes hotplug events on HDMI

--- a/providers/base/units/zapper/jobs.pxu
+++ b/providers/base/units/zapper/jobs.pxu
@@ -2,7 +2,7 @@ unit: template
 template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'
 id: monitor/{index}_zapper_hdmi_{product_slug}
-requires: display.hdmi == 'supported' and zapper_capabilities.capability == 'HDMI' and zapper_capabilities.hotplug == 'True'
+requires: display.hdmi == 'supported' and zapper_capabilities.capability == 'hdmi-capture'
 plugin: shell
 estimated_duration: 20
 _summary: Check if the system recognizes hotplug events on HDMI
@@ -10,7 +10,7 @@ category_id: com.canonical.plainbox::monitor
 command: monitor_hotplug.py hdmi {index} "$ZAPPER_HOST"
 
 id: monitor/zapper-edid
-requires: zapper_capabilities.capability == 'HDMI' and zapper_capabilities.edid_cycling == 'True'
+requires: zapper_capabilities.capability == 'hdmi-capture' and zapper_capabilities.edid_cycling == 'True'
 category_id: com.canonical.plainbox::monitor
 plugin: shell
 estimated_duration: 60

--- a/providers/base/units/zapper/jobs.pxu
+++ b/providers/base/units/zapper/jobs.pxu
@@ -10,6 +10,7 @@ category_id: com.canonical.plainbox::monitor
 command: monitor_hotplug.py hdmi {index} "$ZAPPER_HOST"
 
 id: monitor/zapper-edid
+requires: zapper_capabilities.capability == 'HDMI' and zapper_capabilities.edid_cycling == 'True'
 category_id: com.canonical.plainbox::monitor
 plugin: shell
 estimated_duration: 60


### PR DESCRIPTION
## Description
Start HDMI-related jobs only when the monitor is capable of.

## Resolved issues

Part of: [ZAP-229](https://warthogs.atlassian.net/browse/ZAP-229)

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [x] A list of what tests were run and on what platform/configuration is provided.

Sideloaded in DUT 10.102.158.105
When monitor is not available:
```
==================================[ Results ]===================================
 ☒ : Get setup capabilities
 ☐ : Check if the system automatically changes the resolution based on EDID
 ☑ : Collect information about installed software packages
 ☑ : Creates display resource info from xrandr output
 ☐ : Check if the system recognizes hotplug events on HDMI
```

When B101 is available:
```
==================================[ Results ]===================================
 ☑ : Get setup capabilities
 ☒ : Check if the system automatically changes the resolution based on EDID
 ☑ : Collect information about installed software packages
 ☑ : Creates display resource info from xrandr output
 ☑ : Check if the system recognizes hotplug events on HDMI
 ☑ : Collect information about supported types of USB
 ☑ : USB 3.0 insertion test on port 1
 ☑ : USB 3.0 removal test on port 1

```

[ZAP-229]: https://warthogs.atlassian.net/browse/ZAP-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ