### PR TITLE
Modify reboot cold boot rewrite reboot check

### DIFF
--- a/providers/base/bin/reboot_check_test.sh
+++ b/providers/base/bin/reboot_check_test.sh
@@ -7,7 +7,7 @@ fwts_check="true"
 
 
 fwts_support_check(){
-    echo -e "\n## Check if support fwts.."
+    echo -e "\n## Checking if support fwts..."
     if  type -p fwts > /dev/null ; then
         echo "FWTS supported"
         fwts_supported="true"
@@ -15,12 +15,12 @@ fwts_support_check(){
 }
 
 run_fwts(){
-    echo -e "\n## Run fwts of test: $*"
+    echo -e "\n## Running FWTS of test: $*..."
     fwts -r "$output_dir"/fwts_klog_oops.log "$@"
 }
 
 fwts_log_check(){
-    echo -e "\n## Check fwts log failures.."
+    echo -e "\n## Checking FWTS log failures..."
     fwts_log_path="$output_dir"/fwts_klog_oops.log
     if [[ -f "$fwts_log_path" ]]; then
         sleep_test_log_check.py -v --ignore-warning -t all "$output_dir"/fwts_klog_oops.log
@@ -34,7 +34,7 @@ fwts_log_check(){
 }
 
 service_check() {
-    echo -e "\n## Check system service.."
+    echo -e "\n## Checking system services..."
     COUNT=$(systemctl --system --no-ask-password --no-pager --no-legend list-units --state=failed | wc -l)
     printf "Found %s failed units\n" "$COUNT"
     if [ "$COUNT" != 0 ]; then
@@ -45,27 +45,30 @@ service_check() {
 }
 
 dump() {
-    echo "## Dump the devices information to $output_dir.."
+    echo "## Dumping the devices information to $output_dir..."
     mkdir -p "$output_dir"
+    echo "Gathering information about PCI devices (lspci)..."
     lspci -i "$SNAP"/usr/share/misc/pci.ids > "$output_dir"/lspci_log
+    echo "Gathering information about WiFi connections (iw)..."
     iw dev | grep "Interface\|addr\|ssid" > "$output_dir"/wifi_conn
+    echo "Gathering information about USB devices (lsusb)..."
     checkbox-support-lsusb -f "$CHECKBOX_RUNTIME"/var/lib/usbutils/usb.ids -s | sort > "$output_dir"/lsusb_log
     echo "dump devices complete"
     sync
 }
 
 compare() {
-    echo -e "\n## Compare the devices.."
+    echo -e "\n## Comparing the devices..."
     if ! diff -u "$compare_dir"/lspci_log "$output_dir"/lspci_log; then
-        echo "lspci mismatch during cycle"
+        echo "The list of PCI devices (lspci) is different from the original list gathered at the beginning of the session!"
         device_check="false"
     fi
     if ! diff -u "$compare_dir"/wifi_conn "$output_dir"/wifi_conn; then
-        echo "wifi mismatch during cycle"
+        echo "The list of WiFi connections (iw) is different from the original list gathered at the beginning of the session!"
         device_check="false"
     fi
     if ! diff -u "$compare_dir"/lsusb_log "$output_dir"/lsusb_log; then
-        echo "lsusb mismatch during cycle"
+        echo "The list of USB devices (lsusb) is different from the original list gathered at the beginning of the session!"
         device_check="false"
     fi
 
@@ -104,9 +107,10 @@ main() {
 
 
 help_function() {
-    echo "This script is uses for collect device and compare the difference of device during every reboot iteration"
+    echo "This script is used to collect device information and to check for differences between reboots."
     echo
-    echo "Usage: cold_reboot_by_pdu.sh -t type -p pud-ip:outlet-port"
+    echo "Usage: reboot_check_test.sh -d Output_directory"
+    echo "       reboot_check_test.sh -d Output_directory -c Comparing_directory -s -f"
     echo -e "\t-d    Output directory."
     echo -e "\t-c    The target directory for comparing device"
     echo -e "\t-s    Do service check"

--- a/providers/base/bin/reboot_check_test.sh
+++ b/providers/base/bin/reboot_check_test.sh
@@ -2,6 +2,36 @@
 
 device_check="true"
 service_check="true"
+fwts_supported="false"
+fwts_check="true"
+
+
+fwts_support_check(){
+    echo -e "\n## Check if support fwts.."
+    if  type -p fwts > /dev/null ; then
+        echo "FWTS supported"
+        fwts_supported="true"
+    fi
+}
+
+run_fwts(){
+    echo -e "\n## Run fwts of test: $*"
+    fwts -r "$output_dir"/fwts_klog_oops.log "$@"
+}
+
+fwts_log_check(){
+    echo -e "\n## Check fwts log failures.."
+    fwts_log_path="$output_dir"/fwts_klog_oops.log
+    if [[ -f "$fwts_log_path" ]]; then
+        sleep_test_log_check.py -v --ignore-warning -t all "$output_dir"/fwts_klog_oops.log
+        return_code=$?
+        if [[ $return_code != 0 ]]; then
+            fwts_check="false"
+        fi
+    else
+        fwts_check="false"
+    fi
+}
 
 service_check() {
     echo -e "\n## Check system service.."
@@ -45,6 +75,11 @@ compare() {
 main() {
     if  [[ -n "$output_dir" ]]; then
         dump
+        fwts_support_check
+        if "$fwts_supported"; then
+            run_fwts "klog" "oops"
+            fwts_log_check
+        fi
     fi
 
     if [[ -n "$compare_dir" ]]; then
@@ -61,7 +96,8 @@ main() {
     fi
 
     if [[ -n "$service_opt" && "$service_check" == "false" ]] || \
-       [[ -n "$compare_dir" && "$device_check" == "false" ]]; then
+       [[ -n "$compare_dir" && "$device_check" == "false" ]] || \
+       [[ -n "$fwts_opt" && "$fwts_check" == "false" ]]; then
         exit 1
     fi
 }
@@ -74,16 +110,19 @@ help_function() {
     echo -e "\t-d    Output directory."
     echo -e "\t-c    The target directory for comparing device"
     echo -e "\t-s    Do service check"
+    echo -e "\t-f    Do fwts log failures check"
 }
 
 service_opt=""
+fwts_opt=""
 output_dir=""
 compare_dir=""
-while getopts "d:c:s" opt; do
+while getopts "d:c:sf" opt; do
     case "$opt" in
         d) output_dir="$OPTARG" ;;
         c) compare_dir="$OPTARG" ;;
         s) service_opt="True" ;;
+        f) fwts_opt="True" ;;
         ?) help_function ;;
     esac
 done

--- a/providers/base/bin/reboot_check_test.sh
+++ b/providers/base/bin/reboot_check_test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+device_check="true"
+service_check="true"
+
+service_check() {
+    echo -e "\n## Check system service.."
+    COUNT=$(systemctl --system --no-ask-password --no-pager --no-legend list-units --state=failed | wc -l)
+    printf "Found %s failed units\n" "$COUNT"
+    if [ "$COUNT" != 0 ]; then
+        printf "\nFailed units:\n"
+        systemctl --system --no-ask-password --no-pager list-units --state=failed
+        service_check="false"
+    fi
+}
+
+dump() {
+    echo "## Dump the devices information to $output_dir.."
+    mkdir -p "$output_dir"
+    lspci -i "$SNAP"/usr/share/misc/pci.ids > "$output_dir"/lspci_log
+    iw dev | grep "Interface\|addr\|ssid" > "$output_dir"/wifi_conn
+    checkbox-support-lsusb -f "$CHECKBOX_RUNTIME"/var/lib/usbutils/usb.ids -s | sort > "$output_dir"/lsusb_log
+    echo "dump devices complete"
+    sync
+}
+
+compare() {
+    echo -e "\n## Compare the devices.."
+    if ! diff -u "$compare_dir"/lspci_log "$output_dir"/lspci_log; then
+        echo "lspci mismatch during cycle"
+        device_check="false"
+    fi
+    if ! diff -u "$compare_dir"/wifi_conn "$output_dir"/wifi_conn; then
+        echo "wifi mismatch during cycle"
+        device_check="false"
+    fi
+    if ! diff -u "$compare_dir"/lsusb_log "$output_dir"/lsusb_log; then
+        echo "lsusb mismatch during cycle"
+        device_check="false"
+    fi
+
+    [[ "$device_check" == "true" ]] && echo "Device match during reboot cycle"
+}
+
+main() {
+    if  [[ -n "$output_dir" ]]; then
+        dump
+    fi
+
+    if [[ -n "$compare_dir" ]]; then
+        if  [[ -z "$output_dir" ]]; then
+            echo -e "Error: Please provide output directory!\n"
+            help_function
+            exit 1
+        fi
+        compare
+    fi
+
+    if [[ -n "$service_opt" ]]; then
+        service_check
+    fi
+
+    if [[ -n "$service_opt" && "$service_check" == "false" ]] || \
+       [[ -n "$compare_dir" && "$device_check" == "false" ]]; then
+        exit 1
+    fi
+}
+
+
+help_function() {
+    echo "This script is uses for collect device and compare the difference of device during every reboot iteration"
+    echo
+    echo "Usage: cold_reboot_by_pdu.sh -t type -p pud-ip:outlet-port"
+    echo -e "\t-d    Output directory."
+    echo -e "\t-c    The target directory for comparing device"
+    echo -e "\t-s    Do service check"
+}
+
+service_opt=""
+output_dir=""
+compare_dir=""
+while getopts "d:c:s" opt; do
+    case "$opt" in
+        d) output_dir="$OPTARG" ;;
+        c) compare_dir="$OPTARG" ;;
+        s) service_opt="True" ;;
+        ?) help_function ;;
+    esac
+done
+
+main

