### PR TITLE
Fix: Make dock/thunderbolt3-daisy-chain execute as root

### DIFF
--- a/providers/base/units/dock/jobs.pxu
+++ b/providers/base/units/dock/jobs.pxu
@@ -2011,6 +2011,7 @@ _verification:
 plugin: user-interact-verify
 category_id: dock
 id: dock/thunderbolt3-daisy-chain
+user: root
 flags: also-after-suspend
 estimated_duration: 45.0
 imports: from com.canonical.plainbox import manifest


### PR DESCRIPTION
## Description

Describe your changes here:

- Make dock/thunderbolt3-daisy-chain execute as root

## Resolved issues

None

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [ ] A list of what tests were run and on what platform/configuration is provided.
