### PR TITLE
Enable CPU tests for ARM64

### DIFF
--- a/providers/base/units/cpu/jobs.pxu
+++ b/providers/base/units/cpu/jobs.pxu
@@ -145,7 +145,7 @@ _summary:
  Test offlining of each CPU core
 _description:
  Attempts to offline each core in a multicore system.
-requires: cpuinfo.platform not in ("aarch64", "armv7l")
+requires: cpuinfo.platform not in ("armv7l")
 
 plugin: shell
 category_id: com.canonical.plainbox::cpu

--- a/providers/base/units/cpu/jobs.pxu
+++ b/providers/base/units/cpu/jobs.pxu
@@ -134,18 +134,6 @@ _summary:
 _description:
  Runs a test for clock jitter on SMP machines.
 
-id: cpu_offlining
-estimated_duration: 0.02
-plugin: resource
-command:
- if ls /sys/devices/system/cpu/*/online >& /dev/null
- then
-     echo "state: supported"
- else
-     echo "state: unsupported"
- fi
-_description: Creates resource info for CPU offlining
-
 plugin: shell
 category_id: com.canonical.plainbox::cpu
 id: cpu/offlining_test

--- a/providers/base/units/cpu/jobs.pxu
+++ b/providers/base/units/cpu/jobs.pxu
@@ -134,9 +134,23 @@ _summary:
 _description:
  Runs a test for clock jitter on SMP machines.
 
+id: cpu_offlining
+estimated_duration: 0.02
+plugin: resource
+command:
+ if ls /sys/devices/system/cpu/*/online >& /dev/null
+ then
+     echo "state: supported"
+ else
+     echo "state: unsupported"
+ fi
+_description: Creates resource info for CPU offlining
+
 plugin: shell
 category_id: com.canonical.plainbox::cpu
 id: cpu/offlining_test
+requires:
+  cpu_offlining.state == 'supported'
 flags: also-after-suspend
 estimated_duration: 128.0
 user: root
@@ -145,7 +159,6 @@ _summary:
  Test offlining of each CPU core
 _description:
  Attempts to offline each core in a multicore system.
-requires: cpuinfo.platform not in ("armv7l")
 
 plugin: shell
 category_id: com.canonical.plainbox::cpu

--- a/providers/base/units/cpu/resource.pxu
+++ b/providers/base/units/cpu/resource.pxu
@@ -1,0 +1,11 @@
+id: cpu_offlining
+estimated_duration: 0.02
+plugin: resource
+command:
+ if ls /sys/devices/system/cpu/*/online >& /dev/null
+ then
+     echo "state: supported"
+ else
+     echo "state: unsupported"
+ fi
+_description: Creates resource info for CPU offlining


### PR DESCRIPTION
## Description
For Riverside project, I tried to improve CPU test coverage on ARM64 devices, and found out many tests were skipped because of a requirement limitation on the architecture. Using a side loaded provider, I tried to remove those limitations to see if they are still relevant or not, hoping I could increase the test coverage.
<!--
Describe your changes here:
- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
https://warthogs.atlassian.net/browse/PERI-117
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests
As a result, I can observe the following status on the sub tests [submission.tar.gz](https://github.com/canonical/checkbox/files/11615285/submission.tar.gz)
* cpu/arm_vfp_support_aarch64 is passing without any modification
* cpu/clocktest as well
* cpu/maxfreq_test is running fwts but the subsequent test maxfreq isn’t supported on ARM64, as a result, it is skipped, even if we remove the requirement restriction on ARM64 (which makes sense in that regard)
* cpu/offlining_test runs successfully if we remove the requirement restriction on ARM64
`Successfully turned 11 cores off and back on`
* cpu/scaling_test performs some tests, skip some others and fail one qualified with Medium priority, without any change
* cpu/topology relies on providers/base/bin/cpu_topology.py to compare the cpu descriptions obtained with “/proc/cpuinfo” versus “/sys/devices/system/cpu/' + proc + ‘/topology”. While sysfs gives accurate description, procfs don’t display the core id and physical id of each cpu, so the test can neither pass successfully, nor be adapted. This one should stay disabled for ARM64
* cpu/cstates can’t run as well, as it depends on a cstates subset of tests from fwts, not available for ARM64

In conclusion, the only improvement we can make is to enable the cpu/offlining_test 
