### PR TITLE
Metabox workflow conditional trigger

### DIFF
--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -20,15 +20,13 @@ jobs:
           git diff --exit-code HEAD origin/main -- checkbox-ng metabox
           if [[ $? -eq 0 ]]
             then
-              echo "No changes found. Nothing to do!"
-              exit 1
+              echo "required_run=false" >> $GITHUB_OUTPUT
             else
-              echo "Changes found that require Metabox to run."
-              exit 0
+              echo "required_run=true" >> $GITHUB_OUTPUT
           fi
 
   Metabox:
-    if: (github.event.review.state == 'approved' || github.event_name == 'workflow_dispatch')
+    if: (github.event.review.state == 'approved' || github.event_name == 'workflow_dispatch') && ${{ needs.metabox_run_required.outputs.required_run == 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -26,7 +26,7 @@ jobs:
           fi
 
   Metabox:
-    if: (github.event.review.state == 'approved' || github.event_name == 'workflow_dispatch') && ${{ needs.metabox_run_required.outputs.required_run == 'true' }}
+    if: (github.event.review.state == 'approved' || github.event_name == 'workflow_dispatch') && needs.metabox_run_required.outputs.required_run == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Previous strategy would mark the whole job as fail and send
notifications.

Instead, watch for some variable to be set to continue the Metabox run.

## Resolved issues

Fix CHECKBOX-469
