### PR TITLE
Remove apste_support_on_.* from Server Certification disk tests

### DIFF
--- a/providers/base/units/disk/test-plan.pxu
+++ b/providers/base/units/disk/test-plan.pxu
@@ -17,7 +17,7 @@ include:
     disk/storage_device_.*                     certification-status=blocker
     benchmarks/disk/hdparm-read_.*
     benchmarks/disk/hdparm-cache-read_.*
-    disk/apste_support_on_.*
+    disk/apste_support_on.*
 
 id: disk-cert-blockers
 unit: test plan
@@ -67,4 +67,3 @@ include:
     disk/fstrim_.*                             certification-status=non-blocker
     disk/disk_stress_ng_.*                     certification-status=blocker
     disk/disk_cpu_load_.*                      certification-status=blocker
-    disk/apste_support_on_.*                   certification-status=non-blocker


### PR DESCRIPTION
## Description

Describe your changes here:

Removed apste_support_on_.* from Server Certification disk tests

## Resolved issues

https://warthogs.atlassian.net/browse/SERVCERT-455

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [ ] A list of what tests were run and on what platform/configuration is provided.
