### PR TITLE
Fix: WIFI network test of WPA3-encrypted isn't working for ubuntu 20.04

### DIFF
--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -210,11 +210,12 @@ def secured_connection(args):
            "type wifi "
            "ssid '{}' "
            "-- "
-           "wifi-sec.key-mgmt wpa-psk "
+           "wifi-sec.key-mgmt {} "
            "wifi-sec.psk {} "
            "ipv4.method auto "
            "ipv4.dhcp-timeout 30 "
-           "ipv6.method ignore".format(args.device, args.essid, args.psk))
+           "ipv6.method ignore"
+           .format(args.device, args.essid, args.exchange, args.psk))
     print_cmd(cmd)
     sp.call(cmd, shell=True)
 
@@ -316,6 +317,9 @@ if __name__ == '__main__':
         'device', type=str, help='Device name e.g. wlan0')
     parser_secured.add_argument('essid', type=str, help='ESSID')
     parser_secured.add_argument('psk', type=str, help='Pre-Shared Key')
+    parser_secured.add_argument(
+        '--exchange', type=str, default='wpa-psk',
+        help='exchange type (default: %(default)s)')
     parser_secured.set_defaults(func=secured_connection)
 
     parser_ap = subparsers.add_parser(

--- a/providers/base/units/wireless/jobs.pxu
+++ b/providers/base/units/wireless/jobs.pxu
@@ -209,7 +209,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
-  wifi_nmcli_test.py secured {{ interface }} "$WPA3_AX_SSID" "$WPA3_AX_PSK"
+  wifi_nmcli_test.py secured {{ interface }} "$WPA3_AX_SSID" "$WPA3_AX_PSK" --exchange sae
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
 flags: preserve-locale also-after-suspend


### PR DESCRIPTION




## Description
WIFI network test of WPA3-encrypted isn't working for ubuntu 20.04 due to exchange type incorrect.
Adding one more argument for `secured_connection` from `wifi_nmcli_test.py` will be needed, then modify job `id: wireless/wireless_connection_wpa3_ax_nm_{{ interface }}` to provide this argument to `wifi_nmcli_test.py`

## Resolved issues

Fix #361

## Documentation
- [20.04 test](https://certification.canonical.com/hardware/202208-30580/submission/304901/)
- [22.04 test](https://certification.canonical.com/hardware/202212-30999/submission/304902/)

## Tests
- use checkbox to test all Wireless networking tests under com.canonical.certification::client-desktop-*-automated
