### PR TITLE
Metabox transport scenarios

### DIFF
--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -104,7 +104,7 @@ class ContainerBaseMachine:
                 (ret, out, err) = self._container.execute(
                     ['systemctl', 'is-system-running'])
                 attempts_left -= 1
-            else:
+            if not attempts_left:
                 raise SystemExit("Rollback failed (systemd not ready)")
 
     def put(self, filepath, data, mode=None, uid=1000, gid=1000):

--- a/metabox/metabox/scenarios/config/config_files/custom_transport.conf
+++ b/metabox/metabox/scenarios/config/config_files/custom_transport.conf
@@ -1,0 +1,11 @@
+[transport:config_transport]
+type = submission-service
+staging = yes
+secure_id = config
+
+[exporter:json]
+unit = com.canonical.plainbox::json
+
+[report:config_report]
+transport = config_transport
+exporter = json

--- a/metabox/metabox/scenarios/config/transport.py
+++ b/metabox/metabox/scenarios/config/transport.py
@@ -1,0 +1,112 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Maciej Kisielewski <maciej.kisielewski@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+import textwrap
+from importlib.resources import read_text
+
+from metabox.core.actions import AssertPrinted
+from metabox.core.actions import Put
+from metabox.core.actions import Start
+from metabox.core.scenario import Scenario
+from metabox.core.utils import tag
+
+from . import config_files
+
+
+@tag("config", "transport")
+class TransportSecureIDSetInLauncherOnly(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        [ui]
+        type = silent
+        [test plan]
+        unit = 2021.com.canonical.certification::basic-automated-passing
+        forced = yes
+        [test selection]
+        forced = yes
+        [transport:launcher_transport]
+        type = submission-service
+        staging = yes
+        secure_id = launcher
+        [exporter:json]
+        unit = com.canonical.plainbox::json
+        [report:launcher_report]
+        transport = launcher_transport
+        exporter = json
+        """
+    )
+    steps = [Start(), AssertPrinted("launcher is not a valid secure_id")]
+
+
+@tag("config", "transport")
+class TransportSecureIDSetInConfigOnly(Scenario):
+    modes = ["remote"]
+    checkbox_conf_xdg = read_text(config_files, "custom_transport.conf")
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        [ui]
+        type = silent
+        [test plan]
+        unit = 2021.com.canonical.certification::basic-automated-passing
+        forced = yes
+        [test selection]
+        forced = yes
+        """
+    )
+    steps = [
+        Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="service"),
+        Start(),
+        AssertPrinted("config is not a valid secure_id"),
+    ]
+
+
+@tag("config", "transport")
+class TransportSecureIDOverwrittenByLauncher(Scenario):
+    modes = ["remote"]
+    checkbox_conf_xdg = read_text(config_files, "custom_transport.conf")
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        [ui]
+        type = silent
+        [test plan]
+        unit = 2021.com.canonical.certification::basic-automated-passing
+        forced = yes
+        [test selection]
+        forced = yes
+        [transport:launcher_transport]
+        type = submission-service
+        staging = yes
+        secure_id = launcher
+        [exporter:json]
+        unit = com.canonical.plainbox::json
+        [report:launcher_report]
+        transport = launcher_transport
+        exporter = json
+        """
+    )
+    steps = [
+        Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="service"),
+        Start(),
+        AssertPrinted("launcher is not a valid secure_id"),
+    ]


### PR DESCRIPTION
## Description
This PR brings metabox scenarios for the configuration of the transport section of configs/launchers.

It mostly revolves around manipulating secure_id, as this is the most important bit of the transport section.
See individual scenarios for details.

## Resolved issues
Resolves: [CHECKBOX-441](https://warthogs.atlassian.net/jira/software/c/projects/CHECKBOX/boards/590?modal=detail&selectedIssue=CHECKBOX-441)

Tested and testable using Metabox.

[CHECKBOX-441]: https://warthogs.atlassian.net/browse/CHECKBOX-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