### PR TITLE
Provide more information about suspend/resume times when running 30 cycles with reboots/poweroffs

### DIFF
--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -113,21 +113,37 @@ def get_sleep_times(log, start_marker):
 
 
 def average_times(runs):
+    sleep_run_count = 0
     sleep_total = 0.0
+    resume_run_count = 0
     resume_total = 0.0
-    run_count = 0
-    try:
-        for run in runs.keys():
-            run_count += 1
-            sleep_total += runs[run][0]
-            resume_total += runs[run][1]
-        sleep_avg = sleep_total / run_count
-        resume_avg = resume_total / run_count
+    print()
+    print("{} iterations total.".format(len(runs)))
+    for i in runs.values():
+        if type(i[0]) == float:
+            sleep_run_count += 1
+            sleep_total += i[0]
+        if type(i[1]) == float:
+            resume_run_count += 1
+            resume_total += i[1]
+    if sleep_run_count != len(runs):
+        print(("Warning: Time to sleep was only reported {} times out of {} "
+               "iterations!").format(sleep_run_count, len(runs)))
+    if resume_run_count != len(runs):
+        print(("Warning: Time to resume was only reported {} times out of {} "
+               "iterations!").format(resume_run_count, len(runs)))
+    print()
+    if sleep_run_count:
+        sleep_avg = sleep_total / sleep_run_count
         print('Average time to sleep: %0.5f' % sleep_avg)
-        print('Average time to resume: %0.5f' % resume_avg)
-    except TypeError:
+    else:
         print('Average time to sleep: N/A')
+    if resume_run_count:
+        resume_avg = resume_total / resume_run_count
+        print('Average time to resume: %0.5f' % resume_avg)
+    else:
         print('Average time to resume: N/A')
+    print()
 
 
 def fix_sleep_args(args):

--- a/providers/base/units/stress/jobs.pxu
+++ b/providers/base/units/stress/jobs.pxu
@@ -159,7 +159,7 @@ _description:
 
 plugin: attachment
 category_id: com.canonical.plainbox::stress
-id: power-management/suspend-30-cycle-log-attach-with-reboots
+id: power-management/suspend-30-cycle-log-attach-with-reboots-pm_test.reboot.3.log
 estimated_duration: 1.0
 depends: power-management/suspend_30_cycles_with_reboots
 command: [ -e "$PLAINBOX_SESSION_SHARE"/pm_test.reboot.3.log ] && cat "$PLAINBOX_SESSION_SHARE"/pm_test.reboot.3.log
@@ -167,7 +167,7 @@ _summary: 30 suspend/resume cycles and 1 reboot, 3 times (attach logs)
 _description:
  Attaches the log from the '30 cycle suspend/resume and one reboot times 3' test if it exists
 _siblings: [
-    { "id": "power-management/suspend-30-cycle-log-attach-with-coldboots",
+    { "id": "power-management/suspend-30-cycle-log-attach-with-coldboots-pm_test.poweroff.3.log",
       "depends": "power-management/suspend_30_cycles_with_coldboots",
       "command": "[ -e $PLAINBOX_SESSION_SHARE/pm_test.poweroff.3.log ] && cat $PLAINBOX_SESSION_SHARE/pm_test.poweroff.3.log",
       "_description": "Attaches the log from the '30 cycle Suspend/Resume and one poweroff times 3' test if it exists",

--- a/providers/base/units/stress/test-plan.pxu
+++ b/providers/base/units/stress/test-plan.pxu
@@ -48,7 +48,7 @@ _description: Suspend stress tests (with reboots)
 include:
     power-management/suspend_30_cycles_with_reboots
     power-management/suspend-30-cycles-log-check-with-reboots
-    power-management/suspend-30-cycle-log-attach-with-reboots
+    power-management/suspend-30-cycle-log-attach-with-reboots-pm_test.reboot.3.log
     power-management/suspend-30-cycles-time-check-with-reboots
 
 id: stress-suspend-30-cycles-with-coldboots-automated
@@ -58,7 +58,7 @@ _description: Suspend stress tests (with coldboots)
 include:
     power-management/suspend_30_cycles_with_coldboots
     power-management/suspend-30-cycles-log-check-with-coldboots
-    power-management/suspend-30-cycle-log-attach-with-coldboots
+    power-management/suspend-30-cycle-log-attach-with-coldboots-pm_test.poweroff.3.log
     power-management/suspend-30-cycles-time-check-with-coldboots
 
 id: stress-hibernate-30-cycles-automated


### PR DESCRIPTION
## Description

As requested by QA, the output of `sleep_time_check.py` now includes more
info, namely:

- a warning if suspend/resume times are less than total number of runs
- the average times to suspend/resume for each cycle

Moreover, the script (and therefore the
`suspend-30-cycles-time-check-with-reboots` job) will fail if one or more
times are not reported correctly, which will allow QA team to
investigate.

Finally, the attachment jobs were renamed to add `pm_test.reboot.3.log` and
`pm_test.poweroff.3.log` to its filename to make it more clear for anyone who will debug the submission.

Note that I think there is really an issue with FWTS, since it seems it cannot report the time on newer configs. I've raised an issue about this: https://github.com/ColinIanKing/fwts/issues/8

## Resolved issues

#99 

## Tests

- Run the `stress-suspend-30-cycles-with-reboots-automated` stress test plan

Check that everything runs as expected.

Namely, on a device that fails to provide suspend or resume time, the output of `power-management/suspend-30-cycles-time-check-with-reboots` will look like this, and the job will fail to let users investigate the issue:

```
Warning: Time to resume was only reported 0 times out of 30 iterations!

Average time to sleep: 0.68653

Average time to resume: N/A

ERROR: One or more resume times was not reported correctly:
could not convert string to float: 'N/A'
Warning: Time to resume was only reported 0 times out of 30 iterations!

Average time to sleep: 0.73510

Average time to resume: N/A

ERROR: One or more resume times was not reported correctly:
could not convert string to float: 'N/A'
Warning: Time to resume was only reported 0 times out of 30 iterations!

Average time to sleep: 0.72083

Average time to resume: N/A

ERROR: One or more resume times was not reported correctly:
could not convert string to float: 'N/A'

=================================================
Average time to enter sleep state: 0.7142 seconds
=================================================
```