### PR TITLE
Metabox Install instead of sideloading providers

### DIFF
--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -221,7 +221,7 @@ class LxdMachineProvider:
         provider_path = pkg_resources.resource_filename(
             'metabox', 'metabox-provider')
         metabox_dir_transfers = machine.get_early_dir_transfer() + [
-            (provider_path, '/var/tmp/checkbox-providers/metabox-provider')]
+            (provider_path, '/var/tmp/metabox-provider')] # avoid sideloading
         for src, dest in metabox_dir_transfers + machine.config.transfer:
             logger.debug("Working on {}", dest)
             with self._mounted_source(machine, src):
@@ -247,7 +247,9 @@ class LxdMachineProvider:
             self._transfer_file_preserve_mode(machine, src, dest)
 
     def _run_setup_commands(self, machine):
-        pre_cmds = machine.get_early_setup()
+        pre_cmds = machine.get_early_setup() + [
+            "bash -c 'sudo python3 /var/tmp/metabox-provider/manage.py install'"
+        ]
         post_cmds = machine.get_late_setup()
         for cmd in pre_cmds + machine.config.setup + post_cmds:
             logger.info(f"Running command: {cmd}")

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -220,8 +220,9 @@ class LxdMachineProvider:
     def _run_transfer_commands(self, machine):
         provider_path = pkg_resources.resource_filename(
             'metabox', 'metabox-provider')
+        # Also include the metabox providers
         metabox_dir_transfers = machine.get_early_dir_transfer() + [
-            (provider_path, '/var/tmp/metabox-provider')] # avoid sideloading
+            (provider_path, '/home/ubuntu/metabox-provider')]
         for src, dest in metabox_dir_transfers + machine.config.transfer:
             logger.debug("Working on {}", dest)
             with self._mounted_source(machine, src):
@@ -247,8 +248,9 @@ class LxdMachineProvider:
             self._transfer_file_preserve_mode(machine, src, dest)
 
     def _run_setup_commands(self, machine):
+        # Also install the metabox provider
         pre_cmds = machine.get_early_setup() + [
-            "bash -c 'sudo python3 /var/tmp/metabox-provider/manage.py install'"
+            "bash -c 'sudo python3 /home/ubuntu/metabox-provider/manage.py install'"
         ]
         post_cmds = machine.get_late_setup()
         for cmd in pre_cmds + machine.config.setup + post_cmds:

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -250,13 +250,7 @@ class ContainerSourceMachine(ContainerBaseMachine):
 
     def get_early_dir_transfer(self):
         dirs = [
-            (self.config.uri, "/home/ubuntu/checkbox"),
-            (Path(self.config.uri) / "providers/base",
-             "/var/tmp/checkbox-providers/base"),
-            (Path(self.config.uri) / "providers/resource",
-             "/var/tmp/checkbox-providers/resource"),
-            (Path(self.config.uri) / "providers/certification-client",
-             "/var/tmp/checkbox-providers/certification-client"),
+            (self.config.uri, "/home/ubuntu/checkbox")
         ]
         return dirs
 
@@ -266,12 +260,13 @@ class ContainerSourceMachine(ContainerBaseMachine):
         """
 
         commands = [
-            "bash -c 'chmod +x /var/tmp/checkbox-providers/base/bin/*'",
-            "bash -c 'chmod +x /var/tmp/checkbox-providers/resource/bin/*'",
             ("bash -c 'pushd /home/ubuntu/checkbox/checkbox-ng ; "
              "sudo python3 -m pip install -e .'"),
             ("bash -c 'pushd /home/ubuntu/checkbox/checkbox-support ; "
              "sudo python3 -m pip install -e .'"),
+            "bash -c 'sudo mkdir -p /usr/local/share/plainbox-providers-1/'",
+            ("bash -c 'ls /home/ubuntu/checkbox/providers/**/manage.py"
+             "| xargs -I{} -n1 sudo python3 {} install'")
         ]
 
         if self.config.role in ('remote', 'service'):

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -264,8 +264,15 @@ class ContainerSourceMachine(ContainerBaseMachine):
              "sudo python3 -m pip install -e .'"),
             ("bash -c 'pushd /home/ubuntu/checkbox/checkbox-support ; "
              "sudo python3 -m pip install -e .'"),
+            # Create the providers dir that the install command will use
             "bash -c 'sudo mkdir -p /usr/local/share/plainbox-providers-1/'",
-            ("bash -c 'ls /home/ubuntu/checkbox/providers/**/manage.py"
+            # This installs the providers. This is based on the fact
+            # that each provider dir (that is in `checkbox/providers`)
+            # has a manage.py script that will install the provider
+            # if called with the install parameter.
+            # This lists all manage.py in these locations and calls
+            # them as sudo with an install parameter
+            ("bash -c 'ls /home/ubuntu/checkbox/providers/*/manage.py"
              "| xargs -I{} -n1 sudo python3 {} install'")
         ]
 


### PR DESCRIPTION
## Description

This removes transfers to sideload location and adds install commands for both the metabox-provider and standard providers in source machines

## Resolved issues

Resolves: https://github.com/canonical/checkbox/issues/498, https://warthogs.atlassian.net/browse/CHECKBOX-624

## Documentation

N/A

## Tests

I have tested remote and legacy for multiple distributions with metabox and all tests are still working as expected
