### PR TITLE
fix: sleep for 10s between connection retries in BT A2DP test

### DIFF
--- a/providers/base/bin/bt_a2dp.py
+++ b/providers/base/bin/bt_a2dp.py
@@ -60,6 +60,7 @@ def main():
                 break
             except bluetooth.btcommon.BluetoothError as exc:
                 print("Failed to connect. {}".format(exc))
+                time.sleep(10)
         else:
             raise SystemExit("Failed to connect to Zapper via BT")
 


### PR DESCRIPTION
## Description
Previously the test did not wait between retries which meant that the temporary radio blackouts may have been responsible for failing the test. This patch makes the testing script wait for 10 seconds between retries. Which is my best educated guess on what may fix the problem. It's not test's fault per se.

## Resolved issues
Fixes: [ZAP-443](https://warthogs.atlassian.net/browse/ZAP-443) (Hopefully).

[ZAP-443]: https://warthogs.atlassian.net/browse/ZAP-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