### PR TITLE
Add Memory Technology Device test cases

### DIFF
--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -310,6 +310,7 @@ parts:
       - wget
       - wmctrl
       - xz-utils
+      - mtd-utils
       - on armhf:
         - python3-rpi.gpio # only in focal
       - on arm64:

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -310,6 +310,7 @@ parts:
       - wget
       - wmctrl
       - xz-utils
+      - mtd-utils
       - on armhf:
         - python3-rpi.gpio # only in focal
       - on arm64:

--- a/providers/base/bin/mtd.sh
+++ b/providers/base/bin/mtd.sh
@@ -68,7 +68,12 @@ compareFile() {
 # $2 is the path of compared file 2
 # $3 is the specific mtd. e.g. mtd1
     echo "##### Compare File #####"
-    diff "$1" "$2" && echo "$3 read and write file are consistency!" || (echo "$3 read and write file are inconsistency!!" ; exit 1)
+    if [[ $(diff "$1" "$2") ]]; then
+        echo "$3 read and write file are inconsistency!!"
+        exit 1
+    else
+        echo "$3 read and write file are consistency!"
+    fi
 }
 
 main(){

--- a/providers/base/bin/mtd.sh
+++ b/providers/base/bin/mtd.sh
@@ -12,10 +12,11 @@ listAllMtd() {
 
 countMtd() {
     count=$( listAllMtd | grep -c "MTD_NAME")
-    if [ "${1}" == "$count" ]; then
-        echo "The number of MTD is correct!"
-    else
-        echo "The number of MTD is incorrect!"
+    echo "The expected count is ${1}"
+    echo "The actual count is $count"
+
+    if [ "${1}" -ne "$count" ]; then
+        lsmtd
         exit 1 
     fi
 }

--- a/providers/base/bin/mtd.sh
+++ b/providers/base/bin/mtd.sh
@@ -11,6 +11,12 @@ listAllMtd() {
 }
 
 countMtd() {
+# $1 is the expected count of mtd. e.g. 2
+    if [ -z "${1}" ]; then
+        echo "Please give an expected count as the second parameter when executing 'count' action"
+        exit 1
+    fi
+
     count=$( listAllMtd | grep -c "MTD_NAME")
     echo "The expected count is ${1}"
     echo "The actual count is $count"

--- a/providers/base/bin/mtd.sh
+++ b/providers/base/bin/mtd.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+set -e
+MTDS=$(find /dev -regex '.*mtd[0-9][0-9]?' | awk -F "/" '{print $3}')
+MTD_WRITEABLE_FLAG=0x400
+
+listAllMtd() {
+    for c in ${MTDS}; do
+        echo "MTD_NAME: ${c}"
+        echo ""
+    done
+}
+
+countMtd() {
+    count=$( listAllMtd | grep -c "MTD_NAME")
+    if [ "${1}" == "$count" ]; then
+        echo "The number of MTD is correct!"
+    else
+        echo "The number of MTD is incorrect!"
+        exit 1 
+    fi
+}
+
+# This function will get the size of MTD. (Unit: byte)
+# size_hex is the MTD size convert to HEX, and it's for read and write the file to MTD.
+# is_mtd_writable tells this MTD can be written or not (0 means read-only)
+infoMtd() {
+    info=$(mtd_debug info /dev/"$1")
+    echo "##### MTD info #####"
+    echo "$info"
+    size=$(awk '/mtd.size/ {print $3}' <<< "$info")
+    size_hex=$(printf '%x' "$size")
+    mtd_flag=$(cat /sys/class/mtd/"$1"/flags)
+    is_mtd_writable=$((MTD_WRITEABLE_FLAG & mtd_flag))
+}
+
+createTestFile() {
+# $1 is the file path who will be used as random test file
+# $2 is size of random test file (Unit: byte)
+    echo "##### Create test file #####"
+    dd if=/dev/urandom of="$1" bs=1 count="$2"
+}
+
+eraseMtd() {
+# $1 is the specific mtd. e.g. mtd1
+# $2 is size of random test file (Unit: byte)
+    echo "##### Erase MTD #####"
+    mtd_debug erase /dev/"$1" 0x0 0x"$2"
+}
+
+writeMtd() {
+# $1 is the specific mtd. e.g. mtd1
+# $2 is size of destination file. Should be the value of size_hex variable
+# $3 is the path of destination file
+    echo "##### Write MTD #####"
+    mtd_debug write /dev/"$1" 0x0 0x"$2" "$3"
+}
+
+readMtd() {
+# $1 is the specific mtd. e.g. mtd1
+# $2 is size of random test file. Should be the value of size_hex variable
+# $3 is the path of source file
+    echo "##### Read MTD #####"
+    mtd_debug read /dev/"$1" 0x0 0x"$2" "$3"
+}
+
+compareFile() {
+# $1 is the path of compared file 1
+# $2 is the path of compared file 2
+# $3 is the specific mtd. e.g. mtd1
+    echo "##### Compare File #####"
+    diff "$1" "$2" && echo "$3 read and write file are consistency!" || (echo "$3 read and write file are inconsistency!!" ; exit 1)
+}
+
+main(){
+# $1 is action in list/compare/count
+# $2 is MTD device name. e.g. mtd0, mtd1 ...etc
+    case ${1} in
+        list) listAllMtd ;;
+        compare)
+            infoMtd "${2}"
+            echo
+
+            # Read-only
+            if [[ $is_mtd_writable -eq "0" ]]; then
+                echo "${2} is read-olny"
+                readFile=$(mktemp)
+                echo "1. Read content to $readFile"
+                readMtd "${2}" "$size_hex" "$readFile"
+            else
+                echo "${2} is writable"
+                originalContent=$(mktemp)
+                echo "1. Backup the content to $originalContent.."
+                readMtd "${2}" "$size_hex" "$originalContent"
+
+                echo "2. Perform read and write testing.."
+                readFile=$(mktemp)
+                writeFile=$(mktemp)
+                createTestFile "$writeFile" "$size"
+                eraseMtd "${2}" "$size_hex"
+                writeMtd "${2}" "$size_hex" "$writeFile"
+                readMtd "${2}" "$size_hex" "$readFile"
+                compareFile "$writeFile" "$readFile" "${2}"
+
+                echo "3. Recover original data..."
+                eraseMtd "${2}" "$size_hex"
+                writeMtd "${2}" "$size_hex" "$originalContent"
+            fi
+            ;;
+        count) countMtd "${2}";;
+        *) echo "Need given parameter."
+    esac
+}
+
+main "$@"
+exit $?

