### PR TITLE
Update vendor RPyC 5.3.1

### DIFF
--- a/checkbox-ng/plainbox/vendor/rpyc/__init__.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/__init__.py
@@ -46,7 +46,7 @@ from plainbox.vendor.rpyc.core import (SocketStream, TunneledSocketStream, PipeS
                        Connection, Service, BaseNetref, AsyncResult, GenericException,
                        AsyncResultTimeout, VoidService, SlaveService, MasterService, ClassicService)
 from plainbox.vendor.rpyc.utils.factory import (connect_stream, connect_channel, connect_pipes,
-                                connect_stdpipes, connect, ssl_connect, discover, connect_by_service, connect_subproc,
+                                connect_stdpipes, connect, ssl_connect, list_services, discover, connect_by_service, connect_subproc,
                                 connect_thread, ssh_connect)
 from plainbox.vendor.rpyc.utils.helpers import async_, timed, buffiter, BgServingThread, restricted
 from plainbox.vendor.rpyc.utils import classic

--- a/checkbox-ng/plainbox/vendor/rpyc/__init__.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/__init__.py
@@ -1,43 +1,27 @@
-"""
-::
-
-         #####    #####             ####
-        ##   ##  ##   ##           ##             ####
-        ##  ##   ##  ##           ##                 #
-        #####    #####   ##   ##  ##               ##
-        ##  ##   ##       ## ##   ##                 #
-        ##   ##  ##        ###    ##              ###
-        ##   ##  ##        ##      #####
-     -------------------- ## ------------------------------------------
-                         ##
-
-Remote Python Call (RPyC)
+"""Remote Python Call (RPyC) is a transparent and symmetric distributed computing library
 Licensed under the MIT license (see `LICENSE` file)
-
-A transparent, symmetric and light-weight RPC and distributed computing
-library for python.
 
 Usage::
 
     >>> import rpyc
     >>> c = rpyc.connect_by_service("SERVICENAME")
-    >>> print c.root.some_function(1, 2, 3)
+    >>> print(c.root.some_function(1, 2, 3))
 
 Classic-style usage::
 
     >>> import rpyc
     >>> # `hostname` is assumed to be running a slave-service server
     >>> c = rpyc.classic.connect("hostname")
-    >>> print c.execute("x = 5")
+    >>> print(c.execute("x = 5"))
     None
-    >>> print c.eval("x + 2")
+    >>> print(c.eval("x + 2"))
     7
-    >>> print c.modules.os.listdir(".")       #doctest: +ELLIPSIS
+    >>> print(c.modules.os.listdir("."))  # doctest: +ELLIPSIS
     [...]
-    >>> print c.modules["xml.dom.minidom"].parseString("<a/>")   #doctest: +ELLIPSIS
+    >>> print(c.modules["xml.dom.minidom"].parseString("<a/>"))  # doctest: +ELLIPSIS
     <xml.dom.minidom.Document instance at ...>
-    >>> f = c.builtin.open("foobar.txt", "rb")     #doctest: +SKIP
-    >>> print f.read(100)     #doctest: +SKIP
+    >>> f = c.builtin.open("foobar.txt", "rb")  # doctest: +SKIP
+    >>> print(f.read(100))  # doctest: +SKIP
     ...
 
 """
@@ -49,11 +33,12 @@ from plainbox.vendor.rpyc.utils.factory import (connect_stream, connect_channel,
                                 connect_stdpipes, connect, ssl_connect, list_services, discover, connect_by_service, connect_subproc,
                                 connect_thread, ssh_connect)
 from plainbox.vendor.rpyc.utils.helpers import async_, timed, buffiter, BgServingThread, restricted
-from plainbox.vendor.rpyc.utils import classic
-from plainbox.vendor.rpyc.version import version as __version__
+from plainbox.vendor.rpyc.utils import classic, exposed, service
+from plainbox.vendor.rpyc.version import __version__
 
 from plainbox.vendor.rpyc.lib import setup_logger, spawn
 from plainbox.vendor.rpyc.utils.server import OneShotServer, ThreadedServer, ThreadPoolServer, ForkingServer
+from plainbox.vendor.rpyc import cli
 
 __author__ = "Tomer Filiba (tomerfiliba@gmail.com)"
 

--- a/checkbox-ng/plainbox/vendor/rpyc/cli/rpyc_classic.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/cli/rpyc_classic.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+"""
+classic rpyc server (threaded, forking or std) running a SlaveService
+usage:
+    rpyc_classic.py                         # default settings
+    rpyc_classic.py -m forking -p 12345     # custom settings
+
+    # ssl-authenticated server (keyfile and certfile are required)
+    rpyc_classic.py --ssl-keyfile keyfile.pem --ssl-certfile certfile.pem --ssl-cafile cafile.pem
+"""
+import sys
+import os
+import rpyc
+from plumbum import cli
+from plainbox.vendor.rpyc.utils.server import ThreadedServer, ForkingServer, OneShotServer
+from plainbox.vendor.rpyc.utils.classic import DEFAULT_SERVER_PORT, DEFAULT_SERVER_SSL_PORT
+from plainbox.vendor.rpyc.utils.registry import REGISTRY_PORT
+from plainbox.vendor.rpyc.utils.registry import UDPRegistryClient, TCPRegistryClient
+from plainbox.vendor.rpyc.utils.authenticators import SSLAuthenticator
+from plainbox.vendor.rpyc.lib import setup_logger
+from plainbox.vendor.rpyc.core import SlaveService
+
+
+class ClassicServer(cli.Application):
+    mode = cli.SwitchAttr(["-m", "--mode"], cli.Set("threaded", "forking", "stdio", "oneshot"),
+                          default="threaded", help="The serving mode (threaded, forking, or 'stdio' for "
+                          "inetd, etc.)")
+
+    port = cli.SwitchAttr(["-p", "--port"], cli.Range(0, 65535), default=None,
+                          help="The TCP listener port ("
+                               "default = {DEFAULT_SERVER_PORT!r}, "
+                               "default for SSL = {DEFAULT_SERVER_SSL_PORT!r})",
+                          group="Socket Options")
+    host = cli.SwitchAttr(["--host"], str, default="", help="The host to bind to. "
+                          "The default is localhost", group="Socket Options")
+    ipv6 = cli.Flag(["--ipv6"], help="Enable IPv6", group="Socket Options")
+
+    logfile = cli.SwitchAttr("--logfile", str, default=None, help="Specify the log file to use; "
+                             "the default is stderr", group="Logging")
+    quiet = cli.Flag(["-q", "--quiet"], help="Quiet mode (only errors will be logged)",
+                     group="Logging")
+
+    ssl_keyfile = cli.SwitchAttr("--ssl-keyfile", cli.ExistingFile,
+                                 help="The keyfile to use for SSL. Required for SSL", group="SSL",
+                                 requires=["--ssl-certfile"])
+    ssl_certfile = cli.SwitchAttr("--ssl-certfile", cli.ExistingFile,
+                                  help="The certificate file to use for SSL. Required for SSL", group="SSL",
+                                  requires=["--ssl-keyfile"])
+    ssl_cafile = cli.SwitchAttr("--ssl-cafile", cli.ExistingFile,
+                                help="The certificate authority chain file to use for SSL. "
+                                "Optional; enables client-side authentication",
+                                group="SSL", requires=["--ssl-keyfile"])
+
+    auto_register = cli.Flag("--register", help="Asks the server to attempt registering with "
+                             "a registry server. By default, the server will not attempt to register",
+                             group="Registry")
+    registry_type = cli.SwitchAttr("--registry-type", cli.Set("UDP", "TCP"),
+                                   default="UDP", help="Specify a UDP or TCP registry", group="Registry")
+    registry_port = cli.SwitchAttr("--registry-port", cli.Range(0, 65535), default=REGISTRY_PORT,
+                                   help="The registry's UDP/TCP port", group="Registry")
+    registry_host = cli.SwitchAttr("--registry-host", str, default=None,
+                                   help="The registry host machine. For UDP, the default is 255.255.255.255; "
+                                   "for TCP, a value is required", group="Registry")
+
+    def main(self):
+        if not self.host:
+            self.host = "::1" if self.ipv6 else "127.0.0.1"
+
+        if self.registry_type == "UDP":
+            if self.registry_host is None:
+                self.registry_host = "255.255.255.255"
+            self.registrar = UDPRegistryClient(ip=self.registry_host, port=self.registry_port)
+        else:
+            if self.registry_host is None:
+                raise ValueError("With TCP registry, you must specify --registry-host")
+            self.registrar = TCPRegistryClient(ip=self.registry_host, port=self.registry_port)
+
+        if self.ssl_keyfile:
+            self.authenticator = SSLAuthenticator(self.ssl_keyfile, self.ssl_certfile,
+                                                  self.ssl_cafile)
+            default_port = DEFAULT_SERVER_SSL_PORT
+        else:
+            self.authenticator = None
+            default_port = DEFAULT_SERVER_PORT
+        if self.port is None:
+            self.port = default_port
+
+        setup_logger(self.quiet, self.logfile)
+
+        if self.mode == "threaded":
+            self._serve_mode(ThreadedServer)
+        elif self.mode == "forking":
+            self._serve_mode(ForkingServer)
+        elif self.mode == "oneshot":
+            self._serve_oneshot()
+        elif self.mode == "stdio":
+            self._serve_stdio()
+
+    def _serve_mode(self, factory):
+        t = factory(SlaveService, hostname=self.host, port=self.port,
+                    reuse_addr=True, ipv6=self.ipv6, authenticator=self.authenticator,
+                    registrar=self.registrar, auto_register=self.auto_register)
+        t.start()
+
+    def _serve_oneshot(self):
+        t = OneShotServer(SlaveService, hostname=self.host, port=self.port,
+                          reuse_addr=True, ipv6=self.ipv6, authenticator=self.authenticator,
+                          registrar=self.registrar, auto_register=self.auto_register)
+        t._listen()
+        sys.stdout.write("rpyc-oneshot\n")
+        sys.stdout.write(f"{t.host}\t{t.port}\n")
+        sys.stdout.flush()
+        t.start()
+
+    def _serve_stdio(self):
+        origstdin = sys.stdin
+        origstdout = sys.stdout
+        sys.stdin = open(os.devnull, "r")
+        sys.stdout = open(os.devnull, "w")
+        sys.stderr = open(os.devnull, "w")
+        conn = rpyc.classic.connect_pipes(origstdin, origstdout)
+        try:
+            try:
+                conn.serve_all()
+            except KeyboardInterrupt:
+                print("User interrupt!")
+        finally:
+            conn.close()
+
+
+def main():
+    ClassicServer.run()

--- a/checkbox-ng/plainbox/vendor/rpyc/cli/rpyc_classic.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/cli/rpyc_classic.py
@@ -108,7 +108,7 @@ class ClassicServer(cli.Application):
                           registrar=self.registrar, auto_register=self.auto_register)
         t._listen()
         sys.stdout.write("rpyc-oneshot\n")
-        sys.stdout.write(f"{t.host}\t{t.port}\n")
+        sys.stdout.write("{}\t{}\n".format(t.host, t.port))
         sys.stdout.flush()
         t.start()
 

--- a/checkbox-ng/plainbox/vendor/rpyc/cli/rpyc_registry.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/cli/rpyc_registry.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""
+The registry server listens to broadcasts on UDP port 18812, answering to
+discovery queries by clients and registering keepalives from all running
+servers. In order for clients to use discovery, a registry service must
+be running somewhere on their local network.
+"""
+from plumbum import cli
+from plainbox.vendor.rpyc.utils.registry import REGISTRY_PORT, DEFAULT_PRUNING_TIMEOUT
+from plainbox.vendor.rpyc.utils.registry import UDPRegistryServer, TCPRegistryServer
+from plainbox.vendor.rpyc.lib import setup_logger
+
+
+class RegistryServer(cli.Application):
+    mode = cli.SwitchAttr(["-m", "--mode"], cli.Set("UDP", "TCP"), default="UDP",
+                          help="Serving mode")
+
+    ipv6 = cli.Flag(["-6", "--ipv6"], help="use ipv6 instead of ipv4")
+
+    port = cli.SwitchAttr(["-p", "--port"], cli.Range(0, 65535), default=REGISTRY_PORT,
+                          help="The UDP/TCP listener port")
+
+    logfile = cli.SwitchAttr(["--logfile"], str, default=None,
+                             help="The log file to use; the default is stderr")
+
+    quiet = cli.SwitchAttr(["-q", "--quiet"], help="Quiet mode (only errors are logged)")
+
+    pruning_timeout = cli.SwitchAttr(["-t", "--timeout"], int,
+                                     default=DEFAULT_PRUNING_TIMEOUT, help="Set a custom pruning timeout (in seconds)")
+
+    allow_listing = cli.SwitchAttr(["-l", "--listing"], bool, default=False, help="Enable/disable listing on registry")
+
+    def main(self):
+        if self.mode.upper() == "UDP":
+            server = UDPRegistryServer(host='::' if self.ipv6 else '0.0.0.0', port=self.port,
+                                       pruning_timeout=self.pruning_timeout, allow_listing=self.allow_listing)
+        elif self.mode.upper() == "TCP":
+            server = TCPRegistryServer(port=self.port, pruning_timeout=self.pruning_timeout,
+                                       allow_listing=self.allow_listing)
+        setup_logger(self.quiet, self.logfile)
+        server.start()
+
+
+def main():
+    RegistryServer.run()

--- a/checkbox-ng/plainbox/vendor/rpyc/core/__init__.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa: F401
 from plainbox.vendor.rpyc.core.stream import SocketStream, TunneledSocketStream, PipeStream
 from plainbox.vendor.rpyc.core.channel import Channel
-from plainbox.vendor.rpyc.core.protocol import Connection
+from plainbox.vendor.rpyc.core.protocol import Connection, DEFAULT_CONFIG
 from plainbox.vendor.rpyc.core.netref import BaseNetref
 from plainbox.vendor.rpyc.core.async_ import AsyncResult, AsyncResultTimeout
 from plainbox.vendor.rpyc.core.service import Service, VoidService, SlaveService, MasterService, ClassicService

--- a/checkbox-ng/plainbox/vendor/rpyc/core/async_.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/async_.py
@@ -28,7 +28,7 @@ class AsyncResult(object):
             state = "expired"
         else:
             state = "pending"
-        return f"<AsyncResult object ({state}) at 0x{id(self):08x}>"
+        return "<AsyncResult object ({}) at 0x{:08x}>".format(state, id(self))
 
     def __call__(self, is_exc, obj):
         if self.expired:

--- a/checkbox-ng/plainbox/vendor/rpyc/core/async_.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/async_.py
@@ -1,4 +1,5 @@
 import time  # noqa: F401
+from threading import Event
 from plainbox.vendor.rpyc.lib import Timeout
 from plainbox.vendor.rpyc.lib.compat import TimeoutError as AsyncResultTimeout
 
@@ -12,14 +13,14 @@ class AsyncResult(object):
 
     def __init__(self, conn):
         self._conn = conn
-        self._is_ready = False
+        self._is_ready = Event()
         self._is_exc = None
         self._obj = None
         self._callbacks = []
         self._ttl = Timeout(None)
 
     def __repr__(self):
-        if self._is_ready:
+        if self._is_ready.is_set():
             state = "ready"
         elif self._is_exc:
             state = "error"
@@ -27,14 +28,14 @@ class AsyncResult(object):
             state = "expired"
         else:
             state = "pending"
-        return "<AsyncResult object (%s) at 0x%08x>" % (state, id(self))
+        return f"<AsyncResult object ({state}) at 0x{id(self):08x}>"
 
     def __call__(self, is_exc, obj):
         if self.expired:
             return
         self._is_exc = is_exc
         self._obj = obj
-        self._is_ready = True
+        self._is_ready.set()
         for cb in self._callbacks:
             cb(self)
         del self._callbacks[:]
@@ -43,9 +44,9 @@ class AsyncResult(object):
         """Waits for the result to arrive. If the AsyncResult object has an
         expiry set, and the result did not arrive within that timeout,
         an :class:`AsyncResultTimeout` exception is raised"""
-        while not self._is_ready and not self._ttl.expired():
+        while not self._is_ready.is_set() and not self._ttl.expired():
             self._conn.serve(self._ttl)
-        if not self._is_ready:
+        if not self._is_ready.is_set():
             raise AsyncResultTimeout("result expired")
 
     def add_callback(self, func):
@@ -56,7 +57,7 @@ class AsyncResult(object):
 
         :param func: the callback function to add
         """
-        if self._is_ready:
+        if self._is_ready.is_set():
             func(self)
         else:
             self._callbacks.append(func)
@@ -72,12 +73,12 @@ class AsyncResult(object):
     @property
     def ready(self):
         """Indicates whether the result has arrived"""
-        if self._is_ready:
+        if self._is_ready.is_set():
             return True
         if self._ttl.expired():
             return False
         self._conn.poll_all()
-        return self._is_ready
+        return self._is_ready.is_set()
 
     @property
     def error(self):
@@ -87,7 +88,7 @@ class AsyncResult(object):
     @property
     def expired(self):
         """Indicates whether the AsyncResult has expired"""
-        return not self._is_ready and self._ttl.expired()
+        return not self._is_ready.is_set() and self._ttl.expired()
 
     @property
     def value(self):

--- a/checkbox-ng/plainbox/vendor/rpyc/core/brine.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/brine.py
@@ -184,7 +184,7 @@ def _dump_tuple(obj, stream):
 
 
 def _undumpable(obj, stream):
-    raise TypeError(f"cannot dump {obj}")
+    raise TypeError("cannot dump {}".format(obj))
 
 
 def _dump(obj, stream):

--- a/checkbox-ng/plainbox/vendor/rpyc/core/brine.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/brine.py
@@ -175,7 +175,7 @@ def _dump_tuple(obj, stream):
 
 
 def _undumpable(obj, stream):
-    raise TypeError(f"cannot dump {obj}")
+    raise TypeError("cannot dump {}".format(obj))
 
 
 def _dump(obj, stream):

--- a/checkbox-ng/plainbox/vendor/rpyc/core/brine.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/brine.py
@@ -1,6 +1,6 @@
 """*Brine* is a simple, fast and secure object serializer for **immutable** objects.
 
