### PR TITLE
Add ability to get a numerical Intel gen number to cpuid.py

### DIFF
--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -25,6 +25,7 @@
 # Modifications: 2019 Jeffrey Lane (jeffrey.lane@canonical.com)
 
 import argparse
+from enum import Enum
 import ctypes
 import platform
 import sys
@@ -102,64 +103,225 @@ is_64bit = ctypes.sizeof(ctypes.c_voidp) == 8
 # [5] Base Model
 # [6] Stepping
 
-CPUIDS = {
-        "Amber Lake":       ['0x806e9'],
-        "AMD EPYC":         ['0x800f12'],
-        "AMD Genoa":        ['0xa10f11'],
-        "AMD Lisbon":       ['0x100f81'],
-        "AMD Magny-Cours":  ['0x100f91'],
-        "AMD Milan":        ['0xa00f11'],
-        "AMD Milan-X":      ['0xa00f12'],
-        "AMD ROME":         ['0x830f10'],
-        "AMD Ryzen":        ['0x810f81'],
-        "AMD Bergamo":      ['0xaa0f01'],
-        "Broadwell":        ['0x4067', '0x306d4', '0x5066', '0x406f'],
-        "Canon Lake":       ['0x6066'],
-        "Cascade Lake":     ['0x50655', '0x50656', '0x50657'],
-        "Coffee Lake":      [
-            '0x806ea', '0x906ea', '0x906eb', '0x906ec', '0x906ed'],
-        "Comet Lake":       ['0x806ec', '0xa065'],
-        "Cooper Lake":      ['0x5065a', '0x5065b'],
-        "Haswell":          ['0x306c', '0x4065', '0x4066', '0x306f'],
-        "Ice Lake":         ['0x606e6', '0x606a6', '0x706e6', '0x606c1'],
-        "Ivy Bridge":       ['0x306a', '0x306e'],
-        "Kaby Lake":        ['0x806e9', '0x906e9'],
-        "Knights Landing":  ['0x5067'],
-        "Knights Mill":     ['0x8065'],
-        "Nehalem":          ['0x106a', '0x106e5', '0x206e'],
-        "Pineview":         ['0x106ca'],
-        "Penryn":           ['0x1067a'],
-        "Rocket Lake":      ['0xa0671'],
-        "Sandy Bridge":     ['0x206a', '0x206d6', '0x206d7'],
-        "Sapphire Rapids":  ['0x806f3', '0x806f6', '0x806f7', '0x806f8'],
-        "Skylake":          ['0x406e3', '0x506e3', '0x50654', '0x50652'],
-        "Tiger Lake":       ['0x806c1'],
-        "Aderlake":         ['0x906a4', '0x906A3', '0x90675', '0x90672'],
-        "Raptorlake":       ['0xB0671', '0xB06F2', '0xB06F5', '0xB06A2'],
-        "Westmere":         ['0x2065', '0x206c', '0x206f'],
-        "Whisky Lake":      ['0x806eb', '0x806ec'],
+
+class ChipType(Enum):
+    SERVER = 1
+    CLIENT = 2
+
+
+# Some CPUIDs are full IDs, and others omit the last digit
+CPUDICT = {
+        "AMD EPYC":         {
+                                "cpuids": ['0x800f12'],
+                                "generation":   -1,  # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "AMD Genoa":        {
+                                "cpuids": ['0xa10f11'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "AMD Lisbon":       {
+                                "cpuids": ['0x100f81'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "AMD Magny-Cours":  {
+                                "cpuids": ['0x100f91'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "AMD Milan":        {
+                                "cpuids": ['0xa00f11'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "AMD Milan-X":      {
+                                "cpuids": ['0xa00f12'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "AMD ROME":         {
+                                "cpuids": ['0x830f10'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "AMD Ryzen":        {
+                                "cpuids": ['0x810f81'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "AMD Bergamo":      {
+                                "cpuids": ['0xaa0f01'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "Broadwell":        {
+                                "cpuids": ['0x4067', '0x306d4'],
+                                "generation":   5,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Broadwell Xeon":   {
+                                "cpuids": ['0x5066', '0x406f'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "Cannon Lake":      {
+                                "cpuids": ['0x6066'],
+                                "generation":   8,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Cascade Lake":     {
+                                "cpuids": ['0x50655', '0x50656', '0x50657'],
+                                "generation":   2,
+                                "chiptype":     ChipType.SERVER
+                            },
+        "Coffee Lake":      {
+                                "cpuids": ['0x806ea', '0x906ea', '0x906eb',
+                                           '0x906ec', '0x906ed'],
+                                "generation":   8,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Comet Lake":       {
+                                "cpuids": ['0x806ec', '0xa065'],
+                                "generation":   10,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Cooper Lake":      {
+                                "cpuids": ['0x5065a', '0x5065b'],
+                                "generation":   3,
+                                "chiptype":     ChipType.SERVER
+                            },
+        "Haswell":          {
+                                "cpuids": ['0x306c', '0x4065', '0x4066'],
+                                "generation":   4,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Haswell Xeon":     {
+                                "cpuids": ['0x306f'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "Ice Lake":          {
+                                "cpuids": ['0x606e6', '0x706e6'],
+                                "generation":   10,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Ice Lake Xeon":    {
+                                "cpuids": ['0x606a6', '0x606c1'],
+                                "generation":   3,
+                                "chiptype":     ChipType.SERVER
+                            },
+        "Ivy Bridge":       {
+                                "cpuids": ['0x306a'],
+                                "generation":   3,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Ivy Bridge Xeon":       {
+                                "cpuids": ['0x306e'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "Kaby Lake":        {
+                                "cpuids": ['0x806e9', '0x906e9', '0x806e9'],
+                                "generation":   7,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Knights Landing":  {
+                                "cpuids": ['0x5067'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "Knights Mill":     {
+                                "cpuids": ['0x8065'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "Nehalem":          {
+                                "cpuids": ['0x106e5'],
+                                "generation":   1,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Nehalem Xeon":     {
+                                "cpuids": ['0x106a', '0x206e'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "Pineview":          {
+                                "cpuids": ['0x106ca'],
+                                "generation":   1,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Penryn":           {
+                                "cpuids": ['0x1067a'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Rocket Lake":      {
+                                "cpuids": ['0xa0671'],
+                                "generation":   11,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Sandy Bridge":     {
+                                "cpuids": ['0x206a'],
+                                "generation":   2,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Sandy Bridge Xeon":     {
+                                "cpuids": ['0x206d6', '0x206d7'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "Sapphire Rapids":  {
+                                "cpuids": ['0x806f3', '0x806f6', '0x806f7',
+                                           '0x806f8'],
+                                "generation":   4,
+                                "chiptype":     ChipType.SERVER
+                            },
+        "Skylake":          {
+                                "cpuids": ['0x406e3', '0x506e3'],
+                                "generation":   6,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Skylake Xeon":     {
+                                "cpuids": ['0x50654', '0x50652'],
+                                "generation":   1,
+                                "chiptype":     ChipType.SERVER
+                            },
+        "Tiger Lake":       {
+                                "cpuids": ['0x806c1'],
+                                "generation":   11,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Alder Lake":       {
+                                "cpuids": ['0x906a4', '0x906A3', '0x90675',
+                                           '0x90672', '0x906a2'],
+                                "generation":   12,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Raptor Lake":      {
+                                "cpuids": ['0xB0671', '0xB06F2', '0xB06F5',
+                                           '0xB06A2'],
+                                "generation":   13,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Westmere":         {
+                                "cpuids": ['0x2065'],
+                                "generation":   1,
+                                "chiptype":     ChipType.CLIENT
+                            },
+        "Westmere Xeon":    {
+                                "cpuids": ['0x206c', '0x206f'],
+                                "generation":   -1, # noqa
+                                "chiptype":     ChipType.SERVER
+                            },
+        "Whisky Lake":      {
+                                "cpuids": ['0x806eb', '0x806ec'],
+                                "generation":   10,
+                                "chiptype":     ChipType.CLIENT
+                            },
         }
 
-# Server chips use different generations, so skip them
-INTEL_GEN_TO_NUM = {
-        "Raptorlake":       13,
-        "Alderlake":        12,
-        "Rocket Lake":      11,
-        "Tiger Lake":       11,
-        "Comet Lake":       10,
-        "Amber Lake":       10,
-        "Ice Lake":         10,
-        "Whiskey Lake":     10,
-        "Canon Lake":       8,
-        "Coffee Lake":      8,
-        "Kaby Lake":        7,
-        "Skylake":          6,
-        "Broadwell":        5,
-        "Haswell":          4,
-        "Ivy Bridge":       3,
-        "Sandy Bridge":     2,
-        "Westmere":         1,
-}
 
 class CPUID_struct(ctypes.Structure):
     _fields_ = [(r, c_uint32) for r in ("eax", "ebx", "ecx", "edx")]
@@ -212,7 +374,8 @@ class CPUID(object):
 def main():
     parser = argparse.ArgumentParser(
                     prog='cpuid',
-                    description='Identifies the Intel generation based on cpu ids')
+                    description='Identifies the Intel generation based on cpu \
+                                ids')
     parser.add_argument('--intel_gen_number', action='store_true')
     args = parser.parse_args()
 
@@ -228,17 +391,22 @@ def main():
 
     my_id = (hex(cpu[0]))
     complete = False
-    for key in CPUIDS.keys():
-        for value in CPUIDS[key]:
-            if value.lower() in my_id:
-                if not args.intel_gen_number:
-                    print("CPUID: %s which appears to be a %s processor" %
-                        (my_id, key))
-                else:
-                    if key in INTEL_GEN_TO_NUM:
-                        print(INTEL_GEN_TO_NUM[key])
+    for key in CPUDICT.keys():
+        platform = CPUDICT[key]
+        platform_ids = platform['cpuids']
+        for platform_id in platform_ids:
+            if platform_id.lower() in my_id:
+                if args.intel_gen_number:
+                    if platform['chiptype'] == ChipType.CLIENT and \
+                       platform['generation'] > 0:
+                        print(platform['generation'])
                     else:
-                        print("%s is not supported for conversion to Intel generation number")
+                        print("%s is not supported for conversion to Intel \
+                              generation number")
+                else:
+                    print("CPUID: %s which appears to be a %s processor" %
+                          (my_id, key))
+
                 complete = True
 
     if not complete:


### PR DESCRIPTION
## Description
DEPENDS ON: pull/559

Some feautures we test for may be heavily dependent on the CPU
    generation. For instance, a media stress test for Chromium seems to
    max out VECS on Gen12+ while it maxes out VCS on older generations.

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

    Adding a command line argument to print a simple number allows tests to
be more flexible around different device capabilities at runtime rather than parsing this script's output and deciding which codenames have certain behaviors associate with newer features. 

## Resolved issues
N/A

## Documentation

There is no documentation on this script, as far as I can tell, so there is nothing to update. So I added some command line documentation while I was at it.

## Tests

I ran the script standalone to check the version that comes out (with and without the flag I added to make sure I didn't break the original purpose of the script)
