### PR TITLE
Fix broken tests mkdir put

### DIFF
--- a/metabox/metabox/core/actions.py
+++ b/metabox/metabox/core/actions.py
@@ -25,7 +25,7 @@ __all__ = [
     "Start", "Expect", "Send", "SelectTestPlan",
     "AssertPrinted", "AssertNotPrinted", "AssertRetCode",
     "AssertServiceActive", "Sleep", "RunCmd", "Signal", "Reboot",
-    "NetUp", "NetDown", "Put"
+    "NetUp", "NetDown", "Put", "MkTree"
 ]
 
 
@@ -99,3 +99,7 @@ class NetDown(ActionBase):
 
 class Put(ActionBase):
     handler = 'put'
+
+
+class MkTree(ActionBase):
+    handler = "mktree"

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -24,6 +24,7 @@ the interface to a Scenario.
 """
 import re
 import time
+import shlex
 
 from metabox.core.actions import Start, Expect, Send, SelectTestPlan
 from metabox.core.aggregator import aggregator
@@ -273,3 +274,13 @@ class Scenario:
 
     def is_service_active(self):
         return self.service_machine.is_service_active()
+
+    def mktree(self, path, privileged=False, timeout=0, target='all'):
+        """
+        Creates a directory including any missing parent
+        """
+        cmd = ["mkdir", "-p", path]
+        if privileged:
+            cmd = ["sudo"] + cmd
+        cmd_str = shlex.join(cmd)
+        self.run_cmd(cmd_str, target=target, timeout=timeout)

--- a/metabox/metabox/scenarios/config/environment.py
+++ b/metabox/metabox/scenarios/config/environment.py
@@ -19,10 +19,8 @@
 import textwrap
 from importlib.resources import read_text
 
-from metabox.core.actions import AssertPrinted
-from metabox.core.actions import Start
-from metabox.core.actions import Put
 from metabox.core.scenario import Scenario
+from metabox.core.actions import AssertPrinted, Start, MkTree, Put
 
 from .config_files import environment
 
@@ -68,6 +66,7 @@ class CheckboxConfLocalHome(Scenario):
         forced = yes
         """)
     steps = [
+        MkTree("/home/ubuntu/.config/"),
         Put("/home/ubuntu/.config/checkbox.conf", checkbox_conf),
         Start(),
         AssertPrinted("source: HOME"),
@@ -92,6 +91,7 @@ class CheckboxConfRemoteHome(Scenario):
         forced = yes
         """)
     steps = [
+        MkTree("/root/.config/", privileged=True),
         Put("/root/.config/checkbox.conf", checkbox_conf),
         Start(),
         AssertPrinted("source: HOME"),
@@ -116,6 +116,7 @@ class CheckboxConfSnap(Scenario):
         forced = yes
         """)
     steps = [
+        MkTree("/var/snap/checkbox/current/"),
         Put("/var/snap/checkbox/current/checkbox.conf", checkbox_conf),
         Start(),
         AssertPrinted("source: SNAP"),
@@ -164,6 +165,7 @@ class CheckboxConfLocalHomePrecedence(Scenario):
         """)
     steps = [
         Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg),
+        MkTree("/home/ubuntu/.config/"),
         Put("/home/ubuntu/.config/checkbox.conf", checkbox_conf_home),
         Start(),
         AssertPrinted("source: HOME"),
@@ -229,6 +231,7 @@ class CheckboxConfLocalResolutionOrder(Scenario):
         """)
     steps = [
         Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg),
+        MkTree("/home/ubuntu/.config/"),
         Put("/home/ubuntu/.config/checkbox.conf", checkbox_conf_home),
         Start(),
         AssertPrinted("variables: LAUNCHER HOME XDG"),
@@ -264,6 +267,7 @@ class CheckboxConfRemoteServiceResolutionOrder(Scenario):
     )
     steps = [
         Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="service"),
+        MkTree("/root/.config", privileged=True),
         Put(
             "/root/.config/checkbox.conf", checkbox_conf_home, target="service"
         ),

--- a/metabox/metabox/scenarios/config/test_manifest.py
+++ b/metabox/metabox/scenarios/config/test_manifest.py
@@ -24,14 +24,13 @@ from metabox.core.actions import (
     Start,
     Put,
     Send,
-    RunCmd,
+    MkTree,
+
 )
 from metabox.core.scenario import Scenario
 from metabox.core.utils import tag
 
 from .config_files import test_manifest
-
-MANIFEST_LOCATION = "/var/tmp/checkbox-ng/machine-manifest.json"
 
 conf_wrong = read_text(test_manifest, "wrong.json")
 
