### PR TITLE
Remove: mediacard/sd-preinserted-server

### DIFF
--- a/providers/base/units/mediacard/jobs.pxu
+++ b/providers/base/units/mediacard/jobs.pxu
@@ -156,20 +156,6 @@ _description:
  system under test has a memory card device plugged in prior to checkbox execution.
  It is intended for SRU automated testing.
 
-plugin: shell
-category_id: com.canonical.plainbox::mediacard
-id: mediacard/sd-preinserted-server
-estimated_duration: 30.0
-user: root
-flags: preserve-cwd
-command: removable_storage_test.py -s 268400000 --memorycard -l sdio usb && removable_storage_test.py --memorycard sdio usb
-requires:
- package.name == 'udisks2' or snap.name == 'udisks2'
-_summary: Automated test of SD Card reading & writing (udisk2) for servers
-_description:
- This is a fully automated version of mediacard/sd-automated and assumes that the
- system under test has a memory card device plugged in prior to checkbox execution.
-
 plugin: user-interact
 template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard


### PR DESCRIPTION
## Description

Describe your changes here:

Removed mediacard/sd-preinserted-server, which it turns out is not a useful test for servers

## Resolved issues

https://warthogs.atlassian.net/browse/SERVCERT-84

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [ ] A list of what tests were run and on what platform/configuration is provided.
