### PR TITLE
Fix after-suspend cpu and xrandr attachment test faulty failed

### DIFF
--- a/providers/base/bin/graphic_cycle_resolution.sh
+++ b/providers/base/bin/graphic_cycle_resolution.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# shellcheck disable=SC1091
+
+while [ $# -gt 0 ]
+do
+    case "$1" in
+        --index)
+            shift
+            INDEX=$1
+        ;;
+        --after-suspend)
+            shift
+            KEYWORD="after_suspend"
+        ;;
+        *)
+            echo "Not recognize $1"
+            usage
+        ;;
+    esac
+    shift
+done
+
+if [[ $XDG_SESSION_TYPE == "wayland" ]]
+then
+    gnome_randr_cycle.py --keyword="${INDEX}_${KEYWORD}" --screenshot-dir="$PLAINBOX_SESSION_SHARE"
+else
+    xrandr_cycle.py --keyword="${INDEX}_${KEYWORD}" --screenshot-dir="$PLAINBOX_SESSION_SHARE"
+fi

--- a/providers/base/units/cpu/jobs.pxu
+++ b/providers/base/units/cpu/jobs.pxu
@@ -56,7 +56,7 @@ plugin: attachment
 category_id: com.canonical.plainbox::cpu
 id: after-suspend-cpu/scaling_test-log-attach
 estimated_duration: 1.0
-after: after-suspend-cpu/scaling_test
+depends: after-suspend-cpu/scaling_test
 command: [[ -e "${PLAINBOX_SESSION_SHARE}"/scaling_test_after_suspend.log ]] && cat "${PLAINBOX_SESSION_SHARE}"/scaling_test_after_suspend.log
 _summary:
  Attach CPU scaling capabilities log

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -213,18 +213,10 @@ template-filter: graphics_card.prime_gpu_offload == 'Off'
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_cycle_resolution_{product_slug}
-flags: also-after-suspend
 requires: package.name == 'xorg'
 depends: graphics/VESA_drivers_not_in_use
 command:
- # shellcheck disable=SC1091
- source graphics_env.sh {driver} {index}
- if [[ $XDG_SESSION_TYPE == "wayland" ]]
- then
-   gnome_randr_cycle.py --screenshot-dir="$PLAINBOX_SESSION_SHARE"
- else
-   xrandr_cycle.py --screenshot-dir="$PLAINBOX_SESSION_SHARE"
- fi
+    graphic_cycle_resolution.sh
 estimated_duration: 250.000
 _summary: Test resolution cycling for {vendor} {product}
 _description:
@@ -234,6 +226,11 @@ _description:
      1. Click "Test" to start cycling through the video modes
  VERIFICATION:
      Did the screen appear to be working for each mode?
+_siblings: [
+    {{ "id": "after-suspend-graphics/{index}_cycle_resolution_{product_slug}",
+      "command": "graphic_cycle_resolution.sh --index {index} --after-suspend",
+      "depends": "com.canonical.certification::suspend/suspend_advanced_auto"}}
+    ]
 
 unit: template
 template-resource: graphics_card


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->
1. after-suspend-cpu/scaling_test-log-attach 
failed due to missing dependency on the main case after-suspend-cpu/scaling_test
fixed by set dependency

2. {index}_xrandr_screens_after_suspend.tar.gz_auto 
Previously it looks for a file name with after_suspend postfix, but the main case store attachment without the postfix. Hence fix the main case to store attachments with the postfix

## Resolved issues
#370 After suspend attachment test cases failed
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Tests
1. after-suspend-cpu/scaling_test-log-attach 
https://certification.canonical.com/hardware/202010-28329/submission/313832/
2. {index}_xrandr_screens_after_suspend.tar.gz_auto 
https://certification.canonical.com/hardware/202010-28329/submission/313831/
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
-->
