### PR TITLE
Add missing python package dependencies (pyparsing and packaging)

### DIFF
--- a/metabox/metabox/lxd_profiles/checkbox.profile
+++ b/metabox/metabox/lxd_profiles/checkbox.profile
@@ -24,9 +24,11 @@ config:
       - pulseaudio
       - python3-jinja2
       - python3-markupsafe
+      - python3-packaging
       - python3-padme
       - python3-pip
       - python3-psutil
+      - python3-pyparsing
       - python3-requests-oauthlib
       - python3-tqdm
       - python3-urwid


### PR DESCRIPTION
## Description

Add 2 missing dependencies to the checkbox LXD profile.

## Resolved issues

Exporter units can't be loaded properly:

```
Traceback (most recent call last):
  File "/usr/local/bin/checkbox-cli", line 9, in <module>
    load_entry_point('checkbox-ng', 'console_scripts', 'checkbox-cli')()
  File "/home/ubuntu/checkbox/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py", line 140, in main
    subcmd.invoked(ctx)
  File "/home/ubuntu/checkbox/checkbox-ng/checkbox_ng/launcher/subcommands.py", line 724, in invoked
    self._print_results()
  File "/home/ubuntu/checkbox/checkbox-ng/checkbox_ng/launcher/subcommands.py", line 781, in _print_results
    self.exporter, transport, self.exporter_opts)
  File "/home/ubuntu/checkbox/checkbox-ng/plainbox/impl/decorators.py", line 142, in wrapper
    raise exc
  File "/home/ubuntu/checkbox/checkbox-ng/plainbox/impl/decorators.py", line 136, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/checkbox/checkbox-ng/plainbox/impl/session/assistant.py", line 1655, in export_to_transport
    exporter = self._manager.create_exporter(exporter_id, options)
  File "/home/ubuntu/checkbox/checkbox-ng/plainbox/impl/session/manager.py", line 433, in create_exporter
    exporter_support = self.exporter_map[exporter_id]
KeyError: 'com.canonical.plainbox::text'
```

## Tests

See https://github.com/canonical/checkbox/pull/453