### PR TITLE
Fix version packages stdlib

### DIFF
--- a/checkbox-ng/checkbox_ng/__init__.py
+++ b/checkbox-ng/checkbox_ng/__init__.py
@@ -24,10 +24,13 @@
 CheckBoxNG is a new version of CheckBox built on top of PlainBox
 """
 
-from importlib_metadata import version, PackageNotFoundError
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    from importlib_metadata import version, PackageNotFoundError
 
 try:
-    __version__ = version("checkbox-ng")
+    __version__ = version(__package__)
 except PackageNotFoundError:
     import logging
     logging.error('Failed to retrieve checkbox-ng version')

--- a/checkbox-ng/debian/control
+++ b/checkbox-ng/debian/control
@@ -51,6 +51,7 @@ Depends: python3-jinja2,
          python3-tqdm,
          python3-urwid,
          python3-xlsxwriter,
+         python3-importlib-metadata | python3 (>> 3.8),
          ${misc:Depends},
          ${python3:Depends}
 Breaks: python3-plainbox (<<1)

--- a/checkbox-ng/debian/control
+++ b/checkbox-ng/debian/control
@@ -21,6 +21,7 @@ Build-Depends: debhelper (>= 9),
                python3-tqdm,
                python3-urwid,
                python3-xlsxwriter
+               python3-importlib-metadata | python3 (>> 3.8),
 Standards-Version: 3.9.6
 X-Python3-Version: >= 3.2
 

--- a/checkbox-ng/debian/control
+++ b/checkbox-ng/debian/control
@@ -8,6 +8,7 @@ Build-Depends: debhelper (>= 9),
                python3-all,
                python3-distutils-extra,
                python3-docutils,
+               python3-importlib-metadata | python3 (>> 3.8),
                python3-jinja2,
                python3-packaging,
                python3-padme,
@@ -21,7 +22,6 @@ Build-Depends: debhelper (>= 9),
                python3-tqdm,
                python3-urwid,
                python3-xlsxwriter
-               python3-importlib-metadata | python3 (>> 3.8),
 Standards-Version: 3.9.6
 X-Python3-Version: >= 3.2
 
@@ -42,7 +42,8 @@ Description: CheckBoxNG test runner
 
 Package: python3-checkbox-ng
 Architecture: all
-Depends: python3-jinja2,
+Depends: python3-importlib-metadata | python3 (>> 3.8),
+         python3-jinja2,
          python3-packaging,
          python3-padme,
          python3-pkg-resources,
@@ -52,7 +53,6 @@ Depends: python3-jinja2,
          python3-tqdm,
          python3-urwid,
          python3-xlsxwriter,
-         python3-importlib-metadata | python3 (>> 3.8),
          ${misc:Depends},
          ${python3:Depends}
 Breaks: python3-plainbox (<<1)

--- a/checkbox-ng/plainbox/__init__.py
+++ b/checkbox-ng/plainbox/__init__.py
@@ -27,7 +27,10 @@ All abstract base classes are in :mod:`plainbox.abc`.
 # PEP440 compliant version declaration.
 #
 # This is used by @public decorator to enforce our public API guarantees.
-from importlib_metadata import version, PackageNotFoundError
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    from importlib_metadata import version, PackageNotFoundError
 
 try:
     __version__ = version("checkbox-ng")

--- a/checkbox-ng/setup.py
+++ b/checkbox-ng/setup.py
@@ -51,8 +51,10 @@ else:
         'Jinja2 >= 2.7',
         'xlsxwriter',
         'tqdm',
-        'importlib_metadata',
     ]
+    if sys.version_info[0] == 3 and sys.version_info[1] < 8:
+        # in version 3.8+ we can use importlib.metadata
+        install_requires.append('importlib_metadata')
 
 setup(
     name="checkbox-ng",

--- a/checkbox-ng/setup.py
+++ b/checkbox-ng/setup.py
@@ -51,10 +51,7 @@ else:
         'Jinja2 >= 2.7',
         'xlsxwriter',
         'tqdm',
-    ]
-    if sys.version_info[0] == 3 and sys.version_info[1] < 8:
-        # in version 3.8+ we can use importlib.metadata
-        install_requires.append('importlib_metadata')
+    ] + (["importlib_metadata"] if sys.version_info < (3, 8) else [])
 
 setup(
     name="checkbox-ng",

--- a/checkbox-support/debian/control
+++ b/checkbox-support/debian/control
@@ -17,7 +17,8 @@ Build-Depends:
  python3-requests,
  python3-requests-unixsocket,
  python3-setuptools,
- python3-yaml
+ python3-yaml,
+ python3-importlib-metadata | python3 (>> 3.8)
 Standards-Version: 3.9.6
 X-Python3-Version: >= 3.5
 XS-Testsuite: autopkgtest

--- a/checkbox-support/debian/control
+++ b/checkbox-support/debian/control
@@ -36,6 +36,7 @@ Depends: gir1.2-gudev-1.0,
          python3-yaml,
          udev,
          udisks2,
+         python3-importlib-metadata | python3 (>> 3.8),
          ${misc:Depends},
          ${python3:Depends}
 Description: collection of Python modules used by PlainBox providers

--- a/checkbox-support/debian/control
+++ b/checkbox-support/debian/control
@@ -11,14 +11,14 @@ Build-Depends:
  python3-dbus,
  python3-distro,
  python3-gi,
+ python3-importlib-metadata | python3 (>> 3.8),
  python3-lxml (>= 2.3),
  python3-pkg-resources,
  python3-pyparsing,
  python3-requests,
  python3-requests-unixsocket,
  python3-setuptools,
- python3-yaml,
- python3-importlib-metadata | python3 (>> 3.8)
+ python3-yaml
 Standards-Version: 3.9.6
 X-Python3-Version: >= 3.5
 XS-Testsuite: autopkgtest
@@ -30,6 +30,7 @@ Depends: gir1.2-gudev-1.0,
          python3-dbus,
          python3-distro,
          python3-gi,
+         python3-importlib-metadata | python3 (>> 3.8),
          python3-lxml,
          python3-pyparsing,
          python3-requests,
@@ -37,7 +38,6 @@ Depends: gir1.2-gudev-1.0,
          python3-yaml,
          udev,
          udisks2,
-         python3-importlib-metadata | python3 (>> 3.8),
          ${misc:Depends},
          ${python3:Depends}
 Description: collection of Python modules used by PlainBox providers

--- a/checkbox-support/setup.py
+++ b/checkbox-support/setup.py
@@ -48,13 +48,10 @@ setup(
     description="CheckBox support library",
     long_description=long_description,
     package_data={"checkbox_support": ["parsers/cputable"]},
-    install_requires=[
-        'pyparsing >= 2.2.0',
-        'requests >= 1.0',
-        'distro >= 1.0'
-    ] + (['configparser'] if sys.version_info.major == 2 else []) + (
-        ['requests_unixsocket >= 0.1.2']
-        if sys.version_info >= (3, 5) else []),
+    install_requires=["pyparsing >= 2.2.0", "requests >= 1.0", "distro >= 1.0"]
+    + (["configparser"] if sys.version_info.major == 2 else [])
+    + (["requests_unixsocket >= 0.1.2"] if sys.version_info >= (3, 5) else [])
+    + (["importlib_metadata"] if sys.version_info < (3, 8) else []),
     include_package_data=True,
     entry_points={
         'plainbox.parsers': [


### PR DESCRIPTION
## Description

This fixes the debian build requirements that the __version__ update broke

Minor: This also alters the import of the importlib-metadata to be required only when the stdlib version is not available

## Resolved issues

N/A


## Documentation

N/A

## Tests

N/A
