### PR TITLE
Github workflow: upload snapcraft logs if build step fails

### DIFF
--- a/.github/workflows/checkbox-core-snap-beta-release.yml
+++ b/.github/workflows/checkbox-core-snap-beta-release.yml
@@ -44,9 +44,12 @@ jobs:
           snapcraft-channel: 7.x/stable
           snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
+        if: failure()
         with:
           name: snapcraft-log-series${{ matrix.releases }}
-          path: /home/runner/.cache/snapcraft/log
+          path: |
+            /home/runner/.cache/snapcraft/log/
+            /home/runner/.local/state/snapcraft/log/
       - uses: actions/upload-artifact@v3
         with:
           name: series${{ matrix.releases }}

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -65,9 +65,12 @@ jobs:
           snapcraft-channel: 7.x/stable
           snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
+        if: failure()
         with:
           name: snapcraft-log-series${{ matrix.releases }}
-          path: /home/runner/.cache/snapcraft/log
+          path: |
+            /home/runner/.cache/snapcraft/log/
+            /home/runner/.local/state/snapcraft/log/
       - uses: actions/upload-artifact@v3
         with:
           name: series${{ matrix.releases }}

--- a/.github/workflows/checkbox-snap-beta-release.yml
+++ b/.github/workflows/checkbox-snap-beta-release.yml
@@ -45,9 +45,12 @@ jobs:
           snapcraft-channel: 7.x/stable
           snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
+        if: failure()
         with:
           name: snapcraft-log-series-${{ matrix.type }}${{ matrix.releases }}
-          path: /home/runner/.cache/snapcraft/log
+          path: |
+            /home/runner/.cache/snapcraft/log/
+            /home/runner/.local/state/snapcraft/log/
       - uses: actions/upload-artifact@v3
         with:
           name: series_${{ matrix.type }}${{ matrix.releases }}

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -66,9 +66,12 @@ jobs:
           snapcraft-channel: 7.x/stable
           snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
+        if: failure()
         with:
           name: snapcraft-log-series-${{ matrix.type }}${{ matrix.releases }}
-          path: /home/runner/.cache/snapcraft/log
+          path: |
+            /home/runner/.cache/snapcraft/log/
+            /home/runner/.local/state/snapcraft/log/
       - uses: actions/upload-artifact@v3
         with:
           name: series_${{ matrix.type }}${{ matrix.releases }}


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

When the GIthub actions in charge of building a snap (checkbox runtime, checkbox) fail, no logs are uploaded because the upload-artifact action is not run if the previous step fails. Using a condition in the upload-artifact job to fix this:

https://github.com/actions/upload-artifact#conditional-artifact-upload

Including `/home/runner/.local/state/snapcraft/log/` dir as well since this seems to be what snapcraft is doing now:
https://github.com/canonical/checkbox/actions/runs/5329296264/jobs/9654916215#step:6:144

```
Starting Snapcraft 7.4.3
Logging execution to '/home/runner/.local/state/snapcraft/log/snapcraft-20230621-022645.823345.log'
Snap file not available for arch 'arm64'.
Build log available at 'checkbox18_arm64.txt'
Build failed for arch 'arm64'.
(...)
```

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
-->
