### PR TITLE
Host proxy refactor

### DIFF
--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -19,7 +19,7 @@ import sys
 import time
 from systemd import journal
 
-from checkbox_support.scripts.zapper_proxy import ControlVersionDecider
+from checkbox_support.scripts.zapper_proxy import zapper_run
 
 
 logger = logging.getLogger(__file__)
@@ -67,14 +67,13 @@ class USBWatcher:
             if not zapper_host:
                 raise SystemExit(
                     "ZAPPER_ADDRESS environment variable not found!")
-            zapper_control = ControlVersionDecider().decide(zapper_host)
             usb_address = self.args.zapper_usb_address
             if self.args.testcase == "insertion":
                 print("Calling zapper to connect the USB device")
-                zapper_control.usb_set_state(usb_address, 'DUT')
+                zapper_run(zapper_host, "zombiemux_set_state", usb_address, "DUT")
             elif self.args.testcase == "removal":
                 print("Calling zapper to disconnect the USB device")
-                zapper_control.usb_set_state(usb_address, 'OFF')
+                zapper_run(zapper_host, "zombiemux_set_state", usb_address, "OFF")
         else:
             if self.args.testcase == "insertion":
                 print("\n\nINSERT NOW\n\n", flush=True)

--- a/checkbox-support/checkbox_support/scripts/tests/test_zapper_proxy.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_zapper_proxy.py
@@ -38,8 +38,10 @@ class ZapperProxyV1Tests(TestCase):
         import_mock.return_value = self._rpyc_mock
         self._mocked_conn.root.command.return_value = "test"
 
-        result = zapper_run("0.0.0.0", "command")
-        self._mocked_conn.root.command.assert_called_once()
+        args = ["a", "b"]
+        kwargs = {"k1": "v1", "k2": "v2"}
+        result = zapper_run("0.0.0.0", "command", *args, **kwargs)
+        self._mocked_conn.root.command.assert_called_once_with(*args, **kwargs)
         assert result == "test"
         
 

--- a/checkbox-support/checkbox_support/scripts/tests/test_zapper_proxy.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_zapper_proxy.py
@@ -19,113 +19,113 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
-from checkbox_support.scripts.zapper_proxy import ZapperControlV1
+from checkbox_support.scripts.zapper_proxy import get_capabilities, zapper_run
 
 
 class ZapperProxyV1Tests(TestCase):
-    """Unit tests for ZapperProxyV1 class."""
+    """Unit tests for ZapperProxy module."""
 
     def setUp(self):
+        self._rpyc_mock = Mock()
         self._mocked_conn = Mock()
-        self._mocked_conn.root = Mock()
+        self._rpyc_mock.connect.return_value = self._mocked_conn
 
-    def test_usb_get_state_smoke(self):
+    @patch("checkbox_support.scripts.zapper_proxy.import_module")
+    def test_zapper_run_smoke(self, import_mock):
         """
-        Check if usb_get_state calls appropriate function on the rpyc client.
+        Check if zapper_run calls the appropriate function on Zapper Service.
         """
-        self._mocked_conn.root.zombiemux_get_state = Mock(
-            return_value="ON")
-        zapctl = ZapperControlV1(self._mocked_conn)
+        import_mock.return_value = self._rpyc_mock
+        self._mocked_conn.root.command.return_value = "test"
+        assert zapper_run("0.0.0.0", "command") == "test"
 
-        with patch('builtins.print') as mocked_print:
-            zapctl.usb_get_state(0)
-            mocked_print.assert_called_once_with(
-                'State for address 0 is ON')
+    @patch("checkbox_support.scripts.zapper_proxy.import_module")
+    def test_zapper_run_wrong_cmd(self, import_mock):
+        """
+        Check if SystemExit is raised when an unavailable command is requested.
+        """
+        import_mock.return_value = self._rpyc_mock
+        self._mocked_conn.root.command.side_effect = AttributeError()
+        with self.assertRaises(SystemExit):
+            zapper_run("0.0.0.0", "command")
 
-    def test_usb_get_state_fails(self):
+    @patch("checkbox_support.scripts.zapper_proxy.import_module")
+    def test_zapper_run_service_error(self, import_mock):
         """
-        Check if usb_get_state quits with the exception from
-        the rpyc server on failure.
+        Check if SystemExit is raised when an error occurs on Zapper Service.
         """
-        self._mocked_conn.root.zombiemux_get_state = Mock(
-            side_effect=Exception("Failure message"))
-        zapctl = ZapperControlV1(self._mocked_conn)
-        with self.assertRaises(Exception) as context:
-            zapctl.usb_get_state(0)
-        self.assertEqual(
-            str(context.exception), 'Failure message')
 
