### PR TITLE
Fix the Metabox workflow to allow manual runs via workflow_dispatch

### DIFF
--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -29,7 +29,7 @@ jobs:
           fi
 
   Metabox:
-    if: (github.event.review.state == 'approved' || github.event_name == 'workflow_dispatch') && needs.metabox_run_required.outputs.required_run == 'true'
+    if: (github.event.review.state == 'approved' && needs.metabox_run_required.outputs.required_run == 'true') || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

Fix the metabox workflow to allow manual runs (don't depend on `metabox_run_required`)
This is a cherry-pick from https://github.com/canonical/checkbox/pull/453

## Resolved issues

Metabox workflows was not possible to trigger manually

## Tests

See https://github.com/canonical/checkbox/pull/453
