### PR TITLE
Metabox provisioning does not carry file permissions

### DIFF
--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -198,17 +198,17 @@ class LxdMachineProvider:
             run_or_raise(
                 machine._container, 'mkdir -p {}'.format(dest),
                 verbose=self._debug_machine_setup)
+            dir_mode = os.stat(src).st_mode # preserve permissions
             machine._container.files.recursive_put(
-                os.path.expanduser(src), dest)
+                os.path.expanduser(src), dest, mode=dir_mode)
             run_or_raise(
                 machine._container,
                 'sudo chown -R ubuntu:ubuntu {}'.format(dest),
                 verbose=self._debug_machine_setup)
-            # FIXME: preserve the +x bit
         for src, dest in machine.get_file_transfer():
+            file_mode = os.stat(src).st_mode
             with open(src, "rb") as f:
-                machine._container.files.put(dest, f.read())
-                # FIXME: preserve the +x bit
+                machine._container.files.put(dest, f.read(), mode=file_mode)
 
     def _run_setup_commands(self, machine):
         pre_cmds = machine.get_early_setup()


### PR DESCRIPTION
## Description

When provisioning a new machine metabox creates files without carrying the original permission flags. This makes https://github.com/canonical/checkbox/pull/466 fail because the manifest script is not executable.

This changes the file/dir put operations to also propagate the `st_mode`

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/481

## Documentation

N/A

## Tests

I have tested this on both legacy and remote runs, all files seem to now have the correct permissions and the manifest bin now works correctly (once a provider is installed)
