### PR TITLE
Add: EEPROM test

### DIFF
--- a/providers/base/bin/eeprom_test.sh
+++ b/providers/base/bin/eeprom_test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+eeprom_path=$(find /sys/devices/platform/ -name eeprom)
+if [ ! "$eeprom_path" ];
+then
+echo "Error: Can't find EEPROM in system!!"
+exit 1
+fi
+status=0
+# This for loop is just in case multiple EEPROMs are on the platform. 
+for eeprom in $eeprom_path
+do
+# Generates random data for test. 
+data=$(echo $RANDOM | md5sum | head -c 10)
+echo "Write data ${data} into ${eeprom}"
+if (echo "$data" > "$eeprom")
+then
+    echo "Write data ${data} successfully"
+    echo "Read data back from EEPROM"
+    # Dump the content of EEPROM as a log.
+    od -c < "$eeprom"
+    # The content of EEPROM should be something like this:
+    # root@ubuntu:~# cat "$eeprom_path"|od -c
+    # 0000000   1   2   e   8   6   0   6   7   0   9  \n 377 377 377 377 377
+    # 0000020 377 377 377 377 377 377 377 377 377 377 377 377 377 377 377 377
+    # *
+    # ...
+    # So if we capture the first line of content for the EEPROM.
+    # It will be 12e8606709, and it is exactly the data we put in.
+    read_data=$(awk 'NR==1{printf $i}' "$eeprom")
+    if [ "$data" == "$read_data" ];
+    then
+    echo "Read back data ${read_data} correct!"
+    else
+    echo "Read back data ${data} fail"
+    status=1
+    fi
+else
+    echo "Write data ${data} fail"
+    status=1
+fi
+done
+exit "$status"

--- a/providers/base/units/eeprom/category.pxu
+++ b/providers/base/units/eeprom/category.pxu
@@ -1,0 +1,3 @@
+unit: category
+id: eeprom 
+_name: EEPROM read and write test

--- a/providers/base/units/eeprom/jobs.pxu
+++ b/providers/base/units/eeprom/jobs.pxu
@@ -7,45 +7,4 @@ flags: also-after-suspend
 estimated_duration: 5
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_eeprom == 'True'
-command:
-  eeprom_path=$(find /sys/devices/platform/ -name eeprom)
-  if [ ! "$eeprom_path" ];
-  then
-    echo "Error: Can't find EEPROM in system!!"
-    exit 1
-  fi
-  status=0
-  # This for loop is just in case multiple EEPROMs are on the platform. 
-  for eeprom in $eeprom_path
-  do
-    # Generates randon data for test. 
-    data=$(echo $RANDOM | md5sum | head -c 10)
-    echo "Write data ${data} into ${eeprom}"
-    if (echo "$data" > "$eeprom")
-    then
-      echo "Write data ${data} successfully"
-      echo "Read data back from EEPROM"
-      # Dump the content of EEPROM as a log.
-      od -c < "$eeprom"
-      # The content of EEPROM should be something like this:
-      # root@ubuntu:~# cat "$eeprom_path"|od -c
-      # 0000000   1   2   e   8   6   0   6   7   0   9  \n 377 377 377 377 377
-      # 0000020 377 377 377 377 377 377 377 377 377 377 377 377 377 377 377 377
-      # *
-      # ...
-      # So if we capture the first line of content for the EEPROM.
-      # It will be 12e8606709, and it is exactly the data we put in.
-      read_data=$(awk 'NR==1{printf $i}' "$eeprom")
-      if [ "$data" == "$read_data" ];
-      then
-        echo "Read back data ${read_data} correct!"
-      else
-        echo "Read back data ${data} fail"
-        status=1
-      fi
-    else
-      echo "Write data ${data} fail"
-      status=1
-    fi
-  done
-  exit "$status"
+command: eeprom_test.sh

--- a/providers/base/units/eeprom/jobs.pxu
+++ b/providers/base/units/eeprom/jobs.pxu
@@ -8,22 +8,34 @@ estimated_duration: 5
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_eeprom == 'True'
 command:
-  eeprom_path=$(find /sys/ -name eeprom)
+  eeprom_path=$(find /sys/devices/platform/ -name eeprom)
   if [ ! "$eeprom_path" ];
   then
     echo "Error: Can't find EEPROM in system!!"
     exit 1
   fi
   status=0
+  # This for loop is just in case multiple EEPROMs are on the platform. 
   for eeprom in $eeprom_path
   do
+    # Generates randon data for test. 
     data=$(echo $RANDOM | md5sum | head -c 10)
     echo "Write data ${data} into ${eeprom}"
     if (echo "$data" > "$eeprom")
     then
       echo "Write data ${data} successfully"
       echo "Read data back from EEPROM"
