### PR TITLE
Update stress-ng part to v0.15.08 in checkbox-core-snap

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -84,7 +84,7 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/stress-ng.git/plain/snap/snapcraft.yaml
   stress-ng:
-    source-tag: "V0.15.07"
+    source-tag: "V0.15.08"
     source-depth: 1
     plugin: make
     source: https://github.com/ColinIanKing/stress-ng.git

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -88,7 +88,7 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/stress-ng.git/plain/snap/snapcraft.yaml
   stress-ng:
-    source-tag: "V0.15.07"
+    source-tag: "V0.15.08"
     source-depth: 1
     plugin: make
     source: https://github.com/ColinIanKing/stress-ng.git

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -90,7 +90,7 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/stress-ng.git/plain/snap/snapcraft.yaml
   stress-ng:
-    source-tag: "V0.15.07"
+    source-tag: "V0.15.08"
     source-depth: 1
     plugin: make
     source: https://github.com/ColinIanKing/stress-ng.git

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -90,7 +90,7 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/stress-ng.git/plain/snap/snapcraft.yaml
   stress-ng:
-    source-tag: "V0.15.07"
+    source-tag: "V0.15.08"
     source-depth: 1
     plugin: make
     source: https://github.com/ColinIanKing/stress-ng.git


### PR DESCRIPTION
stress-ng v0.15.08 contains a fix to stressor af-alg which is needed by
 Limerick project

## Description
- There's an existing problem with af-alg stressor in stress-ng v0.15.07 that stress-ng will fail directly when an errorno 95 (EOPNOTSUPP) is returned during the test.
- With the [upstream commit](https://github.com/ColinIanKing/stress-ng/commit/69ddd9d997cddf8d17a594f8df40f1cfdc3158a8) EOPNOTSUPP has been processed as part of exception handling so this kind of errorno return will no longer causing af-alg test to fail.

## Resolved issues
Launchpad bug [#2017827](https://bugs.launchpad.net/limerick/+bug/2017827) in Limerick project

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests
Tested the commit on the device originally used to discover the bug reported, can get passed results with 5 runs in a row (failure rate 0/5)
