### PR TITLE
Add link anchors to documentation and fix broken link to removed Plainbox docs

### DIFF
--- a/docs/explanation/understanding.rst
+++ b/docs/explanation/understanding.rst
@@ -1,8 +1,6 @@
 Understanding Checkbox
 ======================
 
-.. contents::
-
 Checkbox by itself doesn't test anything. It uses unit definitions grouped in
 providers to actually run or do something.
 

--- a/docs/how-to/nested-test-plan.rst
+++ b/docs/how-to/nested-test-plan.rst
@@ -19,7 +19,7 @@ test plan sections in sync and up-to-date.
 What if it could be possible now to have nested test plans. One being built by
 aggregating sections from one or more "base test plans"?
 
-Let's review in detail this new feature available in checkbox since plainbox 0.29
+Let's review this feature in detail.
 
 Quick start
 ===========
@@ -196,8 +196,7 @@ The jobs execution order is:
 How to change category or certification status of jobs coming from nested parts?
 --------------------------------------------------------------------------------
 
-The `test plan override mechanism
-<http://plainbox.readthedocs.io/en/latest/manpages/plainbox-test-plan-units.html?highlight=category-overrides>`_
+The :ref:`test plan override mechanism<Test Plan category-overrides field>`
 still works with nested parts. For example the ``hello`` job from the Baz
 provider was defined as a blocker and did not have a category.
 

--- a/docs/reference/units/category.rst
+++ b/docs/reference/units/category.rst
@@ -15,9 +15,13 @@ Category Fields
 
 There are two fields that are used by the category unit:
 
+.. _Category id field:
+
 ``id``:
     (mandatory) - This field defines the partial identifier of the category. It
     is similar to the ``id`` field on the job definition units.
+
+.. _Category name field:
 
 ``name``:
     (mandatory) - This field defines a human readable name of the category. It

--- a/docs/reference/units/exporter.rst
+++ b/docs/reference/units/exporter.rst
@@ -21,10 +21,14 @@ Fields
 
 Following fields may be used by an exporter unit.
 
+.. _Exporter id field:
+
 ``id``:
     (mandatory) - Unique identifier of the exporter. This field is used to look
     up and store data so please keep it stable across the lifetime of your
     provider.
+
+.. _Exporter summary field:
 
 ``summary``:
     (optional) - A human readable name for the exporter. This value is
@@ -32,14 +36,20 @@ Following fields may be used by an exporter unit.
     exporters. It must be one line long, ideally it should be short (50-70
     characters max).
 
+.. _Exporter entry_point field:
+
 ``entry_point``:
     (mandatory) - This is a key for a pkg_resources entry point from the
     plainbox.exporters namespace.
     Allowed values are: jinja2, text, xlsx, json and rfc822.
 
+.. _Exporter file_extension field:
+
 ``file_extension``:
     (mandatory) - Filename extension to use when the exporter stream is saved
     to a file.
+
+.. _Exporter options field:
 
 ``options``:
     (optional) - comma/space/semicolon separated list of options for this
@@ -74,6 +84,8 @@ Following fields may be used by an exporter unit.
 
     jinja2:
         - without-session-desc
+
+.. _Exporter data field:
 
 ``data``:
     (optional) - Extra data sent to the exporter code, to allow all kind of

--- a/docs/reference/units/job.rst
+++ b/docs/reference/units/job.rst
@@ -253,13 +253,9 @@ Following fields may be used by the job unit:
         in the ``$PLAINBOX_SESSION_SHARE`` directory which can be used by the
         test to automatically resume session. (For instance after a reboot).
 
-.. _job_flag_explicit_fail:
-
     ``explicit-fail``:
         Use this flag to make entering comment mandatory, when the user
         manually fails the job.
-
-.. _job_flag_has_leftovers:
 
     ``has-leftovers``:
         This flag makes plainbox silently ignore (and not log) any files left
@@ -267,8 +263,6 @@ Following fields may be used by the job unit:
         is useful for jobs that don't bother with maintenance of temporary
         directories and just want to rely on the one already created by
         plainbox.
-
-.. _job_flag_simple:
 
     ``simple``:
         This flag makes plainbox disable certain validation advice and have
@@ -289,31 +283,21 @@ Following fields may be used by the job unit:
             command: echo "Jobs are simple!"
             flags: simple
 
