### PR TITLE
Stop listing removable partitions if they contain the OS 

### DIFF
--- a/checkbox-support/checkbox_support/parsers/udevadm.py
+++ b/checkbox-support/checkbox_support/parsers/udevadm.py
@@ -96,7 +96,7 @@ FLASH_RE = re.compile(r"Flash", re.I)
 FLASH_DISK_RE = re.compile(r"Mass|Storage|Disk", re.I)
 MD_DEVICE_RE = re.compile(r"MD_DEVICE_\w+_DEV")
 ROOT_MOUNTPOINT = re.compile(
-    r'MOUNTPOINT=.*/(writable|hostfs|ubuntu-seed|ubuntu-boot)')
+    r'MOUNTPOINT=.*/(writable|hostfs|ubuntu-seed|ubuntu-boot|boot)')
 
 
 def slugify(_string):
@@ -530,6 +530,8 @@ class UdevadmDevice(object):
             if self._list_partitions and devtype == "partition":
                 if self._stack:
                     parent = self._stack[-1]
+                    if find_pkname_is_root_mountpoint(self.name, self._lsblk):
+                        return
                     if parent.category != 'DISK':
                         return "PARTITION"
 


### PR DESCRIPTION
## Description

The removable_partition resource job was listing all partitions even those hosting the OS.
The template jobs using this specific resource should only create jobs for real removable devices.

## Resolved issues

Fixes https://warthogs.atlassian.net/browse/CHECKBOX-119

## Tests

Tested on rpi4B4G / 20.04 with both a usb stick and sd card (os).

```
$ lsblk -i -n -P -o KNAME,TYPE,MOUNTPOINT
KNAME="loop0" TYPE="loop" MOUNTPOINT="/snap/core20/1781"
KNAME="loop1" TYPE="loop" MOUNTPOINT="/snap/lxd/24329"
KNAME="loop2" TYPE="loop" MOUNTPOINT="/snap/snapd/17952"
KNAME="loop3" TYPE="loop" MOUNTPOINT="/snap/core/14449"
KNAME="sda" TYPE="disk" MOUNTPOINT=""
KNAME="sda1" TYPE="part" MOUNTPOINT=""
KNAME="mmcblk0" TYPE="disk" MOUNTPOINT=""
KNAME="mmcblk0p1" TYPE="part" MOUNTPOINT="/boot/firmware"
KNAME="mmcblk0p2" TYPE="part" MOUNTPOINT="/"
```

The modified udev parser only reports:

```
 $ ./udev_resource.py -f PARTITION
path: /devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb2/2-2/2-2:1.0/host0/target0:0:0/0:0:0:0/block/sda/sda1
name: sda1
bus: usb3
category: PARTITION
product: sda1
product_slug: sda1
symlink_uuid: disk/by-uuid/FD26-894B
```
