### PR TITLE
Fix metabox workflow to work with workflow_dispatch events

### DIFF
--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   Metabox:
-    if: github.event.review.state == 'approved'
+    if: (github.event.review.state == 'approved' || github.event_name == 'workflow_dispatch')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
A small fix to allow the manual workflow trigger to work (since there's no approved PR in this context)