### PR TITLE
Improve graphic testing with nvidia card

### DIFF
--- a/providers/base/bin/graphics_env.sh
+++ b/providers/base/bin/graphics_env.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-# This script checks if the submitted VIDEO resource is from AMD or nvidia and if it is
-# a discrete GPU (graphics_card_resource orders GPUs by index: 1 is the
-# integrated one, 2 is the discrete one).
+# This script checks if the submitted VIDEO resource is from AMD or nvidia
+# and if it is a discrete GPU (graphics_card_resource orders GPUs by index:
+# 1 is theintegrated one, 2 is the discrete one).
 #
 # This script has to be sourced in order to set an environment variable that
-# is used by the open source AMD driver and properties nvidia driver to trigger the use of discrete GPU.
+# is used by the open source AMD driver and properties nvidia driver to
+# trigger the use of discrete GPU.
 
 DRIVER=$1
 INDEX=$2
@@ -32,7 +33,7 @@ elif [[ $DRIVER == "nvidia" || $DRIVER == "pcieport" ]]; then
     if [[ $NB_GPU -gt 1 ]]; then
         nvidia_nvlink_check.sh
         NVLINK=$?
-        if [[ $INDEX -gt 1 && ${NVLINK} -ne 0 ]]; then
+        if [[ $INDEX -gt 1 && ${NVLINK} -ne 0 && "$(prime-select query)" = 'on-demand' ]]; then
             echo "Setting up PRIME GPU offloading for nvidia discrete GPU"
             export __NV_PRIME_RENDER_OFFLOAD=1
             export __GLX_VENDOR_LIBRARY_NAME=nvidia

--- a/providers/base/bin/graphics_env.sh
+++ b/providers/base/bin/graphics_env.sh
@@ -30,7 +30,9 @@ if [[ $DRIVER == "amdgpu" || $DRIVER == "radeon" ]]; then
 elif [[ $DRIVER == "nvidia" || $DRIVER == "pcieport" ]]; then
     NB_GPU=$(udev_resource.py -l VIDEO | grep -oP -m1 '\d+')
     if [[ $NB_GPU -gt 1 ]]; then
-        if [[ $INDEX -gt 1 ]]; then
+        nvidia_nvlink_check.sh
+        NVLINK=$?
+        if [[ $INDEX -gt 1 && ${NVLINK} -ne 0 ]]; then
             echo "Setting up PRIME GPU offloading for nvidia discrete GPU"
             export __NV_PRIME_RENDER_OFFLOAD=1
             export __GLX_VENDOR_LIBRARY_NAME=nvidia

--- a/providers/base/bin/graphics_env.sh
+++ b/providers/base/bin/graphics_env.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
-# This script checks if the submitted VIDEO resource is from AMD and if it is
+# This script checks if the submitted VIDEO resource is from AMD or nvidia and if it is
 # a discrete GPU (graphics_card_resource orders GPUs by index: 1 is the
 # integrated one, 2 is the discrete one).
 #
 # This script has to be sourced in order to set an environment variable that
-# is used by the open source AMD driver to trigger the use of discrete GPU.
+# is used by the open source AMD driver and properties nvidia driver to trigger the use of discrete GPU.
 
 DRIVER=$1
 INDEX=$2
 
-# We only want to set the DRI_PRIME env variable on systems with more than
-# 1 GPU running the amdgpu/radeon drivers.
+# We only want to set the variable on systems with more than
+# 1 GPU running the amdgpu/radeon/nvidia drivers.
 if [[ $DRIVER == "amdgpu" || $DRIVER == "radeon" ]]; then
     NB_GPU=$(udev_resource.py -l VIDEO | grep -oP -m1 '\d+')
     if [[ $NB_GPU -gt 1 ]]; then
@@ -25,6 +25,18 @@ if [[ $DRIVER == "amdgpu" || $DRIVER == "radeon" ]]; then
             export DRI_PRIME=1
         else
             export DRI_PRIME=