--- a/providers/base/bin/sleep_test_log_check.py
+++ b/providers/base/bin/sleep_test_log_check.py
@@ -42,11 +42,11 @@ import logging
 # and when a level ends.
 start_level_re = r'^(?P<level>.+) failures: (?P<numfails>NONE|\d+)$'
 start_level_re = re.compile(start_level_re)
-failure_re = re.compile(r'^ (?P<test>(s3|s4)): (?P<details>.+)$')
+failure_re = re.compile(r'^ (?P<test>(\w*)): (?P<details>.+)$')
 end_level_re = re.compile(r"$^")
 
 
-def parse_summary(summary, results):
+def parse_summary(summary, results, filter_test, ignore_warning):
     """
     Parses an entire "Test Failure Summary" section, which contains a short
     summary of failures observed per level. Returns nothing, but adds the
@@ -78,7 +78,8 @@ def parse_summary(summary, results):
                 # reports failures or not.  This is OK because we can later
                 # check results' keys to ensure we saw at least one level; if
                 # results has no keys, it could mean a malformed fwts log file.
-                parse_level(current_acum, results[current_level])
+                parse_level(current_acum, results[current_level],
+                            filter_test, ignore_warning)
             else:
                 logging.debug("Discarding junk")
             current_acum = []
@@ -87,7 +88,8 @@ def parse_summary(summary, results):
             current_acum.append(logline)
 
 
-def parse_level(level_lines, level_results):
+def parse_level(level_lines, level_results,
+                level_filter_test, level_ignore_warning):
     """
     Parses the level's lines, appending the failures to the level's results.
     level_results is a dictionary with a key per test type (s3, s4, and so on).
