### PR TITLE
Checkbox 705/fix stress ng parts

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -104,6 +104,9 @@ parts:
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
       - STATIC=1 VERBOSE=1
+    stage-packages:
+      - libjudydebian1
+      - libsctp1
     build-packages:
       - gcc
       - make
@@ -116,8 +119,6 @@ parts:
       - libcap-dev
       - libsctp-dev
       - libjudy-dev
-      - libjudydebian1
-      - libsctp1
     after: [fwts]
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/snapcraft-snaps.git/tree/acpica/snapcraft.yaml

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -99,8 +99,8 @@ parts:
     source-depth: 1
     plugin: make
     build-environment:
-      - LDFLAGS: "-Wl,-z,relro -lrt"
       - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
+      - LDFLAGS: "-Wl,-z,relro -lrt"
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
       - STATIC=1 VERBOSE=1
@@ -115,14 +115,7 @@ parts:
       - libaio-dev
       - libcap-dev
       - libsctp-dev
-      - libatomic1
       - libjudy-dev
-      - libjpeg-dev
-      - libkmod-dev
-      - libattr1-dev
-      - libxxhash-dev
-      - libmd-dev
-      - on amd64: [ libipsec-mb-dev ]
     after: [fwts]
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/snapcraft-snaps.git/tree/acpica/snapcraft.yaml

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -116,6 +116,8 @@ parts:
       - libcap-dev
       - libsctp-dev
       - libjudy-dev
+      - libjudydebian1
+      - libsctp1
     after: [fwts]
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/snapcraft-snaps.git/tree/acpica/snapcraft.yaml
@@ -141,6 +143,7 @@ parts:
       - python3-requests-unixsocket
       - python3-systemd
       - python3-setuptools
+      - libbluetooth3
     python-packages:
       - pynmea2
       - pybluez
@@ -277,6 +280,9 @@ parts:
       - libasound2
       - libcap2-bin
       - libfdt1
+      - libGLU
+      - libglut
+      - libgpm
       - lsb-release
       - lshw
       - mesa-utils

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -94,7 +94,8 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/stress-ng.git/plain/snap/snapcraft.yaml
   stress-ng:
-    source-tag: "V0.15.08"
+    source-tag: "V0.15.07"
+    # stress-ng remains at version 0.15.07 because libipsec-mb-dev and libxxhash-dev are not available for Ubuntu 16.04 (Xenial).
     source-depth: 1
     plugin: make
     build-environment:

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -98,12 +98,11 @@ parts:
     source-depth: 1
     plugin: make
     build-environment:
-      - LDFLAGS: "Wl,-z,relro -lrt"
+      - LDFLAGS: "-Wl,-z,relro -lrt"
       - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
-      - STATIC=1
-      - LDFLAGS=-lrt
+      - STATIC=1 VERBOSE=1
     build-packages:
       - gcc
       - make
@@ -115,7 +114,14 @@ parts:
       - libaio-dev
       - libcap-dev
       - libsctp-dev
+      - libatomic1
       - libjudy-dev
+      - libjpeg-dev
+      - libkmod-dev
+      - libattr1-dev
+      - libxxhash-dev
+      - libmd-dev
+      - on amd64: [ libipsec-mb-dev ]
     after: [fwts]
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/snapcraft-snaps.git/tree/acpica/snapcraft.yaml

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -261,6 +261,7 @@ parts:
       - efibootmgr
       - ethtool
       - freeipmi-tools
+      - freeglut3
       - fswebcam
       - gir1.2-cheese-3.0
       - gir1.2-clutter-1.0
@@ -281,9 +282,8 @@ parts:
       - libasound2
       - libcap2-bin
       - libfdt1
-      - libGLU
-      - libglut
-      - libgpm
+      - libglu1-mesa
+      - libgpm2
       - lsb-release
       - lshw
       - mesa-utils

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -98,8 +98,8 @@ parts:
     source-depth: 1
     plugin: make
     build-environment:
-      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
       - LDFLAGS: "Wl,-z,relro -lrt"
+      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
       - STATIC=1

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -97,6 +97,9 @@ parts:
     source-tag: "V0.15.08"
     source-depth: 1
     plugin: make
