### PR TITLE
Modify: using also-after-suspend for each cases to keep test consistency before/after suspend for desktop-22-04-manual

### DIFF
--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -32,6 +32,7 @@ _description: Valid sof firmware signature
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/playback_auto
+flags: also-after-suspend
 estimated_duration: 5.0
 depends: audio/list_devices
 requires:
@@ -266,6 +267,7 @@ _description:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/alsa_record_playback_internal
+flags: also-after-suspend
 estimated_duration: 20.0
 depends: audio/playback_auto
 requires:
@@ -293,6 +295,7 @@ _description:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/alsa_record_playback_external
+flags: also-after-suspend
 estimated_duration: 20.0
 depends: audio/playback_headphones
 requires:
@@ -394,6 +397,7 @@ _description:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/channels
+flags: also-after-suspend
 estimated_duration:  20.0
 command: speaker-test -c 2 -l 1 -t wav
 _description:
@@ -423,6 +427,7 @@ _description:
 plugin: manual
 category_id: com.canonical.plainbox::audio
 id: audio/external-lineout
+flags: also-after-suspend
 estimated_duration: 30.0
 requires:
  dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower','Space-saving','All In One','All-In-One','AIO']
@@ -441,6 +446,7 @@ _description:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/external-linein
+flags: also-after-suspend
 estimated_duration: 120.0
 requires:
  dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower','Space-saving','All In One','All-In-One','AIO']
@@ -468,6 +474,7 @@ _description:
 plugin: user-interact
 category_id: com.canonical.plainbox::audio
 id: audio/speaker-headphone-plug-detection
+flags: also-after-suspend
 estimated_duration: 60.0
 requires:
  device.category == 'AUDIO'
@@ -489,6 +496,7 @@ _description:
 plugin: user-interact
 category_id: com.canonical.plainbox::audio
 id: audio/microphone-plug-detection
+flags: also-after-suspend
 estimated_duration: 60.0
 requires:
  device.category == 'AUDIO'
@@ -539,6 +547,7 @@ _description:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/balance_headphones
+flags: also-after-suspend
 depends: audio/playback_headphones
 estimated_duration: 30.0
 requires:

--- a/providers/base/units/audio/test-plan.pxu
+++ b/providers/base/units/audio/test-plan.pxu
@@ -32,10 +32,15 @@ unit: test plan
 _name: Audio tests (after suspend)
 _description: Audio tests (after suspend)
 include:
-    suspend/speaker-headphone-plug-detection-after-suspend certification-status=blocker
-    suspend/microphone-plug-detection-after-suspend        certification-status=blocker
-    suspend/playback_headphones-after-suspend              certification-status=blocker
-    suspend/alsa_record_playback_external-after-suspend    certification-status=blocker
+    after-suspend-audio/speaker-headphone-plug-detection            certification-status=blocker
+    after-suspend-audio/microphone-plug-detection                   certification-status=blocker
+    after-suspend-audio/playback_headphones                         certification-status=blocker
+    after-suspend-audio/alsa_record_playback_external               certification-status=blocker
+    after-suspend-audio/playback_auto                               certification-status=blocker
+    after-suspend-audio/alsa_record_playback_internal               certification-status=blocker
+    after-suspend-audio/channels
+    after-suspend-audio/external-linein
+    after-suspend-audio/external-lineout
 
 id: audio-cert-automated
 unit: test plan

--- a/providers/base/units/disk/jobs.pxu
+++ b/providers/base/units/disk/jobs.pxu
@@ -1,6 +1,7 @@
 plugin: shell
 category_id: com.canonical.plainbox::disk
 id: disk/detect
+flags: also-after-suspend
 requires:
   executable.name == 'lsblk'
 _summary: Gathers information about each disk detected
@@ -132,6 +133,7 @@ command: disk_cpu_load.sh {name}
 plugin: user-interact
 category_id: com.canonical.plainbox::disk
 id: disk/hdd-parking
+flags: also-after-suspend
 estimated_duration: 60.0
 requires:
     device.category == 'DISK'

--- a/providers/base/units/ethernet/jobs.pxu
+++ b/providers/base/units/ethernet/jobs.pxu
@@ -303,7 +303,7 @@ command:
 category_id: com.canonical.plainbox::ethernet
 estimated_duration: 60.0
 user: root
-flags: preserve-locale
+flags: preserve-locale also-after-suspend
 
 unit: template
 template-resource: device

