### PR TITLE
Adding back the jobs lost in PR #304 and #306

### DIFF
--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -240,6 +240,7 @@ _verification:
     
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
+flags: also-after-suspend
 id: audio/playback_headphones
 estimated_duration: 20.0
 depends: audio/list_devices
@@ -350,7 +351,7 @@ plugin: shell
 category_id: com.canonical.plainbox::audio
 id: audio/alsa_record_playback_automated
 flags: also-after-suspend
-depends: audio/detect_sinks_sources
+depends: audio/detect_sinks audio/detect_sources
 estimated_duration: 10.0
 requires:
  package.name == 'python3-gi'
@@ -367,15 +368,31 @@ _description:
 
 plugin: shell
 category_id: com.canonical.plainbox::audio
-id: audio/detect_sinks_sources
+id: audio/detect_sinks
 flags: also-after-suspend
 estimated_duration: 1.0
+imports: from com.canonical.plainbox import manifest
 requires:
   package.name == 'pulseaudio-utils'
+  manifest.has_audio_playback == 'True'
 command:
-  pactl_list.sh
+  pactl_list.sh sinks
 _description:
-  Test to detect if there's available sources and sinks.
+  Test to detect if there's available sinks
+
+plugin: shell
+category_id: com.canonical.plainbox::audio
+flags: also-after-suspend
+id: audio/detect_sources
+estimated_duration: 1.0
+imports: from com.canonical.plainbox import manifest
+requires:
+  package.name == 'pulseaudio-utils'
+  manifest.has_audio_capture == 'True'
+command:
+  pactl_list.sh sources
+_description:
+  Test to detect if there's available sources.
 
 plugin: shell
 category_id: com.canonical.plainbox::audio

--- a/providers/base/units/audio/test-plan.pxu
+++ b/providers/base/units/audio/test-plan.pxu
@@ -48,7 +48,7 @@ _name: Audio tests (automated)
 _description:
  Audio tests (automated)
 include:
-    audio/detect_sinks_sources
+    audio/detect_sinks
     audio/alsa_record_playback_automated
     audio/alsa_info_collect
     audio/alsa_info_attachment
@@ -88,7 +88,8 @@ _name: Audio tests After Suspend (automated)
 _description:
  Audio tests After Suspend (automated)
 include:
-    after-suspend-audio/detect_sinks_sources
+    after-suspend-audio/detect_sinks
+    after-suspend-audio/detect_sources
     after-suspend-audio/alsa_record_playback_automated
 
 id: audio-full

--- a/providers/base/units/graphics/test-plan.pxu
+++ b/providers/base/units/graphics/test-plan.pxu
@@ -120,10 +120,8 @@ include:
     # suspend/suspend_advanced_auto (one GPU)
     # or suspend/{{ index }}_suspend_after_switch_to_card_{{ product_slug }}_auto (two GPUs)
     power-management/lid_close_suspend_open                  certification-status=blocker
-    after-suspend-miscellanea/chvt
     power-management/lid                                     certification-status=blocker
-    power-management/lid_close                               certification-status=blocker
-    power-management/lid_open                                certification-status=blocker
+    after-suspend-miscellanea/chvt
     suspend/1_display_after_suspend_.*_graphics              certification-status=blocker
     after-suspend-graphics/1_maximum_resolution_.*           certification-status=blocker
     after-suspend-graphics/1_glxgears_.*                     certification-status=blocker
@@ -207,9 +205,8 @@ _description: After suspend tests (integrated GPU, certification blockers only)
 include:
     after-suspend-graphics/1_auto_switch_card_.*           certification-status=blocker
     suspend/1_suspend_after_switch_to_card_.*_auto         certification-status=blocker
+    power-management/lid_close_suspend_open                certification-status=blocker
     power-management/lid                                   certification-status=blocker
-    power-management/lid_close                             certification-status=blocker
-    power-management/lid_open                              certification-status=blocker
     suspend/1_gl_support_after_suspend_.*_auto             certification-status=blocker
     suspend/1_driver_version_after_suspend_.*_auto         certification-status=blocker
     suspend/1_resolution_after_suspend_.*_auto             certification-status=blocker

--- a/providers/base/units/power-management/jobs.pxu
+++ b/providers/base/units/power-management/jobs.pxu
@@ -153,6 +153,23 @@ _description:
  VERIFICATION:
      Did the system resume when the lid was opened?
 
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::power-management
+id: power-management/lid_close_suspend_open
+estimated_duration: 20.0
+requires: device.product == 'Lid Switch'
+_purpose:
+    This test will check your lid sensor can detect lid close/open, and DUT will suspend when the lid closed
+_steps:
+    1. Press "Enter" to start the test
+    2. Close the lid (Please close the lid within 10 sec)
+    3. Wait 5 seconds with the lid closed.
+    5. Open the lid
+_verification:
+    Did the system suspend when lid closed, and resume back when the lid opened?
+command:
+    lid_close_suspend_open.sh
+
 plugin: shell
 category_id: com.canonical.plainbox::power-management
 id: power-management/rtc


### PR DESCRIPTION
## Description

In PR #304 and #306, I've accidentally restore other's changes in audio and power-management

This pull request is for adding back the lost jobs in the following changes
1. #284: power-management/lid_close_suspend_open
2. #294: audio/detect_sinks, audio/detect_sources

Also, added the flag also-after-suspend for audio/playback_headphones which was omitted in the previous change.
## Tests
Result for #284 
```
$ checkbox-cli list-bootstrapped com.canonical.certification::client-cert-desktop-22-04-manual | grep lid
com.canonical.certification::power-management/lid_close_suspend_open
com.canonical.certification::power-management/lid
``` 

Result for #294 
```
$ checkbox-cli list-bootstrapped com.canonical.certification::client-cert-desktop-22-04-automated | grep audio
com.canonical.certification::audio/detect_sinks
com.canonical.certification::audio/detect_sources
com.canonical.certification::audio/alsa_record_playback_automated
com.canonical.certification::audio/alsa_info_collect
com.canonical.certification::audio/alsa_info_attachment
com.canonical.certification::audio/list_devices
com.canonical.certification::audio/valid-sof-firmware-sig
com.canonical.certification::suspend/audio_before_suspend
com.canonical.certification::suspend/audio_after_suspend_auto
com.canonical.certification::after-suspend-audio/detect_sinks
com.canonical.certification::after-suspend-audio/detect_sources
com.canonical.certification::after-suspend-audio/alsa_record_playback_automated
``` 
Result for audio/playback_headphones
```
$ checkbox-cli list-bootstrapped com.canonical.certification::client-cert-desktop-22-04-manual | grep headphone
com.canonical.certification::audio/speaker-headphone-plug-detection
com.canonical.certification::audio/playback_headphones
com.canonical.certification::after-suspend-audio/speaker-headphone-plug-detection
com.canonical.certification::after-suspend-audio/playback_headphones
```