+    build-environment:
+      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
+      - LDFLAGS: "Wl,-z,relro -lrt"
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
       - STATIC=1

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -101,6 +101,9 @@ parts:
     source-tag: "V0.15.08"
     source-depth: 1
     plugin: make
+    build-environment:
+      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
+      - LDFLAGS: "Wl,-z,relro -lrt"
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
       - STATIC=1

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -107,6 +107,11 @@ parts:
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
       - STATIC=1 VERBOSE=1
+    stage-packages:
+      - libjpeg-turbo8
+      - libjudydebian1
+      - libsctp1
+      - libxxhash0
     build-packages:
       - gcc
       - make
@@ -150,6 +155,7 @@ parts:
     stage-packages:
       - python3-requests-unixsocket
       - python3-systemd
+      - libbluetooth3
     python-packages:
       - pynmea2
       - pybluez

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -269,6 +269,10 @@ parts:
       - gnome-screenshot
       - gstreamer1.0-tools
       - gstreamer1.0-pulseaudio
+      - libgpm2
+      - libGLU
+      - libglut
+      - libslang
       - on amd64: [hdapsd] # optional as not available for arm
       - hdparm
       - i2c-tools

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -102,8 +102,8 @@ parts:
     source-depth: 1
     plugin: make
     build-environment:
-      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
       - LDFLAGS: "Wl,-z,relro -lrt"
+      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
       - STATIC=1

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -269,10 +269,6 @@ parts:
       - gnome-screenshot
       - gstreamer1.0-tools
       - gstreamer1.0-pulseaudio
-      - libgpm2
-      - libGLU
-      - libglut
-      - libslang
       - on amd64: [hdapsd] # optional as not available for arm
       - hdparm
       - i2c-tools
@@ -285,6 +281,10 @@ parts:
       - libasound2
       - libcap2-bin
       - libfdt1
+      - libgpm2
+      - libGLU
+      - libglut
+      - libslang
       - lsb-release
       - lshw
       - mesa-utils

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -102,12 +102,11 @@ parts:
     source-depth: 1
     plugin: make
     build-environment:
-      - LDFLAGS: "Wl,-z,relro -lrt"
+      - LDFLAGS: "-Wl,-z,relro -lrt"
       - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
-      - STATIC=1
-      - LDFLAGS=-lrt
+      - STATIC=1 VERBOSE=1
     build-packages:
       - gcc
       - make
@@ -122,9 +121,11 @@ parts:
       - libatomic1
       - libjudy-dev
       - libjpeg-dev
-      - libglvnd-dev
-      - libgbm-dev
+      - libkmod-dev
+      - libattr1-dev
       - libxxhash-dev
+      - libmd-dev
+      - on amd64: [ libipsec-mb-dev ]
     after: [fwts]
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/snapcraft-snaps.git/tree/acpica/snapcraft.yaml

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -98,7 +98,7 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/stress-ng.git/plain/snap/snapcraft.yaml
   stress-ng:
-    source-tag: "V0.15.08"
+    source-tag: "V0.15.09"
     source-depth: 1
     plugin: make
     build-environment:

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -102,8 +102,8 @@ parts:
     source-depth: 1
     plugin: make
     build-environment:
-      - LDFLAGS: "-Wl,-z,relro -lrt"
       - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
+      - LDFLAGS: "-Wl,-z,relro -lrt"
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
       - STATIC=1 VERBOSE=1

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -261,6 +261,7 @@ parts:
       - efibootmgr
       - ethtool
       - freeipmi-tools
+      - freeglut3
       - fswebcam
       - gir1.2-cheese-3.0
       - gir1.2-clutter-1.0
@@ -282,9 +283,8 @@ parts:
       - libcap2-bin
       - libfdt1
       - libgpm2
-      - libGLU
-      - libglut
-      - libslang
+      - libglu1-mesa
+      - libslang2
       - lsb-release
       - lshw
       - mesa-utils

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -289,6 +289,8 @@ parts:
       - gnome-screenshot
       - gstreamer1.0-tools
       - gstreamer1.0-pulseaudio
+      - libGLU
+      - libglut
       - on amd64: [hdapsd] # optional as not available for arm
       - hdparm
       - i2c-tools

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -103,22 +103,10 @@ parts:
     plugin: make
     source-tag: "V0.15.08"
     source-depth: 1