--- a/providers/base/units/ethernet/test-plan.pxu
+++ b/providers/base/units/ethernet/test-plan.pxu
@@ -12,6 +12,7 @@ unit: test plan
 _name: Ethernet tests (manual)
 _description: Ethernet tests (manual)
 include:
+    ethernet/detect                                certification-status=blocker
     ethernet/hotplug-.*                            certification-status=blocker
 bootstrap_include:
     device
@@ -81,7 +82,7 @@ _name: Manual ethernet tests (after suspend)
 _description: Manual ethernet tests for Ubuntu Core devices
 estimated_duration: 1m
 include:
-    ethernet/detect                                certification-status=blocker
+    after-suspend-ethernet/detect                  certification-status=blocker
     after-suspend-ethernet/hotplug-.*              certification-status=blocker
 bootstrap_include:
     device

--- a/providers/base/units/ethernet/test-plan.pxu
+++ b/providers/base/units/ethernet/test-plan.pxu
@@ -81,6 +81,10 @@ _name: Manual ethernet tests (after suspend)
 _description: Manual ethernet tests for Ubuntu Core devices
 estimated_duration: 1m
 include:
+    ethernet/detect                                certification-status=blocker
+    after-suspend-ethernet/hotplug-.*              certification-status=blocker
+bootstrap_include:
+    device
 
 id: after-suspend-ethernet-automated
 unit: test plan

--- a/providers/base/units/fingerprint/jobs.pxu
+++ b/providers/base/units/fingerprint/jobs.pxu
@@ -1,6 +1,7 @@
 plugin: shell
 category_id: com.canonical.plainbox::fingerprint
 id: fingerprint/detect
+flags: also-after-suspend
 user: root
 command: fprintd-list "${SUDO_UID:-$NORMAL_USER}"
 estimated_duration: 1.0
@@ -11,6 +12,7 @@ requires: manifest.has_fingerprint_reader == 'True'
 plugin: user-interact
 category_id: com.canonical.plainbox::fingerprint
 id: fingerprint/enroll
+flags: also-after-suspend
 depends: fingerprint/detect
 user: root
 command:
@@ -36,6 +38,7 @@ requires:
 plugin: user-interact
 category_id: com.canonical.plainbox::fingerprint
 id: fingerprint/verify-no-match
+flags: also-after-suspend
 depends: fingerprint/enroll
 user: root
 command:
@@ -58,6 +61,7 @@ requires:
 plugin: user-interact
 category_id: com.canonical.plainbox::fingerprint
 id: fingerprint/verify-match
+flags: also-after-suspend
 depends: fingerprint/verify-no-match
 user: root
 command:
@@ -86,6 +90,7 @@ requires:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::fingerprint
 id: fingerprint/unlock
+flags: also-after-suspend
 depends: fingerprint/verify-match
 user: root
 command:
@@ -109,6 +114,7 @@ requires:
 plugin: shell
 category_id: com.canonical.plainbox::fingerprint
 id: fingerprint/delete
+flags: also-after-suspend
 after: fingerprint/unlock
 user: root
 command: fprintd-delete "${SUDO_UID:-$NORMAL_USER}"

--- a/providers/base/units/fingerprint/test-plan.pxu
+++ b/providers/base/units/fingerprint/test-plan.pxu
@@ -20,6 +20,18 @@ include:
     fingerprint/unlock               certification-status=non-blocker
     fingerprint/delete               certification-status=non-blocker
 
+id: after-suspend-fingerprint-manual
+unit: test plan
+_name: Fingerprint reader tests after suspend
+_description: Manual tests for fingerprint reader after suspend
+include:
+    after-suspend-fingerprint/detect               certification-status=non-blocker
+    after-suspend-fingerprint/enroll               certification-status=non-blocker
+    after-suspend-fingerprint/verify-no-match      certification-status=non-blocker
+    after-suspend-fingerprint/verify-match         certification-status=non-blocker
+    after-suspend-fingerprint/unlock               certification-status=non-blocker
+    after-suspend-fingerprint/delete               certification-status=non-blocker
+
 id: fingerprint-automated
 unit: test plan
 _name: Fingerprint reader tests (Automated)

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -127,6 +127,7 @@ unit: template
 template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'
 id: graphics/{index}_maximum_resolution_{product_slug}
+flags: also-after-suspend
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 requires:
@@ -176,6 +177,7 @@ _summary: Test graphic memory info for {vendor} {product}.
 unit: template
 template-resource: graphics_card
 id: graphics/{index}_video_{product_slug}