-    def test_usb_set_state_smoke(self):
-        """
-        Check if usb_set_state calls appropriate functions on the rpyc client.
-        """
-        self._mocked_conn.root.zombiemux_set_state = Mock()
-        zapctl = ZapperControlV1(self._mocked_conn)
-        with patch('builtins.print') as mocked_print:
-            zapctl.usb_set_state(0, 'ON')
-            mocked_print.assert_called_once_with(
-                "State 'ON' set for the address 0.")
+        class TestException(Exception):
+            pass
 
-    def test_usb_set_state_fails(self):
-        """
-        Check if usb_set_state quits with the exception from
-        the rpcy server on failure.
-        """
-        self._mocked_conn.root.zombiemux_set_state = Mock(
-            side_effect=Exception("Failure message"))
-        zapctl = ZapperControlV1(self._mocked_conn)
-        with self.assertRaises(Exception) as context:
-            zapctl.usb_set_state(0, 'ON')
-        self.assertEqual(
-            str(context.exception), 'Failure message')
+        self._rpyc_mock.core.vinegar.GenericException = TestException
 
-    def test_get_capabilities_one_cap(self):
+        import_mock.return_value = self._rpyc_mock
+
+        self._mocked_conn.root.command.side_effect = TestException()
+        with self.assertRaises(SystemExit):
+            zapper_run("0.0.0.0", "command")
+
+    # TODO test retry exception
+
+    @patch("checkbox_support.scripts.zapper_proxy.import_module")
+    def test_get_capabilities_one_cap(self, import_mock):
         """
         Check if get_capabilities properly prints one record.
 
         The record should be in Checkbox resource syntax and should not be
         surrounded by any newlines.
         """
+        import_mock.return_value = self._rpyc_mock
+
         ret_val = [{'foo': 'bar'}]
         self._mocked_conn.root.get_capabilities = Mock(return_value=ret_val)
-        zapctl = ZapperControlV1(self._mocked_conn)
+
         with patch('builtins.print') as mocked_print:
-            zapctl.get_capabilities()
+            get_capabilities("0.0.0.0")
             mocked_print.assert_called_once_with('foo: bar')
 
-    def test_get_capabilities_empty(self):
+    @patch("checkbox_support.scripts.zapper_proxy.import_module")
+    def test_get_capabilities_empty(self, import_mock):
         """Check if get_capabilities prints nothing on no capabilities."""
+        import_mock.return_value = self._rpyc_mock
+
         ret_val = []
         self._mocked_conn.root.get_capabilities = Mock(return_value=ret_val)
-        zapctl = ZapperControlV1(self._mocked_conn)
         with patch('builtins.print') as mocked_print:
-            zapctl.get_capabilities()
+            get_capabilities("0.0.0.0")
             mocked_print.assert_called_once_with('')
 
-    def test_get_capabilities_multiple_caps(self):
+    @patch("checkbox_support.scripts.zapper_proxy.import_module")
+    def test_get_capabilities_multiple_caps(self, import_mock):
         """
         Check if get_capabilities properly prints multiple records.
 
         The records should be in Checkbox resource syntax. Records should be
         separated by an empty line.
         """
+        import_mock.return_value = self._rpyc_mock
+
         ret_val = [{'foo': 'bar'}, {'baz': 'biz'}]
         self._mocked_conn.root.get_capabilities = Mock(return_value=ret_val)
-        zapctl = ZapperControlV1(self._mocked_conn)
+
         with patch('builtins.print') as mocked_print:
-            zapctl.get_capabilities()
+            get_capabilities("0.0.0.0")
             mocked_print.assert_called_once_with('foo: bar\n\nbaz: biz')
 
-    def test_get_capabilities_one_cap_multi_rows(self):
+    @patch("checkbox_support.scripts.zapper_proxy.import_module")
+    def test_get_capabilities_one_cap_multi_rows(self, import_mock):
         """
         Check if get_capabilities properly prints a record with multiple caps.
 
         Each capability should be printed in a separate line.
         No additional newlines should be printed.
         """
+        import_mock.return_value = self._rpyc_mock
+
         ret_val = [{'foo': 'bar', 'foo2': 'bar2'}]
         self._mocked_conn.root.get_capabilities = Mock(return_value=ret_val)
-        zapctl = ZapperControlV1(self._mocked_conn)
+
         with patch('builtins.print') as mocked_print:
