### PR TITLE
Fix: checkbox crash for non-existent usernames and refactor user handling

### DIFF
--- a/checkbox-ng/checkbox_ng/test_user_utils.py
+++ b/checkbox-ng/checkbox_ng/test_user_utils.py
@@ -86,6 +86,15 @@ class TestGuessNormalUser(unittest.TestCase):
         ]
         self.assertEqual(guess_normal_user(), "user1001")
 
+    @patch("pwd.getpwall")
+    @patch("pwd.getpwuid")
+    def test_cannot_guess_the_user(self, mock_getpwuid, mock_getpwall):
+        mock_getpwall.return_value = []
+        mock_getpwuid.side_effect = [KeyError(), KeyError()]
+
+        with self.assertRaises(RuntimeError):
+            guess_normal_user()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/checkbox-ng/checkbox_ng/test_user_utils.py
+++ b/checkbox-ng/checkbox_ng/test_user_utils.py
@@ -1,0 +1,91 @@
+import unittest
+import pwd
+from unittest.mock import patch
+from checkbox_ng.user_utils import check_user_exists, guess_normal_user
+
+
+class TestCheckUserExists(unittest.TestCase):
+    @patch("pwd.getpwnam")
+    def test_user_exists(self, mock_getpwnam):
+        mock_getpwnam.return_value = pwd.struct_passwd(
+            (
+                "testuser",
+                "x",
+                1001,
+                1001,
+                "Test User",
+                "/home/testuser",
+                "/bin/bash",
+            )
+        )
+        self.assertTrue(check_user_exists("testuser"))
+        mock_getpwnam.assert_called_with("testuser")
+
+    @patch("pwd.getpwnam")
+    def test_user_does_not_exist(self, mock_getpwnam):
+        mock_getpwnam.side_effect = KeyError("testuser not found")
+        self.assertFalse(check_user_exists("testuser"))
+
+    def test_invalid_input(self):
+        with self.assertRaises(TypeError):
+            check_user_exists(None)
+
+
+class TestGuessNormalUser(unittest.TestCase):
+    @patch("pwd.getpwall")
+    def test_guess_ubuntu_user(self, mock_getpwall):
+        mock_getpwall.return_value = [
+            pwd.struct_passwd(
+                (
+                    "ubuntu",
+                    "x",
+                    2222,
+                    2222,
+                    "Ubuntu User",
+                    "/home/ubuntu",
+                    "/bin/bash",
+                )
+            )
+        ]
+        self.assertEqual(guess_normal_user(), "ubuntu")
+
+    @patch("pwd.getpwall")
+    @patch("pwd.getpwuid")
+    def test_guess_uid_1000_user(self, mock_getpwuid, mock_getpwall):
+        mock_getpwall.return_value = []
+        mock_getpwuid.return_value = pwd.struct_passwd(
+            (
+                "user1000",
+                "x",
+                1000,
+                1000,
+                "User 1000",
+                "/home/user1000",
+                "/bin/bash",
+            )
+        )
+        self.assertEqual(guess_normal_user(), "user1000")
+
+    @patch("pwd.getpwall")
+    @patch("pwd.getpwuid")
+    def test_guess_uid_1001_user(self, mock_getpwuid, mock_getpwall):
+        mock_getpwall.return_value = []
+        mock_getpwuid.side_effect = [
+            KeyError("UID 1000 not found"),
+            pwd.struct_passwd(
+                (
+                    "user1001",
+                    "x",
+                    1001,
+                    1001,
+                    "User 1001",
+                    "/home/user1001",
+                    "/bin/bash",
+                )
+            ),
+        ]
+        self.assertEqual(guess_normal_user(), "user1001")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/checkbox-ng/checkbox_ng/user_utils.py
+++ b/checkbox-ng/checkbox_ng/user_utils.py
@@ -50,3 +50,4 @@ def guess_normal_user() -> str:
         user = pwd.getpwuid(1001).pw_name
         _logger.warning("Using `%s` user", user)
         return user
+    raise RuntimeError("Cannot guess which user should run unprivileged jobs!")

