### PR TITLE
Change the menu text to something more clear

### DIFF
--- a/checkbox-ng/checkbox_ng/urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/urwid_ui.py
@@ -692,10 +692,10 @@ def interrupt_dialog(host):
     ]
     choices = [
         _("Nothing, continue testing (ESC)"),
-        _("Stop the test in progress and move on to the next"),
+        _("Stop the test case in progress and move on to the next"),
         _("Disconnect but let the test session continue (CTRL+C)"),
         _("Exit and stop the Checkbox service on the testbed at {}".format(host)),
-        _("Finalize this session and launch a new test plan"),
+        _("End this test session preserving its data and launch a new one"),
     ]
     footer_text = [
         ('Press '), ('start', '<Enter>'), (' or '),

--- a/checkbox-ng/checkbox_ng/urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/urwid_ui.py
@@ -691,11 +691,11 @@ def interrupt_dialog(host):
         ('start', 'dark green,bold', 'black'),
     ]
     choices = [
-        _("Cancel the interruption and resume the session (ESC)"),
-        _("Kill test in progress and move on to next"),
-        _("Disconnect the master (Same as CTRL+C)"),
-        _("Stop the checkbox slave @{}".format(host)),
-        _("Abandon the session on the slave @{}".format(host)),
+        _("Nothing, continue testing (ESC)"),
+        _("Kill test in progress and move on to the next"),
+        _("Exit but let the service test run continue (CTRL+C)"),
+        _("Exit and kill the service test runer at {}".format(host)),
+        _("Finalize this session and launch a new test plan"),
     ]
     footer_text = [
         ('Press '), ('start', '<Enter>'), (' or '),

--- a/checkbox-ng/checkbox_ng/urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/urwid_ui.py
@@ -692,9 +692,9 @@ def interrupt_dialog(host):
     ]
     choices = [
         _("Nothing, continue testing (ESC)"),
-        _("Kill test in progress and move on to the next"),
-        _("Exit but let the service test run continue (CTRL+C)"),
-        _("Exit and kill the service test runer at {}".format(host)),
+        _("Stop the test in progress and move on to the next"),
+        _("Disconnect but let the test session continue (CTRL+C)"),
+        _("Exit and stop the Checkbox service on the testbed at {}".format(host)),
         _("Finalize this session and launch a new test plan"),
     ]
     footer_text = [

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -374,7 +374,9 @@ class UnifiedRunner(IJobRunner):
 
     def send_signal(self, signal, target_user):
         if not target_user:
-            os.kill(self._running_jobs_pid, signal)
+            if self._running_jobs_pid:
+                return os.kill(self._running_jobs_pid, signal)
+            logger.error("No job is currently running")
         else:
             # process used sudo, so sudo is needed to kill it
             in_r, in_w = os.pipe()

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -373,10 +373,13 @@ class UnifiedRunner(IJobRunner):
                             "{}.record.gz".format(slugify(job.id)))
 
     def send_signal(self, signal, target_user):
-        if not target_user:
-            if self._running_jobs_pid:
-                return os.kill(self._running_jobs_pid, signal)
+        if not self._running_jobs_pid:
+            # this can happen because the kill command is issued
+            # just as the job finishes
             logger.error("No job is currently running")
+            return
+        if not target_user:
+            os.kill(self._running_jobs_pid, signal)
         else:
             # process used sudo, so sudo is needed to kill it
             in_r, in_w = os.pipe()


### PR DESCRIPTION
## Description
This fixes the text in the interrupt menu to be easier to understand, also removes the outdated nomenclature for remote and service

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/444, https://github.com/canonical/checkbox/issues/129, https://github.com/canonical/checkbox/issues/19, https://github.com/canonical/checkbox/issues/550

## Documentation

N/A

## Tests

N/A