### PR TITLE
fix: print proper estimated runtime even when some jobs don't provide it

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -236,29 +236,31 @@ class MainLoopStage(CheckboxUiStage):
         return CheckboxUI(self.C.c, show_cmd_output=show_out)
 
     def _run_jobs(self, jobs_to_run):
+        # some jobs that are planned to be run don't have an
+        # estimated_duration defined, but we still want to keep track of
+        # the ones that do.  if any of the job doesn't have it we have to
+        # add "at least" to the estimate
         estimated_time = 0
+        had_unknown_time = False
         for job_id in jobs_to_run:
             job = self.sa.get_job(job_id)
-            if (job.estimated_duration is not None and
-                    estimated_time is not None):
+            if job.estimated_duration is not None:
                 estimated_time += job.estimated_duration
             else:
-                estimated_time = None
+                had_unknown_time = True
+        header = _("Running job {} / {}. Estimated time left{}: {}")
         for job_no, job_id in enumerate(jobs_to_run, start=1):
-            print(self.C.header(
-                _('Running job {} / {}. Estimated time left: {}').format(
-                    job_no, len(jobs_to_run),
-                    seconds_to_human_duration(max(0, estimated_time))
-                    if estimated_time is not None else _("unknown")),
-                fill='-'))
+            print(self.C.header(header.format(
+                job_no, len(jobs_to_run),
+                _(" (at least)") if had_unknown_time else "",
+                seconds_to_human_duration(estimated_time),
+                fill='-')))
             job = self.sa.get_job(job_id)
             builder = self._run_single_job_with_ui_loop(
                 job, self._get_ui_for_job(job))
             result = builder.get_result()
             self.sa.use_job_result(job_id, result)
-            if (job.estimated_duration is not None and
-                    estimated_time is not None):
-                estimated_time -= job.estimated_duration
+            estimated_time -= job.estimated_duration or 0
 
     def _run_bootstrap_jobs(self, jobs_to_run):
         for job_no, job_id in enumerate(jobs_to_run, start=1):


### PR DESCRIPTION
## Description
Drive-by fix for the estimated duration computation that Pierre complained about yesterday.
With this patch, if a job exists that doesn't specify the estimated_duration, Checkbox will still compute the whole estimated runtime but it will add the "at least" clause.

I tested it by creating a provider with two jobs, one with a estimated_duration defined, and one that did not have it.
I've run sessions with varying selections to see if it works properly.