### PR TITLE
Ipdt cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ To get started, setup a test environment, run Checkbox and its providers, run th
     ├── edgex
     ├── gpgpu
     ├── iiotg
-    ├── ipdt
     ├── phoronix
     ├── resource
     ├── sru

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -19,10 +19,6 @@ slots:
     interface: content
     read:
       - $SNAP/providers/checkbox-provider-base
-  provider-ipdt:
-    interface: content
-    read:
-      - $SNAP/providers/checkbox-provider-ipdt
   provider-docker:
     interface: content
     read:
@@ -279,20 +275,6 @@ parts:
       usr/lib/lib*.so*: usr/lib/$SNAPCRAFT_ARCH_TRIPLET/
     after: [checkbox-provider-resource]
 ################################################################################
-  checkbox-provider-ipdt:
-    plugin: dump
-    source: providers/ipdt
-    source-type: local
-    override-build: |
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.8/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
-      for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
-      python3 manage.py validate
-      python3 manage.py build
-      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-ipdt --root="$SNAPCRAFT_PART_INSTALL"
-    stage-packages:
-      - util-linux
-    after: [checkbox-provider-base]
-################################################################################
   checkbox-provider-docker:
     plugin: dump
     source: providers/docker
@@ -305,7 +287,7 @@ parts:
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-docker --root="$SNAPCRAFT_PART_INSTALL"
     stage-packages:
       - apache2-utils
-    after: [checkbox-provider-ipdt]
+    after: [checkbox-provider-base]
 ################################################################################
   checkbox-provider-tpm2:
     plugin: dump

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -23,10 +23,6 @@ slots:
     interface: content
     read:
       - $SNAP/providers/checkbox-provider-snappy
-  provider-ipdt:
-    interface: content
-    read:
-      - $SNAP/providers/checkbox-provider-ipdt
   provider-docker:
     interface: content
     read:
@@ -278,20 +274,6 @@ parts:
       usr/lib/lib*.so*: usr/lib/$SNAPCRAFT_ARCH_TRIPLET/
     after: [checkbox-provider-resource]
 ################################################################################
-  checkbox-provider-ipdt:
-    plugin: dump
-    source: providers/ipdt
-    source-type: local
-    override-build: |
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.8/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
-      for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
-      python3 manage.py validate
-      python3 manage.py build
-      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-ipdt --root="$SNAPCRAFT_PART_INSTALL"
-    stage-packages:
-      - util-linux
-    after: [checkbox-provider-base]
-################################################################################
   checkbox-provider-docker:
     plugin: dump
     source: providers/docker
@@ -304,7 +286,7 @@ parts:
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-docker --root="$SNAPCRAFT_PART_INSTALL"
     stage-packages:
       - apache2-utils
-    after: [checkbox-provider-ipdt]
+    after: [checkbox-provider-base]
 ################################################################################
   checkbox-provider-tpm2:
     plugin: dump

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -19,10 +19,6 @@ slots:
     interface: content
     read:
       - $SNAP/providers/checkbox-provider-base
-  provider-ipdt:
-    interface: content
-    read:
-      - $SNAP/providers/checkbox-provider-ipdt
   provider-docker:
     interface: content
     read:
@@ -327,20 +323,6 @@ parts:
       usr/lib/lib*.so*: usr/lib/$SNAPCRAFT_ARCH_TRIPLET/
     after: [checkbox-provider-resource]
 ################################################################################
-  checkbox-provider-ipdt:
-    plugin: dump
-    source: providers/ipdt
-    source-type: local
-    override-build: |
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.8/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
-      for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
-      python3 manage.py validate
-      python3 manage.py build
-      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-ipdt --root="$SNAPCRAFT_PART_INSTALL"
-    stage-packages:
-      - util-linux
-    after: [checkbox-provider-base]
-################################################################################
   checkbox-provider-docker:
     plugin: dump
     source: providers/docker
@@ -353,7 +335,7 @@ parts:
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-docker --root="$SNAPCRAFT_PART_INSTALL"
     stage-packages:
       - apache2-utils
-    after: [checkbox-provider-ipdt]
+    after: [checkbox-provider-base]
 ################################################################################
   checkbox-provider-tpm2:
     plugin: dump

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -19,10 +19,6 @@ slots:
     interface: content
     read:
       - $SNAP/providers/checkbox-provider-base