-The following types are supported: ``int``, ``long``, ``bool``, ``str``, ``float``,
+The following types are supported: ``int``, ``bool``, ``str``, ``float``,
 ``unicode``, ``bytes``, ``slice``, ``complex``, ``tuple`` (of simple types),
 ``frozenset`` (of simple types) as well as the following singletons: ``None``,
 ``NotImplemented``, and ``Ellipsis``.
@@ -17,7 +17,7 @@ Example::
  >>> x == z
  True
 """
-from plainbox.vendor.rpyc.lib.compat import Struct, BytesIO, is_py_3k, BYTES_LITERAL
+from plainbox.vendor.rpyc.lib.compat import Struct, BytesIO, BYTES_LITERAL
 
 
 # singletons
@@ -30,7 +30,7 @@ TAG_NOT_IMPLEMENTED = b"\x05"
 TAG_ELLIPSIS = b"\x06"
 # types
 TAG_UNICODE = b"\x08"
-TAG_LONG = b"\x09"
+# deprecated w/ py2 support TAG_LONG = b"\x09"
 TAG_STR1 = b"\x0a"
 TAG_STR2 = b"\x0b"
 TAG_STR3 = b"\x0c"
@@ -49,10 +49,7 @@ TAG_FLOAT = b"\x18"
 TAG_SLICE = b"\x19"
 TAG_FSET = b"\x1a"
 TAG_COMPLEX = b"\x1b"
-if is_py_3k:
-    IMM_INTS = dict((i, bytes([i + 0x50])) for i in range(-0x30, 0xa0))
-else:
-    IMM_INTS = dict((i, chr(i + 0x50)) for i in range(-0x30, 0xa0))
+IMM_INTS = dict((i, bytes([i + 0x50])) for i in range(-0x30, 0xa0))
 
 I1 = Struct("!B")
 I4 = Struct("!L")
@@ -156,13 +153,6 @@ def _dump_str(obj, stream):
     _dump_bytes(obj.encode("utf8"), stream)
 
 
-if not is_py_3k:
-    @register(_dump_registry, long)  # noqa: F821
-    def _dump_long(obj, stream):
-        stream.append(TAG_LONG)
-        _dump_int(obj, stream)
-
-
 @register(_dump_registry, tuple)
 def _dump_tuple(obj, stream):
     lenobj = len(obj)
@@ -185,7 +175,7 @@ def _dump_tuple(obj, stream):
 
 
 def _undumpable(obj, stream):
-    raise TypeError("cannot dump %r" % (obj,))
+    raise TypeError(f"cannot dump {obj}")
 
 
 def _dump(obj, stream):
@@ -227,18 +217,6 @@ def _load_empty_tuple(stream):
 @register(_load_registry, TAG_EMPTY_STR)
 def _load_empty_str(stream):
     return b""
-
-
-if is_py_3k:
-    @register(_load_registry, TAG_LONG)
-    def _load_long(stream):
-        obj = _load(stream)
-        return int(obj)
-else:
-    @register(_load_registry, TAG_LONG)
-    def _load_long(stream):
-        obj = _load(stream)
-        return long(obj)  # noqa: F821
 
 
 @register(_load_registry, TAG_FLOAT)
@@ -316,16 +294,10 @@ def _load_tup_l1(stream):
     return tuple(_load(stream) for i in range(l))
 
 
-if is_py_3k:
-    @register(_load_registry, TAG_TUP_L4)
-    def _load_tup_l4(stream):
-        l, = I4.unpack(stream.read(4))
-        return tuple(_load(stream) for i in range(l))
-else:
-    @register(_load_registry, TAG_TUP_L4)
-    def _load_tup_l4(stream):
-        l, = I4.unpack(stream.read(4))
-        return tuple(_load(stream) for i in xrange(l))  # noqa
+@register(_load_registry, TAG_TUP_L4)
+def _load_tup_l4(stream):
+    l, = I4.unpack(stream.read(4))
+    return tuple(_load(stream) for i in range(l))
 
 
 @register(_load_registry, TAG_SLICE)
@@ -385,12 +357,7 @@ def load(data):
     return _load(stream)
 
 
-if is_py_3k:
-    simple_types = frozenset([type(None), int, bool, float, bytes, str, complex,
-                              type(NotImplemented), type(Ellipsis)])
-else:
-    simple_types = frozenset([type(None), int, long, bool, float, bytes, unicode, complex,  # noqa: F821
-                              type(NotImplemented), type(Ellipsis)])
+simple_types = frozenset([type(None), int, bool, float, bytes, str, complex, type(NotImplemented), type(Ellipsis)])
 
 
 def dumpable(obj):

--- a/checkbox-ng/plainbox/vendor/rpyc/core/consts.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/consts.py
@@ -37,6 +37,9 @@ HANDLE_INSTANCECHECK = 20
 # optimized exceptions
 EXC_STOP_ITERATION = 1
 
+# IO values
+STREAM_CHUNK = 64000  # read/write chunk is 64KB, too large of a value will degrade response for other clients
+
 # DEBUG
 # for k in globals().keys():
 #    globals()[k] = k

--- a/checkbox-ng/plainbox/vendor/rpyc/core/netref.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/netref.py
@@ -88,9 +88,9 @@ class NetrefMetaclass(type):
 
     def __repr__(self):
         if self.__module__:
-            return f"<netref class '{self.__module__}.{self.__name__}'>"
+            return "<netref class '{}.{}'>".format(self.__module__, self.__name__)
         else:
-            return f"<netref class '{self.__name__}'>"
+            return "<netref class '{}'>".format(self.__name__)
 
 
 class BaseNetref(with_metaclass(NetrefMetaclass, object)):

--- a/checkbox-ng/plainbox/vendor/rpyc/core/netref.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/netref.py
@@ -4,7 +4,7 @@ of *magic*, so beware.
 import sys
 import types
 from plainbox.vendor.rpyc.lib import get_methods, get_id_pack
-from plainbox.vendor.rpyc.lib.compat import pickle, is_py_3k, maxint, with_metaclass
+from plainbox.vendor.rpyc.lib.compat import pickle, maxint, with_metaclass
 from plainbox.vendor.rpyc.core import consts
 
 
@@ -16,6 +16,7 @@ DELETED_ATTRS = frozenset([
     '__array_struct__', '__array_interface__',
 ])
 
+"""the set of attributes that are local to the netref object"""
 LOCAL_ATTRS = frozenset([
     '____conn__', '____id_pack__', '____refcount__', '__class__', '__cmp__', '__del__', '__delattr__',
     '__dir__', '__doc__', '__getattr__', '__getattribute__', '__hash__', '__instancecheck__',
@@ -24,39 +25,25 @@ LOCAL_ATTRS = frozenset([
     '__weakref__', '__dict__', '__methods__', '__exit__',
     '__eq__', '__ne__', '__lt__', '__gt__', '__le__', '__ge__',
 ]) | DELETED_ATTRS
-"""the set of attributes that are local to the netref object"""
 
+"""a list of types considered built-in (shared between connections)
+this is needed because iterating the members of the builtins module is not enough,
+some types (e.g NoneType) are not members of the builtins module.
+TODO: this list is not complete.
+"""
 _builtin_types = [
     type, object, bool, complex, dict, float, int, list, slice, str, tuple, set,
-    frozenset, Exception, type(None), types.BuiltinFunctionType, types.GeneratorType,
+    frozenset, BaseException, Exception, type(None), types.BuiltinFunctionType, types.GeneratorType,
     types.MethodType, types.CodeType, types.FrameType, types.TracebackType,
-    types.ModuleType, types.FunctionType,
+    types.ModuleType, types.FunctionType, types.MappingProxyType,
 
     type(int.__add__),      # wrapper_descriptor
     type((1).__add__),      # method-wrapper
     type(iter([])),         # listiterator
     type(iter(())),         # tupleiterator
     type(iter(set())),      # setiterator
+    bytes, bytearray, type(iter(range(10))), memoryview
 ]
-"""a list of types considered built-in (shared between connections)"""
-
-try:
-    BaseException
-except NameError:
-    pass
-else:
-    _builtin_types.append(BaseException)
-
-if is_py_3k:
-    _builtin_types.extend([
-        bytes, bytearray, type(iter(range(10))), memoryview,
-    ])
-    xrange = range
-else:
-    _builtin_types.extend([
-        basestring, unicode, long, xrange, type(iter(xrange(10))), file,  # noqa
-        types.InstanceType, types.ClassType, types.DictProxyType,
-    ])
 _normalized_builtin_types = {}
 
 
@@ -101,9 +88,9 @@ class NetrefMetaclass(type):
 
     def __repr__(self):
         if self.__module__:
-            return "<netref class '%s.%s'>" % (self.__module__, self.__name__)
+            return f"<netref class '{self.__module__}.{self.__name__}'>"
         else:
-            return "<netref class '%s'>" % (self.__name__,)
+            return f"<netref class '{self.__name__}'>"
 
 
 class BaseNetref(with_metaclass(NetrefMetaclass, object)):
@@ -316,19 +303,24 @@ def class_factory(id_pack, methods):
     name_pack = id_pack[0]
     class_descriptor = None
     if name_pack is not None:
-        # attempt to resolve __class__ using sys.modules (i.e. builtins and imported modules)
-        _module = None
-        cursor = len(name_pack)
-        while cursor != -1:
-            _module = sys.modules.get(name_pack[:cursor])
-            if _module is None:
-                cursor = name_pack[:cursor].rfind('.')
-                continue
-            _class_name = name_pack[cursor + 1:]
-            _class = getattr(_module, _class_name, None)
-            if _class is not None and hasattr(_class, '__class__'):
-                class_descriptor = NetrefClass(_class)
-            break
+        # attempt to resolve __class__ using normalized builtins first
+        _builtin_class = _normalized_builtin_types.get(name_pack)
+        if _builtin_class is not None:
+            class_descriptor = NetrefClass(_builtin_class)
+        # then by imported modules (this also tries all builtins under "builtins")
+        else:
+            _module = None
+            cursor = len(name_pack)
+            while cursor != -1:
+                _module = sys.modules.get(name_pack[:cursor])
+                if _module is None:
+                    cursor = name_pack[:cursor].rfind('.')
+                    continue
+                _class_name = name_pack[cursor + 1:]
+                _class = getattr(_module, _class_name, None)
+                if _class is not None and hasattr(_class, '__class__'):
+                    class_descriptor = NetrefClass(_class)
+                break
     ns['__class__'] = class_descriptor
     netref_name = class_descriptor.owner.__name__ if class_descriptor is not None else name_pack
     # create methods that must perform a syncreq

--- a/checkbox-ng/plainbox/vendor/rpyc/core/netref.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/netref.py
@@ -88,9 +88,9 @@ class NetrefMetaclass(type):
 
     def __repr__(self):
         if self.__module__:
-            return "<netref class '{}.{}'>".format(self.__module__, self.__name__)
+            return f"<netref class '{self.__module__}.{self.__name__}'>"
         else:
-            return "<netref class '{}'>".format(self.__name__)
+            return f"<netref class '{self.__name__}'>"
 
 
 class BaseNetref(with_metaclass(NetrefMetaclass, object)):

--- a/checkbox-ng/plainbox/vendor/rpyc/core/protocol.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/protocol.py
@@ -8,7 +8,7 @@ import gc  # noqa: F401
 
 from threading import Lock, Condition
 from plainbox.vendor.rpyc.lib import spawn, Timeout, get_methods, get_id_pack
-from plainbox.vendor.rpyc.lib.compat import pickle, next, is_py_3k, maxint, select_error, acquire_lock  # noqa: F401
+from plainbox.vendor.rpyc.lib.compat import pickle, next, maxint, select_error, acquire_lock  # noqa: F401
 from plainbox.vendor.rpyc.lib.colls import WeakValueDict, RefCountingColl
 from plainbox.vendor.rpyc.core import consts, brine, vinegar, netref
 from plainbox.vendor.rpyc.core.async_ import AsyncResult
@@ -39,7 +39,7 @@ DEFAULT_CONFIG = dict(
                     '__rpow__', '__rrshift__', '__rshift__', '__rsub__', '__rtruediv__',
                     '__rxor__', '__setitem__', '__setslice__', '__str__', '__sub__',
                     '__truediv__', '__xor__', 'next', '__length_hint__', '__enter__',
-                    '__exit__', '__next__', ]),
+                    '__exit__', '__next__', '__format__']),
     exposed_prefix="exposed_",
     allow_getattr=True,
     allow_setattr=False,
@@ -60,6 +60,8 @@ DEFAULT_CONFIG = dict(
     endpoints=None,
     logger=None,
     sync_request_timeout=30,
+    before_closed=None,
+    close_catchall=False,
 )
 """
 The default configuration dictionary of the protocol. You can override these parameters
@@ -138,7 +140,7 @@ class Connection(object):
         self._config = DEFAULT_CONFIG.copy()
         self._config.update(config)
         if self._config["connid"] is None:
-            self._config["connid"] = "conn%d" % (next(_connection_id_generator),)
+            self._config["connid"] = f"conn{next(_connection_id_generator)}"
 
         self._HANDLERS = self._request_handlers()
         self._channel = channel
@@ -167,7 +169,7 @@ class Connection(object):
 
     def __repr__(self):
         a, b = object.__repr__(self).split(" object ")
-        return "%s %r object %s" % (a, self._config["connid"], b)
+        return f"{a} {self._config['connid']!r} object {b}"
 
     def _cleanup(self, _anyway=True):  # IO
         if self._closed and not _anyway:
@@ -186,17 +188,19 @@ class Connection(object):
         # self._config.clear()
         del self._HANDLERS
 
-    def close(self, _catchall=True):  # IO
+    def close(self):  # IO
         """closes the connection, releasing all held resources"""
         if self._closed:
             return
-        self._closed = True
         try:
+            self._closed = True
+            if self._config.get("before_closed"):
+                self._config["before_closed"](self.root)
             self._async_request(consts.HANDLE_CLOSE)
         except EOFError:
             pass
         except Exception:
-            if not _catchall:
+            if not self._config["close_catchall"]:
                 raise
         finally:
             self._cleanup(_anyway=True)
@@ -294,7 +298,7 @@ class Connection(object):
                 proxy = self._netref_factory(id_pack)
                 self._proxy_cache[id_pack] = proxy
             return proxy
-        raise ValueError("invalid label %r" % (label,))
+        raise ValueError(f"invalid label {label!r}")
 
     def _netref_factory(self, id_pack):  # boxing
         """id_pack is for remote, so when class id fails to directly match """
@@ -363,7 +367,7 @@ class Connection(object):
             obj = self._unbox_exc(args)
             self._seq_request_callback(msg, seq, True, obj)
         else:
-            raise ValueError("invalid message type: %r" % (msg,))
+            raise ValueError(f"invalid message type: {msg!r}")
 
     def serve(self, timeout=1, wait_for_lock=True):  # serving
         """Serves a single request or reply that arrives within the given
@@ -488,7 +492,7 @@ class Connection(object):
         """
         timeout = kwargs.pop("timeout", None)
         if kwargs:
-            raise TypeError("got unexpected keyword argument(s) %s" % (list(kwargs.keys()),))
+            raise TypeError("got unexpected keyword argument(s) {list(kwargs.keys()}")
         res = AsyncResult(self)
         self._async_request(handler, args, res)
         if timeout is not None:
@@ -505,7 +509,7 @@ class Connection(object):
     def _check_attr(self, obj, name, perm):  # attribute access
         config = self._config
         if not config[perm]:
-            raise AttributeError("cannot access %r" % (name,))
+            raise AttributeError(f"cannot access {name!r}")
         prefix = config["allow_exposed_attrs"] and config["exposed_prefix"]
         plain = config["allow_all_attrs"]
         plain |= config["allow_exposed_attrs"] and name.startswith(prefix)
@@ -518,18 +522,13 @@ class Connection(object):
             return prefix + name
         if plain:
             return name  # chance for better traceback
-        raise AttributeError("cannot access %r" % (name,))
+        raise AttributeError(f"cannot access {name!r}")
 
     def _access_attr(self, obj, name, args, overrider, param, default):  # attribute access
-        if is_py_3k:
-            if type(name) is bytes:
-                name = str(name, "utf8")
-            elif type(name) is not str:
-                raise TypeError("name must be a string")
-        else:
-            if type(name) not in (str, unicode):  # noqa
-                raise TypeError("name must be a string")
-            name = str(name)  # IronPython issue #10 + py3k issue
+        if type(name) is bytes:
+            name = str(name, "utf8")
+        elif type(name) is not str:
+            raise TypeError("name must be a string")
         accessor = getattr(type(obj), overrider, None)
         if accessor is None:
             accessor = default
@@ -638,7 +637,7 @@ class Connection(object):
             # since __mro__ is not a safe attribute the request is forwarded using the proxy connection
             # relates to issue #346 or tests.test_netref_hierachy.Test_Netref_Hierarchy.test_StandardError
             conn = obj.____conn__
-            return conn.sync_request(consts.HANDLE_INSPECT, id_pack)
+            return conn.sync_request(consts.HANDLE_INSPECT, other_id_pack)
         # Create a name pack which would be familiar here and see if there is a hit
         other_id_pack2 = (other_id_pack[0], other_id_pack[1], 0)
         if other_id_pack[0] in netref.builtin_classes_cache:

--- a/checkbox-ng/plainbox/vendor/rpyc/core/protocol.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/protocol.py
@@ -140,7 +140,7 @@ class Connection(object):
         self._config = DEFAULT_CONFIG.copy()
         self._config.update(config)
         if self._config["connid"] is None:
-            self._config["connid"] = f"conn{next(_connection_id_generator)}"
+            self._config["connid"] = "conn{}".format(next(_connection_id_generator))
 
         self._HANDLERS = self._request_handlers()
         self._channel = channel
@@ -169,7 +169,7 @@ class Connection(object):
 
     def __repr__(self):
         a, b = object.__repr__(self).split(" object ")
-        return f"{a} {self._config['connid']!r} object {b}"
+        return "{} {!r} object {}".format(a, self._config['connid'], b)
 
     def _cleanup(self, _anyway=True):  # IO
         if self._closed and not _anyway:
