### PR TITLE
Fix: graphics/nvlink-status-check always failed while less than 2 graphic cards

### DIFF
--- a/providers/base/bin/nvidia_nvlink_check.sh
+++ b/providers/base/bin/nvidia_nvlink_check.sh
@@ -8,7 +8,7 @@ if [ -z "$O" ]; then
     echo "System does not support NVLINK."
     exit 1
 # If any inactive in output that means NVLINK not connected porpery or malfunction, -n use for verify output
-elif echo "$O" | grep -q inactive; then
+elif echo "$O" | grep -iq inactive; then
     echo "NVLINK either the bridge is missing/defective or not configured correctly.";
     exit 1
 else

--- a/providers/base/bin/nvidia_nvlink_check.sh
+++ b/providers/base/bin/nvidia_nvlink_check.sh
@@ -3,16 +3,16 @@
 set -e
 
 O=$(nvidia-smi nvlink -s)
-#Check NVLINK are avaliable first, if only 1 NVIDIA Graphic card, output will be empty.
-if [ -z "$O" ];then
-    echo "System does not support NVLINK or Only 1 NVIDIA graphic card installed";
+# If the system doesn't support NVLINK, the output will be None.
+if [ -z "$O" ]; then
+    echo "System does not support NVLINK."
     exit 1
-#If any inactive in output that means NVLINK not connected porpery or malfunction, -n use for verify output
+# If any inactive in output that means NVLINK not connected porpery or malfunction, -n use for verify output
 elif echo "$O" | grep -q inactive; then
-    echo "NVLINK either the bridge is missing/defective or not configured correctly";
+    echo "NVLINK either the bridge is missing/defective or not configured correctly.";
     exit 1
 else
     #"-e" use for new line character in string"
-    echo -e "NVLINK are Supported!\nStatus as below:\n\n""$O"
+    echo -e "NVLINK Supported!\nStatus as below:\n\n""$O"
     exit 0
 fi

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -544,6 +544,7 @@ id: graphics/nvlink-status-check
 requires:
  dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower', 'Space-saving']
  graphics_card.driver == 'nvidia'
+ nv_graphics_card.nv_card_count >= "2"
 command: nvidia_nvlink_check.sh
 _summary: Check NVIDIA NVLINK status
 _description: Check NVLINK are supported and NVLINK are connected properly on system, please make sure below items before testing:

--- a/providers/resource/bin/nv_card_resource.sh
+++ b/providers/resource/bin/nv_card_resource.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "nv_card_count: $(lspci | grep NVIDIA | grep VGA -c)"
+exit 0

--- a/providers/resource/jobs/resource.pxu
+++ b/providers/resource/jobs/resource.pxu
@@ -318,6 +318,12 @@ plugin: resource
 _summary: Generate an entry for each graphics card present in the system.
 command: graphics_card_resource.py
 
+id: nv_graphics_card
+estimated_duration: 0.05
+plugin: resource
+_summary: Generate an entry for NVIDIA graphics card present in the system.
+command: nv_card_resource.sh
+
 id: fwts
 estimated_duration: 0.5
 plugin: resource


### PR DESCRIPTION
## Description
Nowadays, graphics/nvlink-status-check will always failed while there are only 1  graphic card. However, it shouldn’t fail. Instead, it should be skipped. Because nvlink is based on more than 1 Nvidia GPU.
I create a new resource job for nvidia graphic card to count the nv card in the system. And set it as a requirement for `graphics/nvlink-status-check`.

Note: This job only run on sutton.
## Resolved issues
 - This job will failed when there's only 1 graphic card.
## Tests
Run
```
checkbox-cli run com.canonical.certification::graphics/nvlink-status-check
```
## Submissions
 - 1 NV Card: https://certification.canonical.com/hardware/202303-31331/submission/313692/
 - 2 NV Cards: https://certification.canonical.com/hardware/202303-31333/submission/313388/