+        fi
+    fi
+elif [[ $DRIVER == "nvidia" || $DRIVER == "pcieport" ]]; then
+    NB_GPU=$(udev_resource.py -l VIDEO | grep -oP -m1 '\d+')
+    if [[ $NB_GPU -gt 1 ]]; then
+        if [[ $INDEX -gt 1 ]]; then
+            echo "Setting up PRIME GPU offloading for nvidia discrete GPU"
+            export __NV_PRIME_RENDER_OFFLOAD=1
+            export __GLX_VENDOR_LIBRARY_NAME=nvidia
+        else
+            unset __NV_PRIME_RENDER_OFFLOAD
+            unset __GLX_VENDOR_LIBRARY_NAME
         fi
     fi
 fi

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -279,12 +279,9 @@ category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_valid_opengl_renderer_{product_slug}
 requires: executable.name == 'glxinfo'
 command:
- # shellcheck disable=SC2050
- if [[ "{driver}" == "nvidia" || "{driver}" == "pcieport" ]]; then
-     renderer=$(__NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia glxinfo | grep "OpenGL re")
- else
-     renderer=$(DRI_PRIME=1 glxinfo | grep "OpenGL re")
- fi
+ # shellcheck disable=SC1091
+ source graphics_env.sh {driver} {index}
+ renderer=$(glxinfo | grep "OpenGL re")
  echo "$renderer"
  if grep -qi 'Intel' <<<"$renderer"; then
      echo 'ERROR: renderer is Intel when DRI_PRIME=1'

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -273,19 +273,23 @@ user: root
 
 unit: template
 template-resource: graphics_card
-template-filter: graphics_card.driver in ['amdgpu', 'amdgpu-pro']
+template-filter: graphics_card.driver in ['nvidia', 'pcieport', 'amdgpu', 'amdgpu-pro']
 plugin: shell
 category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_valid_opengl_renderer_{product_slug}
 requires: executable.name == 'glxinfo'
 command:
- renderer=$(DRI_PRIME=1 glxinfo | grep "OpenGL re")
+ if [[ "{driver}" == "nvidia" || "{driver}" == "pcieport" ]]; then
+     renderer=$(__NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia glxinfo | grep "OpenGL re")
+ else
+     renderer=$(DRI_PRIME=1 glxinfo | grep "OpenGL re")
+ fi
  echo "$renderer"
  if grep -qi 'Intel' <<<"$renderer"; then
      echo 'ERROR: renderer is Intel when DRI_PRIME=1'
      exit 1
  fi
-_summary: Check the OpenGL renderer (AMD GPU and DRI_PRIME=1)
+_summary: Check the OpenGL renderer (AMD GPU and DRI_PRIME=1, nvidia GPU and __NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia)
 
 unit: template
 template-resource: graphics_card
@@ -528,6 +532,7 @@ category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_auto_switch_card_{product_slug}
 requires:
  graphics_card.driver in ['nvidia', 'amdgpu-pro', 'pcieport']
+ graphics_card.driver != 'amdgpu-pro' and lsb.release < '22.04'
 _summary: Switch GPU to {vendor} {product} and reboot
 _purpose:
  Switch GPU to {vendor} {product} and reboot the machine

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -279,6 +279,7 @@ category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_valid_opengl_renderer_{product_slug}
 requires: executable.name == 'glxinfo'
 command:
+ # shellcheck disable=SC2050
  if [[ "{driver}" == "nvidia" || "{driver}" == "pcieport" ]]; then
      renderer=$(__NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia glxinfo | grep "OpenGL re")
  else

--- a/providers/resource/bin/graphics_card_resource.py
+++ b/providers/resource/bin/graphics_card_resource.py
@@ -202,12 +202,14 @@ def main():
                 record['driver'] = 'unknown'
             # lp:1636060 – If discrete GPU is using amdgpu driver,
             # we set the prime_gpu_offload flag to 'On'
