### PR TITLE
Metabox fix container creation (and other various fixes)

### DIFF
--- a/metabox/configs/checkbox-core-snap-classic-beta-config.py
+++ b/metabox/configs/checkbox-core-snap-classic-beta-config.py
@@ -1,18 +1,18 @@
 configuration = {
     'local': {
-        'origin': 'classic_snap',
+        'origin': 'classic-snap',
         'checkbox_core_snap': {'risk': 'beta'},
         'checkbox_snap': {'risk': 'stable'},
         'releases': ['bionic', 'focal'],
     },
     'remote': {
-        'origin': 'classic_snap',
+        'origin': 'classic-snap',
         'checkbox_core_snap': {'risk': 'beta'},
         'checkbox_snap': {'risk': 'stable'},
         'releases': ['focal'],
     },
     'service': {
-        'origin': 'classic_snap',
+        'origin': 'classic-snap',
         'checkbox_core_snap': {'risk': 'beta'},
         'checkbox_snap': {'risk': 'stable'},
         'releases': ['bionic', 'focal'],

--- a/metabox/metabox/core/configuration.py
+++ b/metabox/metabox/core/configuration.py
@@ -117,7 +117,7 @@ def _decl_has_a_valid_origin(decl):
         return False
     if decl['origin'] == 'snap':
         return True
-    elif decl['origin'] == 'classic_snap':
+    elif decl['origin'] == 'classic-snap':
         return True
     elif decl['origin'] == 'ppa':
         return True

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -42,8 +42,8 @@ class MachineConfig:
         if not self.snap_name:
             if self.origin == 'snap':
                 self.snap_name = 'checkbox-snappy'
-            elif self.origin == 'classic_snap':
                 self.snap_name = 'checkbox-snappy-classic'
+            elif self.origin == 'classic-snap':
 
     def __members(self):
         return (self.role, self.alias, self.origin, self.snap_name, self.uri,
@@ -385,7 +385,7 @@ class ContainerSnapMachine(ContainerBaseMachine):
                     f'sudo snap install {core_snap} --channel={channel}')
         # Then install the checkbox snap
         confinement = 'devmode'
-        if self.config.origin == 'classic_snap':
+        if self.config.origin == 'classic-snap':
             confinement = 'classic'
         if self.config.checkbox_snap.get('uri'):
             cmds.append(
@@ -427,7 +427,7 @@ class ContainerSnapMachine(ContainerBaseMachine):
 
 
 def machine_selector(config, container):
-    if config.origin in ('snap', 'classic_snap'):
+    if config.origin in ('snap', 'classic-snap'):
         return (ContainerSnapMachine(config, container))
     elif config.origin == 'ppa':
         return (ContainerPPAMachine(config, container))

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -56,7 +56,7 @@ class MachineConfig:
             self.role, self.alias, self.origin)
 
     def __str__(self):
-        return "{}-{}".format(self.role, self.alias)
+        return "{}-{}-{}".format(self.role, self.alias, self.origin)
 
     def __hash__(self):
         return hash(self.__members())

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -40,10 +40,7 @@ class MachineConfig:
         self.checkbox_snap = config.get("checkbox_snap", {})
         self.snap_name = config.get("name", "")
         if not self.snap_name:
-            if self.origin == 'snap':
-                self.snap_name = 'checkbox-snappy'
-                self.snap_name = 'checkbox-snappy-classic'
-            elif self.origin == 'classic-snap':
+            self.snap_name = 'checkbox'
 
     def __members(self):
         return (self.role, self.alias, self.origin, self.snap_name, self.uri,

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -343,11 +343,13 @@ class ContainerSnapMachine(ContainerBaseMachine):
         'xenial': 'checkbox',
         'bionic': 'checkbox18',
         'focal':  'checkbox20',
+        'jammy': 'checkbox22',
     }
     CHECKBOX_SNAP_TRACK_MAP = {
-        'xenial': '16',
-        'bionic': '18',
-        'focal':  '20',
+        'xenial': '16.04',
+        'bionic': '18.04',
+        'focal':  '20.04',
+        'jammy': '22.04',
     }
 
     def __init__(self, config, container):

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -149,6 +149,7 @@ class Runner:
                 logger.warning('No match found!')
                 raise SystemExit(1)
         self._gather_all_machine_spec()
+        logger.debug("Combo: {}", self.combo)
         self.machine_provider = LxdMachineProvider(
             self.config, self.combo,
             self.debug_machine_setup, self.dispose)

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -102,7 +102,7 @@ class Scenario:
         """
         Check if during Checkbox execution a line did not produced that matches
         the pattern.
-        :param patter: regular expresion to check against the lines.
+        :param pattern: regular expression to check against the lines.
         """
         regex = re.compile(pattern)
         if self._pts:


### PR DESCRIPTION
## Description

Various fixes for metabox, mainly to prevent it from crashing early on when creating containers.

This PR also updates the calls to the `checkbox` snap, since both `checkbox-snappy` and `checkbox-snappy-classic` snaps have been removed in favor of the `checkbox` snap.

Finally, added reference to Jammy, added some logging info, and fixed a typo.

## Documentation

- There is currently zero documentation on Metabox, but this is something I hope to improve over the next cycle!

## Tests

1. Setup and activate venv: `python3 -m venv metabox && source metabox/bin/activate`
2. Deploy metabox in it in dev mode: `pip install -e .`
3. Run it with Testing PPA config: `metabox metabox/configs/testing-ppa-config.py --log=TRACE --do-not-dispose`
4. Run the same command again to make sure metabox reuses the same containers and there is no problem
5. Run it with Checkbox snap config: `metabox metabox/configs/checkbox-core-snap-classic-beta-config.py --log=TRACE --do-not-dispose`

All the required containers should be created. There should not be any complaint from LXC about not being able to create an instance because one with the same name already exists.

(The `urwid.testplan.UrwidTestPlanSelection` scenario will probably fail, this is expected, I will have to look into this next...)