-.. _job_flag_preserve_cwd:
-
     ``preserve-cwd``:
         This flag makes plainbox run the job command in the current working
         directory without creating a temp folder (and running the command from
         this temp folder). Sometimes needed on snappy
         (See http://pad.lv/1618197)
 
-.. _job_flag_fail_on_resource:
-
     ``fail-on-resource``:
         This flag makes plainbox fail the job if one of the resource
         requirements evaluates to False.
 
-.. _job_flag_also_after_suspend:
+    ``also-after-suspend``: See :ref:`Job siblings field` below.
 
-    ``also-after-suspend``: See ``siblings`` below.
-
-.. _job_flag_also_after_suspend_manual:
-
-    ``also-after-suspend-manual``: See ``siblings`` below.
+    ``also-after-suspend-manual``: See :ref:`Job siblings field` below.
 
     Additional flags may be present in job definition; they are ignored.
-
-.. _job_flag_cachable:
 
     ``cachable``:
         Saves the output of a resource job in the system, so the next time

--- a/docs/reference/units/job.rst
+++ b/docs/reference/units/job.rst
@@ -235,12 +235,18 @@ Following fields may be used by the job unit:
     commas that might induce plainbox to run the job in particular way.
     Currently, following flags are inspected by plainbox:
 
+    .. _reset-locale flag:
+
     ``reset-locale``:
         This flag makes Checkbox reset locale before running the job.
+
+    .. _win32 flag:
 
     ``win32``:
         This flag makes plainbox run jobs' commands in windows-specific manner.
         Attach this flag to jobs that are run on Windows OS.
+
+    .. _noreturn flag:
 
     ``noreturn``:
         This flag makes plainbox suspend execution after job's command is run.
@@ -253,9 +259,13 @@ Following fields may be used by the job unit:
         in the ``$PLAINBOX_SESSION_SHARE`` directory which can be used by the
         test to automatically resume session. (For instance after a reboot).
 
+    .. _explicit-fail flag:
+
     ``explicit-fail``:
         Use this flag to make entering comment mandatory, when the user
         manually fails the job.
+
+    .. _has-leftovers flag:
 
     ``has-leftovers``:
         This flag makes plainbox silently ignore (and not log) any files left
@@ -263,6 +273,8 @@ Following fields may be used by the job unit:
         is useful for jobs that don't bother with maintenance of temporary
         directories and just want to rely on the one already created by
         plainbox.
+
+    .. _simple flag:
 
     ``simple``:
         This flag makes plainbox disable certain validation advice and have
@@ -283,21 +295,31 @@ Following fields may be used by the job unit:
             command: echo "Jobs are simple!"
             flags: simple
 
+    .. _preserve-cwd flag:
+
     ``preserve-cwd``:
         This flag makes plainbox run the job command in the current working
         directory without creating a temp folder (and running the command from
         this temp folder). Sometimes needed on snappy
         (See http://pad.lv/1618197)
 
+    .. _fail-on-resource flag:
+
     ``fail-on-resource``:
         This flag makes plainbox fail the job if one of the resource
         requirements evaluates to False.
 
+    .. _also-after-suspend flag:
+
     ``also-after-suspend``: See :ref:`Job siblings field` below.
+
+    .. _also-after-suspend-manual flag:
 
     ``also-after-suspend-manual``: See :ref:`Job siblings field` below.
 
     Additional flags may be present in job definition; they are ignored.
+
+    .. _cachable flag:
 
     ``cachable``:
         Saves the output of a resource job in the system, so the next time

--- a/docs/reference/units/job.rst
+++ b/docs/reference/units/job.rst
@@ -21,6 +21,8 @@ Job Fields
 
 Following fields may be used by the job unit:
 
+.. _Job id field:
+
 ``id``:
     (mandatory) - A name for the job. Should be unique, an error will
     be generated if there are duplicates. Should contain characters in
@@ -29,15 +31,19 @@ Following fields may be used by the job unit:
     backwards compatibility it is still recognized and used if ``id`` is
     missing.
 
+.. _Job summary field:
+
 ``summary``:
     (mandatory) - A human readable name for the job. This value is available
     for translation into other languages. It is used when listing jobs. It must
     be one line long, ideally it should be short (50-70 characters max).
 
-.. _category_id:
+.. _Job category_id field:
 
 ``category_id``:
     (optional) - Identifier of the :doc:`category` this job belongs to.
+
+.. _Job plugin field:
 
 ``plugin``:
     (mandatory) - For historical reasons it's called "plugin" but it's
@@ -58,6 +64,8 @@ Following fields may be used by the job unit:
      :resource: A job whose command output results in a set of rfc822
           records, containing key/value pairs, and that can be used in other
           jobs' ``requires`` expressions.
+
+.. _Job certification-status field:
 
 ``certification-status``:
     (optional) - Certification status for the given job. This is used by
@@ -92,6 +100,8 @@ Following fields may be used by the job unit:
         Certification team can evaluate the test report and investigate the
         reasons behind such an outcome.
 
+.. _Job requires field:
+
 ``requires``:
     (optional). If specified, the job will only run if the conditions
     expressed in this field are met.
@@ -107,10 +117,14 @@ Following fields may be used by the job unit:
     respecting the rfc822 multi-line syntax, in which case all
     requirements must be met for the job to run ( ``and`` ed).
 
+.. _Job depends field:
+
 ``depends``:
     (optional). If specified, the job will only run if all the listed
     jobs have run and passed. Multiple job names, separated by spaces,
     can be specified.
+
+.. _Job after field:
 
 ``after``:
     (optional). If specified, the job will only run if all the listed jobs have
@@ -119,10 +133,14 @@ Following fields may be used by the job unit:
 
     This feature is available since plainbox 0.24.
 
+.. _Job salvages field:
+
 ``salvages``:
     (optional). If specified, the job will only run if all the listed jobs have
     failed. This is useful for obtaining logs from a system when something
     fails. Multiple job names, separated by spaces, can be specified.
+
+.. _Job command field:
 
 ``command``:
     (optional). A command can be provided, to be executed under specific
@@ -140,12 +158,16 @@ Following fields may be used by the job unit:
 
     Note that a ``shell`` job without a command will do nothing.
 
+.. _Job purpose field:
+
 ``purpose``:
     (optional). Purpose field is used in tests requiring human interaction as
     an information about what a given test is supposed to do. User interfaces
     should display content of this field prior to test execution. This field
     may be omitted if the summary field is supplied.
     Note that this field is applicable only for human interaction jobs.
+
+.. _Job steps field:
 
 ``steps``:
     (optional). Steps field depicts actions that user should perform as a part
@@ -154,16 +176,22 @@ Following fields may be used by the job unit:
     Note that this field is applicable only for jobs requiring the user to
     perform some actions.
 
+.. _Job verification field:
+
 ``verification``:
     (optional). Verification field is used to inform the user how they can
     resolve a given job outcome.
     Note that this field is applicable only for jobs the result of which is
     determined by the user.
 
+.. _Job user field:
+
 ``user``:
     (optional). If specified, the job will be run as the user specified
     here. This is most commonly used to run jobs as the superuser
     (root).
+
+.. _Job environ field:
 
 ``environ``:
     (optional). If specified, the listed environment variables
@@ -178,7 +206,7 @@ Following fields may be used by the job unit:
     environment, with the downside that useful configuration specified
     in environment variables may be lost in the process.
 
-.. _job_estimated_duration:
+.. _Job estimated_duration field:
 
 ``estimated_duration``:
     (optional) This field contains metadata about how long the job is
@@ -199,6 +227,8 @@ Following fields may be used by the job unit:
     The values can no longer be fractional (you cannot say ``2.5m`` you need to
     say ``2m 30s``). We feel that sub-second granularity does is too
     unpredictable to be useful so that will not be supported in the future.
+
+.. _Job flags field:
 
 ``flags``:
     (optional) This fields contains list of flags separated by spaces or
@@ -292,6 +322,8 @@ Following fields may be used by the job unit:
 
     This flag has no effect on jobs other than resource.
 
+.. _Job siblings field:
+
 ``siblings``:
     (optional) This field creates copies of the current job definition
     but using a dictionary of overridden fields. The intend is to reduce the
@@ -367,6 +399,8 @@ Following fields may be used by the job unit:
                   "_summary": "bar after suspend",
                   "depends": "suspend/advanced"}}
                 ]
