### PR TITLE
Stable release workflow (promotion from beta to stable )

### DIFF
--- a/.github/workflows/checkbox-stable-release.yml
+++ b/.github/workflows/checkbox-stable-release.yml
@@ -1,0 +1,84 @@
+name: Stable version of checkbox
+run-name: Promote beta versions of checkbox to stable
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Publish the release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Edit the draft release and publish it
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit $(git describe --tags --abbrev=0 --match v*) --draft=false
+
+  checkbox_deb_packages:
+    name: Checkbox Debian packages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt update -qq
+          sudo apt install -qq -y python3-launchpadlib
+      - name: Checkout checkbox monorepo
+        uses: actions/checkout@v3
+      - name: Copy deb packages from testing to stable ppa
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
+          CHECKBOX_REPO: ${{ github.repository }}
+        run: |
+          tools/release/lp-copy-packages.py
+
+  checkbox_core_snap:
+    name: Checkbox core snap packages:
+    runs-on: ubuntu-latest
+    env:
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
+    steps:
+      - name: Setup Snapcraft
+        run: |
+          sudo snap install snapcraft --classic
+      - name: Promote checkbox core snaps to the stable channel
+        run: |
+          snapcraft promote checkbox16 --from-channel latest/beta --to-channel latest/candidate --yes
+          snapcraft promote checkbox16 --from-channel latest/beta --to-channel latest/stable --yes
+          snapcraft promote checkbox18 --from-channel latest/beta --to-channel latest/candidate --yes
+          snapcraft promote checkbox18 --from-channel latest/beta --to-channel latest/stable --yes
+          snapcraft promote checkbox20 --from-channel latest/beta --to-channel latest/candidate --yes
+          snapcraft promote checkbox20 --from-channel latest/beta --to-channel latest/stable --yes
+          snapcraft promote checkbox22 --from-channel latest/beta --to-channel latest/candidate --yes
+          snapcraft promote checkbox22 --from-channel latest/beta --to-channel latest/stable --yes
+
+  checkbox_snap:
+    name: Checkbox snap packages:
+    runs-on: ubuntu-latest
+    env:
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
+    steps:
+      - name: Setup Snapcraft
+        run: |
+          sudo snap install snapcraft --classic
+      - name: Promote checkbox snaps to the stable channel
+        run: |
+          snapcraft promote checkbox --from-channel uc16/beta --to-channel uc16/candidate --yes
+          snapcraft promote checkbox --from-channel uc16/beta --to-channel uc16/stable --yes
+          snapcraft promote checkbox --from-channel uc18/beta --to-channel uc18/candidate --yes
+          snapcraft promote checkbox --from-channel uc18/beta --to-channel uc18/stable --yes
+          snapcraft promote checkbox --from-channel uc20/beta --to-channel uc20/candidate --yes
+          snapcraft promote checkbox --from-channel uc20/beta --to-channel uc20/stable --yes
+          snapcraft promote checkbox --from-channel uc22/beta --to-channel uc22/candidate --yes
+          snapcraft promote checkbox --from-channel uc22/beta --to-channel uc22/stable --yes
+          snapcraft promote checkbox --from-channel 16.04/beta --to-channel 16.04/candidate --yes
+          snapcraft promote checkbox --from-channel 16.04/beta --to-channel 16.04/stable --yes
+          snapcraft promote checkbox --from-channel 18.04/beta --to-channel 18.04/candidate --yes
+          snapcraft promote checkbox --from-channel 18.04/beta --to-channel 18.04/stable --yes
+          snapcraft promote checkbox --from-channel 20.04/beta --to-channel 20.04/candidate --yes
+          snapcraft promote checkbox --from-channel 20.04/beta --to-channel 20.04/stable --yes
+          snapcraft promote checkbox --from-channel 22.04/beta --to-channel 22.04/candidate --yes
+          snapcraft promote checkbox --from-channel 22.04/beta --to-channel 22.04/stable --yes
+          snapcraft promote checkbox --from-channel 22.04/beta --to-channel latest/candidate --yes
+          snapcraft promote checkbox --from-channel 22.04/beta --to-channel latest/stable --yes

--- a/tools/release/lp-copy-packages.py
+++ b/tools/release/lp-copy-packages.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Sylvain Pineau <sylvain.pineau@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+import os
+
+from launchpadlib.credentials import Credentials
+from launchpadlib.launchpad import Launchpad
+
+# Authenticate with Launchpad
+credentials = Credentials.from_string(os.getenv("LP_CREDENTIALS"))
+lp = Launchpad(
+    credentials, None, None, service_root="production", version="devel")
+
+# Define the source and destination PPAs
+source_ppa_name = "testing"
+source_owner_name = "checkbox-dev"
+dest_ppa_name = "public"
+dest_owner_name = "hardware-certification"
+
+# Load the source and destination PPA owners
+source_owner = lp.people[source_owner_name]
+dest_owner = lp.people[dest_owner_name]
+
+# Get the source and destination PPAs
+source_ppa = source_owner.getPPAByName(name=source_ppa_name)
+dest_ppa = dest_owner.getPPAByName(name=dest_ppa_name)
+
+# Define the time period for package publication
+one_week_ago = datetime.datetime.utcnow().replace(
+    tzinfo=datetime.timezone.utc
+) - datetime.timedelta(weeks=1)
+
+# Get the packages in the source PPA that were published within the last week
+# and start with "checkbox"
+packages = [
+    p
+    for p in source_ppa.getPublishedSources(created_since_date=one_week_ago)
+    if p.source_package_name.startswith("checkbox")
+]
+
+# Copy each package from the source PPA to the destination PPA,
+# without rebuilding them
+for package in packages:
+    dest_ppa.copyPackage(
+        from_archive=source_ppa,
+        include_binaries=True,
+        to_pocket=package.pocket,
+        source_name=package.source_package_name,
+        version=package.source_package_version,
+    )
+    print(
+        f"Copied {package.source_package_name} "
+        f"version {package.source_package_version} "
+        f"from {source_ppa_name} to {dest_ppa_name} (without rebuilding)"
+    )


### PR DESCRIPTION
## Description

New workflow to promote the checkbox snaps to stable, copy deb packages from the testing ppa to stable and to publish the release on GH.
