### PR TITLE
Fix: update the client-cert-iot-server-22-04 plan

### DIFF
--- a/providers/certification-client/units/client-cert-iot-server-22-04.pxu
+++ b/providers/certification-client/units/client-cert-iot-server-22-04.pxu
@@ -17,7 +17,7 @@ _description:
 include:
 nested_part:
   # until there is reason to diverge, nest these plans
-  client-cert-iot-ubuntucore-20-manual
+  client-cert-iot-ubuntucore-22-manual
 exclude:
   ubuntucore/os-.*
   snappy/os-.*
@@ -31,7 +31,7 @@ _description:
 include:
 nested_part:
   # until there is reason to diverge, nest these plans
-  client-cert-iot-ubuntucore-20-automated
+  client-cert-iot-ubuntucore-22-automated
   ## snappy-snap-automated-lightweight ??
 
 


### PR DESCRIPTION
Bump the version of nested core plan from 20 to 22.

## Description

Describe your changes here:

- Adjust the version of nested core plan to 22

## Resolved issues

I found the `tpm2.0_4.1.1` cases are still executed while I ran the `client-cert-iot-server-22-04` test plan.