+
+.. _Job imports field:
 
 ``imports``:
     (optional) This field lists all the resource jobs that will have to be

--- a/docs/reference/units/manifest-entry.rst
+++ b/docs/reference/units/manifest-entry.rst
@@ -25,10 +25,14 @@ Fields
 
 Following fields may be used by a manifest entry unit.
 
+.. _Manifest Entry id field:
+
 ``id``:
     (mandatory) - Unique identifier of the entry. This field is used to look up
     and store data so please keep it stable across the lifetime of your
     provider.
+
+.. _Manifest Entry name field:
 
 ``name``:
     (mandatory) - A human readable name of the entry. This should read as in a
@@ -41,21 +45,29 @@ Following fields may be used by a manifest entry unit.
     The name is a translatable field so please prefix it with ``_`` as in
     ``_name: Example``.
 
+.. _Manifest Entry value-type field:
+
 ``value-type``:
     (mandatory) - Type of value for this entry. Currently two values are
     allowed: ``bool`` for a yes/no value and ``natural`` for any natural number
     (negative numbers are rejected).
+
+.. _Manifest Entry value-units field:
 
 ``value-units``:
     (optional) - Units in which value is measured in. This is only used when
     ``value-type`` is equal to ``natural``. For example a *"Screen size"*
     manifest entry could be measured in *"inch"* units.
 
