### PR TITLE
Add: GPIO/SYSFS LED indicator test

### DIFF
--- a/providers/base/bin/led_test.sh
+++ b/providers/base/bin/led_test.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+export_gpio() {
+    if [ ! -d "$gpio_node" ]; then
+        echo "## Export GPIO $port to system"
+        echo "$port" > "$path"/export
+        sleep 2
+    fi
+
+    if [ ! -d "$gpio_node" ]; then
+        echo "## Unable to export GPIO $port"
+        exit 1
+    fi
+    echo "out" > "$gpio_node"/direction
+}
+
+test_gpio_leds() {
+    echo "Testing $name on GPIO $port ..."
+    ori_status=$(cat "$gpio_node"/value)
+    i=0
+    while [ "$i" -le 3 ]; do
+        for y in 0 1; do
+            echo "$y" > "$gpio_node"/value
+            sleep 1
+        done
+        i=$((i+1))
+    done
+    echo "$ori_status" > "$gpio_node"/value
+}
+
+test_sysfs_leds() {
+    ori_status=$(cat /sys/class/leds/"$name"/brightness)
+    for i in $(seq 1 3); do
+        for y in 1 0 ; do
+            echo "$y" > /sys/class/leds/"$name"/brightness
+            test "$(cat /sys/class/leds/"$name"/brightness)" == "$y" || exit 1
+            sleep 1
+        done
+    done
+    echo "$ori_status" > /sys/class/leds/"$name"/brightness
+}
+
+main() {
+    if [ "$type" == "gpio" ]; then
+        path="/sys/class/gpio"
+        gpio_node="$path/gpio$port"
+        # Configure GPIO interface if needed
+        export_gpio
+        # Test button
+        test_gpio_leds
+    else
+        test_sysfs_leds
+    fi
+}
+
+help_function() {
+    echo "This script is uses for test GPIO/SYSFS leds"
+    echo "Will light GPIO/SYSFS leds up"
+    echo
+    echo "Usage: leds_test.sh -t led_type -n led_name -p gpio_port"
+    echo -e "\t-t    led type [gpio|sysfs]"
+    echo -e "\t-n    led name"
+    echo -e "\t-p    gpio port"
+}
+
+
+while getopts "t:n:p:" opt; do
+    case "$opt" in
+        t) type="$OPTARG" ;;
+        n) name="$OPTARG" ;;
+        p) port="$OPTARG" ;;
+        ?) help_function ;;
+    esac
+done
+
+if [ -z "$type" ]; then
+    echo -e "Error: LED type is needed!"
+    help_function
+    exit 1
+elif [ "$type" == "gpio" ]; then   
+    if [ -z "$name" ] && [ -z "$port" ]; then
+        echo -e "Error: LED name and GPIO port number is needed for GPIO LED test.\n"
+        help_function
+        exit 1
+    fi
+else
+    if [ -z "$name" ]; then
+        echo -e "Error: LED name is needed for SYSFS LED test.\n"
+        help_function
+        exit 1
+    fi
+fi
+main

--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -265,3 +265,86 @@ _steps:
      2. Fn key LED should be switched on/off every time the key is pressed.
 _verification:
     Did the Fn key LED light as expected?
