### PR TITLE
Fix: starting with snapd 2.59, systemctl calls all turn into no-ops for devmode snaps

### DIFF
--- a/checkbox-ng/plainbox/impl/session/restart.py
+++ b/checkbox-ng/plainbox/impl/session/restart.py
@@ -277,8 +277,11 @@ def detect_restart_strategy(session=None, session_type=None) -> IRestartStrategy
     # or roughly after April of 2022
     if session_type in ('remote', 'checkbox-slave'):
         try:
+            env = os.environ
+            env["SYSTEMD_IGNORE_CHROOT"] = "1"
             subprocess.run(
                 ['systemctl', 'is-active', '--quiet', 'checkbox-ng.service'],
+                env=env,  # http://pad.lv/2003955
                 check=True)
             return RemoteDebRestartStrategy()
         except subprocess.CalledProcessError:


### PR DESCRIPTION
## Description

Setting SYSTEMD_IGNORE_CHROOT=1 helps to select the correct restart strategy.

Ref: https://systemd.io/ENVIRONMENT/

## Resolved issues

Workaround for https://bugs.launchpad.net/snapd/+bug/2003955 

## Tests
Tested using core20 (multipass) / systemd 245 (245.4-4ubuntu3.19) and snapd 2.58.1+git422.g0766efa (18362)

```
$ sudo snap run --shell hello
root@upbeat-kinkajou:/home/ubuntu# 
root@upbeat-kinkajou:/home/ubuntu# systemctl is-active checkbox-ng.service
Running in chroot, ignoring request: is-active
root@upbeat-kinkajou:/home/ubuntu# SYSTEMD_IGNORE_CHROOT=1 systemctl is-active checkbox-ng.service
inactive
root@upbeat-kinkajou:/home/ubuntu# 
```