--- a/providers/base/units/mtd/category.pxu
+++ b/providers/base/units/mtd/category.pxu
@@ -1,3 +1,3 @@
 unit: category
 id: mtd 
-_name: Memory Technology Device Test
+_name: Memory Technology Device Tests

--- a/providers/base/units/mtd/category.pxu
+++ b/providers/base/units/mtd/category.pxu
@@ -1,0 +1,3 @@
+unit: category
+id: mtd 
+_name: Memory Technology Device Test

--- a/providers/base/units/mtd/jobs.pxu
+++ b/providers/base/units/mtd/jobs.pxu
@@ -2,17 +2,24 @@ id: mtd/check-total-count
 category_id: mtd
 _summary: Check the total MTD count for the platform
 _description:
-  Check the total MTD count for the platform, relies on the user specifying the number of mtd. 
+  Check the total MTD count for the platform, relies on the user specifying the count of mtd.
   Usage of environment variable: TOTAL_MTD_COUNT={count}
   e.g. TOTAL_MTD_COUNT=2
 plugin: shell
 user: root
 imports: from com.canonical.plainbox import manifest
-requires: manifest.has_mtd == 'True'
+requires:
+  manifest.has_mtd == 'True'
+  package.name == "mtd-utils"
 flags: also-after-suspend
 estimated_duration: 5
 environ: TOTAL_MTD_COUNT
-command: mtd.sh count "$TOTAL_MTD_COUNT"
+command:
+  if [ -z "$TOTAL_MTD_COUNT" ]; then
+    echo "Missing the 'TOTAL_MTD_COUNT' environment variable. Please define it in checkbox.conf"
+    exit 1
+  fi
+  mtd.sh count "$TOTAL_MTD_COUNT"
 
 id: mtd/mtd-list
 plugin: resource
@@ -34,7 +41,9 @@ _description:
 plugin: shell
 user: root
 imports: from com.canonical.plainbox import manifest
-requires: manifest.has_mtd == 'True'
+requires:
+  manifest.has_mtd == 'True'
+  package.name == "mtd-utils"
 flags: also-after-suspend
 estimated_duration: 30
 command:

--- a/providers/base/units/mtd/jobs.pxu
+++ b/providers/base/units/mtd/jobs.pxu
@@ -2,7 +2,7 @@ id: mtd/check-total-count
 category_id: mtd
 _summary: Check the total MTD count for the platform
 _description:
-  Check the total MTD count for the platform, relies on the user specifying the count of mtd.
+  Check the total MTD count for this platform based on the number specified by the user.
   Usage of environment variable: TOTAL_MTD_COUNT={count}
   e.g. TOTAL_MTD_COUNT=2
 plugin: shell
