### PR TITLE
Bump fwts version from V23.01.00 to V23.05.00 in checkbox runtime snaps

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -60,7 +60,7 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/hwe/fwts.git/plain/snapcraft.yaml
   fwts:
-    source-tag: "V23.01.00"
+    source-tag: "V23.05.00"
     source-depth: 1
     plugin: autotools
     source: git://kernel.ubuntu.com/hwe/fwts

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -64,7 +64,7 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/hwe/fwts.git/plain/snapcraft.yaml
   fwts:
-    source-tag: "V23.01.00"
+    source-tag: "V23.05.00"
     source-depth: 1
     plugin: autotools
     source: git://kernel.ubuntu.com/hwe/fwts

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -64,7 +64,7 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/hwe/fwts.git/plain/snapcraft.yaml
   fwts:
-    source-tag: "V23.01.00"
+    source-tag: "V23.05.00"
     source-depth: 1
     plugin: autotools
     source: git://kernel.ubuntu.com/hwe/fwts

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -64,7 +64,7 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/hwe/fwts.git/plain/snapcraft.yaml
   fwts:
-    source-tag: "V23.01.00"
+    source-tag: "V23.05.00"
     source-depth: 1
     plugin: autotools
     source: git://kernel.ubuntu.com/hwe/fwts


### PR DESCRIPTION
## Description

Bump fwts to the latest tag in checkbox runtime snaps (aka checkbox-core-snap)

## Resolved issues

@Ivanhu5866 has recommended updating the Firmware Test Suite (FWTS) in Checkbox from version 23.01.00 to 23.05.00. This update includes three valuable improvements:

- Fixing the s2idle test, which previously failed to display the resume time accurately on some platforms.
- Updating SMBIOS to version 3.6, allowing for testing of newer BIOS implementations that utilize Smbios3.6 without triggering false alarms.
- The latest ACPICA update from March 31, 2023 (version 20230331).

## Tests

https://wiki.ubuntu.com/FirmwareTestSuite/ReleaseNotes/23.05.00
