### PR TITLE
FIX providers/base/bin/cpuid.py: add another Sapphire Rapids CPUID

### DIFF
--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -129,7 +129,7 @@ CPUIDS = {
         "Penryn":           ['0x1067a'],
         "Rocket Lake":      ['0xa0671'],
         "Sandy Bridge":     ['0x206a', '0x206d6', '0x206d7'],
-        "Sapphire Rapids":  ['0x806f3', '0x806f7', '0x806f8'],
+        "Sapphire Rapids":  ['0x806f3', '0x806f6', '0x806f7', '0x806f8'],
         "Skylake":          ['0x406e3', '0x506e3', '0x50654', '0x50652'],
         "Tiger Lake":       ['0x806c1'],
         "Aderlake":         ['0x906a4', '0x906A3', '0x90675', '0x90672'],


### PR DESCRIPTION
Fixes #420
Fixes SERVCERT-866

## Description

Adds a recently discovered additional CPUID string for SPR CPUs

## Resolved issues

Fixes SERVCERT-866

## Documentation

NA

## Tests

NA - only change is that the cpuid test run against certain SPR CPUs should now properly identify the CPUs