@@ -16,7 +16,7 @@ estimated_duration: 5
 environ: TOTAL_MTD_COUNT
 command:
   if [ -z "$TOTAL_MTD_COUNT" ]; then
-    echo "Missing the 'TOTAL_MTD_COUNT' environment variable. Please define it in checkbox.conf"
+    echo "Missing the 'TOTAL_MTD_COUNT' environment variable. Please define it in the [environment] section of your Checkbox configuration.
     exit 1
   fi
   mtd.sh count "$TOTAL_MTD_COUNT"

--- a/providers/base/units/mtd/jobs.pxu
+++ b/providers/base/units/mtd/jobs.pxu
@@ -1,0 +1,42 @@
+id: mtd/check-total-numbers
+category_id: mtd
+_summary: Check the total MTD numbers for the platform
+_description:
+  Check the total MTD numbers for the platform, relies on the user specifying the number of mtd. 
+  Usage of parameter: {numbers}
+  e.g. TOTAL_MTD_NUM=2
+plugin: shell
+user: root
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_mtd == 'True'
+flags: also-after-suspend
+estimated_duration: 5
+command: mtd.sh count "$TOTAL_MTD_NUM"
+
+id: mtd/mtd-list
+plugin: resource
+_summary: Gather list of MTD on the platform
+_description:
+  Gather list of all Memory Technology Device on the platform
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_mtd == 'True'
+estimated_duration: 1s
+command: mtd.sh list  
+
+unit: template
+template-resource: mtd/mtd-list
+template-unit: job
+id: mtd/read-write-test-{MTD_NAME}
+category_id: mtd
+_summary: Test {MTD_NAME} on the platform
+_description:
+  Write a random value into {MTD_NAME}, and read it back to compare with.
+  To make sure {MTD_NAME} read and write working properly.
+plugin: shell
+user: root
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_mtd == 'True'
+flags: also-after-suspend
+estimated_duration: 30
+command:
+  mtd.sh compare {MTD_NAME}

--- a/providers/base/units/mtd/jobs.pxu
+++ b/providers/base/units/mtd/jobs.pxu
@@ -1,25 +1,24 @@
-id: mtd/check-total-numbers
+id: mtd/check-total-count
 category_id: mtd
-_summary: Check the total MTD numbers for the platform
+_summary: Check the total MTD count for the platform
 _description:
-  Check the total MTD numbers for the platform, relies on the user specifying the number of mtd. 
-  Usage of parameter: {numbers}
-  e.g. TOTAL_MTD_NUM=2
+  Check the total MTD count for the platform, relies on the user specifying the number of mtd. 
+  Usage of environment variable: TOTAL_MTD_COUNT={count}
+  e.g. TOTAL_MTD_COUNT=2
 plugin: shell
 user: root
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_mtd == 'True'
 flags: also-after-suspend
 estimated_duration: 5
-command: mtd.sh count "$TOTAL_MTD_NUM"
+environ: TOTAL_MTD_COUNT
+command: mtd.sh count "$TOTAL_MTD_COUNT"
 
 id: mtd/mtd-list
 plugin: resource
 _summary: Gather list of MTD on the platform
 _description:
   Gather list of all Memory Technology Device on the platform
-imports: from com.canonical.plainbox import manifest
-requires: manifest.has_mtd == 'True'
 estimated_duration: 1s
 command: mtd.sh list  
 

--- a/providers/base/units/mtd/jobs.pxu
+++ b/providers/base/units/mtd/jobs.pxu
@@ -16,7 +16,7 @@ estimated_duration: 5
 environ: TOTAL_MTD_COUNT
 command:
   if [ -z "$TOTAL_MTD_COUNT" ]; then
-    echo "Missing the 'TOTAL_MTD_COUNT' environment variable. Please define it in the [environment] section of your Checkbox configuration.
+    echo "Missing the 'TOTAL_MTD_COUNT' environment variable. Please define it in the [environment] section of your Checkbox configuration."
     exit 1
   fi
   mtd.sh count "$TOTAL_MTD_COUNT"

--- a/providers/base/units/mtd/manifest.pxu
+++ b/providers/base/units/mtd/manifest.pxu
@@ -1,4 +1,4 @@
 unit: manifest entry
 id: has_mtd
-_name: Memory Technology Device (MTD) support?
+_name: Memory Technology Device (MTD)
 value-type: bool

--- a/providers/base/units/mtd/manifest.pxu
+++ b/providers/base/units/mtd/manifest.pxu
@@ -1,4 +1,4 @@
 unit: manifest entry
 id: has_mtd
