### PR TITLE
Metabox: Guess URI if `origin` is set to `source` in config file

### DIFF
--- a/metabox/README.md
+++ b/metabox/README.md
@@ -60,6 +60,10 @@ optional arguments:
                         Turn on verbosity during machine setup. Only works with --log TRACE
 ```
 
+## Examples
+
+### Testing Checkbox from a PPA
+
 Let's say I want to test:
 
 - the [`basic` scenario] (which focuses on Checkbox local)
@@ -94,9 +98,39 @@ container once the testing is done. The next time you run the command, Metabox
 will reopen the existing container and rollback to a clean state in it before
 starting the new tests.
 
+### Testing Checkbox from a local repository
+
+It is possible to test Checkbox directly from a local Git repository using the
+`source` origin. To test all the available Metabox scenarios on Jammy using
+a local copy of Checkbox, create the following `source-local-config.py` file:
+
+```python
+configuration = {
+    'local': {
+        'origin': 'source',
+        # Path to the Checkbox source code repository.
+        # Can be omitted, see below.
+        'uri': '~/checkbox',
+        'releases': ['jammy'],
+    },
+}
+```
+
+Then call Metabox using it:
+
+```
+$ metabox source-local-config.py
+```
+
+**Note:** if `origin` is set to `source`, `uri` is not mandatory. If it is not
+set, it will point to the parent directory of the Metabox package. For
+instance, if Metabox was [installed] from `/home/user/code/checkbox/metabox/`,
+`uri` will be set to `/home/user/code/checkbox/`.
+
 [Checkbox]: https://checkbox.readthedocs.io/
 [Linux containers (LXC)]: https://linuxcontainers.org/
 [`desktop_env` scenario]: ./metabox/scenarios/desktop_env/
 [`basic` scenario]: ./metabox/scenarios/basic/
 [`configs` directory]: ./configs/
 [LXD documentation to install and initialize it]: https://linuxcontainers.org/lxd/getting-started-cli/
+[installed]: #installation

--- a/metabox/metabox/core/configuration.py
+++ b/metabox/metabox/core/configuration.py
@@ -20,6 +20,7 @@
 This module implements functions necessary to load metabox configs.
 """
 import importlib.util
+from importlib.resources import files
 import subprocess
 from pathlib import Path
 
@@ -43,6 +44,22 @@ def read_config(filename):
         logger.critical(exc)
         raise SystemExit()
 
+
+def guess_source_uri(config):
+    """
+    If 'uri' is not present for a 'source' origin, assume it's two directories
+    above metabox Python package.
+    """
+    for kind in config:
+        if config[kind]["origin"] == "source":
+            if "uri" not in config[kind]:
+                logger.info("Config: No 'uri' element defined.")
+                # e.g. '/mnt/documents/dev/work/checkbox/metabox/metabox'
+                metabox_pkg_path = files('metabox')
+                uri = metabox_pkg_path.parent.parent
+                logger.info("Config: Setting 'uri' to '{}'.", uri)
+                config[kind]["uri"] = str(uri)
+    return config
 
 def validate_config(config):
     """

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -22,6 +22,7 @@ import time
 from loguru import logger
 from metabox.core.aggregator import aggregator
 from metabox.core.configuration import read_config
+from metabox.core.configuration import guess_source_uri
 from metabox.core.configuration import validate_config
 from metabox.core.lxd_provider import LxdMachineProvider
 from metabox.core.machine import MachineConfig
@@ -47,6 +48,7 @@ class Runner:
             raise SystemExit('Config file not found!')
         else:
             self.config = read_config(args.config)
+            self.config = guess_source_uri(self.config)
             validate_config(self.config)
         # effective set of machine configs required by scenarios
         self.combo = set()


### PR DESCRIPTION
## Description

With this PR, it's possible, if the config's `origin` is set to `source`, to omit the `uri` element. It is then guessed from where Metabox is located.

## Resolved issues

Fixes CHECKBOX-448

## Documentation

See amended README file.

## Tests

```
pieq@coltrane ~> source ~/.venvs/metabox/bin/activate.fish
(metabox) pieq@coltrane ~> cd ~
(metabox) pieq@coltrane ~> cat dev/work/checkbox/metabox/configs/source-local-config-no-uri.py
configuration = {
    'local': {
        # Metabox can run tests from a local directory containing a copy of
        # the Checkbox source code repository.
        'origin': 'source',
        'releases': ['focal'],
    },
}
(metabox) pieq@coltrane ~> metabox dev/work/checkbox/metabox/configs/source-local-config-no-uri.py --log TRACE --tag config --do-not-dispose
15:44:43 | INFO     Config: No 'uri' element defined.
15:44:43 | INFO     Config: Setting 'uri' to '/mnt/documents/dev/work/checkbox'.
(...)
15:44:44 | INFO     Including scenario tag(s): config
(...)
15:44:48 | DEBUG    [creating    ] metabox-local-focal-source
(...)
15:49:49 | INFO     Starting scenario: config.launcher.CheckboxConfXDG
--------------[ Running job 1 / 2. Estimated time left: unknown ]---------------
(...)
15:50:46 | DEBUG    [stopped     ] metabox-local-focal-source
--------------------------------------------------------------------------------
15:50:46 | ERROR    Ran 5 scenarios in 65.946s
```

(Note: the "ERROR" is due to the fact that [Checkbox implementation does not follow its documentation](https://github.com/canonical/checkbox/pull/310#issuecomment-1440040442) ;))

