### PR TITLE
Fix: XDG_SESSION_TYPE couldn,t be getten by root

### DIFF
--- a/providers/base/bin/graphics_env.sh
+++ b/providers/base/bin/graphics_env.sh
@@ -20,7 +20,9 @@ ensure_xdg_session_type() {
         sleep 1
 
         echo "Waiting for XDG_SESSION_TYPE to be set"
-        XDG_SESSION_TYPE=$(systemctl --user show-environment | grep XDG_SESSION_TYPE | cut -d= -f2)
+        SESSION=$(loginctl list-sessions --no-legend | grep 'seat0' | cut -d ' ' -f 1)
+
+        XDG_SESSION_TYPE=$(loginctl show-session "${SESSION}" | grep 'Type' | cut -d '=' -f 2)
 
         attempt=$((attempt+1))
         if [ $attempt -eq $max_attempts ]; then


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

The command used in PR #523 couldn't work by root. However, checkbox will open terminal with root
and make tests failed that exectued after reboot.
Chnaging to use loginctl to get XDG_SESSION_TYPE.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

Tracking on this [Jira card](https://warthogs.atlassian.net/browse/CQT-2494)

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Submissions

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
-->
20.04
I + A: [Auot](https://certification.canonical.com/hardware/202203-30094/submission/316982/), [Graphic](https://certification.canonical.com/hardware/202203-30094/submission/316996/)
I + N: [Auto](https://certification.canonical.com/hardware/202203-30090/submission/316984/), [Graphic](https://certification.canonical.com/hardware/202203-30090/submission/317004/)

22.04
I + I: [Auto](https://certification.canonical.com/hardware/202306-31654/submission/316981/), [Graphic](https://certification.canonical.com/hardware/202306-31654/submission/316997/)
