### PR TITLE
Edgex cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ To get started, setup a test environment, run Checkbox and its providers, run th
     ├── certification-client
     ├── certification-server
     ├── docker
-    ├── edgex
     ├── gpgpu
     ├── iiotg
     ├── ipdt

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -39,10 +39,6 @@ slots:
     interface: content
     read:
       - $SNAP/providers/checkbox-provider-sru
-  provider-edgex:
-    interface: content
-    read:
-      - $SNAP/providers/checkbox-provider-edgex
   provider-gpgpu:
     interface: content
     read:
@@ -331,20 +327,6 @@ parts:
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-sru --root="$SNAPCRAFT_PART_INSTALL"
     after: [checkbox-provider-tpm2]
 ################################################################################
-  checkbox-provider-edgex:
-    plugin: dump
-    source: providers/edgex
-    source-type: local
-    override-build: |
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.8/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
-      for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
-      python3 manage.py validate
-      python3 manage.py build
-      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-edgex --root="$SNAPCRAFT_PART_INSTALL"
-    stage-packages:
-      - curl
-    after: [checkbox-provider-sru]
-################################################################################
   checkbox-provider-gpgpu:
     plugin: dump
     source: providers/gpgpu
@@ -355,7 +337,7 @@ parts:
       python3 manage.py validate
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-gpgpu --root="$SNAPCRAFT_PART_INSTALL"
-    after: [checkbox-provider-edgex]
+    after: [checkbox-provider-sru]
 ################################################################################
   checkbox-provider-certification-client:
     plugin: dump

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -43,10 +43,6 @@ slots:
     interface: content
     read:
       - $SNAP/providers/checkbox-provider-sru
-  provider-edgex:
-    interface: content
-    read:
-      - $SNAP/providers/checkbox-provider-edgex
   provider-gpgpu:
     interface: content
     read:
@@ -330,20 +326,6 @@ parts:
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-sru --root="$SNAPCRAFT_PART_INSTALL"
     after: [checkbox-provider-tpm2, tpm2-tools-3]
 ################################################################################
-  checkbox-provider-edgex:
-    plugin: dump
-    source: providers/edgex
-    source-type: local
-    override-build: |
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.8/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
-      for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
-      python3 manage.py validate
-      python3 manage.py build
-      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-edgex --root="$SNAPCRAFT_PART_INSTALL"
-    stage-packages:
-      - curl
-    after: [checkbox-provider-sru]
-################################################################################
   checkbox-provider-gpgpu:
     plugin: dump
     source: providers/gpgpu
@@ -354,7 +336,7 @@ parts:
       python3 manage.py validate
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-gpgpu --root="$SNAPCRAFT_PART_INSTALL"
-    after: [checkbox-provider-edgex]
+    after: [checkbox-provider-sru]
 ################################################################################
   checkbox-provider-certification-client:
     plugin: dump

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -43,10 +43,6 @@ slots:
     interface: content
     read:
       - $SNAP/providers/checkbox-provider-sru
-  provider-edgex:
-    interface: content
-    read:
-      - $SNAP/providers/checkbox-provider-edgex
   provider-gpgpu:
     interface: content
     read:
@@ -394,20 +390,6 @@ parts:
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-sru --root="$SNAPCRAFT_PART_INSTALL"
     after: [checkbox-provider-iiotg]
 ################################################################################
-  checkbox-provider-edgex:
-    plugin: dump
-    source: providers/edgex
-    source-type: local
-    override-build: |
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.8/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
-      for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
-      python3 manage.py validate
-      python3 manage.py build
-      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-edgex --root="$SNAPCRAFT_PART_INSTALL"
-    stage-packages:
-      - curl
-    after: [checkbox-provider-sru]
-################################################################################
   checkbox-provider-gpgpu:
     plugin: dump
     source: providers/gpgpu
@@ -418,7 +400,7 @@ parts:
       python3 manage.py validate
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-gpgpu --root="$SNAPCRAFT_PART_INSTALL"
-    after: [checkbox-provider-edgex]
+    after: [checkbox-provider-sru]
 ################################################################################
   checkbox-provider-certification-client:
     plugin: dump

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -43,10 +43,6 @@ slots:
     interface: content
     read:
       - $SNAP/providers/checkbox-provider-sru
-  provider-edgex:
-    interface: content
-    read:
-      - $SNAP/providers/checkbox-provider-edgex
   provider-gpgpu:
     interface: content
     read:
