### PR TITLE
Require user to provide comment for manually skipped or failed cert-blockers

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/master.py
+++ b/checkbox-ng/checkbox_ng/launcher/master.py
@@ -602,10 +602,26 @@ class RemoteMaster(ReportsStage, MainLoopStage):
                             _('Please enter your comments:') + '\n'))
                         self.sa.remember_users_response(new_comment + '\n')
                     elif interaction.kind == 'skip':
-                        self.finish_job(
-                            interaction.extra._builder.get_result())
-                        next_job = True
-                        break
+                        if (
+                            job_state.effective_certification_status == "blocker"
+                            and not isinstance(interaction.extra._builder.comments, str)
+                        ):
+                            print(self.C.RED(_("This job is required to issue"
+                                               " a certificate.")))
+                            print(
+                                self.C.RED(_("Please add a comment to explain"
+                                             " why you want to skip it."))
+                            )
+                            next_job = False
+                            self.sa.rerun_job(
+                                job['id'],
+                                interaction.extra._builder.get_result())
+                            break
+                        else:
+                            self.finish_job(
+                                interaction.extra._builder.get_result())
+                            next_job = True
+                            break
                 else:
                     self.wait_for_job()
                     break

--- a/checkbox-ng/checkbox_ng/launcher/master.py
+++ b/checkbox-ng/checkbox_ng/launcher/master.py
@@ -606,8 +606,8 @@ class RemoteMaster(ReportsStage, MainLoopStage):
                             job_state.effective_certification_status == "blocker"
                             and not isinstance(interaction.extra._builder.comments, str)
                         ):
-                            print(self.C.RED(_("This job is required to issue"
-                                               " a certificate.")))
+                            print(self.C.RED(_("This job is required in order"
+                                               " to issue a certificate.")))
                             print(
                                 self.C.RED(_("Please add a comment to explain"
                                              " why you want to skip it."))

--- a/checkbox-ng/checkbox_ng/launcher/master.py
+++ b/checkbox-ng/checkbox_ng/launcher/master.py
@@ -539,6 +539,7 @@ class RemoteMaster(ReportsStage, MainLoopStage):
 
     def _run_jobs(self, jobs_repr, total_num=0):
         for job in jobs_repr:
+            job_state = self.sa._sa.get_job_state(job['id'])
             SimpleUI.header(
                 _('Running job {} / {}').format(
                     job['num'], total_num,
@@ -584,7 +585,7 @@ class RemoteMaster(ReportsStage, MainLoopStage):
                         job_lite = JobAdapter(job['command'])
                         try:
                             cmd = SimpleUI(None)._interaction_callback(
-                                job_lite, interaction.extra._builder)
+                                job_lite, job_state, interaction.extra._builder)
                             self.sa.remember_users_response(cmd)
                             self.finish_job(
                                 interaction.extra._builder.get_result())

--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -88,15 +88,15 @@ class MainLoopStage(CheckboxUiStage):
 
 
     def _run_single_job_with_ui_loop(self, job, ui):
+        job_state = self.sa.get_job_state(job.id)
         print(self.C.header(job.tr_summary(), fill='-'))
         print(_("ID: {0}").format(job.id))
         print(_("Category: {0}").format(
-            self.sa.get_job_state(job.id).effective_category_id))
+            job_state.effective_category_id))
         comments = ""
         while True:
             if job.plugin in ('user-interact', 'user-interact-verify',
                               'user-verify', 'manual'):