+flags: also-after-suspend
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 requires:
@@ -208,6 +210,7 @@ template-filter: graphics_card.prime_gpu_offload == 'Off'
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_cycle_resolution_{product_slug}
+flags: also-after-suspend
 requires: package.name == 'xorg'
 depends: graphics/VESA_drivers_not_in_use
 command:
@@ -235,6 +238,7 @@ template-filter: graphics_card.prime_gpu_offload == 'Off'
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_rotation_{product_slug}
+flags: also-after-suspend
 command:
  # shellcheck disable=SC1091
  source graphics_env.sh {driver} {index}
@@ -284,6 +288,7 @@ template-resource: graphics_card
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_glxgears_{product_slug}
+flags: also-after-suspend
 requires: executable.name == 'glxgears'
 command:
  # shellcheck disable=SC1091
@@ -306,6 +311,7 @@ template-resource: graphics_card
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_glxgears_fullscreen_{product_slug}
+flags: also-after-suspend
 requires: executable.name == 'glxgears'
 command:
  # shellcheck disable=SC1091

--- a/providers/base/units/graphics/test-plan.pxu
+++ b/providers/base/units/graphics/test-plan.pxu
@@ -117,14 +117,16 @@ include:
     # depending on the amount of graphic cards available on the SUT:
     # suspend/suspend_advanced_auto (one GPU)
     # or suspend/{{ index }}_suspend_after_switch_to_card_{{ product_slug }}_auto (two GPUs)
+    after-suspend-miscellanea/chvt
     power-management/lid                                     certification-status=blocker
     power-management/lid_close                               certification-status=blocker
     power-management/lid_open                                certification-status=blocker
     suspend/1_display_after_suspend_.*_graphics              certification-status=blocker
-    suspend/1_glxgears_after_suspend_.*_graphics             certification-status=blocker
-    suspend/1_rotation_after_suspend_.*_graphics             certification-status=blocker
-    suspend/1_video_after_suspend_.*_graphics                certification-status=blocker
-    suspend/1_cycle_resolutions_after_suspend_.*_graphics    certification-status=non-blocker
+    after-suspend-graphics/1_maximum_resolution_.*           certification-status=blocker
+    after-suspend-graphics/1_glxgears_.*                     certification-status=blocker
+    after-suspend-graphics/1_rotation_.*                     certification-status=blocker
+    after-suspend-graphics/1_video_.*                        certification-status=blocker
+    after-suspend-graphics/1_cycle_resolution_.*             certification-status=non-blocker
     suspend/1_xrandr_screens_after_suspend.tar.gz_auto
 
 id: after-suspend-graphics-discrete-gpu-cert-full
@@ -154,10 +156,11 @@ _name: After suspend tests (discrete GPU manual)
 _description: After suspend tests (discrete GPU manual)
 include:
     suspend/2_display_after_suspend_.*_graphics              certification-status=blocker
-    suspend/2_glxgears_after_suspend_.*_graphics             certification-status=blocker
-    suspend/2_rotation_after_suspend_.*_graphics             certification-status=blocker
-    suspend/2_video_after_suspend_.*_graphics                certification-status=blocker
-    suspend/2_cycle_resolutions_after_suspend_.*_graphics    certification-status=non-blocker
+    after-suspend-graphics/2_maximum_resolution_.*           certification-status=blocker
+    after-suspend-graphics/2_glxgears_.*                     certification-status=blocker
+    after-suspend-graphics/2_rotation_.*                     certification-status=blocker
+    after-suspend-graphics/2_video_.*                        certification-status=blocker
+    after-suspend-graphics/2_cycle_resolution_.*             certification-status=non-blocker
     suspend/2_xrandr_screens_after_suspend_.*.tar.gz_auto
 
 id: graphics-integrated-gpu-cert-blockers

--- a/providers/base/units/input/jobs.pxu
+++ b/providers/base/units/input/jobs.pxu
@@ -4,6 +4,7 @@ template-filter: device.category == 'MOUSE' or device.category == 'TOUCHPAD' or 
 plugin: manual
 category_id: com.canonical.plainbox::input
 id: input/pointing_{product_slug}_{category}_{__index__}
+flags: also-after-suspend
 estimated_duration: 30.0
 _summary: Check pointing functionality for {product}
 _purpose:
@@ -29,6 +30,7 @@ _description:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::input
 id: input/keyboard
+flags: also-after-suspend
 estimated_duration: 30.0
 command: keyboard_test.py
 requires: device.category == 'KEYBOARD'
@@ -44,6 +46,7 @@ _description:
 plugin: user-interact
 category_id: com.canonical.plainbox::input
 id: input/accelerometer