@@ -108,7 +110,12 @@ def parse_level(level_lines, level_results):
             test = failure_matches.group('test')
             details = failure_matches.group('details')
             logging.debug("fail %s was %s", test, details)
-            level_results[test].append(details)
+            if level_filter_test == 'all' or level_filter_test in test:
+                if level_ignore_warning:
+                    if 'Warning:' not in details:
+                        level_results[test].append(details)
+                else:
+                    level_results[test].append(details)
 
 
 def main():
@@ -126,13 +133,20 @@ def main():
                               provide a list of UNIQUE errors encountered in \
                               the log file. It will not display duplicates. \
                               Default is [%(default)s]")
-    parser.add_argument('test',
+    parser.add_argument('-t', '--test',
                         action='store',
-                        choices=['s3', 's4'],
-                        help='The test to check (s3 or s4)')
+                        default='all',
+                        help="The test (ie.s3 ,s4 ,klog ,oope ,...etc) \
+                              to check. Default is [%(default)s]")
     parser.add_argument('logfile',
                         action='store',
                         help='The log file to parse')
+    parser.add_argument('--ignore-warning',
+                        action='store_true',
+                        default=False,
+                        help="If ignore warning option is set, it will \
+                              not show any warning items. \
+                              Default is [%(default)s]")
 
     args = parser.parse_args()
 
@@ -156,14 +170,14 @@ def main():
     # levels and tests.
     for logline in log:
         if "Test Failure Summary" in logline:
