### PR TITLE
Fix the release to stable workflow by cloning with full git history

### DIFF
--- a/.github/workflows/checkbox-stable-release.yml
+++ b/.github/workflows/checkbox-stable-release.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout checkbox monorepo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Edit the draft release and publish it
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Using `fetch-depth: 0`
All tags are available and the following command works as expected:

`$(git describe --tags --abbrev=0 --match v*)`