### PR TITLE
Fix errors for some type hints on python<3.9

### DIFF
--- a/checkbox-ng/checkbox_ng/config.py
+++ b/checkbox-ng/checkbox_ng/config.py
@@ -21,6 +21,7 @@
 :mod:`checkbox_ng.config` -- CheckBoxNG configuration
 =====================================================
 """
+from __future__ import annotations
 import gettext
 import logging
 import os


### PR DESCRIPTION
For python versions prior to 3.9, type hints that look like "list[str]" will get errors like this:
...
  File "/usr/lib/python3/dist-packages/checkbox_ng/config.py", line 50, in <module>
    def _search_configs_by_name(name: str) -> list[str]:                                                                                                        
TypeError: 'type' object is not subscriptable