-            # NVIDIA driver since version 435.17 supports PRIME render offload,
-            # and Ubuntu doesn't support intel mode after 22.04.
-            if index == 2 and ((record['driver'] in ('nvidia', 'pcieport')
-                                and compare_ubuntu_release_version('22.04'))
-                               or record['driver'] == 'amdgpu'):
-                record['prime_gpu_offload'] = 'On'
+            if index == 2:
+                if record['driver'] == 'amdgpu':
+                    record['prime_gpu_offload'] = 'On'
+                # NVIDIA driver supports PRIME render offload since version
+                # 435.17, and Ubuntu doesn't support Intel mode after 22.04.
+                elif (record['driver'] in ('nvidia', 'pcieport')
+                        and compare_ubuntu_release_version('22.04')):
+                    record['prime_gpu_offload'] = 'On'
             else:
                 record['prime_gpu_offload'] = 'Off'
             record['switch_to_cmd'] = switch_cmds[record['driver']][0]


### PR DESCRIPTION
## Description

Describe your changes here:

* `providers/base/bin/graphics_env.sh` -- Add [prime-offload setting of nvidia card](https://download.nvidia.com/XFree86/Linux-x86_64/440.64/README/primerenderoffload.html) and avoid to apply to nvlink enviornment.
* `providers/base/units/graphics/jobs.pxu` -- Add checking prime-offload of nvidia card in `id: graphics/{index}_valid_opengl_renderer_{product_slug}`.
* `providers/base/units/graphics/jobs.pxu` -- Add require condition in `id: graphiocs/{index}_auto_switch_card_{product_slug}` to avoid this job while driver is not amdgpu-pro and Ubuntu version is higher than 22.04.
* `providers/resource/bin/graphics_card_resource.py` -- Add prime_gpu_offload is `On` while dirver is nvidia and Ubuntu version is 22.04 and above.


## Resolved issues

This PR is going to solve [Jira CQT-2046](https://warthogs.atlassian.net/browse/CQT-2046) / https://warthogs.atlassian.net/browse/CHECKBOX-571
Since nvidia driver supports prime offload and doesn't support intel
mode on Ubuntu 22.04 and above. Therefore, this PR follows what amdgpu driver did
to make amdgpu and nvidia driver with the same set of tests.


## Submission
* iGPU = intel, dGPU = None [Auto test](https://certification.canonical.com/hardware/202302-31228/submission/306600/),[Graphic test](https://certification.canonical.com/hardware/202302-31228/submission/306609/)
* iGPU = intel, dGPU = AMD [Auto test](https://certification.canonical.com/hardware/202203-30094/submission/306599/),[Graphic test](https://certification.canonical.com/hardware/202203-30094/submission/306601/)
* iGPU = intel, dGPU = nvidia [Auto test](https://certification.canonical.com/hardware/202212-30999/submission/306624/),[Graphic test](https://certification.canonical.com/hardware/202212-30999/submission/306630/)
* iGPU = AMD, dGPU = None [Auto test](https://certification.canonical.com/hardware/202212-30943/submission/306607/),[Graphic test](https://certification.canonical.com/hardware/202212-30943/submission/306611/)
* iGPU = None, dGPU = AMD [Auto test](https://certification.canonical.com/hardware/202203-30106/submission/306681/),[Graphic test](https://certification.canonical.com/hardware/202203-30106/submission/306726/)
* iGPU = None, dGPU = nvidia(nvlink) [Auto test](https://certification.canonical.com/hardware/202303-31333/submission/306749/),[Graphic test](https://certification.canonical.com/hardware/202303-31333/submission/306724/)
* iGPU = intel, dGPU=intel [Auto test](https://certification.canonical.com/hardware/202303-31406/submission/307315/),[Graphic test](https://certification.canonical.com/hardware/202303-31406/submission/306775/)

