### PR TITLE
Make sure all the expected snaps are built during the release process

### DIFF
--- a/.github/workflows/checkbox-core-snap-beta-release.yml
+++ b/.github/workflows/checkbox-core-snap-beta-release.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   snap:
     strategy:
+      fail-fast: false
       matrix:
         releases: [16, 18, 20, 22]
     runs-on: ubuntu-latest
@@ -50,6 +51,25 @@ jobs:
         with:
           name: series${{ matrix.releases }}
           path: checkbox-core-snap/series${{ matrix.releases }}/*.snap
+      - name: Check that snapcraft built the expected amount of snaps
+        run: |
+          NB_SNAPS=$(ls -l checkbox-core-snap/series${{ matrix.releases }}/*.snap | wc -l)
+          # Expecting 3 snaps for checkbox20 and checkbox22 (amd64, armhf, arm64)
+          # and 4 snaps for checkbox16 and checkbox18 (i386, amd64, armhf, arm64)
+          if [ ${{ matrix.releases }} == "16" ] || [ ${{ matrix.releases }} == "18" ]
+          then
+            if [ ${NB_SNAPS} != "4" ]
+            then
+              echo "Error: Snapcraft should have produced 4 snaps, found ${NB_SNAPS} instead."
+                exit 1
+            fi
+          else
+            if [ ${NB_SNAPS} != "3" ]
+            then
+              echo "Error: Snapcraft should have produced 3 snaps, found ${NB_SNAPS} instead."
+              exit 1
+            fi
+          fi
       - name: Upload checkbox core snaps to the store
         run: |
           for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap

--- a/.github/workflows/checkbox-core-snap-beta-release.yml
+++ b/.github/workflows/checkbox-core-snap-beta-release.yml
@@ -53,7 +53,7 @@ jobs:
           path: checkbox-core-snap/series${{ matrix.releases }}/*.snap
       - name: Check that snapcraft built the expected amount of snaps
         run: |
-          NB_SNAPS=$(ls -l checkbox-core-snap/series${{ matrix.releases }}/*.snap | wc -l)
+          NB_SNAPS=$(find checkbox-core-snap/series${{ matrix.releases }} -maxdepth 1 -type f -name *.snap | wc -l)
           # Expecting 3 snaps for checkbox20 and checkbox22 (amd64, armhf, arm64)
           # and 4 snaps for checkbox16 and checkbox18 (i386, amd64, armhf, arm64)
           if [ ${{ matrix.releases }} == "16" ] || [ ${{ matrix.releases }} == "18" ]

--- a/.github/workflows/checkbox-snap-beta-release.yml
+++ b/.github/workflows/checkbox-snap-beta-release.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   snap:
     strategy:
+      fail-fast: false
       matrix:
         type: [classic, uc]
         releases: [16, 18, 20, 22]
@@ -51,6 +52,25 @@ jobs:
         with:
           name: series_${{ matrix.type }}${{ matrix.releases }}
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
+      - name: Check that snapcraft built the expected amount of snaps
+        run: |
+          NB_SNAPS=$(ls -l checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap | wc -l)
+          # Expecting 3 snaps for 20 and 22 releases (amd64, armhf, arm64)
+          # and 4 snaps for 16 and 18 releases (i386, amd64, armhf, arm64)
+          if [ ${{ matrix.releases }} == "16" ] || [ ${{ matrix.releases }} == "18" ]
+          then
+            if [ ${NB_SNAPS} != "4" ]
+            then
+              echo "Error: Snapcraft should have produced 4 snaps, found ${NB_SNAPS} instead."
+                exit 1
+            fi
+          else
+            if [ ${NB_SNAPS} != "3" ]
+            then
+              echo "Error: Snapcraft should have produced 3 snaps, found ${NB_SNAPS} instead."
+              exit 1
+            fi
+          fi
       - name: Upload checkbox snaps to the store
         run: |
           for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap

--- a/.github/workflows/checkbox-snap-beta-release.yml
+++ b/.github/workflows/checkbox-snap-beta-release.yml
@@ -54,7 +54,7 @@ jobs:
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
       - name: Check that snapcraft built the expected amount of snaps
         run: |
-          NB_SNAPS=$(ls -l checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap | wc -l)
+          NB_SNAPS=$(find checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }} -maxdepth 1 -type f -name *.snap | wc -l)
           # Expecting 3 snaps for 20 and 22 releases (amd64, armhf, arm64)
           # and 4 snaps for 16 and 18 releases (i386, amd64, armhf, arm64)
           if [ ${{ matrix.releases }} == "16" ] || [ ${{ matrix.releases }} == "18" ]


### PR DESCRIPTION
`snapcraft --remote-build` may fail to build all the snaps required (one per architecture), and yet return 0 (no error), resulting in a "passed" GitHub workflow even when not all the snaps have been submitted.

To prevent this, add a step to check the expected number of snaps is present.

fail-fast strategy is set to false so that even if one of the workflow fails, the others will continue. This is useful because it is possible to manually re-run the failed workflow (for instance, the one for checkbox22), so the others (checkbox16, checkbox18, checkbox20) should not be impacted.

[1] https://github.com/snapcore/snapcraft/issues/4142

Fix CHECKBOX-446

