### PR TITLE
Allow reusing containers in metabox provisioning

### DIFF
--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -191,11 +191,11 @@ class LxdMachineProvider:
             self._store_config(machine)
             logger.debug("Stopping container {}...", container.name)
             container.stop(wait=True)
-            logger.debug("Creating 'provisioned' snapshot for {}...", container.name)
             if use_existing:
                 with suppress(NotFound):
                     container.snapshots.get('provisioned').delete(wait=True)
-                    logger.debug("Deleted old provisioned")
+                    logger.debug("Deleted old 'provisioned'")
+            logger.debug("Creating 'provisioned' snapshot for {}...", container.name)
             container.snapshots.create(
                 'provisioned', stateful=False, wait=True)
             logger.debug("Starting container {}...", container.name)
@@ -253,6 +253,13 @@ class LxdMachineProvider:
                     machine._container,
                     "sudo mkdir -p {}".format(os.path.dirname(dest)),
                     verbose=self._debug_machine_setup
+                )
+                # Ensure that the location is not already there
+                #  else cp will copy inside it
+                run_or_raise(
+                    machine._container,
+                    "sudo rm -rf {} 2>/dev/null || true".format(dest),
+                    verbose = self._debug_machine_setup
                 )
                 # Copy the mounted dir to the desired location
                 run_or_raise(

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -134,7 +134,7 @@ class LxdMachineProvider:
                     '{} LXD profile created successfully', profile_name)
 
     def _create_machine(self, config, use_existing=False):
-        if use_existing and config.origin == 'source':
+        if use_existing and not config.origin == 'source':
             raise ValueError(
                 "Use existing can not be enabled in non source runs"
             )

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -81,6 +81,12 @@ class LxdMachineProvider:
                     # existing container(if any), deploy and install the new code.
                     # this will probably take way less than reprovisioning a
                     # full machine, but may not work!
+                    # Also: remove the old owned container, this is re-created by
+                    #       by _create_machine and causes problems because it
+                    #       will not contain up to date infos
+                    self._owned_containers = [
+                        oc for oc in self._owned_containers if oc.config != config
+                    ]
                     self._create_machine(
                         config, use_existing=self._use_existing)
                 continue
@@ -299,7 +305,7 @@ class LxdMachineProvider:
         """Stop and delete (on request) all the containers."""
         for machine in self._owned_containers:
             container = machine._container
-            if container.state().status == "Running":
+            if container.status == "Running":
                 container.stop(wait=True)
                 logger.opt(colors=True).debug(
                     "[<y>stopped</y>     ] {}", container.name)

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -161,7 +161,7 @@ class LxdMachineProvider:
         if use_existing:
             with suppress(NotFound):
                 container = self.client.containers.get(name)
-            logger.opt(colors=True).debug("[<y>re-using</y>    ] {}", name)
+                logger.opt(colors=True).debug("[<y>re-using</y>    ] {}", name)
         try:
             if container is None:
                 logger.opt(colors=True).debug("[<y>creating</y>    ] {}", name)

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -31,12 +31,12 @@ import time
 import yaml
 import subprocess
 from pathlib import Path
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 
 import pkg_resources
 import pylxd
 from loguru import logger
-from pylxd.exceptions import ClientConnectionFailed, LXDAPIException
+from pylxd.exceptions import ClientConnectionFailed, LXDAPIException, NotFound
 
 from metabox.core.machine import MachineConfig
 from metabox.core.machine import machine_selector
@@ -53,12 +53,13 @@ class LxdMachineProvider:
     LXD_MOUNT_DEVICE = 'sde'
 
     def __init__(self, session_config, effective_machine_config,
-                 debug_machine_setup=False, dispose=False):
+                 debug_machine_setup=False, dispose=False, redeploy_existing=False):
         self._session_config = session_config
         self._machine_config = effective_machine_config
         self._debug_machine_setup = debug_machine_setup
         self._owned_containers = []
         self._dispose = dispose
+        self._redeploy_existing = redeploy_existing
 
         # TODO: maybe add handlers for more complicated client connections
         #       like a remote LXD host and/or authenticated access
@@ -75,6 +76,13 @@ class LxdMachineProvider:
         self._get_existing_machines()
         for config in self._machine_config:
             if config in [oc.config for oc in self._owned_containers]:
+                if self._redeploy_existing:
+                    # if redeploy_existing, try to piggy back on the already
+                    # existing machine, deploy and install the new code.
+                    # this will probably take way less than reprovisioning a
+                    # full machine, but may not work!
+                    self._create_machine(
+                        config, use_existing=self._redeploy_existing)
                 continue
             self._create_machine(config)
 
