### PR TITLE
Add: RTC test for multi-RTC

### DIFF
--- a/providers/base/units/rtc/jobs.pxu
+++ b/providers/base/units/rtc/jobs.pxu
@@ -14,3 +14,91 @@ user: root
 category_id: rtc_category
 estimated_duration: 40
 flags: noreturn
+
+id: rtc/rtc_number
+_summary: Check the number of RTC as expected.
+_description:
+    Check the number of RTC on platform as expected.
+plugin: shell
+user: root
+estimated_duration: 1.0
+category_id: com.canonical.certification::rtc_category
+command:
+    if [ -z "$TOTAL_RTC_NUM" ]; then 
+        TOTAL_RTC_NUM=1; 
+    fi
+    SYSFS_RTC_NUM=$(find /dev/ -name "rtc[0-9]" | wc -l)
+    echo "TOTAL_RTC_NUM: $TOTAL_RTC_NUM"
+    echo "Number of RTC devices found in sysfs: $SYSFS_RTC_NUM"
+    if [ "$SYSFS_RTC_NUM" != "$TOTAL_RTC_NUM" ]; then
+        echo "RTC number mismatch"
+        exit 1
+    else
+        echo "RTC number matched"
+    fi
+flags: also-after-suspend
+
+id: rtc_list
+_summary: Generates a rtc list for the platform
+_description:
+ List out all rtc devices on platform, and generate a list for it.
+ Define TOTAL_RTC_NUM in config file if platform have more then one
+ RTC deivces.
+plugin: resource
+user: root
+estimated_duration: 1.0
+category_id: com.canonical.certification::rtc_category
+command:
+    rtcs=$(find /dev/ -name "rtc[0-9]"| awk -F "/" '{print $3}')
+    for c in ${rtcs}; do
+        echo "rtc: ${c}"
+        echo ""
+    done
+
+unit: template
+template-resource: rtc_list
+template-unit: job
+id: rtc/rtc_alarm_{rtc}
+_summary: RTC alarm of {rtc} is worked
+_purpose:
+    Check if RTC alarm of {rtc}
+plugin: shell
+user: root
+category_id: com.canonical.certification::rtc_category
+estimated_duration: 40
+command: 
+    if [ -f "/sys/class/rtc/{rtc}/wakealarm" ]; then 
+        rtcwake -d {rtc} -v -m on -s 30
+    else 
+        echo "{rtc} not support wakealarm"
+        exit 1 
+    fi
+flags: also-after-suspend
+
+unit: template
+template-resource: rtc_list
+template-unit: job
+id: rtc/rtc_clock_{rtc}
+_summary: RTC clock of {rtc} is synced
+_purpose:
+    Check if RTC clock of {rtc}
+plugin: shell
+user: root
+category_id: com.canonical.certification::rtc_category
+estimated_duration: 5
+command: 
+    rtctime=$(date +"%s" -d "$( hwclock --rtc /dev/{rtc} -u)")
+    rtc_date=$(date -d "@$rtctime")
+    systime=$(date +"%s")
+    systime_date=$(date -d "@$systime")
+    result=$(("$systime" - "$rtctime"))
+    if [[ "$result" -le "5" ]]; then
+        echo "{rtc} Clock sync with System Clock"
+        echo "$rtc_date"
+    else
+        echo "{rtc} Clock doesn't sync with System Clock"
+        echo "System clock=" "$systime_date"
+        echo "RTC clock=" "$rtc_date"
+        exit 1
+    fi
+flags: also-after-suspend

--- a/providers/base/units/rtc/jobs.pxu
+++ b/providers/base/units/rtc/jobs.pxu
@@ -22,9 +22,10 @@ _description:
 plugin: shell
 user: root
 estimated_duration: 1.0
-category_id: com.canonical.certification::rtc_category
+category_id: rtc_category
 command:
-    if [ -z "$TOTAL_RTC_NUM" ]; then 
+    if [ -z "$TOTAL_RTC_NUM" ]; then
+        echo "TOTAL_RTC_NUM not defined, defaulting to 1"
         TOTAL_RTC_NUM=1; 
     fi
     SYSFS_RTC_NUM=$(find /dev/ -name "rtc[0-9]" | wc -l)
@@ -37,17 +38,16 @@ command:
         echo "RTC number matched"
     fi
 flags: also-after-suspend
+environ:  TOTAL_RTC_NUM
 
 id: rtc_list
-_summary: Generates a rtc list for the platform
+_summary: Generates a RTC list for the platform
 _description:
- List out all rtc devices on platform, and generate a list for it.
- Define TOTAL_RTC_NUM in config file if platform have more then one
- RTC deivces.
+ List out all RTC devices on platform, and generate a list for it.
 plugin: resource
 user: root
 estimated_duration: 1.0
-category_id: com.canonical.certification::rtc_category
+category_id: rtc_category
 command:
     rtcs=$(find /dev/ -name "rtc[0-9]"| awk -F "/" '{print $3}')
     for c in ${rtcs}; do
@@ -59,18 +59,16 @@ unit: template
 template-resource: rtc_list
 template-unit: job
 id: rtc/rtc_alarm_{rtc}
-_summary: RTC alarm of {rtc} is worked
-_purpose:
-    Check if RTC alarm of {rtc}
+_summary: Check that RTC alarm of {rtc} works
 plugin: shell
 user: root
-category_id: com.canonical.certification::rtc_category
+category_id: rtc_category
 estimated_duration: 40
 command: 
     if [ -f "/sys/class/rtc/{rtc}/wakealarm" ]; then 
         rtcwake -d {rtc} -v -m on -s 30
     else 