+.. _Manifest Entry resource-key field:
+
 ``resource-key``:
     (optional) - Name of the resource key used to store the manifest value when
     representing the manifest as a resource record. This field defaults to the
     so-called *partial id* which is just the ``id:`` field as spelled in the
     unit definition file (so without the name space of the provider)
+
+.. _Manifest Entry prompt field:
 
 ``prompt``:
     (optional) - Allows the manifest unit to customize the prompt presented

--- a/docs/reference/units/packaging-meta-data.rst
+++ b/docs/reference/units/packaging-meta-data.rst
@@ -22,10 +22,14 @@ Fields
 
 Following fields may be used by a manifest entry unit.
 
+.. _Packaging Meta Data os-id field:
+
 ``os-id``:
     (mandatory) - the identifier of the operating system this rule applies to.
     This is the same value as the ``ID`` field in the file ``/etc/os-release``.
     Typical values include ``debian``, ``ubuntu`` or ``fedora``.
+
+.. _Packaging Meta Data os-version-id field:
 
 ``os-version-id``:
     (optional) - the identifier of the specific version of the operating system
@@ -36,13 +40,21 @@ Following fields may be used by a manifest entry unit.
 The remaining fields are custom and depend on the packaging driver. The values
 for **Debian** are:
 
+.. _Packaging Meta Data Depends field:
+
 ``Depends``:
     (optional) - a comma separated list of dependencies for the binary package.
     The syntax is the same as in normal Debian control files (including package
     version dependencies). This field can be split into multiple lines, for
     readability, as newlines are discarded.
+
+.. _Packaging Meta Data Suggests field:
+
 ``Suggests``:
     (optional) - same as ``Depends``.
+
+.. _Packaging Meta Data Recommends field:
+
 ``Recommends``:
     (optional) - same as ``Depends``.
 

--- a/docs/reference/units/template.rst
+++ b/docs/reference/units/template.rst
@@ -16,12 +16,16 @@ Template-Specific Fields
 
 There are four fields that are specific to the template unit:
 
+.. _Template template-unit field:
+
 ``template-unit``:
     Name of the unit type this template will generate. By default job
     definition units are generated (as if the field was specified with the
     value of ``job``) eventually but other values may be used as well.
 
     This field is optional.
+
+.. _Template template-resource field:
 
 ``template-resource``:
     Name of the resource job (if it is a compatible resource identifier) to use
@@ -31,6 +35,8 @@ There are four fields that are specific to the template unit:
     field.
 
     This field is mandatory.
+
+.. _Template template-imports field:
 
 ``template-imports``:
     A resource import statement. It can be used to refer to arbitrary resource
@@ -50,6 +56,8 @@ There are four fields that are specific to the template unit:
     job definition is from another provider namespace or when it is not a valid
     resource identifier and needs to be aliased.
 
+.. _Template template-filter field:
+
 ``template-filter``:
     A resource program that limits the set of records from which template
     instances will be made. The syntax of this field is the same as the syntax
@@ -61,6 +69,8 @@ There are four fields that are specific to the template unit:
     object is used to instantiate a new unit.
 
     This field is optional.
+
+.. _Template template-engine field:
 
 ``template-engine``:
     Name of the template engine to use, default is python string formatting