-            parse_summary(sum_acum, results)
+            parse_summary(sum_acum, results, args.test, args.ignore_warning)
             summaries_found += 1
             sum_acum = []
         else:
             sum_acum.append(logline)
     # We reached the end, so add the last accumulated summary
     if sum_acum:
-        parse_summary(sum_acum, results)
+        parse_summary(sum_acum, results, args.test, args.ignore_warning)
 
     # Report what I found
     for level in sorted(results.keys()):

--- a/providers/base/bin/sleep_test_log_check.py
+++ b/providers/base/bin/sleep_test_log_check.py
@@ -53,13 +53,19 @@ def parse_summary(summary, results, filter_test, ignore_warning):
     results to the passed results dictionary.
 
     :param summary:
-        A list of lines comprised in this summary section
-
+        A list of lines comprised in this summary section.
     :param results:
         The results dictionary into which to put the end result. Should be a
         dict with keys for each level, the values are dicts with keys for each
         test (s3, s4) which in turn contain a list of all the failures observed
         for that level and test.
+    :param filter_test:
+        A string to filter out the results is match with the test type.
+        And `all` will not filter anything.
+    :param ignore_warning:
+        A bool if warning message need to be ignored.
+    :return:
+        None
     """
     current_level = None
     current_acum = []
@@ -99,10 +105,17 @@ def parse_level(level_lines, level_results,
     :param level_lines:
         A list of lines comprised in this level's list of failures.
 
-    : param level_results:
+    :param level_results:
         A dictionary containing this level's results. Should be a dict with
         keys for each test, to which the failures for the level will be
         appended.
+    :param level_filter_test:
+        A string to filter out the results is match with the test type.
+        And `all` will not filter anything.
+    :param level_ignore_warning:
+        A bool if warning message need to be ignored.
+    :return:
+        None
     """
     for failureline in level_lines:
         failure_matches = failure_re.search(failureline)
@@ -136,8 +149,9 @@ def main():
     parser.add_argument('-t', '--test',
                         action='store',
                         default='all',
-                        help="The test (ie.s3 ,s4 ,klog ,oope ,...etc) \
-                              to check. Default is [%(default)s]")
+                        help="The test (ie.all, s3 ,s4 ,klog ,oops ,...etc) \
+                              to check. Default is [%(default)s]. And `all` \
+                              is a special entry to check everything at once.")
     parser.add_argument('logfile',
                         action='store',
                         help='The log file to parse')

--- a/providers/base/units/hibernate/jobs.pxu
+++ b/providers/base/units/hibernate/jobs.pxu
@@ -72,7 +72,7 @@ _verification:
 plugin: shell
 category_id: com.canonical.plainbox::hibernate
 id: power-management/hibernate-single-log-check
-command: [ -e "$PLAINBOX_SESSION_SHARE"/hibernate-single.log ] && sleep_test_log_check.py -v s4 "$PLAINBOX_SESSION_SHARE"/hibernate-single.log
+command: [ -e "$PLAINBOX_SESSION_SHARE"/hibernate-single.log ] && sleep_test_log_check.py -v --ignore-warning -t all "$PLAINBOX_SESSION_SHARE"/hibernate-single.log
 _description:
  Automated check of the hibernate log for errors discovered by fwts
 

--- a/providers/base/units/stress/boot.pxu
+++ b/providers/base/units/stress/boot.pxu
@@ -47,9 +47,7 @@ _description: This creates baseline data sets which be considered the master
 unit: job
 plugin: shell
 command:
-  lspci -i "$SNAP"/usr/share/misc/pci.ids > "$PLAINBOX_SESSION_SHARE"/lspci_original || true
-  nmcli -t -f active,SSID d w l | grep -oP "(?<=^yes:).*" > "$PLAINBOX_SESSION_SHARE"/wifi_original || true
-  checkbox-support-lsusb -f "$CHECKBOX_RUNTIME"/var/lib/usbutils/usb.ids -s | sort > "$PLAINBOX_SESSION_SHARE"/lsusb_original || true
+  reboot_check_test.sh -d "$PLAINBOX_SESSION_SHARE/before_reboot"
 environ: LD_LIBRARY_PATH
 user: root
 estimated_duration: 1s
