### PR TITLE
Rework GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -47,7 +47,7 @@ body:
       label: Relevant log output
       description: >
         Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-      value: |
+      placeholder: |
         - Checkbox session(s) (located in `/var/tmp/checkbox-ng/sessions/`, you usually want to select the most recent one)
         
         - logs from the impacted components (e.g. `lsblk` if this is related to an issue when testing a disk...); a safe option is to install and run `sosreport` to gather as much log as possible.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,28 @@
 ## Description
 
+<!--
 Describe your changes here:
 
 - What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
 - Introduce your implementation approach in a way that helps reviewing it well.
+-->
 
 ## Resolved issues
 
+<!--
 Note the Jira/Launchpad issue(s) resolved by this PR (`Fixes|Resolves ...`).
+-->
 
 ## Documentation
 
-- [ ] Automated tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-- [ ] Necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).
+<!--
+- Please make sure tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
+- Please ensure the necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).
+-->
 
 ## Tests
 
-- [ ] Steps to follow for reviewer to run & manually test are provided.
-- [ ] A list of what tests were run and on what platform/configuration is provided.
+<!--
+- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
+- Please provide a list of what tests were run and on what platform/configuration.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,6 @@ Please make sure that...
   - Documentation in the repository, including contribution guidelines.
   - Process documentation outside the repository.
 - Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-- Please ensure the necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).
 -->
 
 ## Tests

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,11 @@ Make sure that the linked issue titles & descriptions are also up to date.
 ## Documentation
 
 <!--
-- Please make sure tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
+Please make sure that...
+- Documentation impacted by the changes is up to date (becomes so, remains so).
+  - Documentation in the repository, including contribution guidelines.
+  - Process documentation outside the repository.
+- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
 - Please ensure the necessary documentation is provided for the changed functionality in this PR (tests are documentation, too).
 -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,8 @@ Describe your changes here:
 ## Resolved issues
 
 <!--
-Note the Jira/Launchpad issue(s) resolved by this PR (`Fixes|Resolves ...`).
+Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
+Make sure that the linked issue titles & descriptions are also up to date.
 -->
 
 ## Documentation


### PR DESCRIPTION
## Description

Rework some of the templates:

- Bug template: make the "Relevant log output" section a placeholder to avoid cluttering newly opened issues with text that is not... relevant (no pun intended)
- PR template: mark help text as HTML comment to avoid having it appear in the PR, and reword the Documentation and Tests sections
