### PR TITLE
Checkbox 417/wireless detect

### DIFF
--- a/providers/base/bin/network_device_info.py
+++ b/providers/base/bin/network_device_info.py
@@ -96,10 +96,15 @@ class Utils():
 
     @staticmethod
     def get_ipv6_address(interface):
-        cmd = ['/sbin/ip', '-6', '-o', 'addr', 'show', 'dev', interface,
-               'scope', 'link']
+        cmd = ['/sbin/ip', '-6', '-o', 'addr', 'show', 'dev', interface, 'scope', 'link']
         proc = check_output(cmd, universal_newlines=True)
-        return proc.split()[3].strip()
+        try:
+            ipv6_addr = proc.split()[3].strip()
+        except Exception as e:
+            print("ERROR: getting the IPv6 address for %s: %s" %
+                  (interface, repr(e)))
+            ipv6_addr = "***NOT CONFIGURED***"
+        return ipv6_addr
 
     @classmethod
     def get_mac_address(cls, interface):

--- a/providers/base/tests/test_network_device_info.py
+++ b/providers/base/tests/test_network_device_info.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright 2020 Canonical Ltd.
+# Written by:
+#   Dio He <dio.he@canonical.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import fcntl
+import struct
+import socket
+import unittest
+import subprocess
+from unittest.mock import Mock, patch
+
+import network_device_info
+
+class GetIpv4AddressTests(unittest.TestCase):
+    # There are 2 output we could get from fcntl.ioctl():
+    # 1. No WiFi connected 
+    #    (It pulls out bytes data directly from kernel, so if the given SIOCGIFADDR doesn't exist, it raise a OSError)
+    #    "None"
+
+    # 2. Connected with WiFi
+    #    It will pulls out a 256 bytes data into buffer, then we get to parse the IP address
+    #    "192.168.68.101"
+    def test_get_ipv4_address_without_connection(self):
+        test_input = ""
+        mock_ioctl = Mock(return_value=test_input)
+        with patch("fcntl.ioctl", mock_ioctl):
+            interface = "wlo1"
+            addr = get_ipv4_address(interface)
+            self.assertEqual(addr, "***NOT CONFIGURED***")
+
+    def test_get_ipv4_address_with_connection(self):
+        test_input = "192.168.68.101"
+        mock_inet_ntoa = Mock(return_value=test_input)
+        with patch("socket.inet_ntoa", mock_inet_ntoa):
+            interface = "wlo1"
+            addr = get_ipv4_address(interface)
+            self.assertEqual(addr, "192.168.68.101")
+
+class GetIpv6AddressTests(unittest.TestCase):
+    # There are 3 output we could get, but only 2 cases will happen due to the way we command it
+    # 1. No WiFi connected 
+    #    ""
+
+    # 2. Connected with WiFi
+    #    "2: wlo1    inet6 fe80::d9eb:3f93:c7b2:86ba/64 scope link noprefixroute \       valid_lft forever preferred_lft forever"
+
+    # 3. Connected with WiFi, but we ask the wrong interface name (This would not happen in our case, because the name is given by NetworkManager)
+    #    "Device "wlan0" does not exist."
+    def test_get_ipv6_address_without_connection(self):
+        test_input = ""
+        mock_check_output = Mock(return_value=test_input)
+        with patch("subprocess.check_output", mock_check_output):
+            interface = "wlo1"
+            addr = get_ipv6_address(interface)
+            self.assertEqual(addr, "***NOT CONFIGURED***")
+
+    def test_get_ipv6_address_with_connection(self):
+        test_input = "2: wlo1    inet6 fe80::d9eb:3f93:c7b2:86ba/64 scope link noprefixroute \       valid_lft forever preferred_lft forever"
+        mock_check_output = Mock(return_value=test_input)
+        with patch("subprocess.check_output", mock_check_output): # somehow it don't regonize check_output() if I don't put subprocess in front
+            interface = "wlo1"
+            addr = get_ipv6_address(interface)
+            self.assertEqual(addr, "fe80::d9eb:3f93:c7b2:86ba/64")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

<!--
Describe your changes here:
These changes is to solve https://github.com/canonical/checkbox/issues/290
The issue occurs when IoT device runs wireless detect test without connected WiFi.
It's because IoT device doesn't turn off network module, but turn into dormant. Which causing network_device_info.py try to fetch IP address without connected WiFi.

The solution is add a exception handling to prevent OSError.

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
https://github.com/canonical/checkbox/issues/290
https://warthogs.atlassian.net/jira/software/c/projects/CHECKBOX/boards/590?modal=detail&selectedIssue=CHECKBOX-417
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests
$checkbox-nuremberg.shell
$python3 network_device_info.py

Tested on 10.102.160.211 (Ubuntu Core 20)
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
-->