+flags: also-after-suspend
 estimated_duration: 60.0
 user: root
 requires: device.category == 'ACCELEROMETER'

--- a/providers/base/units/input/test-plan.pxu
+++ b/providers/base/units/input/test-plan.pxu
@@ -14,8 +14,9 @@ _name: Input tests (Manual)
 _description:
  Input tests (Manual)
 include:
- input/accelerometer                        certification-status=non-blocker
- input/keyboard                             certification-status=blocker
+    input/pointing_.*                          certification-status=blocker
+    input/clicking_.*                          certification-status=blocker
+    input/keyboard                             certification-status=blocker
 
 id: input-cert-automated
 unit: test plan
@@ -32,8 +33,9 @@ unit: test plan
 _name: Input tests (after suspend)
 _description: Input tests (after suspend)
 include:
-    suspend/pointing-after-suspend_.*          certification-status=blocker
-    suspend/clicking-after-suspend_.*          certification-status=blocker
+    after-suspend-input/pointing_.*                          certification-status=blocker
+    after-suspend-input/clicking_.*                          certification-status=blocker
+    after-suspend-input/keyboard                             certification-status=blocker
 
 id: input-cert-blockers
 unit: test plan

--- a/providers/base/units/keys/jobs.pxu
+++ b/providers/base/units/keys/jobs.pxu
@@ -295,6 +295,7 @@ category_id: com.canonical.plainbox::keys
 _summary:
   Check power button event filtering
 id: keys/power-button-event
+flags: also-after-suspend
 estimated_duration: 15.0
 requires:
   package.name == 'acpid'

--- a/providers/base/units/keys/test-plan.pxu
+++ b/providers/base/units/keys/test-plan.pxu
@@ -53,6 +53,7 @@ include:
     after-suspend-keys/keyboard-backlight       certification-status=blocker
     after-suspend-keys/microphone-mute          certification-status=blocker
     after-suspend-keys/power-button             certification-status=blocker
+    after-suspend-keys/power-button-event       certification-status=blocker
     after-suspend-keys/fn-lock                  certification-status=non-blocker
 
 id: keys-cert-blockers

--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -1,4 +1,5 @@
 id: led/power
+flags: also-after-suspend
 _summary: Power LED behavior when powered
 _purpose:
  Check power led is on when system is powered on
@@ -95,6 +96,7 @@ _description:
 plugin: user-interact-verify
 category_id: led
 id: led/numeric-keypad
+flags: also-after-suspend
 estimated_duration: 30.0
 command: keyboard_test.py
 _description:
@@ -111,6 +113,7 @@ _description:
 plugin: manual
 category_id: led
 id: led/caps-lock
+flags: also-after-suspend
 estimated_duration: 30.0
 _description:
  PURPOSE:

--- a/providers/base/units/led/test-plan.pxu
+++ b/providers/base/units/led/test-plan.pxu
@@ -27,10 +27,9 @@ include:
     led/caps-lock                      certification-status=blocker
     led/numeric-keypad                 certification-status=blocker
     led/power                          certification-status=blocker
-    led/bluetooth                      certification-status=non-blocker
-    led/wlan                           certification-status=non-blocker
-    led/wlan-disabled                  certification-status=non-blocker
     led/fn                             certification-status=non-blocker
+    led/mute                           certification-status=blocker
+    led/microphone-mute                certification-status=blocker
 bootstrap_include:
     device
 
@@ -53,14 +52,11 @@ _name: LED tests (after suspend)
 _description: LED tests (after suspend)
 include:
     after-suspend-camera/led_.*                 certification-status=blocker
-    suspend/led_after_suspend/caps-lock         certification-status=blocker
-    suspend/led_after_suspend/numeric-keypad    certification-status=blocker
-    suspend/led_after_suspend/power             certification-status=blocker
+    after-suspend-led/caps-lock                 certification-status=blocker
+    after-suspend-led/numeric-keypad            certification-status=blocker
+    after-suspend-led/power                     certification-status=blocker
     after-suspend-led/mute                      certification-status=blocker
     after-suspend-led/microphone-mute           certification-status=blocker
-    suspend/led_after_suspend/bluetooth         certification-status=non-blocker
-    suspend/led_after_suspend/wlan              certification-status=non-blocker
-    suspend/led_after_suspend/wlan-disabled     certification-status=non-blocker
     after-suspend-led/fn                        certification-status=non-blocker
 bootstrap_include:
     device

--- a/providers/base/units/mediacard/jobs.pxu
+++ b/providers/base/units/mediacard/jobs.pxu
@@ -174,6 +174,7 @@ plugin: user-interact
 template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/sdhc-insert
