### PR TITLE
Warn if any provider is sideloaded

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/master.py
+++ b/checkbox-ng/checkbox_ng/launcher/master.py
@@ -312,6 +312,8 @@ class RemoteMaster(ReportsStage, MainLoopStage):
 
         try:
             tps = self.sa.start_session(configuration)
+            if self.sa.sideloaded_providers:
+                _logger.warning("Using sideloaded providers")
         except RuntimeError as exc:
             raise SystemExit(exc.args[0]) from exc
         if self.launcher.get_value("test plan", "forced"):

--- a/checkbox-ng/checkbox_ng/launcher/master.py
+++ b/checkbox-ng/checkbox_ng/launcher/master.py
@@ -313,7 +313,7 @@ class RemoteMaster(ReportsStage, MainLoopStage):
         try:
             tps = self.sa.start_session(configuration)
             if self.sa.sideloaded_providers:
-                _logger.warning("Using sideloaded providers")
+                _logger.warning("Agent is using sideloaded providers")
         except RuntimeError as exc:
             raise SystemExit(exc.args[0]) from exc
         if self.launcher.get_value("test plan", "forced"):


### PR DESCRIPTION
## Description

When using a sideloaded provider Checkbox displays a warning message like:
Using sideloaded provider: checkbox-provider-base, version 2.4 from /var/tmp/checkbox-providers/base

The same warning is not displayed when using Checkbox remote.

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/520

## Documentation

N/A

## Tests

This was tested locally and checked that nothing breaks via metabox