### PR TITLE
Show values of GROUP argument for list command help

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -51,6 +51,7 @@ from plainbox.impl.session.storage import WellKnownDirsHelper
 from plainbox.impl.transport import TransportError
 from plainbox.impl.transport import get_all_transports
 from plainbox.impl.transport import SECURE_ID_PATTERN
+from plainbox.impl.unit import all_units
 
 from checkbox_ng.config import load_configs
 from checkbox_ng.launcher.stages import MainLoopStage, ReportsStage
@@ -797,8 +798,9 @@ class Run(MainLoopStage):
 
 class List():
     def register_arguments(self, parser):
+        all_units.load()
         parser.add_argument(
-            'GROUP', nargs='?',
+            'GROUP', nargs='?', choices=all_units.get_all_names(),
             help=_("list objects from the specified group"))
         parser.add_argument(
             '-a', '--attrs', default=False, action="store_true",

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -51,7 +51,6 @@ from plainbox.impl.session.storage import WellKnownDirsHelper
 from plainbox.impl.transport import TransportError
 from plainbox.impl.transport import get_all_transports
 from plainbox.impl.transport import SECURE_ID_PATTERN
-from plainbox.impl.unit import all_units
 
 from checkbox_ng.config import load_configs
 from checkbox_ng.launcher.stages import MainLoopStage, ReportsStage
@@ -798,9 +797,8 @@ class Run(MainLoopStage):
 
 class List():
     def register_arguments(self, parser):
-        all_units.load()
         parser.add_argument(
-            'GROUP', nargs='?', choices=all_units.get_all_names() + ['all-jobs'],
+            'GROUP', nargs='?', choices=Explorer.OBJECT_TYPES,
             help=_("list objects from the specified group"))
         parser.add_argument(
             '-a', '--attrs', default=False, action="store_true",

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -800,7 +800,7 @@ class List():
     def register_arguments(self, parser):
         all_units.load()
         parser.add_argument(
-            'GROUP', nargs='?', choices=all_units.get_all_names(),
+            'GROUP', nargs='?', choices=all_units.get_all_names() + ['all-jobs'],
             help=_("list objects from the specified group"))
         parser.add_argument(
             '-a', '--attrs', default=False, action="store_true",

--- a/checkbox-ng/plainbox/impl/highlevel.py
+++ b/checkbox-ng/plainbox/impl/highlevel.py
@@ -122,6 +122,21 @@ class Explorer:
     Class simplifying discovery of various PlainBox objects.
     """
 
+    OBJECT_TYPES = [
+            'category',
+            'exporter',
+            'job',
+            'manifest entry',
+            'packaging meta-data',
+            'template',
+            'test plan',
+            'file',
+            'provider',
+            'storage',
+            'service',
+            'all-jobs'
+    ]
+
     def __init__(self, provider_list=None):
         """
         Initialize a new Explorer


### PR DESCRIPTION
It can be helpful to have the list of all possible values for GROUP argument

## Description

## Resolved issues

## Documentation

## Tests

Manual test done

$ checkbox-cli list -h
usage: checkbox-cli [-h] [-a] [-f FORMAT] [{category,exporter,job,manifest entry,packaging meta-data,template,test plan,unit}]

positional arguments:
  {category,exporter,job,manifest entry,packaging meta-data,template,test plan,unit}
                        list objects from the specified group

options:
  -h, --help            show this help message and exit
  -a, --attrs           show object attributes
  -f FORMAT, --format FORMAT
                        output format, as passed to print function. Use '?' to list possible values

