### PR TITLE
add ACPI OEM _OSI test

### DIFF
--- a/providers/base/bin/acpi_tests.sh
+++ b/providers/base/bin/acpi_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+OEM_OSI_LIST=( Linux-Dell-Video Linux-Lenovo-NV-HDMI-Audio Linux-HPI-Hybrid-Graphics )
+for osi in "${OEM_OSI_LIST[@]}"
+do
+	grep -q -r $osi /sys/firmware/acpi/* && exit 1
+done
+
+exit 0

--- a/providers/base/bin/acpi_tests.sh
+++ b/providers/base/bin/acpi_tests.sh
@@ -3,7 +3,9 @@
 OEM_OSI_LIST=( Linux-Dell-Video Linux-Lenovo-NV-HDMI-Audio Linux-HPI-Hybrid-Graphics )
 for osi in "${OEM_OSI_LIST[@]}"
 do
-	grep -q -r "$osi" /sys/firmware/acpi/* && exit 1
+	grep -q -r "$osi" /sys/firmware/acpi/* && \
+	echo "Found ACPI OEM _OSI strings are used as workaround, they shouldn't be present in current firmware implementation." && \
+	exit 1
 done
 
 exit 0

--- a/providers/base/bin/acpi_tests.sh
+++ b/providers/base/bin/acpi_tests.sh
@@ -3,7 +3,7 @@
 OEM_OSI_LIST=( Linux-Dell-Video Linux-Lenovo-NV-HDMI-Audio Linux-HPI-Hybrid-Graphics )
 for osi in "${OEM_OSI_LIST[@]}"
 do
-	grep -q -r $osi /sys/firmware/acpi/* && exit 1
+	grep -q -r "$osi" /sys/firmware/acpi/* && exit 1
 done
 
 exit 0

--- a/providers/base/units/acpi/category.pxu
+++ b/providers/base/units/acpi/category.pxu
@@ -1,0 +1,8 @@
+# Copyright 2020 Canonical Ltd.
+# All rights reserved.
+#
+# Author: Alex Hung<alex.hung@canonical.com>
+
+unit: category
+id: acpi
+_name: Advanced Configuration and Power Interface

--- a/providers/base/units/acpi/jobs.pxu
+++ b/providers/base/units/acpi/jobs.pxu
@@ -1,0 +1,8 @@
+id: acpi/oem_osi
+_summary: test ACPI OEM _OSI strings
+_description:
+  This checks if the depreciated OEM _OSI strings are still used by checking the ACPI DSDT and SSDT tables
+plugin: shell
+user: root
+estimated_duration: 1
+command: acpi_tests.sh

--- a/providers/base/units/acpi/jobs.pxu
+++ b/providers/base/units/acpi/jobs.pxu
@@ -3,6 +3,8 @@ _summary: test ACPI OEM _OSI strings
 _description:
   This checks if the depreciated OEM _OSI strings are still used by checking the ACPI DSDT and SSDT tables
 plugin: shell
+requires:
+ cpuinfo.platform in ("i386", "x86_64")
 user: root
 estimated_duration: 1
 command: acpi_tests.sh

--- a/providers/base/units/acpi/test-plan.pxu
+++ b/providers/base/units/acpi/test-plan.pxu
@@ -1,4 +1,4 @@
-id: acpi_oem_osi_strings
+id: acpi-automated
 unit: test plan
 _name: ACPI OEM _OSI string tests
 include:

--- a/providers/base/units/acpi/test-plan.pxu
+++ b/providers/base/units/acpi/test-plan.pxu
@@ -1,0 +1,5 @@
+id: acpi_oem_osi_strings
+unit: test plan
+_name: ACPI OEM _OSI string tests
+include:
+    acpi/oem_osi

--- a/providers/certification-client/units/client-cert-desktop-18-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-18-04.pxu
@@ -70,7 +70,6 @@ nested_part:
     after-suspend-usb-c-cert-full
     # after-suspend-wireless-cert-full # auto only
     info-attachment-cert-manual
-    acpi_oem_osi_strings
 exclude:
     keys/hibernate
 
@@ -86,6 +85,7 @@ include:
 nested_part:
     submission-cert-automated
     info-attachment-cert-automated
+    acpi-automated
     audio-cert-automated
     bluetooth-cert-automated
     camera-cert-automated
@@ -133,7 +133,6 @@ nested_part:
     # with.
     power-management-reboot-poweroff-cert-automated
     tpm2.0_3.0.4
-    acpi_oem_osi_strings
 bootstrap_include:
     device
     graphics_card

--- a/providers/certification-client/units/client-cert-desktop-18-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-18-04.pxu
@@ -70,6 +70,7 @@ nested_part:
     after-suspend-usb-c-cert-full
     # after-suspend-wireless-cert-full # auto only
     info-attachment-cert-manual
+    acpi_oem_osi_strings
 exclude:
     keys/hibernate
 
@@ -132,6 +133,7 @@ nested_part:
     # with.
     power-management-reboot-poweroff-cert-automated
     tpm2.0_3.0.4
+    acpi_oem_osi_strings
 bootstrap_include:
     device
     graphics_card

--- a/providers/certification-client/units/client-cert-desktop-20-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-20-04.pxu
@@ -73,6 +73,7 @@ nested_part:
     after-suspend-usb-c-cert-full
     # after-suspend-wireless-cert-full # auto only
     info-attachment-cert-manual
+    acpi_oem_osi_strings
 exclude:
     keys/hibernate
 
@@ -135,6 +136,7 @@ nested_part:
     # with.
     power-management-reboot-poweroff-cert-automated
     tpm-cert-focal-automated
+    acpi_oem_osi_strings
 bootstrap_include:
     device
     graphics_card

--- a/providers/certification-client/units/client-cert-desktop-20-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-20-04.pxu
@@ -73,7 +73,6 @@ nested_part:
     after-suspend-usb-c-cert-full
     # after-suspend-wireless-cert-full # auto only
     info-attachment-cert-manual
-    acpi_oem_osi_strings
 exclude:
     keys/hibernate
 
@@ -89,6 +88,7 @@ include:
 nested_part:
     submission-cert-automated
     info-attachment-cert-automated
+    acpi-automated
     audio-cert-automated
     bluetooth-cert-automated
     camera-cert-automated
@@ -136,7 +136,6 @@ nested_part:
     # with.
     power-management-reboot-poweroff-cert-automated
     tpm-cert-focal-automated
-    acpi_oem_osi_strings
 bootstrap_include:
     device
     graphics_card

--- a/providers/certification-client/units/client-cert-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-22-04.pxu
@@ -78,6 +78,7 @@ nested_part:
     after-suspend-usb-c-cert-full
     # after-suspend-wireless-cert-full # auto only
     info-attachment-cert-manual
+    acpi_oem_osi_strings
 exclude:
     keys/hibernate
 
@@ -152,6 +153,7 @@ nested_part:
     # with.
     power-management-reboot-poweroff-cert-automated
     tpm-cert-automated
+    acpi_oem_osi_strings
 bootstrap_include:
     device
     graphics_card

--- a/providers/certification-client/units/client-cert-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-22-04.pxu
@@ -78,7 +78,6 @@ nested_part:
     after-suspend-usb-c-cert-full
     # after-suspend-wireless-cert-full # auto only
     info-attachment-cert-manual
-    acpi_oem_osi_strings
 exclude:
     keys/hibernate
 
@@ -93,6 +92,7 @@ include:
 nested_part:
     submission-cert-automated
     info-attachment-cert-automated
+    acpi-automated
     audio-cert-automated
     bluetooth-cert-automated
     camera-cert-automated
@@ -153,7 +153,6 @@ nested_part:
     # with.
     power-management-reboot-poweroff-cert-automated
     tpm-cert-automated
-    acpi_oem_osi_strings
 bootstrap_include:
     device
     graphics_card

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-16.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-16.pxu
@@ -74,7 +74,6 @@ nested_part:
   after-suspend-wireless-manual
   after-suspend-wireless-wifi-master-mode-manual
   after-suspend-wwan-manual
-  acpi_oem_osi_strings
 
 id: client-cert-iot-ubuntucore-16-automated
 _name: IoT Client Certification for Ubuntu Core 16 (Automated Tests)
@@ -105,6 +104,7 @@ nested_part:
   submission-cert-automated
   self-automated
   iot-fwts-automated
+  acpi-automated
   audio-automated
   bluez-automated
   camera-automated
@@ -141,7 +141,6 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
-  acpi_oem_osi_strings
 
 id: client-cert-iot-ubuntucore-16-stress
 _name: IoT Client Certification for Ubuntu Core 16 (Stress Tests)

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-16.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-16.pxu
@@ -74,7 +74,7 @@ nested_part:
   after-suspend-wireless-manual
   after-suspend-wireless-wifi-master-mode-manual
   after-suspend-wwan-manual
-
+  acpi_oem_osi_strings
 
 id: client-cert-iot-ubuntucore-16-automated
 _name: IoT Client Certification for Ubuntu Core 16 (Automated Tests)
@@ -141,7 +141,7 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
-
+  acpi_oem_osi_strings
 
 id: client-cert-iot-ubuntucore-16-stress
 _name: IoT Client Certification for Ubuntu Core 16 (Stress Tests)

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-18.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-18.pxu
@@ -76,7 +76,6 @@ nested_part:
   after-suspend-wireless-manual
   after-suspend-wireless-wifi-master-mode-manual
   after-suspend-wwan-manual
-  acpi_oem_osi_strings
 
 id: client-cert-iot-ubuntucore-18-automated
 _name: IoT Client Certification for Ubuntu Core 18 (Automated Tests)
@@ -107,6 +106,7 @@ nested_part:
   submission-cert-automated
   self-automated
   iot-fwts-automated
+  acpi-automated
   audio-automated
   bluez-automated
   camera-automated
@@ -144,7 +144,6 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
-  acpi_oem_osi_strings
 
 id: client-cert-iot-ubuntucore-18-stress
 _name: IoT Client Certification for Ubuntu Core 18 (Stress Tests)

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-18.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-18.pxu
@@ -76,7 +76,7 @@ nested_part:
   after-suspend-wireless-manual
   after-suspend-wireless-wifi-master-mode-manual
   after-suspend-wwan-manual
-
+  acpi_oem_osi_strings
 
 id: client-cert-iot-ubuntucore-18-automated
 _name: IoT Client Certification for Ubuntu Core 18 (Automated Tests)
@@ -144,7 +144,7 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
-
+  acpi_oem_osi_strings
 
 id: client-cert-iot-ubuntucore-18-stress
 _name: IoT Client Certification for Ubuntu Core 18 (Stress Tests)

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-20.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-20.pxu
@@ -77,7 +77,6 @@ nested_part:
   after-suspend-wireless-manual
   after-suspend-wireless-wifi-master-mode-manual
   after-suspend-wwan-manual
-  acpi_oem_osi_strings
 
 id: client-cert-iot-ubuntucore-20-automated
 _name: IoT Client Certification for Ubuntu Core 20 (Automated Tests)
@@ -109,6 +108,7 @@ nested_part:
   self-automated
   ubuntucore-automated
   iot-fwts-automated
+  acpi-automated
   audio-automated
   bluez-automated
   camera-automated
@@ -146,7 +146,6 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
-  acpi_oem_osi_strings
 
 id: client-cert-iot-ubuntucore-20-stress
 _name: IoT Client Certification for Ubuntu Core 20 (Stress Tests)

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-20.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-20.pxu
@@ -77,7 +77,7 @@ nested_part:
   after-suspend-wireless-manual
   after-suspend-wireless-wifi-master-mode-manual
   after-suspend-wwan-manual
-
+  acpi_oem_osi_strings
 
 id: client-cert-iot-ubuntucore-20-automated
 _name: IoT Client Certification for Ubuntu Core 20 (Automated Tests)
@@ -146,7 +146,7 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
-
+  acpi_oem_osi_strings
 
 id: client-cert-iot-ubuntucore-20-stress
 _name: IoT Client Certification for Ubuntu Core 20 (Stress Tests)

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu
@@ -77,7 +77,6 @@ nested_part:
   after-suspend-wireless-manual
   after-suspend-wireless-wifi-master-mode-manual
   after-suspend-wwan-manual
-  acpi_oem_osi_strings
 
 
 id: client-cert-iot-ubuntucore-22-automated
@@ -110,6 +109,7 @@ nested_part:
   self-automated
   ubuntucore-automated
   iot-fwts-automated
+  acpi-automated
   audio-automated
   bluez-automated
   camera-automated
@@ -147,7 +147,6 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
-  acpi_oem_osi_strings
 
 
 id: client-cert-iot-ubuntucore-22-stress

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu
@@ -77,6 +77,7 @@ nested_part:
   after-suspend-wireless-manual
   after-suspend-wireless-wifi-master-mode-manual
   after-suspend-wwan-manual
+  acpi_oem_osi_strings
 
 
 id: client-cert-iot-ubuntucore-22-automated
@@ -146,6 +147,7 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
+  acpi_oem_osi_strings
 
 
 id: client-cert-iot-ubuntucore-22-stress

--- a/providers/certification-client/units/client-cert-odm-desktop-18-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-desktop-18-04.pxu
@@ -59,7 +59,6 @@ nested_part:
     after-suspend-usb-c-cert-full # no manual only
     # after-suspend-wireless-cert-full # auto only
     info-attachment-cert-full
-    acpi_oem_osi_strings
 exclude:
     com.canonical.certification::keys/hibernate
     com.canonical.certification::keys/lock-screen
@@ -106,6 +105,7 @@ _description:
 include:
 nested_part:
     submission-cert-full
+    acpi-automated
     audio-cert-automated
     bluetooth-cert-automated
     camera-cert-automated
@@ -170,7 +170,6 @@ nested_part:
     stress-ng-cert-automated
     tpm2.0_3.0.4
     info-attachment-cert-full
-    acpi_oem_osi_strings
 exclude:
     com.canonical.certification::keys/hibernate
     com.canonical.certification::keys/lock-screen

--- a/providers/certification-client/units/client-cert-odm-desktop-18-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-desktop-18-04.pxu
@@ -59,6 +59,7 @@ nested_part:
     after-suspend-usb-c-cert-full # no manual only
     # after-suspend-wireless-cert-full # auto only
     info-attachment-cert-full
+    acpi_oem_osi_strings
 exclude:
     com.canonical.certification::keys/hibernate
     com.canonical.certification::keys/lock-screen
@@ -169,6 +170,7 @@ nested_part:
     stress-ng-cert-automated
     tpm2.0_3.0.4
     info-attachment-cert-full
+    acpi_oem_osi_strings
 exclude:
     com.canonical.certification::keys/hibernate
     com.canonical.certification::keys/lock-screen

--- a/providers/certification-client/units/client-cert-odm-desktop-20-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-desktop-20-04.pxu
@@ -61,6 +61,7 @@ nested_part:
     after-suspend-usb-c-cert-full # no manual only
     # after-suspend-wireless-cert-full # auto only
     info-attachment-cert-full
+    acpi_oem_osi_strings
 exclude:
     com.canonical.certification::keys/hibernate
     com.canonical.certification::keys/lock-screen
@@ -173,6 +174,7 @@ nested_part:
     stress-ng-cert-automated
     tpm-cert-focal-automated
     info-attachment-cert-full
+    acpi_oem_osi_strings
 exclude:
     com.canonical.certification::keys/hibernate
     com.canonical.certification::keys/lock-screen

--- a/providers/certification-client/units/client-cert-odm-desktop-20-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-desktop-20-04.pxu
@@ -61,7 +61,6 @@ nested_part:
     after-suspend-usb-c-cert-full # no manual only
     # after-suspend-wireless-cert-full # auto only
     info-attachment-cert-full
-    acpi_oem_osi_strings
 exclude:
     com.canonical.certification::keys/hibernate
     com.canonical.certification::keys/lock-screen
@@ -108,6 +107,7 @@ _description:
 include:
 nested_part:
     submission-cert-full
+    acpi-automated
     audio-cert-automated
     bluetooth-cert-automated
     camera-cert-automated
@@ -174,7 +174,6 @@ nested_part:
     stress-ng-cert-automated
     tpm-cert-focal-automated
     info-attachment-cert-full
-    acpi_oem_osi_strings
 exclude:
     com.canonical.certification::keys/hibernate
     com.canonical.certification::keys/lock-screen

--- a/providers/certification-client/units/client-cert-odm-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-desktop-22-04.pxu
@@ -62,7 +62,6 @@ nested_part:
     after-suspend-usb-c-cert-full # no manual only
     # after-suspend-wireless-cert-full # auto only
     info-attachment-cert-full
-    acpi_oem_osi_strings
 exclude:
     com.canonical.certification::keys/hibernate
     com.canonical.certification::keys/lock-screen
@@ -109,6 +108,7 @@ _description:
 include:
 nested_part:
     submission-cert-full
+    acpi-automated
     audio-cert-automated
     bluetooth-cert-automated
     camera-cert-automated
@@ -175,7 +175,6 @@ nested_part:
     stress-ng-cert-automated
     tpm-cert-automated
     info-attachment-cert-full
-    acpi_oem_osi_strings
 exclude:
     com.canonical.certification::keys/hibernate
     com.canonical.certification::keys/lock-screen

--- a/providers/certification-client/units/client-cert-odm-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-desktop-22-04.pxu
@@ -62,6 +62,7 @@ nested_part:
     after-suspend-usb-c-cert-full # no manual only
     # after-suspend-wireless-cert-full # auto only
     info-attachment-cert-full
+    acpi_oem_osi_strings
 exclude:
     com.canonical.certification::keys/hibernate
     com.canonical.certification::keys/lock-screen
@@ -174,6 +175,7 @@ nested_part:
     stress-ng-cert-automated
     tpm-cert-automated
     info-attachment-cert-full
+    acpi_oem_osi_strings
 exclude:
     com.canonical.certification::keys/hibernate
     com.canonical.certification::keys/lock-screen

--- a/providers/certification-client/units/client-cert-odm-server-18-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-server-18-04.pxu
@@ -44,6 +44,7 @@ nested_part:
     after-suspend-bluetooth-manual
     after-suspend-ethernet-manual
     after-suspend-wwan-manual
+   acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
@@ -112,6 +113,7 @@ nested_part:
     after-suspend-wwan-automated
     warm-boot-stress-test
     cold-boot-stress-test
+    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*

--- a/providers/certification-client/units/client-cert-odm-server-18-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-server-18-04.pxu
@@ -44,7 +44,6 @@ nested_part:
     after-suspend-bluetooth-manual
     after-suspend-ethernet-manual
     after-suspend-wwan-manual
-   acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
@@ -86,6 +85,7 @@ bootstrap_include:
 nested_part:
     submission-cert-automated
     self-automated
+    acpi-automated
     bluez-automated
     camera-automated
     mediacard-automated
@@ -113,7 +113,6 @@ nested_part:
     after-suspend-wwan-automated
     warm-boot-stress-test
     cold-boot-stress-test
-    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*

--- a/providers/certification-client/units/client-cert-odm-server-20-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-server-20-04.pxu
@@ -45,7 +45,6 @@ nested_part:
     after-suspend-bluetooth-manual
     after-suspend-ethernet-manual
     after-suspend-wwan-manual
-    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
@@ -87,6 +86,7 @@ bootstrap_include:
 nested_part:
     submission-cert-automated
     self-automated
+    acpi-automated
     bluez-automated
     camera-automated
     edac-automated
@@ -116,7 +116,6 @@ nested_part:
     after-suspend-wwan-automated
     warm-boot-stress-test
     cold-boot-stress-test
-    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*

--- a/providers/certification-client/units/client-cert-odm-server-20-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-server-20-04.pxu
@@ -45,6 +45,7 @@ nested_part:
     after-suspend-bluetooth-manual
     after-suspend-ethernet-manual
     after-suspend-wwan-manual
+    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
@@ -115,6 +116,7 @@ nested_part:
     after-suspend-wwan-automated
     warm-boot-stress-test
     cold-boot-stress-test
+    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*

--- a/providers/certification-client/units/client-cert-odm-server-22-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-server-22-04.pxu
@@ -48,7 +48,6 @@ nested_part:
     after-suspend-ethernet-manual
     after-suspend-wwan-manual
     after-suspend-thunderbolt-cert-manual
-    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
@@ -88,6 +87,7 @@ bootstrap_include:
 nested_part:
     submission-cert-automated
     self-automated
+    acpi-automated
     bluez-automated
     camera-automated
     edac-automated
@@ -119,7 +119,6 @@ nested_part:
     after-suspend-wwan-automated
     warm-boot-stress-test
     cold-boot-stress-test
-    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*

--- a/providers/certification-client/units/client-cert-odm-server-22-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-server-22-04.pxu
@@ -48,6 +48,7 @@ nested_part:
     after-suspend-ethernet-manual
     after-suspend-wwan-manual
     after-suspend-thunderbolt-cert-manual
+    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
@@ -118,6 +119,7 @@ nested_part:
     after-suspend-wwan-automated
     warm-boot-stress-test
     cold-boot-stress-test
+    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*

--- a/providers/certification-client/units/client-cert-odm-ubuntucore-18.pxu
+++ b/providers/certification-client/units/client-cert-odm-ubuntucore-18.pxu
@@ -45,8 +45,7 @@ nested_part:
     after-suspend-bluetooth-manual
     after-suspend-ethernet-manual
     after-suspend-wwan-manual
-    after-suspend-thunderbolt-cert-manual 
-    acpi_oem_osi_strings
+    after-suspend-thunderbolt-cert-manual
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
@@ -86,6 +85,7 @@ bootstrap_include:
 nested_part:
     submission-cert-automated
     self-automated
+    acpi-automated
     bluez-automated
     camera-automated
     mediacard-automated
@@ -115,7 +115,6 @@ nested_part:
     after-suspend-wwan-automated
     warm-boot-stress-test
     cold-boot-stress-test
-    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*

--- a/providers/certification-client/units/client-cert-odm-ubuntucore-18.pxu
+++ b/providers/certification-client/units/client-cert-odm-ubuntucore-18.pxu
@@ -46,6 +46,7 @@ nested_part:
     after-suspend-ethernet-manual
     after-suspend-wwan-manual
     after-suspend-thunderbolt-cert-manual 
+    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
@@ -114,6 +115,7 @@ nested_part:
     after-suspend-wwan-automated
     warm-boot-stress-test
     cold-boot-stress-test
+    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*

--- a/providers/certification-client/units/client-cert-odm-ubuntucore-20.pxu
+++ b/providers/certification-client/units/client-cert-odm-ubuntucore-20.pxu
@@ -47,7 +47,6 @@ nested_part:
     after-suspend-ethernet-manual
     after-suspend-wwan-manual
     after-suspend-thunderbolt-cert-manual
-    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
@@ -86,6 +85,7 @@ bootstrap_include:
 nested_part:
     submission-cert-automated
     self-automated
+    acpi-automated
     bluez-automated
     camera-automated
     edac-automated
@@ -117,7 +117,6 @@ nested_part:
     after-suspend-wwan-automated
     warm-boot-stress-test
     cold-boot-stress-test
-    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*

--- a/providers/certification-client/units/client-cert-odm-ubuntucore-20.pxu
+++ b/providers/certification-client/units/client-cert-odm-ubuntucore-20.pxu
@@ -47,6 +47,7 @@ nested_part:
     after-suspend-ethernet-manual
     after-suspend-wwan-manual
     after-suspend-thunderbolt-cert-manual
+    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
@@ -116,6 +117,7 @@ nested_part:
     after-suspend-wwan-automated
     warm-boot-stress-test
     cold-boot-stress-test
+    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*

--- a/providers/certification-client/units/client-cert-odm-ubuntucore-22.pxu
+++ b/providers/certification-client/units/client-cert-odm-ubuntucore-22.pxu
@@ -48,7 +48,6 @@ nested_part:
     after-suspend-ethernet-manual
     after-suspend-wwan-manual
     after-suspend-thunderbolt-cert-manual
-    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
@@ -87,6 +86,7 @@ bootstrap_include:
 nested_part:
     submission-cert-automated
     self-automated
+    acpi-automated
     bluez-automated
     camera-automated
     edac-automated
@@ -120,7 +120,6 @@ nested_part:
     after-suspend-wwan-automated
     warm-boot-stress-test
     cold-boot-stress-test
-    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*

--- a/providers/certification-client/units/client-cert-odm-ubuntucore-22.pxu
+++ b/providers/certification-client/units/client-cert-odm-ubuntucore-22.pxu
@@ -48,6 +48,7 @@ nested_part:
     after-suspend-ethernet-manual
     after-suspend-wwan-manual
     after-suspend-thunderbolt-cert-manual
+    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*
@@ -119,6 +120,7 @@ nested_part:
     after-suspend-wwan-automated
     warm-boot-stress-test
     cold-boot-stress-test
+    acpi_oem_osi_strings
 exclude:
     usb-c/c-to-a-adapter.*
     mediacard/mmc-.*


### PR DESCRIPTION
OEM _OSI strings were for workarounds in 2016 and 2017. They shouldn't be used in BIOS/firmware anymore.