### PR TITLE
Remove IPDT tests from certification test plans

### DIFF
--- a/providers/certification-client/units/client-cert-iot-ubuntucore-16.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-16.pxu
@@ -104,7 +104,6 @@ bootstrap_include:
 nested_part:
   submission-cert-automated
   self-automated
-  com.intel.ipdt::ipdt-plan
   iot-fwts-automated
   audio-automated
   bluez-automated

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-18.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-18.pxu
@@ -106,7 +106,6 @@ bootstrap_include:
 nested_part:
   submission-cert-automated
   self-automated
-  com.intel.ipdt::ipdt-plan
   iot-fwts-automated
   audio-automated
   bluez-automated

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-20.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-20.pxu
@@ -108,7 +108,6 @@ nested_part:
   submission-cert-automated
   self-automated
   ubuntucore-automated
-  com.intel.ipdt::ipdt-plan
   iot-fwts-automated
   audio-automated
   bluez-automated

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu
@@ -108,7 +108,6 @@ nested_part:
   submission-cert-automated
   self-automated
   ubuntucore-automated
-  com.intel.ipdt::ipdt-plan
   iot-fwts-automated
   audio-automated
   bluez-automated

--- a/providers/certification-client/units/client-cert-odm-server-18-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-server-18-04.pxu
@@ -45,7 +45,6 @@ nested_part:
     after-suspend-ethernet-manual
     after-suspend-wwan-manual
 exclude:
-    com.intel.ipdt::ipdt/PCH-.*
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
     mediacard/cf-.*
@@ -96,7 +95,6 @@ nested_part:
     usb3-automated
     watchdog-automated
     wwan-automated
-    com.intel.ipdt::ipdt-plan
     cpu-automated
     disk-automated
     ethernet-automated
@@ -115,7 +113,6 @@ nested_part:
     warm-boot-stress-test
     cold-boot-stress-test
 exclude:
-    com.intel.ipdt::ipdt/PCH-.*
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
     mediacard/cf-.*

--- a/providers/certification-client/units/client-cert-odm-server-20-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-server-20-04.pxu
@@ -46,7 +46,6 @@ nested_part:
     after-suspend-ethernet-manual
     after-suspend-wwan-manual
 exclude:
-    com.intel.ipdt::ipdt/PCH-.*
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
     mediacard/cf-.*
@@ -99,7 +98,6 @@ nested_part:
     usb-dwc3-automated
     watchdog-automated
     wwan-automated
-    com.intel.ipdt::ipdt-plan
     cpu-automated
     disk-automated
     ethernet-automated
@@ -118,7 +116,6 @@ nested_part:
     warm-boot-stress-test
     cold-boot-stress-test
 exclude:
-    com.intel.ipdt::ipdt/PCH-.*
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
     mediacard/cf-.*

--- a/providers/certification-client/units/client-cert-odm-server-22-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-server-22-04.pxu
@@ -49,7 +49,6 @@ nested_part:
     after-suspend-wwan-manual
     after-suspend-thunderbolt-cert-manual
 exclude:
-    com.intel.ipdt::ipdt/PCH-.*
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
     mediacard/cf-.*
@@ -101,7 +100,6 @@ nested_part:
     thunderbolt-cert-automated
     watchdog-automated
     wwan-automated
-    com.intel.ipdt::ipdt-plan
     cpu-automated
     disk-automated
     ethernet-automated
@@ -121,7 +119,6 @@ nested_part:
     warm-boot-stress-test
     cold-boot-stress-test
 exclude:
-    com.intel.ipdt::ipdt/PCH-.*
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
     mediacard/cf-.*

--- a/providers/certification-client/units/client-cert-odm-ubuntucore-18.pxu
+++ b/providers/certification-client/units/client-cert-odm-ubuntucore-18.pxu
@@ -47,7 +47,6 @@ nested_part:
     after-suspend-wwan-manual
     after-suspend-thunderbolt-cert-manual 
 exclude:
-    com.intel.ipdt::ipdt/PCH-.*
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
     mediacard/cf-.*
@@ -97,7 +96,6 @@ nested_part:
     thunderbolt-cert-automated
     watchdog-automated
     wwan-automated
-    com.intel.ipdt::ipdt-plan
     cpu-automated
     disk-automated
     ethernet-automated
@@ -117,7 +115,6 @@ nested_part:
     warm-boot-stress-test
     cold-boot-stress-test
 exclude:
-    com.intel.ipdt::ipdt/PCH-.*
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
     mediacard/cf-.*

--- a/providers/certification-client/units/client-cert-odm-ubuntucore-20.pxu
+++ b/providers/certification-client/units/client-cert-odm-ubuntucore-20.pxu
@@ -48,7 +48,6 @@ nested_part:
     after-suspend-wwan-manual
     after-suspend-thunderbolt-cert-manual
 exclude:
-    com.intel.ipdt::ipdt/PCH-.*
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
     mediacard/cf-.*
@@ -99,7 +98,6 @@ nested_part:
     thunderbolt-cert-automated
     watchdog-automated
     wwan-automated
-    com.intel.ipdt::ipdt-plan
     cpu-automated
     disk-automated
     ethernet-automated
@@ -119,7 +117,6 @@ nested_part:
     warm-boot-stress-test
     cold-boot-stress-test
 exclude:
-    com.intel.ipdt::ipdt/PCH-.*
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
     mediacard/cf-.*

--- a/providers/certification-client/units/client-cert-odm-ubuntucore-22.pxu
+++ b/providers/certification-client/units/client-cert-odm-ubuntucore-22.pxu
@@ -49,7 +49,6 @@ nested_part:
     after-suspend-wwan-manual
     after-suspend-thunderbolt-cert-manual
 exclude:
-    com.intel.ipdt::ipdt/PCH-.*
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
     mediacard/cf-.*
@@ -100,7 +99,6 @@ nested_part:
     thunderbolt-cert-automated
     watchdog-automated
     wwan-automated
-    com.intel.ipdt::ipdt-plan
     cpu-automated
     disk-automated
     ethernet-automated
@@ -122,7 +120,6 @@ nested_part:
     warm-boot-stress-test
     cold-boot-stress-test
 exclude:
-    com.intel.ipdt::ipdt/PCH-.*
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
     mediacard/cf-.*


### PR DESCRIPTION
## Description

IPDT is no longer maintained for [linux](https://community.intel.com/t5/Processors/Intel-IPDT-for-Linux-platform/td-p/582166).
Several tests integrated in UC certification test plans always fail, blocking automatic cert-testing completion / sign-off.
This PR removes all ipdt nested parts from certification test plans

## Resolved issues
Fixes: https://github.com/canonical/checkbox/issues/317

