### PR TITLE
Fix Morris Doctest (compliance with python3.11)

### DIFF
--- a/checkbox-ng/plainbox/vendor/morris/__init__.py
+++ b/checkbox-ng/plainbox/vendor/morris/__init__.py
@@ -218,7 +218,7 @@ Here's a simple example using all of the above:
     >>> suite = unittest.TestLoader().loadTestsFromTestCase(AppTests)
     >>> runner = unittest.TextTestRunner(stream=sys.stdout, verbosity=2)
     >>> runner.run(suite)  # doctest: +ELLIPSIS
-    test_login (plainbox.vendor.morris.AppTests) ... ok
+    test_login (plainbox.vendor.morris.AppTests... ok
     <BLANKLINE>
     ----------------------------------------------------------------------
     Ran 1 test in ...s


### PR DESCRIPTION
## Description

checkbox-ng FTBFS (See https://code.launchpad.net/~checkbox-dev/+archive/ubuntu/ppa/+build/25514194)

This patch fixes the expected output using a larger doctest.ELLIPSIS match

## Resolved issues

```
======================================================================
FAIL: morris (plainbox.vendor)
Doctest: plainbox.vendor.morris
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.11/doctest.py", line 2221, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for plainbox.vendor.morris
  File "/<<PKGBUILDDIR>>/checkbox-ng/plainbox/vendor/morris/__init__.py", line 17, in morris

----------------------------------------------------------------------
File "/<<PKGBUILDDIR>>/checkbox-ng/plainbox/vendor/morris/__init__.py", line 220, in plainbox.vendor.morris
Failed example:
    runner.run(suite)  # doctest: +ELLIPSIS
Expected:
    test_login (plainbox.vendor.morris.AppTests) ... ok
    <BLANKLINE>
    ----------------------------------------------------------------------
    Ran 1 test in ...s
    <BLANKLINE>
    OK
    <unittest.runner.TextTestResult run=1 errors=0 failures=0>
Got:
    test_login (plainbox.vendor.morris.AppTests.test_login) ... ok
    <BLANKLINE>
    ----------------------------------------------------------------------
    Ran 1 test in 0.000s
    <BLANKLINE>
    OK
    <unittest.runner.TextTestResult run=1 errors=0 failures=0>
```

## Tests
Tested in a container w/ python3.11 (`setup.py test`)
