### PR TITLE
Add launcher option and refactor args

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/check_config.py
+++ b/checkbox-ng/checkbox_ng/launcher/check_config.py
@@ -24,9 +24,9 @@ class CheckConfig:
     """Implementation of the `check-config` sub-command."""
 
     @staticmethod
-    def invoked(_):
+    def invoked(context):
         """Function that's run with `check-config` invocation."""
-        config = load_configs()
+        config = load_configs(context.args.launcher)
         print("Configuration files:")
         for source in config.sources:
             print(" - {}".format(source))
@@ -52,3 +52,6 @@ class CheckConfig:
     @classmethod
     def register_arguments(cls, parser):
         """Register extra args for this subcmd. No extra args ATM."""
+        parser.add_argument(
+            "launcher", nargs="?", help="launcher definition file to use"
+        )

--- a/checkbox-ng/checkbox_ng/launcher/check_config.py
+++ b/checkbox-ng/checkbox_ng/launcher/check_config.py
@@ -49,5 +49,6 @@ class CheckConfig:
             print("- ", problem)
         return 1
 
-    def register_arguments(self, parser):
+    @classmethod
+    def register_arguments(cls, parser):
         """Register extra args for this subcmd. No extra args ATM."""

--- a/checkbox-ng/checkbox_ng/launcher/check_config.py
+++ b/checkbox-ng/checkbox_ng/launcher/check_config.py
@@ -51,7 +51,6 @@ class CheckConfig:
 
     @classmethod
     def register_arguments(cls, parser):
-        """Register extra args for this subcmd. No extra args ATM."""
         parser.add_argument(
             "launcher", nargs="?", help="launcher definition file to use"
         )

--- a/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
+++ b/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
@@ -127,6 +127,11 @@ def parse_args(default_command, commands, deprecated_commands={}):
             # args makes them overwrite each other
             args_dict["launcher"] = args.launcher_file
             args = argparse.Namespace(**args_dict)
+    elif "launcher" in args and args.launcher_file:
+        # both args.launcher and args.launcher_file provided
+        raise SystemExit(
+            "Launcher provided twice, use either --launcher or the positional arg"
+        )
     return args
 
 

--- a/checkbox-ng/checkbox_ng/launcher/master.py
+++ b/checkbox-ng/checkbox_ng/launcher/master.py
@@ -423,7 +423,8 @@ class RemoteMaster(ReportsStage, MainLoopStage):
         self.sa.finish_job_selection()
         self.run_jobs()
 
-    def register_arguments(self, parser):
+    @classmethod
+    def register_arguments(cls, parser):
         parser.add_argument("host", help=_("target host"))
         parser.add_argument(
             "launcher", nargs="?", help=_("launcher definition file to use")

--- a/checkbox-ng/checkbox_ng/launcher/merge_reports.py
+++ b/checkbox-ng/checkbox_ng/launcher/merge_reports.py
@@ -40,7 +40,9 @@ CERTIFICATION_NS = 'com.canonical.certification::'
 
 
 class MergeReports():
-    def register_arguments(self, parser):
+
+    @classmethod
+    def register_arguments(cls, parser):
         parser.add_argument(
             'submission', nargs='*', metavar='SUBMISSION',
             help='submission tarball')

--- a/checkbox-ng/checkbox_ng/launcher/merge_submissions.py
+++ b/checkbox-ng/checkbox_ng/launcher/merge_submissions.py
@@ -30,7 +30,8 @@ from plainbox.impl.session import SessionManager
 class MergeSubmissions(MergeReports):
     name = 'merge-submissions'
 
-    def register_arguments(self, parser):
+    @classmethod
+    def register_arguments(cls, parser):
         parser.add_argument(
             'submission', nargs='*', metavar='SUBMISSION',
             help='submission tarball')

--- a/checkbox-ng/checkbox_ng/launcher/slave.py
+++ b/checkbox-ng/checkbox_ng/launcher/slave.py
@@ -159,7 +159,8 @@ class RemoteSlave():
             self._server.close)
         self._server.start()
 