-            zapctl.get_capabilities()
+            get_capabilities("0.0.0.0")
             mocked_print.assert_called_once_with('foo: bar\nfoo2: bar2')

--- a/checkbox-support/checkbox_support/scripts/tests/test_zapper_proxy.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_zapper_proxy.py
@@ -33,7 +33,7 @@ class ZapperProxyV1Tests(TestCase):
     @patch("checkbox_support.scripts.zapper_proxy.import_module")
     def test_zapper_run_smoke(self, import_mock):
         """
-        Check if zapper_run calls the appropriate function on Zapper Service.
+        Check if zapper_run calls the appropriate function on the rpyc client.
         """
         import_mock.return_value = self._rpyc_mock
         self._mocked_conn.root.command.return_value = "test"
@@ -56,7 +56,7 @@ class ZapperProxyV1Tests(TestCase):
     @patch("checkbox_support.scripts.zapper_proxy.import_module")
     def test_zapper_run_service_error(self, import_mock):
         """
-        Check if SystemExit is raised when an error occurs on Zapper Service.
+        Check if SystemExit is raised when an error occurs on Zapper service.
         """
         import_mock.return_value = self._rpyc_mock
 

--- a/checkbox-support/checkbox_support/scripts/zapper_proxy.py
+++ b/checkbox-support/checkbox_support/scripts/zapper_proxy.py
@@ -17,173 +17,83 @@
 """
 This program acts as a proxy to Zapper Hardware.
 
-It uses internal Zapper Control RPyC API. Should this API change, additional
-ZapperControl classes should be added here.
+It uses internal Zapper Control RPyC API.
 """
+import argparse
 import os
+import time
 
-from abc import abstractmethod
 from importlib import import_module
 
-from checkbox_support.vendor.auto_argparse import AutoArgParser
 
-
-# Zapper Control is expected to change its RPC API.  Following adapter classes
-# serve the purpose of maintaining funcionality throughout the RPC API version
-# changes.
-
-class IZapperControl:
-    """Interface to the Zapper Control."""
-    @abstractmethod
-    def usb_get_state(self, address):
-        """
-        Get state of USBMUX addon.
-        Note that the address string is used as-is without any checks done on
-        this side. Any validation and use of that param will be done on the
-        remote end.
-
-        :param str address: address of USBMUX to get state from.
-        :return str: state of the USBMUX addon.
-        """
-
-    @abstractmethod
-    def usb_set_state(self, address, state):
-        """
-        Set state of USBMUX addon.
-        Note that both arguments are used as-is without any checks done on
-        this side. Any validation and use of those params will be done on the
-        remote end.
-
-        :param str address: address of USBMUX the state should be set on.
-        :param str state: state to set on the USBMUX addon
-        """
-
-    @abstractmethod
-    def change_edid(self, edid_file=None):
-        """
-        Set EDID on HDMI output. If input is None, clear EDID.
-        Note that the argument is used as-is without any checks done on
-        this side. Any validation and use of it will be done on the
-        remote end.
-
-        :param bytes edid_file: EDID binary file
-        """
-
-    @abstractmethod
-    def get_capabilities(self):
-        """Get Zapper's setup capabilities in checkbox resource form."""
-
-
-class ZapperControlV1(IZapperControl):
+def zapper_run(host, cmd, *args, **kwargs):
     """
-    Control Zapper via RPyC using v1 of the API.
+    Run command on Zapper.
 
-    :return str: list of capabilities in Checkbox resource form.
+    :param host: Zapper IP address
+    :param cmd: command to be executed
+    :param args: command arguments
+    :returns: whatever is returned by Zapper service
+    :raises SystemExit: if command is unknown or service errors occur
     """