+
+id: led-indicator/gpio-leds
+plugin: resource
+_summary: Gather a list of LED indicators for the device that controls via GPIO.
+_description:
+    A LED GPIO number mapping resource that relies on the user specifying in config variable.
+    Usage of parameter: GPIO_LEDS={name1}:{port1} {name2}:{port2} ...
+    e.g. GPIO_LEDS=dl1:488 dl2:489 dl44:507
+estimated_duration: 3
+environ: GPIO_LEDS
+command:
+    awk '{
+        split($0, record, " ")
+        for (i in record) {
+            split(record[i], data, ":")
+            printf "name: %s\nport: %s\n\n", data[1], data[2]
+        }
+    }' <<< "$GPIO_LEDS"
+
+unit: template
+template-resource: led-indicator/gpio-leds
+template-unit: job
+category_id: led
+id: led-indicator/gpio-leds-{name}
+estimated_duration: 10
+plugin: user-interact-verify
+user: root
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_led_indicator == 'True'
+flags: also-after-suspend
+_summary: Check control of {name} LED indecator.
+_description:
+    Check that {name} LED turns on and off.
+_steps:
+    1. Press Enter and observe LED behavior on DUT.
+_verification:
+    Does the "{name}" LED blink?
+command:
+    led_test.sh -t gpio -n {name} -p {port}
+
+id: led-indicator/sysfs-leds
+plugin: resource
+_summary: Gather a list of LED indicators for the device that control via sysfs path.
+_description:
+    A LED path mapping resource that relies on the user specifying in config variable.
+    Usage of parameter: SYS_LEDS={name1}:{path1} {name2}:{path2} ...
+    path under "/sys/class/leds/{path}"
+    e.g. SYS_LEDS=DL1:beat-yel-led DL2:shtdwn-grn-led.
+    Note: make sure name of LED not includes symbol ":"
+estimated_duration: 3
+environ: SYS_LEDS
+command:
+    awk '{
+    split($0, record, " ")
+    for (i in record) {
+        # To handle that led path includes symbol ":"
+        # Get the index of the first match ":" in record[i]
+        pos = index(record[i],":");
+        # Split string by matching ":" to get the string before first ":"
+        printf "name: %s\npath: %s\n\n", substr(record[i],1,pos-1),substr(record[i],pos+1)
+        }
+    }' <<< "$SYS_LEDS"
+
+unit: template
+template-resource: led-indicator/sysfs-leds
+template-unit: job
+id: led-indicator/sysfs-leds-{name}
+category_id: led
+_summary: Check control of {name} LED.
+_description:
+  Check that {name} LED turns on and off.
+_steps:
+    1. Press enter and observe LED behavior on DUT.
+_verification:
+    Does the {name} LED blink?
+plugin: user-interact-verify
+user: root
+flags: also-after-suspend
+estimated_duration: 10
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_led_indicator == 'True'
+command:
+    led_test.sh -t sysfs -n {path}

--- a/providers/base/units/led/manifest.pxu
+++ b/providers/base/units/led/manifest.pxu
@@ -1,0 +1,4 @@
+unit: manifest entry
+id: has_led_indicator
+_name: Does device supported LED indicator?
+value-type: bool

--- a/providers/base/units/led/test-plan.pxu
+++ b/providers/base/units/led/test-plan.pxu
@@ -115,3 +115,25 @@ include:
     led/sysfs_led_brightness_off_.*
 bootstrap_include:
     dmi
+
+id: led-indicator-manual
+unit: test plan
+_name: Manual LED indicator tests for IoT
+_description: Manual LED indicator tests for IoT devices
+include:
+    led-indicator/gpio-leds-.*
+    led-indicator/sysfs-leds-.*
+bootstrap_include:
+    led-indicator/gpio-leds
+    led-indicator/sysfs-leds
+
+id: after-suspend-led-indicator-manual
+unit: test plan
+_name: Manual LED indicator tests for IoT (after_suspend)
+_description: Manual LED indicator tests for IoT devices (after_suspend)
+include:
+    after-suspend-led-indicator/gpio-leds-.*
+    after-suspend-led-indicator/sysfs-leds-.*
+bootstrap_include:
+    led-indicator/gpio-leds
+    led-indicator/sysfs-leds


### PR DESCRIPTION
## Description

Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
There are some devices that support LED indicators. Those LED indicators can be controlled via GPIO or the sysfs path. Therefore, we add jobs to cover these kinds of scenarios. 
- Introduce your implementation approach in a way that helps reviewing it well.
We break the LED indicator test into two parts, one is controlled via GPIO and the other is via sysfs path.
And user can predefine the config variable "GPIO_LEDS" for GPIO LEDs or "SYS_LEDS" for sysfs path LEDs.
The format of variables is as follows:
GPIO_LEDS = {LED_name1}:{GPIO_port_number1} {LED_name2}:{GPIO_port_number2} ...
SYS_LEDS = {LED_name1}:{LED_path1} {LED_name2}:{LED_path2}

## Resolved issues

Note the Jira/Launchpad issue(s) resolved by this PR (`Fixes|Resolves ...`).

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
Side load result without manifest:
[sugarland-PDK with sysfs LEDs](https://pastebin.canonical.com/p/JNC3jSnHGx/)
[shiner-firecpu2.0 with GPIO LEDs](https://pastebin.canonical.com/p/sDJ2rRMPqt/)
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [ ] A list of what tests were run and on what platform/configuration is provided.
Side load result without manifest:
[sugarland-PDK with sysfs LEDs](https://pastebin.canonical.com/p/JNC3jSnHGx/)
[shiner-firecpu2.0 with GPIO LEDs](https://pastebin.canonical.com/p/sDJ2rRMPqt/)