### PR TITLE
Fix the path to the runtime snap for the series16 classic checkbox snap

### DIFF
--- a/checkbox-snap/series_classic16/launchers/wrapper_local
+++ b/checkbox-snap/series_classic16/launchers/wrapper_local
@@ -18,7 +18,7 @@ esac
 # Launcher common exports for any checkbox app #
 ################################################
 
-RUNTIME=/snap/checkbox/current
+RUNTIME=/snap/checkbox16/current
 if [ ! -d "$RUNTIME" ]; then
     echo "You need to install the checkbox16 snap."
     echo ""


### PR DESCRIPTION
## Description

Fix the path to the runtime snap for the s16 classic checkbox snap (checkbox instead of checkbox16)

## Resolved issues

```
root@xenial:~/checkbox/checkbox-core-snap/series16# snap install checkbox --channel 16.04/stable --classic    
error: cannot perform the following tasks:
- Run configure hook of "checkbox" snap if present (run hook "configure": ERROR: no /snap/checkbox/current/wrapper_common_classic found)
```

## Documentation

N/A

## Tests

Tested in a 16.04 (classic) container
