### PR TITLE
Store DMI ID key in its own field

### DIFF
--- a/checkbox-support/checkbox_support/parsers/dmidecode.py
+++ b/checkbox-support/checkbox_support/parsers/dmidecode.py
@@ -49,7 +49,7 @@ class DmidecodeParser(object):
 
     _key_map = {
         "Form Factor": "form",
-        "ID": "serial",
+        "ID": "id",
         "Manufacturer": "vendor",
         "Product Name": "name",
         "Serial Number": "serial",


### PR DESCRIPTION
Making this change posthumously as there is use case where we would like to be able to identify processor micro-architectures from machine reports already in the HEXR db. The field would have allowed this to be worked out but it seems to get squashed by the serial key.