-  provider-ipdt:
-    interface: content
-    read:
-      - $SNAP/providers/checkbox-provider-ipdt
   provider-docker:
     interface: content
     read:
@@ -327,20 +323,6 @@ parts:
       usr/lib/lib*.so*: usr/lib/$SNAPCRAFT_ARCH_TRIPLET/
     after: [checkbox-provider-resource]
 ################################################################################
-  checkbox-provider-ipdt:
-    plugin: dump
-    source: providers/ipdt
-    source-type: local
-    override-build: |
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.10/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
-      for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
-      python3 manage.py validate
-      python3 manage.py build
-      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-ipdt --root="$SNAPCRAFT_PART_INSTALL"
-    stage-packages:
-      - util-linux
-    after: [checkbox-provider-base]
-################################################################################
   checkbox-provider-docker:
     plugin: dump
     source: providers/docker
@@ -353,7 +335,7 @@ parts:
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-docker --root="$SNAPCRAFT_PART_INSTALL"
     stage-packages:
       - apache2-utils
-    after: [checkbox-provider-ipdt]
+    after: [checkbox-provider-base]
 ################################################################################
   checkbox-provider-tpm2:
     plugin: dump

--- a/checkbox-ng/docs/custom-app.rst
+++ b/checkbox-ng/docs/custom-app.rst
@@ -104,7 +104,6 @@ testing suite from plainbox-provider-snappy.
 
     nested_part:
 	device-connections-tp
-	2016.com.intel.ipdt::ipdt-plan
 	com.canonical.certification::usb-automated
 	# com.canonical.certification::audio-automated # no working auto tests
 	com.canonical.certification::cpu-automated

--- a/checkbox-ng/docs/side-loading.rst
+++ b/checkbox-ng/docs/side-loading.rst
@@ -31,13 +31,11 @@ snap.
 Make sure that checkbox snap is installed. It comes with following providers
 available::
 
-    plainbox-provider-checkbox
-    plainbox-provider-docker
-    plainbox-provider-ipdt
-    plainbox-provider-resource-generic
-    plainbox-provider-snappy
-    plainbox-provider-sru
-    plainbox-provider-tpm2
+    checkbox-provider-base
+    checkbox-provider-docker
+    checkbox-provider-resource
+    checkbox-provider-sru
+    checkbox-provider-tpm2
 
 Create ``checkbox-providers`` directory in ``/var/tmp/``::
 

--- a/checkbox-snap/series_uc16/launchers/configure
+++ b/checkbox-snap/series_uc16/launchers/configure
@@ -33,7 +33,6 @@ You can do this with those commands:
 snap connect $SNAP_NAME:checkbox-runtime  checkbox16:checkbox-runtime
 snap connect $SNAP_NAME:provider-resource checkbox16:provider-resource
 snap connect $SNAP_NAME:provider-checkbox checkbox16:provider-checkbox
-snap connect $SNAP_NAME:provider-ipdt     checkbox16:provider-ipdt
 snap connect $SNAP_NAME:provider-docker   checkbox16:provider-docker
 snap connect $SNAP_NAME:provider-tpm2     checkbox16:provider-tpm2
 snap connect $SNAP_NAME:provider-sru      checkbox16:provider-sru

--- a/checkbox-snap/series_uc16/snap/hooks/configure
+++ b/checkbox-snap/series_uc16/snap/hooks/configure
@@ -55,7 +55,6 @@ You can do this with those commands:
 snap connect $SNAP_NAME:checkbox-runtime  checkbox16:checkbox-runtime
 snap connect $SNAP_NAME:provider-resource checkbox16:provider-resource
 snap connect $SNAP_NAME:provider-checkbox checkbox16:provider-checkbox
-snap connect $SNAP_NAME:provider-ipdt     checkbox16:provider-ipdt
 snap connect $SNAP_NAME:provider-docker   checkbox16:provider-docker
 snap connect $SNAP_NAME:provider-tpm2     checkbox16:provider-tpm2
 snap connect $SNAP_NAME:provider-sru      checkbox16:provider-sru

--- a/checkbox-snap/series_uc16/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc16/snap/snapcraft.yaml
@@ -22,10 +22,6 @@ plugs:
     interface: content
     target: $SNAP/providers/checkbox-provider-checkbox
     default-provider: checkbox16
