### PR TITLE
Add: USB-C OTG test

### DIFF
--- a/providers/base/units/usb/manifest.pxu
+++ b/providers/base/units/usb/manifest.pxu
@@ -12,3 +12,8 @@ unit: manifest entry
 id: has_usb_storage
 _name: USB Storage Device Connected
 value-type: bool
+
+unit: manifest entry
+id: has_usbc_otg
+_name: Does the platform support USB OTG?
+value-type: bool

--- a/providers/base/units/usb/manifest.pxu
+++ b/providers/base/units/usb/manifest.pxu
@@ -15,5 +15,5 @@ value-type: bool
 
 unit: manifest entry
 id: has_usbc_otg
-_name: Does the platform support USB OTG?
+_name: Does the platform support USB-C OTG?
 value-type: bool

--- a/providers/base/units/usb/test-plan.pxu
+++ b/providers/base/units/usb/test-plan.pxu
@@ -280,6 +280,12 @@ include:
     usb-c/insert
     usb-c/storage-automated
     usb-c/remove
+    usb-c-otg/g_serial
+    usb-c-otg/g_serial-cleanup
+    usb-c-otg/g_mass_storage
+    usb-c-otg/g_mass_storage-cleanup
+    usb-c-otg/g_ether
+    usb-c-otg/g_ether-cleanup
 
 id: usb-c-automated
 unit: test plan
@@ -349,6 +355,12 @@ include:
     after-suspend-usb-c/insert
     after-suspend-usb-c/storage-automated
     after-suspend-usb-c/remove
+    after-suspend-usb-c-otg/g_serial
+    after-suspend-usb-c-otg/g_serial-cleanup
+    after-suspend-usb-c-otg/g_mass_storage
+    after-suspend-usb-c-otg/g_mass_storage-cleanup
+    after-suspend-usb-c-otg/g_ether
+    after-suspend-usb-c-otg/g_ether-cleanup
 
 id: after-suspend-usb-c-automated
 unit: test plan

--- a/providers/base/units/usb/usb-c.pxu
+++ b/providers/base/units/usb/usb-c.pxu
@@ -208,3 +208,129 @@ _steps:
  2. Start the test
  3. When the message "INSERT NOW" is shown, plug in the adapter to Type-C port
 estimated_duration: 20
