### PR TITLE
Upload snapcraft remote-build logs for checkbox-core-snap and checkbox-snap even if no failure raised

### DIFF
--- a/.github/workflows/checkbox-core-snap-beta-release.yml
+++ b/.github/workflows/checkbox-core-snap-beta-release.yml
@@ -43,7 +43,6 @@ jobs:
           snapcraft-channel: 7.x/stable
           snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
-        if: failure()
         with:
           name: snapcraft-log-series${{ matrix.releases }}
           path: /home/runner/.cache/snapcraft/log

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -57,7 +57,6 @@ jobs:
           snapcraft-channel: 7.x/stable
           snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
-        if: failure()
         with:
           name: snapcraft-log-series${{ matrix.releases }}
           path: /home/runner/.cache/snapcraft/log

--- a/.github/workflows/checkbox-snap-beta-release.yml
+++ b/.github/workflows/checkbox-snap-beta-release.yml
@@ -45,6 +45,10 @@ jobs:
           snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
         with:
+          name: snapcraft-log-series-${{ matrix.type }}${{ matrix.releases }}
+          path: /home/runner/.cache/snapcraft/log
+      - uses: actions/upload-artifact@v3
+        with:
           name: series_${{ matrix.type }}${{ matrix.releases }}
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
       - name: Upload checkbox snaps to the store

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -59,6 +59,10 @@ jobs:
           snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
         with:
+          name: snapcraft-log-series-${{ matrix.type }}${{ matrix.releases }}
+          path: /home/runner/.cache/snapcraft/log
+      - uses: actions/upload-artifact@v3
+        with:
           name: series_${{ matrix.type }}${{ matrix.releases }}
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
       - name: Upload checkbox snaps to the store


### PR DESCRIPTION
Since snapcraft remote-build does not actually fail if only one snap fails to build (see [this example](https://github.com/canonical/checkbox/actions/runs/4370668139/jobs/7645803544#step:6:281)), the logs upload step is never triggered.

Changing that, and also add the same workflow to the checkbox-snap, because why not.