### PR TITLE
Add: Support parser the "availbility group" in the port attribute of …

### DIFF
--- a/checkbox-support/checkbox_support/parsers/pactl.py
+++ b/checkbox-support/checkbox_support/parsers/pactl.py
@@ -243,6 +243,12 @@ class Port(Node):
         + p.Word(p.nums).setParseAction(
             lambda t: int(t[0])
         ).setResultsName('port-priority')
+        + p.Optional(
+            p.Suppress(',')
+            + p.Keyword('availability group').suppress()
+            + p.Suppress(':')
+            + p.Word(p.alphanums + " -;").suppress()
+        )
         + p.MatchFirst([
             p.Suppress(',') + p.Literal('not available'),
             p.Suppress(',') + p.Literal('available'),
@@ -337,6 +343,12 @@ class PortWithProfile(Node):
                 + p.Literal("usec").suppress(),
                 p.Empty().setParseAction(lambda t: '')
             ]).setResultsName('port-latency-offset')
+        )
+        + p.Optional(
+            p.Suppress(',')
+            + p.Keyword('availability group').suppress()
+            + p.Suppress(':')
+            + p.Word(p.alphanums + " -;").suppress()
         )
         + p.Optional(
             p.MatchFirst([

--- a/checkbox-support/checkbox_support/parsers/tests/pactl_data/cards-desktop-jammy-latitude3540.txt
+++ b/checkbox-support/checkbox_support/parsers/tests/pactl_data/cards-desktop-jammy-latitude3540.txt
@@ -1,0 +1,40 @@
+Card #0
+	Name: alsa_card.pci-0000_00_1f.3-platform-skl_hda_dsp_generic
+	Driver: module-alsa-card.c
+	Owner Module: 22
+	Properties:
+		alsa.card = "0"
+		alsa.card_name = "sof-hda-dsp"
+		alsa.long_card_name = "DellInc.-Latitude3540--"
+		alsa.driver_name = "snd_soc_skl_hda_dsp"
+		device.bus_path = "pci-0000:00:1f.3-platform-skl_hda_dsp_generic"
+		sysfs.path = "/devices/pci0000:00/0000:00:1f.3/skl_hda_dsp_generic/sound/card0"
+		device.bus = "pci"
+		device.vendor.id = "8086"
+		device.vendor.name = "Intel Corporation"
+		device.product.id = "51ca"
+		device.string = "0"
+		device.description = "sof-hda-dsp"
+		module-udev-detect.discovered = "1"
+		device.icon_name = "audio-card-pci"
+	Profiles:
+		HiFi: Play HiFi quality Music (sinks: 4, sources: 2, priority: 40768, available: yes)
+		off: Off (sinks: 0, sources: 0, priority: 0, available: yes)
+	Active Profile: HiFi
+	Ports:
+		[Out] HDMI3: HDMI / DisplayPort 3 Output (type: HDMI, priority: 700, latency offset: 0 usec, not available)
+			Part of profile(s): HiFi
+		[Out] HDMI2: HDMI / DisplayPort 2 Output (type: HDMI, priority: 600, latency offset: 0 usec, not available)
+			Part of profile(s): HiFi
+		[Out] HDMI1: HDMI / DisplayPort 1 Output (type: HDMI, priority: 500, latency offset: 0 usec, not available)
+			Part of profile(s): HiFi
+		[Out] Speaker: Speaker (type: Speaker, priority: 100, latency offset: 0 usec, availability unknown)
+			Part of profile(s): HiFi
+		[Out] Headphones: Headphones (type: Headphones, priority: 200, availability group: Headphone Mic, not available)
+			Part of profile(s): HiFi
+		[In] Headset: Headset Mono Microphone (type: Headset, priority: 300, latency offset: 0 usec, availability group: Headphone Mic, not available)
+			Part of profile(s): HiFi
+		[In] Mic2: Headphones Stereo Microphone (type: Mic, priority: 200, latency offset: 0 usec, availability group: Headphone Mic, not available)
+			Part of profile(s): HiFi
+		[In] Mic1: Digital Microphone (type: Mic, priority: 100, latency offset: 0 usec, availability unknown)
+			Part of profile(s): HiFi

--- a/checkbox-support/checkbox_support/parsers/tests/pactl_data/desktop-jammy-latitude3540.txt
+++ b/checkbox-support/checkbox_support/parsers/tests/pactl_data/desktop-jammy-latitude3540.txt
@@ -1,0 +1,938 @@
+Module #0
+	Name: module-device-restore
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Lennart Poettering"
+		module.description = "Automatically restore the volume/mute state of devices"
+		module.version = "15.99.1"
+
+Module #1
+	Name: module-stream-restore
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Lennart Poettering"
+		module.description = "Automatically restore the volume/mute/device state of streams"
+		module.version = "15.99.1"
+
+Module #2
+	Name: module-card-restore
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Lennart Poettering"
+		module.description = "Automatically restore profile of cards"
+		module.version = "15.99.1"
+
+Module #3
+	Name: module-augment-properties
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Lennart Poettering"
+		module.description = "Augment the property sets of streams with additional static information"
+		module.version = "15.99.1"
+
+Module #4
+	Name: module-switch-on-port-available
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "David Henningsson"
+		module.description = "Switches ports and profiles when devices are plugged/unplugged"
+		module.version = "15.99.1"
+
+Module #5
+	Name: module-switch-on-connect
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Michael Terry"
+		module.description = "When a sink/source is added, switch to it or conditionally switch to it"
+		module.version = "15.99.1"
+
+Module #6
+	Name: module-udev-detect
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Lennart Poettering"
+		module.description = "Detect available audio hardware and load matching drivers"
+		module.version = "15.99.1"
+
+Module #7
+	Name: module-bluetooth-policy
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Frédéric Dalleau, Pali Rohár"
+		module.description = "Policy module to make using bluetooth devices out-of-the-box easier"
+		module.version = "15.99.1"
+
+Module #8
+	Name: module-bluetooth-discover
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "João Paulo Rechi Vita"
+		module.description = "Detect available Bluetooth daemon and load the corresponding discovery module"
+		module.version = "15.99.1"
+
+Module #9
+	Name: module-bluez5-discover
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "João Paulo Rechi Vita"
+		module.description = "Detect available BlueZ 5 Bluetooth audio devices and load BlueZ 5 Bluetooth audio drivers"
+		module.version = "15.99.1"
+
+Module #10
+	Name: module-native-protocol-unix
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Lennart Poettering"
+		module.description = "Native protocol (UNIX sockets)"
+		module.version = "15.99.1"
+
+Module #11
+	Name: module-default-device-restore
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Lennart Poettering"
+		module.description = "Automatically restore the default sink and source"
+		module.version = "15.99.1"
+
+Module #12
+	Name: module-always-sink
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Colin Guthrie"
+		module.description = "Always keeps at least one sink loaded even if it's a null one"
+		module.version = "15.99.1"
+
+Module #14
+	Name: module-intended-roles
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Lennart Poettering"
+		module.description = "Automatically set device of streams based on intended roles of devices"
+		module.version = "15.99.1"
+
+Module #15
+	Name: module-suspend-on-idle
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Lennart Poettering"
+		module.description = "When a sink/source is idle for too long, suspend it"
+		module.version = "15.99.1"
+
+Module #16
+	Name: module-systemd-login
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Lennart Poettering"
+		module.description = "Create a client for each login session of this user"
+		module.version = "15.99.1"
+
+Module #17
+	Name: module-position-event-sounds
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Lennart Poettering"
+		module.description = "Position event sounds between L and R depending on the position on screen of the widget triggering them."
+		module.version = "15.99.1"
+
+Module #18
+	Name: module-role-cork
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Lennart Poettering"
+		module.description = "Mute & cork streams with certain roles while others exist"
+		module.version = "15.99.1"
+
+Module #19
+	Name: module-snap-policy
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Canonical Ltd"
+		module.description = "Ubuntu Snap policy management"
+		module.version = "15.99.1"
+
+Module #20
+	Name: module-filter-heuristics
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Colin Guthrie"
+		module.description = "Detect when various filters are desirable"
+		module.version = "15.99.1"
+
+Module #21
+	Name: module-filter-apply
+	Argument: 
+	Usage counter: n/a
+	Properties:
+		module.author = "Colin Guthrie"
+		module.description = "Load filter sinks automatically when needed"
+		module.version = "15.99.1"
+
+Module #22
+	Name: module-alsa-card
+	Argument: device_id="0" name="pci-0000_00_1f.3-platform-skl_hda_dsp_generic" card_name="alsa_card.pci-0000_00_1f.3-platform-skl_hda_dsp_generic" namereg_fail=false tsched=yes fixed_latency_range=no ignore_dB=no deferred_volume=yes use_ucm=yes avoid_resampling=no card_properties="module-udev-detect.discovered=1"
+	Usage counter: 3
+	Properties:
+		module.author = "Lennart Poettering"
+		module.description = "ALSA Card"
+		module.version = "15.99.1"
+
+Sink #1
+	State: SUSPENDED
+	Name: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_5__sink
+	Description: sof-hda-dsp HDMI / DisplayPort 3 Output
+	Driver: module-alsa-card.c
+	Sample Specification: s16le 2ch 48000Hz
+	Channel Map: front-left,front-right
+	Owner Module: 22
+	Mute: no
+	Volume: front-left: 32768 /  50% / -18.06 dB,   front-right: 32768 /  50% / -18.06 dB
+	        balance 0.00
+	Base Volume: 65536 / 100% / 0.00 dB
+	Monitor Source: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_5__sink.monitor
+	Latency: 0 usec, configured 0 usec
+	Flags: HARDWARE DECIBEL_VOLUME LATENCY 
+	Properties:
+		alsa.resolution_bits = "16"
+		device.api = "alsa"
+		device.class = "sound"
+		alsa.class = "generic"
+		alsa.subclass = "generic-mix"
+		alsa.name = ""
+		alsa.id = "HDMI3 (*)"
+		alsa.subdevice = "0"
+		alsa.subdevice_name = "subdevice #0"
+		alsa.device = "5"
+		alsa.card = "0"
+		alsa.card_name = "sof-hda-dsp"
+		alsa.long_card_name = "DellInc.-Latitude3540--"
+		alsa.driver_name = "snd_soc_skl_hda_dsp"
+		device.bus_path = "pci-0000:00:1f.3-platform-skl_hda_dsp_generic"
+		sysfs.path = "/devices/pci0000:00/0000:00:1f.3/skl_hda_dsp_generic/sound/card0"
+		device.bus = "pci"
+		device.vendor.id = "8086"
+		device.vendor.name = "Intel Corporation"
+		device.product.id = "51ca"
+		device.string = "_ucm0001.hw:sofhdadsp,5"
+		device.buffering.buffer_size = "65536"
+		device.buffering.fragment_size = "16384"
+		device.access_mode = "mmap+timer"
+		device.profile.name = "HiFi: hw:sofhdadsp,5: sink"
+		device.profile.description = "HDMI / DisplayPort 3 Output"
+		alsa.mixer_device = "_ucm0001.hw:sofhdadsp"
+		device.description = "sof-hda-dsp HDMI / DisplayPort 3 Output"
+		module-udev-detect.discovered = "1"
+		device.icon_name = "audio-card-pci"
+	Ports:
+		[Out] HDMI3: HDMI / DisplayPort 3 Output (type: HDMI, priority: 700, not available)
+	Active Port: [Out] HDMI3
+	Formats:
+		pcm
+
+Sink #2
+	State: SUSPENDED
+	Name: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_4__sink
+	Description: sof-hda-dsp HDMI / DisplayPort 2 Output
+	Driver: module-alsa-card.c
+	Sample Specification: s16le 2ch 48000Hz
+	Channel Map: front-left,front-right
+	Owner Module: 22
+	Mute: no
+	Volume: front-left: 65536 / 100% / 0.00 dB,   front-right: 65536 / 100% / 0.00 dB
+	        balance 0.00
+	Base Volume: 65536 / 100% / 0.00 dB
+	Monitor Source: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_4__sink.monitor
+	Latency: 0 usec, configured 0 usec
+	Flags: HARDWARE DECIBEL_VOLUME LATENCY 
+	Properties:
+		alsa.resolution_bits = "16"
+		device.api = "alsa"
+		device.class = "sound"
+		alsa.class = "generic"
+		alsa.subclass = "generic-mix"
+		alsa.name = ""
+		alsa.id = "HDMI2 (*)"
+		alsa.subdevice = "0"
+		alsa.subdevice_name = "subdevice #0"
+		alsa.device = "4"
+		alsa.card = "0"
+		alsa.card_name = "sof-hda-dsp"
+		alsa.long_card_name = "DellInc.-Latitude3540--"
+		alsa.driver_name = "snd_soc_skl_hda_dsp"
+		device.bus_path = "pci-0000:00:1f.3-platform-skl_hda_dsp_generic"
+		sysfs.path = "/devices/pci0000:00/0000:00:1f.3/skl_hda_dsp_generic/sound/card0"
+		device.bus = "pci"
+		device.vendor.id = "8086"
+		device.vendor.name = "Intel Corporation"
+		device.product.id = "51ca"
+		device.string = "_ucm0001.hw:sofhdadsp,4"
+		device.buffering.buffer_size = "65536"
+		device.buffering.fragment_size = "16384"
+		device.access_mode = "mmap+timer"
+		device.profile.name = "HiFi: hw:sofhdadsp,4: sink"
+		device.profile.description = "HDMI / DisplayPort 2 Output"
+		alsa.mixer_device = "_ucm0001.hw:sofhdadsp"
+		device.description = "sof-hda-dsp HDMI / DisplayPort 2 Output"
+		module-udev-detect.discovered = "1"
+		device.icon_name = "audio-card-pci"
+	Ports:
+		[Out] HDMI2: HDMI / DisplayPort 2 Output (type: HDMI, priority: 600, not available)
+	Active Port: [Out] HDMI2
+	Formats:
+		pcm
+
+Sink #3
+	State: SUSPENDED
+	Name: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_3__sink
+	Description: sof-hda-dsp HDMI / DisplayPort 1 Output
+	Driver: module-alsa-card.c
+	Sample Specification: s16le 2ch 48000Hz
+	Channel Map: front-left,front-right
+	Owner Module: 22
+	Mute: no
+	Volume: front-left: 65536 / 100% / 0.00 dB,   front-right: 65536 / 100% / 0.00 dB
+	        balance 0.00
+	Base Volume: 65536 / 100% / 0.00 dB
+	Monitor Source: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_3__sink.monitor
+	Latency: 0 usec, configured 0 usec
+	Flags: HARDWARE DECIBEL_VOLUME LATENCY 
+	Properties:
+		alsa.resolution_bits = "16"
+		device.api = "alsa"
+		device.class = "sound"
+		alsa.class = "generic"
+		alsa.subclass = "generic-mix"
+		alsa.name = ""
+		alsa.id = "HDMI1 (*)"
+		alsa.subdevice = "0"
+		alsa.subdevice_name = "subdevice #0"
+		alsa.device = "3"
+		alsa.card = "0"
+		alsa.card_name = "sof-hda-dsp"
+		alsa.long_card_name = "DellInc.-Latitude3540--"
+		alsa.driver_name = "snd_soc_skl_hda_dsp"
+		device.bus_path = "pci-0000:00:1f.3-platform-skl_hda_dsp_generic"
+		sysfs.path = "/devices/pci0000:00/0000:00:1f.3/skl_hda_dsp_generic/sound/card0"
+		device.bus = "pci"
+		device.vendor.id = "8086"
+		device.vendor.name = "Intel Corporation"
+		device.product.id = "51ca"
+		device.string = "_ucm0001.hw:sofhdadsp,3"
+		device.buffering.buffer_size = "65536"
+		device.buffering.fragment_size = "16384"
+		device.access_mode = "mmap+timer"
+		device.profile.name = "HiFi: hw:sofhdadsp,3: sink"
+		device.profile.description = "HDMI / DisplayPort 1 Output"
+		alsa.mixer_device = "_ucm0001.hw:sofhdadsp"
+		device.description = "sof-hda-dsp HDMI / DisplayPort 1 Output"
+		module-udev-detect.discovered = "1"
+		device.icon_name = "audio-card-pci"
+	Ports:
+		[Out] HDMI1: HDMI / DisplayPort 1 Output (type: HDMI, priority: 500, not available)
+	Active Port: [Out] HDMI1
+	Formats:
+		pcm
+
+Sink #4
+	State: IDLE
+	Name: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink
+	Description: sof-hda-dsp Speaker + Headphones
+	Driver: module-alsa-card.c
+	Sample Specification: s16le 2ch 48000Hz
+	Channel Map: front-left,front-right
+	Owner Module: 22
+	Mute: no
+	Volume: front-left: 32099 /  49% / -18.60 dB,   front-right: 32099 /  49% / -18.60 dB
+	        balance 0.00
+	Base Volume: 65536 / 100% / 0.00 dB
+	Monitor Source: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink.monitor
+	Latency: 39920 usec, configured 40000 usec
+	Flags: HARDWARE HW_MUTE_CTRL HW_VOLUME_CTRL DECIBEL_VOLUME LATENCY 
+	Properties:
+		alsa.resolution_bits = "16"
+		device.api = "alsa"
+		device.class = "sound"
+		alsa.class = "generic"
+		alsa.subclass = "generic-mix"
+		alsa.name = ""
+		alsa.id = "HDA Analog (*)"
+		alsa.subdevice = "0"
+		alsa.subdevice_name = "subdevice #0"
+		alsa.device = "0"
+		alsa.card = "0"
+		alsa.card_name = "sof-hda-dsp"
+		alsa.long_card_name = "DellInc.-Latitude3540--"
+		alsa.driver_name = "snd_soc_skl_hda_dsp"
+		device.bus_path = "pci-0000:00:1f.3-platform-skl_hda_dsp_generic"
+		sysfs.path = "/devices/pci0000:00/0000:00:1f.3/skl_hda_dsp_generic/sound/card0"
+		device.bus = "pci"
+		device.vendor.id = "8086"
+		device.vendor.name = "Intel Corporation"
+		device.product.id = "51ca"
+		device.string = "_ucm0001.hw:sofhdadsp"
+		device.buffering.buffer_size = "65536"
+		device.buffering.fragment_size = "16384"
+		device.access_mode = "mmap+timer"
+		device.profile.name = "HiFi: hw:sofhdadsp: sink"
+		device.profile.description = "Speaker + Headphones"
+		alsa.mixer_device = "_ucm0001.hw:sofhdadsp"
+		device.description = "sof-hda-dsp Speaker + Headphones"
+		module-udev-detect.discovered = "1"
+		device.icon_name = "audio-card-pci"
+	Ports:
+		[Out] Speaker: Speaker (type: Speaker, priority: 100, availability group: Headphone Mic, availability unknown)
+		[Out] Headphones: Headphones (type: Headphones, priority: 200, availability group: Headphone Mic, not available)
+	Active Port: [Out] Speaker
+	Formats:
+		pcm
+
+Source #1
+	State: SUSPENDED
+	Name: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_5__sink.monitor
+	Description: Monitor of sof-hda-dsp HDMI / DisplayPort 3 Output
+	Driver: module-alsa-card.c
+	Sample Specification: s16le 2ch 48000Hz
+	Channel Map: front-left,front-right
+	Owner Module: 22
+	Mute: no
+	Volume: front-left: 65536 / 100% / 0.00 dB,   front-right: 65536 / 100% / 0.00 dB
+	        balance 0.00
+	Base Volume: 65536 / 100% / 0.00 dB
+	Monitor of Sink: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_5__sink
+	Latency: 0 usec, configured 0 usec
+	Flags: DECIBEL_VOLUME LATENCY 
+	Properties:
+		device.description = "Monitor of sof-hda-dsp HDMI / DisplayPort 3 Output"
+		device.class = "monitor"
+		alsa.card = "0"
+		alsa.card_name = "sof-hda-dsp"
+		alsa.long_card_name = "DellInc.-Latitude3540--"
+		alsa.driver_name = "snd_soc_skl_hda_dsp"
+		device.bus_path = "pci-0000:00:1f.3-platform-skl_hda_dsp_generic"
+		sysfs.path = "/devices/pci0000:00/0000:00:1f.3/skl_hda_dsp_generic/sound/card0"
+		device.bus = "pci"
+		device.vendor.id = "8086"
+		device.vendor.name = "Intel Corporation"
+		device.product.id = "51ca"
+		device.string = "0"
+		module-udev-detect.discovered = "1"
+		device.icon_name = "audio-card-pci"
+	Formats:
+		pcm
+
+Source #2
+	State: SUSPENDED
+	Name: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_4__sink.monitor
+	Description: Monitor of sof-hda-dsp HDMI / DisplayPort 2 Output
+	Driver: module-alsa-card.c
+	Sample Specification: s16le 2ch 48000Hz
+	Channel Map: front-left,front-right
+	Owner Module: 22
+	Mute: no
+	Volume: front-left: 65536 / 100% / 0.00 dB,   front-right: 65536 / 100% / 0.00 dB
+	        balance 0.00
+	Base Volume: 65536 / 100% / 0.00 dB
+	Monitor of Sink: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_4__sink
+	Latency: 0 usec, configured 0 usec
+	Flags: DECIBEL_VOLUME LATENCY 
+	Properties:
+		device.description = "Monitor of sof-hda-dsp HDMI / DisplayPort 2 Output"
+		device.class = "monitor"
+		alsa.card = "0"
+		alsa.card_name = "sof-hda-dsp"
+		alsa.long_card_name = "DellInc.-Latitude3540--"
+		alsa.driver_name = "snd_soc_skl_hda_dsp"
+		device.bus_path = "pci-0000:00:1f.3-platform-skl_hda_dsp_generic"
+		sysfs.path = "/devices/pci0000:00/0000:00:1f.3/skl_hda_dsp_generic/sound/card0"
+		device.bus = "pci"
+		device.vendor.id = "8086"
+		device.vendor.name = "Intel Corporation"
+		device.product.id = "51ca"
+		device.string = "0"
+		module-udev-detect.discovered = "1"
+		device.icon_name = "audio-card-pci"
+	Formats:
+		pcm
+
+Source #3
+	State: SUSPENDED
+	Name: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_3__sink.monitor
+	Description: Monitor of sof-hda-dsp HDMI / DisplayPort 1 Output
+	Driver: module-alsa-card.c
+	Sample Specification: s16le 2ch 48000Hz
+	Channel Map: front-left,front-right
+	Owner Module: 22
+	Mute: no
+	Volume: front-left: 65536 / 100% / 0.00 dB,   front-right: 65536 / 100% / 0.00 dB
+	        balance 0.00
+	Base Volume: 65536 / 100% / 0.00 dB
+	Monitor of Sink: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_3__sink
+	Latency: 0 usec, configured 0 usec
+	Flags: DECIBEL_VOLUME LATENCY 
+	Properties:
+		device.description = "Monitor of sof-hda-dsp HDMI / DisplayPort 1 Output"
+		device.class = "monitor"
+		alsa.card = "0"
+		alsa.card_name = "sof-hda-dsp"
+		alsa.long_card_name = "DellInc.-Latitude3540--"
+		alsa.driver_name = "snd_soc_skl_hda_dsp"
+		device.bus_path = "pci-0000:00:1f.3-platform-skl_hda_dsp_generic"
+		sysfs.path = "/devices/pci0000:00/0000:00:1f.3/skl_hda_dsp_generic/sound/card0"
+		device.bus = "pci"
+		device.vendor.id = "8086"
+		device.vendor.name = "Intel Corporation"
+		device.product.id = "51ca"
+		device.string = "0"
+		module-udev-detect.discovered = "1"
+		device.icon_name = "audio-card-pci"
+	Formats:
+		pcm
+
+Source #4
+	State: RUNNING
+	Name: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink.monitor
+	Description: Monitor of sof-hda-dsp Speaker + Headphones
+	Driver: module-alsa-card.c
+	Sample Specification: s16le 2ch 48000Hz
+	Channel Map: front-left,front-right
+	Owner Module: 22
+	Mute: no
+	Volume: front-left: 65536 / 100% / 0.00 dB,   front-right: 65536 / 100% / 0.00 dB
+	        balance 0.00
+	Base Volume: 65536 / 100% / 0.00 dB
+	Monitor of Sink: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink
+	Latency: 0 usec, configured 40000 usec
+	Flags: DECIBEL_VOLUME LATENCY 
+	Properties:
+		device.description = "Monitor of sof-hda-dsp Speaker + Headphones"
+		device.class = "monitor"
+		alsa.card = "0"
+		alsa.card_name = "sof-hda-dsp"
+		alsa.long_card_name = "DellInc.-Latitude3540--"
+		alsa.driver_name = "snd_soc_skl_hda_dsp"
+		device.bus_path = "pci-0000:00:1f.3-platform-skl_hda_dsp_generic"
+		sysfs.path = "/devices/pci0000:00/0000:00:1f.3/skl_hda_dsp_generic/sound/card0"
+		device.bus = "pci"
+		device.vendor.id = "8086"
+		device.vendor.name = "Intel Corporation"
+		device.product.id = "51ca"
+		device.string = "0"
+		module-udev-detect.discovered = "1"
+		device.icon_name = "audio-card-pci"
+	Formats:
+		pcm
+
+Source #5
+	State: SUSPENDED
+	Name: alsa_input.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__source
+	Description: sof-hda-dsp Headset Mono Microphone + Headphones Stereo Microphone
+	Driver: module-alsa-card.c
+	Sample Specification: s16le 2ch 48000Hz
+	Channel Map: front-left,front-right
+	Owner Module: 22
+	Mute: no
+	Volume: front-left: 6553 /  10% / -60.00 dB,   front-right: 6553 /  10% / -60.00 dB
+	        balance 0.00
+	Base Volume: 6554 /  10% / -60.00 dB
+	Monitor of Sink: n/a
+	Latency: 0 usec, configured 0 usec
+	Flags: HARDWARE HW_MUTE_CTRL HW_VOLUME_CTRL DECIBEL_VOLUME LATENCY 
+	Properties:
+		alsa.resolution_bits = "16"
+		device.api = "alsa"
+		device.class = "sound"
+		alsa.class = "generic"
+		alsa.subclass = "generic-mix"
+		alsa.name = ""
+		alsa.id = "HDA Analog (*)"
+		alsa.subdevice = "0"
+		alsa.subdevice_name = "subdevice #0"
+		alsa.device = "0"
+		alsa.card = "0"
+		alsa.card_name = "sof-hda-dsp"
+		alsa.long_card_name = "DellInc.-Latitude3540--"
+		alsa.driver_name = "snd_soc_skl_hda_dsp"
+		device.bus_path = "pci-0000:00:1f.3-platform-skl_hda_dsp_generic"
+		sysfs.path = "/devices/pci0000:00/0000:00:1f.3/skl_hda_dsp_generic/sound/card0"
+		device.bus = "pci"
+		device.vendor.id = "8086"
+		device.vendor.name = "Intel Corporation"
+		device.product.id = "51ca"
+		device.string = "_ucm0001.hw:sofhdadsp"
+		device.buffering.buffer_size = "65536"
+		device.buffering.fragment_size = "16384"
+		device.access_mode = "mmap+timer"
+		device.profile.name = "HiFi: hw:sofhdadsp: source"
+		device.profile.description = "Headset Mono Microphone + Headphones Stereo Microphone"
+		alsa.mixer_device = "_ucm0001.hw:sofhdadsp"
+		device.description = "sof-hda-dsp Headset Mono Microphone + Headphones Stereo Microphone"
+		module-udev-detect.discovered = "1"
+		device.icon_name = "audio-card-pci"
+	Ports:
+		[In] Headset: Headset Mono Microphone (type: Headset, priority: 300, availability group: Headphone Mic, not available)
+		[In] Mic2: Headphones Stereo Microphone (type: Mic, priority: 200, availability group: Headphone Mic, not available)
+	Active Port: [In] Headset
+	Formats:
+		pcm
+
+Source #6
+	State: RUNNING
+	Name: alsa_input.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_6__source
+	Description: sof-hda-dsp Digital Microphone
+	Driver: module-alsa-card.c
+	Sample Specification: s16le 2ch 48000Hz
+	Channel Map: front-left,front-right
+	Owner Module: 22
+	Mute: yes
+	Volume: front-left: 20150 /  31% / -30.73 dB,   front-right: 20150 /  31% / -30.73 dB
+	        balance 0.00
+	Base Volume: 30419 /  46% / -20.00 dB
+	Monitor of Sink: n/a
+	Latency: 7580 usec, configured 40000 usec
+	Flags: HARDWARE HW_MUTE_CTRL HW_VOLUME_CTRL DECIBEL_VOLUME LATENCY 
+	Properties:
+		alsa.resolution_bits = "16"
+		device.api = "alsa"
+		device.class = "sound"
+		alsa.class = "generic"
+		alsa.subclass = "generic-mix"
+		alsa.name = ""
+		alsa.id = "DMIC (*)"
+		alsa.subdevice = "0"
+		alsa.subdevice_name = "subdevice #0"
+		alsa.device = "6"
+		alsa.card = "0"
+		alsa.card_name = "sof-hda-dsp"
+		alsa.long_card_name = "DellInc.-Latitude3540--"
+		alsa.driver_name = "snd_soc_skl_hda_dsp"
+		device.bus_path = "pci-0000:00:1f.3-platform-skl_hda_dsp_generic"
+		sysfs.path = "/devices/pci0000:00/0000:00:1f.3/skl_hda_dsp_generic/sound/card0"
+		device.bus = "pci"
+		device.vendor.id = "8086"
+		device.vendor.name = "Intel Corporation"
+		device.product.id = "51ca"
+		device.string = "_ucm0001.hw:sofhdadsp,6"
+		device.buffering.buffer_size = "65536"
+		device.buffering.fragment_size = "16384"
+		device.access_mode = "mmap+timer"
+		device.profile.name = "HiFi: hw:sofhdadsp,6: source"
+		device.profile.description = "Digital Microphone"
+		alsa.mixer_device = "_ucm0001.hw:sofhdadsp"
+		device.description = "sof-hda-dsp Digital Microphone"
+		module-udev-detect.discovered = "1"
+		device.icon_name = "audio-card-pci"
+	Ports:
+		[In] Mic1: Digital Microphone (type: Mic, priority: 100, availability unknown)
+	Active Port: [In] Mic1
+	Formats:
+		pcm
+
+Source Output #4
+	Driver: protocol-native.c
+	Owner Module: 10
+	Client: 14
+	Source: 4
+	Sample Specification: float32le 1ch 25Hz
+	Channel Map: mono
+	Format: pcm, format.sample_format = "\"float32le\""  format.rate = "25"  format.channels = "1"  format.channel_map = "\"mono\""
+	Corked: no
+	Mute: no
+	Volume: mono: 65536 / 100% / 0.00 dB
+	        balance 0.00
+	Buffer Latency: 43666 usec
+	Source Latency: 0 usec
+	Resample method: peaks
+	Properties:
+		application.id = "org.gnome.VolumeControl"
+		media.name = "Peak detect"
+		application.name = "GNOME Settings"
+		native-protocol.peer = "UNIX socket client"
+		native-protocol.version = "35"
+		application.icon_name = "multimedia-volume-control"
+		application.version = "41.7"
+		application.process.id = "6527"
+		application.process.user = "ubuntu"
+		application.process.host = "ubuntu"
+		application.process.binary = "gnome-control-center"
+		application.language = "en_US.UTF-8"
+		window.x11.display = ":0"
+		application.process.machine_id = "59226316abceac801182b32863b78aab"
+		module-stream-restore.id = "source-output-by-application-id:org.gnome.VolumeControl"
+
+Source Output #5
+	Driver: protocol-native.c
+	Owner Module: 10
+	Client: 14
+	Source: 6
+	Sample Specification: float32le 1ch 25Hz
+	Channel Map: mono
+	Format: pcm, format.sample_format = "\"float32le\""  format.rate = "25"  format.channels = "1"  format.channel_map = "\"mono\""
+	Corked: no
+	Mute: no
+	Volume: mono: 65536 / 100% / 0.00 dB
+	        balance 0.00
+	Buffer Latency: 8833 usec
+	Source Latency: 8085 usec
+	Resample method: peaks
+	Properties:
+		application.id = "org.gnome.VolumeControl"
+		media.name = "Peak detect"
+		application.name = "GNOME Settings"
+		native-protocol.peer = "UNIX socket client"
+		native-protocol.version = "35"
+		application.icon_name = "multimedia-volume-control"
+		application.version = "41.7"
+		application.process.id = "6527"
+		application.process.user = "ubuntu"
+		application.process.host = "ubuntu"
+		application.process.binary = "gnome-control-center"
+		application.language = "en_US.UTF-8"
+		window.x11.display = ":0"
+		application.process.machine_id = "59226316abceac801182b32863b78aab"
+		module-stream-restore.id = "source-output-by-application-id:org.gnome.VolumeControl"
+
+Client #0
+	Driver: module-systemd-login.c
+	Owner Module: 16
+	Properties:
+		application.name = "Login Session 1"
+		systemd-login.session = "1"
+
+Client #1
+	Driver: protocol-native.c
+	Owner Module: 10
+	Properties:
+		application.name = "GNOME Shell Volume Control"
+		native-protocol.peer = "UNIX socket client"
+		native-protocol.version = "35"
+		application.id = "org.gnome.VolumeControl"
+		application.icon_name = "multimedia-volume-control"
+		application.version = "42.5"
+		application.process.id = "1729"
+		application.process.user = "ubuntu"
+		application.process.host = "ubuntu"
+		application.process.binary = "gnome-shell"
+		application.language = "en_US.UTF-8"
+		window.x11.display = ":0"
+		application.process.machine_id = "59226316abceac801182b32863b78aab"
+
+Client #2
+	Driver: protocol-native.c
+	Owner Module: 10
+	Properties:
+		application.name = "GNOME Volume Control Media Keys"
+		native-protocol.peer = "UNIX socket client"
+		native-protocol.version = "35"
+		application.id = "org.gnome.VolumeControl"
+		application.icon_name = "multimedia-volume-control"
+		application.version = ""
+		application.process.id = "1929"
+		application.process.user = "ubuntu"
+		application.process.host = "ubuntu"
+		application.process.binary = "gsd-media-keys"
+		application.language = "en_US.UTF-8"
+		window.x11.display = ":0"
+		application.process.machine_id = "59226316abceac801182b32863b78aab"
+
+Client #3
+	Driver: protocol-native.c
+	Owner Module: 10
+	Properties:
+		application.name = "Terminal"
+		native-protocol.peer = "UNIX socket client"
+		native-protocol.version = "35"
+		application.icon_name = "org.gnome.Terminal"
+		window.x11.display = ":0"
+		window.x11.screen = "0"
+		application.process.id = "2084"
+		application.process.user = "ubuntu"
+		application.process.host = "ubuntu"
+		application.process.binary = "gnome-terminal-server"
+		application.language = "en_US.UTF-8"
+		application.process.machine_id = "59226316abceac801182b32863b78aab"
+
+Client #4
+	Driver: protocol-native.c
+	Owner Module: 10
+	Properties:
+		application.name = "org.gnome.Nautilus"
+		native-protocol.peer = "UNIX socket client"
+		native-protocol.version = "35"
+		application.icon_name = "org.gnome.Nautilus"
+		window.x11.display = ":0"
+		window.x11.screen = "0"
+		application.process.id = "2468"
+		application.process.user = "ubuntu"
+		application.process.host = "ubuntu"
+		application.process.binary = "nautilus"
+		application.language = "en_US.UTF-8"
+		application.process.machine_id = "59226316abceac801182b32863b78aab"
+
+Client #5
+	Driver: protocol-native.c
+	Owner Module: 10
+	Properties:
+		application.name = "Mutter"
+		native-protocol.peer = "UNIX socket client"
+		native-protocol.version = "35"
+		application.process.id = "1729"
+		application.process.user = "ubuntu"
+		application.process.host = "ubuntu"
+		application.process.binary = "gnome-shell"
+		application.language = "en_US.UTF-8"
+		window.x11.display = ":0"
+		application.process.machine_id = "59226316abceac801182b32863b78aab"
+
+Client #7
+	Driver: protocol-native.c
+	Owner Module: 10
+	Properties:
+		application.name = "apport-gtk"
+		native-protocol.peer = "UNIX socket client"
+		native-protocol.version = "35"
+		application.icon_name = "apport"
+		window.x11.display = ":0"
+		window.x11.screen = "0"
+		application.process.id = "6239"
+		application.process.user = "ubuntu"
+		application.process.host = "ubuntu"
+		application.process.binary = "python3.10"
+		application.language = "en_US.UTF-8"
+		application.process.machine_id = "59226316abceac801182b32863b78aab"
+
+Client #14
+	Driver: protocol-native.c
+	Owner Module: 10
+	Properties:
+		application.name = "GNOME Settings"
+		native-protocol.peer = "UNIX socket client"
+		native-protocol.version = "35"
+		application.id = "org.gnome.VolumeControl"
+		application.icon_name = "multimedia-volume-control"
+		application.version = "41.7"
+		application.process.id = "6527"
+		application.process.user = "ubuntu"
+		application.process.host = "ubuntu"
+		application.process.binary = "gnome-control-center"
+		application.language = "en_US.UTF-8"
+		window.x11.display = ":0"
+		application.process.machine_id = "59226316abceac801182b32863b78aab"
+
+Client #15
+	Driver: protocol-native.c
+	Owner Module: 10
+	Properties:
+		application.name = "Settings"
+		native-protocol.peer = "UNIX socket client"
+		native-protocol.version = "35"
+		window.x11.display = ":0"
+		window.x11.screen = "0"
+		application.process.id = "6527"
+		application.process.user = "ubuntu"
+		application.process.host = "ubuntu"
+		application.process.binary = "gnome-control-center"
+		application.language = "en_US.UTF-8"
+		application.process.machine_id = "59226316abceac801182b32863b78aab"
+		application.icon_name = "org.gnome.Settings"
+
+Client #19
+	Driver: protocol-native.c
+	Owner Module: 10
+	Properties:
+		application.name = "pactl"
+		native-protocol.peer = "UNIX socket client"
+		native-protocol.version = "35"
+		application.process.id = "6881"
+		application.process.user = "ubuntu"
+		application.process.host = "ubuntu"
+		application.process.binary = "pactl"
+		application.language = "en_US.UTF-8"
+		window.x11.display = ":0"
+		application.process.machine_id = "59226316abceac801182b32863b78aab"
+
+Sample #0
+	Name: bell-window-system
+	Sample Specification: s16le 2ch 44100Hz
+	Channel Map: front-left,front-right
+	Volume: (invalid)
+	        balance 0.00
+	Duration: 0.3s
+	Size: 49.9 KiB
+	Lazy: no
+	Filename: n/a
+	Properties:
+		media.role = "event"
+		event.description = "Bell event"
+		event.id = "bell-window-system"
+		media.name = "bell-window-system"
+		media.filename = "/usr/share//sounds/Yaru/stereo/bell.oga"
+		application.name = "Mutter"
+		native-protocol.peer = "UNIX socket client"
+		native-protocol.version = "35"
+		application.process.id = "1729"
+		application.process.user = "ubuntu"
+		application.process.host = "ubuntu"
+		application.process.binary = "gnome-shell"
+		application.language = "en_US.UTF-8"
+		window.x11.display = ":0"
+		application.process.machine_id = "59226316abceac801182b32863b78aab"
+
+Card #0
+	Name: alsa_card.pci-0000_00_1f.3-platform-skl_hda_dsp_generic
+	Driver: module-alsa-card.c
+	Owner Module: 22
+	Properties:
+		alsa.card = "0"
+		alsa.card_name = "sof-hda-dsp"
+		alsa.long_card_name = "DellInc.-Latitude3540--"
+		alsa.driver_name = "snd_soc_skl_hda_dsp"
+		device.bus_path = "pci-0000:00:1f.3-platform-skl_hda_dsp_generic"
+		sysfs.path = "/devices/pci0000:00/0000:00:1f.3/skl_hda_dsp_generic/sound/card0"
+		device.bus = "pci"
+		device.vendor.id = "8086"
+		device.vendor.name = "Intel Corporation"
+		device.product.id = "51ca"
+		device.string = "0"
+		device.description = "sof-hda-dsp"
+		module-udev-detect.discovered = "1"
+		device.icon_name = "audio-card-pci"
+	Profiles:
+		HiFi: Play HiFi quality Music (sinks: 4, sources: 2, priority: 40768, available: yes)
+		off: Off (sinks: 0, sources: 0, priority: 0, available: yes)
+	Active Profile: HiFi
+	Ports:
+		[Out] HDMI3: HDMI / DisplayPort 3 Output (type: HDMI, priority: 700, latency offset: 0 usec, not available)
+			Part of profile(s): HiFi
+		[Out] HDMI2: HDMI / DisplayPort 2 Output (type: HDMI, priority: 600, latency offset: 0 usec, not available)
+			Part of profile(s): HiFi
+		[Out] HDMI1: HDMI / DisplayPort 1 Output (type: HDMI, priority: 500, latency offset: 0 usec, not available)
+			Part of profile(s): HiFi
+		[Out] Speaker: Speaker (type: Speaker, priority: 100, latency offset: 0 usec, availability unknown)
+			Part of profile(s): HiFi
+		[Out] Headphones: Headphones (type: Headphones, priority: 200, availability group: Headphone Mic, not available)
+			Part of profile(s): HiFi
+		[In] Headset: Headset Mono Microphone (type: Headset, priority: 300, latency offset: 0 usec, availability group: Headphone Mic, not available)
+			Part of profile(s): HiFi
+		[In] Mic2: Headphones Stereo Microphone (type: Mic, priority: 200, latency offset: 0 usec, availability group: Headphone Mic, not available)
+			Part of profile(s): HiFi
+		[In] Mic1: Digital Microphone (type: Mic, priority: 100, latency offset: 0 usec, availability unknown)
+			Part of profile(s): HiFi

--- a/checkbox-support/checkbox_support/parsers/tests/pactl_data/sinks-desktop-jammy-latitude3540.txt
+++ b/checkbox-support/checkbox_support/parsers/tests/pactl_data/sinks-desktop-jammy-latitude3540.txt
@@ -1,0 +1,52 @@
+Sink #4
+	State: IDLE
+	Name: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink
+	Description: sof-hda-dsp Speaker + Headphones
+	Driver: module-alsa-card.c
+	Sample Specification: s16le 2ch 48000Hz
+	Channel Map: front-left,front-right
+	Owner Module: 22
+	Mute: no
+	Volume: front-left: 32099 /  49% / -18.60 dB,   front-right: 32099 /  49% / -18.60 dB
+	        balance 0.00
+	Base Volume: 65536 / 100% / 0.00 dB
+	Monitor Source: alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink.monitor
+	Latency: 39920 usec, configured 40000 usec
+	Flags: HARDWARE HW_MUTE_CTRL HW_VOLUME_CTRL DECIBEL_VOLUME LATENCY 
+	Properties:
+		alsa.resolution_bits = "16"
+		device.api = "alsa"
+		device.class = "sound"
+		alsa.class = "generic"
+		alsa.subclass = "generic-mix"
+		alsa.name = ""
+		alsa.id = "HDA Analog (*)"
+		alsa.subdevice = "0"
+		alsa.subdevice_name = "subdevice #0"
+		alsa.device = "0"
+		alsa.card = "0"
+		alsa.card_name = "sof-hda-dsp"
+		alsa.long_card_name = "DellInc.-Latitude3540--"
+		alsa.driver_name = "snd_soc_skl_hda_dsp"
+		device.bus_path = "pci-0000:00:1f.3-platform-skl_hda_dsp_generic"
+		sysfs.path = "/devices/pci0000:00/0000:00:1f.3/skl_hda_dsp_generic/sound/card0"
+		device.bus = "pci"
+		device.vendor.id = "8086"
+		device.vendor.name = "Intel Corporation"
+		device.product.id = "51ca"
+		device.string = "_ucm0001.hw:sofhdadsp"
+		device.buffering.buffer_size = "65536"
+		device.buffering.fragment_size = "16384"
+		device.access_mode = "mmap+timer"
+		device.profile.name = "HiFi: hw:sofhdadsp: sink"
+		device.profile.description = "Speaker + Headphones"
+		alsa.mixer_device = "_ucm0001.hw:sofhdadsp"
+		device.description = "sof-hda-dsp Speaker + Headphones"
+		module-udev-detect.discovered = "1"
+		device.icon_name = "audio-card-pci"
+	Ports:
+		[Out] Speaker: Speaker (type: Speaker, priority: 100, availability group: Headphone Mic, availability unknown)
+		[Out] Headphones: Headphones (type: Headphones, priority: 200, availability group: Headphone Mic, not available)
+	Active Port: [Out] Speaker
+	Formats:
+		pcm


### PR DESCRIPTION
## Description

Describe your changes here:

- For some Dell's platform, they have the "availbility group" in the the port attribute, which cannot be parsed by the pactl. It seems by now no one had used it, so just suppress it in the pactl. 
- Add some unit tests for the modification and correct some unit test issues.

## Resolved issues

Fix: #278 microphone/headphone detect encounter ParseException