@@ -94,21 +92,7 @@ unit: job
 plugin: shell
 environ: LD_LIBRARY_PATH
 command:
-  lspci -i "$SNAP"/usr/share/misc/pci.ids > "$PLAINBOX_SESSION_SHARE"/lspci_test
-  nmcli -t -f active,SSID d w l | grep -oP "(?<=^yes:).*" > "$PLAINBOX_SESSION_SHARE"/wifi_test
-  checkbox-support-lsusb -f "$CHECKBOX_RUNTIME"/var/lib/usbutils/usb.ids -s | sort > "$PLAINBOX_SESSION_SHARE"/lsusb_test
-  if ! diff -u "$PLAINBOX_SESSION_SHARE"/lspci_original "$PLAINBOX_SESSION_SHARE"/lspci_test; then
-    echo "lspci mismatch during cycle 1"
-    exit 1
-  fi
-  if ! diff -u "$PLAINBOX_SESSION_SHARE"/wifi_original "$PLAINBOX_SESSION_SHARE"/wifi_test; then
-    echo "wifi mismatch during cycle 1"
-    exit 1
-  fi
-  if ! diff -u "$PLAINBOX_SESSION_SHARE"/lsusb_original "$PLAINBOX_SESSION_SHARE"/lsusb_test; then
-    echo "lsusb mismatch during cycle 1"
-    exit 1
-  fi
+  reboot_check_test.sh -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle1" -s
 user: root
 flags: preserve-locale
 estimated_duration: 1.0
@@ -124,21 +108,7 @@ template-unit: job
 plugin: shell
 environ: LD_LIBRARY_PATH
 command:
-  lspci -i "$SNAP"/usr/share/misc/pci.ids > "$PLAINBOX_SESSION_SHARE"/lspci_test
-  nmcli -t -f active,SSID d w l | grep -oP "(?<=^yes:).*" > "$PLAINBOX_SESSION_SHARE"/wifi_test
-  checkbox-support-lsusb -f "$CHECKBOX_RUNTIME"/var/lib/usbutils/usb.ids -s | sort > "$PLAINBOX_SESSION_SHARE"/lsusb_test
-  if ! diff -u "$PLAINBOX_SESSION_SHARE"/lspci_original "$PLAINBOX_SESSION_SHARE"/lspci_test; then
-    echo "lspci mismatch during cycle {reboot_id}"
-    exit 1
-  fi
-  if ! diff -u "$PLAINBOX_SESSION_SHARE"/wifi_original "$PLAINBOX_SESSION_SHARE"/wifi_test; then
-    echo "wifi mismatch during cycle {reboot_id}"
-    exit 1
-  fi
-  if ! diff -u "$PLAINBOX_SESSION_SHARE"/lsusb_original "$PLAINBOX_SESSION_SHARE"/lsusb_test; then
-    echo "lsusb mismatch during cycle {reboot_id}"
-    exit 1
-  fi
+  reboot_check_test.sh -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle{reboot_id}" -s
 user: root
 flags: preserve-locale
 estimated_duration: 1.0
@@ -186,21 +156,7 @@ unit: job
 plugin: shell
 environ: LD_LIBRARY_PATH
 command:
-  lspci -i "$SNAP"/usr/share/misc/pci.ids > "$PLAINBOX_SESSION_SHARE"/lspci_test
-  nmcli -t -f active,SSID d w l | grep -oP "(?<=^yes:).*" > "$PLAINBOX_SESSION_SHARE"/wifi_test
-  checkbox-support-lsusb -f "$CHECKBOX_RUNTIME"/var/lib/usbutils/usb.ids -s | sort > "$PLAINBOX_SESSION_SHARE"/lsusb_test
-  if ! diff -u "$PLAINBOX_SESSION_SHARE"/lspci_original "$PLAINBOX_SESSION_SHARE"/lspci_test; then
-    echo "lspci mismatch during cycle 1"
-    exit 1
-  fi
-  if ! diff -u "$PLAINBOX_SESSION_SHARE"/wifi_original "$PLAINBOX_SESSION_SHARE"/wifi_test; then
-    echo "wifi mismatch during cycle 1"
-    exit 1
-  fi
-  if ! diff -u "$PLAINBOX_SESSION_SHARE"/lsusb_original "$PLAINBOX_SESSION_SHARE"/lsusb_test; then
-    echo "lsusb mismatch during cycle 1"
-    exit 1
-  fi
+  reboot_check_test.sh -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle1" -s
 user: root
 flags: preserve-locale
 estimated_duration: 1.0
