### PR TITLE
Modify - split the audio/detect_sinks_sources job

### DIFF
--- a/providers/base/bin/pactl_list.sh
+++ b/providers/base/bin/pactl_list.sh
@@ -2,9 +2,9 @@
 
 EXIT_CODE=0
 
-for device in "sources" "sinks"
+for device in "$@"
 do
-    if ! pactl list $device short | grep -v -E "monitor|auto_null"
+    if ! pactl list "$device" short | grep -v -E "monitor|auto_null"
     then
         echo "No available $device found"
         case $device in

--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -346,7 +346,7 @@ _description:
 plugin: shell
 category_id: com.canonical.plainbox::audio
 id: audio/alsa_record_playback_automated
-depends: audio/detect_sinks_sources
+depends: audio/detect_sinks audio/detect_sources
 estimated_duration: 10.0
 requires:
  package.name == 'python3-gi'
@@ -363,14 +363,29 @@ _description:
 
 plugin: shell
 category_id: com.canonical.plainbox::audio
-id: audio/detect_sinks_sources
+id: audio/detect_sinks
 estimated_duration: 1.0
+imports: from com.canonical.plainbox import manifest
 requires:
   package.name == 'pulseaudio-utils'
+  manifest.has_audio_playback == 'True'
 command:
-  pactl_list.sh
+  pactl_list.sh sinks
 _description:
-  Test to detect if there's available sources and sinks.
+  Test to detect if there's available sinks
+
+plugin: shell
+category_id: com.canonical.plainbox::audio
+id: audio/detect_sources
+estimated_duration: 1.0
+imports: from com.canonical.plainbox import manifest
+requires:
+  package.name == 'pulseaudio-utils'
+  manifest.has_audio_capture == 'True'
+command:
+  pactl_list.sh sources
+_description:
+  Test to detect if there's available sources.
 
 plugin: shell
 category_id: com.canonical.plainbox::audio


### PR DESCRIPTION
To consider some of systems do not support any one of audio inputs or outputs, we need to make sure the hardware component precisely, split audio/detect_sinks_sources job and add two of them to the system manifest, modify audio/alsa_record_playback_automated job to depend on audio/detect_sinks and audio/detect_sources.

## Description

Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.

## Resolved issues

Note the Jira/Launchpad issue(s) resolved by this PR (`Fixes|Resolves ...`).

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [x] A list of what tests were run and on what platform/configuration is provided.

Test Result:https://certification.canonical.com/hardware/202212-30965/submission/294281/