### PR TITLE
Support the insertion and removal of thunderbolt storage in run_watcher script

### DIFF
--- a/providers/base/units/thunderbolt/jobs.pxu
+++ b/providers/base/units/thunderbolt/jobs.pxu
@@ -1,10 +1,17 @@
 plugin: user-interact
 category_id: com.canonical.plainbox::disk
 id: thunderbolt/insert
+user: root
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt == 'True'
 estimated_duration: 20.0
-command: removable_storage_watcher.py insert --timeout 40 scsi
+template-engine: jinja2
+command:
+    {%- if __on_ubuntucore__ %}
+        checkbox-support-run_watcher insertion thunderbolt
+    {%- else %}
+        removable_storage_watcher.py insert --timeout 40 scsi
+    {% endif -%}
 _siblings: [
     { "id": "after-suspend-thunderbolt/insert",
       "_summary": "thunderbolt/insert after suspend",
@@ -45,11 +52,18 @@ _description:
 plugin: user-interact
 category_id: com.canonical.plainbox::disk
 id: thunderbolt/remove
+user: root
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt == 'True'
 depends: thunderbolt/insert
 estimated_duration: 10.0
-command: removable_storage_watcher.py remove scsi
+template-engine: jinja2
+command:
+    {%- if __on_ubuntucore__ %}
+        checkbox-support-run_watcher insertion thunderbolt
+    {%- else %}
+        removable_storage_watcher.py remove scsi
+    {% endif -%}
 _summary: Storage removal detection on Thunderbolt
 _siblings: [
     { "id": "after-suspend-thunderbolt/remove",
@@ -93,10 +107,17 @@ _description:
 plugin: user-interact
 category_id: com.canonical.plainbox::disk
 id: thunderbolt3/insert
+user: root
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 estimated_duration: 20.0
-command: removable_storage_watcher.py insert --timeout 40 scsi
+template-engine: jinja2
+command:
+    {%- if __on_ubuntucore__ %}
+        checkbox-support-run_watcher insertion thunderbolt
+    {%- else %}
+        removable_storage_watcher.py insert --timeout 40 scsi
+    {% endif -%}
 _siblings: [
     { "id": "after-suspend-thunderbolt3/insert",
       "_summary": "thunderbolt3/insert after suspend",
@@ -151,11 +172,18 @@ _description:
 plugin: user-interact
 category_id: com.canonical.plainbox::disk
 id: thunderbolt3/remove
+user: root
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 depends: thunderbolt3/insert
 estimated_duration: 10.0
-command: removable_storage_watcher.py remove scsi
+template-engine: jinja2
+command:
+    {%- if __on_ubuntucore__ %}
+        checkbox-support-run_watcher removal thunderbolt
+    {%- else %}
+        removable_storage_watcher.py remove scsi
+    {% endif -%}
 _siblings: [
     { "id": "after-suspend-thunderbolt3/remove",
       "_summary": "thunderbolt3/remove after suspend",


### PR DESCRIPTION
## Description

Modify: Refactor run_watcher and add TBT detection

On Core image, there's no UDisks D-Bus interface, and the origianl
thunderbolt storage script, removable_storage_watcher.py, is not
suitable. Therefore, I add the detection logic of Thunderbolt
storage.

I also refactor the run_watcher.py script.
- The StorageWatcher class is responsible for getting and dispatching
  the journal message line by line to the candidate storage only. No
  any detection logic in this class anymore.
- The StorageInterface defines the methods that each type of storage
  should strictly follow. In this way, developer will have clear idea
  what functions are mandatory for developing new type of storage
  class.
- Separate the logic of USB and Mediacard to two independent storage
  classes but keep their original judgement.

## Resolved issues

#288 

## Documentation

- [x] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [x] A list of what tests were run and on what platform/configuration is provided.
  - [Result on Core22 image (Insertion and removal)](https://certification.canonical.com/hardware/202109-29435/submission/297948/test-results/pass/)