### PR TITLE
Fix: Always run job commands with SYSTEMD_IGNORE_CHROOT=1

### DIFF
--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -275,6 +275,9 @@ class UnifiedRunner(IJobRunner):
                                             nest_dir)
             if self._user_provider():
                 env['NORMAL_USER'] = self._user_provider()
+            # Always set SYSTEMD_IGNORE_CHROOT
+            # See https://bugs.launchpad.net/snapd/+bug/2003955
+            env["SYSTEMD_IGNORE_CHROOT"] = "1"
             # run the command
             logger.debug(_("job[%(ID)s] executing %(CMD)r with env %(ENV)r"),
                          {"ID": job.id, "CMD": cmd,


### PR DESCRIPTION
## Description

A follow-up to https://github.com/canonical/checkbox/pull/316

Recent snapd beta (rev 18745) makes all commands relying on systemd to silently fail when called from the checkbox service with the following error msg:

```
----------------------------[ Running job 21 / 21 ]-----------------------------
---------------------------[ Perform warm reboot 2 ]----------------------------
ID: com.canonical.certification::warm-boot-loop-reboot2
Category: Warm-boot Stress Test
--------------------------------------------------------------------------------
Running in chroot, ignoring request.
```
This patch applies the fix already deployed to select the correct restart strategy by setting SYSTEMD_IGNORE_CHROOT=1 for all jobs commands (user: root or not)

