### PR TITLE
Avoid running the lsblk command in unit tests

### DIFF
--- a/checkbox-support/checkbox_support/parsers/tests/test_udevadm.py
+++ b/checkbox-support/checkbox_support/parsers/tests/test_udevadm.py
@@ -935,11 +935,11 @@ class TestUdevadmParser(TestCase, UdevadmDataMixIn):
     def test_SHUTTLE_DH170_WITH_USB_DISK(self):
         """ DH170 with USB stick comparing pre and post reboot. """
         devices_pre = self.parse("SHUTTLE_DH170_WITH_USB_DISK",
-                                 with_partitions=True)
+                                 with_partitions=True, with_lsblk=False)
         self.assertEqual(len(devices_pre), 70)
         self.assertEqual(self.count(devices_pre, "PARTITION"), 1)
         devices_post = self.parse("SHUTTLE_DH170_WITH_USB_DISK_REBOOTED",
-                                  with_partitions=True)
+                                  with_partitions=True, with_lsblk=False)
         self.assertEqual(len(devices_post), 70)
         self.assertEqual(self.count(devices_post, "PARTITION"), 1)
         # Pre and post have same number of deviecs and partitions


### PR DESCRIPTION
## Description

A fix to the unit tests of the udev parser.
W/o an extr arg, the output of `lsblk` is used to evaluate if partitions have to be categorized as such by the parser.

## Resolved issues

Recent instability with Tox, see https://github.com/canonical/checkbox/actions/runs/4128463822/attempts/1

## Tests

Tested on python 3.5.2/3.5.10//3.6/3.8/3.10 in LXC
