### PR TITLE
Change: update the tbt3 storage-test job command

### DIFF
--- a/providers/base/units/thunderbolt/jobs.pxu
+++ b/providers/base/units/thunderbolt/jobs.pxu
@@ -38,7 +38,13 @@ imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt == 'True'
 depends: thunderbolt/insert
 estimated_duration: 45.0
-command: removable_storage_test.py -s 268400000 scsi
+template-engine: jinja2
+command:
+    {%- if __on_ubuntucore__ %}
+        checkbox-support-usb_read_write
+    {%- else %}
+        removable_storage_test.py -s 268400000 scsi
+    {% endif -%}
 _siblings: [
     { "id": "after-suspend-thunderbolt/storage-test",
       "_summary": "thunderbolt/storage-test after suspend",
@@ -141,7 +147,13 @@ imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 depends: thunderbolt3/insert
 estimated_duration: 45.0
-command: removable_storage_test.py -s 268400000 scsi
+template-engine: jinja2
+command:
+    {%- if __on_ubuntucore__ %}
+        checkbox-support-usb_read_write
+    {%- else %}
+        removable_storage_test.py -s 268400000 scsi
+    {% endif -%}
 _summary: Storage test on Thunderbolt 3
 _description:
  This is an automated test which performs read/write operations on an attached


### PR DESCRIPTION
Use checkbox-support-usb_read_write script to perform the storage-test testing for Thunderbolt storage in Ubuntu Core image because there's no udisks2 package installed by default.

## Description

Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
  -  The removable_storage_test.py script tries to perform the storage test through `dbus.udisks` service, however, there's no udisks service in Ubuntu Core image, so the script, removable_storage_test.py, is no longer suitable.
  - Error message
    - `FileNotFoundError: [Errno 2] No such file or directory: 'udisks2.udisksctl'`

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [x] Steps to follow for reviewer to run & manually test are provided.
  - Run job via command `checkbox.checkbox-cli run com.canonical.certification::thunderbolt3/storage-test`
- [x] A list of what tests were run and on what platform/configuration is provided.
  - Sideload submission of solving this issue: https://certification.canonical.com/hardware/202109-29435/submission/305954/test-results/