@@ -216,21 +172,7 @@ template-unit: job
 plugin: shell
 environ: LD_LIBRARY_PATH
 command:
-  lspci -i "$SNAP"/usr/share/misc/pci.ids > "$PLAINBOX_SESSION_SHARE"/lspci_test
-  nmcli -t -f active,SSID d w l | grep -oP "(?<=^yes:).*" > "$PLAINBOX_SESSION_SHARE"/wifi_test
-  checkbox-support-lsusb -f "$CHECKBOX_RUNTIME"/var/lib/usbutils/usb.ids -s | sort > "$PLAINBOX_SESSION_SHARE"/lsusb_test
-  if ! diff -u "$PLAINBOX_SESSION_SHARE"/lspci_original "$PLAINBOX_SESSION_SHARE"/lspci_test; then
-    echo "lspci mismatch during cycle {reboot_id}"
-    exit 1
-  fi
-  if ! diff -u "$PLAINBOX_SESSION_SHARE"/wifi_original "$PLAINBOX_SESSION_SHARE"/wifi_test; then
-    echo "wifi mismatch during cycle {reboot_id}"
-    exit 1
-  fi
-  if ! diff -u "$PLAINBOX_SESSION_SHARE"/lsusb_original "$PLAINBOX_SESSION_SHARE"/lsusb_test; then
-    echo "lsusb mismatch during cycle {reboot_id}"
-    exit 1
-  fi
+  reboot_check_test.sh -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle{reboot_id}" -s
 user: root
 flags: preserve-locale
 estimated_duration: 1.0

--- a/providers/base/units/stress/boot.pxu
+++ b/providers/base/units/stress/boot.pxu
@@ -92,7 +92,7 @@ unit: job
 plugin: shell
 environ: LD_LIBRARY_PATH
 command:
-  reboot_check_test.sh -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle1" -s
+  reboot_check_test.sh -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle1" -s -f
 user: root
 flags: preserve-locale
 estimated_duration: 1.0
@@ -108,7 +108,7 @@ template-unit: job
 plugin: shell
 environ: LD_LIBRARY_PATH
 command:
-  reboot_check_test.sh -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle{reboot_id}" -s
+  reboot_check_test.sh -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle{reboot_id}" -s -f
 user: root
 flags: preserve-locale
 estimated_duration: 1.0
@@ -156,7 +156,7 @@ unit: job
 plugin: shell
 environ: LD_LIBRARY_PATH
 command:
-  reboot_check_test.sh -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle1" -s
+  reboot_check_test.sh -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle1" -s -f
 user: root
 flags: preserve-locale
 estimated_duration: 1.0
@@ -172,7 +172,7 @@ template-unit: job
 plugin: shell
 environ: LD_LIBRARY_PATH
 command:
-  reboot_check_test.sh -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle{reboot_id}" -s
+  reboot_check_test.sh -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle{reboot_id}" -s -f
 user: root
 flags: preserve-locale
 estimated_duration: 1.0

--- a/providers/base/units/stress/jobs.pxu
+++ b/providers/base/units/stress/jobs.pxu
@@ -62,7 +62,7 @@ plugin: shell
 category_id: com.canonical.plainbox::stress
 id: power-management/hibernate-30-cycles-log-check
 estimated_duration: 1.0
-command: [ -e "$PLAINBOX_SESSION_SHARE"/hibernate_30_cycles.log ] && sleep_test_log_check.py -v s4 "$PLAINBOX_SESSION_SHARE"/hibernate_30_cycles.log
+command: [ -e "$PLAINBOX_SESSION_SHARE"/hibernate_30_cycles.log ] && sleep_test_log_check.py -v --ignore-warning -t all "$PLAINBOX_SESSION_SHARE"/hibernate_30_cycles.log
 _description:
  Automated check of the 30 cycle hibernate log for errors detected by fwts.
 
@@ -126,7 +126,7 @@ category_id: com.canonical.plainbox::stress
 id: power-management/suspend-30-cycles-log-check
 depends: power-management/suspend_30_cycles
 estimated_duration: 1.0
