### PR TITLE
Revamp Metabox Source Container (formerly known as Venv Container)

### DIFF
--- a/metabox/metabox/core/configuration.py
+++ b/metabox/metabox/core/configuration.py
@@ -138,7 +138,7 @@ def _decl_has_a_valid_origin(decl):
             logger.error("{} --name failed", setup_file)
             return False
         if not package_name == 'checkbox-ng':
-            logger.error("{} must be a lp:checkbox-ng fork", source)
+            logger.error("{} must be a fork of gh:canonical/checkbox", source)
             return False
         return True
     return False

--- a/metabox/metabox/core/configuration.py
+++ b/metabox/metabox/core/configuration.py
@@ -126,7 +126,7 @@ def _decl_has_a_valid_origin(decl):
         if not source.is_dir():
             logger.error("{} doesn't look like a directory", source)
             return False
-        setup_file = source / 'setup.py'
+        setup_file = source / 'checkbox-ng' / 'setup.py'
         if not setup_file.exists():
             logger.error("{} not found", setup_file)
             return False

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -61,9 +61,10 @@ class LxdMachineProvider:
         try:
             # TODO: Find a suitable timeout value here
             self.client = pylxd.Client(timeout=None)
-        except ClientConnectionFailed as exc:
-            logger.exception("Cannot connect to LXD. Is it installed?")
-            sys.exit()
+        except ClientConnectionFailed:
+            msg = "Cannot connect to LXD. Is it installed?"
+            logger.exception(msg)
+            raise SystemExit(msg)
 
     def setup(self):
         self._create_profiles()

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -61,10 +61,10 @@ class LxdMachineProvider:
         try:
             # TODO: Find a suitable timeout value here
             self.client = pylxd.Client(timeout=None)
-        except ClientConnectionFailed:
-            msg = "Cannot connect to LXD. Is it installed?"
+        except ClientConnectionFailed as exc:
+            msg = f"Cannot connect to LXD. Is it installed? {exc}"
             logger.exception(msg)
-            raise SystemExit(msg)
+            raise SystemExit(msg) from exc
 
     def setup(self):
         self._create_profiles()

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -26,6 +26,7 @@ LXD machines are containers that can run metabox scenarios in them.
 """
 import json
 import os
+import sys
 import time
 import yaml
 from pathlib import Path
@@ -61,7 +62,8 @@ class LxdMachineProvider():
             # TODO: Find a suitable timeout value here
             self.client = pylxd.Client(timeout=None)
         except ClientConnectionFailed as exc:
-            raise SystemExit from exc
+            logger.exception("Cannot connect to LXD. Is it installed?")
+            sys.exit()
 
     def setup(self):
         self._create_profiles()
@@ -77,8 +79,11 @@ class LxdMachineProvider():
                 continue
             try:
                 logger.debug("Getting information about {}...", container.name)
+                logger.debug("Starting {}...", container.name)
                 container.start(wait=True)
+                logger.debug("Retrieving config file for {}...", container.name)
                 content = container.files.get(self.LXD_INTERNAL_CONFIG_PATH)
+                logger.debug("Stopping {}...", container.name)
                 container.stop(wait=True)
                 config_dict = json.loads(content)
                 config = MachineConfig(config_dict['role'], config_dict)
@@ -208,12 +213,13 @@ class LxdMachineProvider():
         pre_cmds = machine.get_early_setup()
         post_cmds = machine.get_late_setup()
         for cmd in pre_cmds + machine.config.setup + post_cmds:
+            logger.info(f"Running command: {cmd}")
             res = run_or_raise(
                 machine._container, cmd,
                 verbose=self._debug_machine_setup)
             if res.exit_code:
                 msg = "Failed to run command in the container! Command: \n"
-                msg += cmd + '\n' + res.stderr
+                msg += cmd + '\n' + res.stdout + '\n' + res.stderr
                 logger.critical(msg)
                 raise SystemExit()
 

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -41,7 +41,7 @@ from metabox.core.machine import machine_selector
 from metabox.core.lxd_execute import run_or_raise
 
 
-class LxdMachineProvider():
+class LxdMachineProvider:
     """Machine provider that uses container managed by LXD as targets."""
 
     LXD_CREATE_TIMEOUT = 300

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -65,7 +65,7 @@ class MachineConfig:
             return False
 
 
-class ContainerBaseMachine():
+class ContainerBaseMachine:
     """Base implementation of Machine using LXD container as the backend."""
 
     CHECKBOX = 'checkbox-cli '  # mind the trailing space !
@@ -427,8 +427,8 @@ class ContainerSnapMachine(ContainerBaseMachine):
 
 def machine_selector(config, container):
     if config.origin in ('snap', 'classic-snap'):
-        return (ContainerSnapMachine(config, container))
+        return ContainerSnapMachine(config, container)
     elif config.origin == 'ppa':
-        return (ContainerPPAMachine(config, container))
+        return ContainerPPAMachine(config, container)
     elif config.origin == 'source':
         return (ContainerVenvMachine(config, container))

--- a/metabox/metabox/lxd_profiles/checkbox.profile
+++ b/metabox/metabox/lxd_profiles/checkbox.profile
@@ -18,6 +18,7 @@ config:
       - gir1.2-gstreamer-1.0
       - gstreamer1.0-plugins-good
       - gstreamer1.0-pulseaudio
+      - jq
       - libgstreamer1.0-0
       - mesa-utils
       - pulseaudio


### PR DESCRIPTION
## Description

Metabox can be used to test Checkbox directly from a source code repository. I reworked this feature to make it a little bit better:

- Deploy a systemd service when running Checkbox remote testing, so that if the container running the Checkbox service part is rebooter, Checkbox is restarted as soon as the container is avaible (this makes the `restart` scenario work even in this case, in addition to PPA and Snaps)
- Deploy Checkbox source code directly into the container using pip instead of installing it in a virtual environment: since we do everything in a container, we don't really need a venv

I made some changes in some of the methods (notably `start_service()`, `stop_service()`, `reboot_service()` and `is_service_active()`), but since they are not widely used by any scenario at the moment, I'm not 100% sure of my implementation. I would appreciate feedback on those, especially.

## Resolved issues

Fix CHECKBOX-419

## Tests

I created the following config file (`source-config.py`):

```python
configuration = {
    'local': {
        'origin': 'source',
        'uri': '/home/pieq/path/to/checkbox',
        'releases': ['focal'],
    },
    'remote': {
        'origin': 'source',
        'uri': '/home/pieq/path/to/checkbox',
        'releases': ['focal'],
    },
    'service': {
        'origin': 'source',
        'uri': '/home/pieq/path/to/checkbox',
        'releases': ['focal'],
    },
}
```

and ran Metabox with

```
metabox source-config.py --log TRACE --do-not-dispose
```

Every scenario passed, except the `urwid.testplan.UrwidTestPlanSelection` because the output expected by this scenario has changed with recent commits made in Checkbox, so it will have to be modified at a later date.

