### PR TITLE
fix: make network-info jobs require ethtool to be available  (bugfix)

### DIFF
--- a/providers/base/units/networking/jobs.pxu
+++ b/providers/base/units/networking/jobs.pxu
@@ -16,6 +16,7 @@ id: networking/info_device{__index__}_{interface}
 flags: also-after-suspend
 _summary: Network Information of device {__index__} ({interface})
 estimated_duration: 1.0
+requires: executable.name == 'ethtool'
 command:
   network_device_info.py info NETWORK --interface {interface}
 _description:

--- a/providers/base/units/networking/packaging.pxu
+++ b/providers/base/units/networking/packaging.pxu
@@ -1,6 +1,6 @@
 unit: packaging meta-data
 os-id: debian
-Depends: ntpdate, net-tools
+Depends: ntpdate, net-tools, ethtool
 
 unit: packaging meta-data
 os-id: debian

--- a/providers/base/units/networking/test-plan.pxu
+++ b/providers/base/units/networking/test-plan.pxu
@@ -15,6 +15,7 @@ include:
     networking/info_device.*                       certification-status=blocker
 bootstrap_include:
     device
+    executable
 
 id: networking-cert-automated
 unit: test plan
@@ -43,6 +44,7 @@ include:
     networking/ntp                                 certification-status=blocker
 bootstrap_include:
     device
+    executable
 
 id: networking-full
 unit: test plan
@@ -87,6 +89,7 @@ include:
     after-suspend-networking/info_device.*                       certification-status=blocker
 bootstrap_include:
     device
+    executable
 
 id: after-suspend-networking-automated
 unit: test plan


### PR DESCRIPTION
## Description
Make network-info jobs require ethtool.
See bug link for details.

## Resolved issues

Fixes: : [CHECKBOX-626] (https://github.com/canonical/checkbox/issues/488)

## Testing
Tested on a system without the ethtool and now it yields:
```
==============[ Running job 1 / 1. Estimated time left: 0:00:01 ]===============
-------------------[ Network Information of device 1 (eno1) ]-------------------
ID: com.canonical.certification::networking/info_device1_eno1
Category: com.canonical.plainbox::networking
Job cannot be started because:
 - resource expression "executable.name == 'ethtool'" evaluates to false
Outcome: job cannot be started
Finalizing session that hasn't been submitted anywhere: checkbox-run-2023-05-24T07.16.45
==================================[ Results ]===================================
 ☑ : Enumerate available system executables
 ☑ : Collect information about hardware devices (udev)
 ☐ : Network Information of device 1 (eno1)
```
And with it installed it proceeds to run.


[CHECKBOX-626]: https://warthogs.atlassian.net/browse/CHECKBOX-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