+flags: also-after-suspend
 estimated_duration: 30.0
 command:
  {%- if __on_ubuntucore__ %}
@@ -206,7 +207,7 @@ id: mediacard/sdhc-storage
 estimated_duration: 30.0
 depends: mediacard/sdhc-insert
 user: root
-flags: preserve-cwd reset-locale
+flags: preserve-cwd reset-locale also-after-suspend
 command:
  {%- if __on_ubuntucore__ %}
      checkbox-support-usb_read_write
@@ -222,6 +223,7 @@ plugin: user-interact
 template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/sdhc-remove
+flags: also-after-suspend
 estimated_duration: 30.0
 depends: mediacard/sdhc-insert
 command:

--- a/providers/base/units/mediacard/test-plan.pxu
+++ b/providers/base/units/mediacard/test-plan.pxu
@@ -31,9 +31,9 @@ unit: test plan
 _name: Mediacard tests (after suspend)
 _description: Mediacard tests (after suspend)
 include:
-    suspend/sdhc-insert-after-suspend              certification-status=blocker
-    suspend/sdhc-storage-after-suspend             certification-status=blocker
-    suspend/sdhc-remove-after-suspend              certification-status=blocker
+ after-suspend-mediacard/sdhc-insert                          certification-status=blocker
+ after-suspend-mediacard/sdhc-storage                         certification-status=blocker
+ after-suspend-mediacard/sdhc-remove                          certification-status=blocker
 
 id: mediacard-cert-blockers
 unit: test plan

--- a/providers/base/units/miscellanea/jobs.pxu
+++ b/providers/base/units/miscellanea/jobs.pxu
@@ -54,6 +54,7 @@ _description:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::miscellanea
 id: miscellanea/chvt
+flags: also-after-suspend
 requires:
  package.name == 'kbd'
 user: root

--- a/providers/base/units/networking/jobs.pxu
+++ b/providers/base/units/networking/jobs.pxu
@@ -27,6 +27,7 @@ _description:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::networking
 id: networking/modem_connection
+flags: also-after-suspend
 command: network_check.py
 _description:
  PURPOSE:

--- a/providers/base/units/networking/test-plan.pxu
+++ b/providers/base/units/networking/test-plan.pxu
@@ -75,6 +75,9 @@ unit: test plan
 _name: Manual networking tests for devices (after suspend)
 _description: Manual networking tests for devices (after suspend)
 include:
+    after-suspend-networking/info_device.*                       certification-status=blocker
+bootstrap_include:
+    device
 
 id: after-suspend-networking-automated
 unit: test plan

--- a/providers/base/units/optical/test-plan.pxu
+++ b/providers/base/units/optical/test-plan.pxu
@@ -16,6 +16,7 @@ _name: Optical drive tests (Manual)
 _description:
  Optical drive tests (Manual)
 include:
+ optical/detect                                 certification-status=blocker
  optical/read_.*                                certification-status=blocker
  optical/bluray-read_.*                         certification-status=blocker
 bootstrap_include:

--- a/providers/base/units/suspend/suspend-graphics.pxu
+++ b/providers/base/units/suspend/suspend-graphics.pxu
@@ -113,7 +113,7 @@ template-filter: graphics_card.prime_gpu_offload == 'Off'
 plugin: attachment
 category_id: com.canonical.plainbox::suspend
 id: suspend/{index}_xrandr_screens_after_suspend.tar.gz_auto
-depends: suspend/{index}_cycle_resolutions_after_suspend_{product_slug}_graphics
+depends: after-suspend-graphics/{index}_cycle_resolution_{product_slug}
 command: [ -f "$PLAINBOX_SESSION_SHARE"/xrandr_screens_{index}_after_suspend.tgz ] && cat "$PLAINBOX_SESSION_SHARE"/xrandr_screens_{index}_after_suspend.tgz
 _description: This attaches screenshots from the suspend/cycle_resolutions_after_suspend test to the results submission.
 

--- a/providers/base/units/thunderbolt/jobs.pxu
+++ b/providers/base/units/thunderbolt/jobs.pxu
@@ -93,15 +93,11 @@ _description:
 plugin: user-interact
 category_id: com.canonical.plainbox::disk
 id: thunderbolt3/insert
+flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 estimated_duration: 20.0
 command: removable_storage_watcher.py insert --timeout 40 scsi
