### PR TITLE
Fixed TP selection empty to be interactive

### DIFF
--- a/metabox/metabox/scenarios/config/test_selection.py
+++ b/metabox/metabox/scenarios/config/test_selection.py
@@ -277,7 +277,7 @@ class TestPlanSelectionFilterEmpty(Scenario):
         filter = [^\w\d]
         """)
     steps = [
-        AssertPrinted(".*There were no test plans to select from.*")
+        Expect("There were no test plans to select from"),
     ]
 
 class TestPlanSelectionFilter(Scenario):


### PR DESCRIPTION
## Description

Test does not pass in main because checkbox is started non iteractively and fails before the expected failure
