### PR TITLE
Fix: Import checkbox-ng version from the repo not from pypi

### DIFF
--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -1,4 +1,6 @@
-checkbox-ng
+psutil
+urwid
+tqdm
 sphinx
 sphinx-autobuild
 sphinx-design

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,10 +1,12 @@
 import datetime
+import os
 import sys
 
-try:
-    import checkbox_ng
-except ImportError:
-    raise SystemExit("checkbox_ng has to be importable")
+sys.path.append(os.path.abspath(
+    os.path.join(__file__, "../../checkbox-ng")
+))
+
+import checkbox_ng
 
 # Configuration file for the Sphinx documentation builder.
 #


### PR DESCRIPTION
## Description

Fix the Checkbox documentation version on RTD (always rendered as 1.18.1)

## Resolved issues

checkbox-ng was imported from the version installed via pip, not from source.

## Tests

Tested locally using `make install` and `make run`