-_siblings: [
-    { "id": "after-suspend-thunderbolt3/insert",
-      "_summary": "thunderbolt3/insert after suspend",
-      "depends": "suspend/suspend_advanced_auto"}
-    ]
 _summary: Storage insert detection on Thunderbolt 3 port
 _description:
  PURPOSE:
@@ -118,17 +114,13 @@ _description:
 plugin: shell
 category_id: com.canonical.plainbox::disk
 id: thunderbolt3/storage-test
+flags: also-after-suspend
 user: root
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 depends: thunderbolt3/insert
 estimated_duration: 45.0
 command: removable_storage_test.py -s 268400000 scsi
-_siblings: [
-    { "id": "after-suspend-thunderbolt3/storage-test",
-      "_summary": "thunderbolt3/storage-test after suspend",
-      "depends": "after-suspend-thunderbolt3/insert"}
-    ]
 _summary: Storage test on Thunderbolt 3
 _description:
  This is an automated test which performs read/write operations on an attached
@@ -151,16 +143,12 @@ _description:
 plugin: user-interact
 category_id: com.canonical.plainbox::disk
 id: thunderbolt3/remove
+flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 depends: thunderbolt3/insert
 estimated_duration: 10.0
 command: removable_storage_watcher.py remove scsi
-_siblings: [
-    { "id": "after-suspend-thunderbolt3/remove",
-      "_summary": "thunderbolt3/remove after suspend",
-      "depends": "after-suspend-thunderbolt3/insert"}
-    ]
 _summary: Storage removal detection on Thunderbolt 3 port
 _description:
  PURPOSE:

--- a/providers/base/units/touchpad/jobs.pxu
+++ b/providers/base/units/touchpad/jobs.pxu
@@ -1,6 +1,7 @@
 plugin: manual
 category_id: com.canonical.plainbox::touchpad
 id: touchpad/basic
+flags: also-after-suspend
 requires: dmi.product in ['Notebook','Laptop','Portable','Convertible']
 estimated_duration: 120.0
 _purpose:
@@ -86,6 +87,7 @@ _siblings:
 plugin: manual
 category_id: com.canonical.plainbox::touchpad
 id: touchpad/multitouch-rightclick
+flags: also-after-suspend
 requires: dmi.product in ['Notebook','Laptop','Portable','Convertible']
 estimated_duration: 120.0
 _purpose:
@@ -103,6 +105,7 @@ _siblings:
 plugin: user-interact
 category_id: com.canonical.plainbox::touchpad
 id: touchpad/multitouch
+flags: also-after-suspend
 requires: dmi.product in ['Notebook','Laptop','Portable','Convertible']
 command: touchpad_test.py up down right left
 estimated_duration: 120.0
@@ -188,6 +191,7 @@ _siblings:
 plugin: user-interact
 category_id: com.canonical.plainbox::touchpad
 id: touchpad/continuous-move
+flags: also-after-suspend
 requires: dmi.product in ['Notebook','Laptop','Portable','Convertible']
 estimated_duration: 12
 command: qmlscene -qt5 --fullscreen "$PLAINBOX_PROVIDER_DATA"/touch_continuous_move_test.qml 2>&1 | grep -o PASS
@@ -219,6 +223,7 @@ _description:
  make sure that firmware/labeling bit is set in touchpad firmware.
 
 id: touchpad/palm-rejection
+flags: also-after-suspend
 plugin: user-interact
 category_id: com.canonical.plainbox::touchpad
 requires: dmi.product in ['Notebook','Laptop','Portable','Convertible']

--- a/providers/base/units/touchpad/test-plan.pxu
+++ b/providers/base/units/touchpad/test-plan.pxu
@@ -37,14 +37,13 @@ unit: test plan
 _name: Touchpad tests
 _description: Touchpad tests
 include:
-    touchpad/basic-after-suspend                   certification-status=blocker
-    touchpad/detected-as-mouse-after-suspend       certification-status=blocker
-    touchpad/palm-rejection-after-suspend          certification-status=non-blocker
-    touchpad/continuous-move-after-suspend         certification-status=blocker
-    touchpad/singletouch-selection-after-suspend   certification-status=blocker
-    touchpad/drag-and-drop-after-suspend           certification-status=blocker
-    touchpad/multitouch-rightclick-after-suspend   certification-status=blocker
-    touchpad/multitouch-after-suspend              certification-status=blocker
+    after-suspend-touchpad/basic                                 certification-status=blocker
+    after-suspend-touchpad/palm-rejection                        certification-status=non-blocker
+    after-suspend-touchpad/continuous-move                       certification-status=blocker
+    after-suspend-touchpad/singletouch-selection                 certification-status=blocker
+    after-suspend-touchpad/drag-and-drop                         certification-status=blocker
+    after-suspend-touchpad/multitouch-rightclick                 certification-status=blocker
+    after-suspend-touchpad/multitouch                            certification-status=blocker
 
 id: touchpad-cert-blockers
 unit: test plan

