### PR TITLE
add "Mini PC" as a valid desktop platform

### DIFF
--- a/providers/base/units/monitor/jobs.pxu
+++ b/providers/base/units/monitor/jobs.pxu
@@ -112,7 +112,7 @@ unit: template
 template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'
 id: monitor/{index}_multi-head_{product_slug}
-requires: dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower', 'Space-saving']
+requires: dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower', 'Space-saving', 'Mini PC']
 flags: also-after-suspend
 plugin: manual
 category_id: com.canonical.plainbox::monitor


### PR DESCRIPTION
## Description

I found some skipped tests when certifying NUC-like devices from HP. Turns out they weren't recognized as Desktops.
This patch makes "Mini PC" a valid PC form factor enabling multi-head tests for those.

Tested on other FFs.
Behaviour doesn't change on other FFs.