### PR TITLE
metabox: Change container creation timeout

### DIFF
--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -43,7 +43,7 @@ from metabox.core.lxd_execute import run_or_raise
 class LxdMachineProvider():
     """Machine provider that uses container managed by LXD as targets."""
 
-    LXD_CREATE_TIMEOUT = 120
+    LXD_CREATE_TIMEOUT = 300
     LXD_POLL_INTERVAL = 5
     LXD_INTERNAL_CONFIG_PATH = '/var/tmp/machine_config.json'
 


### PR DESCRIPTION
## Description

Change metabox container creation timeout from 2 minutes to 5 minutes. This helps initial creation scenario where a lot of data (images) has to be pulled from the network.

Thanks to this change, I can finally run

```
metabox configs/testing-ppa-config.py --log=TRACE --do-not-dispose
```

and see the command complete successfully!

(the code is still flimsy, and I will look into that later)