### PR TITLE
Fix: Add new python3-packaging dependency to checkbox core snaps

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -154,6 +154,7 @@ parts:
     stage-packages:
       - python3-markupsafe
       - python3-jinja2
+      - python3-packaging
       - python3-padme
       - python3-requests-oauthlib
       - python3-urwid

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -156,6 +156,7 @@ parts:
     stage-packages:
       - python3-markupsafe
       - python3-jinja2
+      - python3-packaging
       - python3-padme
       - python3-requests-oauthlib
       - python3-urwid

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -177,6 +177,7 @@ parts:
     stage-packages:
       - python3-markupsafe
       - python3-jinja2
+      - python3-packaging
       - python3-padme
       - python3-requests-oauthlib
       - python3-urwid

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -177,6 +177,7 @@ parts:
     stage-packages:
       - python3-markupsafe
       - python3-jinja2
+      - python3-packaging
       - python3-padme
       - python3-requests-oauthlib
       - python3-urwid


### PR DESCRIPTION
## Description

Add missing python3-packaging to checkbox-core snaps, 16 and 18 can automatically get it from pypi but not 20 and 22.