-        echo "{rtc} not support wakealarm"
+        echo "{rtc} does not support wakealarm"
         exit 1 
     fi
 flags: also-after-suspend
@@ -79,12 +77,10 @@ unit: template
 template-resource: rtc_list
 template-unit: job
 id: rtc/rtc_clock_{rtc}
-_summary: RTC clock of {rtc} is synced
-_purpose:
-    Check if RTC clock of {rtc}
+_summary: Check that {rtc} clock is synchronized with system clock
 plugin: shell
 user: root
-category_id: com.canonical.certification::rtc_category
+category_id: rtc_category
 estimated_duration: 5
 command: 
     rtctime=$(date +"%s" -d "$( hwclock --rtc /dev/{rtc} -u)")
@@ -93,10 +89,10 @@ command:
     systime_date=$(date -d "@$systime")
     result=$(("$systime" - "$rtctime"))
     if [[ "$result" -le "5" ]]; then
-        echo "{rtc} Clock sync with System Clock"
+        echo "{rtc} Clock synchronized with System Clock"
         echo "$rtc_date"
     else
-        echo "{rtc} Clock doesn't sync with System Clock"
+        echo "{rtc} Clock not synchronized with System Clock"
         echo "System clock=" "$systime_date"
         echo "RTC clock=" "$rtc_date"
         exit 1

--- a/providers/base/units/rtc/test-plan.pxu
+++ b/providers/base/units/rtc/test-plan.pxu
@@ -36,14 +36,14 @@ nested_part:
 
 id: after-suspend-rtc-manual
 unit: test plan
-_name: Multiple RTC manual tests (after suspend)
-_description: Manual after suspend multiple RTC tests
+_name: RTC manual tests (after suspend)
+_description: Manual after suspend RTC tests
 include:
 
 id: after-suspend-rtc-automated
 unit: test plan
-_name: Multiple RTC auto tests (after suspend)
-_description: Automated after suspend multiple RTC tests
+_name: RTC auto tests (after suspend)
+_description: Automated after suspend RTC tests
 bootstrap_include:
     rtc_list
 include:

--- a/providers/base/units/rtc/test-plan.pxu
+++ b/providers/base/units/rtc/test-plan.pxu
@@ -5,6 +5,7 @@ _description: QA RTC tests for Snappy Ubuntu Core devices
 include:
 nested_part:
     rtc-manual
+    rtc-automated
 
 id: rtc-manual
 unit: test plan
@@ -17,4 +18,35 @@ id: rtc-automated
 unit: test plan
 _name: Automated RTC tests
 _description: Automated RTC tests for Snappy Ubuntu Core devices
+bootstrap_include:
+    rtc_list
 include:
+    rtc/rtc_number
+    rtc/rtc_alarm_.*
+    rtc/rtc_clock_.*
+
+id: after-suspend-rtc-full
+unit: test plan
+_name: RTC tests (after suspend)
+_description: QA RTC tests for Snappy Ubuntu Core devices
+include:
+nested_part:
+    after-suspend-rtc-manual
+    after-suspend-rtc-automated
+
+id: after-suspend-rtc-manual
+unit: test plan
+_name: Multiple RTC manual tests (after suspend)
+_description: Manual after suspend multiple RTC tests
+include:
+
+id: after-suspend-rtc-automated
+unit: test plan
+_name: Multiple RTC auto tests (after suspend)
+_description: Automated after suspend multiple RTC tests
+bootstrap_include:
+    rtc_list
+include:
+    after-suspend-rtc/rtc_number
+    after-suspend-rtc/rtc_alarm_.*
+    after-suspend-rtc/rtc_clock_.*


### PR DESCRIPTION
## Description

Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).

1. Cover if the platform supports more than one RTC.
2. Check if RTC supports wake-up alarms, and test it if supported.
3. Check RTC clock is synced with system time.

- Introduce your implementation approach in a way that helps reviewing it well.

1. Determine RTC numbers for the platform with variable $TOTAL_RTC_NUM, And one RTC will be a default value if not set it up.
2. Generate a list according to the RTC device under path "/dev/"
3. Check if RTC support aturbuite "wakealarm" under path "/sys/class/rtc/{rtc}/wakealarm"
5. Use "rtcwake -m on -s 30" to setting up RTC wake-up alarm and wait for the alarm to be triggered without putting the system into suspend or power off status.
> The reason that we don't really put the system into suspend or power off is we have other similar purpose jobs in the checkbox base already.

## Resolved issues

Note the Jira/Launchpad issue(s) resolved by this PR (`Fixes|Resolves ...`).

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.

1. Test result with RTC number mismatched and RTC clock is not synced with system time.
    https://pastebin.canonical.com/p/gm3BRWYNSb/
2. Test result with RTC number matched and RTC clock is synced with system time.
    https://pastebin.canonical.com/p/ng9xH5mqcr/

- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
1. Side load provider
2. Setting up the variable $TOTAL_RTC_NUM
3. Run the command 
   $ checkbox-cli run com.canonical.certification::rtc/rtc-automated

- [ ] A list of what tests were run and on what platform/configuration is provided.
1. [Sugarland-PDK](https://certification.canonical.com/hardware/202105-29111/submission/282346/test-results/?term=rtc)
4. [Shiner-Fire](https://certification.canonical.com/hardware/202109-29394/submission/295310/test-results/?term=rtc)