--- a/providers/base/units/touchscreen/jobs.pxu
+++ b/providers/base/units/touchscreen/jobs.pxu
@@ -209,6 +209,7 @@ template-unit: job
 plugin: user-interact
 category_id: com.canonical.plainbox::touchscreen
 id: touchscreen/evdev/single-touch-tap-{{ product_slug }}
+flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_touchscreen == 'True'
 estimated_duration: 10.0
@@ -222,7 +223,6 @@ _description:
      If the tap is not detected the test will time out after 10 seconds.
 user: root
 command: timeout 10 evdev_touch_test.py '{{ product }}' -x 1
-flags: also-after-suspend
 
 unit: template
 template-resource: device

--- a/providers/base/units/touchscreen/test-plan.pxu
+++ b/providers/base/units/touchscreen/test-plan.pxu
@@ -17,6 +17,8 @@ include:
  touchscreen/drag-n-drop                    certification-status=blocker
  touchscreen/multitouch-zoom                certification-status=blocker
  touchscreen/multitouch-rotate
+ touchscreen/evdev/single-touch-tap-.*      certification-status=blocker
+ touchscreen/evdev/2-touch-tap-.*           certification-status=blocker
  touchscreen/evdev/3-touch-tap-.*           certification-status=blocker
  touchscreen/evdev/4-touch-tap-.*           certification-status=blocker
 bootstrap_include:
@@ -45,11 +47,13 @@ _name: Touchscreen tests (Manual)
 _description:
  Touchscreen tests (Manual)
 include:
- after-suspend-touchscreen/drag-n-drop             certification-status=blocker
- after-suspend-touchscreen/multitouch-zoom         certification-status=blocker
+ after-suspend-touchscreen/drag-n-drop                certification-status=blocker
+ after-suspend-touchscreen/multitouch-zoom            certification-status=blocker
  after-suspend-touchscreen/multitouch-rotate
- after-suspend-touchscreen/evdev/3-touch-tap-.*    certification-status=blocker
- after-suspend-touchscreen/evdev/4-touch-tap-.*    certification-status=blocker
+ after-suspend-touchscreen/evdev/single-touch-tap-.*  certification-status=blocker
+ after-suspend-touchscreen/evdev/2-touch-tap-.*       certification-status=blocker
+ after-suspend-touchscreen/evdev/3-touch-tap-.*       certification-status=blocker
+ after-suspend-touchscreen/evdev/4-touch-tap-.*       certification-status=blocker
 bootstrap_include:
  device
 

--- a/providers/base/units/usb/test-plan.pxu
+++ b/providers/base/units/usb/test-plan.pxu
@@ -76,18 +76,19 @@ unit: test plan
 _name: USB tests (after suspend)
 _description: USB tests (after suspend)
 include:
-    suspend/usb_insert_after_suspend                       certification-status=blocker
-    suspend/usb_storage_automated_after_suspend            certification-status=blocker
-    suspend/usb_remove_after_suspend                       certification-status=blocker
+ after-suspend-usb/HID                                    certification-status=blocker
+ after-suspend-usb/insert                                 certification-status=blocker
+ after-suspend-usb/storage-automated                      certification-status=blocker
+ after-suspend-usb/remove                                 certification-status=blocker
 
 id: after-suspend-usb3-cert-full
 unit: test plan
 _name: USB3 tests (after suspend)
 _description: USB3 tests (after suspend)
 include:
-    suspend/usb3_insert_after_suspend                      certification-status=blocker
-    suspend/usb3_storage_automated_after_suspend           certification-status=blocker
-    suspend/usb3_remove_after_suspend                      certification-status=blocker
+ after-suspend-usb3/insert                                certification-status=blocker
+ after-suspend-usb3/storage-automated                     certification-status=blocker
+ after-suspend-usb3/remove                                certification-status=blocker
 
 id: after-suspend-usb-c-cert-full
 unit: test plan

--- a/providers/base/units/usb/usb.pxu
+++ b/providers/base/units/usb/usb.pxu
@@ -64,7 +64,6 @@ _verification:
  The verification of this test is automated.
  Do not change the automatically selected result.
 plugin: user-interact
-flags: also-after-suspend
 user: root
 command:
  {%- if __on_ubuntucore__ %}
