### PR TITLE
SERVCERT-221-fix-ipmi_test-non-UTF8-char-issue

### DIFF
--- a/providers/base/bin/ipmi_test.py
+++ b/providers/base/bin/ipmi_test.py
@@ -65,7 +65,7 @@ class FreeIpmiTest:
             get_path('ipmi-chassis'), '--get-status']
         self._cmd_ipmi_channel = [
             get_path('ipmi-config'), '--checkout',
-            '--lan-channel-number']
+            '-S', 'User1', '--lan-channel-number']
         self._cmd_get_bmc_info = [
             get_path('bmc-info')]
         self._cmd_ipmi_locate = [
@@ -225,7 +225,7 @@ class FreeIpmiTest:
     def _ipmi_channel_hlpr(self, i, regex, channel):
         """get_ipmi_channel discovery loop."""
         cmd = self._cmd_ipmi_channel
-        if len(cmd) > 3:
+        if len(cmd) > 5:
             cmd.pop(-1)
         cmd.append(str(i))
         output = self._subproc_logging(cmd)


### PR DESCRIPTION
Cleans up the ipmi channel test case to prevent it from choking on non-UTF8 characters in the k_r key. fixes #116

## Description

Previous behaviour was to just fully dump the channel (ipmi checkout). This also dumped the security key data and in some machines from Chinese makers, the k_r key may have non-UTF8 chars in it.  This caused Python to dump a stack trace every time that case ran.

Changing the test case to only dump User1 satisfies the case (that we can issue the command and successfully get some data back) an avoids getting the potentialy problematic k_r key value.  It's also cleaner than trying to enforce a differrent character decoding which could potentially break other things.

## Resolved issues

Fixes #116

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [ ] A list of what tests were run and on what platform/configuration is provided.
