### PR TITLE
Update the list of partitions names to exclude

### DIFF
--- a/checkbox-support/checkbox_support/parsers/udevadm.py
+++ b/checkbox-support/checkbox_support/parsers/udevadm.py
@@ -96,7 +96,8 @@ FLASH_RE = re.compile(r"Flash", re.I)
 FLASH_DISK_RE = re.compile(r"Mass|Storage|Disk", re.I)
 MD_DEVICE_RE = re.compile(r"MD_DEVICE_\w+_DEV")
 ROOT_MOUNTPOINT = re.compile(
-    r'MOUNTPOINT=.*/(writable|hostfs|ubuntu-seed|ubuntu-boot|boot)')
+    r'MOUNTPOINT=.*/(writable|hostfs|'
+    r'ubuntu-seed|ubuntu-boot|ubuntu-save|data|boot)')
 
 
 def slugify(_string):


### PR DESCRIPTION



## Description

UC20 and UC22 installed on SD cards and running on rpi end up with the following partitions:

```
KNAME="mmcblk0p1" TYPE="part" MOUNTPOINT="/run/mnt/ubuntu-seed"
KNAME="mmcblk0p2" TYPE="part" MOUNTPOINT="/run/mnt/ubuntu-boot"
KNAME="mmcblk0p3" TYPE="part" MOUNTPOINT="/run/mnt/ubuntu-save"
KNAME="mmcblk0p4" TYPE="part" MOUNTPOINT="/run/mnt/data"
```
This patch adds both ubuntu-save and data to the exclusion list.


## Resolved issues

Fixes: #202 #23



