### PR TITLE
Add comments/context to explain why and how python-distro was patched on s16/18

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -135,6 +135,12 @@ parts:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$PYTHONPATH
     override-stage: |
       snapcraftctl stage
+      # The oneliner below was required in 2019 to fix an upstream bug:
+      # https://github.com/python-distro/distro/issues/260
+      # This patch was meant to catch and ignore subprocess.CalledProcessError
+      # when running lsb_release on ubuntu core
+      # The fix was finally released with the distro 1.6 release available as of
+      # 22.04 (i.e base: core22)
       sed -i 's|except OSError:  # Command not found|except subprocess.CalledProcessError:  # Command not found|g' lib/python3.*/site-packages/distro.py
     build-packages:
       - libbluetooth-dev

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -144,6 +144,12 @@ parts:
     after: [acpi-tools]
     override-stage: |
       snapcraftctl stage
+      # The oneliner below was required in 2019 to fix an upstream bug:
+      # https://github.com/python-distro/distro/issues/260
+      # This patch was meant to catch and ignore subprocess.CalledProcessError
+      # when running lsb_release on ubuntu core
+      # The fix was finally released with the distro 1.6 release available as of
+      # 22.04 (i.e base: core22)
       sed -i 's|except OSError:  # Command not found|except subprocess.CalledProcessError:  # Command not found|g' lib/python3.*/site-packages/distro/distro.py
 ################################################################################
   checkbox-ng:


### PR DESCRIPTION
## Description

python3-distro was broken until the 1.6 release.
See https://github.com/python-distro/distro/issues/260

## Resolved issues

this `sed` oneliner was added in 2019 w/o any context/info

## Documentation

Inline comments added for future readers/maintainers

## Tests

snapcraft clean and build commands