@@ -298,7 +298,7 @@ class Connection(object):
                 proxy = self._netref_factory(id_pack)
                 self._proxy_cache[id_pack] = proxy
             return proxy
-        raise ValueError(f"invalid label {label!r}")
+        raise ValueError("invalid label {!r}".format(label))
 
     def _netref_factory(self, id_pack):  # boxing
         """id_pack is for remote, so when class id fails to directly match """
@@ -367,7 +367,7 @@ class Connection(object):
             obj = self._unbox_exc(args)
             self._seq_request_callback(msg, seq, True, obj)
         else:
-            raise ValueError(f"invalid message type: {msg!r}")
+            raise ValueError("invalid message type: {!r}".format(msg))
 
     def serve(self, timeout=1, wait_for_lock=True):  # serving
         """Serves a single request or reply that arrives within the given
@@ -509,7 +509,7 @@ class Connection(object):
     def _check_attr(self, obj, name, perm):  # attribute access
         config = self._config
         if not config[perm]:
-            raise AttributeError(f"cannot access {name!r}")
+            raise AttributeError("cannot access {!r}".format(name))
         prefix = config["allow_exposed_attrs"] and config["exposed_prefix"]
         plain = config["allow_all_attrs"]
         plain |= config["allow_exposed_attrs"] and name.startswith(prefix)
@@ -522,7 +522,7 @@ class Connection(object):
             return prefix + name
         if plain:
             return name  # chance for better traceback
-        raise AttributeError(f"cannot access {name!r}")
+        raise AttributeError("cannot access {!r}".format(name))
 
     def _access_attr(self, obj, name, args, overrider, param, default):  # attribute access
         if type(name) is bytes:

--- a/checkbox-ng/plainbox/vendor/rpyc/core/protocol.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/protocol.py
@@ -155,7 +155,7 @@ class Connection(object):
         self._config = DEFAULT_CONFIG.copy()
         self._config.update(config)
         if self._config["connid"] is None:
-            self._config["connid"] = f"conn{next(_connection_id_generator)}"
+            self._config["connid"] = "conn{}".format(next(_connection_id_generator))
 
         self._HANDLERS = self._request_handlers()
         self._channel = channel
@@ -193,7 +193,7 @@ class Connection(object):
 
     def __repr__(self):
         a, b = object.__repr__(self).split(" object ")
-        return f"{a} {self._config['connid']!r} object {b}"
+        return "{} {!r} object {}".format(a, self._config['connid'], b)
 
     def _cleanup(self, _anyway=True):  # IO
         if self._closed and not _anyway:
@@ -333,7 +333,7 @@ class Connection(object):
                 proxy = self._netref_factory(id_pack)
                 self._proxy_cache[id_pack] = proxy
             return proxy
-        raise ValueError(f"invalid label {label!r}")
+        raise ValueError("invalid label {!r}".format(label))
 
     def _netref_factory(self, id_pack):  # boxing
         """id_pack is for remote, so when class id fails to directly match """
@@ -410,7 +410,7 @@ class Connection(object):
                 obj = self._unbox_exc(args)
                 self._seq_request_callback(msg, seq, True, obj)
             else:
-                raise ValueError(f"invalid message type: {msg!r}")
+                raise ValueError("invalid message type: {!r}".format(msg))
 
     def serve(self, timeout=1, wait_for_lock=True):  # serving
         """Serves a single request or reply that arrives within the given
@@ -754,7 +754,7 @@ class Connection(object):
     def _check_attr(self, obj, name, perm):  # attribute access
         config = self._config
         if not config[perm]:
-            raise AttributeError(f"cannot access {name!r}")
+            raise AttributeError("cannot access {!r}".format(name))
         prefix = config["allow_exposed_attrs"] and config["exposed_prefix"]
         plain = config["allow_all_attrs"]
         plain |= config["allow_exposed_attrs"] and name.startswith(prefix)
@@ -767,7 +767,7 @@ class Connection(object):
             return prefix + name
         if plain:
             return name  # chance for better traceback
-        raise AttributeError(f"cannot access {name!r}")
+        raise AttributeError("cannot access {!r}".format(name))
 
     def _access_attr(self, obj, name, args, overrider, param, default):  # attribute access
         if type(name) is bytes:

--- a/checkbox-ng/plainbox/vendor/rpyc/core/stream.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/stream.py
@@ -8,6 +8,7 @@ import socket
 import errno
 from plainbox.vendor.rpyc.lib import safe_import, Timeout, socket_backoff_connect
 from plainbox.vendor.rpyc.lib.compat import poll, select_error, BYTES_LITERAL, get_exc_errno, maxint  # noqa: F401
+from plainbox.vendor.rpyc.core.consts import STREAM_CHUNK
 win32file = safe_import("win32file")
 win32pipe = safe_import("win32pipe")
 win32event = safe_import("win32event")
@@ -111,7 +112,7 @@ class SocketStream(Stream):
     """A stream over a socket"""
 
     __slots__ = ("sock",)
-    MAX_IO_CHUNK = 64000  # read/write chunk is 64KB, too large of a value will degrade response for other clients
+    MAX_IO_CHUNK = STREAM_CHUNK
 
     def __init__(self, sock):
         self.sock = sock
@@ -291,7 +292,7 @@ class PipeStream(Stream):
     """A stream over two simplex pipes (one used to input, another for output)"""
 
     __slots__ = ("incoming", "outgoing")
-    MAX_IO_CHUNK = 32000
+    MAX_IO_CHUNK = STREAM_CHUNK
 
     def __init__(self, incoming, outgoing):
         outgoing.flush()
@@ -369,7 +370,7 @@ class Win32PipeStream(Stream):
 
     __slots__ = ("incoming", "outgoing", "_fileno", "_keepalive")
     PIPE_BUFFER_SIZE = 130000
-    MAX_IO_CHUNK = 32000
+    MAX_IO_CHUNK = STREAM_CHUNK
 
     def __init__(self, incoming, outgoing):
         import msvcrt

--- a/checkbox-ng/plainbox/vendor/rpyc/core/stream.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/stream.py
@@ -12,6 +12,7 @@ from plainbox.vendor.rpyc.core.consts import STREAM_CHUNK
 win32file = safe_import("win32file")
 win32pipe = safe_import("win32pipe")
 win32event = safe_import("win32event")
+ssl = safe_import("ssl")
 
 
 retry_errnos = (errno.EAGAIN, errno.EWOULDBLOCK)
@@ -196,8 +197,8 @@ class SocketStream(Stream):
 
         :param host: the host name
         :param port: the TCP port
-        :param ssl_kwargs: a dictionary of keyword arguments to be passed
-                           directly to ``ssl.wrap_socket``
+        :param ssl_kwargs: a dictionary of keyword arguments for
+                           ``ssl.SSLContext`` and ``ssl.SSLContext.wrap_socket``
         :param kwargs: additional keyword arguments: ``family``, ``socktype``,
                        ``proto``, ``timeout``, ``nodelay``, passed directly to
                        the ``socket`` constructor, or ``ipv6``.
@@ -206,12 +207,31 @@ class SocketStream(Stream):
 
         :returns: a :class:`SocketStream`
         """
-        import ssl
         if kwargs.pop("ipv6", False):
             kwargs["family"] = socket.AF_INET6
         s = cls._connect(host, port, **kwargs)
         try:
-            s2 = ssl.wrap_socket(s, **ssl_kwargs)
+            if "ssl_version" in ssl_kwargs:
+                context = ssl.SSLContext(ssl_kwargs.pop("ssl_version"))
+            else:
+                context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
+            certfile = ssl_kwargs.pop("certfile", None)
+            keyfile = ssl_kwargs.pop("keyfile", None)
+            if certfile is not None:
+                context.load_cert_chain(certfile, keyfile=keyfile)
+            ca_certs = ssl_kwargs.pop("ca_certs", None)
+            if ca_certs is not None:
+                context.load_verify_locations(ca_certs)
+            ciphers = ssl_kwargs.pop("ciphers", None)
+            if ciphers is not None:
+                context.set_ciphers(ciphers)
+            check_hostname = ssl_kwargs.pop("check_hostname", None)
+            if check_hostname is not None:
+                context.check_hostname = check_hostname
+            cert_reqs = ssl_kwargs.pop("cert_reqs", None)
+            if cert_reqs is not None:
+                context.verify_mode = cert_reqs
+            s2 = context.wrap_socket(s, server_hostname=host, **ssl_kwargs)
             return cls(s2)
         except BaseException:
             s.close()

--- a/checkbox-ng/plainbox/vendor/rpyc/core/vinegar.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/vinegar.py
@@ -76,7 +76,7 @@ def dump(typ, val, tb, include_local_traceback, include_local_version):
                 attrval = repr(attrval)
             attrs.append((name, attrval))
     if include_local_version:
-        attrs.append(("_remote_version", version.version_string))
+        attrs.append(("_remote_version", version.__version__))
     else:
         attrs.append(("_remote_version", "<version denied>"))
     return (typ.__module__, typ.__name__), tuple(args), tuple(attrs), tbtext
@@ -131,11 +131,11 @@ def load(val, import_custom_exceptions, instantiate_custom_exceptions, instantia
         cls = None
 
     if cls is None:
-        fullname = "{}.{}".format(modname, clsname)
+        fullname = f"{modname}.{clsname}"
         # py2: `type()` expects `str` not `unicode`!
         fullname = str(fullname)
         if fullname not in _generic_exceptions_cache:
-            fakemodule = {"__module__": "{}/{}".format(__name__, modname)}
+            fakemodule = {"__module__": f"{__name__}/{modname}"}
             if isinstance(GenericException, ClassType):
                 _generic_exceptions_cache[fullname] = ClassType(fullname, (GenericException,), fakemodule)
             else:
@@ -161,7 +161,7 @@ def load(val, import_custom_exceptions, instantiate_custom_exceptions, instantia
     remote_ver = getattr(exc, "_remote_version", "<version denied>")
     if remote_ver != "<version denied>" and remote_ver.split('.')[0] != str(version.version[0]):
         _warn = '\nWARNING: Remote is on RPyC {} and local is on RPyC {}.\n\n'
-        tbtext += _warn.format(remote_ver, version.version_string)
+        tbtext += _warn.format(remote_ver, version.__version__)
 
     exc._remote_tb = tbtext
     return exc

--- a/checkbox-ng/plainbox/vendor/rpyc/core/vinegar.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/vinegar.py
@@ -22,19 +22,11 @@ except ImportError:
 from plainbox.vendor.rpyc.core import brine
 from plainbox.vendor.rpyc.core import consts
 from plainbox.vendor.rpyc import version
-from plainbox.vendor.rpyc.lib.compat import is_py_3k
 
 
 REMOTE_LINE_START = "\n\n========= Remote Traceback "
 REMOTE_LINE_END = " =========\n"
 REMOTE_LINE = "{0}({{}}){1}".format(REMOTE_LINE_START, REMOTE_LINE_END)
-
-
-try:
-    BaseException
-except NameError:
-    # python 2.4 compatible
-    BaseException = Exception
 
 
 def dump(typ, val, tb, include_local_traceback, include_local_version):
@@ -135,23 +127,15 @@ def load(val, import_custom_exceptions, instantiate_custom_exceptions, instantia
     else:
         cls = None
 
-    if is_py_3k:
-        if not isinstance(cls, type) or not issubclass(cls, BaseException):
-            cls = None
-    else:
-        if not isinstance(cls, (type, ClassType)):
-            cls = None
-        elif issubclass(cls, ClassType) and not instantiate_oldstyle_exceptions:
-            cls = None
-        elif not issubclass(cls, BaseException):
-            cls = None
+    if not isinstance(cls, type) or not issubclass(cls, BaseException):
+        cls = None
 
     if cls is None:
-        fullname = "%s.%s" % (modname, clsname)
+        fullname = f"{modname}.{clsname}"
         # py2: `type()` expects `str` not `unicode`!
         fullname = str(fullname)
         if fullname not in _generic_exceptions_cache:
-            fakemodule = {"__module__": "%s/%s" % (__name__, modname)}
+            fakemodule = {"__module__": f"{__name__}/{modname}"}
             if isinstance(GenericException, ClassType):
                 _generic_exceptions_cache[fullname] = ClassType(fullname, (GenericException,), fakemodule)
             else:

--- a/checkbox-ng/plainbox/vendor/rpyc/core/vinegar.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/core/vinegar.py
@@ -131,11 +131,11 @@ def load(val, import_custom_exceptions, instantiate_custom_exceptions, instantia
         cls = None
 
     if cls is None:
-        fullname = f"{modname}.{clsname}"
+        fullname = "{}.{}".format(modname, clsname)
         # py2: `type()` expects `str` not `unicode`!
         fullname = str(fullname)
         if fullname not in _generic_exceptions_cache:
-            fakemodule = {"__module__": f"{__name__}/{modname}"}
+            fakemodule = {"__module__": "{}/{}".format(__name__, modname)}
             if isinstance(GenericException, ClassType):
                 _generic_exceptions_cache[fullname] = ClassType(fullname, (GenericException,), fakemodule)
             else:

--- a/checkbox-ng/plainbox/vendor/rpyc/lib/__init__.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/lib/__init__.py
@@ -19,8 +19,8 @@ class MissingModule(object):
 
     def __getattr__(self, name):
         if name.startswith("__"):  # issue 71
-            raise AttributeError(f"module {self.__name!r} not found")
-        raise ImportError(f"module {self.__name!r} not found")
+            raise AttributeError("module {!r} not found".format(self.__name))
+        raise ImportError("module {!r} not found".format(self.__name))
 
     def __bool__(self):
         return False

--- a/checkbox-ng/plainbox/vendor/rpyc/lib/__init__.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/lib/__init__.py
@@ -19,8 +19,8 @@ class MissingModule(object):
 
     def __getattr__(self, name):
         if name.startswith("__"):  # issue 71
-            raise AttributeError("module %r not found" % (self.__name,))
-        raise ImportError("module %r not found" % (self.__name,))
+            raise AttributeError(f"module {self.__name!r} not found")
+        raise ImportError(f"module {self.__name!r} not found")
 
     def __bool__(self):
         return False
@@ -96,7 +96,7 @@ def spawn_waitready(init, main):
     return thread, stack.pop()
 
 
-class Timeout:
+class Timeout(object):
 
     def __init__(self, timeout):
         if isinstance(timeout, Timeout):
@@ -175,7 +175,7 @@ def get_id_pack(obj):
                 else:
                     name_pack = '{0}.{1}'.format(obj.__class__.__module__, obj.__name__)
             elif inspect.ismodule(obj):
-                name_pack = '{0}.{1}'.format(obj__module__, obj.__name__)
+                name_pack = '{0}.{1}'.format(obj.__module__, obj.__name__)
                 print(name_pack)
             elif hasattr(obj, '__module__'):
                 name_pack = '{0}.{1}'.format(obj.__module__, obj.__name__)

--- a/checkbox-ng/plainbox/vendor/rpyc/lib/__init__.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/lib/__init__.py
@@ -22,8 +22,8 @@ class MissingModule(object):
 
     def __getattr__(self, name):
         if name.startswith("__"):  # issue 71
-            raise AttributeError(f"module {self.__name!r} not found")
-        raise ImportError(f"module {self.__name!r} not found")
+            raise AttributeError("module {!r} not found".format(self.__name))
+        raise ImportError("module {!r} not found".format(self.__name))
 
     def __bool__(self):
         return False
@@ -57,7 +57,7 @@ def setup_logger(quiet=False, logfile=None, namespace=None):
     if logfile:
         opts['filename'] = logfile
     logging.basicConfig(**opts)
-    return logging.getLogger('rpyc' if namespace is None else f'rpyc.{namespace}')
+    return logging.getLogger('rpyc' if namespace is None else 'rpyc.{}'.format(namespace))
 
 
 class hybridmethod(object):
@@ -88,8 +88,8 @@ def hasattr_static(obj, attr):
 def spawn(*args, **kwargs):
     """Start and return daemon thread. ``spawn(func, *args, **kwargs)``."""
     func, args = args[0], args[1:]
-    str_id_pack = '-'.join([f'{i}' for i in get_id_pack(func)])
-    thread = threading.Thread(name=f'{SPAWN_THREAD_PREFIX}-{str_id_pack}', target=func, args=args, kwargs=kwargs)
+    str_id_pack = '-'.join(['{}'.format(i) for i in get_id_pack(func)])
+    thread = threading.Thread(name='{}-{}'.format(SPAWN_THREAD_PREFIX, str_id_pack), target=func, args=args, kwargs=kwargs)
     thread.daemon = True
     thread.start()
     return thread

--- a/checkbox-ng/plainbox/vendor/rpyc/lib/compat.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/lib/compat.py
@@ -7,6 +7,7 @@ import time
 
 is_py_3k = (sys.version_info[0] >= 3)
 is_py_gte38 = is_py_3k and (sys.version_info[1] >= 8)
+is_py_gte37 = is_py_3k and (sys.version_info[1] >= 7)
 
 
 if is_py_3k:

--- a/checkbox-ng/plainbox/vendor/rpyc/lib/compat.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/lib/compat.py
@@ -6,6 +6,8 @@ import sys
 import time
 
 is_py_3k = (sys.version_info[0] >= 3)
+is_py_gte311 = is_py_3k and (sys.version_info[1] >= 11)
+is_py_gte310 = is_py_3k and (sys.version_info[1] >= 10)
 is_py_gte38 = is_py_3k and (sys.version_info[1] >= 8)
 is_py_gte37 = is_py_3k and (sys.version_info[1] >= 7)
 

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/__init__.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/__init__.py
@@ -1,3 +1,41 @@
 """
 Utilities (not part of the core protocol)
 """
+import functools
+import inspect
+from plainbox.vendor.rpyc.core import DEFAULT_CONFIG
+
+
+def service(cls):
+    """find and rename exposed decorated attributes"""
+    # NOTE: inspect.getmembers invokes getattr for each attribute-name. Descriptors may raise AttributeError.
+    # Only the AttributeError exception is caught when raised. This decorator will if a descriptor raises
+    # any exception other than AttributeError when getattr is called.
+    for attr_name, attr_obj in inspect.getmembers(cls):  # rebind exposed decorated attributes
+        exposed_prefix = getattr(attr_obj, '__exposed__', False)
+        if exposed_prefix and not inspect.iscode(attr_obj):  # exclude the implementation
+            renamed = exposed_prefix + attr_name
+            if inspect.isclass(attr_obj):  # recurse exposed objects such as a class
+                attr_obj = service(attr_obj)
+            setattr(cls, attr_name, attr_obj)
+            setattr(cls, renamed, attr_obj)
+    return cls
+
+
+def exposed(arg):
+    """decorator that adds the exposed prefix information to functions which `service` uses to rebind attrs"""
+    exposed_prefix = DEFAULT_CONFIG['exposed_prefix']
+    if isinstance(arg, str):
+        # When the arg is a string (i.e. `@rpyc.exposed("customPrefix_")`) the prefix
+        # is partially evaluated into the wrapper. The function returned is "frozen" and used as a decorator.
+        return functools.partial(_wrapper, arg)
+    elif hasattr(arg, '__call__') or hasattr(arg, '__get__'):
+        # When the arg is callable (i.e. `@rpyc.exposed`) then use default prefix and invoke
+        return _wrapper(exposed_prefix, arg)
+    else:
+        raise TypeError('rpyc.exposed expects a callable object, descriptor, or string')
+
+
+def _wrapper(exposed_prefix, exposed_obj):
+    exposed_obj.__exposed__ = exposed_prefix
+    return exposed_obj

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/authenticators.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/authenticators.py
@@ -71,7 +71,7 @@ class SSLAuthenticator(object):
         else:
             self.cert_reqs = cert_reqs
         if ssl_version is None:
-            self.ssl_version = ssl.PROTOCOL_TLSv1
+            self.ssl_version = ssl.PROTOCOL_TLS
         else:
             self.ssl_version = ssl_version
 

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/authenticators.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/authenticators.py
@@ -35,7 +35,7 @@ class AuthenticationError(Exception):
 
 class SSLAuthenticator(object):
     """An implementation of the authenticator protocol for ``SSL``. The given
