### PR TITLE
Change: renamed zombiemux -> typecmux

### DIFF
--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -78,11 +78,11 @@ class StorageWatcher:
             if self.args.testcase == "insertion":
                 print("Calling zapper to connect the USB device")
                 zapper_run(
-                    zapper_host, "zombiemux_set_state", usb_address, "DUT")
+                    zapper_host, "typecmux_set_state", usb_address, "DUT")
             elif self.args.testcase == "removal":
                 print("Calling zapper to disconnect the USB device")
                 zapper_run(
-                    zapper_host, "zombiemux_set_state", usb_address, "OFF")
+                    zapper_host, "typecmux_set_state", usb_address, "OFF")
         else:
             if self.args.testcase == "insertion":
                 print("\n\nINSERT NOW\n\n", flush=True)

--- a/providers/base/bin/removable_storage_watcher.py
+++ b/providers/base/bin/removable_storage_watcher.py
@@ -926,12 +926,12 @@ def main():
 
         def do_the_insert():
             logging.info("Calling zapper to connect the USB device")
-            zapper_run(zapper_host, "zombiemux_set_state", usb_address, 'DUT')
+            zapper_run(zapper_host, "typecmux_set_state", usb_address, 'DUT')
         insert_timer = threading.Timer(delay, do_the_insert)
 
         def do_the_remove():
             logging.info("Calling zapper to disconnect the USB device")
-            zapper_run(zapper_host, "zombiemux_set_state", usb_address, 'OFF')
+            zapper_run(zapper_host, "typecmux_set_state", usb_address, 'OFF')
         remove_timer = threading.Timer(delay, do_the_remove)
         if args.action == "insert":
             logging.info("Starting timer for delayed insertion")


### PR DESCRIPTION
## Description

When using Host Proxy, renamed `zombiemux` to `typecmux`.

## Resolved issues

Part of [ZAP-377](https://warthogs.atlassian.net/browse/ZAP-377)

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [X] Steps to follow for reviewer to run & manually test are provided.
- [X] A list of what tests were run and on what platform/configuration is provided.

Run

- `proxy.py --host <HOST> typecmux_set_state 1 <DUT/TS/OFF>` 


[ZAP-377]: https://warthogs.atlassian.net/browse/ZAP-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