### PR TITLE
Add example in metabox README to check remote/service

### DIFF
--- a/metabox/README.md
+++ b/metabox/README.md
@@ -127,6 +127,29 @@ set, it will point to the parent directory of the Metabox package. For
 instance, if Metabox was [installed] from `/home/user/code/checkbox/metabox/`,
 `uri` will be set to `/home/user/code/checkbox/`.
 
+### Testing Checkbox remote
+
+You can test your local modifications to Checkbox Remote with the following
+configuration:
+
+```python
+configuration = {
+    'remote': {
+        'origin': 'source',
+        'uri': '~/checkbox',
+        'releases': ['jammy', 'focal', 'bionic'],
+    },
+    'service': {
+        'origin': 'source',
+        'uri': '~/checkbox',
+        'releases': ['jammy', 'focal', 'bionic'],
+    },
+}
+```
+
+**Note:** Metabox is always going to check **all possible combinations** of
+`releases`, that means that this example will execute 9 test runs.
+
 [Checkbox]: https://checkbox.readthedocs.io/
 [Linux containers (LXC)]: https://linuxcontainers.org/
 [`desktop_env` scenario]: ./metabox/scenarios/desktop_env/


### PR DESCRIPTION
## Description

This adds an example to the metabox README.md about how to use metabox to check a remote + service configuration. Also, this clarifies that if given multiple releases in the config, metabox will do a cartesian product of the two release lists

## Resolved issues
Fixes: [CHECKBOX-581](https://warthogs.atlassian.net/browse/CHECKBOX-581)

## Documentation
N/A

## Tests
N/A


[CHECKBOX-581]: https://warthogs.atlassian.net/browse/CHECKBOX-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