@@ -93,7 +92,6 @@ _verification:
  The verification of this test is automated.
  Do not change the automatically selected result.
 plugin: user-interact
-flags: also-after-suspend
 user: root
 command:
  {%- if __on_ubuntucore__ %}
@@ -119,7 +117,6 @@ _verification:
  Do not change the automatically selected result.
 plugin: user-interact
 depends: usb/insert
-flags: also-after-suspend
 user: root
 command:
  {%- if __on_ubuntucore__ %}
@@ -144,7 +141,6 @@ _verification:
  The verification of this test is automated.
  Do not change the automatically selected result.
 plugin: user-interact
-flags: also-after-suspend
 depends: usb3/insert
 user: root
 command:
@@ -206,7 +202,6 @@ _verification:
  This task is fully automatic and will verify the result for you.
 plugin: shell
 depends: usb/insert
-flags: also-after-suspend
 user: root
 command:
  {%- if __on_ubuntucore__ %}
@@ -229,7 +224,6 @@ _verification:
  This task is fully automatic and will verify the result for you.
 plugin: shell
 depends: usb3/insert
-flags: also-after-suspend
 user: root
 command:
  {%- if __on_ubuntucore__ %}

--- a/providers/base/units/usb/usb.pxu
+++ b/providers/base/units/usb/usb.pxu
@@ -34,6 +34,7 @@ _description:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::usb
 id: usb/HID
+flags: also-after-suspend
 depends: usb/detect
 estimated_duration: 1.0
 command: keyboard_test.py
@@ -48,6 +49,7 @@ _description:
      Did the device work as expected?
 
 id: usb/insert
+flags: also-after-suspend
 template-engine: jinja2
 _summary: USB 2.0 storage device insertion detected
 _purpose:
@@ -74,6 +76,7 @@ category_id: com.canonical.plainbox::usb
 estimated_duration: 120
 
 id: usb3/insert
+flags: also-after-suspend
 template-engine: jinja2
 requires:
  usb.usb3 == 'supported'
@@ -102,6 +105,7 @@ category_id: com.canonical.plainbox::usb
 estimated_duration: 120
 
 id: usb/remove
+flags: also-after-suspend
 template-engine: jinja2
 _summary: USB 2.0 storage device removal detected
 _purpose:
@@ -127,6 +131,7 @@ category_id: com.canonical.plainbox::usb
 estimated_duration: 120
 
 id: usb3/remove
+flags: also-after-suspend
 template-engine: jinja2
 _summary: USB 3.0 storage device removal detected
 _purpose:
@@ -190,6 +195,7 @@ _description:
      automatically selected result.
 
 id: usb/storage-automated
+flags: also-after-suspend
 template-engine: jinja2
 _summary: USB 2.0 storage device read & write works
 _purpose:
@@ -212,6 +218,7 @@ category_id: com.canonical.plainbox::usb
 estimated_duration: 300
 
 id: usb3/storage-automated
+flags: also-after-suspend
 template-engine: jinja2
 _summary: USB 3.0 storage device read & write works
 _purpose:

--- a/providers/certification-client/units/client-cert-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-22-04.pxu
@@ -62,10 +62,14 @@ nested_part:
     after-suspend-audio-cert-full
     after-suspend-bluetooth-cert-manual
     after-suspend-camera-cert-full
+    after-suspend-thunderbolt-cert-manual
     after-suspend-input-cert-full
+    after-suspend-fingerprint-manual
     after-suspend-keys-cert-full
     after-suspend-led-cert-full
     after-suspend-mediacard-cert-full
+    after-suspend-ethernet-manual
+    after-suspend-networking-manual
     after-suspend-optical-cert-full
     after-suspend-touchpad-cert-full
     after-suspend-touchscreen-cert-manual


### PR DESCRIPTION
## Description

To make sure we test extact same cases before and after suspend, I've made following change:
1. Use flag: also-after-suspend for all test cases
2. Modify desktop manual test plan to use after-suspend test instead of suspend/
changes only applied to desktop-22-04-manual for now

Note: removed led/wlan and led/bluetooth since we don't have these leds on recent hardwares

## Resolved issues

None

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

$ checkbox-cli list-bootstrapped com.canonical.certification::client-cert-desktop-22-04-manual
https://pastebin.canonical.com/p/6qpsY7ZhF8/

following cases are still in the test plan since they are created for after suspend scenario only.
suspend/*_display_after_suspend_*
suspend/oops_after_suspend
suspend/oops_results_after_suspend.log