### PR TITLE
Add Intel dGPU prime offload support

### DIFF
--- a/providers/base/bin/graphics_env.sh
+++ b/providers/base/bin/graphics_env.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 # This script checks if the submitted VIDEO resource is from AMD or nvidia
 # and if it is a discrete GPU (graphics_card_resource orders GPUs by index:
-# 1 is theintegrated one, 2 is the discrete one).
+# 1 is the integrated one, 2 is the discrete one).
 #
 # This script has to be sourced in order to set an environment variable that
-# is used by the open source AMD driver and properties nvidia driver to
+# is used by the open source AMD driver and nvidia proprietary driver to
 # trigger the use of discrete GPU.
 
 DRIVER=$1
 INDEX=$2
+PCIBUS="$(echo "$3" | rev | cut -d '/' -f 1 | rev)"
+PCIBUS_OFFLOAD_FORMAT=pci-"${PCIBUS//[:.]/_}"
 
 # Some environment variables(like XDG_SESSION_TYPE) are set by some services
 # (like graphical-session.target), but during system suspend/resume, they will
@@ -16,7 +18,7 @@ INDEX=$2
 ensure_xdg_session_type() {
     local max_attempts=5
     local attempt=0
-    while [ -z "$XDG_SESSION_TYPE" ]; do
+    while [ -z "${XDG_SESSION_TYPE}" ]; do
         sleep 1
 
         echo "Waiting for XDG_SESSION_TYPE to be set"
@@ -25,8 +27,8 @@ ensure_xdg_session_type() {
         XDG_SESSION_TYPE=$(loginctl show-session "${SESSION}" | grep 'Type' | cut -d '=' -f 2)
 
         attempt=$((attempt+1))
-        if [ $attempt -eq $max_attempts ]; then
-            >&2 echo "XDG_SESSION_TYPE was not set after $max_attempts attempts"
+        if [ ${attempt} -eq ${max_attempts} ]; then
+            >&2 echo "XDG_SESSION_TYPE was not set after ${max_attempts} attempts"
             exit 1
         fi
     done
@@ -35,11 +37,11 @@ ensure_xdg_session_type() {
 }
 
 # We only want to set the variable on systems with more than
-# 1 GPU running the amdgpu/radeon/nvidia drivers.
-if [[ $DRIVER == "amdgpu" || $DRIVER == "radeon" ]]; then
-    NB_GPU=$(udev_resource.py -l VIDEO | grep -oP -m1 '\d+')
-    if [[ $NB_GPU -gt 1 ]]; then
-        if [[ $INDEX -gt 1 ]]; then
+# 1 GPU running the amdgpu/radeon/nvidia/i915 drivers.
+NB_GPU=$(udev_resource.py -l VIDEO | grep -oP -m1 '\d+')
+if [[ ${NB_GPU} -gt 1 ]]; then
+    if [[ ${DRIVER} == "amdgpu" || ${DRIVER} == "radeon" ]]; then
+        if [[ ${INDEX} -gt 1 ]]; then
             # See https://wiki.archlinux.org/index.php/PRIME
             echo "Setting up PRIME GPU offloading for AMD discrete GPU"
             if ! cat /var/log/Xorg.0.log ~/.local/share/xorg/Xorg.0.log 2>&1 | grep -q DRI3; then
@@ -51,13 +53,10 @@ if [[ $DRIVER == "amdgpu" || $DRIVER == "radeon" ]]; then
         else
             export DRI_PRIME=
         fi
-    fi
-elif [[ $DRIVER == "nvidia" || $DRIVER == "pcieport" ]]; then
-    NB_GPU=$(udev_resource.py -l VIDEO | grep -oP -m1 '\d+')
-    if [[ $NB_GPU -gt 1 ]]; then
+    elif [[ ${DRIVER} == "nvidia" || ${DRIVER} == "pcieport" ]]; then
         nvidia_nvlink_check.sh
         NVLINK=$?
-        if [[ $INDEX -gt 1 && ${NVLINK} -ne 0 && "$(prime-select query)" = 'on-demand' ]]; then
+        if [[ ${INDEX} -gt 1 && ${NVLINK} -ne 0 && "$(prime-select query)" = 'on-demand' ]]; then
             echo "Setting up PRIME GPU offloading for nvidia discrete GPU"
             export __NV_PRIME_RENDER_OFFLOAD=1
             export __GLX_VENDOR_LIBRARY_NAME=nvidia
@@ -65,7 +64,12 @@ elif [[ $DRIVER == "nvidia" || $DRIVER == "pcieport" ]]; then
             unset __NV_PRIME_RENDER_OFFLOAD
             unset __GLX_VENDOR_LIBRARY_NAME
         fi
+    elif [[ ${DRIVER} == "i915" && -n "${PCIBUS}" ]]; then
+        echo "Setting up PRIME GPU offloading for pci@${PCIBUS} Intel GPU"
+        export DRI_PRIME=${PCIBUS_OFFLOAD_FORMAT}
     fi
+else
+    unset DRI_PRIME
 fi
 
 ensure_xdg_session_type

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -187,7 +187,7 @@ requires:
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
 command:
  # shellcheck disable=SC1091
- source graphics_env.sh {driver} {index}
+ source graphics_env.sh {driver} {index} {path}
  gst_pipeline_test.py -t 2 'videotestsrc ! videoconvert ! autovideosink' || gst_pipeline_test.py -t 2 'videotestsrc ! ffmpegcolorspace ! autovideosink'
 _summary: Test that video can be displayed with {vendor} {product}
 _description:
@@ -280,7 +280,7 @@ id: graphics/{index}_valid_opengl_renderer_{product_slug}
 requires: executable.name == 'glxinfo'
 command:
  # shellcheck disable=SC1091
- source graphics_env.sh {driver} {index}
+ source graphics_env.sh {driver} {index} {path}
  renderer=$(glxinfo | grep "OpenGL re")
  echo "$renderer"
  if grep -qi 'Intel' <<<"$renderer"; then
@@ -298,7 +298,7 @@ flags: also-after-suspend
 requires: executable.name == 'glxgears'
 command:
  # shellcheck disable=SC1091
- source graphics_env.sh {driver} {index}
+ source graphics_env.sh {driver} {index} {path}
  glxgears
  true
 _summary: Test that glxgears works for {vendor} {product}
@@ -321,7 +321,7 @@ flags: also-after-suspend
 requires: executable.name == 'glxgears'
 command:
  # shellcheck disable=SC1091
- source graphics_env.sh {driver} {index}
+ source graphics_env.sh {driver} {index} {path}
  glxgears -fullscreen
  true
 _summary: Test that glxgears works on fullscreen for {vendor} {product}

--- a/providers/base/units/suspend/suspend-graphics.pxu
+++ b/providers/base/units/suspend/suspend-graphics.pxu
@@ -154,7 +154,7 @@ depends:
 requires: executable.name == 'glxgears'
 command:
  # shellcheck disable=SC1091
- source graphics_env.sh {{ driver }} {{ index }}
+ source graphics_env.sh {{ driver }} {{ index }} {{ path }}
  glxgears
  true
 _summary: Test that glxgears works for {{ vendor }} {{ product }} after suspend

--- a/providers/resource/bin/graphics_card_resource.py
+++ b/providers/resource/bin/graphics_card_resource.py
@@ -210,6 +210,10 @@ def main():
                 elif (record['driver'] in ('nvidia', 'pcieport')
                         and compare_ubuntu_release_version('22.04')):
                     record['prime_gpu_offload'] = 'On'
+                elif record['driver'] == 'i915':
+                    record['prime_gpu_offload'] = 'On'
+                else:
+                    record['prime_gpu_offload'] = 'Off'
             else:
                 record['prime_gpu_offload'] = 'Off'
             record['switch_to_cmd'] = switch_cmds[record['driver']][0]


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

Since [DRI_PRIME could use pci bus to set prime offload to specific GPU](https://wiki.archlinux.org/title/PRIME), this PR use this method to set prime offload to specific `Intel GPU` that doesn't use `index` anymore.

While testing, could use `sudo cat /sys/kernel/debug/dri/<card number>/clients` to check `glxgears` is running on while GPU.


## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

The coming DUTs inlcude one `Intel iGPU + Intel dGPU` combination. On `checkbox v2.7`, the graphic test scope is same with `Intel iGPU + AMD dGPU` and `Intel iGPU + Nvidia dGPU`. However, `Intel dGPU` isn't really tested on `checkbox v2.7`, and have to add this support for Intel dGPU.

## Submissions

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
-->
20.04

- Intel iGPU + AMD dGPU: [Auto](https://certification.canonical.com/hardware/202203-30094/submission/317125/), [Graphic](https://certification.canonical.com/hardware/202203-30094/submission/317124/)
- Intel iGPU + Nvidia dGPU: [Auto](https://certification.canonical.com/hardware/202203-30090/submission/317127/), [Graphic](https://certification.canonical.com/hardware/202203-30090/submission/317126/)

22.04

- Intel iGPU + Intel dGPU: [Auto](https://certification.canonical.com/hardware/202306-31654/submission/317122/), [Graphic](https://certification.canonical.com/hardware/202306-31654/submission/317123/)

