### PR TITLE
Adding additional support for Sapphire Rapids cpu's 0x806f8

### DIFF
--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -128,7 +128,7 @@ CPUIDS = {
         "Penryn":           ['0x1067a'],
         "Rocket Lake":      ['0xa0671'],
         "Sandy Bridge":     ['0x206a', '0x206d6', '0x206d7'],
-        "Sapphire Rapids":  ['0x806f3'],
+        "Sapphire Rapids":  ['0x806f3', '0x806f8'],
         "Skylake":          ['0x406e3', '0x506e3', '0x50654', '0x50652'],
         "Tiger Lake":       ['0x806c1'],
         "Westmere":         ['0x2065', '0x206c', '0x206f'],


### PR DESCRIPTION
## Description

I observed an additional CPUID  (0x806f8) for Sapphire Rapids in recent test results and I am adding it to the cpuid.py script. 

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.

## Resolved issues

I observed an additional CPUID  (0x806f8) for Sapphire Rapids in recent test results and I am adding it to the cpuid.py script. 
Jira Issue resolved by the PR (https://warthogs.atlassian.net/jira/software/c/projects/SERVCERT/boards/865?modal=detail&selectedIssue=SERVCERT-732)


## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [ ] A list of what tests were run and on what platform/configuration is provided.
