### PR TITLE
Restore test plan filters in all odm-certification launchers

### DIFF
--- a/checkbox-snap/series_classic18/launchers/odm-certification
+++ b/checkbox-snap/series_classic18/launchers/odm-certification
@@ -5,5 +5,12 @@ stock_reports = text, submission_files
 
 [test plan]
 unit = com.canonical.certification::client-cert-odm-desktop-18-04-manual
-filter = com.canonical.certification::client-cert-odm-desktop-18-04-*
+filter = com.canonical.certification::client-cert-odm-desktop-22-04-*
+    com.canonical.certification::client-cert-odm-desktop-20-04-*
+    com.canonical.certification::client-cert-odm-desktop-18-04-*
+    com.canonical.certification::client-cert-odm-server-22-04-*
+    com.canonical.certification::client-cert-odm-server-20-04-*
     com.canonical.certification::client-cert-odm-server-18-04-*
+    com.canonical.certification::client-cert-odm-ubuntucore-22-*
+    com.canonical.certification::client-cert-odm-ubuntucore-20-*
+    com.canonical.certification::client-cert-odm-ubuntucore-18-*

--- a/checkbox-snap/series_classic20/launchers/odm-certification
+++ b/checkbox-snap/series_classic20/launchers/odm-certification
@@ -5,5 +5,12 @@ stock_reports = text, submission_files
 
 [test plan]
 unit = com.canonical.certification::client-cert-odm-desktop-20-04-manual
-filter = com.canonical.certification::client-cert-odm-desktop-20-04-*
+filter = com.canonical.certification::client-cert-odm-desktop-22-04-*
+    com.canonical.certification::client-cert-odm-desktop-20-04-*
+    com.canonical.certification::client-cert-odm-desktop-18-04-*
+    com.canonical.certification::client-cert-odm-server-22-04-*
     com.canonical.certification::client-cert-odm-server-20-04-*
+    com.canonical.certification::client-cert-odm-server-18-04-*
+    com.canonical.certification::client-cert-odm-ubuntucore-22-*
+    com.canonical.certification::client-cert-odm-ubuntucore-20-*
+    com.canonical.certification::client-cert-odm-ubuntucore-18-*

--- a/checkbox-snap/series_classic22/launchers/odm-certification
+++ b/checkbox-snap/series_classic22/launchers/odm-certification
@@ -6,4 +6,11 @@ stock_reports = text, submission_files
 [test plan]
 unit = com.canonical.certification::client-cert-odm-desktop-22-04-manual
 filter = com.canonical.certification::client-cert-odm-desktop-22-04-*
+    com.canonical.certification::client-cert-odm-desktop-20-04-*
+    com.canonical.certification::client-cert-odm-desktop-18-04-*
     com.canonical.certification::client-cert-odm-server-22-04-*
+    com.canonical.certification::client-cert-odm-server-20-04-*
+    com.canonical.certification::client-cert-odm-server-18-04-*
+    com.canonical.certification::client-cert-odm-ubuntucore-22-*
+    com.canonical.certification::client-cert-odm-ubuntucore-20-*
+    com.canonical.certification::client-cert-odm-ubuntucore-18-*

--- a/checkbox-snap/series_uc18/launchers/odm-certification
+++ b/checkbox-snap/series_uc18/launchers/odm-certification
@@ -5,4 +5,12 @@ stock_reports = text, submission_files
 
 [test plan]
 unit = com.canonical.certification::client-cert-odm-ubuntucore-18-manual
-filter = com.canonical.certification::client-cert-odm-ubuntucore-18-*
+filter = com.canonical.certification::client-cert-odm-desktop-22-04-*
+    com.canonical.certification::client-cert-odm-desktop-20-04-*
+    com.canonical.certification::client-cert-odm-desktop-18-04-*
+    com.canonical.certification::client-cert-odm-server-22-04-*
+    com.canonical.certification::client-cert-odm-server-20-04-*
+    com.canonical.certification::client-cert-odm-server-18-04-*
+    com.canonical.certification::client-cert-odm-ubuntucore-22-*
+    com.canonical.certification::client-cert-odm-ubuntucore-20-*
+    com.canonical.certification::client-cert-odm-ubuntucore-18-*

--- a/checkbox-snap/series_uc20/launchers/odm-certification
+++ b/checkbox-snap/series_uc20/launchers/odm-certification
@@ -5,4 +5,12 @@ stock_reports = text, submission_files
 
 [test plan]
 unit = com.canonical.certification::client-cert-odm-ubuntucore-20-manual
-filter = com.canonical.certification::client-cert-odm-ubuntucore-20-*
+filter = com.canonical.certification::client-cert-odm-desktop-22-04-*
+    com.canonical.certification::client-cert-odm-desktop-20-04-*
+    com.canonical.certification::client-cert-odm-desktop-18-04-*
+    com.canonical.certification::client-cert-odm-server-22-04-*
+    com.canonical.certification::client-cert-odm-server-20-04-*
+    com.canonical.certification::client-cert-odm-server-18-04-*
+    com.canonical.certification::client-cert-odm-ubuntucore-22-*
+    com.canonical.certification::client-cert-odm-ubuntucore-20-*
+    com.canonical.certification::client-cert-odm-ubuntucore-18-*

--- a/checkbox-snap/series_uc22/launchers/odm-certification
+++ b/checkbox-snap/series_uc22/launchers/odm-certification
@@ -5,4 +5,12 @@ stock_reports = text, submission_files
 
 [test plan]
 unit = com.canonical.certification::client-cert-odm-ubuntucore-22-manual
-filter = com.canonical.certification::client-cert-odm-ubuntucore-22-*
+filter = com.canonical.certification::client-cert-odm-desktop-22-04-*
+    com.canonical.certification::client-cert-odm-desktop-20-04-*
+    com.canonical.certification::client-cert-odm-desktop-18-04-*
+    com.canonical.certification::client-cert-odm-server-22-04-*
+    com.canonical.certification::client-cert-odm-server-20-04-*
+    com.canonical.certification::client-cert-odm-server-18-04-*
+    com.canonical.certification::client-cert-odm-ubuntucore-22-*
+    com.canonical.certification::client-cert-odm-ubuntucore-20-*
+    com.canonical.certification::client-cert-odm-ubuntucore-18-*


### PR DESCRIPTION
## Description

Add the full list of ODM test plans in odm-certification launchers

## Resolved issues

The SUT can run a different version of ubuntu (Core or classic) than the remote side. Presuming the test plan selection had to match the remote os version was a mistake as it prevents the selection of the correct and targeted OS. 