-command: [ -e "$PLAINBOX_SESSION_SHARE"/suspend_30_cycles.log ] && sleep_test_log_check.py -v s3 "$PLAINBOX_SESSION_SHARE"/suspend_30_cycles.log
+command: [ -e "$PLAINBOX_SESSION_SHARE"/suspend_30_cycles.log ] && sleep_test_log_check.py -v --ignore-warning -t all "$PLAINBOX_SESSION_SHARE"/suspend_30_cycles.log
 _description:
  Automated check of the 30 cycle suspend log for errors detected by fwts.
 
@@ -135,14 +135,14 @@ category_id: com.canonical.plainbox::stress
 id: power-management/suspend-30-cycles-log-check-with-reboots
 depends: power-management/suspend_30_cycles_with_reboots
 estimated_duration: 1.0
-command: [ -e "$PLAINBOX_SESSION_SHARE"/pm_test.reboot.3.log ] && sleep_test_log_check.py -v s3 "$PLAINBOX_SESSION_SHARE"/pm_test.reboot.3.log
+command: [ -e "$PLAINBOX_SESSION_SHARE"/pm_test.reboot.3.log ] && sleep_test_log_check.py -v --ignore-warning -t all "$PLAINBOX_SESSION_SHARE"/pm_test.reboot.3.log
 _summary: 30 suspend/resume cycles and 1 reboot, 3 times (check logs for errors)
 _description:
  Automated check of the '30 cycle suspend and 1 reboot times 3' logs for errors detected by fwts.
 _siblings: [
     { "id": "power-management/suspend-30-cycles-log-check-with-coldboots",
       "depends": "power-management/suspend_30_cycles_with_coldboots",
-      "command": "[ -e $PLAINBOX_SESSION_SHARE/pm_test.poweroff.3.log ] && sleep_test_log_check.py -v s3 $PLAINBOX_SESSION_SHARE/pm_test.poweroff.3.log",
+      "command": "[ -e $PLAINBOX_SESSION_SHARE/pm_test.poweroff.3.log ] && sleep_test_log_check.py -v --ignore-warning -t all $PLAINBOX_SESSION_SHARE/pm_test.poweroff.3.log",
       "_description": "Automated check of the '30 cycle suspend and 1 poweroff times 3' logs for errors detected by fwts.",
       "_summary": "30 suspend/resume cycles and 1 poweroff, 3 times (check logs for errors)"
     }

--- a/providers/base/units/stress/s3s4.pxu
+++ b/providers/base/units/stress/s3s4.pxu
@@ -80,7 +80,7 @@ id: stress-tests/suspend-{s3_iterations}-cycles-log-check
 after: stress-tests/suspend_{s3_iterations}_cycles
 requires: cpuinfo.platform in ("i386", "x86_64")
 estimated_duration: 1.0
-command: [ -e "$PLAINBOX_SESSION_SHARE"/suspend_{s3_iterations}_cycles.log ] && sleep_test_log_check.py -v s3 "$PLAINBOX_SESSION_SHARE"/suspend_{s3_iterations}_cycles.log
+command: [ -e "$PLAINBOX_SESSION_SHARE"/suspend_{s3_iterations}_cycles.log ] && sleep_test_log_check.py -v --ignore-warning -t all "$PLAINBOX_SESSION_SHARE"/suspend_{s3_iterations}_cycles.log
 _description:
  Automated check of the {s3_iterations} cycles suspend log for errors detected by fwts.
 
@@ -133,7 +133,7 @@ id: stress-tests/hibernate-{s4_iterations}-cycles-log-check
 after: stress-tests/hibernate_{s4_iterations}_cycles
 requires: cpuinfo.platform in ("i386", "x86_64")
 estimated_duration: 1.0
-command: [ -e "$PLAINBOX_SESSION_SHARE"/hibernate_{s4_iterations}_cycles.log ] && sleep_test_log_check.py -v s4 "$PLAINBOX_SESSION_SHARE"/hibernate_{s4_iterations}_cycles.log
+command: [ -e "$PLAINBOX_SESSION_SHARE"/hibernate_{s4_iterations}_cycles.log ] && sleep_test_log_check.py -v --ignore-warning -t all "$PLAINBOX_SESSION_SHARE"/hibernate_{s4_iterations}_cycles.log
 _description:
  Automated check of the {s4_iterations} cycles hibernate log for errors detected by fwts.
 

--- a/providers/base/units/stress/test-plan.pxu
+++ b/providers/base/units/stress/test-plan.pxu
@@ -104,6 +104,15 @@ include:
     memory/memory_stress_ng                        certification-status=blocker
     stress/restore_oomd_config
 
+id: stress-warmboot-coldboot-automated
+unit: test plan
+_name: Stress of warm boot and cold boot cycles (automated)
+_description: Stress of warm boot and cold boot cycles (automated)
+include:
+nested_part:
+    warm-boot-stress-test
+    cold-boot-stress-test
+
 id: stress-full
 unit: test plan
 _name: Stress tests

--- a/providers/base/units/suspend/suspend.pxu
+++ b/providers/base/units/suspend/suspend.pxu
@@ -296,7 +296,7 @@ category_id: com.canonical.plainbox::suspend
 id: suspend/suspend-single-log-check
 depends: suspend/suspend_advanced_auto
 estimated_duration: 1.2
-command: [ -e "$PLAINBOX_SESSION_SHARE"/suspend_single.log ] && sleep_test_log_check.py -v s3 "$PLAINBOX_SESSION_SHARE"/suspend_single.log
+command: [ -e "$PLAINBOX_SESSION_SHARE"/suspend_single.log ] && sleep_test_log_check.py -v --ignore-warning -t all "$PLAINBOX_SESSION_SHARE"/suspend_single.log
 _summary: Automated check of the suspend log for errors reported by fwts
 
 plugin: attachment
@@ -323,7 +323,7 @@ category_id: com.canonical.plainbox::suspend
 id: suspend/{index}_hybrid-sleep-single-log-check
 depends: suspend/{index}_hybrid_sleep_{product_slug}
 estimated_duration: 1.2
-command: [ -e "$PLAINBOX_SESSION_SHARE"/{index}_hybrid_sleep_single.log ] && sleep_test_log_check.py -v s3 "$PLAINBOX_SESSION_SHARE"/{index}_hybrid_sleep_single.log
+command: [ -e "$PLAINBOX_SESSION_SHARE"/{index}_hybrid_sleep_single.log ] && sleep_test_log_check.py -v --ignore-warning -t all "$PLAINBOX_SESSION_SHARE"/{index}_hybrid_sleep_single.log
 _summary: Automated check of the hybrid sleep log for errors reported by fwts
 
 unit: template

--- a/providers/certification-client/units/client-cert-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-22-04.pxu
@@ -172,6 +172,5 @@ nested_part:
     stress-iperf3-automated
     #stress-cert-full
     stress-suspend-30-cycles-with-reboots-automated
-    #stress-30-reboot-poweroff-automated
     stress-warmboot-coldboot-automated
     stress-pm-graph

--- a/providers/certification-client/units/client-cert-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-22-04.pxu
@@ -172,5 +172,6 @@ nested_part:
     stress-iperf3-automated
     #stress-cert-full
     stress-suspend-30-cycles-with-reboots-automated
-    stress-30-reboot-poweroff-automated
+    #stress-30-reboot-poweroff-automated
+    stress-warmboot-coldboot-automated
     stress-pm-graph


### PR DESCRIPTION
## Description
Seperate the reboot/poweroff 30 from pm_test.py.
Add a script for post warm/cold boot check.
Make sleep_test_log_check.py can support to parser all fwts tester.

## Resolved issues
[[Checkbox-Remote] System turns off during stress test and won't wake up to complete rest tests](https://warthogs.atlassian.net/browse/CQT-486)
[[Checkbox Desktop]Separate reboot_30 | poweroff_30 from pm_test.py](https://warthogs.atlassian.net/browse/CQT-2040)

## Documentation

## Tests
Local run on deb version(side load):
- https://certification.canonical.com/hardware/202301-31089/submission/313503/
- https://certification.canonical.com/hardware/202301-31090/submission/313504/

Local run on snap version on FED desktop image (side load):
- https://certification.canonical.com/hardware/202207-30448/submission/313502/

Jenkins to trigger it (side load, and without cpu-stress, and memory stress)
- [submission.html](http://10.102.135.50:8080/job/sanity-3-testflinger-dummy-202301-31089-staging/5/artifact/artifacts/submission.html)
- [consoleFull](http://10.102.135.50:8080/job/sanity-3-testflinger-dummy-202301-31089-staging/5/consoleFull)