-    source: https://github.com/ColinIanKing/stress-ng
-    source-type: git
-    override-pull: |
-      snapcraftctl pull
-      description="$(git describe HEAD --tags)"
-      sha=$(echo $description | tr '-' ' ' | awk '{print $NF}')
-      version=${description%$sha}
-      commits=$(git log --oneline | wc -l)
-      date=$(date +'%Y%m%d')
-      if test "$description" = "$sha"
-      then
-        version="$description"
-      else
-        version=$(echo $version$date-$commits-$sha | cut -c1-32)
-      fi
-      snapcraftctl set-version "$version"
+    build-environment:
+      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
+      - LDFLAGS: "Wl,-z,relro -lrt"
+    source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
       - STATIC=1 VERBOSE=1
       - LDFLAGS=-lrt

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -103,8 +103,8 @@ parts:
     source-tag: "V0.15.09"
     source-depth: 1
     build-environment:
-      - LDFLAGS: "-Wl,-z,relro -lrt"
       - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
+      - LDFLAGS: "-Wl,-z,relro -lrt"
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
       - STATIC=1 VERBOSE=1

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -295,6 +295,7 @@ parts:
       - efibootmgr
       - ethtool
       - freeipmi-tools
+      - freeglut3
       - fswebcam
       - gir1.2-cheese-3.0
       - gir1.2-clutter-1.0
@@ -316,8 +317,7 @@ parts:
       - libasound2
       - libcap2-bin
       - libfdt1
-      - libGLU
-      - libglut
+      - libglu1-mesa
       - lsb-release
       - lshw
       - mesa-utils

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -102,6 +102,7 @@ parts:
   stress-ng:
     source-tag: "V0.15.09"
     source-depth: 1
+    plugin: make
     build-environment:
       - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
       - LDFLAGS: "-Wl,-z,relro -lrt"

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -104,8 +104,8 @@ parts:
     source-tag: "V0.15.08"
     source-depth: 1
     build-environment:
-      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
       - LDFLAGS: "Wl,-z,relro -lrt"
+      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
       - STATIC=1 VERBOSE=1

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -100,8 +100,7 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/stress-ng.git/plain/snap/snapcraft.yaml
   stress-ng:
-    plugin: make
-    source-tag: "V0.15.08"
+    source-tag: "V0.15.09"
     source-depth: 1
     build-environment:
       - LDFLAGS: "-Wl,-z,relro -lrt"

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -104,23 +104,11 @@ parts:
     source-tag: "V0.15.08"
     source-depth: 1
     build-environment:
-      - LDFLAGS: "Wl,-z,relro -lrt"
+      - LDFLAGS: "-Wl,-z,relro -lrt"
       - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
       - STATIC=1 VERBOSE=1
-      - LDFLAGS=-lrt
-    stage-packages:
-      - libdrm2
-      - libegl1
-      - libgbm1
-      - libgles2
-      - libglvnd0
-      - libjpeg-turbo8
-      - libjudydebian1
-      - libsctp1
-      - libwayland-server0
-      - libxxhash0
     build-packages:
       - gcc
       - make
@@ -140,7 +128,8 @@ parts:
       - libxxhash-dev
       - libmd-dev
       - on amd64: [ libipsec-mb-dev ]
-  ################################################################################
+    after: [fwts]
+################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/snapcraft-snaps.git/tree/acpica/snapcraft.yaml
   acpi-tools:
     source-tag: "R10_20_22"

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -289,8 +289,6 @@ parts:
       - gnome-screenshot
       - gstreamer1.0-tools
       - gstreamer1.0-pulseaudio
-      - libGLU
-      - libglut
       - on amd64: [hdapsd] # optional as not available for arm
       - hdparm
       - i2c-tools
@@ -303,6 +301,8 @@ parts:
       - libasound2
       - libcap2-bin
       - libfdt1
+      - libGLU
+      - libglut
       - lsb-release
       - lshw
       - mesa-utils

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -104,8 +104,8 @@ parts:
     source-depth: 1
     plugin: make
     build-environment:
-      - LDFLAGS: "-Wl,-z,relro -lrt"
       - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
