### PR TITLE
Metabox optimizations

### DIFF
--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -51,9 +51,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup LXD
         uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
-      - name: Install pyopenssl
-        run: python3 -m pip install pyopenssl --upgrade
+      - name: Install dependencies
+        run: python3 -m pip install --upgrade pyopenssl pytest
       - name: Install Metabox
         run: python3 -m pip install -e .
       - name: Run Metabox scenarios
-        run: metabox configs/${{ matrix.mode }}-source-${{ matrix.os }}.py --log TRACE
+        run: pytest --config configs/${{ matrix.mode }}-source-${{ matrix.os }}.py --log-lvl TRACE -v --color=yes

--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -29,7 +29,7 @@ jobs:
           fi
 
   Metabox:
-    if: (github.event.review.state == 'approved' || github.event_name == 'workflow_dispatch') && needs.metabox_run_required.outputs.required_run == 'true'
+    if: (github.event.review.state == 'approved' && needs.metabox_run_required.outputs.required_run == 'true') || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -51,6 +51,14 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup LXD
         uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
+      - name: Add ZFS storage
+        run: |
+          lxc storage list
+          lxc profile device remove default root
+          lxc storage delete default
+          lxc storage create metabox${{ matrix.os }} zfs
+          lxc profile device add default root disk path=/ pool=metabox${{ matrix.os }}
+          lxc storage list
       - name: Install dependencies
         run: python3 -m pip install --upgrade pyopenssl pytest
       - name: Install Metabox

