### PR TITLE
Disable buffering in deb jobs

### DIFF
--- a/.github/workflows/deb-beta-release.yml
+++ b/.github/workflows/deb-beta-release.yml
@@ -23,6 +23,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
           CHECKBOX_REPO: ${{ github.repository }}
+          PYTHONUNBUFFERED: 1
         run: |
           gh release create $(git describe --tags --abbrev=0 --match v*) -d --generate-notes
           tools/release/release_deb_monorepo.py

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -22,5 +22,6 @@ jobs:
       - name: Check for new commits, push build and wait result
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
+          PYTHONUNBUFFERED: 1
         run: |
           tools/daily-builds/deb_daily_builds.py


### PR DESCRIPTION
## Description

This disables output buffering in deb daily and beta jobs to (hopefully) allow `ppa-dev-tools` to output continuously even in github jobs.

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/CHECKBOX-702

## Documentation

N/A

## Tests

N/A
