### PR TITLE
Increase timeout of lid_close_suspend_open.sh

### DIFF
--- a/providers/base/bin/lid_close_suspend_open.sh
+++ b/providers/base/bin/lid_close_suspend_open.sh
@@ -4,7 +4,7 @@ echo "Number of successful suspends until now: $prev_suspend_number"
 echo "Please close the lid and wait for 5 sec to make it suspend~"
 echo "============================================================="
 echo ""
-runTime="10 second"
+runTime="20 second"
 endTimeout=$(date -d "$runTime" +%s)
 echo "Wait for lid close ..."
 echo "-------------------------------------------------------------"


### PR DESCRIPTION
Some mobile workstations need more time when resume. So increase the timeout.

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
--> Increase the timeout of lid_close_suspend_open.sh

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
--> Some mobile workstations take more time when resume, but the function of lid close/open work fine.
Increase the timeout to make the test case more tolerant.
https://bugs.launchpad.net/stella/+bug/2019302

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
--> 

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
--> Test on certain machine and the test case passed.
