### PR TITLE
Fix: Checkbox is killed by systemd-oomd when running memory/memory_stress_ng job

### DIFF
--- a/providers/base/units/memory/jobs.pxu
+++ b/providers/base/units/memory/jobs.pxu
@@ -54,4 +54,3 @@ _description:
  stress_ng tool. This test also includes an over-commit function to force
  swapping to disk, thus SUTs should have suitably large swap files for the
  amount of RAM they have installed.
-

--- a/providers/base/units/stress/stress-ng.pxu
+++ b/providers/base/units/stress/stress-ng.pxu
@@ -38,3 +38,52 @@ command:
     0|3|4) exit 0;;
     *)     exit 1;;
  esac
+
+plugin:shell
+category_id: com.canonical.plainbox::stress
+id: stress/store_and_change_oomd_config
+estimated_duration: 3.0
+user: root
+_summary:
+  Store and change 10-oomd-user-service-defaults.conf
+command:
+  systemd_oomd_conf_path=/usr/lib/systemd/system/user@.service.d/10-oomd-user-service-defaults.conf
+  if [ -e ${systemd_oomd_conf_path} ]; then
+    echo "Storing original oomd config..."
+    cat ${systemd_oomd_conf_path} > "$PLAINBOX_SESSION_SHARE"/10-oomd-user-service-defaults.conf
+    echo "Before changing config (Original config):"
+    cat ${systemd_oomd_conf_path}
+    echo
+    echo "Changing oomd config to auto..."
+    sed -i 's/ManagedOOMMemoryPressure=kill/ManagedOOMMemoryPressure=auto/g' ${systemd_oomd_conf_path}
+    systemctl daemon-reload
+    echo "After changing config:"
+    cat ${systemd_oomd_conf_path}
+  else
+    echo "Config doesn't exist."
+    echo "Won't change anything"
+  fi
+
+plugin:shell
+category_id: com.canonical.plainbox::stress
+id: stress/restore_oomd_config
+depends: stress/store_and_change_oomd_config
+estimated_duration: 3.0
+user: root
+_summary:
+  Restore to original 10-oomd-user-service-defaults.conf
+command:
+  systemd_oomd_conf_path=/usr/lib/systemd/system/user@.service.d/10-oomd-user-service-defaults.conf
+  if [ -e ${systemd_oomd_conf_path} ]; then
+    echo "Before restoring config:"
+    cat ${systemd_oomd_conf_path}
+    echo
+    echo "Restoring original oomd config..."
+    cat "$PLAINBOX_SESSION_SHARE"/10-oomd-user-service-defaults.conf > ${systemd_oomd_conf_path}
+    systemctl daemon-reload
+    echo "After restoring config (Original config):"
+    cat ${systemd_oomd_conf_path}
+  else
+    echo "Config doesn't exist."
+    echo "Won't restore anything."
+  fi

--- a/providers/base/units/stress/test-plan.pxu
+++ b/providers/base/units/stress/test-plan.pxu
@@ -99,8 +99,10 @@ unit: test plan
 _name: Stress NG tests (automated)
 _description: Stress NG tests (automated)
 include:
+    stress/store_and_change_oomd_config
     stress/cpu_stress_ng_test                      certification-status=blocker
     memory/memory_stress_ng                        certification-status=blocker
+    stress/restore_oomd_config
 
 id: stress-full
 unit: test plan

--- a/providers/certification-client/units/client-cert-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-22-04.pxu
@@ -151,9 +151,9 @@ nested_part:
     # The following tests are purely automated and/or lenghty stress tests.
     # They have been moved to the end of the test run to improve the testing
     # process.
+    stress-ng-cert-automated
     stress-iperf3-automated
     #stress-cert-full
     stress-suspend-30-cycles-with-reboots-automated
-    stress-ng-cert-automated
     stress-30-reboot-poweroff-automated
     stress-pm-graph


### PR DESCRIPTION
To solve the issue that the stress test stops during memory stress test. Mainly, I add 1 job before the memory stress test (memory/store_and_change_oomd_config) to store the original oomd config and change it to "kill" then reload the config. I also add another job (memory/restore_oomd_config) to restore the original config back.
Fixes #51 