### PR TITLE
Continue Metabox workflow when the check_diff step returns 1

### DIFF
--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -16,6 +16,7 @@ jobs:
           fetch-depth: 0
       - name: Use git diff to see if there are any changes in the metabox and checkbox-ng directories
         id: check_diff
+        continue-on-error: true
         run: |
           git diff --exit-code HEAD origin/main -- checkbox-ng metabox
           if [[ $? -eq 0 ]]


### PR DESCRIPTION
The check_diff step returns 1 when there are changes in the metabox and checkbox-ng dir. This is expected, and it should trigger the following step (to actually run Metabox).

Adding continue-on-error to make sure the workflow doesn't stop there.

See [Github docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) for more info.

