### PR TITLE
Fix: make a warning about bad secure_id more informative

### DIFF
--- a/checkbox-ng/checkbox_ng/certification.py
+++ b/checkbox-ng/checkbox_ng/certification.py
@@ -121,5 +121,8 @@ class SubmissionServiceTransport(TransportBase):
 
     def _validate_secure_id(self, secure_id):
         if not re.match(SECURE_ID_PATTERN, secure_id):
-            raise InvalidSecureIDError(
-                _("secure_id must be 15-character (or more) alphanumeric string"))
+            message = _((
+                "{} is not a valid secure_id. secure_id must be a "
+                "15-character (or more) alphanumeric string"
+            ).format(secure_id))
+            raise InvalidSecureIDError(message)

--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -552,8 +552,8 @@ class ReportsStage(CheckboxUiStage):
                         # again
                         self.transports.pop(params['transport'])
                         continue
-                except InvalidSecureIDError:
-                    _logger.warning(_("Invalid secure_id"))
+                except InvalidSecureIDError as exc:
+                    _logger.warning( _("Invalid secure_id: %s"), exc)
                     if not self.is_interactive:
                         # secure_id will not magically change if the session
                         # is a non-interactive one, so let's stop trying


### PR DESCRIPTION
## Description
This adds more context to the InvalidSecureIDError so we can properly test it in metabox.

## Testing:
Tested by running sessions with different secure_ids.
