### PR TITLE
Add manifest as requires for some monitor jobs

### DIFF
--- a/providers/base/units/monitor/jobs.pxu
+++ b/providers/base/units/monitor/jobs.pxu
@@ -329,6 +329,7 @@ _verification:
  Output to display works
 plugin: manual
 category_id: com.canonical.plainbox::monitor
+imports: from com.canonical.plainbox import manifest
 requires: manifest.has_dvi == 'True'
 estimated_duration: 300
 flags: also-after-suspend
@@ -344,6 +345,7 @@ _verification:
  Output to display works
 plugin: manual
 category_id: com.canonical.plainbox::monitor
+imports: from com.canonical.plainbox import manifest
 requires: manifest.has_hdmi == 'True'
 estimated_duration: 300
 flags: also-after-suspend
@@ -359,6 +361,7 @@ _verification:
  Output to display works
 plugin: manual
 category_id: com.canonical.plainbox::monitor
+imports: from com.canonical.plainbox import manifest
 requires: manifest.has_dp == 'True'
 estimated_duration: 300
 flags: also-after-suspend
@@ -374,6 +377,7 @@ _verification:
  Output to display works
 plugin: manual
 category_id: com.canonical.plainbox::monitor
+imports: from com.canonical.plainbox import manifest
 requires: manifest.has_dvi == 'True'
 estimated_duration: 300
 flags: also-after-suspend
@@ -389,6 +393,7 @@ _verification:
  Output to display works
 plugin: manual
 category_id: com.canonical.plainbox::monitor
+imports: from com.canonical.plainbox import manifest
 requires: manifest.has_hdmi == 'True'
 estimated_duration: 300
 flags: also-after-suspend
@@ -397,6 +402,7 @@ id: monitor/displayport_hotplug
 _summary: Can hotplug monitor (DisplayPort)
 plugin: manual
 category_id: com.canonical.plainbox::monitor
+imports: from com.canonical.plainbox import manifest
 requires: manifest.has_dp == 'True'
 _purpose:
      This test will check the DisplayPort port and the ability to do hotplugging.
@@ -419,6 +425,7 @@ _verification:
  Output to display works
 plugin: manual
 category_id: com.canonical.plainbox::monitor
+imports: from com.canonical.plainbox import manifest
 requires: manifest.has_vga == 'True'
 estimated_duration: 300
 flags: also-after-suspend

--- a/providers/base/units/monitor/jobs.pxu
+++ b/providers/base/units/monitor/jobs.pxu
@@ -329,6 +329,7 @@ _verification:
  Output to display works
 plugin: manual
 category_id: com.canonical.plainbox::monitor
+requires: manifest.has_dvi == 'True'
 estimated_duration: 300
 flags: also-after-suspend
 
@@ -343,6 +344,7 @@ _verification:
  Output to display works
 plugin: manual
 category_id: com.canonical.plainbox::monitor
+requires: manifest.has_hdmi == 'True'
 estimated_duration: 300
 flags: also-after-suspend
 
@@ -357,6 +359,7 @@ _verification:
  Output to display works
 plugin: manual
 category_id: com.canonical.plainbox::monitor
+requires: manifest.has_dp == 'True'
 estimated_duration: 300
 flags: also-after-suspend
 
@@ -371,6 +374,7 @@ _verification:
  Output to display works
 plugin: manual
 category_id: com.canonical.plainbox::monitor
+requires: manifest.has_dvi == 'True'
 estimated_duration: 300
 flags: also-after-suspend
 
@@ -385,6 +389,7 @@ _verification:
  Output to display works
 plugin: manual
 category_id: com.canonical.plainbox::monitor
+requires: manifest.has_hdmi == 'True'
 estimated_duration: 300
 flags: also-after-suspend
 
@@ -392,6 +397,7 @@ id: monitor/displayport_hotplug
 _summary: Can hotplug monitor (DisplayPort)
 plugin: manual
 category_id: com.canonical.plainbox::monitor
+requires: manifest.has_dp == 'True'
 _purpose:
      This test will check the DisplayPort port and the ability to do hotplugging.
 _steps:
@@ -413,6 +419,7 @@ _verification:
  Output to display works
 plugin: manual
 category_id: com.canonical.plainbox::monitor
+requires: manifest.has_vga == 'True'
 estimated_duration: 300
 flags: also-after-suspend
 


### PR DESCRIPTION
## Description
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
  - Add the manifest as requires for some of monitor jobs, such as monitor/dp, monitor/hdmi, etc.
    These jobs are still used in monitor-manual test plan and this test plan is included in client-cert-iot-ubuntucore-xx-manual test plan. Therefore, these requires will help tester to skip jobs via corresponding manifests.

## Resolved issues

Reduce the time and effort that tester has to skip these jobs manually. 

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [ ] Steps to follow for reviewer to run & manually test are provided.
- [ ] A list of what tests were run and on what platform/configuration is provided.
