### PR TITLE
Avoid flooding stdout with reconnecting

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/master.py
+++ b/checkbox-ng/checkbox_ng/launcher/master.py
@@ -171,7 +171,7 @@ class RemoteMaster(ReportsStage, MainLoopStage):
         #  check if ever disconnected
         ever_disconnected = False
         #  this to animate the dash
-        spinner = itertools.cycle('-/|\\')
+        spinner = itertools.cycle('-\\|/')
         #  this tracks the disconnection time
         disconnection_time = 0
         while True:
@@ -267,12 +267,12 @@ class RemoteMaster(ReportsStage, MainLoopStage):
                     raise
                 # it's reconnecting, so we can ignore refuses
                 if not printed_reconnecting:
-                    print('Reconnecting ', end="")
+                    print("Reconnecting ", end="")
                     disconnection_time = time.time()
                     ever_disconnected = True
                     printed_reconnecting = True
                 print(next(spinner), end="\b", flush=True)
-                time.sleep(1)
+                time.sleep(.25)
             except KeyboardInterrupt:
                 interrupted = True
 

--- a/metabox/metabox/scenarios/restart/launcher.py
+++ b/metabox/metabox/scenarios/restart/launcher.py
@@ -22,7 +22,6 @@ import textwrap
 from metabox.core.actions import AssertPrinted
 from metabox.core.scenario import Scenario
 
-
 class Reboot(Scenario):
 
     modes = ['remote']
@@ -42,5 +41,6 @@ class Reboot(Scenario):
     steps = [
         AssertPrinted('Connection lost!'),
         AssertPrinted('Reconnecting'),
+        AssertPrinted("Reconnected\s+\(took"),
         AssertPrinted('job passed   : Warm reboot'),
     ]

--- a/metabox/metabox/scenarios/restart/launcher.py
+++ b/metabox/metabox/scenarios/restart/launcher.py
@@ -41,6 +41,6 @@ class Reboot(Scenario):
     """)
     steps = [
         AssertPrinted('Connection lost!'),
-        AssertPrinted('Reconnecting...'),
+        AssertPrinted('Reconnecting'),
         AssertPrinted('job passed   : Warm reboot'),
     ]


### PR DESCRIPTION
## Description

When disconnected from service, remote prints two reconnecting per second and this is suboptimal because it fills the stdout (and logs) for no reason

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/159

## Documentation

N/A

## Tests

This was tested via metabox on jammy