@@ -108,7 +107,8 @@ class ManifestConfigCacheAuto(Scenario):
     """)
 
     steps = [
-        Put(MANIFEST_LOCATION, conf_correct),
+        MkTree("/var/tmp/checkbox-ng"),
+        Put("/var/tmp/checkbox-ng/machine-manifest.json", conf_correct),
         Start(),
         AssertPrinted(".*Outcome: job passed.*"),
     ]
@@ -132,7 +132,8 @@ class ManifestConfigCacheManual(Scenario):
     """)
 
     steps = [
-        Put(MANIFEST_LOCATION, conf_correct),
+        MkTree("/var/tmp/checkbox-ng"),
+        Put("/var/tmp/checkbox-ng/machine-manifest.json", conf_correct),
         Start(),
         Expect("tests to run on your system"),
         Send("T"),
@@ -167,7 +168,8 @@ class ManifestConfigPrecedenceAuto(Scenario):
     """)
 
     steps = [
-        Put(MANIFEST_LOCATION, conf_wrong),
+        MkTree("/var/tmp/checkbox-ng"),
+        Put("/var/tmp/checkbox-ng/machine-manifest.json", conf_wrong),
         Start(),
         AssertPrinted(".*Outcome: job passed.*")
     ]
@@ -194,7 +196,8 @@ class ManifestConfigPrecedenceManual(Scenario):
     """)
 
     steps = [
-        Put(MANIFEST_LOCATION, conf_wrong),
+        MkTree("/var/tmp/checkbox-ng"),
+        Put("/var/tmp/checkbox-ng/machine-manifest.json", conf_wrong),
         Start(),
         Expect("tests to run on your system"),
         Send("T"),

--- a/metabox/metabox/scenarios/config/test_selection.py
+++ b/metabox/metabox/scenarios/config/test_selection.py
@@ -20,7 +20,7 @@ import textwrap
 from importlib.resources import read_text
 
 from metabox.core.actions import AssertPrinted, AssertNotPrinted, Expect,\
-        Start, Put, Send
+        Start, Put, Send, MkTree
 from metabox.core.scenario import Scenario
 
 from .config_files import test_selection
@@ -116,6 +116,7 @@ class LocalTestSelectionResolution(Scenario):
         forced = yes
         """)
     steps = [
+        MkTree("/home/ubuntu/.config"),
         Put("/home/ubuntu/.config/checkbox.conf", checkbox_conf_home),
         Put("/etc/xdg/checkbox.conf", checkbox_conf_etc),
         Start(),
@@ -151,6 +152,7 @@ class RemoteTestSelectionResolution(Scenario):
         forced = yes
         """)
     steps = [
+        MkTree("/home/ubuntu/.config", target="service"),
         Put("/home/ubuntu/.config/checkbox.conf", checkbox_conf_home,
             target="service"),
         Put("/etc/xdg/checkbox.conf", checkbox_conf_etc,
@@ -167,7 +169,7 @@ class TestPlanSelectionSkip(Scenario):
 
     This scenario has to work locally and remotely
     """
-    # the conf file should be overwritten by the launcher, 
+    # the conf file should be overwritten by the launcher,
     # if it is not, this will make the test fail intentionally
     checkbox_conf = read_text(
         test_selection, "checkbox_testplan_unit_forced.conf"
@@ -181,7 +183,8 @@ class TestPlanSelectionSkip(Scenario):
         forced = yes
         """)
     steps = [
-        Put("/home/ubuntu/.config/checkbox.conf", 
+        MkTree("/home/ubuntu/.config", target="service"),
+        Put("/home/ubuntu/.config/checkbox.conf",
             checkbox_conf, target="service"),
         Put("/etc/xdg/checkbox.conf", checkbox_conf,
             target = "service"),
@@ -197,7 +200,7 @@ class TestPlanPreselected(Scenario):
 
     This scenario has to work locally and remotely
     """
-    # the conf file should be overwritten by the launcher, 
+    # the conf file should be overwritten by the launcher,
     # if it is not, this will make the test fail intentionally
     checkbox_conf = read_text(
         test_selection, "checkbox_testplan_unit_forced.conf"
@@ -213,7 +216,8 @@ class TestPlanPreselected(Scenario):
         unit = com.canonical.certification::smoke
         """)
     steps = [
-        Put("/home/ubuntu/.config/checkbox.conf", 
+        MkTree("/home/ubuntu/.config", target="service"),
+        Put("/home/ubuntu/.config/checkbox.conf",
             checkbox_conf, target="service"),
         Put("/etc/xdg/checkbox.conf", checkbox_conf,
             target = "service"),
@@ -248,7 +252,7 @@ class TestPlanSelectionPreselectFailWrongName(Scenario):
 class TestPlanSelectionPreselectNothing(Scenario):
     """
     If no unit is provided to checkbox, when prompted to continue
-    or forced to do so in the test plan selection screen it should 
+    or forced to do so in the test plan selection screen it should
     quit given that no test plan was selected.
     """
     launcher = textwrap.dedent("""


### PR DESCRIPTION
## Description

Some tests were relying on the old Put behaviour of creating the parent directory of a path if a Put failed. We have removed it in favor of a clear error but now tests are failing because of that.

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/527

## Documentation

N/A

## Tests

All tests are now in the green both legacy and remote
