### PR TITLE
Remove all references to PTS from the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ To get started, setup a test environment, run Checkbox and its providers, run th
     ├── gpgpu
     ├── iiotg
     ├── ipdt
-    ├── phoronix
     ├── resource
     ├── sru
     └── tpm2

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -18,7 +18,6 @@ release
 * [providers/sru](https://github.com/canonical/checkbox/tree/main/providers/sru)
 * [providers/tpm2](https://github.com/canonical/checkbox/tree/main/providers/tpm2)
 * [providers/ipdt](https://github.com/canonical/checkbox/tree/main/providers/ipdt)
-* [providers/phoronix](https://github.com/canonical/checkbox/tree/main/providers/phoronix)
 * [providers/gpgpu](https://github.com/canonical/checkbox/tree/main/providers/gpgpu)
 
 ## Release steps summary
@@ -87,8 +86,7 @@ Before applying RC tags, it's recommended to first perform a **dry run** of the 
     "provider-certification-server": true,
     "provider-certification-client": true,
     "provider-gpgpu": true,
-    "provider-ipdt": true,
-    "provider-phoronix": true
+    "provider-ipdt": true
 }
 ```
 
@@ -107,8 +105,7 @@ After reviewing the changelog, **dry run** can be set to false:
     "provider-certification-server": true,
     "provider-certification-client": true,
     "provider-gpgpu": true,
-    "provider-ipdt": true,
-    "provider-phoronix": true
+    "provider-ipdt": true
 }
 ```
 
@@ -150,8 +147,7 @@ The same workflow can run using the JSON config below of course:
     "provider-certification-server": false,
     "provider-certification-client": false,
     "provider-gpgpu": false,
-    "provider-ipdt": false,
-    "provider-phoronix": false
+    "provider-ipdt": false
 }
 ```
 
@@ -174,8 +170,7 @@ stable release tag to the same commit the latest RC tag was applied to.
     "provider-certification-server": true,
     "provider-certification-client": true,
     "provider-gpgpu": true,
-    "provider-ipdt": true,
-    "provider-phoronix": true
+    "provider-ipdt": true
 }
 ```
 


### PR DESCRIPTION
## Description

PTS is no longer used in SRU test plans (See https://github.com/canonical/checkbox/pull/38)

## Resolved issues

This is a prerequisite to a clean removal of the provider (See https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository#using-git-filter-repo):
`git filter-repo --invert-paths --path providers/phoronix/`