-  provider-ipdt:
-    interface: content
-    target: $SNAP/providers/checkbox-provider-ipdt
-    default-provider: checkbox16
   provider-docker:
     interface: content
     target: $SNAP/providers/checkbox-provider-docker

--- a/checkbox-snap/series_uc18/launchers/configure
+++ b/checkbox-snap/series_uc18/launchers/configure
@@ -33,7 +33,6 @@ You can do this with those commands:
 snap connect $SNAP_NAME:checkbox-runtime  checkbox18:checkbox-runtime
 snap connect $SNAP_NAME:provider-resource checkbox18:provider-resource
 snap connect $SNAP_NAME:provider-checkbox checkbox18:provider-checkbox
-snap connect $SNAP_NAME:provider-ipdt     checkbox18:provider-ipdt
 snap connect $SNAP_NAME:provider-docker   checkbox18:provider-docker
 snap connect $SNAP_NAME:provider-tpm2     checkbox18:provider-tpm2
 snap connect $SNAP_NAME:provider-sru      checkbox18:provider-sru

--- a/checkbox-snap/series_uc18/snap/hooks/configure
+++ b/checkbox-snap/series_uc18/snap/hooks/configure
@@ -55,7 +55,6 @@ You can do this with those commands:
 snap connect $SNAP_NAME:checkbox-runtime  checkbox18:checkbox-runtime
 snap connect $SNAP_NAME:provider-resource checkbox18:provider-resource
 snap connect $SNAP_NAME:provider-checkbox checkbox18:provider-checkbox
-snap connect $SNAP_NAME:provider-ipdt     checkbox18:provider-ipdt
 snap connect $SNAP_NAME:provider-docker   checkbox18:provider-docker
 snap connect $SNAP_NAME:provider-tpm2     checkbox18:provider-tpm2
 snap connect $SNAP_NAME:provider-sru      checkbox18:provider-sru

--- a/checkbox-snap/series_uc18/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc18/snap/snapcraft.yaml
@@ -22,10 +22,6 @@ plugs:
     interface: content
     target: $SNAP/providers/checkbox-provider-checkbox
     default-provider: checkbox18
-  provider-ipdt:
-    interface: content
-    target: $SNAP/providers/checkbox-provider-ipdt
-    default-provider: checkbox18
   provider-docker:
     interface: content
     target: $SNAP/providers/checkbox-provider-docker

--- a/checkbox-snap/series_uc20/launchers/configure
+++ b/checkbox-snap/series_uc20/launchers/configure
@@ -33,7 +33,6 @@ You can do this with those commands:
 snap connect $SNAP_NAME:checkbox-runtime  checkbox20:checkbox-runtime
 snap connect $SNAP_NAME:provider-resource checkbox20:provider-resource
 snap connect $SNAP_NAME:provider-checkbox checkbox20:provider-checkbox
-snap connect $SNAP_NAME:provider-ipdt     checkbox20:provider-ipdt
 snap connect $SNAP_NAME:provider-docker   checkbox20:provider-docker
 snap connect $SNAP_NAME:provider-tpm2     checkbox20:provider-tpm2
 snap connect $SNAP_NAME:provider-sru      checkbox20:provider-sru

--- a/checkbox-snap/series_uc20/snap/hooks/configure
+++ b/checkbox-snap/series_uc20/snap/hooks/configure
@@ -55,7 +55,6 @@ You can do this with those commands:
 snap connect $SNAP_NAME:checkbox-runtime  checkbox20:checkbox-runtime
 snap connect $SNAP_NAME:provider-resource checkbox20:provider-resource
 snap connect $SNAP_NAME:provider-checkbox checkbox20:provider-checkbox
-snap connect $SNAP_NAME:provider-ipdt     checkbox20:provider-ipdt
 snap connect $SNAP_NAME:provider-docker   checkbox20:provider-docker
 snap connect $SNAP_NAME:provider-tpm2     checkbox20:provider-tpm2
 snap connect $SNAP_NAME:provider-sru      checkbox20:provider-sru

--- a/checkbox-snap/series_uc20/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc20/snap/snapcraft.yaml
@@ -22,10 +22,6 @@ plugs:
     interface: content
     target: $SNAP/providers/checkbox-provider-checkbox
     default-provider: checkbox20
