### PR TITLE
Fix stream scraping in AssertPrint and AssertNotPrint

### DIFF
--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -123,8 +123,9 @@ class Scenario:
         regex = re.compile(pattern)
         if self._pts:
             found = (
-                regex.search(self._pts.stdout_data_full.decode('utf-8', errors='ignore')) or
-                regex.search(self._pts.stderr.decode('utf-8', errors='ignore'))
+                regex.search(
+                    self._pts.stdout_data_full.decode('utf-8', errors='ignore')
+                )
             )
         else:
             found = regex.search(self._stdout) or regex.search(self._stderr)
@@ -184,6 +185,7 @@ class Scenario:
         return self.service_machine.start_service(force)
 
     def expect(self, data, timeout=60):
+        breakpoint()
         assert(self._pts is not None)
         outcome = self._pts.expect(data, timeout)
         self._checks.append(outcome)

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -110,7 +110,9 @@ class Scenario:
         :param patter: regular expresion to check against the lines.
         """
         regex = re.compile(pattern)
-        self._checks.append(bool(regex.search(self._stdout)))
+        self._checks.append(
+            bool(regex.search(self._stdout)) or bool(regex.search(self._stderr))
+        )
 
     def assert_not_printed(self, pattern):
         """
@@ -120,11 +122,13 @@ class Scenario:
         """
         regex = re.compile(pattern)
         if self._pts:
-            self._checks.append(
-                bool(not regex.search(self._pts.stdout_data_full.decode(
-                    'utf-8', errors='ignore'))))
+            found = (
+                regex.search(self._pts.stdout_data_full.decode('utf-8', errors='ignore')) or
+                regex.search(self._pts.stderr.decode('utf-8', errors='ignore'))
+            )
         else:
-            self._checks.append(bool(not regex.search(self._stdout)))
+            found = regex.search(self._stdout) or regex.search(self._stderr)
+        self._checks.append(not found)
 
     def assert_ret_code(self, code):
         """Check if Checkbox returned given code."""

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -185,7 +185,6 @@ class Scenario:
         return self.service_machine.start_service(force)
 
     def expect(self, data, timeout=60):
-        breakpoint()
         assert(self._pts is not None)
         outcome = self._pts.expect(data, timeout)
         self._checks.append(outcome)


### PR DESCRIPTION
Fixed so that both functions search in stdout and stderr for the provided regex

## Description

This makes metabox's AssertPrinted and AssertNotPrinted steps also look into stderr

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/455

## Documentation

This does not change the meaning of the action so it should not require any update to the documentation

## Tests

I have run locally the following: 
```
$ metabox remote-source-22.04.py --do-not-dispose --tag config
```