-_name: Does platfrom support Memory Technology Device?
+_name: Does platform support Memory Technology Device?
 value-type: bool

--- a/providers/base/units/mtd/manifest.pxu
+++ b/providers/base/units/mtd/manifest.pxu
@@ -1,4 +1,4 @@
 unit: manifest entry
 id: has_mtd
-_name: Does platfrom supported Memory Technology Device?
+_name: Does platfrom support Memory Technology Device?
 value-type: bool

--- a/providers/base/units/mtd/manifest.pxu
+++ b/providers/base/units/mtd/manifest.pxu
@@ -1,4 +1,4 @@
 unit: manifest entry
 id: has_mtd
-_name: Does platform support Memory Technology Device?
+_name: Memory Technology Device (MTD) support?
 value-type: bool

--- a/providers/base/units/mtd/manifest.pxu
+++ b/providers/base/units/mtd/manifest.pxu
@@ -1,0 +1,4 @@
+unit: manifest entry
+id: has_mtd
+_name: Does platfrom supported Memory Technology Device?
+value-type: bool

--- a/providers/base/units/mtd/test-plan.pxu
+++ b/providers/base/units/mtd/test-plan.pxu
@@ -22,7 +22,7 @@ _description: Automated Memory Technology Device tests for devices
 bootstrap_include:
     mtd/mtd-list
 include:
-    mtd/check-total-numbers
+    mtd/check-total-count
     mtd/read-write-test-.*
 
 id: after-suspend-mtd-manual
@@ -38,5 +38,5 @@ _description: Automated after-suspend Memory Technology Device tests for devices
 bootstrap_include:
     mtd/mtd-list
 include:
-    also-after-suspend-mtd/check-total-numbers
+    also-after-suspend-mtd/check-total-count
     also-after-suspend-mtd/read-write-test-.*

--- a/providers/base/units/mtd/test-plan.pxu
+++ b/providers/base/units/mtd/test-plan.pxu
@@ -1,0 +1,42 @@
+id: mtd-full
+unit: test plan
+_name: Memory Technology Device tests
+_description: Full Memory Technology Device tests for devices
+include:
+nested_part:
+    mtd-manual
+    mtd-automated
+    after-suspend-mtd-manual
+    after-suspend-mtd-automated
+
+id: mtd-manual
+unit: test plan
+_name: Memory Technology Device manual tests
+_description: Manual Memory Technology Device tests for devices
+include:
+
+id: mtd-automated
+unit: test plan
+_name: Memory Technology Device auto tests
+_description: Automated Memory Technology Device tests for devices
+bootstrap_include:
+    mtd/mtd-list
+include:
+    mtd/check-total-numbers
+    mtd/read-write-test-.*
+
+id: after-suspend-mtd-manual
+unit: test plan
+_name: After suspend Memory Technology Device manual tests
+_description: Manual after-suspend Memory Technology Device tests for devices
+include:
+
+id: after-suspend-mtd-automated
+unit: test plan
+_name: After suspend Memory Technology Device auto tests
+_description: Automated after-suspend Memory Technology Device tests for devices
+bootstrap_include:
+    mtd/mtd-list
+include:
+    also-after-suspend-mtd/check-total-numbers
+    also-after-suspend-mtd/read-write-test-.*


### PR DESCRIPTION
In order to testing MTD, I leverage the mtd-utils which is an open source tool and can be downloaded from Ubuntu packages.

## Description

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).

  - The MTD subsystem has been used in lots of devices widely, so I add MTD related test cases to cover the MTD read and write test

- Introduce your implementation approach in a way that helps reviewing it well.
  - Add has_mtd manifest to determine if the platform supports MTD
  - Job mtd/check-total-numbers to make sure the number of MTD partitions in System should match the expectation which is defined by using the TOTAL_MTD_NUM environment variable
  - Resource Jjob mtd/mtd-list shows and generates all of the MTD nodes under /dev directory
  - Job mtd/read-write-test-{MTD_NAME} is a template job which is in charge of the testing for each MTD partition
    - If this MTD is read-only, I only read its content to a file.
    - If this MTD is writable, backup its original content to a file, then do the compare procedure, finally, recover its content back.

## Resolved issues
N/A

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

CID: 202304-31517
Submission: https://certification.canonical.com/hardware/202304-31517/submission/320303/test-results/
Total MTD number: 17. Start from mt0 to mtd16
Read-only MTD: mtd0, mtd1, mtd6, mtd8, mtd10, mtd11, mtd14
