### PR TITLE
Fix: boot_mode_test.py can crash with a traceback if EFI info file is…

### DIFF
--- a/providers/base/bin/boot_mode_test.py
+++ b/providers/base/bin/boot_mode_test.py
@@ -69,7 +69,11 @@ def reboot_to_firmware_check():
     if os.path.isdir(osis_dir):
         if os.path.isfile(osis_var):
             with open(osis_var) as fh:
-                fw_info = fh.read()
+                try:
+                    fw_info = fh.read()
+                except IOError:
+                    logging.error("FAIL: I/O error reading EFI data")
+                    return 1
             if ord(fw_info[4]) & 1:
                 logging.info("PASS: Reboot-to-firmware feature is present.")
                 return 0
@@ -97,7 +101,11 @@ def secure_boot_check():
     if os.path.isdir(sb_dir):
         if os.path.isfile(sb_var):
             with open(sb_var) as fh:
-                sb_info = fh.read()
+                try:
+                    sb_info = fh.read()
+                except IOError:
+                    logging.error("FAIL: I/O error reading EFI data")
+                    return 1
             if ord(sb_info[4]) == 1:
                 logging.info("PASS: System booted with Secure Boot active.")
                 return 0


### PR DESCRIPTION
… unreadable

## Description

The miscellanea/reboot_firmware test has, at least once, crashed with a Python traceback because of a file I/O error on a file in the /sys/firmware/efi/efivars directory. This was likely a quirky problem on a non-standard installation, which I could not reproduce a few days later; but it's easy enough to put the offending line in a try/except clause.

I found a second similar instance in the code, which could affect the Secure Boot check (miscellanea/secure_boot_mode), so I made the same change there.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/SERVCERT-774
Fixes: https://github.com/canonical/checkbox/issues/332

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [ ] A list of what tests were run and on what platform/configuration is provided.