@@ -394,20 +390,6 @@ parts:
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-sru --root="$SNAPCRAFT_PART_INSTALL"
     after: [checkbox-provider-iiotg]
 ################################################################################
-  checkbox-provider-edgex:
-    plugin: dump
-    source: providers/edgex
-    source-type: local
-    override-build: |
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.10/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
-      for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
-      python3 manage.py validate
-      python3 manage.py build
-      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-edgex --root="$SNAPCRAFT_PART_INSTALL"
-    stage-packages:
-      - curl
-    after: [checkbox-provider-sru]
-################################################################################
   checkbox-provider-gpgpu:
     plugin: dump
     source: providers/gpgpu
@@ -418,7 +400,7 @@ parts:
       python3 manage.py validate
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-gpgpu --root="$SNAPCRAFT_PART_INSTALL"
-    after: [checkbox-provider-edgex]
+    after: [checkbox-provider-sru]
 ################################################################################
   checkbox-provider-certification-client:
     plugin: dump

--- a/checkbox-snap/series_uc20/launchers/configure
+++ b/checkbox-snap/series_uc20/launchers/configure
@@ -37,7 +37,6 @@ snap connect $SNAP_NAME:provider-ipdt     checkbox20:provider-ipdt
 snap connect $SNAP_NAME:provider-docker   checkbox20:provider-docker
 snap connect $SNAP_NAME:provider-tpm2     checkbox20:provider-tpm2
 snap connect $SNAP_NAME:provider-sru      checkbox20:provider-sru
-snap connect $SNAP_NAME:provider-edgex    checkbox20:provider-edgex
     """
     print(os.path.expandvars(msg), file=sys.stderr)
     sys.exit(1)

--- a/checkbox-snap/series_uc20/snap/hooks/configure
+++ b/checkbox-snap/series_uc20/snap/hooks/configure
@@ -59,7 +59,6 @@ snap connect $SNAP_NAME:provider-ipdt     checkbox20:provider-ipdt
 snap connect $SNAP_NAME:provider-docker   checkbox20:provider-docker
 snap connect $SNAP_NAME:provider-tpm2     checkbox20:provider-tpm2
 snap connect $SNAP_NAME:provider-sru      checkbox20:provider-sru
-snap connect $SNAP_NAME:provider-edgex    checkbox20:provider-edgex
 snap connect $SNAP_NAME:provider-certification-client  checkbox20:provider-certification-client
     """
     print(os.path.expandvars(msg), file=sys.stderr)

--- a/checkbox-snap/series_uc22/launchers/configure
+++ b/checkbox-snap/series_uc22/launchers/configure
@@ -37,7 +37,6 @@ snap connect $SNAP_NAME:provider-ipdt     checkbox22:provider-ipdt
 snap connect $SNAP_NAME:provider-docker   checkbox22:provider-docker
 snap connect $SNAP_NAME:provider-tpm2     checkbox22:provider-tpm2
 snap connect $SNAP_NAME:provider-sru      checkbox22:provider-sru
-snap connect $SNAP_NAME:provider-edgex    checkbox22:provider-edgex
     """
     print(os.path.expandvars(msg), file=sys.stderr)
     sys.exit(1)

--- a/checkbox-snap/series_uc22/snap/hooks/configure
+++ b/checkbox-snap/series_uc22/snap/hooks/configure
@@ -59,7 +59,6 @@ snap connect $SNAP_NAME:provider-ipdt     checkbox22:provider-ipdt
 snap connect $SNAP_NAME:provider-docker   checkbox22:provider-docker
 snap connect $SNAP_NAME:provider-tpm2     checkbox22:provider-tpm2
 snap connect $SNAP_NAME:provider-sru      checkbox22:provider-sru
-snap connect $SNAP_NAME:provider-edgex    checkbox22:provider-edgex
 snap connect $SNAP_NAME:provider-certification-client  checkbox22:provider-certification-client
     """
     print(os.path.expandvars(msg), file=sys.stderr)


### PR DESCRIPTION
## Description

The EdgeX provider is no longer maintained in the monorepo.
The maintained repo is: https://github.com/canonical/edgex-checkbox-provider

## Resolved issues

This is a prerequisite to a clean removal of the provider (See https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository#using-git-filter-repo):
git filter-repo --invert-paths --path providers/edgex/