-    socket is wrapped by ``ssl.wrap_socket`` and is validated based on
+    socket is wrapped by ``ssl.SSLContext.wrap_socket`` and is validated based on
     certificates
 
     :param keyfile: the server's key file
@@ -48,7 +48,7 @@ class SSLAuthenticator(object):
                     to restrict the available ciphers. New in Python 2.7/3.2
     :param ssl_version: the SSL version to use
 
-    Refer to `ssl.wrap_socket <http://docs.python.org/dev/library/ssl.html#ssl.wrap_socket>`_
+    Refer to `ssl.SSLContext <http://docs.python.org/dev/library/ssl.html#ssl.SSLContext>`_
     for more info.
 
     Clients can connect to this authenticator using
@@ -70,19 +70,22 @@ class SSLAuthenticator(object):
                 self.cert_reqs = ssl.CERT_NONE
         else:
             self.cert_reqs = cert_reqs
-        if ssl_version is None:
-            self.ssl_version = ssl.PROTOCOL_TLS
-        else:
-            self.ssl_version = ssl_version
+        self.ssl_version = ssl_version
 
     def __call__(self, sock):
-        kwargs = dict(keyfile=self.keyfile, certfile=self.certfile,
-                      server_side=True, ca_certs=self.ca_certs, cert_reqs=self.cert_reqs,
-                      ssl_version=self.ssl_version)
-        if self.ciphers is not None:
-            kwargs["ciphers"] = self.ciphers
         try:
-            sock2 = ssl.wrap_socket(sock, **kwargs)
+            if self.ssl_version is None:
+                context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
+            else:
+                context = ssl.SSLContext(self.ssl_version)
+            context.load_cert_chain(self.certfile, keyfile=self.keyfile)
+            if self.ca_certs is not None:
+                context.load_verify_locations(self.ca_certs)
+            if self.ciphers is not None:
+                context.set_ciphers(self.ciphers)
+            if self.cert_reqs is not None:
+                context.verify_mode = self.cert_reqs
+            sock2 = context.wrap_socket(sock, server_side=True)
         except ssl.SSLError:
             ex = sys.exc_info()[1]
             raise AuthenticationError(str(ex))

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/classic.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/classic.py
@@ -97,17 +97,20 @@ def ssl_connect(host, port=DEFAULT_SERVER_SSL_PORT, keyfile=None,
     :param port: the TCP port to use
     :param ipv6: whether to create an IPv6 socket or an IPv4 one
 
-    The following arguments are passed directly to
-    `ssl.wrap_socket <http://docs.python.org/dev/library/ssl.html#ssl.wrap_socket>`_:
+    The following arguments are passed to
+    `ssl.SSLContext <http://docs.python.org/dev/library/ssl.html#ssl.SSLContext>`_ and
+    its corresponding methods:
 
-    :param keyfile: see ``ssl.wrap_socket``. May be ``None``
-    :param certfile: see ``ssl.wrap_socket``. May be ``None``
-    :param ca_certs: see ``ssl.wrap_socket``. May be ``None``
-    :param cert_reqs: see ``ssl.wrap_socket``. By default, if ``ca_cert`` is specified,
-                      the requirement is set to ``CERT_REQUIRED``; otherwise it is
-                      set to ``CERT_NONE``
-    :param ssl_version: see ``ssl.wrap_socket``. The default is ``PROTOCOL_TLSv1``
-    :param ciphers: see ``ssl.wrap_socket``. May be ``None``. New in Python 2.7/3.2
+    :param keyfile: see ``ssl.SSLContext.load_cert_chain``. May be ``None``
+    :param certfile: see ``ssl.SSLContext.load_cert_chain``. May be ``None``
+    :param ca_certs: see ``ssl.SSLContext.load_verify_locations``. May be ``None``
+    :param cert_reqs: see ``ssl.SSLContext.verify_mode``. By default, if ``ca_cert`` is
+                      specified, the requirement is set to ``CERT_REQUIRED``; otherwise
+                      it is set to ``CERT_NONE``
+    :param ssl_version: see ``ssl.SSLContext``. The default is defined by
+                        ``ssl.create_default_context``
+    :param ciphers: see ``ssl.SSLContext.set_ciphers``. May be ``None``. New in
+                    Python 2.7/3.2
 
     :returns: an RPyC connection exposing ``SlaveService``
 
@@ -187,7 +190,7 @@ def upload(conn, localpath, remotepath, filter=None, ignore_invalid=False, chunk
         upload_file(conn, localpath, remotepath, chunk_size)
     else:
         if not ignore_invalid:
-            raise ValueError("cannot upload {!r}".format(localpath))
+            raise ValueError(f"cannot upload {localpath!r}")
 
 
 def upload_file(conn, localpath, remotepath, chunk_size=STREAM_CHUNK):
@@ -226,7 +229,7 @@ def download(conn, remotepath, localpath, filter=None, ignore_invalid=False, chu
         download_file(conn, remotepath, localpath, chunk_size)
     else:
         if not ignore_invalid:
-            raise ValueError("cannot download {!r}".format(remotepath))
+            raise ValueError(f"cannot download {remotepath!r}")
 
 
 def download_file(conn, remotepath, localpath, chunk_size=STREAM_CHUNK):

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/classic.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/classic.py
@@ -187,7 +187,7 @@ def upload(conn, localpath, remotepath, filter=None, ignore_invalid=False, chunk
         upload_file(conn, localpath, remotepath, chunk_size)
     else:
         if not ignore_invalid:
-            raise ValueError(f"cannot upload {localpath!r}")
+            raise ValueError("cannot upload {!r}".format(localpath))
 
 
 def upload_file(conn, localpath, remotepath, chunk_size=STREAM_CHUNK):
@@ -226,7 +226,7 @@ def download(conn, remotepath, localpath, filter=None, ignore_invalid=False, chu
         download_file(conn, remotepath, localpath, chunk_size)
     else:
         if not ignore_invalid:
-            raise ValueError(f"cannot download {remotepath!r}")
+            raise ValueError("cannot download {!r}".format(remotepath))
 
 
 def download_file(conn, remotepath, localpath, chunk_size=STREAM_CHUNK):

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/classic.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/classic.py
@@ -2,10 +2,11 @@ from __future__ import with_statement
 import sys
 import os
 import inspect
-from plainbox.vendor.rpyc.lib.compat import pickle, execute, is_py_3k  # noqa: F401
+from plainbox.vendor.rpyc.lib.compat import pickle, execute
 from plainbox.vendor.rpyc.core.service import ClassicService, Slave
 from plainbox.vendor.rpyc.utils import factory
 from plainbox.vendor.rpyc.core.service import ModuleNamespace  # noqa: F401
+from plainbox.vendor.rpyc.core.consts import STREAM_CHUNK
 from contextlib import contextmanager
 
 
@@ -171,7 +172,7 @@ def connect_multiprocess(args={}):
 # remoting utilities
 # ===============================================================================
 
-def upload(conn, localpath, remotepath, filter=None, ignore_invalid=False, chunk_size=16000):
+def upload(conn, localpath, remotepath, filter=None, ignore_invalid=False, chunk_size=STREAM_CHUNK):
     """uploads a file or a directory to the given remote path
 
     :param localpath: the local file or directory
@@ -186,10 +187,10 @@ def upload(conn, localpath, remotepath, filter=None, ignore_invalid=False, chunk
         upload_file(conn, localpath, remotepath, chunk_size)
     else:
         if not ignore_invalid:
-            raise ValueError("cannot upload %r" % (localpath,))
+            raise ValueError(f"cannot upload {localpath!r}")
 
 
-def upload_file(conn, localpath, remotepath, chunk_size=16000):
+def upload_file(conn, localpath, remotepath, chunk_size=STREAM_CHUNK):
     with open(localpath, "rb") as lf:
         with conn.builtin.open(remotepath, "wb") as rf:
             while True:
@@ -199,7 +200,7 @@ def upload_file(conn, localpath, remotepath, chunk_size=16000):
                 rf.write(buf)
 
 
-def upload_dir(conn, localpath, remotepath, filter=None, chunk_size=16000):
+def upload_dir(conn, localpath, remotepath, filter=None, chunk_size=STREAM_CHUNK):
     if not conn.modules.os.path.isdir(remotepath):
         conn.modules.os.makedirs(remotepath)
     for fn in os.listdir(localpath):
@@ -209,7 +210,7 @@ def upload_dir(conn, localpath, remotepath, filter=None, chunk_size=16000):
             upload(conn, lfn, rfn, filter=filter, ignore_invalid=True, chunk_size=chunk_size)
 
 
-def download(conn, remotepath, localpath, filter=None, ignore_invalid=False, chunk_size=16000):
+def download(conn, remotepath, localpath, filter=None, ignore_invalid=False, chunk_size=STREAM_CHUNK):
     """
     download a file or a directory to the given remote path
 
@@ -220,15 +221,15 @@ def download(conn, remotepath, localpath, filter=None, ignore_invalid=False, chu
     :param chunk_size: the IO chunk size
     """
     if conn.modules.os.path.isdir(remotepath):
-        download_dir(conn, remotepath, localpath, filter)
+        download_dir(conn, remotepath, localpath, filter, chunk_size)
     elif conn.modules.os.path.isfile(remotepath):
         download_file(conn, remotepath, localpath, chunk_size)
     else:
         if not ignore_invalid:
-            raise ValueError("cannot download %r" % (remotepath,))
+            raise ValueError(f"cannot download {remotepath!r}")
 
 
-def download_file(conn, remotepath, localpath, chunk_size=16000):
+def download_file(conn, remotepath, localpath, chunk_size=STREAM_CHUNK):
     with conn.builtin.open(remotepath, "rb") as rf:
         with open(localpath, "wb") as lf:
             while True:
@@ -238,17 +239,17 @@ def download_file(conn, remotepath, localpath, chunk_size=16000):
                 lf.write(buf)
 
 
-def download_dir(conn, remotepath, localpath, filter=None, chunk_size=16000):
+def download_dir(conn, remotepath, localpath, filter=None, chunk_size=STREAM_CHUNK):
     if not os.path.isdir(localpath):
         os.makedirs(localpath)
     for fn in conn.modules.os.listdir(remotepath):
         if not filter or filter(fn):
             rfn = conn.modules.os.path.join(remotepath, fn)
             lfn = os.path.join(localpath, fn)
-            download(conn, rfn, lfn, filter=filter, ignore_invalid=True)
+            download(conn, rfn, lfn, filter=filter, ignore_invalid=True, chunk_size=chunk_size)
 
 
-def upload_package(conn, module, remotepath=None, chunk_size=16000):
+def upload_package(conn, module, remotepath=None, chunk_size=STREAM_CHUNK):
     """
     uploads a module or a package to the remote party
 
@@ -384,12 +385,17 @@ def teleport_function(conn, func, globals=None, def_=True):
             import os
             return (os.getpid() + y) * x
 
+    .. note:: While it is not forbidden to "teleport" functions across different Python
+              versions, it *may* result in errors due to Python bytecode differences. It is
+              recommended to ensure both the client and the server are of the same Python
+              version when using this function.
+
     :param conn: the RPyC connection
     :param func: the function object to be delivered to the other party
     """
     if globals is None:
         globals = conn.namespace
-    from plainbox.vendor.rpyc.utils.teleportation import export_function
+    from rpyc.utils.teleportation import export_function
     exported = export_function(func)
     return conn.modules["rpyc.utils.teleportation"].import_function(
         exported, globals, def_)

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/classic.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/classic.py
@@ -190,7 +190,7 @@ def upload(conn, localpath, remotepath, filter=None, ignore_invalid=False, chunk
         upload_file(conn, localpath, remotepath, chunk_size)
     else:
         if not ignore_invalid:
-            raise ValueError(f"cannot upload {localpath!r}")
+            raise ValueError("cannot upload {!r}".format(localpath))
 
 
 def upload_file(conn, localpath, remotepath, chunk_size=STREAM_CHUNK):
@@ -229,7 +229,7 @@ def download(conn, remotepath, localpath, filter=None, ignore_invalid=False, chu
         download_file(conn, remotepath, localpath, chunk_size)
     else:
         if not ignore_invalid:
-            raise ValueError(f"cannot download {remotepath!r}")
+            raise ValueError("cannot download {!r}".format(remotepath))
 
 
 def download_file(conn, remotepath, localpath, chunk_size=STREAM_CHUNK):

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/factory.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/factory.py
@@ -224,12 +224,12 @@ def discover(service_name, host=None, registrar=None, timeout=2):
         registrar = UDPRegistryClient(timeout=timeout)
     addrs = registrar.discover(service_name)
     if not addrs:
-        raise DiscoveryError(f"no servers exposing {service_name!r} were found")
+        raise DiscoveryError("no servers exposing {!r} were found".format(service_name))
     if host:
         ips = socket.gethostbyname_ex(host)[2]
         addrs = [(h, p) for h, p in addrs if h in ips]
     if not addrs:
-        raise DiscoveryError(f"no servers exposing {service_name} were found on {host}")
+        raise DiscoveryError("no servers exposing {} were found on {}".format(service_name, host))
     return addrs
 
 
@@ -264,7 +264,7 @@ def connect_by_service(service_name, host=None, registrar=None, timeout=2, servi
             return connect(host, port, service, config=config)
         except socket.error:
             pass
-    raise DiscoveryError(f"All services are down: {addrs}")
+    raise DiscoveryError("All services are down: {}".format(addrs))
 
 
 def connect_subproc(args, service=VoidService, config={}):

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/factory.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/factory.py
@@ -5,7 +5,7 @@ cases)
 from __future__ import with_statement
 import socket
 from contextlib import closing
-
+from functools import partial
 import threading
 try:
     from thread import interrupt_main
@@ -19,13 +19,17 @@ except ImportError:
 
 from plainbox.vendor.rpyc.core.channel import Channel
 from plainbox.vendor.rpyc.core.stream import SocketStream, TunneledSocketStream, PipeStream
-from plainbox.vendor.rpyc.core.service import VoidService
+from plainbox.vendor.rpyc.core.service import VoidService, MasterService, SlaveService
 from plainbox.vendor.rpyc.utils.registry import UDPRegistryClient
 from plainbox.vendor.rpyc.lib import safe_import, spawn
 ssl = safe_import("ssl")
 
 
 class DiscoveryError(Exception):
+    pass
+
+
+class ForbiddenError(Exception):
     pass
 
 
@@ -216,16 +220,26 @@ def discover(service_name, host=None, registrar=None, timeout=2):
         registrar = UDPRegistryClient(timeout=timeout)
     addrs = registrar.discover(service_name)
     if not addrs:
-        raise DiscoveryError("no servers exposing %r were found" % (service_name,))
+        raise DiscoveryError(f"no servers exposing {service_name!r} were found")
     if host:
         ips = socket.gethostbyname_ex(host)[2]
         addrs = [(h, p) for h, p in addrs if h in ips]
     if not addrs:
-        raise DiscoveryError("no servers exposing %r were found on %r" % (service_name, host))
+        raise DiscoveryError(f"no servers exposing {service_name} were found on {host}")
     return addrs
 
 
-def connect_by_service(service_name, host=None, service=VoidService, config={}):
+def list_services(registrar=None, timeout=2):
+    services = ()
+    if registrar is None:
+        registrar = UDPRegistryClient(timeout=timeout)
+    services = registrar.list()
+    if services is None:
+        raise ForbiddenError("Registry doesn't allow listing")
+    return services
+
+
+def connect_by_service(service_name, host=None, registrar=None, timeout=2, service=VoidService, config={}):
     """create a connection to an arbitrary server that exposes the requested service
 
     :param service_name: the service to discover
@@ -240,13 +254,13 @@ def connect_by_service(service_name, host=None, service=VoidService, config={}):
     # some of which could be dead. We iterate over the list returned and return the first
     # one we could connect to. If none of the registered servers is responsive we re-throw
     # the exception
-    addrs = discover(service_name, host=host)
+    addrs = discover(service_name, host=host, registrar=registrar, timeout=timeout)
     for host, port in addrs:
         try:
             return connect(host, port, service, config=config)
         except socket.error:
             pass
-    raise DiscoveryError("All services are down: %s" % (addrs,))
+    raise DiscoveryError(f"All services are down: {addrs}")
 
 
 def connect_subproc(args, service=VoidService, config={}):
@@ -264,6 +278,27 @@ def connect_subproc(args, service=VoidService, config={}):
     return conn
 
 
+def _server(listener, remote_service, remote_config, args=None):
+    try:
+        with closing(listener):
+            client = listener.accept()[0]
+        conn = connect_stream(SocketStream(client), service=remote_service, config=remote_config)
+        if isinstance(args, dict):
+            _oldstyle = (MasterService, SlaveService)
+            is_newstyle = isinstance(remote_service, type) and not issubclass(remote_service, _oldstyle)
+            is_newstyle |= not isinstance(remote_service, type) and not isinstance(remote_service, _oldstyle)
+            is_voidservice = isinstance(remote_service, type) and issubclass(remote_service, VoidService)
+            is_voidservice |= not isinstance(remote_service, type) and isinstance(remote_service, VoidService)
+            if is_newstyle and not is_voidservice:
+                conn._local_root.exposed_namespace.update(args)
+            elif not is_voidservice:
+                conn._local_root.namespace.update(args)
+
+        conn.serve_all()
+    except KeyboardInterrupt:
+        interrupt_main()
+
+
 def connect_thread(service=VoidService, config={}, remote_service=VoidService, remote_config={}):
     """starts an rpyc server on a new thread, bound to an arbitrary port,
     and connects to it over a socket.
@@ -276,18 +311,8 @@ def connect_thread(service=VoidService, config={}, remote_service=VoidService, r
     listener = socket.socket()
     listener.bind(("localhost", 0))
     listener.listen(1)
-
-    def server(listener=listener):
-        with closing(listener):
-            client = listener.accept()[0]
-        conn = connect_stream(SocketStream(client), service=remote_service,
-                              config=remote_config)
-        try:
-            conn.serve_all()
-        except KeyboardInterrupt:
-            interrupt_main()
-
-    spawn(server)
+    remote_server = partial(_server, listener, remote_service, remote_config)
+    spawn(remote_server)
     host, port = listener.getsockname()
     return connect(host, port, service=service, config=config)
 
@@ -311,19 +336,8 @@ def connect_multiprocess(service=VoidService, config={}, remote_service=VoidServ
     listener = socket.socket()
     listener.bind(("localhost", 0))
     listener.listen(1)
-
-    def server(listener=listener, args=args):
-        with closing(listener):
-            client = listener.accept()[0]
-        conn = connect_stream(SocketStream(client), service=remote_service, config=remote_config)
-        try:
-            for k in args:
-                conn._local_root.exposed_namespace[k] = args[k]
-            conn.serve_all()
-        except KeyboardInterrupt:
-            interrupt_main()
-
-    t = Process(target=server)
+    remote_server = partial(_server, listener, remote_service, remote_config, args)
+    t = Process(target=remote_server)
     t.start()
     host, port = listener.getsockname()
     return connect(host, port, service=service, config=config)

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/factory.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/factory.py
@@ -220,12 +220,12 @@ def discover(service_name, host=None, registrar=None, timeout=2):
         registrar = UDPRegistryClient(timeout=timeout)
     addrs = registrar.discover(service_name)
     if not addrs:
-        raise DiscoveryError(f"no servers exposing {service_name!r} were found")
+        raise DiscoveryError("no servers exposing {!r} were found".format(service_name))
     if host:
         ips = socket.gethostbyname_ex(host)[2]
         addrs = [(h, p) for h, p in addrs if h in ips]
     if not addrs:
-        raise DiscoveryError(f"no servers exposing {service_name} were found on {host}")
+        raise DiscoveryError("no servers exposing {} were found on {}".format(service_name, host))
     return addrs
 
 
@@ -260,7 +260,7 @@ def connect_by_service(service_name, host=None, registrar=None, timeout=2, servi
             return connect(host, port, service, config=config)
         except socket.error:
             pass
-    raise DiscoveryError(f"All services are down: {addrs}")
+    raise DiscoveryError("All services are down: {}".format(addrs))
 
 
 def connect_subproc(args, service=VoidService, config={}):

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/helpers.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/helpers.py
@@ -34,7 +34,7 @@ def buffiter(obj, chunk=10, max_chunk=1000, factor=2):
             print id, name, dob
     """
     if factor < 1:
-        raise ValueError("factor must be >= 1, got %r" % (factor,))
+        raise ValueError(f"factor must be >= 1, got {factor!r}")
     it = iter(obj)
     count = chunk
     while True:
@@ -102,7 +102,7 @@ class _Async(object):
         return asyncreq(self.proxy, HANDLE_CALL, args, tuple(kwargs.items()))
 
     def __repr__(self):
-        return "async_(%r)" % (self.proxy,)
+        return f"async_({self.proxy!r})"
 
 
 _async_proxies_cache = WeakValueDict()
@@ -145,9 +145,9 @@ def async_(proxy):
     if pid in _async_proxies_cache:
         return _async_proxies_cache[pid]
     if not hasattr(proxy, "____conn__") or not hasattr(proxy, "____id_pack__"):
-        raise TypeError("'proxy' must be a Netref: %r", (proxy,))
+        raise TypeError(f"'proxy' must be a Netref: {proxy!r}")
     if not callable(proxy):
-        raise TypeError("'proxy' must be callable: %r" % (proxy,))
+        raise TypeError(f"'proxy' must be callable: {proxy!r}")
     caller = _Async(proxy)
     _async_proxies_cache[id(caller)] = _async_proxies_cache[pid] = caller
     return caller
@@ -186,7 +186,7 @@ class timed(object):
         return res
 
     def __repr__(self):
-        return "timed(%r, %r)" % (self.proxy.proxy, self.timeout)
+        return f"timed({self.proxy.proxy!r}, {self.timeout!r})"
 
 
 class BgServingThread(object):

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/helpers.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/helpers.py
@@ -34,7 +34,7 @@ def buffiter(obj, chunk=10, max_chunk=1000, factor=2):
             print id, name, dob
     """
     if factor < 1:
-        raise ValueError(f"factor must be >= 1, got {factor!r}")
+        raise ValueError("factor must be >= 1, got {!r}".format(factor))
     it = iter(obj)
     count = chunk
     while True:
@@ -102,7 +102,7 @@ class _Async(object):
         return asyncreq(self.proxy, HANDLE_CALL, args, tuple(kwargs.items()))
 
     def __repr__(self):
-        return f"async_({self.proxy!r})"
+        return "async_({!r})".format(self.proxy)
 
 
 _async_proxies_cache = WeakValueDict()
@@ -145,9 +145,9 @@ def async_(proxy):
     if pid in _async_proxies_cache:
         return _async_proxies_cache[pid]
     if not hasattr(proxy, "____conn__") or not hasattr(proxy, "____id_pack__"):
-        raise TypeError(f"'proxy' must be a Netref: {proxy!r}")
+        raise TypeError("'proxy' must be a Netref: {!r}".format(proxy))
     if not callable(proxy):
-        raise TypeError(f"'proxy' must be callable: {proxy!r}")
+        raise TypeError("'proxy' must be callable: {!r}".format(proxy))
     caller = _Async(proxy)
     _async_proxies_cache[id(caller)] = _async_proxies_cache[pid] = caller
     return caller
@@ -186,7 +186,7 @@ class timed(object):
         return res
 
     def __repr__(self):
-        return f"timed({self.proxy.proxy!r}, {self.timeout!r})"
+        return "timed({!r}, {!r})".format(self.proxy.proxy, self.timeout)
 
 
 class BgServingThread(object):

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/helpers.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/helpers.py
@@ -34,7 +34,7 @@ def buffiter(obj, chunk=10, max_chunk=1000, factor=2):
             print id, name, dob
     """
     if factor < 1:
-        raise ValueError("factor must be >= 1, got {!r}".format(factor))
+        raise ValueError(f"factor must be >= 1, got {factor!r}")
     it = iter(obj)
     count = chunk
     while True:
@@ -102,7 +102,7 @@ class _Async(object):
         return asyncreq(self.proxy, HANDLE_CALL, args, tuple(kwargs.items()))
 
     def __repr__(self):
-        return "async_({!r})".format(self.proxy)
+        return f"async_({self.proxy!r})"
 
 
 _async_proxies_cache = WeakValueDict()
@@ -145,9 +145,9 @@ def async_(proxy):
     if pid in _async_proxies_cache:
         return _async_proxies_cache[pid]
     if not hasattr(proxy, "____conn__") or not hasattr(proxy, "____id_pack__"):
-        raise TypeError("'proxy' must be a Netref: {!r}".format(proxy))
+        raise TypeError(f"'proxy' must be a Netref: {proxy!r}")
     if not callable(proxy):
-        raise TypeError("'proxy' must be callable: {!r}".format(proxy))
+        raise TypeError(f"'proxy' must be callable: {proxy!r}")
     caller = _Async(proxy)
     _async_proxies_cache[id(caller)] = _async_proxies_cache[pid] = caller
     return caller
@@ -186,7 +186,7 @@ class timed(object):
         return res
 
     def __repr__(self):
-        return "timed({!r}, {!r})".format(self.proxy.proxy, self.timeout)
+        return f"timed({self.proxy.proxy!r}, {self.timeout!r})"
 
 
 class BgServingThread(object):
@@ -211,10 +211,12 @@ class BgServingThread(object):
     SERVE_INTERVAL = 0.0
     SLEEP_INTERVAL = 0.1
 
-    def __init__(self, conn, callback=None):
+    def __init__(self, conn, callback=None, serve_interval=SERVE_INTERVAL, sleep_interval=SLEEP_INTERVAL):
         self._conn = conn
         self._active = True
         self._callback = callback
+        self._serve_interval = serve_interval
+        self._sleep_interval = sleep_interval
         self._thread = spawn(self._bg_server)
 
     def __del__(self):
@@ -224,8 +226,8 @@ class BgServingThread(object):
     def _bg_server(self):
         try:
             while self._active:
-                self._conn.serve(self.SERVE_INTERVAL)
-                time.sleep(self.SLEEP_INTERVAL)  # to reduce contention
+                self._conn.serve(self._serve_interval)
+                time.sleep(self._sleep_interval)  # to reduce contention
         except Exception:
             if self._active:
                 self._active = False

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/registry.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/registry.py
@@ -1,13 +1,8 @@
 """
-RPyC **registry server** implementation. The registry is much like
-`Avahi <http://en.wikipedia.org/wiki/Avahi_(software)>`_ or
-`Bonjour <http://en.wikipedia.org/wiki/Bonjour_(software)>`_, but tailored to
-the needs of RPyC. Also, neither of them supports (or supported) Windows,
-and Bonjour has a restrictive license. Moreover, they are too "powerful" for
-what RPyC needed and required too complex a setup.
+RPyC Registry Server maintains service information on RPyC services for *Service Registry and Discovery patterns*. Service Registry and Discovery patterns solve the connectivity problem for communication between services and external consumers. RPyC services will register with the server when :code:`auto_register` is :code:`True`.
 
-If anyone wants to implement the RPyC registry using Avahi, Bonjour, or any
-other zeroconf implementation -- I'll be happy to include them.
+Service registries such as `Avahi <http://en.wikipedia.org/wiki/Avahi_(software)>`_ and
+`Bonjour <http://en.wikipedia.org/wiki/Bonjour_(software)>`_ are alternatives to the RPyC Registry Server. These alternatives do no support Windows and have more restrictive licensing.
 
 Refer to :file:`rpyc/scripts/rpyc_registry.py` for more info.
 """
@@ -31,7 +26,7 @@ REGISTRY_PORT = 18811
 class RegistryServer(object):
     """Base registry server"""
 
-    def __init__(self, listenersock, pruning_timeout=None, logger=None):
+    def __init__(self, listenersock, pruning_timeout=None, logger=None, allow_listing=False):
         self.sock = listenersock
         self.port = self.sock.getsockname()[1]
         self.active = False
@@ -41,6 +36,7 @@ class RegistryServer(object):
         self.pruning_timeout = pruning_timeout
         if logger is None:
             logger = self._get_logger()
+        self.allow_listing = allow_listing
         self.logger = logger
 
     def _get_logger(self):
@@ -79,7 +75,7 @@ class RegistryServer(object):
     def cmd_query(self, host, name):
         """implementation of the ``query`` command"""
         name = name.upper()
-        self.logger.debug("querying for %r", name)
+        self.logger.debug(f"querying for {name!r}")
         if name not in self.services:
             self.logger.debug("no such service")
             return ()
@@ -89,24 +85,35 @@ class RegistryServer(object):
         servers = []
         for addrinfo, t in all_servers:
             if t < oldest:
-                self.logger.debug("discarding stale %s:%s", *addrinfo)
+                self.logger.debug(f"discarding stale {addrinfo[0]}:{addrinfo[1]}")
                 self._remove_service(name, addrinfo)
             else:
                 servers.append(addrinfo)
 
-        self.logger.debug("replying with %r", servers)
+        self.logger.debug(f"replying with {servers!r}")
         return tuple(servers)
+
+    def cmd_list(self, host):
+        """implementation for the ``list`` command"""
+        self.logger.debug("querying for services list:")
+        if not self.allow_listing:
+            self.logger.debug("listing is disabled")
+            return None
+        services = tuple(self.services.keys())
+        self.logger.debug(f"replying with {services}")
+
+        return services
 
     def cmd_register(self, host, names, port):
         """implementation of the ``register`` command"""
-        self.logger.debug("registering %s:%s as %s", host, port, ", ".join(names))
+        self.logger.debug(f"registering {host}:{port} as {', '.join(names)}")
         for name in names:
             self._add_service(name.upper(), (host, port))
         return "OK"
 
     def cmd_unregister(self, host, port):
         """implementation of the ``unregister`` command"""
-        self.logger.debug("unregistering %s:%s", host, port)
+        self.logger.debug(f"unregistering {host}:{port}")
         for name in list(self.services.keys()):
             self._remove_service(name, (host, port))
         return "OK"
@@ -128,11 +135,11 @@ class RegistryServer(object):
             except Exception:
                 continue
             if magic != "RPYC":
-                self.logger.warn("invalid magic: %r", magic)
+                self.logger.warn(f"invalid magic: {magic!r}")
                 continue
-            cmdfunc = getattr(self, "cmd_%s" % (cmd.lower(),), None)
+            cmdfunc = getattr(self, f"cmd_{cmd.lower()}", None)
             if not cmdfunc:
-                self.logger.warn("unknown command: %r", cmd)
+                self.logger.warn(f"unknown command: {cmd!r}")
                 continue
 
             try:
@@ -148,7 +155,8 @@ class RegistryServer(object):
             raise ValueError("server is already running")
         if self.sock is None:
             raise ValueError("object disposed")
-        self.logger.debug("server started on %s:%s", *self.sock.getsockname()[:2])
+        addrinfo = self.sock.getsockname()[:2]
+        self.logger.debug(f"server started on {addrinfo[0]}:{addrinfo[1]}")
         try:
             self.active = True
             self._work()
@@ -174,17 +182,17 @@ class UDPRegistryServer(RegistryServer):
 
     TIMEOUT = 1.0
 
-    def __init__(self, host="0.0.0.0", port=REGISTRY_PORT, pruning_timeout=None, logger=None):
+    def __init__(self, host="0.0.0.0", port=REGISTRY_PORT, pruning_timeout=None, logger=None, allow_listing=False):
         family, socktype, proto, _, sockaddr = socket.getaddrinfo(host, port, 0,
                                                                   socket.SOCK_DGRAM)[0]
         sock = socket.socket(family, socktype, proto)
         sock.bind(sockaddr)
         sock.settimeout(self.TIMEOUT)
         RegistryServer.__init__(self, sock, pruning_timeout=pruning_timeout,
-                                logger=logger)
+                                logger=logger, allow_listing=allow_listing)
 
     def _get_logger(self):
-        return logging.getLogger("REGSRV/UDP/%d" % (self.port,))
+        return logging.getLogger(f"REGSRV/UDP/{self.port}")
 
     def _recv(self):
         return self.sock.recvfrom(MAX_DGRAM_SIZE)
@@ -204,10 +212,9 @@ class TCPRegistryServer(RegistryServer):
     TIMEOUT = 3.0
 
     def __init__(self, host="0.0.0.0", port=REGISTRY_PORT, pruning_timeout=None,
-                 logger=None, reuse_addr=True):
+                 logger=None, reuse_addr=True, allow_listing=False):
 
-        family, socktype, proto, _, sockaddr = socket.getaddrinfo(host, port, 0,
-                                                                  socket.SOCK_STREAM)[0]
+        family, socktype, proto, _, sockaddr = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)[0]
         sock = socket.socket(family, socktype, proto)
         if reuse_addr and sys.platform != "win32":
             # warning: reuseaddr is not what you expect on windows!
@@ -216,11 +223,11 @@ class TCPRegistryServer(RegistryServer):
         sock.listen(10)
         sock.settimeout(self.TIMEOUT)
         RegistryServer.__init__(self, sock, pruning_timeout=pruning_timeout,
-                                logger=logger)
+                                logger=logger, allow_listing=allow_listing)
         self._connected_sockets = {}
 
     def _get_logger(self):
-        return logging.getLogger("REGSRV/TCP/%d" % (self.port,))
+        return logging.getLogger(f"REGSRV/TCP/{self.port}")
 
     def _recv(self):
         sock2, _ = self.sock.accept()
@@ -267,6 +274,13 @@ class RegistryClient(object):
         """
         raise NotImplementedError()
 
+    def list(self):
+        """
+        Send a query for the full lists of exposed servers
+        :returns: a list of `` service_name ``
+        """
+        raise NotImplementedError()
+
     def register(self, aliases, port):
         """Registers the given service aliases with the given TCP port. This
         API is intended to be called only by an RPyC server.
@@ -293,6 +307,7 @@ class UDPRegistryClient(RegistryClient):
     Example::
 
         registrar = UDPRegistryClient()
+        list_of_services = registrar.list()
         list_of_servers = registrar.discover("foo")
 
     .. note::
@@ -334,8 +349,26 @@ class UDPRegistryClient(RegistryClient):
                 servers = brine.load(data)
         return servers
 
+    def list(self):
+        sock = socket.socket(self.sock_family, socket.SOCK_DGRAM)
+
+        with closing(sock):
+            if self.bcast:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, True)
+            data = brine.dump(("RPYC", "LIST", ()))
+            sock.sendto(data, (self.ip, self.port))
+            sock.settimeout(self.timeout)
+
+            try:
+                data, _ = sock.recvfrom(MAX_DGRAM_SIZE)
+            except (socket.error, socket.timeout):
+                services = ()
+            else:
+                services = brine.load(data)
+        return services
+
     def register(self, aliases, port, interface=""):
-        self.logger.info("registering on %s:%s", self.ip, self.port)
+        self.logger.info(f"registering on {self.ip}:{self.port}")
         sock = socket.socket(self.sock_family, socket.SOCK_DGRAM)
         with closing(sock):
             sock.bind((interface, 0))
@@ -360,14 +393,14 @@ class UDPRegistryClient(RegistryClient):
                 except Exception:
                     continue
                 if reply == "OK":
-                    self.logger.info("registry %s:%s acknowledged", rip, rport)
+                    self.logger.info(f"registry {rip}:{rport} acknowledged")
                     return True
             else:
                 self.logger.warn("no registry acknowledged")
                 return False
 
     def unregister(self, port):
-        self.logger.info("unregistering from %s:%s", self.ip, self.port)
+        self.logger.info(f"unregistering from {self.ip}:{self.port}")
         sock = socket.socket(self.sock_family, socket.SOCK_DGRAM)
         with closing(sock):
             if self.bcast:
@@ -383,6 +416,7 @@ class TCPRegistryClient(RegistryClient):
     Example::
 
         registrar = TCPRegistryClient("localhost")
+        list_of_services = registrar.list()
         list_of_servers = registrar.discover("foo")
 
     .. note::
@@ -412,8 +446,24 @@ class TCPRegistryClient(RegistryClient):
                 servers = brine.load(data)
         return servers
 
+    def list(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        with closing(sock):
+            sock.settimeout(self.timeout)
+            data = brine.dump(("RPYC", "LIST", ()))
+            sock.connect((self.ip, self.port))
+            sock.send(data)
+
+            try:
+                data = sock.recv(MAX_DGRAM_SIZE)
+            except (socket.error, socket.timeout):
+                servers = ()
+            else:
+                servers = brine.load(data)
+        return servers
+
     def register(self, aliases, port, interface=""):
-        self.logger.info("registering on %s:%s", self.ip, self.port)
+        self.logger.info(f"registering on {self.ip}:{self.port}")
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         with closing(sock):
             sock.bind((interface, 0))
@@ -436,12 +486,12 @@ class TCPRegistryClient(RegistryClient):
                 self.logger.warn("received corrupted data from registry")
                 return False
             if reply == "OK":
-                self.logger.info("registry %s:%s acknowledged", self.ip, self.port)
+                self.logger.info(f"registry {self.ip}:{self.port} acknowledged")
 
             return True
 
     def unregister(self, port):
-        self.logger.info("unregistering from %s:%s", self.ip, self.port)
+        self.logger.info(f"unregistering from {self.ip}:{self.port}")
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         with closing(sock):
             sock.settimeout(self.timeout)

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/registry.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/registry.py
@@ -75,7 +75,7 @@ class RegistryServer(object):
     def cmd_query(self, host, name):
         """implementation of the ``query`` command"""
         name = name.upper()
-        self.logger.debug("querying for {!r}".format(name))
+        self.logger.debug(f"querying for {name!r}")
         if name not in self.services:
             self.logger.debug("no such service")
             return ()
@@ -85,35 +85,43 @@ class RegistryServer(object):
         servers = []
         for addrinfo, t in all_servers:
             if t < oldest:
-                self.logger.debug("discarding stale {}:{}".format(addrinfo[0], addrinfo[1]))
+                self.logger.debug(f"discarding stale {addrinfo[0]}:{addrinfo[1]}")
                 self._remove_service(name, addrinfo)
             else:
                 servers.append(addrinfo)
 
-        self.logger.debug("replying with {!r}".format(servers))
+        self.logger.debug(f"replying with {servers!r}")
         return tuple(servers)
 
-    def cmd_list(self, host):
+    def cmd_list(self, host, filter_host):
         """implementation for the ``list`` command"""
         self.logger.debug("querying for services list:")
         if not self.allow_listing:
             self.logger.debug("listing is disabled")
             return None
-        services = tuple(self.services.keys())
-        self.logger.debug("replying with {}".format(services))
+        services = []
+        if filter_host[0]:
+            for serv in self.services.keys():
+                known_hosts = [h[0] for h in self.services[serv].keys()]
+                if filter_host[0] in known_hosts:
+                    services.append(serv)
+            services = tuple(services)
+        else:
+            services = tuple(self.services.keys())
+        self.logger.debug(f"replying with {services}")
 
         return services
 
     def cmd_register(self, host, names, port):
         """implementation of the ``register`` command"""
-        self.logger.debug("registering {}:{} as {}".format(host, port, ', '.join(names)))
+        self.logger.debug(f"registering {host}:{port} as {', '.join(names)}")
         for name in names:
             self._add_service(name.upper(), (host, port))
         return "OK"
 
     def cmd_unregister(self, host, port):
         """implementation of the ``unregister`` command"""
-        self.logger.debug("unregistering {}:{}".format(host, port))
+        self.logger.debug(f"unregistering {host}:{port}")
         for name in list(self.services.keys()):
             self._remove_service(name, (host, port))
         return "OK"
@@ -135,11 +143,11 @@ class RegistryServer(object):
             except Exception:
                 continue
             if magic != "RPYC":
-                self.logger.warn("invalid magic: {!r}".format(magic))
+                self.logger.warn(f"invalid magic: {magic!r}")
                 continue
-            cmdfunc = getattr(self, "cmd_{}".format(cmd.lower()), None)
+            cmdfunc = getattr(self, f"cmd_{cmd.lower()}", None)
             if not cmdfunc:
-                self.logger.warn("unknown command: {!r}".format(cmd))
+                self.logger.warn(f"unknown command: {cmd!r}")
                 continue
 
             try:
@@ -156,7 +164,7 @@ class RegistryServer(object):
         if self.sock is None:
             raise ValueError("object disposed")
         addrinfo = self.sock.getsockname()[:2]
-        self.logger.debug("server started on {}:{}".format(addrinfo[0], addrinfo[1]))
+        self.logger.debug(f"server started on {addrinfo[0]}:{addrinfo[1]}")
         try:
             self.active = True
             self._work()
@@ -192,7 +200,7 @@ class UDPRegistryServer(RegistryServer):
                                 logger=logger, allow_listing=allow_listing)
 
     def _get_logger(self):
-        return logging.getLogger("REGSRV/UDP/{}".format(self.port))
+        return logging.getLogger(f"REGSRV/UDP/{self.port}")
 
     def _recv(self):
         return self.sock.recvfrom(MAX_DGRAM_SIZE)
@@ -227,7 +235,7 @@ class TCPRegistryServer(RegistryServer):
         self._connected_sockets = {}
 
     def _get_logger(self):
-        return logging.getLogger("REGSRV/TCP/{}".format(self.port))
+        return logging.getLogger(f"REGSRV/TCP/{self.port}")
 
     def _recv(self):
         sock2, _ = self.sock.accept()
@@ -274,7 +282,7 @@ class RegistryClient(object):
         """
         raise NotImplementedError()
 
-    def list(self):
+    def list(self, filter_host=None):
         """
         Send a query for the full lists of exposed servers
         :returns: a list of `` service_name ``
@@ -349,18 +357,18 @@ class UDPRegistryClient(RegistryClient):
                 servers = brine.load(data)
         return servers
 
-    def list(self):
+    def list(self, filter_host=None):
         sock = socket.socket(self.sock_family, socket.SOCK_DGRAM)
 
         with closing(sock):
             if self.bcast:
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, True)
-            data = brine.dump(("RPYC", "LIST", ()))
+            data = brine.dump(("RPYC", "LIST", ((filter_host,),)))
             sock.sendto(data, (self.ip, self.port))
             sock.settimeout(self.timeout)
 
             try:
