### PR TITLE
Removed wrong `-a` switch from bluetooth manual jobs

### DIFF
--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -368,7 +368,7 @@ _purpose:
  Check bluetooth input device works
 _steps:
  1. Run the following command to start bluetoothctl console:
- sudo bluetoothctl -a
+ sudo bluetoothctl
  ***Following steps are run in bluetoothctl console***
  2. Power on the device:
  power on

--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -160,7 +160,7 @@ _purpose:
  Check bluetooth LED behavior is correct
 _steps:
  1. Run following command to start bluetoothctl console:
-  sudo bluetoothctl -a
+  sudo bluetoothctl
  ***Following steps are run in bluetoothctl console***
  2. Power on the device:
   power on


### PR DESCRIPTION
## Description

Before `ver 5.64` bluetoothctl ignored the missing parameter to `-a` making the instructions "correct". Now it errors out due to the missing AGENT parameter (that we do not need or provide)

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/385

## Tests

This was tested on the `xenial` version of `bluetoothctl 5.37` and on `bluetoothctl 5.66`. Both created an interactive console when launched without any parameter. 
