### PR TITLE
Fix the AudioPlayback scenario to not depend on the base provider

### DIFF
--- a/metabox/metabox/metabox-provider/bin/gst_pipeline_test.py
+++ b/metabox/metabox/metabox-provider/bin/gst_pipeline_test.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+from argparse import ArgumentParser
+import gi
+import sys
+import time
+gi.require_version('Gst', '1.0')
+gi.require_version('GLib', '2.0')
+from gi.repository import Gst        # noqa: E402
+from gi.repository import GLib       # noqa: E402
+
+
+def main():
+    parser = ArgumentParser(description='Simple GStreamer pipeline player')
+    parser.add_argument(
+        'PIPELINE',
+        help='Quoted GStreamer pipeline to launch')
+    parser.add_argument(
+        '-t', '--timeout',
+        type=int, required=True,
+        help='Timeout for running the pipeline')
+    args = parser.parse_args()
+    exit_code = 0
+    Gst.init(None)
+    try:
+        print("Attempting to initialize Gstreamer pipeline: {}".format(
+              args.PIPELINE))
+        element = Gst.parse_launch(args.PIPELINE)
+    except GLib.GError as error:
+        print("Specified pipeline couldn't be processed.")
+        print("Error when processing pipeline: {}".format(error))
+        # Exit harmlessly
+        return 2
+    print("Pipeline initialized, now starting playback.")
+    element.set_state(Gst.State.PLAYING)
+    if args.timeout:
+        time.sleep(args.timeout)
+    element.set_state(Gst.State.NULL)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/metabox/metabox/metabox-provider/units/basic-jobs.pxu
+++ b/metabox/metabox/metabox-provider/units/basic-jobs.pxu
@@ -232,3 +232,20 @@ _description:
  VERIFICATION:
      1. Did the 3d animation appear?
      2. Was the animation free from slowness/jerkiness?
+
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::audio
+id: audio/playback_auto
+estimated_duration: 5.0
+command:
+  gst_pipeline_test.py -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+_description:
+ PURPOSE:
+     This test will check that internal speakers work correctly
+ STEPS:
+     1. Make sure that no external speakers or headphones are connected
+        When testing a desktop, you can skip this test if there is no
+        internal speaker, we will test the external output later
+     2. Commence the test to play a brief tone on your audio device
+ VERIFICATION:
+     Did you hear a tone?

--- a/metabox/metabox/metabox-provider/units/basic-tps.pxu
+++ b/metabox/metabox/metabox-provider/units/basic-tps.pxu
@@ -36,7 +36,7 @@ unit: test plan
 id: audio-manual
 _name: Audio Manual
 include:
-  com.canonical.certification::audio/playback_auto
+  audio/playback_auto
 
 unit: test plan
 id: config-automated


### PR DESCRIPTION
## Description

The Audio scenario ran the `com.canonical.certification::audio/playback_auto` job from the base provider.

The new metabox provider job is using a lighter version of the `gst_pipeline_test.py` script and does not depend on the `udev` resource.

Requires https://github.com/canonical/checkbox/pull/486

## Resolved issues

```
 -----------------------------[ Running job 4 / 4 ]------------------------------
----------------------------[ audio/playback_auto ]-----------------------------
ID: com.canonical.certification::audio/playback_auto
Category: Audio tests
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Outcome: job cannot be started
```

## Tests

Tested locally with a modified version of `get_early_setup` to ensure the new script permission (+x) are preserved:
 
```
     def get_early_setup(self):
         """
         Installation from source and, if required, creation of systemd service.
         """
 
         commands = [
             "bash -c 'chmod +x /var/tmp/checkbox-providers/base/bin/*'",
             "bash -c 'chmod +x /var/tmp/checkbox-providers/resource/bin/*'",
+            "bash -c 'chmod +x "
+            "/var/tmp/checkbox-providers/metabox-provider/bin/*'",
             ("bash -c 'pushd /home/ubuntu/checkbox/checkbox-ng ; "
              "sudo python3 -m pip install -e .'"),
             ("bash -c 'pushd /home/ubuntu/checkbox/checkbox-support ; "
              "sudo python3 -m pip install -e .'"),
         ]
```