### PR TITLE
Switch to the ZFS storage driver for LXD

### DIFF
--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -50,9 +50,17 @@ jobs:
       - name: Checkout Checkbox monorepo
         uses: actions/checkout@v3
       - name: Setup LXD
-        uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
-      - name: Install pyopenssl
-        run: python3 -m pip install pyopenssl --upgrade
+        uses: canonical/setup-lxd@v0.1.1
+      - name: Add ZFS storage
+        run: |
+          lxc storage list
+          lxc profile device remove default root
+          lxc storage delete default
+          lxc storage create metabox${{ matrix.os }} zfs
+          lxc profile device add default root disk path=/ pool=metabox${{ matrix.os }}
+          lxc storage list
+      - name: Install dependencies
+        run: python3 -m pip install --upgrade pyopenssl
       - name: Install Metabox
         run: python3 -m pip install -e .
       - name: Run Metabox scenarios

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -94,30 +94,28 @@ class ContainerBaseMachine:
         self._container.start(wait=True)
         logger.opt(colors=True).debug(
             "[<y>restored</y>    ] {}", self._container.name)
-        attempt = 0
-        # FIXME: in case containers are restarted after reboot, sometime we hit
-        # the degraded state.
-        # So be sure to wait long enough to claim it started.
-        # https://discuss.linuxcontainers.org/t/snap-lxd-activate-service-hanging-after-system-reboot/8374/16
-        max_attempt = 60
-        old_out = ''
-        while attempt < max_attempt:
-            time.sleep(1)
-            (ret, out, err) = self._container.execute(
-                ['systemctl', 'is-system-running'])
-            if out != old_out:
-                logger.opt(colors=True).debug(
-                    "[<y>{: <12}</y>] {}", out.rstrip(), self._container.name)
-                old_out = out
-            if 'running' in out:
-                break
-            elif 'degraded' in out:
-                break
-            attempt += 1
-        else:
-            raise SystemExit(
-                "Rollback to {} failed (systemd not in running state)".format(
-                    savepoint))
+        if self.config.role == 'service':
+            attempt = 0
+            max_attempt = 60
+            old_out = ''
+            while attempt < max_attempt:
+                time.sleep(1)
+                (ret, out, err) = self._container.execute(
+                    ['systemctl', 'is-system-running'])
+                if out != old_out:
+                    logger.opt(colors=True).debug(
+                        "[<y>{: <12}</y>] {}",
+                        out.rstrip(), self._container.name)
+                    old_out = out
+                if 'starting' in out:
+                    break
+                elif 'running' in out:
+                    break
+                elif 'degraded' in out:
+                    break
+                attempt += 1
+            else:
+                raise SystemExit("Rollback failed (systemd not ready)")
 
     def put(self, filepath, data, mode=None, uid=1000, gid=1000):
         try:

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -95,25 +95,15 @@ class ContainerBaseMachine:
         logger.opt(colors=True).debug(
             "[<y>restored</y>    ] {}", self._container.name)
         if self.config.role == 'service':
-            attempt = 0
-            max_attempt = 60
-            old_out = ''
-            while attempt < max_attempt:
+            attempts_left = 60
+            out = ''
+            while attempts_left and out.rstrip() not in (
+                'starting', 'running', 'degraded'
+            ):
                 time.sleep(1)
                 (ret, out, err) = self._container.execute(
                     ['systemctl', 'is-system-running'])
-                if out != old_out:
-                    logger.opt(colors=True).debug(
-                        "[<y>{: <12}</y>] {}",
-                        out.rstrip(), self._container.name)
-                    old_out = out
-                if 'starting' in out:
-                    break
-                elif 'running' in out:
-                    break
-                elif 'degraded' in out:
-                    break
-                attempt += 1
+                attempts_left -= 1
             else:
                 raise SystemExit("Rollback failed (systemd not ready)")
 

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -289,7 +289,7 @@ class ContainerSourceMachine(ContainerBaseMachine):
         if self.config.role in ('remote', 'service'):
             commands += [
                 "sudo bash -c 'systemctl daemon-reload'",
-                "sudo bash -c 'systemctl enable checkbox-ng.service'",
+                "sudo bash -c 'systemctl enable checkbox-ng.service --now'",
             ]
             service_content = textwrap.dedent("""
                 [Unit]


### PR DESCRIPTION
## Description

ZFS storage for much faster LXD snapshots (create and restore operations).
See https://linuxcontainers.org/lxd/docs/latest/reference/storage_drivers/#feature-comparison

## Resolved issues

The total execution time for that workflow was nearly 45 minutes. The ZFS storage itself brings down the execution time to around 10 minutes.

## Tests

See https://github.com/canonical/checkbox/pull/453
