### PR TITLE
Warn on unused develop PROVIDERPATH

### DIFF
--- a/checkbox-ng/plainbox/provider_manager.py
+++ b/checkbox-ng/plainbox/provider_manager.py
@@ -552,7 +552,10 @@ class DevelopCommand(ManageCommand):
     def invoked(self, ns):
         pp_env = os.getenv("PROVIDERPATH")
         if pp_env and not os.path.samefile(pp_env, ns.directory):
-            _logger.warning("$PROVIDERPATH is defined, ignoring -d/--directory and developing there")
+            _logger.warning(
+                "$PROVIDERPATH is defined, ignoring -d/--directory"
+                " and developing in: %s", pp_env
+            )
             ns.directory = pp_env
         pathname = os.path.join(
             ns.directory, "{}.provider".format(

--- a/checkbox-ng/plainbox/provider_manager.py
+++ b/checkbox-ng/plainbox/provider_manager.py
@@ -550,6 +550,10 @@ class DevelopCommand(ManageCommand):
             help=_("directory to use (defaults to user's home provider path)"))
 
     def invoked(self, ns):
+        pp_env = os.getenv("PROVIDERPATH")
+        if pp_env and not os.path.samefile(pp_env, ns.directory):
+            _logger.warning("$PROVIDERPATH is defined, ignoring -d/--directory and developing there")
+            ns.directory = pp_env
         pathname = os.path.join(
             ns.directory, "{}.provider".format(
                 self.definition.name.replace(':', '.')))


### PR DESCRIPTION
## Description

The develop command of the providers accepts a `-d/--directory` arg that is, by default, not `$PROVIDERPATH`. This leads to the counter intuitive result that if one develops a provider with the provider path envvar defined without providing it explicitly to the develop command, it will not show up in the list of providers. 

With this patch the `-d` arg is ignored when the `PROVIDERPATH` envvar is defined and a warning is issued if the two did not specify the same location

## Resolved issues

N/A

## Documentation

N/A

## Tests

This was tested locally by checking every combination