-  provider-ipdt:
-    interface: content
-    target: $SNAP/providers/checkbox-provider-ipdt
-    default-provider: checkbox20
   provider-docker:
     interface: content
     target: $SNAP/providers/checkbox-provider-docker

--- a/checkbox-snap/series_uc22/launchers/configure
+++ b/checkbox-snap/series_uc22/launchers/configure
@@ -33,7 +33,6 @@ You can do this with those commands:
 snap connect $SNAP_NAME:checkbox-runtime  checkbox22:checkbox-runtime
 snap connect $SNAP_NAME:provider-resource checkbox22:provider-resource
 snap connect $SNAP_NAME:provider-checkbox checkbox22:provider-checkbox
-snap connect $SNAP_NAME:provider-ipdt     checkbox22:provider-ipdt
 snap connect $SNAP_NAME:provider-docker   checkbox22:provider-docker
 snap connect $SNAP_NAME:provider-tpm2     checkbox22:provider-tpm2
 snap connect $SNAP_NAME:provider-sru      checkbox22:provider-sru

--- a/checkbox-snap/series_uc22/snap/hooks/configure
+++ b/checkbox-snap/series_uc22/snap/hooks/configure
@@ -55,7 +55,6 @@ You can do this with those commands:
 snap connect $SNAP_NAME:checkbox-runtime  checkbox22:checkbox-runtime
 snap connect $SNAP_NAME:provider-resource checkbox22:provider-resource
 snap connect $SNAP_NAME:provider-checkbox checkbox22:provider-checkbox
-snap connect $SNAP_NAME:provider-ipdt     checkbox22:provider-ipdt
 snap connect $SNAP_NAME:provider-docker   checkbox22:provider-docker
 snap connect $SNAP_NAME:provider-tpm2     checkbox22:provider-tpm2
 snap connect $SNAP_NAME:provider-sru      checkbox22:provider-sru

--- a/checkbox-snap/series_uc22/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc22/snap/snapcraft.yaml
@@ -22,10 +22,6 @@ plugs:
     interface: content
     target: $SNAP/providers/checkbox-provider-checkbox
     default-provider: checkbox22
-  provider-ipdt:
-    interface: content
-    target: $SNAP/providers/checkbox-provider-ipdt
-    default-provider: checkbox22
   provider-docker:
     interface: content
     target: $SNAP/providers/checkbox-provider-docker

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -17,7 +17,6 @@ release
 * [providers/certification-server](https://github.com/canonical/checkbox/tree/main/providers/certification-server)
 * [providers/sru](https://github.com/canonical/checkbox/tree/main/providers/sru)
 * [providers/tpm2](https://github.com/canonical/checkbox/tree/main/providers/tpm2)
-* [providers/ipdt](https://github.com/canonical/checkbox/tree/main/providers/ipdt)
 * [providers/phoronix](https://github.com/canonical/checkbox/tree/main/providers/phoronix)
 * [providers/gpgpu](https://github.com/canonical/checkbox/tree/main/providers/gpgpu)
 
@@ -87,7 +86,6 @@ Before applying RC tags, it's recommended to first perform a **dry run** of the 
     "provider-certification-server": true,
     "provider-certification-client": true,
     "provider-gpgpu": true,
-    "provider-ipdt": true,
     "provider-phoronix": true
 }
 ```
@@ -107,7 +105,6 @@ After reviewing the changelog, **dry run** can be set to false:
     "provider-certification-server": true,
     "provider-certification-client": true,
     "provider-gpgpu": true,
-    "provider-ipdt": true,
     "provider-phoronix": true
 }
 ```
@@ -150,7 +147,6 @@ The same workflow can run using the JSON config below of course:
     "provider-certification-server": false,
     "provider-certification-client": false,
     "provider-gpgpu": false,
-    "provider-ipdt": false,
     "provider-phoronix": false
 }
 ```
@@ -174,7 +170,6 @@ stable release tag to the same commit the latest RC tag was applied to.
     "provider-certification-server": true,
     "provider-certification-client": true,
     "provider-gpgpu": true,
-    "provider-ipdt": true,
     "provider-phoronix": true
 }
 ```


### PR DESCRIPTION
## Description

IPDT is no longer used in certification test plans (See https://github.com/canonical/checkbox/pull/318)

## Resolved issues

This is a prerequisite to a clean removal of the provider (See https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository#using-git-filter-repo):
git filter-repo --invert-paths --path providers/ipdt/