-      read_data=$(cat < "$eeprom" | od -c | awk 'NR==1{for(i=2;i<=11;i++) printf $i}')
+      # Dump the content of EEPROM as a log.
+      od -c < "$eeprom"
+      # The content of EEPROM should be something like this:
+      # root@ubuntu:~# cat "$eeprom_path"|od -c
+      # 0000000   1   2   e   8   6   0   6   7   0   9  \n 377 377 377 377 377
+      # 0000020 377 377 377 377 377 377 377 377 377 377 377 377 377 377 377 377
+      # *
+      # ...
+      # So if we capture the first line of content for the EEPROM.
+      # It will be 12e8606709, and it is exactly the data we put in.
+      read_data=$(awk 'NR==1{printf $i}' "$eeprom")
       if [ "$data" == "$read_data" ];
       then
         echo "Read back data ${read_data} correct!"

--- a/providers/base/units/eeprom/jobs.pxu
+++ b/providers/base/units/eeprom/jobs.pxu
@@ -1,0 +1,39 @@
+id: eeprom/read-write
+_summary: Test EEPROM read and write functions for the system. 
+plugin: shell
+user: root
+category_id: eeprom 
+flags: also-after-suspend
+estimated_duration: 5
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_eeprom == 'True'
+command:
+  eeprom_path=$(find /sys/ -name eeprom)
+  if [ ! "$eeprom_path" ];
+  then
+    echo "Error: Can't find EEPROM in system!!"
+    exit 1
+  fi
+  status=0
+  for eeprom in $eeprom_path
+  do
+    data=$(echo $RANDOM | md5sum | head -c 10)
+    echo "Write data ${data} into ${eeprom}"
+    if (echo "$data" > "$eeprom")
+    then
+      echo "Write data ${data} successfully"
+      echo "Read data back from EEPROM"
+      read_data=$(cat < "$eeprom" | od -c | awk 'NR==1{for(i=2;i<=11;i++) printf $i}')
+      if [ "$data" == "$read_data" ];
+      then
+        echo "Read back data ${read_data} correct!"
+      else
+        echo "Read back data ${data} fail"
+        status=1
+      fi
+    else
+      echo "Write data ${data} fail"
+      status=1
+    fi
+  done
+  exit "$status"

--- a/providers/base/units/eeprom/manifest.pxu
+++ b/providers/base/units/eeprom/manifest.pxu
@@ -1,0 +1,4 @@
+unit: manifest entry
+id: has_eeprom
+_name: Does device supported EEPROM?
+value-type: bool

--- a/providers/base/units/eeprom/test-plan.pxu
+++ b/providers/base/units/eeprom/test-plan.pxu
@@ -1,0 +1,43 @@
+id: eeprom-full
+unit: test plan
+_name: EEPROM tests
+_description: Full EEPROM tests for devices
+include:
+nested_part:
+    eeprom-manual
+    eeprom-automated
+
+id: eeprom-manual
+unit: test plan
+_name: EEPROM manual tests
+_description: Manual EEPROM tests for devices
+include:
+
+id: eeprom-automated
+unit: test plan
+_name: EEPROM auto tests
+_description: Automated EEPROM tests for devices
+include:
+    eeprom/read-write
+
+id: after-suspend-eeprom-full
+unit: test plan
+_name: EEPROM tests (after suspend)
+_description: Full after suspend EEPROM tests for devices
+include:
+nested_part:
+    after-suspend-eeprom-manual
+    after-suspend-eeprom-automated
+
+id: after-suspend-eeprom-manual
+unit: test plan
+_name: EEPROM manual tests (after suspend)
+_description: Manual after suspend EEPROM tests for devices
+include:
+
+id: after-suspend-eeprom-automated
+unit: test plan
+_name: EEPROM auto tests (after suspend)
+_description: Automated after suspend EEPROM tests for devices
+include:
+    after-suspend-eeprom/read-write


### PR DESCRIPTION
## Description

Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).

1. To cover EEPROM read and write test. Since some projects came with EEPROM support.

- Introduce your implementation approach in a way that helps reviewing it well.

1. Using manifest to determine if the platform supports EEPROM or not.
2. Check if EEPROM is probed as a system device. And return exit code 1 if didn't find any EEPROM device.
3. Generate a 10 byte long random data, and write it into EEPROM
4. Read back the date from EEPROM and check if written data and read-back data are consistent.

## Resolved issues

Note the Jira/Launchpad issue(s) resolved by this PR (`Fixes|Resolves ...`).

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.

1. [Side load result](https://pastebin.canonical.com/p/BTRDZrpshq/) with exclude manifest, since manifest will always be "False" if using side load provider.

- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.

1. `checkbox.checkbox-cli run com.canonical.certification::eeprom-automated`, and the manifest part should be marked if in the side load environment.

- [ ] A list of what tests were run and on what platform/configuration is provided.
1. [Shiner JACE9000](https://certification.canonical.com/hardware/202211-30889/submission/293753/test/151783/result/30451535/)
