### PR TITLE
Fix checkbox-stable-release.yml, checkout the repo before calling gh release

### DIFF
--- a/.github/workflows/checkbox-stable-release.yml
+++ b/.github/workflows/checkbox-stable-release.yml
@@ -9,6 +9,8 @@ jobs:
     name: Publish the release
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout checkbox monorepo
+        uses: actions/checkout@v3
       - name: Edit the draft release and publish it
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

`gh release edit` must be run from a repository or use `-R <repository>`.
This patch adds a checkout step to the stable workflow