--- a/checkbox-ng/checkbox_ng/user_utils.py
+++ b/checkbox-ng/checkbox_ng/user_utils.py
@@ -1,0 +1,52 @@
+"""
+This modules has utilities to handle information about users available in the
+system.
+"""
+import logging
+import pwd
+
+from contextlib import suppress
+
+_logger = logging.getLogger("checkbox_ng.user_utils")
+
+
+def check_user_exists(user: str) -> bool:
+    """
+    Check if a user exists in the system.
+
+    :param str user: The username to check.
+    :return: True if the user exists, False otherwise.
+    :rtype: bool
+    :raises TypeError: If the input is not a string.
+    """
+    try:
+        pwd.getpwnam(user)
+        return True
+    except KeyError:
+        return False
+
+
+def guess_normal_user() -> str:
+    """
+    Guess the normal user in the system by checking for specific users
+    and UIDs.
+
+    This function first checks if the 'ubuntu' user exists in the system.
+    If not found, it tries to find a user with UID 1000.
+    If still not found, it tries to find a user with UID 1001.
+
+    :return: The username of the guessed normal user.
+    :rtype: str
+    """
+    for entry in pwd.getpwall():
+        if entry.pw_name == "ubuntu":
+            _logger.warning("Using `ubuntu` user")
+            return "ubuntu"
+    with suppress(KeyError):
+        user = pwd.getpwuid(1000).pw_name
+        _logger.warning("Using `%s` user", user)
+        return user
+    with suppress(KeyError):
+        user = pwd.getpwuid(1001).pw_name
+        _logger.warning("Using `%s` user", user)
+        return user

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -40,6 +40,9 @@ from plainbox.abc import IJobResult
 
 from checkbox_ng.config import load_configs
 from checkbox_ng.launcher.run import SilentUI
+from checkbox_ng.user_utils import check_user_exists
+from checkbox_ng.user_utils import guess_normal_user
+
 
 import psutil
 
@@ -283,13 +286,17 @@ class RemoteSessionAssistant():
                 session_desc = self._launcher.session_desc
 
         self._sa.use_alternate_configuration(self._launcher)
-
         if configuration['normal_user']:
             self._normal_user = configuration['normal_user']
         else:
             self._normal_user = self._launcher.normal_user
-            if not self._normal_user:
-                self._normal_user = _guess_normal_user()
+        if self._normal_user:
+            if not check_user_exists(self._normal_user):
+                raise RuntimeError(
+                    "User '{}' doesn't exist!".format(self._normal_user)
+                )
+        else:
+            self._normal_user = guess_normal_user()
         runner_kwargs = {
             'normal_user_provider': lambda: self._normal_user,
             'stdin': self._pipe_to_subproc,
@@ -733,21 +740,3 @@ class RemoteSessionAssistant():
         exporter.dump_from_session_manager(self._sa._manager, exported_stream)
         exported_stream.flush()
         return exported_stream
-
-def _guess_normal_user():
-    _logger.warning("normal_user not supplied via config(s).")
-    for entry in pwd.getpwall():
-        if entry.pw_name == 'ubuntu':
-            _logger.warning("Using `ubuntu` user")
-            return 'ubuntu'
-    with suppress(KeyError):
-        user = pwd.getpwuid(1000).pw_name
-        _logger.warning("Using `%s` user", user)
-        return user
-    with suppress(KeyError):
-        user = pwd.getpwuid(1001).pw_name
-        _logger.warning("Using `%s` user", user)
-        return user
-    raise RuntimeError(
-        ("normal_user not supplied via config(s). "
-            "User `ubuntu` and username for uid 1000 or 1001 were not found"))


### PR DESCRIPTION
## Description

This patch fixes a problem where checkbox would crash when controller provided a username that doesn't exists on the controlled system. It also moves the user handling heuristics into a new module and simplifies the existing logic.

See bug on JIRA and unit tests from this patch for details.

## Resolved issues
Fixes: [CHECKBOX-597](https://warthogs.atlassian.net/browse/CHECKBOX-597)

## Documentation
The functionality doesn't change so no docs.

## Tests
In this patch I provide unit tests for the heuristics.
Moreover the following PR will have a metabox test that will test this as well.

## Testing
I tested the branch using a remote/service combo with launchers specifying random combination of existing and non-existent users.
And of course tox + metabox.


[CHECKBOX-597]: https://warthogs.atlassian.net/browse/CHECKBOX-597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