--- a/docs/reference/units/test-plan.rst
+++ b/docs/reference/units/test-plan.rst
@@ -30,6 +30,8 @@ maintain backwards compatibility so some of the test plans it defines may have
 non-typical constructs required to ensure proper behavior. You don't have to
 copy such constructs when working on a new test plan from scratch
 
+.. _Test Plan id field:
+
 ``id``:
     Each test plan needs to have a unique identifier. This is exactly the same
     as with other units that have an identifier (like job definitions
@@ -37,6 +39,8 @@ copy such constructs when working on a new test plan from scratch
 
     This field is not used for display purposes but you may need to refer
     to it on command line so keeping it descriptive is useful
+
+.. _Test Plan name field:
 
 ``name``:
     A human-readable name of the test plan. The name should be relatively short
@@ -57,6 +61,8 @@ copy such constructs when working on a new test plan from scratch
     lines. This field should be marked as translatable by prepending the
     underscore character (\_) in front. This field is mandatory.
 
+.. _Test Plan description field:
+
 ``description``:
     A human-readable description of this test plan. Here you can include as
     many or few details as you'd like. Some applications may offer a way
@@ -73,6 +79,8 @@ copy such constructs when working on a new test plan from scratch
     The field has no size limit. It can contain newline characters. This field
     should be marked as translatable by prepending the underscore character
     (\_) in front. This field is optional.
+
+.. _Test Plan include field:
 
 ``include``:
     A multi-line list of job identifiers or patterns matching such identifiers
@@ -106,6 +114,8 @@ copy such constructs when working on a new test plan from scratch
     on how you can refer to jobs from other providers (you simply use their
     fully qualified name for that)
 
+.. _Test Plan mandatory_include field:
+
 ``mandatory_include``:
     A multi-line list of job identifiers or patterns matching such identifiers
     that should always be executed.
@@ -126,6 +136,8 @@ copy such constructs when working on a new test plan from scratch
     Note that mandatory jobs will always be run first (along with their
     dependent jobs)
 
+.. _Test Plan bootstrap_include field:
+
 ``bootstrap_include``:
     A multi-line list of job identifiers that should be run first, before the
     main body of testing begins. The job that should be included in the
@@ -141,12 +153,16 @@ copy such constructs when working on a new test plan from scratch
     identifier and cannot be a regular expression pattern.
     Also note that only resource jobs are allowed in this section.
 
+.. _Test Plan nested_part field:
+
 ``nested_part``:
    A multi-line list of test-plan identifiers whose contents will become part
    of this test-plan. This is a method of creating a tree of test plans,
    something that can be useful for organization and de-duplication of test plan
    definitions. For a full discussion of this capability see
    :ref:`nested-test-plan`.
+
+.. _Test Plan exclude field:
 
 ``exclude``:
     A multi-line list of job identifiers or patterns matching such identifiers
@@ -162,6 +178,8 @@ copy such constructs when working on a new test plan from scratch
     as the ``include``.
 
     When a job is both included and excluded, exclusion always takes priority.
+
+.. _Test Plan category-overrides field:
 
 ``category-overrides``:
     A multi-line list of category override statements.
@@ -213,7 +231,7 @@ copy such constructs when working on a new test plan from scratch
     The job definition with the partial identifier ``foo`` will be associated
     with the ``cat-2`` category.
 
-.. _testplan_estimated_duration:
+.. _Test Plan estimated_duration field:
 
 ``estimated_duration``:
     An approximate time to execute this test plan, in seconds.


### PR DESCRIPTION
## Description

With the recent removal of Plainbox docs, one link in the Checkbox docs was reported as broken:

https://github.com/canonical/checkbox/actions/runs/5213187789/jobs/9407950316?pr=542#step:4:81

While fixing this, I took the opportunity to rework the anchors to all the fields for all the Checkbox unit types. This will make it easier for us to point users to the right place in the documentation. This is because we list the different fields as a definition list, which does not create HTML anchors. They need to be created manually.

For example, I can now point to the [`command` field of the Job unit](https://canonical-checkbox--543.com.readthedocs.build/en/543/reference/units/job.html#job-command-field).

Edit: this patch also removes an uncessary table of content in the "Understanding" page.

## Resolved issues

https://warthogs.atlassian.net/browse/CHECKBOX-594



## Tests

Tested by building docs locally:

```
cd docs/
make install
make run 
```