-    def register_arguments(self, parser):
+    @classmethod
+    def register_arguments(cls, parser):
         parser.add_argument('--resume', action='store_true', help=_(
             "resume last session"))
         parser.add_argument('--port', type=int, default=18871, help=_(

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -783,6 +783,9 @@ class Run(MainLoopStage):
             help=_("run jobs matching the given regular expression"),
         )
         parser.add_argument(
+            "launcher", nargs="?", help=_("launcher definition file to use")
+        )
+        parser.add_argument(
             "--non-interactive",
             action="store_true",
             help=_("skip tests that require interactivity"),
@@ -877,7 +880,7 @@ class Run(MainLoopStage):
             self.ctx = ctx
 
             self._configure_restart()
-            config = load_configs()
+            config = load_configs(ctx.args.launcher)
             self.sa.use_alternate_configuration(config)
             self.sa.start_new_session(
                 self.ctx.args.title or "checkbox-run", UnifiedRunner

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -72,7 +72,9 @@ _logger = logging.getLogger("checkbox-ng.launcher.subcommands")
 
 
 class Submit:
-    def register_arguments(self, parser):
+
+    @classmethod
+    def register_arguments(cls, parser):
         def secureid(secure_id):
             if not re.match(SECURE_ID_PATTERN, secure_id):
                 raise ArgumentTypeError(
@@ -166,7 +168,9 @@ class Submit:
 
 
 class StartProvider:
-    def register_arguments(self, parser):
+
+    @classmethod
+    def register_arguments(cls, parser):
         parser.add_argument(
             "name",
             metavar=_("name"),
@@ -702,7 +706,8 @@ class Launcher(MainLoopStage, ReportsStage):
             show_out = True
         return CheckboxUI(self.C.c, show_cmd_output=show_out)
 
-    def register_arguments(self, parser):
+    @classmethod
+    def register_arguments(cls, parser):
         parser.add_argument(
             "launcher",
             metavar=_("LAUNCHER"),
@@ -769,7 +774,9 @@ class CheckboxUI(NormalUI):
 
 
 class Run(MainLoopStage):
-    def register_arguments(self, parser):
+
+    @classmethod
+    def register_arguments(cls, parser):
         parser.add_argument(
             "PATTERN",
             nargs="*",
@@ -988,7 +995,9 @@ class Run(MainLoopStage):
 
 
 class List:
-    def register_arguments(self, parser):
+
+    @classmethod
+    def register_arguments(cls, parser):
         parser.add_argument(
             'GROUP', nargs='?', choices=Explorer.OBJECT_TYPES,
             help=_("list objects from the specified group"))
@@ -1066,7 +1075,8 @@ class ListBootstrapped:
     def sa(self):
         return self.ctx.sa
 
-    def register_arguments(self, parser):
+    @classmethod
+    def register_arguments(cls, parser):
         parser.add_argument("TEST_PLAN", help=_("test-plan id to bootstrap"))
         parser.add_argument(
             "-f",
@@ -1129,7 +1139,8 @@ class TestPlanExport:
     def sa(self):
         return self.ctx.sa
 
-    def register_arguments(self, parser):
+    @classmethod
+    def register_arguments(cls, parser):
         parser.add_argument("TEST_PLAN", help=_("test-plan id to bootstrap"))
         parser.add_argument("-n", "--nofake", action="store_true")
 
@@ -1201,7 +1212,9 @@ def print_objs(group, sa, show_attrs=False, filter_fun=None):
 
 
 class Show:
-    def register_arguments(self, parser):
+
+    @classmethod
+    def register_arguments(cls, parser):
         parser.add_argument(
             "IDs", nargs="+", help=_("Show the definitions of objects")
         )


### PR DESCRIPTION
## Description

In order to deterministically pass to a checkbox-cli instance a launcher, one has to wonder if the specific sub-command that is about to be launched does actually read it and put it as the last positional argument. This is not great for automatic testing (namely, one has to parse the start command to see if the launcher can be provided or not) and it is not great for programmatic usage as well (for the same reason).  Additionally, some options that should read the launcher do not (most notably: `check-config` and `run`). This aims to fix these two things while also upgrading the cli arg parser to use sub-parsers and avoid hacking sys.argv

After this patch the following will be possible
```
# Added in this patch, support for launcher in check config
checkbox-cli check-config launcher.conf
# Added in this patch, support for launcher in run
checkbox-cli run ... launcher.conf
# Added in this patch, support for launcher positional arg
checkbox-cli --launcher abc.conf check-config
```

Also, although not fully portable
```
#!/usr/bin/env -S checkbox-cli --launcher
```
is now a more powerful shebang for launchers, allowing a launcher to be used with any checkbox command like this:
```
./launcher.conf check-config
./launcher.conf remote 127.0.0.1
```

## Resolved issues

N/A

## Documentation

The new option is documented in the cli interface

## Tests

This was tested via metabox in legacy and remote runs.
