### PR TITLE
Add: kernel snap refresh and revert tests

### DIFF
--- a/checkbox-support/checkbox_support/snap_utils/snapd.py
+++ b/checkbox-support/checkbox_support/snap_utils/snapd.py
@@ -138,14 +138,15 @@ class Snapd():
     def info(self, snap):
         return self.find(snap, exact=True)[0]
 
-    def refresh(self, snap, channel='stable', revision=None):
+    def refresh(self, snap, channel='stable', revision=None, reboot=False):
         path = self._snaps + '/' + snap
         data = {'action': 'refresh', 'channel': channel}
         if revision is not None:
             data['revision'] = revision
         r = self._post(path, json.dumps(data))
-        if r['type'] == 'async' and r['status'] == 'Accepted':
+        if r['type'] == 'async' and r['status'] == 'Accepted' and not reboot:
             self._poll_change(r['change'])
+        return r
 
     def change(self, change_id):
         path = self._changes + '/' + change_id
@@ -157,14 +158,15 @@ class Snapd():
         r = self._get(path)
         return r['result']['tasks']
 
-    def revert(self, snap, channel='stable', revision=None):
+    def revert(self, snap, channel='stable', revision=None, reboot=False):
         path = self._snaps + '/' + snap
         data = {'action': 'revert', 'channel': channel}
         if revision is not None:
             data['revision'] = revision
         r = self._post(path, json.dumps(data))
-        if r['type'] == 'async' and r['status'] == 'Accepted':
+        if r['type'] == 'async' and r['status'] == 'Accepted' and not reboot:
             self._poll_change(r['change'])
+        return r
 
     def get_configuration(self, snap, key):
         path = self._snaps + '/' + snap + '/conf'

--- a/providers/base/bin/kernel_snap_test.py
+++ b/providers/base/bin/kernel_snap_test.py
@@ -23,8 +23,7 @@ import logging
 import sys
 import time
 
-# from checkbox_support.snap_utils.snapd import Snapd
-from snapd import Snapd
+from checkbox_support.snap_utils.snapd import Snapd
 
 
 class KernelSnapTest:
@@ -54,9 +53,15 @@ class KernelSnapTest:
 
     def kernel_refresh(self):
         data = {}
-        data["original_revision"] = self.kernel_info["installed_revision"]
+        original_revision = self.kernel_info["installed_revision"]
+        data["original_revision"] = original_revision
         channel = "{}stable".format(self.kernel_info["tracking_prefix"])
-        logging.info("Refreshing kernel snap to stable...")
+        stable_rev = self.kernel_info["revisions"].get(channel, "")
+        logging.info(
+            "Refreshing kernel snap to stable (from rev %s to rev %s)",
+            original_revision,
+            stable_rev,
+        )
         r = self.snapd.refresh(
             self.kernel_info["name"], channel=channel, reboot=True
         )
@@ -110,7 +115,14 @@ class KernelSnapTest:
     def kernel_revert(self):
         with open(self.path, "r") as file:
             data = json.load(file)
-        logging.info("Reverting kernel snap...")
+        original_rev = data["original_revision"]
+        channel = "{}stable".format(self.kernel_info["tracking_prefix"])
+        stable_rev = self.kernel_info["revisions"].get(channel, "")
+        logging.info(
+            "Reverting kernel snap (from rev %s to rev %s)",
+            stable_rev,
+            original_rev,
+        )
         r = self.snapd.revert(self.kernel_info["name"], reboot=True)
         logging.info("Reverting requested")
         with open(self.path, "w") as file:

