### PR TITLE
info/secure-boot-check: Don't fail if the system does not support Sec…

### DIFF
--- a/providers/base/units/info/jobs.pxu
+++ b/providers/base/units/info/jobs.pxu
@@ -510,7 +510,7 @@ estimated_duration: 0.2
 requires:
  package.name == 'mokutil'
 command:
- mokutil --sb-state
+ mokutil --sb-state || true
 _summary: Check secure boot state
 _description:
  Output secure boot is enabled or disabled


### PR DESCRIPTION
…ure Boot

If a system does not support secure-boot, `mokutil --sb-state` will report that and exit non-zero:

```
ubuntu@d05-4:~$ sudo mokutil --sb-state
This system doesn't support Secure Boot
ubuntu@d05-4:~$ echo $?
255
```

It seems to me that this is no reason to fail the test - the info was collected. Let's just ignore the error code from mokutil.

## Description

Describe your changes here:

- False positive test failure
- Ignore the error code when an error message itself is a satisfactory fulfillment of the info

## Resolved issues

N/A

## Documentation

- [x] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
I don't know that there's a reasonable way to add a test for this test.
- [x] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [x] Steps to follow for reviewer to run & manually test are provided.
- [x] A list of what tests were run and on what platform/configuration is provided.

Ran it on a system that is known not to support Secure Boot.