+      - LDFLAGS: "-Wl,-z,relro -lrt"
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
       - STATIC=1 VERBOSE=1

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -100,7 +100,7 @@ parts:
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/stress-ng.git/plain/snap/snapcraft.yaml
   stress-ng:
-    source-tag: "V0.15.08"
+    source-tag: "V0.15.09"
     source-depth: 1
     plugin: make
     build-environment:

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -104,8 +104,8 @@ parts:
     source-depth: 1
     plugin: make
     build-environment:
-      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
       - LDFLAGS: "Wl,-z,relro -lrt"
+      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
       - STATIC=1

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -104,11 +104,11 @@ parts:
     source-depth: 1
     plugin: make
     build-environment:
-      - LDFLAGS: "Wl,-z,relro -lrt"
+      - LDFLAGS: "-Wl,-z,relro -lrt"
       - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
-      - STATIC=1
+      - STATIC=1 VERBOSE=1
     build-packages:
       - gcc
       - make
@@ -123,9 +123,11 @@ parts:
       - libatomic1
       - libjudy-dev
       - libjpeg-dev
-      - libglvnd-dev
-      - libgbm-dev
+      - libkmod-dev
+      - libattr1-dev
       - libxxhash-dev
+      - libmd-dev
+      - on amd64: [ libipsec-mb-dev ]
     after: [fwts]
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/snapcraft-snaps.git/tree/acpica/snapcraft.yaml

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -103,6 +103,9 @@ parts:
     source-tag: "V0.15.08"
     source-depth: 1
     plugin: make
+    build-environment:
+      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
+      - LDFLAGS: "Wl,-z,relro -lrt"
     source: https://github.com/ColinIanKing/stress-ng.git
     make-parameters:
       - STATIC=1


### PR DESCRIPTION
## Description
All the snapcraft.yaml in checkbox-core-snap needs to update due to the build environment and dependencies of stress-ng is updated. More precisely, stress-ng adds flags to specifies stack protection method, and check the security of formatted strings. So checkbox-core-snap needs to be in sync with it.

According to [this forum](https://forum.snapcraft.io/t/build-snaps-with-hardened-toolchain-by-default/5444), when using `Wl` to make gcc inform what parameters should linker be dealing with, it should be writing as `-Wl`. Which is different from [upstream](https://github.com/ColinIanKing/stress-ng/blob/master/snap/snapcraft.yaml#L19).

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
https://warthogs.atlassian.net/browse/CHECKBOX-705
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Tests
Precondition: set up a LXD container
1. `lxc launch ubuntu:20.04 ubuntu20` # "ubuntu20" could be what ever name you want
2. `lxc exec ubuntu20 -- apt update`

Container for ubuntu16.04 has some extra steps because of [CGroup version issue](https://discuss.linuxcontainers.org/t/error-the-image-used-by-this-instance-requires-a-cgroupv1-host-system-when-using-clustering/13885):
1. `lxc launch ubuntu:16.04 ubuntu16`
2. `lxc exec ubuntu16 -- apt update`
3. `vi /etc/default/grub`
4. find `GRUB_CMDLINE_LINUX` and add `“systemd.unified_cgroup_hierarchy=false"`
5. `update-grub`
6. reboot

Build a snap and install into the container
1. `cd checkbox/checkbox-core-snap/`
2. `./prepare.sh series20`
3. `cd series20`
4. `snapcraft --use-lxd`
5. `lxc file push checkbox20_2.8_amd64.snap ubuntu20/root/`
6. `lxc exec ubuntu20 -- snap install checkbox20_2.8_amd64.snap --dangerous`
7. `lxc exec ubuntu20 -- bash` # enter the container
8. `sudo snap install checkbox --classic --channel=20.04/stable`
9. `checkbox.shell` # enter the checkbox shell
10. `type stress-ng`
11. `stress-ng -V`
12. check if output matchs:
```
root@ubuntu20:~# type stress-ng
stress-ng is /snap/checkbox20/current/usr/bin/stress-ng
root@ubuntu20:~# stress-ng -V
stress-ng, version 0.15.09 (gcc 9.4.0, x86_64 Linux 5.19.0-42-generic) 💻🔥
```

If the current snapcraft.yaml is different from the previous one, you need to run `snapcraft clean` first. Otherwise, the stress-ng part would be skipped during the build because it has already been built with the previous settings.

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
-->
