### PR TITLE
Explain remote checkbox testing in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,24 @@ You should now be able to run checkbox, select a test plan and run it:
 ``` bash
 (venv) $ checkbox-cli
 ```
+### Running/Testing checkbox remote
+
+By default `checkbox-cli` runs locally. If you want to run the 
+[remote version](https://checkbox.readthedocs.io/en/latest/remote.html) you
+have to activate the `checkbox-cli service` on the Machine under test:
+```bash
+(venv) # checkbox-cli service
+```
+> Note: Keep in mind that service has to be run as root and needs the 
+> virtual env, you may have to re-enable/activate it after a `sudo -s`
+
+Now you can run the remote command to connect to it:
+```bash
+(venv) $ checkbox-cli remote IP 
+```
+
+> Note: `service` and `remote` can both run on the same machine. 
+> in that situation, simply use `127.0.0.1`
 
 ### Writing and running unit tests for Checkbox
 


### PR DESCRIPTION
## Description

This adds a mini tutorial, a link to the docs for the remote version, a note to remind the tester that running service as sudo may need a venv activattion and a note to specify that one can use the remote version locally.

## Resolved issues
Fixes [CHECKBOX-577](https://warthogs.atlassian.net/browse/CHECKBOX-577)

## Documentation

N/A

## Tests

N/A


[CHECKBOX-577]: https://warthogs.atlassian.net/browse/CHECKBOX-577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