### PR TITLE
Modify: Seperate stress-ng test from class based to stressor based

### DIFF
--- a/providers/base/bin/capture-stressor.py
+++ b/providers/base/bin/capture-stressor.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+
+import subprocess
+
+classes_list = ['cpu', 'cpu-cache', 'memory', 'os', 'pipe', 'scheduler', 'vm']
+
+stressors_list = []
+
+for stress_ng_class in classes_list:
+    cmd_get_stressors = ['stress-ng', '--class', '{}?'.format(stress_ng_class)]
+    try:
+        output = subprocess.run(cmd_get_stressors, capture_output=True,
+                                universal_newlines=True, check=True).stdout
+    except Exception as err:
+        raise SystemExit(err)
+
+    class_stressor_list = output.split(': ')[1].split()
+
+    for class_stressor in class_stressor_list:
+        if class_stressor in stressors_list:
+            continue
+        stressors_list.append(class_stressor)
+
+stressors_list.sort()
+for stressor in stressors_list:
+    print('stressor: {}'.format(stressor))
+    print()

--- a/providers/base/units/stress/stress-ng.pxu
+++ b/providers/base/units/stress/stress-ng.pxu
@@ -1,18 +1,13 @@
 unit: job
-id: stress-ng-classes
+id: stress-ng-stressors
 plugin: resource
-_summary: Gather list of test classes from stress-ng
+_summary: Gather list of test stressors from stress-ng
 _description:
- stress-ng divides tests in to classes. Get a list of classes so can divide
- up tests. Complete class list: cpu, cpu-cache, device, io, interrupt,
- filesystem, memory, network, os, pipe, scheduler, vm.
+ stress-ng divides tests in to stressors. Get a list of stressors so can divide
+ up tests.
 command:
  command -v stress-ng >/dev/null 2>&1 || { >&2 echo "stress-ng command not found"; exit 1; }
- CLASSES="cpu cpu-cache memory os pipe scheduler vm"
- for c in $CLASSES; do
-  echo "stress-ng-class: $c"
-  echo
- done
+ capture-stressor.py
 estimated_duration: 1s
 flags: preserve-locale
 

--- a/providers/base/units/stress/stress-ng.pxu
+++ b/providers/base/units/stress/stress-ng.pxu
@@ -12,20 +12,20 @@ estimated_duration: 1s
 flags: preserve-locale
 
 unit: template
-template-resource: stress-ng-classes
+template-resource: stress-ng-stressors
 template-unit: job
-id: stress/stress-ng-test-for-class-{stress-ng-class}
+id: stress/stress-ng-test-for-stressor-{stressor}
 category_id: stress-tests
-_summary: Run the stress-ng stressors for class {stress-ng-class}
+_summary: Run the stress-ng for stressor {stressor}
 _description:
- Runs the stressors for the class defined. Tests run sequentially using the
+ Runs the stressors from stress-ng. Tests run using the
  same number of proccesses as online processors.
 plugin: shell
-estimated_duration: 1200.0
-environ: STRESS_NG_CLASSES_TIMEOUT
+estimated_duration: 30.0
+environ: STRESS_NG_STRESSORS_TIMEOUT
 command:
  cd /var/tmp || exit $?
- stress-ng --sequential 0 --class {stress-ng-class} --timeout "${{STRESS_NG_CLASSES_TIMEOUT:-30}}" --skip-silent --verbose
+ stress-ng --{stressor} 0 --timeout "${{STRESS_NG_STRESSORS_TIMEOUT:-30}}" --skip-silent --verbose
  # Error code definition - 3(no resource), 4(not implemented)
  EXIT_CODE=$?
  echo "EXIT_CODE="$EXIT_CODE

--- a/providers/base/units/stress/test-plan.pxu
+++ b/providers/base/units/stress/test-plan.pxu
@@ -245,11 +245,11 @@ unit: test plan
 _name: Automated stress-ng tests
 _description: Automated stress-ng tests for Snappy Ubuntu Core devices
 include:
-    stress/stress-ng-test-for-class-.*
+    stress/stress-ng-test-for-stressor-.*
     disk/disk_stress_ng_.*
 bootstrap_include:
     device
-    stress-ng-classes
+    stress-ng-stressors
 
 id: stress-iperf3-automated
 unit: test plan


### PR DESCRIPTION
## Description
I break the tests run in stress/stress-ng-test-for-class-{stress-ng-class} from class based jobs into stressor based jobs.
However these pull request is based on stress-ng V0.15.03, so we have to upgrade it first. #322 

## Resolved issues
After these commits, we could easily tell which stressor failed after test instead of reviewing the log to find out what cause failed.