-                data, _ = sock.recvfrom(MAX_DGRAM_SIZE)
+                data, _ = sock.recvfrom(MAX_DGRAM_SIZE * 10)
             except (socket.error, socket.timeout):
                 services = ()
             else:
@@ -368,7 +376,7 @@ class UDPRegistryClient(RegistryClient):
         return services
 
     def register(self, aliases, port, interface=""):
-        self.logger.info("registering on {}:{}".format(self.ip, self.port))
+        self.logger.info(f"registering on {self.ip}:{self.port}")
         sock = socket.socket(self.sock_family, socket.SOCK_DGRAM)
         with closing(sock):
             sock.bind((interface, 0))
@@ -393,14 +401,14 @@ class UDPRegistryClient(RegistryClient):
                 except Exception:
                     continue
                 if reply == "OK":
-                    self.logger.info("registry {}:{} acknowledged".format(rip, rport))
+                    self.logger.info(f"registry {rip}:{rport} acknowledged")
                     return True
             else:
                 self.logger.warn("no registry acknowledged")
                 return False
 
     def unregister(self, port):
-        self.logger.info("unregistering from {}:{}".format(self.ip, self.port))
+        self.logger.info(f"unregistering from {self.ip}:{self.port}")
         sock = socket.socket(self.sock_family, socket.SOCK_DGRAM)
         with closing(sock):
             if self.bcast:
@@ -446,11 +454,11 @@ class TCPRegistryClient(RegistryClient):
                 servers = brine.load(data)
         return servers
 
-    def list(self):
+    def list(self, filter_host=None):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         with closing(sock):
             sock.settimeout(self.timeout)
-            data = brine.dump(("RPYC", "LIST", ()))
+            data = brine.dump(("RPYC", "LIST", ((filter_host,),)))
             sock.connect((self.ip, self.port))
             sock.send(data)
 
@@ -463,7 +471,7 @@ class TCPRegistryClient(RegistryClient):
         return servers
 
     def register(self, aliases, port, interface=""):
-        self.logger.info("registering on {}:{}".format(self.ip, self.port))
+        self.logger.info(f"registering on {self.ip}:{self.port}")
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         with closing(sock):
             sock.bind((interface, 0))
@@ -486,12 +494,12 @@ class TCPRegistryClient(RegistryClient):
                 self.logger.warn("received corrupted data from registry")
                 return False
             if reply == "OK":
-                self.logger.info("registry {}:{} acknowledged".format(self.ip, self.port))
+                self.logger.info(f"registry {self.ip}:{self.port} acknowledged")
 
             return True
 
     def unregister(self, port):
-        self.logger.info("unregistering from {}:{}".format(self.ip, self.port))
+        self.logger.info(f"unregistering from {self.ip}:{self.port}")
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         with closing(sock):
             sock.settimeout(self.timeout)

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/registry.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/registry.py
@@ -75,7 +75,7 @@ class RegistryServer(object):
     def cmd_query(self, host, name):
         """implementation of the ``query`` command"""
         name = name.upper()
-        self.logger.debug(f"querying for {name!r}")
+        self.logger.debug("querying for {!r}".format(name))
         if name not in self.services:
             self.logger.debug("no such service")
             return ()
@@ -85,12 +85,12 @@ class RegistryServer(object):
         servers = []
         for addrinfo, t in all_servers:
             if t < oldest:
-                self.logger.debug(f"discarding stale {addrinfo[0]}:{addrinfo[1]}")
+                self.logger.debug("discarding stale {}:{}".format(addrinfo[0], addrinfo[1]))
                 self._remove_service(name, addrinfo)
             else:
                 servers.append(addrinfo)
 
-        self.logger.debug(f"replying with {servers!r}")
+        self.logger.debug("replying with {!r}".format(servers))
         return tuple(servers)
 
     def cmd_list(self, host):
@@ -100,20 +100,20 @@ class RegistryServer(object):
             self.logger.debug("listing is disabled")
             return None
         services = tuple(self.services.keys())
-        self.logger.debug(f"replying with {services}")
+        self.logger.debug("replying with {}".format(services))
 
         return services
 
     def cmd_register(self, host, names, port):
         """implementation of the ``register`` command"""
-        self.logger.debug(f"registering {host}:{port} as {', '.join(names)}")
+        self.logger.debug("registering {}:{} as {}".format(host, port, ', '.join(names)))
         for name in names:
             self._add_service(name.upper(), (host, port))
         return "OK"
 
     def cmd_unregister(self, host, port):
         """implementation of the ``unregister`` command"""
-        self.logger.debug(f"unregistering {host}:{port}")
+        self.logger.debug("unregistering {}:{}".format(host, port))
         for name in list(self.services.keys()):
             self._remove_service(name, (host, port))
         return "OK"
@@ -135,11 +135,11 @@ class RegistryServer(object):
             except Exception:
                 continue
             if magic != "RPYC":
-                self.logger.warn(f"invalid magic: {magic!r}")
+                self.logger.warn("invalid magic: {!r}".format(magic))
                 continue
-            cmdfunc = getattr(self, f"cmd_{cmd.lower()}", None)
+            cmdfunc = getattr(self, "cmd_{}".format(cmd.lower()), None)
             if not cmdfunc:
-                self.logger.warn(f"unknown command: {cmd!r}")
+                self.logger.warn("unknown command: {!r}".format(cmd))
                 continue
 
             try:
@@ -156,7 +156,7 @@ class RegistryServer(object):
         if self.sock is None:
             raise ValueError("object disposed")
         addrinfo = self.sock.getsockname()[:2]
-        self.logger.debug(f"server started on {addrinfo[0]}:{addrinfo[1]}")
+        self.logger.debug("server started on {}:{}".format(addrinfo[0], addrinfo[1]))
         try:
             self.active = True
             self._work()
@@ -192,7 +192,7 @@ class UDPRegistryServer(RegistryServer):
                                 logger=logger, allow_listing=allow_listing)
 
     def _get_logger(self):
-        return logging.getLogger(f"REGSRV/UDP/{self.port}")
+        return logging.getLogger("REGSRV/UDP/{}".format(self.port))
 
     def _recv(self):
         return self.sock.recvfrom(MAX_DGRAM_SIZE)
@@ -227,7 +227,7 @@ class TCPRegistryServer(RegistryServer):
         self._connected_sockets = {}
 
     def _get_logger(self):
-        return logging.getLogger(f"REGSRV/TCP/{self.port}")
+        return logging.getLogger("REGSRV/TCP/{}".format(self.port))
 
     def _recv(self):
         sock2, _ = self.sock.accept()
@@ -368,7 +368,7 @@ class UDPRegistryClient(RegistryClient):
         return services
 
     def register(self, aliases, port, interface=""):
-        self.logger.info(f"registering on {self.ip}:{self.port}")
+        self.logger.info("registering on {}:{}".format(self.ip, self.port))
         sock = socket.socket(self.sock_family, socket.SOCK_DGRAM)
         with closing(sock):
             sock.bind((interface, 0))
@@ -393,14 +393,14 @@ class UDPRegistryClient(RegistryClient):
                 except Exception:
                     continue
                 if reply == "OK":
-                    self.logger.info(f"registry {rip}:{rport} acknowledged")
+                    self.logger.info("registry {}:{} acknowledged".format(rip, rport))
                     return True
             else:
                 self.logger.warn("no registry acknowledged")
                 return False
 
     def unregister(self, port):
-        self.logger.info(f"unregistering from {self.ip}:{self.port}")
+        self.logger.info("unregistering from {}:{}".format(self.ip, self.port))
         sock = socket.socket(self.sock_family, socket.SOCK_DGRAM)
         with closing(sock):
             if self.bcast:
@@ -463,7 +463,7 @@ class TCPRegistryClient(RegistryClient):
         return servers
 
     def register(self, aliases, port, interface=""):
-        self.logger.info(f"registering on {self.ip}:{self.port}")
+        self.logger.info("registering on {}:{}".format(self.ip, self.port))
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         with closing(sock):
             sock.bind((interface, 0))
@@ -486,12 +486,12 @@ class TCPRegistryClient(RegistryClient):
                 self.logger.warn("received corrupted data from registry")
                 return False
             if reply == "OK":
-                self.logger.info(f"registry {self.ip}:{self.port} acknowledged")
+                self.logger.info("registry {}:{} acknowledged".format(self.ip, self.port))
 
             return True
 
     def unregister(self, port):
-        self.logger.info(f"unregistering from {self.ip}:{self.port}")
+        self.logger.info("unregistering from {}:{}".format(self.ip, self.port))
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         with closing(sock):
             sock.settimeout(self.timeout)

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/registry.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/registry.py
@@ -75,7 +75,7 @@ class RegistryServer(object):
     def cmd_query(self, host, name):
         """implementation of the ``query`` command"""
         name = name.upper()
-        self.logger.debug(f"querying for {name!r}")
+        self.logger.debug("querying for {!r}".format(name))
         if name not in self.services:
             self.logger.debug("no such service")
             return ()
@@ -85,12 +85,12 @@ class RegistryServer(object):
         servers = []
         for addrinfo, t in all_servers:
             if t < oldest:
-                self.logger.debug(f"discarding stale {addrinfo[0]}:{addrinfo[1]}")
+                self.logger.debug("discarding stale {}:{}".format(addrinfo[0], addrinfo[1]))
                 self._remove_service(name, addrinfo)
             else:
                 servers.append(addrinfo)
 
-        self.logger.debug(f"replying with {servers!r}")
+        self.logger.debug("replying with {!r}".format(servers))
         return tuple(servers)
 
     def cmd_list(self, host, filter_host):
@@ -108,20 +108,20 @@ class RegistryServer(object):
             services = tuple(services)
         else:
             services = tuple(self.services.keys())
-        self.logger.debug(f"replying with {services}")
+        self.logger.debug("replying with {}".format(services))
 
         return services
 
     def cmd_register(self, host, names, port):
         """implementation of the ``register`` command"""
