### PR TITLE
Add support to cpuid.py for AMD Bergamo

### DIFF
--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -111,6 +111,7 @@ CPUIDS = {
         "AMD Milan-X":      ['0xa00f12'],
         "AMD ROME":         ['0x830f10'],
         "AMD Ryzen":        ['0x810f81'],
+        "AMD Bergamo":      ['0xaa0f01'],
         "Broadwell":        ['0x4067', '0x306d4', '0x5066', '0x406f'],
         "Canon Lake":       ['0x6066'],
         "Cascade Lake":     ['0x50655', '0x50656', '0x50657'],


### PR DESCRIPTION
## Description
In cpuid.py  support has been added for the AMD Bergamo CPU
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Test results for cpuid had been failing when servers with the AMD Bergamo cpu were tested.
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
-->