-    def __init__(self, connection):
-        self._conn = connection
-
-    def usb_get_state(self, address):
-        state = self._conn.root.zombiemux_get_state(address)
-        print("State for address {} is {}".format(address, state))
-
-    def usb_set_state(self, address, state):
-        self._conn.root.zombiemux_set_state(address, state)
-        print("State '{}' set for the address {}.".format(state, address))
-
-    def change_edid(self, edid_file=None):
-        self._conn.root.change_edid(edid_file)
-
-    def get_capabilities(self):
-        capabilities = self._conn.root.get_capabilities()
-
-        def stringify_cap(cap):
-            return '\n'.join(
-                '{}: {}'.format(key, val) for key, val in sorted(cap.items()))
-        print('\n\n'.join(stringify_cap(cap) for cap in capabilities))
-
-
-class ControlVersionDecider:
-    """
-    This class helps establish which API version of Zapper Control to use.
-
-    Normally it would be just in the main function, but some of the clients of
-    this functionality may be internal code from checkbox-support, this class
-    makes it possible to use the code without spawning new python process
-    (processing args etc.)
-
-    It is a class and not a function, because we should inform the user about
-    missing RPyC module as soon as possible, in this case in the __init__.  The
-    RPyC is kept in the instance state, so later on it may be used to run the
-    actual functionality.
-    """
-    def __init__(self):
-        # to not make checkbox-support dependant on RPyC let's use one
-        # available in the system, and if it's not available let's try loading
-        # one provided by Checkbox. Real world usecase would be to run this
-        # program from within Checkbox, so chances for not finding it are
-        # pretty slim.
+    try:
+        _rpyc = import_module('rpyc')
+    except ImportError:
         try:
-            self._rpyc = import_module('rpyc')
-        except ImportError:
-            try:
-                self._rpyc = import_module('plainbox.vendor.rpyc')
-            except ImportError as exc:
-                msg = "RPyC not found. Neither from sys nor from Checkbox"
-                raise SystemExit(msg) from exc
+            _rpyc = import_module('plainbox.vendor.rpyc')
+        except ImportError as exc:
+            msg = "RPyC not found. Neither from sys nor from Checkbox"
+            raise SystemExit(msg) from exc
 
-    def decide(self, host):
-        """
-        Determine which version of Zapper Control API to use.
-
-        :param str host: Address of the Zapper host to connect to.
-        :returns IZapperControl: An appropriate ZapperControl instance.
-        """
-        conn = self._rpyc.connect(
-            host, 60000, config={"allow_all_attrs": True})
+    for _ in range(2):
         try:
-            version = conn.root.get_api_version()
-        except AttributeError:
-            # there was no "get_api_version" method on Zapper
-            # so this means the oldest version possible - 1
-            version = 1
-        # the following mapping could be replaced by something that generates
-        # a class name and tries looking it up in this module, but using dict
-        # feels simpler due to explicitness and can include classes defined in
-        # some other modules
-        control_cls = {
-            1: ZapperControlV1,
-        }.get(version, None)
-        if control_cls is None:
-            raise SystemExit((
-                "Zapper host returned unknown Zapper Control Version: {ver}\n"
-                "Implement ZapperControlV{ver} in checkbox_support!"
-            ).format(ver=version))
-        return control_cls(conn)
+            conn = _rpyc.connect(
+                host, 60000, config={"allow_all_attrs": True})
+            break
+        except ConnectionRefusedError:
+            time.sleep(1)
+    else:
+        raise SystemExit("Cannot connect to Zapper Host.")
+
+    try:
+        return getattr(conn.root, cmd)(*args, **kwargs)
+    except AttributeError:
+        raise SystemExit("Zapper host does not provide a '{}' command.".format(cmd))
+    except _rpyc.core.vinegar.GenericException as exc:
+        raise SystemExit("Zapper host failed to process the requested command.") from exc
+
+def get_capabilities(host):
+    """Get Zapper capabilities."""
+    capabilities = zapper_run(host, "get_capabilities")
+    def stringify_cap(cap):
+        return '\n'.join(
+            '{}: {}'.format(key, val) for key, val in sorted(cap.items()))
+    print('\n\n'.join(stringify_cap(cap) for cap in capabilities))
 
 
 def main():
     """Entry point."""
-    decider = ControlVersionDecider()
 
-    # generate argparse from the interface of Zapper Control
-    parser = AutoArgParser(cls=IZapperControl)
+    parser = argparse.ArgumentParser()
     parser.add_argument(
         '--host', default=os.environ.get('ZAPPER_HOST'),
         help=("Address of Zapper to connect to. If not supplied, "
               "ZAPPER_HOST environment variable will be used.")
     )
-    # turn Namespace into a normal dict
+    parser.add_argument('cmd')
+    parser.add_argument('args', nargs="*")
     args = parser.parse_args()
-    # popping elements from the dict, so at the end the end the right method
-    # is called with only the item that are expected
-    host = args.host
-    if host is None:
+
+    if args.host is None:
         raise SystemExit(
             "You have to provide Zapper host, either via '--host' or via "
             "ZAPPER_HOST environment variable")
-    zapper_control = decider.decide(host)
-    parser.run(zapper_control)
+
+    if args.cmd == "get_capabilities":
+        get_capabilities(args.host)
+    else:
+        result = zapper_run(args.host, args.cmd, *args.args)
+        print(result)
 
 
 if __name__ == '__main__':