-        self.logger.debug(f"registering {host}:{port} as {', '.join(names)}")
+        self.logger.debug("registering {}:{} as {}".format(host, port, ', '.join(names)))
         for name in names:
             self._add_service(name.upper(), (host, port))
         return "OK"
 
     def cmd_unregister(self, host, port):
         """implementation of the ``unregister`` command"""
-        self.logger.debug(f"unregistering {host}:{port}")
+        self.logger.debug("unregistering {}:{}".format(host, port))
         for name in list(self.services.keys()):
             self._remove_service(name, (host, port))
         return "OK"
@@ -143,11 +143,11 @@ class RegistryServer(object):
             except Exception:
                 continue
             if magic != "RPYC":
-                self.logger.warn(f"invalid magic: {magic!r}")
+                self.logger.warn("invalid magic: {!r}".format(magic))
                 continue
-            cmdfunc = getattr(self, f"cmd_{cmd.lower()}", None)
+            cmdfunc = getattr(self, "cmd_{}".format(cmd.lower()), None)
             if not cmdfunc:
-                self.logger.warn(f"unknown command: {cmd!r}")
+                self.logger.warn("unknown command: {!r}".format(cmd))
                 continue
 
             try:
@@ -164,7 +164,7 @@ class RegistryServer(object):
         if self.sock is None:
             raise ValueError("object disposed")
         addrinfo = self.sock.getsockname()[:2]
-        self.logger.debug(f"server started on {addrinfo[0]}:{addrinfo[1]}")
+        self.logger.debug("server started on {}:{}".format(addrinfo[0], addrinfo[1]))
         try:
             self.active = True
             self._work()
@@ -200,7 +200,7 @@ class UDPRegistryServer(RegistryServer):
                                 logger=logger, allow_listing=allow_listing)
 
     def _get_logger(self):
-        return logging.getLogger(f"REGSRV/UDP/{self.port}")
+        return logging.getLogger("REGSRV/UDP/{}".format(self.port))
 
     def _recv(self):
         return self.sock.recvfrom(MAX_DGRAM_SIZE)
@@ -235,7 +235,7 @@ class TCPRegistryServer(RegistryServer):
         self._connected_sockets = {}
 
     def _get_logger(self):
-        return logging.getLogger(f"REGSRV/TCP/{self.port}")
+        return logging.getLogger("REGSRV/TCP/{}".format(self.port))
 
     def _recv(self):
         sock2, _ = self.sock.accept()
@@ -376,7 +376,7 @@ class UDPRegistryClient(RegistryClient):
         return services
 
     def register(self, aliases, port, interface=""):
-        self.logger.info(f"registering on {self.ip}:{self.port}")
+        self.logger.info("registering on {}:{}".format(self.ip, self.port))
         sock = socket.socket(self.sock_family, socket.SOCK_DGRAM)
         with closing(sock):
             sock.bind((interface, 0))
@@ -401,14 +401,14 @@ class UDPRegistryClient(RegistryClient):
                 except Exception:
                     continue
                 if reply == "OK":
-                    self.logger.info(f"registry {rip}:{rport} acknowledged")
+                    self.logger.info("registry {}:{} acknowledged".format(rip, rport))
                     return True
             else:
                 self.logger.warn("no registry acknowledged")
                 return False
 
     def unregister(self, port):
-        self.logger.info(f"unregistering from {self.ip}:{self.port}")
+        self.logger.info("unregistering from {}:{}".format(self.ip, self.port))
         sock = socket.socket(self.sock_family, socket.SOCK_DGRAM)
         with closing(sock):
             if self.bcast:
@@ -471,7 +471,7 @@ class TCPRegistryClient(RegistryClient):
         return servers
 
     def register(self, aliases, port, interface=""):
-        self.logger.info(f"registering on {self.ip}:{self.port}")
+        self.logger.info("registering on {}:{}".format(self.ip, self.port))
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         with closing(sock):
             sock.bind((interface, 0))
@@ -494,12 +494,12 @@ class TCPRegistryClient(RegistryClient):
                 self.logger.warn("received corrupted data from registry")
                 return False
             if reply == "OK":
-                self.logger.info(f"registry {self.ip}:{self.port} acknowledged")
+                self.logger.info("registry {}:{} acknowledged".format(self.ip, self.port))
 
             return True
 
     def unregister(self, port):
-        self.logger.info(f"unregistering from {self.ip}:{self.port}")
+        self.logger.info("unregistering from {}:{}".format(self.ip, self.port))
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         with closing(sock):
             sock.settimeout(self.timeout)

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/server.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/server.py
@@ -26,8 +26,8 @@ class Server(object):
     """Base server implementation
 
     :param service: the :class:`~rpyc.core.service.Service` to expose
-    :param hostname: the host to bind to. Default is IPADDR_ANY, but you may
-                     want to restrict it only to ``localhost`` in some setups
+    :param hostname: the host to bind to. By default, the 'wildcard address' is used to listen on all interfaces.
+                     if not properly secured, the server can receive traffic from unintended or even malicious sources.
     :param ipv6: whether to create an IPv6 or IPv4 socket. The default is IPv4
     :param port: the TCP port to bind to
     :param backlog: the socket's backlog (passed to ``listen()``)
@@ -47,9 +47,9 @@ class Server(object):
                              on embedded platforms with limited battery)
     """
 
-    def __init__(self, service, hostname="", ipv6=False, port=0,
+    def __init__(self, service, hostname=None, ipv6=False, port=0,
                  backlog=socket.SOMAXCONN, reuse_addr=True, authenticator=None, registrar=None,
-                 auto_register=None, protocol_config={}, logger=None, listener_timeout=0.5,
+                 auto_register=None, protocol_config=None, logger=None, listener_timeout=0.5,
                  socket_path=None):
         self.active = False
         self._closed = False
@@ -60,11 +60,15 @@ class Server(object):
             self.auto_register = bool(registrar)
         else:
             self.auto_register = auto_register
+
+        if protocol_config is None:
+            protocol_config = {}
+
         self.protocol_config = protocol_config
         self.clients = set()
 
         if socket_path is not None:
-            if hostname != "" or port != 0 or ipv6 is not False:
+            if hostname is not None or port != 0 or ipv6 is not False:
                 raise ValueError("socket_path is mutually exclusive with: hostname, port, ipv6")
             self.listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             self.listener.bind(socket_path)
@@ -72,20 +76,18 @@ class Server(object):
             self.host, self.port = "", socket_path
         else:
             if ipv6:
-                if hostname == "localhost" and sys.platform != "win32":
-                    # on windows, you should bind to localhost even for ipv6
-                    hostname = "localhost6"
-                self.listener = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+                family = socket.AF_INET6
             else:
-                self.listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                family = socket.AF_INET
+            self.listener = socket.socket(family, socket.SOCK_STREAM)
+            address = socket.getaddrinfo(hostname, port, family=family, type=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP, flags=socket.AI_PASSIVE)[0][-1]
 
             if reuse_addr and sys.platform != "win32":
                 # warning: reuseaddr is not what you'd expect on windows!
                 # it allows you to bind an already bound port, resulting in
                 # "unexpected behavior" (quoting MSDN)
                 self.listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-
-            self.listener.bind((hostname, port))
+            self.listener.bind(address)
             self.listener.settimeout(listener_timeout)
 
             # hack for IPv6 (the tuple can be longer than 2)
@@ -93,7 +95,7 @@ class Server(object):
             self.host, self.port = sockname[0], sockname[1]
 
         if logger is None:
-            logger = logging.getLogger("%s/%s" % (self.service.get_service_name(), self.port))
+            logger = logging.getLogger(f"{self.service.get_service_name()}/{self.port}")
         self.logger = logger
         if "logger" not in self.protocol_config:
             self.protocol_config["logger"] = self.logger
@@ -151,7 +153,7 @@ class Server(object):
             return
 
         sock.setblocking(True)
-        self.logger.info("accepted %s with fd %s", addrinfo, sock.fileno())
+        self.logger.info(f"accepted {addrinfo} with fd {sock.fileno()}")
         self.clients.add(sock)
         self._accept_method(sock)
 
@@ -169,10 +171,10 @@ class Server(object):
                 try:
                     sock2, credentials = self.authenticator(sock)
                 except AuthenticationError:
-                    self.logger.info("%s failed to authenticate, rejecting connection", addrinfo)
+                    self.logger.info(f"{addrinfo} failed to authenticate... rejecting connection")
                     return
                 else:
-                    self.logger.info("%s authenticated successfully", addrinfo)
+                    self.logger.info(f"{addrinfo} authenticated successfully")
             else:
                 credentials = None
                 sock2 = sock
@@ -192,16 +194,16 @@ class Server(object):
     def _serve_client(self, sock, credentials):
         addrinfo = sock.getpeername()
         if credentials:
-            self.logger.info("welcome %s (%r)", addrinfo, credentials)
+            self.logger.info(f"welcome {addrinfo} ({credentials!r})")
         else:
-            self.logger.info("welcome %s", addrinfo)
+            self.logger.info(f"welcome {addrinfo}")
         try:
             config = dict(self.protocol_config, credentials=credentials,
                           endpoints=(sock.getsockname(), addrinfo), logger=self.logger)
             conn = self.service._connect(Channel(SocketStream(sock)), config)
             self._handle_connection(conn)
         finally:
-            self.logger.info("goodbye %s", addrinfo)
+            self.logger.info(f"goodbye {addrinfo}")
 
     def _handle_connection(self, conn):
         """This methoed should implement the server's logic."""
@@ -210,7 +212,7 @@ class Server(object):
     def _bg_register(self):
         interval = self.registrar.REREGISTER_INTERVAL
         self.logger.info("started background auto-register thread "
-                         "(interval = %s)", interval)
+                         f"(interval = {interval})")
         tnext = 0
         try:
             while self.active:
@@ -245,12 +247,11 @@ class Server(object):
             # Note that for AF_UNIX the following won't work (but we are safe
             # since we already saved the socket_path into self.port):
             self.port = self.listener.getsockname()[1]
-        self.logger.info("server started on [%s]:%s", self.host, self.port)
+        self.logger.info(f"server started on [{self.host}]:{self.port}")
         self.active = True
 
     def _register(self):
         if self.auto_register:
-            self.auto_register = False
             spawn(self._bg_register)
 
     def start(self):
@@ -340,7 +341,7 @@ class ThreadPoolServer(Server):
         self.workers = []
         for i in range(self.nbthreads):
             t = spawn(self._serve_clients)
-            t.setName('Worker%i' % i)
+            t.setName(f"Worker{i}")
             self.workers.append(t)
         # setup a thread for polling inactive connections
         self.polling_thread = spawn(self._poll_inactive_clients)
@@ -381,7 +382,7 @@ class ThreadPoolServer(Server):
             pass
 
         # close connection
-        self.logger.info("Closing connection for fd %d", fd)
+        self.logger.info(f"Closing connection for fd {fd}")
         if conn:
             conn.close()
 
@@ -419,7 +420,7 @@ class ThreadPoolServer(Server):
             except Exception:
                 ex = sys.exc_info()[1]
                 # "Caught exception in Worker thread" message
-                self.logger.warning("Failed to poll clients, caught exception : %s", str(ex))
+                self.logger.warning(f"Failed to poll clients, caught exception : {ex}")
                 # wait a bit so that we do not loop too fast in case of error
                 time.sleep(0.2)
 
@@ -467,7 +468,7 @@ class ThreadPoolServer(Server):
                 time.sleep(0.2)
 
     def _authenticate_and_build_connection(self, sock):
