### PR TITLE
Add: set multiple MAC in one BTDEVADDR feature

### DIFF
--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -415,7 +415,21 @@ command:
     echo "btdevaddr option not set to device address of Bluetooth target in checkbox.conf"
     exit 1
   fi
-  set -o pipefail; bluetooth_test.py "$PLAINBOX_PROVIDER_DATA"/images/JPEG_Color_Image_Ubuntu.jpg "$BTDEVADDR" send 2>&1 | ansi_parser.py
+  for bt in $(echo "${BTDEVADDR}" | cut -d = -f 2 | sed s/,/\\n/g)
+  do
+    echo "Host:[${bt}]"
+    if echo 'u' | sudo -S l2ping -c 5 -t 5 "${bt}"
+        then
+        echo "Get avaiable BTDEVADDR:[${bt}]"
+        set -o pipefail
+        if bluetooth_test.py "$PLAINBOX_PROVIDER_DATA"/images/JPEG_Color_Image_Ubuntu.jpg "${bt}" send 2>&1 | ansi_parser.py
+        then
+            exit 0
+        fi
+    fi
+  done
+  echo "There are no avaiable BT devices."
+  exit 1
 flags: also-after-suspend
 _summary: Bluetooth OBEX send
 _description:

--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -420,7 +420,7 @@ command:
     echo "Host:[${bt}]"
     if echo 'u' | sudo -S l2ping -c 5 -t 5 "${bt}"
         then
-        echo "Get avaiable BTDEVADDR:[${bt}]"
+        echo "Get available BTDEVADDR:[${bt}]"
         set -o pipefail
         if bluetooth_test.py "$PLAINBOX_PROVIDER_DATA"/images/JPEG_Color_Image_Ubuntu.jpg "${bt}" send 2>&1 | ansi_parser.py
         then

--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -428,7 +428,7 @@ command:
         fi
     fi
   done
-  echo "There are no avaiable BT devices."
+  echo "There are no available BT devices."
   exit 1
 flags: also-after-suspend
 _summary: Bluetooth OBEX send


### PR DESCRIPTION
## Description

Describe your changes here:

BTDEVADDR could not set multiple BT MAC addresses at the same time. It will make automatic testing failed, if the test BT server be occupied or not available.

The only impact job is `com.canonical.plainbox::bluetooth/bluetooth_obex_send`.

Setting of BTDEVADDR is changing from
```
BTDEVADDR = 28:3A:4D:46:79:C0
```
to
```
BTDEVADDR = 28:3A:4D:46:79:C0,7C:B2:7D:4B:14:95,34:6F:24:A8:93:EE,80:32:53:D8:0D:1E
```

## Resolved issues
- #175
- [Jira card CQT-2031](https://warthogs.atlassian.net/browse/CQT-2031)

## Documentation

- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).

## Tests

- [Only setting one Mac address](https://certification.canonical.com/hardware/202212-30999/submission/307865/)
- [First one Mac address could be used](https://certification.canonical.com/hardware/202212-30999/submission/307869/)
- [Latest one Mac address could be used](https://certification.canonical.com/hardware/202212-30999/submission/307868/)
- [One of the Mac address could be used](https://certification.canonical.com/hardware/202212-30999/submission/307867/)
- [All Mac address could not be used](https://certification.canonical.com/hardware/202212-30999/submission/307870/)
