### PR TITLE
Added OPEN_AX_SSID variable

### DIFF
--- a/checkbox-snap/common_series_uc/config_vars
+++ b/checkbox-snap/common_series_uc/config_vars
@@ -6,6 +6,7 @@ NET_DEVICE_INFO=ven_rsi_sdio ven_rsi_91x
 OPEN_N_SSID=ubuntu-cert-n-open
 OPEN_BG_SSID=ubuntu-cert-bg-open
 OPEN_AC_SSID=ubuntu-cert-ac-open
+OPEN_AX_SSID=ubuntu-cert-ax-open
 WPA_N_SSID=ubuntu-cert-n-wpa
 WPA_BG_SSID=ubuntu-cert-bg-wpa
 WPA_AC_SSID=ubuntu-cert-ac-wpa

--- a/checkbox-snap/series_classic22/config_vars
+++ b/checkbox-snap/series_classic22/config_vars
@@ -6,6 +6,7 @@ NET_DEVICE_INFO=ven_rsi_sdio ven_rsi_91x
 OPEN_N_SSID=ubuntu-cert-n-open
 OPEN_BG_SSID=ubuntu-cert-bg-open
 OPEN_AC_SSID=ubuntu-cert-ac-open
+OPEN_AX_SSID=ubuntu-cert-ax-open
 WPA_N_SSID=ubuntu-cert-n-wpa
 WPA_BG_SSID=ubuntu-cert-bg-wpa
 WPA_AC_SSID=ubuntu-cert-ac-wpa


### PR DESCRIPTION
## Description

Added OPEN_AX_SSID in config_vars to allow execution of WiFi AX tests. Without this variable setup WiFi AX tests fails. Current workaround: sudo checkbox.configure OPEN_AX_SSID=<ssid>

## Resolved issues
No issues reported