--- a/metabox/README.md
+++ b/metabox/README.md
@@ -150,6 +150,39 @@ configuration = {
 **Note:** Metabox is always going to check **all possible combinations** of
 `releases`, that means that this example will execute 9 test runs.
 
+# Running Metabox with pytest
+
+Pytest offers a richer command-line and complements nicely the metabox runner.
+A [conftest.py] turns metabox scenarios into a pytest compatible session.
+
+### List the scenarios using keywords expression
+
+An expression is a Python evaluatable expression where all names are
+substring-matched against test names and their parent classes.
+The matching is case-insensitive.
+```
+$ pytest --config configs/source-remote-config.py -k "remote and reboot" --collect-only
+$ pytest --config configs/source-remote-config.py -k "remote and not reboot" --collect-only
+$ pytest --config configs/source-remote-config.py -k "remote and not reboot and not desktop" --collect-only
+$ pytest --config configs/testing-ppa-config.py -k "remote and not jammy" --collect-only
+$ pytest --config configs/source-local-config.py -k CheckboxConfLocalResolutionOrder --collect-only
+```
+### Run scenarios using the TRACE logging level
+**Note:** `--log-lvl` option adjust loguru logging level
+(`log-level` is already a pytest option)
+```
+$ pytest --config configs/source-local-config.py --log-lvl TRACE -v -k CheckboxConfLocalResolutionOrder
+```
+### Exit instantly on first error or failed test  with -x
+**Note:** `metabox --hold-on-fail` is handled with the pytest exitfirst option.
+```
+$ pytest --config configs/source-local-config.py --log-lvl TRACE -v -x
+```
+### Do not capture test output with -s
+```
+$ pytest --config configs/source-local-config.py --log-lvl TRACE -v -s
+```
+
 [Checkbox]: https://checkbox.readthedocs.io/
 [Linux containers (LXC)]: https://linuxcontainers.org/
 [`desktop_env` scenario]: ./metabox/scenarios/desktop_env/
@@ -157,3 +190,4 @@ configuration = {
 [`configs` directory]: ./configs/
 [LXD documentation to install and initialize it]: https://linuxcontainers.org/lxd/getting-started-cli/
 [installed]: #installation
+[conftest.py]: ./conftest.py

--- a/metabox/configs/source-local-config.py
+++ b/metabox/configs/source-local-config.py
@@ -3,8 +3,6 @@ configuration = {
         # Metabox can run tests from a local directory containing a copy of
         # the Checkbox source code repository.
         'origin': 'source',
-        # Path to the Checkbox source code repository
-        'uri': '~/dev/work/checkbox',
         'releases': ['focal'],
     },
 }

--- a/metabox/configs/source-remote-config.py
+++ b/metabox/configs/source-remote-config.py
@@ -1,12 +1,10 @@
 configuration = {
     'remote': {
         'origin': 'source',
-        'uri': '~/dev/work/checkbox',
         'releases': ['focal'],
     },
     'service': {
         'origin': 'source',
-        'uri': '~/dev/work/checkbox',
         'releases': ['focal'],
     },
 }

--- a/metabox/conftest.py
+++ b/metabox/conftest.py
@@ -1,0 +1,181 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Sylvain Pineau <sylvain.pineau@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+"""
+This pytest configuration file defines a custom test item `MetaboxItem` that
+allows running Metabox scenarios.
+"""
+
+import inspect
+import logging
+from pathlib import Path
+
+import pytest
+from loguru._logger import Core
+from metabox.core.machine import MachineConfig
+from metabox.core.runner import Runner
+from metabox.core.scenario import Scenario
+
+
+def pytest_addoption(parser):
+    """
+    This pytest hook defines command-line options for Metabox, such as
+    specifying the configuration file to use, the scenario logging level, and
+    whether to delete LXD containers after a run.
+    """
+    parser.addoption(
+        '--config', metavar='CONFIG', type=Path,
+        help='Metabox configuration file'
+    )
+    parser.addoption(
+        "--log-lvl", dest="scenario_log_level", choices=Core().levels.keys(),
+        default='WARNING',
+        help="Set the scenario logging level",
+    )
+    parser.addoption(
+        '--do-not-dispose', action='store_true',
+        help="Do not delete LXD containers after the run")
+    parser.addoption(
+        '--debug-machine-setup', action='store_true',
+        help="Turn on verbosity during machine setup. "
+             "Only works with --log TRACE")
+
+
+def pytest_pycollect_makeitem(collector, name, obj):
+    """
+    This function is a pytest hook that allows for the dynamic creation of test
+    items. It creates a pytest item for each Scenario subclass that exists in
+    the Metabox project.
+    """
+    if (
+        inspect.isclass(obj) and issubclass(obj, Scenario) and
+        "Scenario" not in obj.__name__
+    ):
+        variants = []
+        for scn in collector.config.runner.scn_variants:
+            if (
+                "{}.{}".format(
+                    collector.parent.name, collector.path.stem) in scn.name and
+                scn.name.endswith('.' + name)
+            ):
+                variants.append(
+                    MetaboxItem.from_parent(
+                        collector,
+                        name=f"{name} [{scn.mode}]{scn.releases}",
+                        scn=scn)
+                    )
+        return variants
+    elif inspect.isclass(obj) and issubclass(obj, Scenario):
+        return []
+
+
+def pytest_configure(config):
+    """
+    Initialization of the Runner object with the command-line options passed to
+    pytest.
+    """
+    logger = logging.getLogger('ws4py')
+    logger.disabled = True
+    runner = Runner(config.option)
+    runner.collect()
+    config.runner = runner
+
+
+def pytest_collection_finish(session):
+    """
+    This hook is called once all tests have been collected.
+    It sets up the runner with the collected scenarios.
+    """
+    if session.config.option.collectonly:
+        return
+    runner = session.config.runner
+    runner.scn_variants = [i.scn for i in session.items]
+    runner.setup()
+
+
+class MetaboxItem(pytest.Item):
+    """
+    Custom pytest item for running a Scenario.
+    It loads the  appropriate machine configurations based on the scenario
+    variant and mode, sets up the machines, and runs the scenario.
+    It also handles cleanup and reporting of any failures that occur during the
+    run.
+    """
+    def __init__(self, *, scn, **kwargs):
+        super().__init__(**kwargs)
+        self.scn = scn
+
+    def __repr__(self) -> str:
+        return "<Scenario {}>".format(getattr(self, "name", None))
+
+    def _load(self, mode, release_alias):
+        config = self.config.runner.config[mode].copy()
+        config['alias'] = release_alias
+        config['role'] = mode
+        return self.config.runner.machine_provider.get_machine_by_config(
+            MachineConfig(mode, config))
+
+    def runtest(self):
+        scn = self.scn
+        if scn.mode == "remote":
+            scn.remote_machine = self._load("remote", scn.releases[0])
+            scn.service_machine = self._load("service", scn.releases[1])
+            scn.remote_machine.rollback_to('provisioned')
+            scn.service_machine.rollback_to('provisioned')
+            if scn.launcher:
+                scn.remote_machine.put(scn.LAUNCHER_PATH, scn.launcher)
+            scn.service_machine.start_user_session()
+        elif scn.mode == "local":
+            scn.local_machine = self._load("local", scn.releases[0])
+            scn.local_machine.rollback_to('provisioned')
+            if scn.launcher:
+                scn.local_machine.put(scn.LAUNCHER_PATH, scn.launcher)
+            scn.local_machine.start_user_session()
+        scn.run()
+        if not scn.has_passed():
+            if self.config.option.maxfail:
+                if scn.mode == "remote":
+                    msg = (
+                        "You may hop onto the target machines by issuing "
+                        "the following commands:\n{}\n{}").format(
+                            scn.remote_machine.get_connecting_cmd(),
+                            scn.service_machine.get_connecting_cmd())
+                elif scn.mode == "local":
+                    msg = (
+                        "You may hop onto the target machine by issuing "
+                        "the following command:\n{}").format(
+                            scn.local_machine.get_connecting_cmd())
+                print(msg)
+            else:
+                self.config.runner.machine_provider.cleanup()
+            raise MetaboxException(
+                self, self.scn.problems)
+        self.config.runner.machine_provider.cleanup()
+
+    def repr_failure(self, excinfo):
+        """Called when self.runtest() raises an exception."""
+        if isinstance(excinfo.value, MetaboxException):
+            err_msg = "Scenario execution failed\n    "
+            err_msg += "\n    ".join(excinfo.value.args[1])
+            return err_msg
+
+    def reportinfo(self):
+        return self.path, 0, f"Scenario: {self.name}"
+
+
+class MetaboxException(Exception):
+    """Custom exception for error reporting."""

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -160,18 +160,11 @@ class LxdMachineProvider:
                 attempt += 1
             else:
                 raise SystemExit("Timeout reached (still running cloud-init)")
-            logger.debug("Stopping container {}...", container.name)
-            container.stop(wait=True)
-            logger.debug("Creating 'base' snapshot for {}...", container.name)
-            container.snapshots.create('base', stateful=False, wait=True)
-            logger.debug("Starting container {}...", container.name)
-            container.start(wait=True)
             logger.opt(colors=True).debug(
                 "[<y>created</y>     ] {}", container.name)
             logger.opt(colors=True).debug(
                 "[<y>provisioning</y>] {}", container.name)
             self._run_transfer_commands(machine)
-            time.sleep(5)  # FIXME: is it still needed?
             self._run_setup_commands(machine)
             self._store_config(machine)
             logger.debug("Stopping container {}...", container.name)

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -94,30 +94,28 @@ class ContainerBaseMachine:
         self._container.start(wait=True)
         logger.opt(colors=True).debug(
             "[<y>restored</y>    ] {}", self._container.name)
-        attempt = 0
-        # FIXME: in case containers are restarted after reboot, sometime we hit
-        # the degraded state.
-        # So be sure to wait long enough to claim it started.
-        # https://discuss.linuxcontainers.org/t/snap-lxd-activate-service-hanging-after-system-reboot/8374/16
-        max_attempt = 60
-        old_out = ''
-        while attempt < max_attempt:
-            time.sleep(1)
-            (ret, out, err) = self._container.execute(
-                ['systemctl', 'is-system-running'])
-            if out != old_out:
-                logger.opt(colors=True).debug(
-                    "[<y>{: <12}</y>] {}", out.rstrip(), self._container.name)
-                old_out = out
-            if 'running' in out:
-                break
-            elif 'degraded' in out:
-                break
-            attempt += 1
-        else:
-            raise SystemExit(
-                "Rollback to {} failed (systemd not in running state)".format(
-                    savepoint))
+        if self.config.role == 'service':
+            attempt = 0
+            max_attempt = 60
+            old_out = ''
+            while attempt < max_attempt:
+                time.sleep(1)
+                (ret, out, err) = self._container.execute(
+                    ['systemctl', 'is-system-running'])
+                if out != old_out:
+                    logger.opt(colors=True).debug(
+                        "[<y>{: <12}</y>] {}",
+                        out.rstrip(), self._container.name)
+                    old_out = out
+                if 'starting' in out:
+                    break
+                elif 'running' in out:
+                    break
+                elif 'degraded' in out:
+                    break
+                attempt += 1
+            else:
+                raise SystemExit("Rollback failed (systemd not ready)")
 
     def put(self, filepath, data, mode=None, uid=1000, gid=1000):
         try:

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -289,7 +289,7 @@ class ContainerSourceMachine(ContainerBaseMachine):
         if self.config.role in ('remote', 'service'):
             commands += [
                 "sudo bash -c 'systemctl daemon-reload'",
-                "sudo bash -c 'systemctl enable checkbox-ng.service'",
+                "sudo bash -c 'systemctl enable checkbox-ng.service --now'",
             ]
             service_content = textwrap.dedent("""
                 [Unit]

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -40,11 +40,11 @@ class Runner:
         logger.add(
             sys.stdout,
             format=self._formatter,
-            level=args.log_level)
+            level=args.scenario_log_level)
         logger.level("TRACE", color="<w><dim>")
         logger.level("DEBUG", color="<w><dim>")
         # session config
-        if not args.config.exists():
+        if not args.config or not args.config.exists():
             raise SystemExit('Config file not found!')
         else:
             self.config = read_config(args.config)
@@ -52,12 +52,21 @@ class Runner:
             validate_config(self.config)
         # effective set of machine configs required by scenarios
         self.combo = set()
-        self.scn_variants = None
+        self.scn_variants = []
         self.machine_provider = None
         self.failed = False
-        self.tags = set(self.args.tags or [])
-        self.exclude_tags = set(self.args.exclude_tags or [])
-        self.hold_on_fail = self.args.hold_on_fail
+        try:
+            self.tags = set(self.args.tags or [])
+        except AttributeError:
+            self.tags = []
+        try:
+            self.exclude_tags = set(self.args.exclude_tags or [])
+        except AttributeError:
+            self.exclude_tags = []
+        try:
+            self.hold_on_fail = self.args.hold_on_fail
+        except AttributeError:
+            self.hold_on_fail = False
         self.debug_machine_setup = self.args.debug_machine_setup
         self.dispose = not self.args.do_not_dispose
         aggregator.load_all()
@@ -102,9 +111,8 @@ class Runner:
                 filtered_suite.append(scn)
         return filtered_suite
 
-    def setup(self):
+    def collect(self):
         self.scenarios = aggregator.all_scenarios()
-        self.scn_variants = []
         # Generate all scenario variants
         for scenario_cls in self.scenarios:
             for mode in scenario_cls.modes:
@@ -149,17 +157,19 @@ class Runner:
                             logger.debug("Adding scenario: [{}][{}] {}", mode, origin,
                                          scenario_cls.name)
                             self.scn_variants.append(scenario_cls(mode, alias))
-        if self.args.tags or self.args.exclude_tags:
-            if self.args.tags:
+        if self.tags or self.exclude_tags:
+            if self.tags:
                 logger.info('Including scenario tag(s): %s' % ', '.join(
-                    sorted(self.args.tags)))
-            if self.args.exclude_tags:
+                    sorted(self.tags)))
+            if self.exclude_tags:
                 logger.info('Excluding scenario tag(s): %s' % ', '.join(
-                    sorted(self.args.exclude_tags)))
+                    sorted(self.exclude_tags)))
             self.scn_variants = self._filter_scn_by_tags()
             if not self.scn_variants:
                 logger.warning('No match found!')
                 raise SystemExit(1)
+
+    def setup(self):
         self._gather_all_machine_spec()
         logger.debug("Combo: {}", self.combo)
         self.machine_provider = LxdMachineProvider(

--- a/metabox/metabox/lxd_profiles/checkbox.profile
+++ b/metabox/metabox/lxd_profiles/checkbox.profile
@@ -24,9 +24,11 @@ config:
       - pulseaudio
       - python3-jinja2
       - python3-markupsafe
+      - python3-packaging
       - python3-padme
       - python3-pip
       - python3-psutil
+      - python3-pyparsing
       - python3-requests-oauthlib
       - python3-tqdm
       - python3-urwid

--- a/metabox/metabox/main.py
+++ b/metabox/metabox/main.py
@@ -54,9 +54,9 @@ def main():
              'Can be used multiple times.',
     )
     parser.add_argument(
-        "--log", dest="log_level", choices=Core().levels.keys(),
+        "--log", dest="scenario_log_level", choices=Core().levels.keys(),
         default='SUCCESS',
-        help="Set the logging level",
+        help="Set the scenario logging level",
     )
     parser.add_argument(
         '--do-not-dispose', action='store_true',
@@ -73,6 +73,7 @@ def main():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         runner = Runner(parser.parse_args())
+        runner.collect()
         runner.setup()
         runner.run()
         raise SystemExit(not runner.wasSuccessful())

--- a/metabox/metabox/metabox-provider/manage.py
+++ b/metabox/metabox/metabox-provider/manage.py
@@ -2,8 +2,9 @@
 from plainbox.provider_manager import setup, N_
 
 setup(
-    name='2021.com.canonical.certification:metabox',
+    name='checkbox-provider-metabox',
+    namespace='com.canonical.certification',
     version="1.0",
-    description=N_("The 2021.com.canonical.certification:metabox provider"),
-    gettext_domain="2021_com_canonical_certification_metabox",
+    description=N_("Metabox provider"),
+    gettext_domain="checkbox-provider-metabox",
 )

--- a/metabox/metabox/metabox-provider/units/basic-jobs.pxu
+++ b/metabox/metabox/metabox-provider/units/basic-jobs.pxu
@@ -220,7 +220,7 @@ command: false
 estimated_duration: 25
 
 plugin: user-interact-verify
-id: graphics/glxgears
+id: metabox/graphics/glxgears
 command: glxgears; true
 _summary: Test that glxgears works
 _description:
@@ -232,3 +232,25 @@ _description:
  VERIFICATION:
      1. Did the 3d animation appear?
      2. Was the animation free from slowness/jerkiness?
+
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::audio
+id: metabox/audio/playback_auto
+estimated_duration: 5.0
+command:
+  audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  audio_settings.py set --device=pci --volume=50
+  gst_pipeline_test.py -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+  EXIT_CODE=$?
+  audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  exit $EXIT_CODE
+_description:
+ PURPOSE:
+     This test will check that internal speakers work correctly
+ STEPS:
+     1. Make sure that no external speakers or headphones are connected
+        When testing a desktop, you can skip this test if there is no
+        internal speaker, we will test the external output later
+     2. Commence the test to play a brief tone on your audio device
+ VERIFICATION:
+     Did you hear a tone?

--- a/metabox/metabox/metabox-provider/units/basic-tps.pxu
+++ b/metabox/metabox/metabox-provider/units/basic-tps.pxu
@@ -27,16 +27,16 @@ include:
  stub/user-interact-verify
 
 unit: test plan
-id: display-manual
-_name: Display Manual
+id: display-metabox
+_name: Display
 include:
-  graphics/glxgears
+  metabox/graphics/glxgears
 
 unit: test plan
-id: audio-manual
-_name: Audio Manual
+id: audio-metabox
+_name: Audio
 include:
-  com.canonical.certification::audio/playback_auto
+  metabox/audio/playback_auto
 
 unit: test plan
 id: config-automated

--- a/metabox/metabox/scenarios/basic/run-invocation.py
+++ b/metabox/metabox/scenarios/basic/run-invocation.py
@@ -29,9 +29,8 @@ from metabox.core.scenario import Scenario
 class RunTestplan(Scenario):
 
     modes = ['local']
-    config_override = {'local': {'releases': ['bionic']}}
     steps = [
-        Start('run 2021.com.canonical.certification::'
+        Start('run com.canonical.certification::'
               'basic-automated-passing', timeout=30),
         AssertRetCode(0)
     ]
@@ -41,7 +40,7 @@ class RunFailingTestplan(Scenario):
 
     modes = ['local']
     steps = [
-        Start('run 2021.com.canonical.certification::'
+        Start('run com.canonical.certification::'
               'basic-automated-failing', timeout=30),
         AssertRetCode(0)
     ]
@@ -52,7 +51,7 @@ class RunTestplanWithEnvvar(Scenario):
     modes = ['local']
     environment = {'foo': 42}
     steps = [
-        Start('run 2021.com.canonical.certification::basic-automated',
+        Start('run com.canonical.certification::basic-automated',
               timeout=30),
         AssertPrinted("foo: 42"),
     ]
@@ -62,7 +61,7 @@ class RunManualplan(Scenario):
 
     modes = ['local']
     steps = [
-        Start('run 2021.com.canonical.certification::basic-manual'),
+        Start('run com.canonical.certification::basic-manual'),
         Expect('Pick an action'),
         Send(keys.KEY_ENTER),
         Expect('Pick an action', timeout=30),

--- a/metabox/metabox/scenarios/cert_blocker_comment/launcher.py
+++ b/metabox/metabox/scenarios/cert_blocker_comment/launcher.py
@@ -38,7 +38,7 @@ class ManualJobFailed(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::cert-blocker-manual
+        unit = com.canonical.certification::cert-blocker-manual
         forced = yes
         [test selection]
         forced = yes
@@ -71,7 +71,7 @@ class ManualJobSkipped(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::cert-blocker-manual
+        unit = com.canonical.certification::cert-blocker-manual
         forced = yes
         [test selection]
         forced = yes
@@ -105,7 +105,7 @@ class UserInteractVerifyJobFailed(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::cert-blocker-user-interact-verify
+        unit = com.canonical.certification::cert-blocker-user-interact-verify
         forced = yes
         [test selection]
         forced = yes
@@ -141,7 +141,7 @@ class UserInteractVerifyJobSkippedAfterRun(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::cert-blocker-user-interact-verify
+        unit = com.canonical.certification::cert-blocker-user-interact-verify
         forced = yes
         [test selection]
         forced = yes
@@ -177,7 +177,7 @@ class UserInteractVerifyJobSkippedBeforeRun(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::cert-blocker-user-interact-verify
+        unit = com.canonical.certification::cert-blocker-user-interact-verify
         forced = yes
         [test selection]
         forced = yes
@@ -211,7 +211,7 @@ class UserInteractJobSkippedBeforeRun(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::cert-blocker-user-interact
+        unit = com.canonical.certification::cert-blocker-user-interact
         forced = yes
         [test selection]
         forced = yes
@@ -245,7 +245,7 @@ class ManualJobSkippedWhenResumingSession(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::cert-blocker-manual-resume
+        unit = com.canonical.certification::cert-blocker-manual-resume
         forced = yes
         [test selection]
         forced = yes

--- a/metabox/metabox/scenarios/config/environment.py
+++ b/metabox/metabox/scenarios/config/environment.py
@@ -38,7 +38,7 @@ class CheckboxConfXDG(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::config-automated
+        unit = com.canonical.certification::config-automated
         forced = yes
         [test selection]
         forced = yes
@@ -62,7 +62,7 @@ class CheckboxConfLocalHome(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::config-automated
+        unit = com.canonical.certification::config-automated
         forced = yes
         [test selection]
         forced = yes
@@ -86,7 +86,7 @@ class CheckboxConfRemoteHome(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::config-automated
+        unit = com.canonical.certification::config-automated
         forced = yes
         [test selection]
         forced = yes
@@ -110,7 +110,7 @@ class CheckboxConfSnap(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::config-automated
+        unit = com.canonical.certification::config-automated
         forced = yes
         [test selection]
         forced = yes
@@ -132,7 +132,7 @@ class CheckboxConfLauncher(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::config-automated
+        unit = com.canonical.certification::config-automated
         forced = yes
         [test selection]
         forced = yes
@@ -157,7 +157,7 @@ class CheckboxConfLocalHomePrecedence(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::config-automated
+        unit = com.canonical.certification::config-automated
         forced = yes
         [test selection]
         forced = yes
@@ -182,7 +182,7 @@ class CheckboxConfLauncherPrecedence(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::config-automated
+        unit = com.canonical.certification::config-automated
         forced = yes
         [test selection]
         forced = yes
@@ -220,7 +220,7 @@ class CheckboxConfLocalResolutionOrder(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::config-automated
+        unit = com.canonical.certification::config-automated
         forced = yes
         [test selection]
         forced = yes
@@ -254,7 +254,7 @@ class CheckboxConfRemoteServiceResolutionOrder(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::config-automated
+        unit = com.canonical.certification::config-automated
         forced = yes
         [test selection]
         forced = yes

--- a/metabox/metabox/scenarios/config/test_selection.py
+++ b/metabox/metabox/scenarios/config/test_selection.py
@@ -56,7 +56,6 @@ class TestSelectionForced(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        #unit = 2021.com.canonical.certification::config-automated
         unit = com.canonical.certification::smoke
         forced = yes
         [test selection]
@@ -79,7 +78,7 @@ class TestSelectionExcludedJob(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::config-automated
+        unit = com.canonical.certification::config-automated
         forced = yes
         [test selection]
         forced = yes
@@ -112,7 +111,7 @@ class LocalTestSelectionResolution(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::config-automated
+        unit = com.canonical.certification::config-automated
         forced = yes
         [test selection]
         exclude =
@@ -147,7 +146,7 @@ class RemoteTestSelectionResolution(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::config-automated
+        unit = com.canonical.certification::config-automated
         forced = yes
         [test selection]
         exclude =

--- a/metabox/metabox/scenarios/desktop_env/launcher.py
+++ b/metabox/metabox/scenarios/desktop_env/launcher.py
@@ -35,7 +35,7 @@ class GlxGears(Scenario):
     launcher_version = 1
     stock_reports = text
     [test plan]
-    unit = 2021.com.canonical.certification::display-manual
+    unit = com.canonical.certification::display-metabox
     forced = yes
     [test selection]
     forced = yes
@@ -58,7 +58,7 @@ class AudioPlayback(Scenario):
     launcher_version = 1
     stock_reports = text
     [test plan]
-    unit = 2021.com.canonical.certification::audio-manual
+    unit = com.canonical.certification::audio-metabox
     forced = yes
     [test selection]
     forced = yes

--- a/metabox/metabox/scenarios/urwid/testplan.py
+++ b/metabox/metabox/scenarios/urwid/testplan.py
@@ -29,22 +29,10 @@ class UrwidTestPlanSelection(Scenario):
     modes = ['local']
     steps = [
         Expect('Select test plan'),
-        #SelectTestPlan('com.canonical.certification::stress-pm-graph'),
-        #SelectTestPlan(
-        #    'com.canonical.certification::'
-        #    'after-suspend-graphics-discrete-gpu-cert-automated'),
         SelectTestPlan(
             'com.canonical.certification::client-cert-desktop-18-04'),
         Send(keys.KEY_ENTER),
         Expect('Choose tests to run on your system:'),
         Send('d' + keys.KEY_ENTER),
         Expect('Choose tests to run on your system:'),
-        #Send(keys.KEY_DOWN * 18 + keys.KEY_SPACE + 't'),
-        #Expect('System Manifest:'),
-        #Send('y' * 11 + 't'),
-        Send('t'),
-        #Expect('Pick an action'),
-        #Send('s' + keys.KEY_ENTER),
-        #Expect('Finish'),
-        #Send('f' + keys.KEY_ENTER),
     ]

--- a/metabox/pytest.ini
+++ b/metabox/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = metabox/scenarios
+python_files = *.py


### PR DESCRIPTION
## Description

Set of optimizations/fixes for Metabox:
- New Metabox workflow based on pytest (with pytest only the failed scenarios will display the corresponding execution logs.)
- ZFS storage for much faster LXD snapshots (create and restore operations)
- Adopt the certification provider namespace (instead of the 2021 variant)
- Fix the metabox audio test (no dependency on udev resources) 

Tests

Tested and deployed in the staging env: https://github.com/canonical/checkbox-staging/actions/runs/3747735301/jobs/6364279483

## Resolved issues

- The total execution time for that workflow was nearly 45 minutes. The ZFS storage itself brings down the execution time to around 10 minutes.
- Pytest provides all the command line features required to execute metabox w/o having to reinvent them (fail-fast, collect-only, run only a subset of tests, capture or not the test output, test summary, test progress %, etc...)

## Documentation

Several examples of pytest commands added to the Metabox README file.

## Tests

Tested and deployed in the staging env: https://github.com/canonical/checkbox-staging/actions/runs/4957394688
