### PR TITLE
Remove hardcoded version strings in python code

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -34,10 +34,6 @@ message = Bump version: {current_version} → {new_version}
 search = version="{current_version}"
 replace = version="{new_version}"
 
-[bumpversion:file:checkbox-ng/checkbox_ng/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [bumpversion:file:checkbox-ng/plainbox/__init__.py]
 search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -38,10 +38,6 @@ replace = version="{new_version}"
 search = version="{current_version}"
 replace = version="{new_version}"
 
-[bumpversion:file:providers/certification-server/manage.py]
-search = version="{current_version}"
-replace = version="{new_version}"
-
 [bumpversion:file:providers/gpgpu/manage.py]
 search = version="{current_version}"
 replace = version="{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -38,10 +38,6 @@ replace = version="{new_version}"
 search = version="{current_version}"
 replace = version="{new_version}"
 
-[bumpversion:file:providers/base/manage.py]
-search = version="{current_version}"
-replace = version="{new_version}"
-
 [bumpversion:file:providers/certification-client/manage.py]
 search = version="{current_version}"
 replace = version="{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -38,10 +38,6 @@ replace = version="{new_version}"
 search = version="{current_version}"
 replace = version="{new_version}"
 
-[bumpversion:file:providers/gpgpu/manage.py]
-search = version="{current_version}"
-replace = version="{new_version}"
-
 [bumpversion:file:providers/resource/manage.py]
 search = version="{current_version}"
 replace = version="{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -38,10 +38,6 @@ replace = version="{new_version}"
 search = version="{current_version}"
 replace = version="{new_version}"
 
-[bumpversion:file:providers/resource/manage.py]
-search = version="{current_version}"
-replace = version="{new_version}"
-
 [bumpversion:file:providers/sru/manage.py]
 search = version="{current_version}"
 replace = version="{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -38,10 +38,6 @@ replace = version="{new_version}"
 search = version="{current_version}"
 replace = version="{new_version}"
 
-[bumpversion:file:providers/certification-client/manage.py]
-search = version="{current_version}"
-replace = version="{new_version}"
-
 [bumpversion:file:providers/certification-server/manage.py]
 search = version="{current_version}"
 replace = version="{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -38,10 +38,6 @@ replace = version="{new_version}"
 search = version="{current_version}"
 replace = version="{new_version}"
 
-[bumpversion:file:providers/sru/manage.py]
-search = version="{current_version}"
-replace = version="{new_version}"
-
 [bumpversion:file:providers/tpm2/manage.py]
 search = version="{current_version}"
 replace = version="{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -34,10 +34,6 @@ message = Bump version: {current_version} → {new_version}
 search = version="{current_version}"
 replace = version="{new_version}"
 
-[bumpversion:file:checkbox-ng/plainbox/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [bumpversion:file:checkbox-support/setup.py]
 search = version="{current_version}"
 replace = version="{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -38,10 +38,6 @@ replace = version="{new_version}"
 search = version="{current_version}"
 replace = version="{new_version}"
 
-[bumpversion:file:providers/tpm2/manage.py]
-search = version="{current_version}"
-replace = version="{new_version}"
-
 [bumpversion:part:release]
 optional_value = RELEASE
 values = RELEASE

--- a/checkbox-ng/checkbox_ng/__init__.py
+++ b/checkbox-ng/checkbox_ng/__init__.py
@@ -30,6 +30,6 @@ try:
     __version__ = version("checkbox-ng")
 except PackageNotFoundError:
     import logging
-    logging.error('Failed to retieve checkbox-ng version')
+    logging.error('Failed to retrieve checkbox-ng version')
     __version__ = 'unknown'
 

--- a/checkbox-ng/checkbox_ng/__init__.py
+++ b/checkbox-ng/checkbox_ng/__init__.py
@@ -24,5 +24,12 @@
 CheckBoxNG is a new version of CheckBox built on top of PlainBox
 """
 
-__version__ = '2.6'
+from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("checkbox-ng")
+except PackageNotFoundError:
+    import logging
+    logging.error('Failed to retieve checkbox-ng version')
+    __version__ = 'unknown'
 

--- a/checkbox-ng/plainbox/__init__.py
+++ b/checkbox-ng/plainbox/__init__.py
@@ -27,7 +27,14 @@ All abstract base classes are in :mod:`plainbox.abc`.
 # PEP440 compliant version declaration.
 #
 # This is used by @public decorator to enforce our public API guarantees.
-__version__ = '2.6'
+from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("checkbox-ng")
+except PackageNotFoundError:
+    import logging
+    logging.error('Failed to retieve checkbox-ng version')
+    __version__ = 'unknown'
 
 def get_version_string():
     import os

--- a/checkbox-ng/plainbox/__init__.py
+++ b/checkbox-ng/plainbox/__init__.py
@@ -33,7 +33,7 @@ try:
     __version__ = version("checkbox-ng")
 except PackageNotFoundError:
     import logging
-    logging.error('Failed to retieve checkbox-ng version')
+    logging.error('Failed to retrieve checkbox-ng version')
     __version__ = 'unknown'
 
 def get_version_string():

--- a/checkbox-ng/setup.py
+++ b/checkbox-ng/setup.py
@@ -51,6 +51,7 @@ else:
         'Jinja2 >= 2.7',
         'xlsxwriter',
         'tqdm',
+        'importlib_metadata',
     ]
 
 setup(

--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -12,3 +12,4 @@ sphinxext-opengraph
 lxd-sphinx-extensions
 sphinx-copybutton
 myst-parser
+importlib_metadata

--- a/providers/base/manage.py
+++ b/providers/base/manage.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
+import plainbox
+
 from plainbox.provider_manager import setup
 from plainbox.provider_manager import N_
 
 setup(
     name='checkbox-provider-base',
     namespace='com.canonical.certification',
-    version="2.6",
+    version=plainbox.__version__,
     description=N_("Checkbox provider base"),
     gettext_domain='checkbox-provider-base',
     strict=False, deprecated=False,

--- a/providers/certification-client/manage.py
+++ b/providers/certification-client/manage.py
@@ -21,6 +21,7 @@
 import shutil
 import os
 
+import plainbox
 from plainbox.provider_manager import InstallCommand
 from plainbox.provider_manager import SourceDistributionCommand
 from plainbox.provider_manager import _logger
@@ -79,7 +80,7 @@ class InstallCommandExt(InstallCommand):
 setup(
     name='checkbox-provider-certification-client',
     namespace='com.canonical.certification',
-    version="2.6",
+    version=plainbox.__version__,
     description=N_("Client Certification provider"),
     gettext_domain="checkbox-provider-certification-client",
     deprecated=False,

--- a/providers/certification-server/manage.py
+++ b/providers/certification-server/manage.py
@@ -21,6 +21,7 @@
 import shutil
 import os
 
+import plainbox
 from plainbox.provider_manager import InstallCommand
 from plainbox.provider_manager import SourceDistributionCommand
 from plainbox.provider_manager import _logger
@@ -79,7 +80,7 @@ class InstallCommandExt(InstallCommand):
 setup(
     name='checkbox-provider-certification-server',
     namespace='com.canonical.certification',
-    version="2.6",
+    version=plainbox.__version__,
     description=N_("Server Certification provider"),
     gettext_domain="checkbox-provider-certification-server",
     strict=False, deprecated=False,

--- a/providers/gpgpu/manage.py
+++ b/providers/gpgpu/manage.py
@@ -21,6 +21,7 @@
 import shutil
 import os
 
+import plainbox
 from plainbox.provider_manager import InstallCommand
 from plainbox.provider_manager import SourceDistributionCommand
 from plainbox.provider_manager import _logger
@@ -79,7 +80,7 @@ class InstallCommandExt(InstallCommand):
 setup(
     name='checkbox-provider-gpgpu',
     namespace='com.canonical.certification',
-    version="2.6",
+    version=plainbox.__version__,
     description=N_("Checkbox Provider for GPGPU Testing"),
     gettext_domain='checkbox-provider-gpgpu',
 )

--- a/providers/resource/manage.py
+++ b/providers/resource/manage.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import subprocess
 
+import plainbox
 from plainbox.provider_manager import N_
 from plainbox.provider_manager import SourceDistributionCommand
 from plainbox.provider_manager import manage_py_extension
@@ -44,7 +45,7 @@ class SourceDistributionCommandExt(SourceDistributionCommand):
 setup(
     name='checkbox-provider-resource',
     namespace='com.canonical.certification',
-    version="2.6",
+    version=plainbox.__version__,
     description=N_("Checkbox provider resource"),
     gettext_domain='checkbox-provider-resource',
     strict=False, deprecated=False,

--- a/providers/sru/manage.py
+++ b/providers/sru/manage.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import plainbox
 from plainbox.provider_manager import setup, N_
 
 # You can inject other stuff here but please don't go overboard.
@@ -16,7 +17,7 @@ from plainbox.provider_manager import setup, N_
 setup(
     name='checkbox-provider-sru',
     namespace='com.canonical.certification',
-    version="2.6",
+    version=plainbox.__version__,
     description=N_("The SRU provider"),
     gettext_domain="checkbox-provider-sru",
 )

--- a/providers/tpm2/manage.py
+++ b/providers/tpm2/manage.py
@@ -19,13 +19,14 @@
 
 """Management script for the TPM 2.0 provider."""
 
+import plainbox
 from plainbox.provider_manager import setup
 from plainbox.provider_manager import N_
 
 setup(
     name='checkbox-provider-tpm2',
     namespace='com.canonical.certification',
-    version="2.6",
+    version=plainbox.__version__,
     description=N_("Checkbox Provider for TPM 2.0 (trusted platform module)"),
     gettext_domain='checkbox-provider-tpm2',
 )


### PR DESCRIPTION
## Description
This changes all `version` and `__version__` variables/kwargs from being hardcoded to be retrieved at runtime

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-614

## Documentation
N/A

## Tests

This was tested running metabox scenarios for both the legacy and the remote version
