### PR TITLE
Upload snapcraft logs as an artefact if snapcraft build fails

### DIFF
--- a/.github/workflows/checkbox-core-snap-beta-release.yml
+++ b/.github/workflows/checkbox-core-snap-beta-release.yml
@@ -43,6 +43,11 @@ jobs:
           snapcraft-channel: 7.x/stable
           snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: snapcraft-log-series${{ matrix.releases }}
+          path: /home/runner/.cache/snapcraft/log
+      - uses: actions/upload-artifact@v3
         with:
           name: series${{ matrix.releases }}
           path: checkbox-core-snap/series${{ matrix.releases }}/*.snap

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -57,6 +57,11 @@ jobs:
           snapcraft-channel: 7.x/stable
           snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: snapcraft-log-series${{ matrix.releases }}
+          path: /home/runner/.cache/snapcraft/log
+      - uses: actions/upload-artifact@v3
         with:
           name: series${{ matrix.releases }}
           path: checkbox-core-snap/series${{ matrix.releases }}/*.snap


### PR DESCRIPTION
Snapcraft 7.x stopped outputing everything to stdout and instead puts build logs in a `~/.cache/snapcraft/log/` directory. This is not ideal when running snapcraft as part of an automated workflow, because errors are not visible in stdout anymore, instead simply stating:

Logging execution to '/home/runner/.cache/snapcraft/log/xxx.log'

Add a step to capture these log files as artefact and upload them to the Github Action if the build fails.

Fixes CHECKBOX-445