@@ -125,7 +133,11 @@ class LxdMachineProvider:
                 logger.debug(
                     '{} LXD profile created successfully', profile_name)
 
-    def _create_machine(self, config):
+    def _create_machine(self, config, use_existing=False):
+        assert (
+            not use_existing or
+            (use_existing and config.origin == 'source')
+        ), "Use existing can not be enabled in non source runs"
         name = 'metabox-{}'.format(config)
         base_profiles = ["default", "checkbox"]
         alias = config.alias
@@ -145,9 +157,15 @@ class LxdMachineProvider:
                 'server': server
             }
         }
+        container = None
+        if use_existing:
+            with suppress(NotFound):
+                container = self.client.containers.get(name)
+            logger.opt(colors=True).debug("[<y>re-using</y>    ] {}", name)
         try:
-            logger.opt(colors=True).debug("[<y>creating</y>    ] {}", name)
-            container = self.client.containers.create(lxd_config, wait=True)
+            if container is None:
+                logger.opt(colors=True).debug("[<y>creating</y>    ] {}", name)
+                container = self.client.containers.create(lxd_config, wait=True)
             machine = machine_selector(config, container)
             container.start(wait=True)
             attempt = 0
@@ -174,6 +192,10 @@ class LxdMachineProvider:
             logger.debug("Stopping container {}...", container.name)
             container.stop(wait=True)
             logger.debug("Creating 'provisioned' snapshot for {}...", container.name)
+            if use_existing:
+                with suppress(NotFound):
+                    container.snapshots.get('provisioned').delete(wait=True)
+                    logger.debug("Deleted old provisioned")
             container.snapshots.create(
                 'provisioned', stateful=False, wait=True)
             logger.debug("Starting container {}...", container.name)
@@ -277,7 +299,7 @@ class LxdMachineProvider:
         """Stop and delete (on request) all the containers."""
         for machine in self._owned_containers:
             container = machine._container
-            if container.status == "Running":
+            if container.state().status == "Running":
                 container.stop(wait=True)
                 logger.opt(colors=True).debug(
                     "[<y>stopped</y>     ] {}", container.name)

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -53,13 +53,13 @@ class LxdMachineProvider:
     LXD_MOUNT_DEVICE = 'sde'
 
     def __init__(self, session_config, effective_machine_config,
-                 debug_machine_setup=False, dispose=False, redeploy_existing=False):
+                 debug_machine_setup=False, dispose=False, use_existing=False):
         self._session_config = session_config
         self._machine_config = effective_machine_config
         self._debug_machine_setup = debug_machine_setup
         self._owned_containers = []
         self._dispose = dispose
-        self._redeploy_existing = redeploy_existing
+        self._use_existing = use_existing
 
         # TODO: maybe add handlers for more complicated client connections
         #       like a remote LXD host and/or authenticated access
@@ -76,13 +76,13 @@ class LxdMachineProvider:
         self._get_existing_machines()
         for config in self._machine_config:
             if config in [oc.config for oc in self._owned_containers]:
-                if self._redeploy_existing:
-                    # if redeploy_existing, try to piggy back on the already
-                    # existing machine, deploy and install the new code.
+                if self._use_existing:
+                    # if use_existing, try to piggy back on the already
+                    # existing container(if any), deploy and install the new code.
                     # this will probably take way less than reprovisioning a
                     # full machine, but may not work!
                     self._create_machine(
-                        config, use_existing=self._redeploy_existing)
+                        config, use_existing=self._use_existing)
                 continue
             self._create_machine(config)
 

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -254,17 +254,10 @@ class LxdMachineProvider:
                     "sudo mkdir -p {}".format(os.path.dirname(dest)),
                     verbose=self._debug_machine_setup
                 )
-                # Ensure that the location is not already there
-                #  else cp will copy inside it
-                run_or_raise(
-                    machine._container,
-                    "sudo rm -rf {} 2>/dev/null || true".format(dest),
-                    verbose = self._debug_machine_setup
-                )
                 # Copy the mounted dir to the desired location
                 run_or_raise(
                     machine._container,
-                    "sudo cp -r /{} {}".format(self.LXD_SOURCE_MOUNT_POINT, dest),
+                    "sudo cp -rT /{} {}".format(self.LXD_SOURCE_MOUNT_POINT, dest),
                     verbose=self._debug_machine_setup
                 )
                 # Own it to the correct user

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -134,10 +134,10 @@ class LxdMachineProvider:
                     '{} LXD profile created successfully', profile_name)
 
     def _create_machine(self, config, use_existing=False):
