### PR TITLE
Fix put crash metabox

### DIFF
--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -117,14 +117,16 @@ class ContainerBaseMachine:
         Returns:
             True if successful, False otherwise.
         """
-        with suppress(pylxd.exceptions.NotFound):
+        # Catch LXDAPIException because sometimes it is raised instead of
+        #  NotFound
+        with suppress(pylxd.exceptions.LXDAPIException):
             self._container.files.put(filepath, data, mode, uid, gid)
             return True
         dirname = os.path.dirname(filepath)
         logger.debug(("Cannot put {} on container. Trying to create"
                       " directory {} and put the file again..."), filepath,
                      dirname)
-        with suppress(pylxd.exceptions.NotFound):
+        with suppress(pylxd.exceptions.LXDAPIException):
             self._container.files.mk_dir(dirname, mode, uid, gid)
             self._container.files.put(filepath, data, mode, uid, gid)
             return True

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -232,14 +232,17 @@ class Scenario:
     def put(self, filepath, data, mode=None, uid=1000, gid=1000, target='all'):
         if self.mode == 'remote':
             if target == 'remote':
-                self.remote_machine.put(filepath, data, mode, uid, gid)
+                ok = self.remote_machine.put(filepath, data, mode, uid, gid)
             elif target == 'service':
-                self.service_machine.put(filepath, data, mode, uid, gid)
+                ok = self.service_machine.put(filepath, data, mode, uid, gid)
             else:
-                self.remote_machine.put(filepath, data, mode, uid, gid)
-                self.service_machine.put(filepath, data, mode, uid, gid)
+                ok = (
+                    self.remote_machine.put(filepath, data, mode, uid, gid) and
+                    self.service_machine.put(filepath, data, mode, uid, gid)
+                )
         else:
-            self.local_machine.put(filepath, data, mode, uid, gid)
+            res = self.local_machine.put(filepath, data, mode, uid, gid)
+        self._check.append(ok)
 
     def switch_on_networking(self, target='all'):
         if self.mode == 'remote':

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -242,7 +242,7 @@ class Scenario:
                 )
         else:
             res = self.local_machine.put(filepath, data, mode, uid, gid)
-        self._check.append(ok)
+        self._checks.append(ok)
 
     def switch_on_networking(self, target='all'):
         if self.mode == 'remote':

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -241,7 +241,7 @@ class Scenario:
                     self.service_machine.put(filepath, data, mode, uid, gid)
                 )
         else:
-            res = self.local_machine.put(filepath, data, mode, uid, gid)
+            ok = self.local_machine.put(filepath, data, mode, uid, gid)
         self._checks.append(ok)
 
     def switch_on_networking(self, target='all'):

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -232,17 +232,14 @@ class Scenario:
     def put(self, filepath, data, mode=None, uid=1000, gid=1000, target='all'):
         if self.mode == 'remote':
             if target == 'remote':
-                ok = self.remote_machine.put(filepath, data, mode, uid, gid)
+                self.remote_machine.put(filepath, data, mode, uid, gid)
             elif target == 'service':
-                ok = self.service_machine.put(filepath, data, mode, uid, gid)
+                self.service_machine.put(filepath, data, mode, uid, gid)
             else:
-                ok = (
-                    self.remote_machine.put(filepath, data, mode, uid, gid) and
-                    self.service_machine.put(filepath, data, mode, uid, gid)
-                )
+                self.remote_machine.put(filepath, data, mode, uid, gid)
+                self.service_machine.put(filepath, data, mode, uid, gid)
         else:
-            ok = self.local_machine.put(filepath, data, mode, uid, gid)
-        self._checks.append(ok)
+            self.local_machine.put(filepath, data, mode, uid, gid)
 
     def switch_on_networking(self, target='all'):
         if self.mode == 'remote':


### PR DESCRIPTION
## Description

If a scenario contains a Put action to a location that can not be written, this will raise an uncaught pylxd.exceptions.NotFound crashing metabox

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/472

## Documentation

N/A

## Tests

N/A