--- a/providers/base/bin/kernel_snap_test.py
+++ b/providers/base/bin/kernel_snap_test.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# All rights reserved.
+#
+# Written by:
+#    Patrick Liu <patrick.liu@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import json
+import logging
+import sys
+import time
+
+# from checkbox_support.snap_utils.snapd import Snapd
+from snapd import Snapd
+
+
+class KernelSnapTest:
+    def __init__(self, info_path):
+        self.snapd = Snapd()
+        self.kernel_info = self.get_kernel_info()
+        self.path = info_path
+
+    def get_kernel_info(self):
+        kernel_info = {}
+        installed_snaps = self.snapd.list()
+        for item in installed_snaps:
+            if item["type"] == "kernel":
+                kernel_info["name"] = item["name"]
+                kernel_info["tracking_channel"] = item["tracking-channel"]
+                kernel_info["installed_revision"] = item["revision"]
+        tracking = kernel_info["tracking_channel"]
+        prefix = (tracking.split("/")[0] + "/") if "/" in tracking else ""
+        kernel_info["tracking_prefix"] = prefix
+
+        snap_info = self.snapd.find(kernel_info["name"], exact=True)
+        kernel_info["revisions"] = {}
+        for item in snap_info:
+            for channel, info in item["channels"].items():
+                kernel_info["revisions"][channel] = info["revision"]
+        return kernel_info
+
+    def kernel_refresh(self):
+        data = {}
+        data["original_revision"] = self.kernel_info["installed_revision"]
+        channel = "{}stable".format(self.kernel_info["tracking_prefix"])
+        logging.info("Refreshing kernel snap to stable...")
+        r = self.snapd.refresh(
+            self.kernel_info["name"], channel=channel, reboot=True
+        )
+        logging.info("Refreshing requested")
+        with open(self.path, "w") as file:
+            data["refresh_id"] = r["change"]
+            json.dump(data, file)
+        logging.info("Waiting for reboot...")
+
+    def verify_refresh(self):
+        with open(self.path, "r") as file:
+            data = json.load(file)
+        id = data["refresh_id"]
+
+        logging.info("Checking kernel refresh status")
+        start_time = time.time()
+        timeout = 300  # 5 minutes timeout
+        while True:
+            result = self.snapd.change(str(id))
+            if result == "Done":
+                logging.info("Kernel refresh is complete")
+                break
+
+            if time.time() - start_time >= timeout:
+                logging.error(
+                    "Kernel refresh did not complete within 5 minutes"
+                )
+                return False
+            logging.info(
+                "Waiting for kernel refreshing to be done..."
+                "trying again in 10 seconds"
+            )
+            time.sleep(10)
+
+        current_rev = self.snapd.list(self.kernel_info["name"])["revision"]
+        channel = "{}stable".format(self.kernel_info["tracking_prefix"])
+        stable_rev = self.kernel_info["revisions"][channel]
+        if current_rev != stable_rev:
+            logging.error(
+                "Current revision %s is NOT equal to stable revision %s",
+                current_rev,
+                stable_rev,
+            )
+            return False
+        else:
+            logging.info(
+                "PASS: current revision matches the stable channel revision"
+            )
+        return True
+
+    def kernel_revert(self):
+        with open(self.path, "r") as file:
+            data = json.load(file)
+        logging.info("Reverting kernel snap...")
+        r = self.snapd.revert(self.kernel_info["name"], reboot=True)
+        logging.info("Reverting requested")
+        with open(self.path, "w") as file:
+            data["revert_id"] = r["change"]
+            json.dump(data, file)
+        logging.info("Waiting for reboot...")
+
+    def verify_revert(self):
+        with open(self.path, "r") as file:
+            data = json.load(file)
+        id = data["revert_id"]
+        original_rev = data["original_revision"]
+
+        logging.info("Checking kernel revert status")
+        start_time = time.time()
+        timeout = 300  # 5 minutes timeout
+        while True:
+            result = self.snapd.change(str(id))
+            if result == "Done":
+                logging.info("Kernel revert is complete")
+                break
+
+            if time.time() - start_time >= timeout:
+                logging.error(
+                    "Kernel revert did not complete within 5 minutes"
+                )
+                return False
+            logging.info(
+                "Waiting for kernel reverting to be done..."
+                "trying again in 10 seconds"
+            )
+            time.sleep(10)
+
+        current_rev = self.snapd.list(self.kernel_info["name"])["revision"]
+        if current_rev != original_rev:
+            logging.error(
+                "Current revision %s is NOT equal to original revision %s",
+                current_rev,
+                original_rev,
+            )
+            return False
+        else:
+            logging.info(
+                "PASS: current revision matches the original revision"
+            )
+        return True
+
+    def print_resource_info(self):
+        info = self.get_kernel_info()
+        tracking = info["tracking_channel"]
+
+        prefix = self.kernel_info["tracking_prefix"]
+        stable_rev = info["revisions"].get("{}stable".format(prefix), "")
+        cand_rev = info["revisions"].get("{}candidate".format(prefix), "")
+        beta_rev = info["revisions"].get("{}beta".format(prefix), "")
+        edge_rev = info["revisions"].get("{}edge".format(prefix), "")
+        installed_rev = info.get("installed_revision", "")
+
+        print("kernel_name: {}".format(info["name"]))
+        print("tracking: {}".format(tracking))
+        print("stable_rev: {}".format(stable_rev))
+        print("candidate_rev: {}".format(cand_rev))
+        print("beta_rev: {}".format(beta_rev))
+        print("edge_rev: {}".format(edge_rev))
+        print("original_installed_rev: {}".format(installed_rev))
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)-8s %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--resource",
+        action="store_true",
+        help="Refresh kernel snap",
+    )
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Refresh kernel snap",
+    )
+    parser.add_argument(
+        "--verify-refresh",
+        action="store_true",
+        help="Verify revision after refreshing kernel",
+    )
+    parser.add_argument(
+        "--revert",
+        action="store_true",
+        help="Revert kernel snap",
+    )
+    parser.add_argument(
+        "--verify-revert",
+        action="store_true",
+        help="Verify revision after reverting kernel",
+    )
+    parser.add_argument(
+        "--info-path",
+        help="Path to the information file",
+    )
+
+    args = parser.parse_args()
+    info_path = args.info_path
+    test = KernelSnapTest(info_path)
+
+    exit_code = 0
+    if args.resource:
+        test.print_resource_info()
+    if args.refresh:
+        if not test.kernel_refresh():
+            exit_code = 1
+    if args.verify_refresh:
+        if not test.verify_refresh():
+            exit_code = 1
+    if args.revert:
+        if not test.kernel_revert():
+            exit_code = 1
+    if args.verify_revert:
+        if not test.verify_revert():
+            exit_code = 1
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/providers/base/units/ubuntucore/jobs.pxu
+++ b/providers/base/units/ubuntucore/jobs.pxu
@@ -152,3 +152,81 @@ _verification:
  Check if system could boot, and kernel version is the one before switched to
  "failboot" kernel
 category_id: ubuntucore
