### PR TITLE
Fix: Bug #539 - network.py crashes with ZeroDivisionError on some systems

### DIFF
--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -288,7 +288,7 @@ class IPerfPerformanceTest(object):
         t = []
         results.clear()
         for thread_num in range(0, python_threads):
-            if self.iperf3:
+            if self.iperf3 and len(core_list) > 0:
                 core = core_list[thread_num % len(core_list)]
                 full_cmd = cmd + " -A {}".format(core)
             else:


### PR DESCRIPTION
Fix: Bug #539 - network.py crashes with ZeroDivisionError on some systems

## Description

This PR adds protection against a divide-by-zero error, causing the script to not perform the division (actually a modulo operator) or try to use the iperf3 option that relies on the result of that operator. This should be OK, since the relevant code was added to support machines with multiple NUMA nodes, and the affected system seems to lack these, so omitting the NUMA-node option should be harmless.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/539
Resolves: https://warthogs.atlassian.net/browse/SERVCERT-1165

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

No documentation changes needed; this just fixes a bug.

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
-->

I was unable to re-create the problem, since I lack a Raspberry Pi; however, I faked it by temporarily adjusting the code. I tested the fix against this adjusted code, and it worked; the divide-by-zero error was bypassed and the script ran normally. I then reverted the adjustment to fake the problem and left the fix in place. It's just a one-line change.