### PR TITLE
add: metabox scenarios for the daemon section

### DIFF
--- a/metabox/metabox/metabox-provider/units/configs-testing.pxu
+++ b/metabox/metabox/metabox-provider/units/configs-testing.pxu
@@ -5,5 +5,5 @@ _summary: Print who is running the job
 
 id: whoami_as_user_tp
 unit: test plan
-_name: Priting who runs the job
+_name: Printing who runs the job
 include: whoami_as_user

--- a/metabox/metabox/metabox-provider/units/configs-testing.pxu
+++ b/metabox/metabox/metabox-provider/units/configs-testing.pxu
@@ -1,0 +1,9 @@
+id: whoami_as_user
+plugin: shell
+command: echo -n user:&& whoami
+_summary: Print who is running the job
+
+id: whoami_as_user_tp
+unit: test plan
+_name: Priting who runs the job
+include: whoami_as_user

--- a/metabox/metabox/scenarios/config/config_files/daemon_section_only.conf
+++ b/metabox/metabox/scenarios/config/config_files/daemon_section_only.conf
@@ -1,0 +1,2 @@
+[daemon]
+normal_user = config_user

--- a/metabox/metabox/scenarios/config/daemon.py
+++ b/metabox/metabox/scenarios/config/daemon.py
@@ -1,0 +1,129 @@
+import textwrap
+from importlib.resources import read_text
+
+from metabox.core.actions import AssertPrinted
+from metabox.core.actions import Start
+from metabox.core.actions import Put
+from metabox.core.actions import RunCmd
+from metabox.core.scenario import Scenario
+from metabox.core.utils import tag
+
+from . import config_files
+
+
+@tag("daemon", "normal_user")
+class DaemonNormalUserSetInLauncherNoConfig(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::whoami_as_user_tp
+        forced = yes
+        [test selection]
+        forced = yes
+        [daemon]
+        normal_user = launcher_user
+        """
+    )
+    steps = [
+        RunCmd("sudo useradd launcher_user"),
+        Start(),
+        AssertPrinted("user:launcher_user"),
+    ]
+
+
+@tag("daemon", "normal_user")
+class DaemonNormalUserSetInConfig(Scenario):
+    modes = ["remote"]
+    checkbox_conf_xdg = read_text(config_files, "daemon_section_only.conf")
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::whoami_as_user_tp
+        forced = yes
+        [test selection]
+        forced = yes
+        """
+    )
+    steps = [
+        Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="service"),
+        RunCmd("sudo useradd config_user"),
+        Start(),
+        AssertPrinted("user:config_user"),
+    ]
+
+
+@tag("daemon", "normal_user")
+class DaemonNormalUserOverwittenByLauncher(Scenario):
+    modes = ["remote"]
+    checkbox_conf_xdg = read_text(config_files, "daemon_section_only.conf")
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::whoami_as_user_tp
+        forced = yes
+        [test selection]
+        forced = yes
+        [daemon]
+        normal_user = launcher_user
+        """
+    )
+    steps = [
+        Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="service"),
+        RunCmd("sudo useradd launcher_user"),
+        Start(),
+        AssertPrinted("user:launcher_user"),
+    ]
+
+
+@tag("daemon", "normal_user")
+class DaemonNormalUserGuessed(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::whoami_as_user_tp
+        forced = yes
+        [test selection]
+        forced = yes
+        """
+    )
+    steps = [
+        Start(),
+        AssertPrinted("user:ubuntu"),
+    ]
+
+
+@tag("daemon", "normal_user")
+class DaemonNormalUserDoesntExist(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::whoami_as_user_tp
+        forced = yes
+        [test selection]
+        forced = yes
+        [daemon]
+        normal_user = testuser
+        """
+    )
+    steps = [
+        Start(),
+        AssertPrinted("User 'testuser' doesn't exist!"),
+    ]

--- a/metabox/metabox/scenarios/config/environment.py
+++ b/metabox/metabox/scenarios/config/environment.py
@@ -23,7 +23,6 @@ from metabox.core.actions import AssertPrinted
 from metabox.core.actions import Start
 from metabox.core.actions import Put
 from metabox.core.scenario import Scenario
-from metabox.core.utils import tag
 
 from .config_files import environment
 

--- a/metabox/metabox/scenarios/config/environment.py
+++ b/metabox/metabox/scenarios/config/environment.py
@@ -23,6 +23,7 @@ from metabox.core.actions import AssertPrinted
 from metabox.core.actions import Start
 from metabox.core.actions import Put
 from metabox.core.scenario import Scenario
+from metabox.core.utils import tag
 
 from .config_files import environment
 
@@ -260,11 +261,13 @@ class CheckboxConfRemoteServiceResolutionOrder(Scenario):
         forced = yes
         [environment]
         var2 = LAUNCHER
-        """)
+        """
+    )
     steps = [
         Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="service"),
-        Put("/root/.config/checkbox.conf", checkbox_conf_home,
-            target="service"),
+        Put(
+            "/root/.config/checkbox.conf", checkbox_conf_home, target="service"
+        ),
         Start(),
         AssertPrinted("variables: HOME LAUNCHER XDG"),
     ]


### PR DESCRIPTION
## Description
This PR brings new scenarios for the [daemon] section of configs and launchers.

## Resolved issues
[CHECKBOX-438](https://warthogs.atlassian.net/jira/software/c/projects/CHECKBOX/boards/590?modal=detail&selectedIssue=CHECKBOX-438)

Tested by running metabox locally.


[CHECKBOX-438]: https://warthogs.atlassian.net/browse/CHECKBOX-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