-        '''Authenticate a client and if it succees, wraps the socket in a connection object.
+        '''Authenticate a client and if it succeeds, wraps the socket in a connection object.
         Note that this code is cut and paste from the rpyc internals and may have to be
         changed if rpyc evolves'''
         # authenticate
@@ -476,27 +477,27 @@ class ThreadPoolServer(Server):
         else:
             credentials = None
         # build a connection
-        h, p = sock.getpeername()
-        config = dict(self.protocol_config, credentials=credentials, connid="%s:%d" % (h, p),
-                      endpoints=(sock.getsockname(), (h, p)))
+        addrinfo = sock.getpeername()
+        config = dict(self.protocol_config, credentials=credentials, connid="{}".format(addrinfo),
+                      endpoints=(sock.getsockname(), addrinfo))
         return sock, self.service._connect(Channel(SocketStream(sock)), config)
 
     def _accept_method(self, sock):
         '''Implementation of the accept method : only pushes the work to the internal queue.
         In case the queue is full, raises an AsynResultTimeout error'''
         try:
-            h, p = None, None
+            addrinfo = None
             # authenticate and build connection object
             sock, conn = self._authenticate_and_build_connection(sock)
             # put the connection in the active queue
-            h, p = sock.getpeername()
+            addrinfo = sock.getpeername()
             fd = conn.fileno()
-            self.logger.debug("Created connection to %s:%d with fd %d", h, p, fd)
+            self.logger.debug("Created connection to {addrinfo} with fd {fd}")
             self.fd_to_conn[fd] = conn
             self._add_inactive_connection(fd)
             self.clients.clear()
         except Exception:
-            err_msg = "Failed to serve client for {}:{}, caught exception".format(h, p)
+            err_msg = "Failed to serve client for {}, caught exception".format(addrinfo)
             self.logger.exception(err_msg)
             sock.close()
 
@@ -563,7 +564,6 @@ class GeventServer(Server):
 
     def _register(self):
         if self.auto_register:
-            self.auto_register = False
             gevent.spawn(self._bg_register)
 
     def _accept_method(self, sock):

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/server.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/server.py
@@ -96,7 +96,7 @@ class Server(object):
             self.host, self.port = sockname[0], sockname[1]
 
         if logger is None:
-            logger = logging.getLogger(f"{self.service.get_service_name()}/{self.port}")
+            logger = logging.getLogger("{}/{}".format(self.service.get_service_name(), self.port))
         self.logger = logger
         if "logger" not in self.protocol_config:
             self.protocol_config["logger"] = self.logger
@@ -154,7 +154,7 @@ class Server(object):
             return
 
         sock.setblocking(True)
-        self.logger.info(f"accepted {addrinfo} with fd {sock.fileno()}")
+        self.logger.info("accepted {} with fd {}".format(addrinfo, sock.fileno()))
         self.clients.add(sock)
         self._accept_method(sock)
 
@@ -172,10 +172,10 @@ class Server(object):
                 try:
                     sock2, credentials = self.authenticator(sock)
                 except AuthenticationError:
-                    self.logger.info(f"{addrinfo} failed to authenticate... rejecting connection")
+                    self.logger.info("{} failed to authenticate... rejecting connection".format(addrinfo))
                     return
                 else:
-                    self.logger.info(f"{addrinfo} authenticated successfully")
+                    self.logger.info("{} authenticated successfully".format(addrinfo))
             else:
                 credentials = None
                 sock2 = sock
@@ -195,16 +195,16 @@ class Server(object):
     def _serve_client(self, sock, credentials):
         addrinfo = sock.getpeername()
         if credentials:
-            self.logger.info(f"welcome {addrinfo} ({credentials!r})")
+            self.logger.info("welcome {} ({!r})".format(addrinfo, credentials))
         else:
-            self.logger.info(f"welcome {addrinfo}")
+            self.logger.info("welcome {}".format(addrinfo))
         try:
             config = dict(self.protocol_config, credentials=credentials,
                           endpoints=(sock.getsockname(), addrinfo), logger=self.logger)
             conn = self.service._connect(Channel(SocketStream(sock)), config)
             self._handle_connection(conn)
         finally:
-            self.logger.info(f"goodbye {addrinfo}")
+            self.logger.info("goodbye {}".format(addrinfo))
 
     def _handle_connection(self, conn):
         """This methoed should implement the server's logic."""
@@ -213,7 +213,7 @@ class Server(object):
     def _bg_register(self):
         interval = self.registrar.REREGISTER_INTERVAL
         self.logger.info("started background auto-register thread "
-                         f"(interval = {interval})")
+                         "(interval = {})".format(interval))
         tnext = 0
         try:
             while self.active:
@@ -248,7 +248,7 @@ class Server(object):
             # Note that for AF_UNIX the following won't work (but we are safe
             # since we already saved the socket_path into self.port):
             self.port = self.listener.getsockname()[1]
-        self.logger.info(f"server started on [{self.host}]:{self.port}")
+        self.logger.info("server started on [{}]:{}".format(self.host, self.port))
         self.active = True
 
     def _register(self):
@@ -342,7 +342,7 @@ class ThreadPoolServer(Server):
         self.workers = []
         for i in range(self.nbthreads):
             t = spawn(self._serve_clients)
-            t.name = f"Worker{i}"
+            t.name = "Worker{}".format(i)
             self.workers.append(t)
         # setup a thread for polling inactive connections
         self.polling_thread = spawn(self._poll_inactive_clients)
@@ -383,7 +383,7 @@ class ThreadPoolServer(Server):
             pass
 
         # close connection
-        self.logger.info(f"Closing connection for fd {fd}")
+        self.logger.info("Closing connection for fd {}".format(fd))
         if conn:
             conn.close()
 
@@ -421,7 +421,7 @@ class ThreadPoolServer(Server):
             except Exception:
                 ex = sys.exc_info()[1]
                 # "Caught exception in Worker thread" message
-                self.logger.warning(f"Failed to poll clients, caught exception : {ex}")
+                self.logger.warning("Failed to poll clients, caught exception : {}".format(ex))
                 # wait a bit so that we do not loop too fast in case of error
                 time.sleep(0.2)
 

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/server.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/server.py
@@ -95,7 +95,7 @@ class Server(object):
             self.host, self.port = sockname[0], sockname[1]
 
         if logger is None:
-            logger = logging.getLogger(f"{self.service.get_service_name()}/{self.port}")
+            logger = logging.getLogger("{}/{}".format(self.service.get_service_name(), self.port))
         self.logger = logger
         if "logger" not in self.protocol_config:
             self.protocol_config["logger"] = self.logger
@@ -153,7 +153,7 @@ class Server(object):
             return
 
         sock.setblocking(True)
-        self.logger.info(f"accepted {addrinfo} with fd {sock.fileno()}")
+        self.logger.info("accepted {} with fd {}".format(addrinfo, sock.fileno()))
         self.clients.add(sock)
         self._accept_method(sock)
 
@@ -171,10 +171,10 @@ class Server(object):
                 try:
                     sock2, credentials = self.authenticator(sock)
                 except AuthenticationError:
-                    self.logger.info(f"{addrinfo} failed to authenticate... rejecting connection")
+                    self.logger.info("{} failed to authenticate... rejecting connection".format(addrinfo))
                     return
                 else:
-                    self.logger.info(f"{addrinfo} authenticated successfully")
+                    self.logger.info("{} authenticated successfully".format(addrinfo))
             else:
                 credentials = None
                 sock2 = sock
@@ -194,16 +194,16 @@ class Server(object):
     def _serve_client(self, sock, credentials):
         addrinfo = sock.getpeername()
         if credentials:
-            self.logger.info(f"welcome {addrinfo} ({credentials!r})")
+            self.logger.info("welcome {} ({!r})".format(addrinfo, credentials))
         else:
-            self.logger.info(f"welcome {addrinfo}")
+            self.logger.info("welcome {}".format(addrinfo))
         try:
             config = dict(self.protocol_config, credentials=credentials,
                           endpoints=(sock.getsockname(), addrinfo), logger=self.logger)
             conn = self.service._connect(Channel(SocketStream(sock)), config)
             self._handle_connection(conn)
         finally:
-            self.logger.info(f"goodbye {addrinfo}")
+            self.logger.info("goodbye {}".format(addrinfo))
 
     def _handle_connection(self, conn):
         """This methoed should implement the server's logic."""
@@ -212,7 +212,7 @@ class Server(object):
     def _bg_register(self):
         interval = self.registrar.REREGISTER_INTERVAL
         self.logger.info("started background auto-register thread "
-                         f"(interval = {interval})")
+                         "(interval = {})".format(interval))
         tnext = 0
         try:
             while self.active:
@@ -247,7 +247,7 @@ class Server(object):
             # Note that for AF_UNIX the following won't work (but we are safe
             # since we already saved the socket_path into self.port):
             self.port = self.listener.getsockname()[1]
-        self.logger.info(f"server started on [{self.host}]:{self.port}")
+        self.logger.info("server started on [{}]:{}".format(self.host, self.port))
         self.active = True
 
     def _register(self):
@@ -341,7 +341,7 @@ class ThreadPoolServer(Server):
         self.workers = []
         for i in range(self.nbthreads):
             t = spawn(self._serve_clients)
-            t.setName(f"Worker{i}")
+            t.setName("Worker{}".format(i))
             self.workers.append(t)
         # setup a thread for polling inactive connections
         self.polling_thread = spawn(self._poll_inactive_clients)
@@ -382,7 +382,7 @@ class ThreadPoolServer(Server):
             pass
 
         # close connection
-        self.logger.info(f"Closing connection for fd {fd}")
+        self.logger.info("Closing connection for fd {}".format(fd))
         if conn:
             conn.close()
 
@@ -420,7 +420,7 @@ class ThreadPoolServer(Server):
             except Exception:
                 ex = sys.exc_info()[1]
                 # "Caught exception in Worker thread" message
-                self.logger.warning(f"Failed to poll clients, caught exception : {ex}")
+                self.logger.warning("Failed to poll clients, caught exception : {}".format(ex))
                 # wait a bit so that we do not loop too fast in case of error
                 time.sleep(0.2)
 

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/teleportation.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/teleportation.py
@@ -1,48 +1,21 @@
 import opcode
-import sys
-try:
-    import __builtin__
-except ImportError:
-    import builtins as __builtin__  # noqa: F401
-from plainbox.vendor.rpyc.lib.compat import is_py_3k, is_py_gte38
+
+from plainbox.vendor.rpyc.lib.compat import is_py_gte38
 from types import CodeType, FunctionType
-from plainbox.vendor.rpyc.core import brine
-from plainbox.vendor.rpyc.core import netref
+from plainbox.vendor.rpyc.core import brine, netref
+from dis import _unpack_opargs
 
 CODEOBJ_MAGIC = "MAg1c J0hNNzo0hn ZqhuBP17LQk8"
 
 
 # NOTE: dislike this kind of hacking on the level of implementation details,
 # should search for a more reliable/future-proof way:
-CODE_HAVEARG_SIZE = 2 if sys.version_info >= (3, 6) else 3
-try:
-    from dis import _unpack_opargs
-except ImportError:
-    # COPIED from 3.5's `dis.py`, this should hopefully be correct for <=3.5:
-    def _unpack_opargs(code):
-        extended_arg = 0
-        n = len(code)
-        i = 0
-        while i < n:
-            op = code[i]
-            offset = i
-            i = i + 1
-            arg = None
-            if op >= opcode.HAVE_ARGUMENT:
-                arg = code[i] + code[i + 1] * 256 + extended_arg
-                extended_arg = 0
-                i = i + 2
-                if op == opcode.EXTENDED_ARG:
-                    extended_arg = arg * 65536
-            yield (offset, op, arg)
+CODE_HAVEARG_SIZE = 3
 
 
 def decode_codeobj(codeobj):
     # adapted from dis.dis
-    if is_py_3k:
-        codestr = codeobj.co_code
-    else:
-        codestr = [ord(ch) for ch in codeobj.co_code]
+    codestr = codeobj.co_code
     free = None
     for i, op, oparg in _unpack_opargs(codestr):
         opname = opcode.opname[op]
@@ -73,7 +46,7 @@ def _export_codeobj(cobj):
         elif isinstance(const, CodeType):
             consts2.append(_export_codeobj(const))
         else:
-            raise TypeError("Cannot export a function with non-brinable constants: %r" % (const,))
+            raise TypeError(f"Cannot export a function with non-brinable constants: {const!r}")
 
     if is_py_gte38:
         # Constructor was changed in 3.8 to support "advanced" programming styles
@@ -81,50 +54,41 @@ def _export_codeobj(cobj):
                     cobj.co_stacksize, cobj.co_flags, cobj.co_code, tuple(consts2), cobj.co_names, cobj.co_varnames,
                     cobj.co_filename, cobj.co_name, cobj.co_firstlineno, cobj.co_lnotab, cobj.co_freevars,
                     cobj.co_cellvars)
-    elif is_py_3k:
+    else:
         exported = (cobj.co_argcount, cobj.co_kwonlyargcount, cobj.co_nlocals, cobj.co_stacksize, cobj.co_flags,
                     cobj.co_code, tuple(consts2), cobj.co_names, cobj.co_varnames, cobj.co_filename,
                     cobj.co_name, cobj.co_firstlineno, cobj.co_lnotab, cobj.co_freevars, cobj.co_cellvars)
-    else:
-        exported = (cobj.co_argcount, cobj.co_nlocals, cobj.co_stacksize, cobj.co_flags,
-                    cobj.co_code, tuple(consts2), cobj.co_names, cobj.co_varnames, cobj.co_filename,
-                    cobj.co_name, cobj.co_firstlineno, cobj.co_lnotab, cobj.co_freevars, cobj.co_cellvars)
-
     assert brine.dumpable(exported)
     return (CODEOBJ_MAGIC, exported)
 
 
 def export_function(func):
-    if is_py_3k:
-        func_closure = func.__closure__
-        func_code = func.__code__
-        func_defaults = func.__defaults__
-    else:
-        func_closure = func.func_closure
-        func_code = func.func_code
-        func_defaults = func.func_defaults
+    closure = func.__closure__
+    code = func.__code__
+    defaults = func.__defaults__
+    kwdefaults = func.__kwdefaults__
+    if kwdefaults is not None:
+        kwdefaults = tuple(kwdefaults.items())
 
-    if func_closure:
+    if closure:
         raise TypeError("Cannot export a function closure")
-    if not brine.dumpable(func_defaults):
-        raise TypeError("Cannot export a function with non-brinable defaults (func_defaults)")
+    if not brine.dumpable(defaults):
+        raise TypeError("Cannot export a function with non-brinable defaults (__defaults__)")
+    if not brine.dumpable(kwdefaults):
+        raise TypeError("Cannot export a function with non-brinable defaults (__kwdefaults__)")
 
-    return func.__name__, func.__module__, func_defaults, _export_codeobj(func_code)[1]
+    return func.__name__, func.__module__, defaults, kwdefaults, _export_codeobj(code)[1]
 
 
 def _import_codetup(codetup):
-    if is_py_3k:
-        # Handle tuples sent from 3.8 as well as 3 < version < 3.8.
-        if len(codetup) == 16:
-            (argcount, posonlyargcount, kwonlyargcount, nlocals, stacksize, flags, code, consts, names, varnames,
-             filename, name, firstlineno, lnotab, freevars, cellvars) = codetup
-        else:
-            (argcount, kwonlyargcount, nlocals, stacksize, flags, code, consts, names, varnames,
-             filename, name, firstlineno, lnotab, freevars, cellvars) = codetup
-            posonlyargcount = 0
-    else:
-        (argcount, nlocals, stacksize, flags, code, consts, names, varnames,
+    # Handle tuples sent from 3.8 as well as 3 < version < 3.8.
+    if len(codetup) == 16:
+        (argcount, posonlyargcount, kwonlyargcount, nlocals, stacksize, flags, code, consts, names, varnames,
          filename, name, firstlineno, lnotab, freevars, cellvars) = codetup
+    else:
+        (argcount, kwonlyargcount, nlocals, stacksize, flags, code, consts, names, varnames,
+         filename, name, firstlineno, lnotab, freevars, cellvars) = codetup
+        posonlyargcount = 0
 
     consts2 = []
     for const in consts:
@@ -136,17 +100,14 @@ def _import_codetup(codetup):
     if is_py_gte38:
         codetup = (argcount, posonlyargcount, kwonlyargcount, nlocals, stacksize, flags, code, consts, names, varnames,
                    filename, name, firstlineno, lnotab, freevars, cellvars)
-    elif is_py_3k:
+    else:
         codetup = (argcount, kwonlyargcount, nlocals, stacksize, flags, code, consts, names, varnames, filename, name,
                    firstlineno, lnotab, freevars, cellvars)
-    else:
-        codetup = (argcount, nlocals, stacksize, flags, code, consts, names, varnames, filename, name, firstlineno,
-                   lnotab, freevars, cellvars)
     return CodeType(*codetup)
 
 
 def import_function(functup, globals=None, def_=True):
-    name, modname, defaults, codetup = functup
+    name, modname, defaults, kwdefaults, codetup = functup
     if globals is None:
         try:
             mod = __import__(modname, None, None, "*")
@@ -155,11 +116,13 @@ def import_function(functup, globals=None, def_=True):
         globals = mod.__dict__
     # function globals must be real dicts, sadly:
     if isinstance(globals, netref.BaseNetref):
-        from plainbox.vendor.rpyc.utils.classic import obtain
+        from rpyc.utils.classic import obtain
         globals = obtain(globals)
     globals.setdefault('__builtins__', __builtins__)
     codeobj = _import_codetup(codetup)
     funcobj = FunctionType(codeobj, globals, name, defaults)
+    if kwdefaults is not None:
+        funcobj.__kwdefaults__ = {t[0]: t[1] for t in kwdefaults}
     if def_:
         globals[name] = funcobj
     return funcobj

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/teleportation.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/teleportation.py
@@ -46,7 +46,7 @@ def _export_codeobj(cobj):
         elif isinstance(const, CodeType):
             consts2.append(_export_codeobj(const))
         else:
-            raise TypeError(f"Cannot export a function with non-brinable constants: {const!r}")
+            raise TypeError("Cannot export a function with non-brinable constants: {!r}".format(const))
 
     if is_py_gte38:
         # Constructor was changed in 3.8 to support "advanced" programming styles

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/teleportation.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/teleportation.py
@@ -46,7 +46,7 @@ def _export_codeobj(cobj):
         elif isinstance(const, CodeType):
             consts2.append(_export_codeobj(const))
         else:
-            raise TypeError(f"Cannot export a function with non-brinable constants: {const!r}")
+            raise TypeError("Cannot export a function with non-brinable constants: {!r}".format(const))
 
     if is_py_gte311:
         # Constructor was changed in 3.11 by adding exceptionable and qualname

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/zerodeploy.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/zerodeploy.py
@@ -55,7 +55,7 @@ $EXTRA_SETUP$
 t = ServerCls(SlaveService, hostname = "localhost", port = 0, reuse_addr = True, logger = logger)
 thd = t._start_in_thread()
 
-sys.stdout.write("%s\n" % (t.port,))
+sys.stdout.write(f"{t.port}\n")
 sys.stdout.flush()
 
 try:
@@ -111,7 +111,7 @@ class DeployedServer(object):
             major = sys.version_info[0]
             minor = sys.version_info[1]
             cmd = None
-            for opt in ["python%s.%s" % (major, minor), "python%s" % (major,)]:
+            for opt in [f"python{major}.{minor}", f"python{major}"]:
                 try:
                     cmd = remote_machine[opt]
                 except CommandNotFound:
@@ -155,15 +155,26 @@ class DeployedServer(object):
         if self.proc is not None:
             try:
                 self.proc.terminate()
+                self.proc.communicate()
             except Exception:
                 pass
             self.proc = None
         if self.tun is not None:
             try:
+                self.tun._session.proc.terminate()
+                self.tun._session.proc.communicate()
                 self.tun.close()
             except Exception:
                 pass
             self.tun = None
+        if self.remote_machine is not None:
+            try:
+                self.remote_machine._session.proc.terminate()
+                self.remote_machine._session.proc.communicate()
+                self.remote_machine.close()
+            except Exception:
+                pass
+            self.remote_machine = None
         if self._tmpdir_ctx is not None:
             try:
                 self._tmpdir_ctx.__exit__(None, None, None)

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/zerodeploy.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/zerodeploy.py
@@ -4,6 +4,7 @@
 Requires [plumbum](http://plumbum.readthedocs.org/)
 """
 from __future__ import with_statement
+from subprocess import TimeoutExpired
 import sys
 import socket  # noqa: F401
 from plainbox.vendor.rpyc.lib.compat import BYTES_LITERAL
@@ -111,7 +112,7 @@ class DeployedServer(object):
             major = sys.version_info[0]
             minor = sys.version_info[1]
             cmd = None
-            for opt in ["python{}.{}".format(major, minor), "python{}".format(major)]:
+            for opt in [f"python{major}.{minor}", f"python{major}"]:
                 try:
                     cmd = remote_machine[opt]
                 except CommandNotFound:
@@ -151,27 +152,36 @@ class DeployedServer(object):
     def __exit__(self, t, v, tb):
         self.close()
 
-    def close(self):
+    def close(self, timeout=None):
         if self.proc is not None:
             try:
                 self.proc.terminate()
-                self.proc.communicate()
+                self.proc.communicate(timeout=timeout)
+            except TimeoutExpired:
+                self.proc.kill()
+                raise
             except Exception:
                 pass
             self.proc = None
         if self.tun is not None:
             try:
                 self.tun._session.proc.terminate()
-                self.tun._session.proc.communicate()
+                self.tun._session.proc.communicate(timeout=timeout)
                 self.tun.close()
+            except TimeoutExpired:
+                self.tun._session.proc.kill()
+                raise
             except Exception:
                 pass
             self.tun = None
         if self.remote_machine is not None:
             try:
                 self.remote_machine._session.proc.terminate()
-                self.remote_machine._session.proc.communicate()
+                self.remote_machine._session.proc.communicate(timeout=timeout)
                 self.remote_machine.close()
+            except TimeoutExpired:
+                self.remote_machine._session.proc.kill()
+                raise
             except Exception:
                 pass
             self.remote_machine = None

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/zerodeploy.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/zerodeploy.py
@@ -56,7 +56,7 @@ $EXTRA_SETUP$
 t = ServerCls(SlaveService, hostname = "localhost", port = 0, reuse_addr = True, logger = logger)
 thd = t._start_in_thread()
 
-sys.stdout.write(f"{t.port}\n")
+sys.stdout.write("{}\n".format(t.port))
 sys.stdout.flush()
 
 try:
@@ -112,7 +112,7 @@ class DeployedServer(object):
             major = sys.version_info[0]
             minor = sys.version_info[1]
             cmd = None
-            for opt in [f"python{major}.{minor}", f"python{major}"]:
+            for opt in ["python{}.{}".format(major, minor), "python{}".format(major)]:
                 try:
                     cmd = remote_machine[opt]
                 except CommandNotFound:

--- a/checkbox-ng/plainbox/vendor/rpyc/utils/zerodeploy.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/utils/zerodeploy.py
@@ -111,7 +111,7 @@ class DeployedServer(object):
             major = sys.version_info[0]
             minor = sys.version_info[1]
             cmd = None
-            for opt in [f"python{major}.{minor}", f"python{major}"]:
+            for opt in ["python{}.{}".format(major, minor), "python{}".format(major)]:
                 try:
                     cmd = remote_machine[opt]
                 except CommandNotFound:

--- a/checkbox-ng/plainbox/vendor/rpyc/version.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/version.py
@@ -1,3 +1,3 @@
-version = (4, 1, 4)
+version = (5, 1, 0)
 version_string = ".".join(map(str, version))
-release_date = "2020.1.30"
+release_date = "2022-02-26"

--- a/checkbox-ng/plainbox/vendor/rpyc/version.py
+++ b/checkbox-ng/plainbox/vendor/rpyc/version.py
@@ -1,3 +1,3 @@
-version = (5, 1, 0)
-version_string = ".".join(map(str, version))
-release_date = "2022-02-26"
+__version__ = '5.3.1'
+version = tuple(__version__.split('.'))
+release_date = "2023-02-21"


### PR DESCRIPTION
## Description

This updates RPyC vendor module to version `5.3.1`.

## Resolved issues

N/A

## Documentation

- The version was copied from upstream 5.3.1
- All imports were fixed to the vendor ones 
- f-strings were converted to `.format` to maintain py3.5 compatibility

## Tests

- [ ] Launch one checkbox-cli service instance
- [ ] Connect to it via a checkbox-cli remote instance
- [ ] Run a test 

Note: I am unable to prove an incompatibility between the new version of the library and the old one both client5/server4 and server4/client5 although I presumed that to be the case. Both experiments run to completion without crashing or any change to the output, maybe there is a better way to test this.