+
+id: kernel_revision_info
+plugin: resource
+_summary: Gather the name, tracking, and revision info of the kernel snap
+estimated_duration: 3s
+command:
+    kernel_snap_test.py --resource
+
+unit: template
+template-resource: kernel_revision_info
+template-unit: job
+id: ubuntucore/kernel-refresh-{kernel_name}
+_summary: Test refreshing kernel snap to the stable channel
+_description:
+    This test is currently for SUV process, the kernel to be tested is on
+    the beta channel. Test the availability to refresh to the older version
+    on the stable channel. This test will be excuted only when the current
+    installed revision (on beta channel) is different from the revsion in
+    stable channel.
+plugin: shell
+estimated_duration: 3m
+category_id: ubuntucore
+user: root
+imports: from com.canonical.certification import kernel_revision_info
+requires:
+    kernel_revision_info.stable_rev != ""
+    kernel_revision_info.original_installed_rev != kernel_revision_info.stable_rev
+flags: noreturn autorestart
+command:
+    path="$PLAINBOX_SESSION_SHARE/kernel_revision_info"
+    kernel_snap_test.py --refresh --info-path "$path"
+    sleep 90
+    reboot
+
+unit: template
+template-resource: kernel_revision_info
+template-unit: job
+id: ubuntucore/kernel-verify-after-refresh-{kernel_name}
+_summary: Verify the kernel revision after refreshing to stable channel
+plugin: shell
+estimated_duration: 3s
+category_id: ubuntucore
+user: root
+depends: ubuntucore/kernel-refresh-{kernel_name}
+command:
+    path="$PLAINBOX_SESSION_SHARE/kernel_revision_info"
+    kernel_snap_test.py --verify-refresh --info-path "$path"
+
+unit: template
+template-resource: kernel_revision_info
+template-unit: job
+id: ubuntucore/kernel-revert-{kernel_name}
+_summary: Revert kernel snap to the original revision
+plugin: shell
+estimated_duration: 3m
+category_id: ubuntucore
+user: root
+depends: ubuntucore/kernel-verify-after-refresh-{kernel_name}
+flags: noreturn autorestart
+command:
+    path="$PLAINBOX_SESSION_SHARE/kernel_revision_info"
+    kernel_snap_test.py --revert --info-path "$path"
+    sleep 90
+    reboot
+
+unit: template
+template-resource: kernel_revision_info
+template-unit: job
+id: ubuntucore/kernel-verify-after-revert-{kernel_name}
+_summary: Verify the kernel revision after reverting
+plugin: shell
+estimated_duration: 3s
+category_id: ubuntucore
+user: root
+depends: ubuntucore/kernel-revert-{kernel_name}
+command:
+    path="$PLAINBOX_SESSION_SHARE/kernel_revision_info"
+    kernel_snap_test.py --verify-revert --info-path "$path"

