### PR TITLE
Add support for fish shell

### DIFF
--- a/checkbox-ng/mk-venv
+++ b/checkbox-ng/mk-venv
@@ -21,5 +21,8 @@ echo "set -gx PROVIDERPATH $venv_path/share/plainbox-providers-1" >> $venv_path/
 
 echo "virtualenv with an empty provider database created at $venv_path"
 echo "To activate your virtualenv run:"
-echo "$ . $venv_path/bin/activate"
-
+if [ "$(basename "$SHELL")" = "fish" ]; then
+    echo "$ . $venv_path/bin/activate.fish"
+else
+    echo "$ . $venv_path/bin/activate"
+fi

--- a/checkbox-ng/mk-venv
+++ b/checkbox-ng/mk-venv
@@ -2,22 +2,24 @@
 
 venv_path=${1:-venv}
 
-venv_path=$(realpath $venv_path)
+venv_path=$(realpath "$venv_path")
 
-if [ -d $venv_path ]; then
+if [ -d "$venv_path" ]; then
     echo "$venv_path already exists"
     exit 1
 fi
 
-virtualenv --quiet --system-site-packages --python=python3 $venv_path
+virtualenv --quiet --system-site-packages --python=python3 "$venv_path"
 
-. $venv_path/bin/activate
+# To prevent https://www.shellcheck.net/wiki/SC1091
+# shellcheck source=/dev/null
+. "$venv_path"/bin/activate
 python3 setup.py develop --quiet | sed -e 's/^/I (develop output) /'
 pip install tqdm psutil
 
 mkdir -p "$venv_path/share/plainbox-providers-1"
-echo "export PROVIDERPATH=$venv_path/share/plainbox-providers-1" >> $venv_path/bin/activate
-echo "set -gx PROVIDERPATH $venv_path/share/plainbox-providers-1" >> $venv_path/bin/activate.fish
+echo "export PROVIDERPATH=$venv_path/share/plainbox-providers-1" >> "$venv_path"/bin/activate
+echo "set -gx PROVIDERPATH $venv_path/share/plainbox-providers-1" >> "$venv_path"/bin/activate.fish
 
 echo "virtualenv with an empty provider database created at $venv_path"
 echo "To activate your virtualenv run:"

--- a/checkbox-ng/mk-venv
+++ b/checkbox-ng/mk-venv
@@ -17,6 +17,7 @@ pip install tqdm psutil
 
 mkdir -p "$venv_path/share/plainbox-providers-1"
 echo "export PROVIDERPATH=$venv_path/share/plainbox-providers-1" >> $venv_path/bin/activate
+echo "set -gx PROVIDERPATH $venv_path/share/plainbox-providers-1" >> $venv_path/bin/activate.fish
 
 echo "virtualenv with an empty provider database created at $venv_path"
 echo "To activate your virtualenv run:"


### PR DESCRIPTION
Add $PROVIDERPATH to activate.fish so that people using this shell can contribute to Checkbox as well.

This is the (partial) backport of a [patch](https://code.launchpad.net/~pieq/checkbox-ng/+git/checkbox-ng/+merge/426281) I submitted last year on Launchpad that didn't make it, but it's still a pain for fish users to deploy Checkbox locally, so I submit it again :)