### PR TITLE
Warning for skipped file at provider loading

### DIFF
--- a/checkbox-ng/plainbox/impl/secure/providers/v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/v1.py
@@ -586,12 +586,26 @@ class ProviderContentLoader:
         self.problem_list.extend(self.provider.content_collection.problem_list)
         self.is_loaded = True
 
+    def _warn_ignored_file(self, filename):
+        """
+        Print an warning message for each file that is skipped at loading
+        Do not print warning for all skipped files, do it only for file that is located
+        inside a official provider folder (bin, data, units, ..).
+        """
+        if ((self.provider.units_dir and filename.startswith(self.provider.units_dir))
+            or (self.provider.jobs_dir and filename.startswith(self.provider.jobs_dir))
+            or (self.provider.data_dir and filename.startswith(self.provider.data_dir))
+            or (self.provider.bin_dir and filename.startswith(self.provider.bin_dir))
+            or (self.provider.locale_dir and filename.startswith(self.provider.locale_dir))):
+            logger.warn("Skipped file: %s", filename)
+
     def _load_file(self, filename, text, plugin_kwargs):
         # NOTE: text is lazy, call str() or iter() to see the real content This
         # prevents us from trying to read binary blobs.
         classification = self.provider.classify(filename)
         role, base_dir, plugin_cls = classification
         if plugin_cls is None:
+            self._warn_ignored_file(filename)
             return
         try:
             plugin = plugin_cls(


### PR DESCRIPTION
Currently, if we put a non executable file in the provider bin folder the file will be skipped at provider deployment and can cause the provider malfunction. Tools like checkbox-provider-tools just silently ignores the file at validation and install steps. Printing some warning message would help users to figure out more quickly these kinds of mistake.

## Description

## Resolved issues

N/A

## Documentation

N/A

## Tests

Put a non executable python lib file in bin folder, the checkbox-provider-tools will print warning for this skipped file.
 
```
checkbox-provider-kivu$ checkbox-provider-tools install --layout=relocatable --prefix=/providers/checkbox-provider-kivu --root=/tmp/

WARNING plainbox.secure.providers.v1: Skipped file: /home/hector/workspace/src/kivu/conf/checkbox-providers/checkbox-kivu-git/checkbox-provider-kivu/bin/gpu_utils.py
```