--- a/checkbox-support/checkbox_support/scripts/zapper_proxy.py
+++ b/checkbox-support/checkbox_support/scripts/zapper_proxy.py
@@ -33,6 +33,7 @@ def zapper_run(host, cmd, *args, **kwargs):
     :param host: Zapper IP address
     :param cmd: command to be executed
     :param args: command arguments
+    :param kwargs: command keyword arguments
     :returns: whatever is returned by Zapper service
     :raises SystemExit: if the connection cannot be established
                         or the command is unknown

--- a/checkbox-support/checkbox_support/scripts/zapper_proxy.py
+++ b/checkbox-support/checkbox_support/scripts/zapper_proxy.py
@@ -34,7 +34,9 @@ def zapper_run(host, cmd, *args, **kwargs):
     :param cmd: command to be executed
     :param args: command arguments
     :returns: whatever is returned by Zapper service
-    :raises SystemExit: if command is unknown or service errors occur
+    :raises SystemExit: if the connection cannot be established
+                        or the command is unknown
+                        or a service error occurs
     """
     try:
         _rpyc = import_module('rpyc')

--- a/providers/base/bin/edid_cycle.py
+++ b/providers/base/bin/edid_cycle.py
@@ -15,7 +15,7 @@ import sys
 import time
 
 from checkbox_support.scripts.zapper_proxy import (             # noqa: E402
-    ControlVersionDecider)
+    zapper_run)
 
 
 def check_resolution():
@@ -28,10 +28,8 @@ def check_resolution():
 
 
 def change_edid(host, edid_file):
-    zapper_control = ControlVersionDecider().decide(host)
-
     with open(edid_file, 'rb') as f:
-        zapper_control.change_edid(f.read())
+        zapper_run(host, "change_edid", f.read())
 
 
 def main():

--- a/providers/base/bin/removable_storage_watcher.py
+++ b/providers/base/bin/removable_storage_watcher.py
@@ -25,7 +25,7 @@ from checkbox_support.parsers.udevadm import CARD_READER_RE     # noqa: E402
 from checkbox_support.parsers.udevadm import GENERIC_RE         # noqa: E402
 from checkbox_support.parsers.udevadm import FLASH_RE           # noqa: E402
 from checkbox_support.scripts.zapper_proxy import (             # noqa: E402
-    ControlVersionDecider)
+    zapper_run)
 from checkbox_support.udev import get_interconnect_speed        # noqa: E402
 from checkbox_support.udev import get_udev_block_devices        # noqa: E402
 
@@ -921,18 +921,17 @@ def main():
         if not zapper_host:
             raise SystemExit(
                 "ZAPPER_HOST environment variable not found!")
-        zapper_control = ControlVersionDecider().decide(zapper_host)
         usb_address = args.zapper_usb_address
         delay = 5  # in seconds
 
         def do_the_insert():
             logging.info("Calling zapper to connect the USB device")
-            zapper_control.usb_set_state(usb_address, 'DUT')
+            zapper_run(zapper_host, "zombiemux_set_state", usb_address, 'DUT')
         insert_timer = threading.Timer(delay, do_the_insert)
 
         def do_the_remove():
             logging.info("Calling zapper to disconnect the USB device")
-            zapper_control.usb_set_state(usb_address, 'OFF')
+            zapper_run(zapper_host, "zombiemux_set_state", usb_address, 'OFF')
         remove_timer = threading.Timer(delay, do_the_remove)
         if args.action == "insert":
             logging.info("Starting timer for delayed insertion")


### PR DESCRIPTION
## Description
Current Host Proxy keeps a RPyC connection open during any entire test job. In order to avoid statefulness and any re-connection logic, this PR replaces the current implementation with a couple of simpler functions: proxy_run and get_capabilities. The former more general and used in test jobs, the latter dedicated to listing resources.

Moreover, the current implementation requires an explicit function for each different service method: this means reworking the proxy each time a new function is added to the service. With this PR any service function can be called and, in case of problems, an exception is reported to the user.

## Resolved issues

Resolves [ZAP-291](https://warthogs.atlassian.net/browse/ZAP-291)

## Documentation

- [X] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [X] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [X] Steps to follow for reviewer to run & manually test are provided.
- [X] A list of what tests were run and on what platform/configuration is provided.

Tested sideloading the provider and checkbox-support to our CI device in the lab.


[ZAP-291]: https://warthogs.atlassian.net/browse/ZAP-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