-        assert (
-            not use_existing or
-            (use_existing and config.origin == 'source')
-        ), "Use existing can not be enabled in non source runs"
+        if use_existing and config.origin == 'source':
+            raise ValueError(
+                "Use existing can not be enabled in non source runs"
+            )
         name = 'metabox-{}'.format(config)
         base_profiles = ["default", "checkbox"]
         alias = config.alias

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -89,14 +89,10 @@ class ContainerBaseMachine:
             timeout)
 
     def rollback_to(self, savepoint):
-        # Note: Use _container.state().status and not .status
-        #       it *seems* to not be always updated
-        if self._container.state().status != 'Stopped':
+        if self._container.status != 'Stopped':
             self._container.stop(wait=True)
         self._container.restore_snapshot(savepoint, wait=True)
-        assert self._container.state().status == "Stopped"
         self._container.start(wait=True)
-        assert self._container.state().status == "Running"
         logger.opt(colors=True).debug(
             "[<y>restored</y>    ] {}", self._container.name)
         if self.config.role == 'service':

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -89,10 +89,14 @@ class ContainerBaseMachine:
             timeout)
 
     def rollback_to(self, savepoint):
-        if self._container.status != 'Stopped':
+        # Note: Use _container.state().status and not .status
+        #       it *seems* to not be always updated
+        if self._container.state().status != 'Stopped':
             self._container.stop(wait=True)
         self._container.restore_snapshot(savepoint, wait=True)
+        assert self._container.state().status == "Stopped"
         self._container.start(wait=True)
+        assert self._container.state().status == "Running"
         logger.opt(colors=True).debug(
             "[<y>restored</y>    ] {}", self._container.name)
         if self.config.role == 'service':

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -60,6 +60,7 @@ class Runner:
         self.hold_on_fail = self.args.hold_on_fail
         self.debug_machine_setup = self.args.debug_machine_setup
         self.dispose = not self.args.do_not_dispose
+        self.redeploy_existing = self.args.redeploy_existing
         aggregator.load_all()
 
     def _formatter(self, record):
@@ -164,7 +165,8 @@ class Runner:
         logger.debug("Combo: {}", self.combo)
         self.machine_provider = LxdMachineProvider(
             self.config, self.combo,
-            self.debug_machine_setup, self.dispose)
+            self.debug_machine_setup, self.dispose,
+            redeploy_existing=self.redeploy_existing)
         self.machine_provider.setup()
 
     def _load(self, mode, release_alias):

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -60,7 +60,7 @@ class Runner:
         self.hold_on_fail = self.args.hold_on_fail
         self.debug_machine_setup = self.args.debug_machine_setup
         self.dispose = not self.args.do_not_dispose
-        self.redeploy_existing = self.args.redeploy_existing
+        self.use_existing = self.args.use_existing
         aggregator.load_all()
 
     def _formatter(self, record):
@@ -166,7 +166,7 @@ class Runner:
         self.machine_provider = LxdMachineProvider(
             self.config, self.combo,
             self.debug_machine_setup, self.dispose,
-            redeploy_existing=self.redeploy_existing)
+            use_existing=self.use_existing)
         self.machine_provider.setup()
 
     def _load(self, mode, release_alias):

--- a/metabox/metabox/main.py
+++ b/metabox/metabox/main.py
@@ -62,6 +62,9 @@ def main():
         '--do-not-dispose', action='store_true',
         help="Do not delete LXD containers after the run")
     parser.add_argument(
+        '--redeploy-existing', action='store_true',
+        help="Re-Deploy and install existing containers")
+    parser.add_argument(
         '--hold-on-fail', action='store_true',
         help="Pause testing when a scenario fails")
     parser.add_argument(

--- a/metabox/metabox/main.py
+++ b/metabox/metabox/main.py
@@ -62,8 +62,8 @@ def main():
         '--do-not-dispose', action='store_true',
         help="Do not delete LXD containers after the run")
     parser.add_argument(
-        '--redeploy-existing', action='store_true',
-        help="Re-Deploy and install existing containers")
+        '--use-existing', action='store_true',
+        help="Use existing containers updating the source inside them")
     parser.add_argument(
         '--hold-on-fail', action='store_true',
         help="Pause testing when a scenario fails")


### PR DESCRIPTION
## Description

When changing the code of anything that is included in the provisioning (providers or checkbox) the only way to test these changes via metabox is re-provisioning the containers. This operation may take a lot of time and it is not always necessary. This PR introduces the option of re-using the already provisioned container by overwriting the source code and re-installing it. The idea is that by doing this we save the time it takes to install all of the dependencies (because they are already there) and creating the "base" machine (setting up the image etc.).

In my tests this saves around 2 minutes per provisioning, cutting the time from 3minutes to 1, double that for remote tests

## Resolved issues

N/A

## Documentation

The option has a standard CLI help prompt 

## Tests

All tests 
