### PR TITLE
Fix the acpica FTBFS error by switching to the source-commit with the upstream patch

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -114,7 +114,7 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/snapcraft-snaps.git/tree/acpica/snapcraft.yaml
   acpi-tools:
-    source-tag: "R03_31_22"
+    source-tag: "R10_20_22"
     source-depth: 1
     plugin: make
     source: https://github.com/acpica/acpica.git

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -123,7 +123,7 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/snapcraft-snaps.git/tree/acpica/snapcraft.yaml
   acpi-tools:
-    source-tag: "R03_31_22"
+    source-tag: "R10_20_22"
     source-depth: 1
     plugin: make
     source: https://github.com/acpica/acpica.git

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -125,7 +125,7 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/snapcraft-snaps.git/tree/acpica/snapcraft.yaml
   acpi-tools:
-    source-tag: "R03_31_22"
+    source-tag: "R10_20_22"
     source-depth: 1
     plugin: make
     source: https://github.com/acpica/acpica.git

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -125,7 +125,7 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/snapcraft-snaps.git/tree/acpica/snapcraft.yaml
   acpi-tools:
-    source-tag: "R03_31_22"
+    source-tag: "R10_20_22"
     source-depth: 1
     plugin: make
     source: https://github.com/acpica/acpica.git


### PR DESCRIPTION
## Description

checkbox core snap is currently failing to build because of the `acpi-tools` part:

```
In file included from ../../../source/include/actbl.h:549,
                 from ../../../source/include/acpi.h:169,
                 from ../../../source/tools/acpiexec/aecommon.h:159,
                 from ../../../source/tools/acpiexec/aeexception.c:152:
../../../source/include/actbl2.h:1553:29: error: flexible array member in a struct with no named members
 1553 |     UINT8                   OemData[];
      |                             ^~~~~~~
make[1]: *** [../Makefile.rules:20: obj/acfileio.o] Error 1
make[1]: *** [../Makefile.rules:20: obj/aeexec.o] Error 1
make[1]: *** [../Makefile.rules:20: obj/aeexception.o] Error 1
make[1]: Leaving directory '/build/checkbox22/parts/acpi-tools/build/generate/unix/acpiexec'
make: *** [generate/unix/Makefile.common:7: acpiexec] Error 2
Failed to build 'acpi-tools'.
```
This PR bump the stable tag to R10_20_22