-                job_state = self.sa.get_job_state(job.id)
                 if (not self.is_interactive and
                         job.plugin in ('user-interact',
                                        'user-interact-verify',
@@ -132,13 +132,30 @@ class MainLoopStage(CheckboxUiStage):
                             comments += new_comment + '\n'
                         continue
                     elif cmd == 'skip':
-                        result_builder = JobResultBuilder(
-                            outcome=IJobResult.OUTCOME_SKIP,
-                            comments=_("Explicitly skipped before"
-                                       " execution"))
-                        if comments != "":
-                            result_builder.comments = comments
-                        break
+                        if (
+                            job_state.effective_certification_status == "blocker"
+                            and comments == ""
+                        ):
+                            print(
+                                self.C.RED(
+                                    _("This job is required to issue a certificate.")
+                                )
+                            )
+                            print(
+                                self.C.RED(
+                                    _(
+                                        "Please add a comment to explain why you want to skip it."
+                                    )
+                                )
+                            )
+                            continue
+                        else:
+                            result_builder = JobResultBuilder(
+                                outcome=IJobResult.OUTCOME_SKIP,
+                                comments=_("Explicitly skipped before execution"))
+                            if comments != "":
+                                result_builder.comments = comments
+                            break
                     elif cmd == 'quit':
                         raise SystemExit()
                 else:
@@ -153,14 +170,14 @@ class MainLoopStage(CheckboxUiStage):
                     if comments != "":
                         result_builder.comments = comments
                     ui.notify_about_verification(job)
-                    self._interaction_callback(job, result_builder)
+                    self._interaction_callback(job, job_state, result_builder)
                 except ReRunJob:
                     self.sa.use_job_result(job.id, result_builder.get_result())
                     continue
             break
         return result_builder
 
-    def _interaction_callback(self, job, result_builder,
+    def _interaction_callback(self, job, job_state, result_builder,
                               prompt=None, allowed_outcome=None):
         result = result_builder.get_result()
         if prompt is None:
@@ -212,9 +229,33 @@ class MainLoopStage(CheckboxUiStage):
             if cmd == 'set-pass':
                 result_builder.outcome = IJobResult.OUTCOME_PASS
             elif cmd == 'set-fail':
-                result_builder.outcome = IJobResult.OUTCOME_FAIL
+                if (
+                    job_state.effective_certification_status == "blocker"
+                    and not isinstance(result_builder.comments, str)
+                ):
+                    print(self.C.RED(_("This job is required to issue a certificate.")))
+                    print(
+                        self.C.RED(_("Please add a comment to explain why it failed."))
+                    )
+                    continue
+                else:
+                    result_builder.outcome = IJobResult.OUTCOME_FAIL
             elif cmd == 'set-skip' or cmd is None:
-                result_builder.outcome = IJobResult.OUTCOME_SKIP
+                if (
+                   job_state.effective_certification_status == "blocker"
+                   and not isinstance(result_builder.comments, str)
+                ):
+                    print(self.C.RED(_("This job is required to issue a certificate.")))
+                    print(
+                        self.C.RED(
+                            _(
+                                "Please add a comment to explain why you want to skip it."
+                            )
+                        )
+                    )
+                    continue
+                else:
+                    result_builder.outcome = IJobResult.OUTCOME_SKIP
             elif cmd == 'set-suggested':
                 result_builder.outcome = suggested_outcome
             elif cmd == 'set-comments':

--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -138,7 +138,7 @@ class MainLoopStage(CheckboxUiStage):
                         ):
                             print(
                                 self.C.RED(
-                                    _("This job is required to issue a certificate.")
+                                    _("This job is required in order to issue a certificate.")
                                 )
                             )
                             print(
@@ -233,7 +233,7 @@ class MainLoopStage(CheckboxUiStage):
                     job_state.effective_certification_status == "blocker"
                     and not isinstance(result_builder.comments, str)
                 ):
-                    print(self.C.RED(_("This job is required to issue a certificate.")))
+                    print(self.C.RED(_("This job is required in order to issue a certificate.")))
                     print(
                         self.C.RED(_("Please add a comment to explain why it failed."))
                     )
@@ -245,7 +245,7 @@ class MainLoopStage(CheckboxUiStage):
                    job_state.effective_certification_status == "blocker"
                    and not isinstance(result_builder.comments, str)
                 ):
-                    print(self.C.RED(_("This job is required to issue a certificate.")))
+                    print(self.C.RED(_("This job is required in order to issue a certificate.")))
                     print(
                         self.C.RED(
                             _(

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -460,29 +460,69 @@ class Launcher(MainLoopStage, ReportsStage):
 
         print(_("Previous session run tried to execute job: {}").format(
             last_job))
-        cmd = self._pick_action_cmd([
-            Action('s', _("skip that job"), 'skip'),
-            Action('p', _("mark it as passed and continue"), 'pass'),
-            Action('f', _("mark it as failed and continue"), 'fail'),
-            Action('r', _("run it again"), 'run'),
-        ], _("What do you want to do with that job?"))
-        if cmd == 'skip' or cmd is None:
-            result = MemoryJobResult({
-                'outcome': IJobResult.OUTCOME_SKIP,
-                'comments': _("Skipped after resuming execution")
-            })
-        elif cmd == 'pass':
-            result = MemoryJobResult({
-                'outcome': IJobResult.OUTCOME_PASS,
-                'comments': _("Passed after resuming execution")
-            })
-        elif cmd == 'fail':
-            result = MemoryJobResult({
-                'outcome': IJobResult.OUTCOME_FAIL,
-                'comments': _("Failed after resuming execution")
-            })
-        elif cmd == 'run':
-            result = None
+        last_job_cert_status = self.ctx.sa.get_job_state(last_job).effective_certification_status
+        result_dict = {
+            "outcome": IJobResult.OUTCOME_NONE,
+            "comments": ""
+        }
+        while True:
+            cmd = self._pick_action_cmd([
+                Action("c", _("add comment"), "comment"),
+                Action("s", _("skip that job"), "skip"),
+                Action("p", _("mark it as passed and continue"), "pass"),
+                Action("f", _("mark it as failed and continue"), "fail"),
+                Action("r", _("run it again"), "run"),
+            ], _("What do you want to do with that job?"))
+            if cmd == "skip" or cmd is None:
+                if (last_job_cert_status == "blocker" and not result_dict["comments"]):
+                    print(
+                        self.C.RED(_("This job is required to issue a certificate."))
+                    )
+                    print(
+                        self.C.RED(
+                            _(
+                                "Please add a comment to explain why you want to skip it."
+                            )
+                        )
+                    )
+                    continue
+                else:
+                    if not result_dict["comments"]:
+                        result_dict["comments"] = _("Skipped after resuming execution")
+                    result_dict["outcome"] = IJobResult.OUTCOME_SKIP
+                    result = MemoryJobResult(result_dict)
+                    break
+            elif cmd == "pass":
+                if not result_dict["comments"]:
+                    result_dict["comments"] = _("Passed after resuming execution")
+                result_dict["outcome"] = IJobResult.OUTCOME_PASS
+                result = MemoryJobResult(result_dict)
+                break
+            elif cmd == "fail":
+                if (last_job_cert_status == "blocker" and not result_dict["comments"]):
+                    print(
+                        self.C.RED(_("This job is required to issue a certificate."))
+                    )
+                    print(
+                        self.C.RED(_("Please add a comment to explain why it failed."))
+                    )
+                    continue
+                else:
+                    if not result_dict["comments"]:
+                        result_dict["comments"] = _("Failed after resuming execution")
+                    result_dict["outcome"] = IJobResult.OUTCOME_FAIL
+                    result = MemoryJobResult(result_dict)
+                    break
+            elif cmd == "comment":
+                new_comment = input(
+                    self.C.BLUE(_("Please enter your comments:") + "\n")
+                )
+                if new_comment:
+                    result_dict["comments"] += new_comment + "\n"
+                continue
+            elif cmd == "run":
+                result = None
+                break
         if result:
             self.ctx.sa.use_job_result(last_job, result)
 

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -476,7 +476,7 @@ class Launcher(MainLoopStage, ReportsStage):
             if cmd == "skip" or cmd is None:
                 if (last_job_cert_status == "blocker" and not result_dict["comments"]):
                     print(
-                        self.C.RED(_("This job is required to issue a certificate."))
+                        self.C.RED(_("This job is required in order to issue a certificate."))
                     )
                     print(
                         self.C.RED(
@@ -501,7 +501,7 @@ class Launcher(MainLoopStage, ReportsStage):
             elif cmd == "fail":
                 if (last_job_cert_status == "blocker" and not result_dict["comments"]):
                     print(
-                        self.C.RED(_("This job is required to issue a certificate."))
+                        self.C.RED(_("This job is required in order to issue a certificate."))
                     )
                     print(
                         self.C.RED(_("Please add a comment to explain why it failed."))

--- a/checkbox-ng/docs/units/job.rst
+++ b/checkbox-ng/docs/units/job.rst
@@ -59,6 +59,39 @@ Following fields may be used by the job unit:
           records, containing key/value pairs, and that can be used in other
           jobs' ``requires`` expressions.
 
+``certification-status``:
+    (optional) - Certification status for the given job. This is used by
+    Canonical to determine the jobs that **must** be run in order to be able to
+    issue a certificate. The allowed values are:
+
+    :unspecified:
+        This value means that a job was not analyzed in the context of
+        certification status classification and it has no classification at this
+        time. This is also the default certification status for all jobs.
+    :not-part-of-certification:
+        This value means that a given job may fail and this will not affect the
+        certification process in any way. Typically jobs with this certification
+        status are not executed during the certification process.
+    :non-blocker:
+        This value means that a given job may fail and while that should be
+        regarded as a possible future problem it will not block the
+        certification process. Canonical reserves the right to promote jobs from
+        *non-blocker* to *blocker*.
+    :blocker:
+        This value means that a given job **must** pass for the certification
+        process to succeed.
+
+    .. note::
+        The certification status can be overridden in a test plan.
+
+    .. warning::
+        If a job requiring user interaction (i.e. its ``plugin`` value is set to
+        ``manual``, ``user-interact`` or ``user-interact-verify``) has a
+        ``certification-status`` set to ``blocker``, it cannot be skipped or
+        failed unless the user provides a comment. This is so that the
+        Certification team can evaluate the test report and investigate the
+        reasons behind such an outcome.
+
 ``requires``:
     (optional). If specified, the job will only run if the conditions
     expressed in this field are met.

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -441,10 +441,11 @@ class RemoteSessionAssistant():
             if self._last_response == 'skip':
                 def skipped_builder(*args, **kwargs):
                     result_builder = JobResultBuilder(
-                        outcome=IJobResult.OUTCOME_SKIP,
-                        comments=_("Explicitly skipped before execution"))
+                        outcome=IJobResult.OUTCOME_SKIP)
                     if self._current_comments != "":
                         result_builder.comments = self._current_comments
+                    elif job_state.effective_certification_status != "blocker":
+                        result_builder.comments = "Explicitly skipped before execution"
                     return result_builder
                 self._be = BackgroundExecutor(
                     self, job_id, skipped_builder)

--- a/checkbox-ng/plainbox/impl/unit/job.py
+++ b/checkbox-ng/plainbox/impl/unit/job.py
@@ -121,29 +121,22 @@ class _CertificationStatusValues(SymbolDef):
     Particular values have the following meanings.
 
     unspecified:
-        One of the new possible certification status values. This value means
-        that a job was not analyzed in the context of certification status
-        classification and it has no classification at this time. This is also
-        the implicit certification status for all jobs.
+        This value means that a job was not analyzed in the context of
+        certification status classification and it has no classification at this
+        time. This is also the implicit certification status for all jobs.
     not-part-of-certification:
-        One of the new possible certification status values. This value means
-        that a given job may fail and this will not affect the certification
-        process in any way. Typically jobs with this certification status are
-        not executed during the certification process. In the past this was
-        informally referred to as a *blacklist item*.
+        This value means that a given job may fail and this will not affect the
+        certification process in any way. Typically jobs with this certification
+        status are not executed during the certification process.
     non-blocker:
-        One of the new possible certification status values. This value means
-        that a given job may fail and while that should be regarded as a
-        possible future problem it will not block the certification process. In
-        the past this was informally referred to as a *graylist item*.
-        Canonical reserves the right to promote jobs from the *non-blocker* to
-        *blocker*.
+        This value means that a given job may fail and while that should be
+        regarded as a possible future problem it will not block the
+        certification process. Canonical reserves the right to promote jobs from
+        *non-blocker* to *blocker*.
     blocker:
-        One of the new possible certification status values. This value means
-        that a given job must pass for the certification process to succeed. In
-        the past this was informally referred to as a *whitelist item*. The
-        term *blocker* was chosen to disambiguate the meaning of the two
-        concepts.
+        This value means that a given job must pass for the certification
+        process to succeed. The term *blocker* was chosen to disambiguate the
+        meaning of the two concepts.
     """
     unspecified = 'unspecified'
     not_part_of_certification = 'not-part-of-certification'

--- a/metabox/metabox/metabox-provider/units/cert-blocker-tps.pxu
+++ b/metabox/metabox/metabox-provider/units/cert-blocker-tps.pxu
@@ -1,0 +1,35 @@
+id: cert-blocker-manual
+unit: test plan
+_name: Manual cert-blocker test
+_description:
+    Test that a cert-blocker manual job cannot be skipped or failed without a
+    comment.
+include:
+    stub/split-fields/manual certification-status=blocker
+
+id: cert-blocker-user-interact-verify
+unit: test plan
+_name: User interact verify cert-blocker test
+_description:
+    Test that cert-blocker user-interact-verify job cannot be skipped or failed
+    without a comment.
+include:
+    stub/split-fields/user-interact-verify certification-status=blocker
+
+id: cert-blocker-user-interact
+unit: test plan
+_name: User interact verify cert-blocker test
+_description:
+    Test that cert-blocker user-interact job cannot be skipped without a comment.
+include:
+    stub/split-fields/user-interact certification-status=blocker
+
+id: cert-blocker-manual-resume
+unit: test plan
+_name: Manual cert-blocker test
+_description:
+    Test that a job marked as cert-blocker cannot be skipped without a comment
+    when resuming a session
+include:
+    stub/split-fields/manual certification-status=blocker
+    stub/split-fields/user-interact

--- a/metabox/metabox/scenarios/cert_blocker_comment/launcher.py
+++ b/metabox/metabox/scenarios/cert_blocker_comment/launcher.py
@@ -1,0 +1,275 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Pierre Equoy <pierre.equoy@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+import textwrap
+import metabox.core.keys as keys
+from metabox.core.actions import Expect
+from metabox.core.actions import Send
+from metabox.core.actions import Start
+from metabox.core.scenario import Scenario
+from metabox.core.utils import _re
+
+
+class ManualJobFailed(Scenario):
+    """
+    Run a test plan with a manual job with a certification-status set to
+    "blocker" and make sure it can only be marked as failed if a comment is
+    entered.
+    """
+
+    modes = ['local']
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::cert-blocker-manual
+        forced = yes
+        [test selection]
+        forced = yes
+        """)
+    steps = [
+        Start(),
+        Expect('Pick an action'),
+        Send('f' + keys.KEY_ENTER),
+        Expect('Please add a comment to explain why it failed.', timeout=30),
+        Send('c' + keys.KEY_ENTER),
+        Expect('Please enter your comments:'),
+        Send('This is a comment' + keys.KEY_ENTER),
+        Expect('Pick an action'),
+        Send('f' + keys.KEY_ENTER),
+        Expect('Select jobs to re-run'),
+        Send('f' + keys.KEY_ENTER),
+        Expect(_re('(☒|job failed).*A simple manual job')),
+    ]
+
+
+class ManualJobSkipped(Scenario):
+    """
+    Run a test plan with a manual job with a certification-status set to
+    "blocker" and make sure it can only be skipped if a comment is entered.
+    """
+
+    modes = ['local']
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::cert-blocker-manual
+        forced = yes
+        [test selection]
+        forced = yes
+        """)
+    steps = [
+        Start(),
+        Expect('Pick an action'),
+        Send('s' + keys.KEY_ENTER),
+        Expect('Please add a comment to explain why you want to skip it.', timeout=30),
+        Send('c' + keys.KEY_ENTER),
+        Expect('Please enter your comments:'),
+        Send('This is a comment' + keys.KEY_ENTER),
+        Expect('Pick an action'),
+        Send('s' + keys.KEY_ENTER),
+        Expect('Select jobs to re-run'),
+        Send('f' + keys.KEY_ENTER),
+        Expect(_re('(☐|job skipped).*A simple manual job')),
+    ]
+
+
+class UserInteractVerifyJobFailed(Scenario):
+    """
+    Run a test plan with a user-interact-verify job with a certification-status
+    set to "blocker" and make sure it can only be marked as failed if a comment
+    is entered.
+    """
+
+    modes = ['local']
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::cert-blocker-user-interact-verify
+        forced = yes
+        [test selection]
+        forced = yes
+        """)
+    steps = [
+        Start(),
+        Expect('Pick an action'),
+        Send(keys.KEY_ENTER),
+        Expect('job needs verification', timeout=30),
+        Send('f' + keys.KEY_ENTER),
+        Expect('Please add a comment to explain why it failed.', timeout=30),
+        Send('c' + keys.KEY_ENTER),
+        Expect('Please enter your comments:'),
+        Send('This is a comment' + keys.KEY_ENTER),
+        Expect('Pick an action'),
+        Send('f' + keys.KEY_ENTER),
+        Expect('Select jobs to re-run'),
+        Send('f' + keys.KEY_ENTER),
+        Expect(_re('(☒|job failed).*user interaction and verification job')),
+    ]
+
+
+class UserInteractVerifyJobSkippedAfterRun(Scenario):
+    """
+    Run a test plan with a user-interact-verify job with a certification-status
+    set to "blocker" and make sure it can only be skipped if a comment is
+    entered after actually running it.
+    """
+
+    modes = ['local']
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::cert-blocker-user-interact-verify
+        forced = yes
+        [test selection]
+        forced = yes
+        """)
+    steps = [
+        Start(),
+        Expect('Pick an action'),
+        Send(keys.KEY_ENTER),
+        Expect('job needs verification', timeout=30),
+        Send('s' + keys.KEY_ENTER),
+        Expect('Please add a comment to explain why you want to skip it.', timeout=30),
+        Send('c' + keys.KEY_ENTER),
+        Expect('Please enter your comments:'),
+        Send('This is a comment' + keys.KEY_ENTER),
+        Expect('Pick an action'),
+        Send('s' + keys.KEY_ENTER),
+        Expect('Select jobs to re-run'),
+        Send('f' + keys.KEY_ENTER),
+        Expect(_re('(☐|job skipped).*user interaction and verification job')),
+    ]
+
+
+class UserInteractVerifyJobSkippedBeforeRun(Scenario):
+    """
+    Run a test plan with a user-interact-verify job with a certification-status
+    set to "blocker" and make sure it can only be skipped if a comment is
+    entered before actually running it.
+    """
+
+    modes = ['local']
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::cert-blocker-user-interact-verify
+        forced = yes
+        [test selection]
+        forced = yes
+        """)
+    steps = [
+        Start(),
+        Expect('Pick an action'),
+        Send('s' + keys.KEY_ENTER),
+        Expect('Please add a comment to explain why you want to skip it.', timeout=30),
+        Send('c' + keys.KEY_ENTER),
+        Expect('Please enter your comments:'),
+        Send('This is a comment' + keys.KEY_ENTER),
+        Expect('Pick an action'),
+        Send('s' + keys.KEY_ENTER),
+        Expect('Select jobs to re-run'),
+        Send('f' + keys.KEY_ENTER),
+        Expect(_re('(☐|job skipped).*user interaction and verification job')),
+    ]
+
+
+class UserInteractJobSkippedBeforeRun(Scenario):
+    """
+    Run a test plan with a user-interact job with a certification-status set to
+    "blocker" and make sure it can only be skipped if a comment is entered
+    before actually running it.
+    """
+
+    modes = ['local']
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::cert-blocker-user-interact
+        forced = yes
+        [test selection]
+        forced = yes
+        """)
+    steps = [
+        Start(),
+        Expect('Pick an action'),
+        Send('s' + keys.KEY_ENTER),
+        Expect('Please add a comment to explain why you want to skip it.', timeout=30),
+        Send('c' + keys.KEY_ENTER),
+        Expect('Please enter your comments:'),
+        Send('This is a comment' + keys.KEY_ENTER),
+        Expect('Pick an action'),
+        Send('s' + keys.KEY_ENTER),
+        Expect('Select jobs to re-run'),
+        Send('f' + keys.KEY_ENTER),
+        Expect(_re('(☐|job skipped).*User-interact job')),
+    ]
+
+
+class ManualJobSkippedWhenResumingSession(Scenario):
+    """
+    Run a test plan with a manual job set to cert-blocker. Save and quit the
+    session, resume it and make sure it cannot be skipped until a comment is
+    added.
+    """
+
+    modes = ['local']
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::cert-blocker-manual-resume
+        forced = yes
+        [test selection]
+        forced = yes
+        """)
+    steps = [
+        Start(),
+        Expect('Pick an action'),
+        Send('p' + keys.KEY_ENTER),
+        Expect('save the session and quit'),
+        Send('q' + keys.KEY_ENTER),
+        Start(),
+        Expect('resume this session'),
+        Send('r' + keys.KEY_ENTER),
+        Expect('What do you want to do with that job?'),
+        Send('s' + keys.KEY_ENTER),
+        Expect('Please add a comment to explain why you want to skip it.', timeout=30),
+        Send('c' + keys.KEY_ENTER),
+        Expect('Please enter your comments:'),
+        Send('This is a comment' + keys.KEY_ENTER),
+        Expect('What do you want to do with that job?'),
+        Send('s' + keys.KEY_ENTER),
+        Expect('Pick an action'),
+        Send(keys.KEY_ENTER),
+        Expect('Select jobs to re-run'),
+        Send('f' + keys.KEY_ENTER),
+        Expect(_re('(☐|job skipped).*A simple manual job')),
+    ]


### PR DESCRIPTION
## Description

When issuing certificates for a device, the team reviews the different test reports generated. Jobs that have a certification status set to "blocker" must pass in order to issue a review.

Sometimes, it is not the case, but users do not necessarily provide a comment that would help with the review.

Semi-automated jobs ([`user-interact` and `user-interact-verify`](https://checkbox.readthedocs.io/en/latest/units/job.html#job-fields)) can be skipped before being started or after they've run.

Manual jobs can be skipped after been "run", meaning after their content has been displayed to the user and the user has to pick an outcome.

These are handled in

- checkbox_ng.launcher.stages._run_single_job_with_ui_loop
- checkbox_ng.launcher.stages._interaction_callback

Checkbox local and Checkbox remote call _interaction_callback() differently; Checkbox remote does not provide the current job's state, which is required to know the job's effective certification status (this status can be set in the job definition, but overriden in the test plan). checkbox_ng.launcher.stages._interaction_callback() signature is modified to pass the job state.

Fix #387

![Demo screenshot showing a cert-blocker being manually skipped/failed, and Checkbox asking the user to provide a comment](https://user-images.githubusercontent.com/512471/231788080-fb899495-1ab0-42e6-b5ba-3f6587a89db3.png)

## Resolved issues

CHECKBOX-484

## Tests

Test that any interactive jobs (`manual`, `user-interact` and `user-interact-verify`) marked as `blocker` in a sample test plan cannot be skipped. An error message is displayed until the user adds a comment.

To do so, create a sample test plan such as:

```
id: gh387
_name: Check that interactive cert-blockers cannot be skipped/failed without a comment
unit: test plan
include:
    smoke/user-interact          certification-status=blocker
    smoke/user-interact-verify          certification-status=blocker
    smoke/manual          certification-status=blocker
``` 

Tests need to be run with Checkbox local and Checkbox remote.

**Note:** The sample test plan above only contain `blocker` jobs, but you can try to set some to normal jobs and make sure they can be skipped or failed without requiring a comment.

### Checkbox local

#### During a session run

Run:

```
checkbox-cli run com.canonical.certification::gh387
```

and try to mark one of the job as skipped or failed. Checkbox should display an error message asking you to add a comment first.

#### When resuming a session

1. Run `checkbox-cli` and select the test plan you created.
2. When prompted, select `q => save the session and quit`
3. Restart checkbox-cli, select `r => resume this session`. A message should be displayed, such as:

```
Previous session run tried to execute job: com.canonical.certification::smoke/manual`.
What do you want to do with that job?
  c => add comment
  s => skip that job
  p => mark it as passed and continue
  f => mark it as failed and continue
  r => run it again
```

4. Try to mark the job as failed or skipped. Checkbox should display an error message and ask you to enter a comment first. 

*(Unrelated: there is a bug with the `run it again` option, see #428)*

### Checkbox Remote

Prepare a launcher:

```
[launcher]
app_id = com.canonical.certification:checkbox
launcher_version = 1
stock_reports = text

[test plan]
unit = com.canonical.certification::gh387
forced = yes

[test selection]
forced = yes
```

Start Checkbox service in a separate process (needs to be done as root):

```
checkbox-cli service
```

then start Checkbox remote:

```
checkbox-cli remote 127.0.0.1 /path/to/your/launcher
```

Try to set some cert-blocker jobs to `fail` or `skip`: Checkbox should display an error and ask you to input a comment in order to continue.