+
+id: usb-c-otg/g_serial
+_summary: Check if USB OTG can work as a serial port.
+category_id: com.canonical.plainbox::usb
+plugin: user-interact-verify
+user: root
+estimated_duration: 300.0
+command:
+   modprobe g_serial
+_steps:
+ 1. Press enter to probe USB OTG g_serial
+ 2. Connect a USB cable from an Ubuntu host to the USB OTG (it's the USB type C connector) port on DUT.
+ 3. On the host, to check if ttyACM0 has been probed
+    $ ls /dev/ttyACM0
+ 4. On the host, listen to the ttyACM0 port as a receive side.
+    $ sudo su
+    $ cat /dev/ttyACM0
+ 5. On DUT, send a string via /dev/ttyGS0 as a send side.
+    $ sudo su
+    $ echo 123 > /dev/ttyGS0
+ 6. Check if received the string "123" on the host side.
+ 7. Check the string sending from the host to DUT by repeating steps 4-6, but swap the send and receive sides.
+_verification:
+    Does string send and receive work?
+flags: preserve-locale also-after-suspend
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_usbc_otg == 'True'
+
+id: usb-c-otg/g_serial-cleanup
+_summary: Cleanup USB OTG serial interface setup after serial device test
+plugin: shell
+after: usb-c-otg/g_serial
+category_id: com.canonical.plainbox::usb
+command:
+  echo "Removing g_serial module..."
+  modprobe -r g_serial
+user: root
+estimated_duration: 1s
+flags: also-after-suspend
+
+id: usb-c-otg/g_mass_storage
+_summary: Check DUT can be detected as a mass storage device
+_purpose:
+  Check that after connecting the device under test (DUT) to another device
+  (host), DUT can be detected as a mass storage device by the host.
+_steps:
+  1. Press Enter to setup a 16 MB FAT32 image on the device.
+  2. From an Ubuntu host, connect a cable to the USB OTG port 
+     (it's the USB type C connector) of the DUT.
+_verification:
+  The host detects and mounts a mass storage device. It has read and write 
+  permissions on it.
+plugin: user-interact-verify
+command:
+  echo "Creating 16 MB image file..."
+  dd if=/dev/zero of="${PLAINBOX_SESSION_SHARE}"/checkbox-mass-storage-test.img bs=1M count=16
+  echo "Formatting image file as FAT32..."
+  mkdosfs -F 32 "${PLAINBOX_SESSION_SHARE}"/checkbox-mass-storage-test.img
+  echo "loading g_mass_storage module..."
+  modprobe g_mass_storage file="${PLAINBOX_SESSION_SHARE}"/checkbox-mass-storage-test.img stall=0
+user: root
+category_id: com.canonical.plainbox::usb
+estimated_duration: 5m
+flags: preserve-locale also-after-suspend
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_usbc_otg == 'True'
+
+id: usb-c-otg/g_mass_storage-cleanup
+_summary: Cleanup mass storage setup after mass storage device test
+plugin: shell
+after: usb-c-otg/g_mass_storage
+command:
+  echo "Removing g_mass_storage module..."
+  modprobe -r g_mass_storage
+  if [ -f "${PLAINBOX_SESSION_SHARE}/checkbox-mass-storage-test.img" ]; then
+    echo "Removing image file..."
+    rm "${PLAINBOX_SESSION_SHARE}"/checkbox-mass-storage-test.img
+  fi
+user: root
+estimated_duration: 1s
+category_id: com.canonical.plainbox::usb
+flags: also-after-suspend
+
+id: usb-c-otg/g_ether
+_summary: Check DUT can be detected as USB ethernet device
+_steps:
+  1. From an Ubuntu host, connect a cable to the USB OTG port 
+     (it's the USB type C connector) of the DUT.
+  2. Press Enter to config the IP address for the USB OTG ethernet interface on the DUT.
+     (IP will be 192.168.9.1/24)
+  3. On the host, config the IP address for the USB OTG ethernet interface. And it should be 
+     the same subnet with DUT. (eg. 192.168.9.2/24)
+  4. Try to ping between the host and DUT.
+_verification:
+  The host and DUT can ping each other.
+plugin: user-interact-verify
+command:
+   echo "Setting up the IP address for USB OTG ethernet interface..."
+   modprobe g_ether
+   if  (ip -c a | grep -q usb0) ; then 
+      echo "USB OTG ethernet interface exist. Configuring..."
+      ip addr add 192.168.9.1/24 dev usb0
+      echo "USB OTG ethernet interface IP address been set as 192.168.9.1/24"
+      ip link set dev usb0 up
+   else 
+      echo "USB OTG ethernet interface does not exist."
+      exit 1
+   fi
+user: root
+category_id: com.canonical.plainbox::usb
+estimated_duration: 5m
+flags: preserve-locale also-after-suspend
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_usbc_otg == 'True'
+
+id: usb-c-otg/g_ether-cleanup
+_summary: Cleanup USB OTG ethernet interface setup after ethernet device test
+plugin: shell
+after: usb-c-otg/g_ether
+command:
+  echo "Removing g_ether module..."
+  modprobe -r g_ether
+user: root
+estimated_duration: 1s
+category_id: com.canonical.plainbox::usb
+flags: also-after-suspend

--- a/providers/base/units/usb/usb-c.pxu
+++ b/providers/base/units/usb/usb-c.pxu
@@ -246,7 +246,11 @@ command:
   modprobe -r g_serial
 user: root
 estimated_duration: 1s
-flags: also-after-suspend
+_siblings: [
+     { "id": "after-suspend-usb-c-otg/g_serial-cleanup",
+       "_summary": "Cleanup USB OTG serial interface setup after serial device test (after suspend)",
+       "after": "after-suspend-usb-c-otg/g_serial"
+     }]
 
 id: usb-c-otg/g_mass_storage
 _summary: Check DUT can be detected as a mass storage device
@@ -289,7 +293,11 @@ command:
 user: root
 estimated_duration: 1s
 category_id: com.canonical.plainbox::usb
-flags: also-after-suspend
+_siblings: [
+     { "id": "after-suspend-usb-c-otg/g_mass_storage-cleanup",
+       "_summary": "Cleanup mass storage setup after mass storage device test (after suspend)",
+       "after": "after-suspend-usb-c-otg/g_mass_storage"
+     }]
 
 id: usb-c-otg/g_ether
 _summary: Check DUT can be detected as USB ethernet device
@@ -333,4 +341,8 @@ command:
 user: root
 estimated_duration: 1s
 category_id: com.canonical.plainbox::usb
-flags: also-after-suspend
+_siblings: [
+     { "id": "after-suspend-usb-c-otg/g_ether-cleanup",
+       "_summary": "Cleanup USB OTG ethernet interface setup after ethernet device test (after suspend)",
+       "after": "after-suspend-usb-c-otg/g_ether"
+     }]


### PR DESCRIPTION
## Description

Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
We have a few IoT projects that require support for USB-C OTG. 
- Introduce your implementation approach in a way that helps reviewing it well.
USB-C OTG requires manual interaction to plug the USB-C cable. Therefore, we only implement manual jobs for it.
And it includes USB OTG serial, mass storage, and ethernet. The mass_storage job was mimicked from "usb-dwc3/mass-storage" in provider iiotg, However, the description was different, and it is more neutral in here.
## Resolved issues

Note the Jira/Launchpad issue(s) resolved by this PR (`Fixes|Resolves ...`).

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
We use those jobs in a few different projects.
[Sugarland PDK](https://certification.canonical.com/hardware/202105-29109/submission/286801/test-results/pass/?term=otg)
[Medina](https://certification.canonical.com/hardware/202204-30178/submission/275286/test-results/?term=otg)

- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [ ] A list of what tests were run and on what platform/configuration is provided.
[Sugarland PDK](https://certification.canonical.com/hardware/202105-29109/submission/286801/test-results/pass/?term=otg)
[Medina](https://certification.canonical.com/hardware/202204-30178/submission/275286/test-results/?term=otg)