--- a/providers/base/units/ubuntucore/test-plan.pxu
+++ b/providers/base/units/ubuntucore/test-plan.pxu
@@ -11,7 +11,13 @@ id: ubuntucore-automated
 unit: test plan
 _name: Automated Ubuntu Core OS feature tests
 _description: Automated OS feature tests for Ubuntu Core devices
+bootstrap_include:
+    kernel_revision_info
 include:
+    ubuntucore/kernel-refresh-.*
+    ubuntucore/kernel-verify-after-refresh-.*
+    ubuntucore/kernel-revert-.*
+    ubuntucore/kernel-verify-after-revert-.*
 
 id: ubuntucore-manual
 unit: test plan


### PR DESCRIPTION
## Description
This pull request is for CHECKBOX-455 to create automated test cases for kernel refresh and revert.
This PR contains 5 test jobs,
1. `kernel_revision_info` is a resource job to gather the kernel name, tracking, and revisions info including original-installed, stable, candidate, beta, and edge revisions for the kernel snap
2. `ubuntucore/kernel-refresh-{kernel}` gets the track name from `kernel_revision_info` and refreshes the kernel to the stable channel. It will only execute when the revision in stable channel exists and the original-installed revision is different from the revision in stable channel.
3. `ubuntucore/kernel-verify-after-refresh-{kernel}` verify the kernel revision is the same as the one in stable channel.
4. `ubuntucore/kernel-revert-{kernel}` waits until the kernel refreshing is `Done` and then reverts the kernel back to the original revision.
5. `ubuntucore/kernel-verify-after-revert-{kernel}` check the revision is back to the original one

The output of `kernel_revision_info` will be like
```
kernel_name: xxxxx-kernel
tracking: latest/stable
tracking_prefix: latest/
stable_rev: 126
candidate_rev: 126
beta_rev: 126
edge_rev: 126
original_installed_rev: 124
```

Note that Tillamook project has different channel names for kernel snap like `stable`, `latest/stable`, and `20/stable`. So the job will capture the current track and then refresh to the corresponding channel. For example, if it's on `20/beta`, then it will refresh to `20/stable` channel.
Also, I noticed sometimes, or on some slow devices, after refreshing the kernel and rebooting, it requires a few seconds to a few minutes to wait for the refreshing process done. Before it is done, we cannot do the kernel revert, so I've added a polling wait for up to 5 minutes on the kernel revert job.

## Resolved issues
CHECKBOX-455
Created kernel refresh and revert test cases for SUV process.

## Tests
* Sideload result on Tillamook device:
https://pastebin.canonical.com/p/sHqfQ7mjbD/
* Sideload result on Nuremberg device:
https://pastebin.canonical.com/p/D57cv8rzsx/
* When the originally installed revision is the same as the revision in the stable channel or there's no revision in the stable channel, the result will be like this:
https://pastebin.canonical.com/p/QzkJpxQFsS/
