### PR TITLE
Change order of stress-ng-cert-automated nested parts in 22.04 desktop test plan

### DIFF
--- a/providers/certification-client/units/client-cert-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-22-04.pxu
@@ -167,9 +167,9 @@ nested_part:
     # The following tests are purely automated and/or lenghty stress tests.
     # They have been moved to the end of the test run to improve the testing
     # process.
+    stress-ng-cert-automated
     stress-iperf3-automated
     #stress-cert-full
     stress-suspend-30-cycles-with-reboots-automated
-    stress-ng-cert-automated
     stress-30-reboot-poweroff-automated
     stress-pm-graph


### PR DESCRIPTION
There was a little misshap and Vincent's changes in commit 57b6c69ceb015af879fbd5459c90edbc9d43ad9e were partially reverted.

stress-ng-cert-automated is moved to the beginning of the stress tests section because it contains the mechanism to modify oom-killer configuration (and restore it at the end) and it does not play well with later parts which may occur after a reboot[1].

[1] https://github.com/canonical/checkbox/pull/297/files#r1067766303
