### PR TITLE
Fix checking inactive nvlink status error

### DIFF
--- a/providers/base/bin/nvidia_nvlink_check.sh
+++ b/providers/base/bin/nvidia_nvlink_check.sh
@@ -8,7 +8,7 @@ if [ -z "$O" ];then
     echo "System does not support NVLINK or Only 1 NVIDIA graphic card installed";
     exit 1
 #If any inactive in output that means NVLINK not connected porpery or malfunction, -n use for verify output
-elif echo "$O" | grep -q inactive; then
+elif echo "$O" | grep -iq inactive; then
     echo "NVLINK either the bridge is missing/defective or not configured correctly";
     exit 1
 else


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

The term of `inactive` from output of `nvidia-smi nvlink -s` is `inActive`. However, the command used in `nvidia_nvlink_check.sh` is case sensitive.

[output from working nvlink](https://certification.canonical.com/hardware/202303-31333/submission/306724/test/91231/result/32316109/)

[output from inactive nvlink](https://certification.canonical.com/hardware/202305-31617/submission/315253/test/91231/result/33625925/)

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

Tracing in this [jira card](https://warthogs.atlassian.net/browse/CQT-2590)

## Documentation



<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
-->
