### PR TITLE
Metabox revision testing

### DIFF
--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -312,10 +312,12 @@ class LxdMachineProvider:
     def _run_setup_commands(self, machine):
         pre_cmds = []
         if machine.config.revision != "current":
+            # if not testing current revision, reset and clean before switching
+            # to avoid clashes with target revision
             pre_cmds.append(
                 "bash -c 'cd /home/ubuntu/checkbox && "
                 "git clean -xfd && " # clean all untracked and changes to
-                "git checkout . && " # avoid clashes with revision
+                "git reset --hard && " # avoid clashes with revision
                 "git checkout {} -- .'".format( # checkout to revision
                     machine.config.revision
                 )

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -258,16 +258,18 @@ class LxdMachineProvider:
             machine._container.name, self.LXD_MOUNT_DEVICE,
             "disk", "source={}".format(path),
             "path={}".format(self.LXD_SOURCE_MOUNT_POINT)
-        ], stderr=subprocess.PIPE, text=True)
-        logger.debug(output)
+        ], stderr=subprocess.PIPE, text=True).strip()
+        if output:
+            logger.debug(output)
 
     def _unmount_source(self, machine):
         logger.debug("Unmounting dir...")
         output = subprocess.check_output([
             "lxc", "config", "device", "remove",
             machine._container.name, self.LXD_MOUNT_DEVICE
-        ], stderr=subprocess.PIPE, text=True)
-        logger.debug(output)
+        ], stderr=subprocess.PIPE, text=True).strip()
+        if output:
+            logger.debug(output)
 
     @contextmanager
     def _mounted_source(self, machine, path):
@@ -308,8 +310,15 @@ class LxdMachineProvider:
             self._transfer_file_preserve_mode(machine, src, dest)
 
     def _run_setup_commands(self, machine):
+        pre_cmds = []
+        if machine.config.revision != "HEAD":
+            pre_cmds.append(
+                "bash -c 'cd /home/ubuntu/checkbox && git checkout {} -- .'".format(
+                    machine.config.revision
+                )
+            )
         # Also install the metabox provider
-        pre_cmds = machine.get_early_setup() + [
+        pre_cmds += machine.get_early_setup() + [
             "bash -c 'sudo python3 /home/ubuntu/metabox-provider/manage.py install'"
         ]
         post_cmds = machine.get_late_setup()

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -311,9 +311,12 @@ class LxdMachineProvider:
 
     def _run_setup_commands(self, machine):
         pre_cmds = []
-        if machine.config.revision != "HEAD":
+        if machine.config.revision != "current":
             pre_cmds.append(
-                "bash -c 'cd /home/ubuntu/checkbox && git checkout {} -- .'".format(
+                "bash -c 'cd /home/ubuntu/checkbox && "
+                "git clean -xfd && " # clean all untracked and changes to
+                "git checkout . && " # avoid clashes with revision
+                "git checkout {} -- .'".format( # checkout to revision
                     machine.config.revision
                 )
             )

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -30,7 +30,6 @@ from metabox.core.lxd_execute import interactive_execute
 from metabox.core.lxd_execute import run_or_raise
 
 class MachineConfig:
-    NAME_VALID_CHAR_RE = re.compile(r"[\w\d]+")
     def __init__(self, role, config):
         self.role = role
         self.alias = config['alias']
@@ -46,9 +45,10 @@ class MachineConfig:
         if not self.snap_name:
             self.snap_name = 'checkbox'
 
-    def _revision_to_str(self):
+    def _slug_revision(self):
         # make revision a valid name str
-        return "-".join(self.NAME_VALID_CHAR_RE.findall(self.revision))
+        # avoid slash, not valid in lxd names
+        return self.revision.replace("/", "-")
 
     def __members(self):
         return (self.role, self.alias, self.origin,
@@ -62,7 +62,7 @@ class MachineConfig:
             self.role, self.alias, self.origin, self.revision)
 
     def __str__(self):
-        return "{}-{}-{}-{}".format(self.role, self.alias, self.origin, self._revision_to_str())
+        return "{}-{}-{}-{}".format(self.role, self.alias, self.origin, self._slug_revision())
 
     def __hash__(self):
         return hash(self.__members())

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -31,7 +31,7 @@ from metabox.core.lxd_execute import run_or_raise
 
 class MachineConfig:
     NAME_VALID_CHAR_RE = re.compile(r"[\w\d]+")
-    def __init__(self, role, config, revision="HEAD"):
+    def __init__(self, role, config):
         self.role = role
         self.alias = config['alias']
         self.origin = config['origin']
@@ -42,7 +42,7 @@ class MachineConfig:
         self.checkbox_core_snap = config.get("checkbox_core_snap", {})
         self.checkbox_snap = config.get("checkbox_snap", {})
         self.snap_name = config.get("name", "")
-        self.revision = revision
+        self.revision = config.get("revision", "current")
         if not self.snap_name:
             self.snap_name = 'checkbox'
 
@@ -58,8 +58,8 @@ class MachineConfig:
                 ' '.join(self.setup))
 
     def __repr__(self):
-        return "<{} alias:{!r} origin:{!r}>".format(
-            self.role, self.alias, self.origin)
+        return "<{} alias:{!r} origin:{!r} revision: {!r}>".format(
+            self.role, self.alias, self.origin, self.revision)
 
     def __str__(self):
         return "{}-{}-{}-{}".format(self.role, self.alias, self.origin, self._revision_to_str())

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -233,7 +233,8 @@ class Runner:
 
     def run(self):
         startTime = time.perf_counter()
-        for scn in self.scn_variants:
+        total = len(self.scn_variants)
+        for idx, scn in enumerate(self.scn_variants, 1):
             if scn.mode == "remote":
                 scn.remote_machine = self._load("remote", scn.releases[0])
                 scn.service_machine = self._load("service", scn.releases[1])
@@ -250,7 +251,9 @@ class Runner:
                 scn.local_machine.start_user_session()
 
             scenario_description = self._get_scenario_description(scn)
-            logger.info("Starting scenario: {}".format(scenario_description))
+            logger.info(
+                "Starting scenario ({}/{}): {}".format(idx, total, scenario_description)
+            )
             scn.run()
             if not scn.has_passed():
                 self.failed = True
@@ -274,15 +277,12 @@ class Runner:
                     print(msg)
                     input()
             else:
-                logger.success(
-                    scenario_description + " scenario has passed."
-                )
+                logger.success(scenario_description + " scenario has passed.")
             self.machine_provider.cleanup()
         del self.machine_provider
         stopTime = time.perf_counter()
         timeTaken = stopTime - startTime
         print("-" * 80)
-        total = len(self.scn_variants)
         status = "Ran {} scenario{} in {:.3f}s".format(
             total, total != 1 and "s" or "", timeTaken
         )

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -179,7 +179,6 @@ class Runner:
             else:
                 raise ValueError("Unknown mode {}".format(mode))
             for args, kwargs in releases:
-                print(args, kwargs)
                 logger.debug(
                     "Adding scenario: [{}][{}] {}", mode, origin, scenario_cls.name
                 )

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -220,7 +220,7 @@ class Runner:
     def _get_scenario_description(self, scn):
         scenario_description_fmt = "[{mode}][{release_version}] {name}"
         if scn.mode == "local":
-            return self.scenario_description_fmt.format(
+            return scenario_description_fmt.format(
                 mode=scn.mode, release_version=scn.releases, name=scn.name
             )
         remote_rv = scn.releases[0]
@@ -229,7 +229,7 @@ class Runner:
             remote_rv += " {}".format(scn.remote_revision)
         if scn.service_revision != "current":
             service_rv += " {}".format(scn.service_revision)
-        return self.scenario_description_fmt.format(
+        return scenario_description_fmt.format(
             mode=scn.mode,
             release_version="({}, {})".format(remote_rv, service_rv),
             name=scn.name,

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -18,6 +18,8 @@
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 import sys
 import time
+from itertools import product
+from contextlib import suppress
 
 from loguru import logger
 from metabox.core.aggregator import aggregator
@@ -37,15 +39,12 @@ class Runner:
         self.args = args
         # logging
         logger.remove()
-        logger.add(
-            sys.stdout,
-            format=self._formatter,
-            level=args.log_level)
+        logger.add(sys.stdout, format=self._formatter, level=args.log_level)
         logger.level("TRACE", color="<w><dim>")
         logger.level("DEBUG", color="<w><dim>")
         # session config
         if not args.config.exists():
-            raise SystemExit('Config file not found!')
+            raise SystemExit("Config file not found!")
         else:
             self.config = read_config(args.config)
             self.config = guess_source_uri(self.config)
@@ -74,107 +73,133 @@ class Runner:
 
     def _gather_all_machine_spec(self):
         for v in self.scn_variants:
-            if v.mode == 'remote':
-                remote_config = self.config['remote'].copy()
-                service_config = self.config['service'].copy()
+            if v.mode == "remote":
+                remote_config = self.config["remote"].copy()
+                service_config = self.config["service"].copy()
                 remote_release, service_release = v.releases
-                remote_config['alias'] = remote_release
-                service_config['alias'] = service_release
-                self.combo.add(MachineConfig('remote', remote_config))
-                self.combo.add(MachineConfig('service', service_config))
-            elif v.mode == 'local':
-                local_config = self.config['local'].copy()
-                local_config['alias'] = v.releases[0]
-                self.combo.add(MachineConfig('local', local_config))
+                remote_config["alias"] = remote_release
+                service_config["alias"] = service_release
+                revisions = self._get_revisions_jobs()
+                for remote_revision, service_revision in revisions:
+                    remote_config['revision'] = remote_revision
+                    self.combo.add(MachineConfig("remote", remote_config, revision=remote_revision))
+                    service_config['revision'] = service_revision
+                    self.combo.add(MachineConfig("service", service_config, revision=service_revision))
+            elif v.mode == "local":
+                local_config = self.config["local"].copy()
+                local_config["alias"] = v.releases[0]
+                self.combo.add(MachineConfig("local", local_config))
 
     def _filter_scn_by_tags(self):
         filtered_suite = []
         for scn in self.scn_variants:
             # Add scenario name,file,dir,mode and releases as implicit tags
-            scn_tags = set(scn.name.split('.'))
+            scn_tags = set(scn.name.split("."))
             scn_tags.add(scn.mode)
             scn_tags.update(scn.releases)
-            scn_tags.update(getattr(scn, 'tags', set()))
+            scn_tags.update(getattr(scn, "tags", set()))
             matched_tags = scn_tags.intersection(self.tags)
-            if (
-                (matched_tags or not self.tags) and not
-                scn_tags.intersection(self.exclude_tags)
+            if (matched_tags or not self.tags) and not scn_tags.intersection(
+                self.exclude_tags
             ):
                 filtered_suite.append(scn)
         return filtered_suite
+
+    def _override_filter_or_get(self, override, root_key, inner_key):
+        with suppress(KeyError):
+            values = set(override[root_key][inner_key])
+            requested = set(self.config[root_key][inner_key])
+            # get all values that are in this run config and
+            #  requested by the scenario override
+            return list(values & requested)
+        return self.config[root_key][inner_key]
+
+    def _get_revisions_jobs(self):
+        remote_revisions = self.config["remote"].get("revisions", ["HEAD"])
+        service_revisions = self.config["service"].get("revisions", ["HEAD"])
+        if "HEAD" not in remote_revisions:
+            logger.warning("Remote revisions does not include HEAD")
+        if "HEAD" not in service_revisions:
+            logger.warning("Service revisions does not include HEAD")
+        return product(remote_revisions, service_revisions)
 
     def setup(self):
         self.scenarios = aggregator.all_scenarios()
         self.scn_variants = []
         # Generate all scenario variants
-        for scenario_cls in self.scenarios:
-            for mode in scenario_cls.modes:
-                for origin in scenario_cls.origins:
-                    if mode not in self.config:
-                        logger.debug(
-                            "Skipping a scenario: [{}] {}",
-                            mode, scenario_cls.name)
-                        continue
-                    if origin != self.config[mode]["origin"]:
-                        logger.debug(
-                            "Skipping a scenario: [{}][{}] {}",
-                            mode, origin, scenario_cls.name)
-                        continue
-                    scn_config = scenario_cls.config_override
-                    if mode == 'remote':
-                        try:
-                            remote_releases = scn_config['remote']['releases']
-                        except KeyError:
-                            remote_releases = self.config['remote']['releases']
-                        try:
-                            service_releases = scn_config['service']['releases']
-                        except KeyError:
-                            service_releases = self.config['service']['releases']
-                        for r_alias in self.config['remote']['releases']:
-                            if r_alias not in remote_releases:
-                                continue
-                            for s_alias in self.config['service']['releases']:
-                                if s_alias not in service_releases:
-                                    continue
-                                logger.debug("Adding scenario: [{}][{}] {}", mode, origin, scenario_cls.name)
-                                self.scn_variants.append(
-                                    scenario_cls(mode, r_alias, s_alias))
-                    elif mode == 'local':
-                        try:
-                            local_releases = scn_config[mode]['releases']
-                        except KeyError:
-                            local_releases = self.config[mode]['releases']
-                        for alias in self.config[mode]['releases']:
-                            if alias not in local_releases:
-                                continue
-                            logger.debug("Adding scenario: [{}][{}] {}", mode, origin,
-                                         scenario_cls.name)
-                            self.scn_variants.append(scenario_cls(mode, alias))
+        scenarios_modes_origins = (
+            (scenario_cls, mode, origin)
+            for scenario_cls in self.scenarios
+            for (mode, origin) in product(scenario_cls.modes, scenario_cls.origins)
+        )
+        for scenario_cls, mode, origin in scenarios_modes_origins:
+            if mode not in self.config:
+                logger.debug("Skipping a scenario: [{}] {}", mode, scenario_cls.name)
+                continue
+            if origin != self.config[mode]["origin"]:
+                logger.debug(
+                    "Skipping a scenario: [{}][{}] {}", mode, origin, scenario_cls.name
+                )
+                continue
+            scn_config = scenario_cls.config_override
+            if mode == "remote":
+                remote_releases = self._override_filter_or_get(
+                    scn_config, "remote", "releases"
+                )
+                service_releases = self._override_filter_or_get(
+                    scn_config, "service", "releases"
+                )
+                releases = (
+                    (mode, r_alias, s_alias)
+                    for (r_alias, s_alias) in product(
+                        self.config["remote"]["releases"],
+                        self.config["service"]["releases"],
+                    )
+                )
+            elif mode == "local":
+                releases = (
+                    (mode, alias)
+                    for alias in self._override_filter_or_get(
+                        scn_config, mode, "releases"
+                    )
+                )
+            else:
+                raise ValueError("Unknown mode {}".format(mode))
+            for mode_release in releases:
+                logger.debug(
+                    "Adding scenario: [{}][{}] {}", mode, origin, scenario_cls.name
+                )
+                self.scn_variants.append(scenario_cls(*mode_release))
         if self.args.tags or self.args.exclude_tags:
             if self.args.tags:
-                logger.info('Including scenario tag(s): %s' % ', '.join(
-                    sorted(self.args.tags)))
+                logger.info(
+                    "Including scenario tag(s): %s" % ", ".join(sorted(self.args.tags))
+                )
             if self.args.exclude_tags:
-                logger.info('Excluding scenario tag(s): %s' % ', '.join(
-                    sorted(self.args.exclude_tags)))
+                logger.info(
+                    "Excluding scenario tag(s): %s"
+                    % ", ".join(sorted(self.args.exclude_tags))
+                )
             self.scn_variants = self._filter_scn_by_tags()
-            if not self.scn_variants:
-                logger.warning('No match found!')
-                raise SystemExit(1)
+        if not self.scn_variants:
+            logger.warning("No match found!")
+            raise SystemExit(1)
         self._gather_all_machine_spec()
         logger.debug("Combo: {}", self.combo)
         self.machine_provider = LxdMachineProvider(
-            self.config, self.combo,
-            self.debug_machine_setup, self.dispose,
-            use_existing=self.use_existing)
+            self.config,
+            self.combo,
+            self.debug_machine_setup,
+            self.dispose,
+            use_existing=self.use_existing,
+        )
         self.machine_provider.setup()
 
     def _load(self, mode, release_alias):
         config = self.config[mode].copy()
-        config['alias'] = release_alias
-        config['role'] = mode
-        return self.machine_provider.get_machine_by_config(
-                        MachineConfig(mode, config))
+        config["alias"] = release_alias
+        config["role"] = mode
+        return self.machine_provider.get_machine_by_config(MachineConfig(mode, config))
 
     def run(self):
         startTime = time.perf_counter()
@@ -182,14 +207,14 @@ class Runner:
             if scn.mode == "remote":
                 scn.remote_machine = self._load("remote", scn.releases[0])
                 scn.service_machine = self._load("service", scn.releases[1])
-                scn.remote_machine.rollback_to('provisioned')
-                scn.service_machine.rollback_to('provisioned')
+                scn.remote_machine.rollback_to("provisioned")
+                scn.service_machine.rollback_to("provisioned")
                 if scn.launcher:
                     scn.remote_machine.put(scn.LAUNCHER_PATH, scn.launcher)
                 scn.service_machine.start_user_session()
             elif scn.mode == "local":
                 scn.local_machine = self._load("local", scn.releases[0])
-                scn.local_machine.rollback_to('provisioned')
+                scn.local_machine.rollback_to("provisioned")
                 if scn.launcher:
                     scn.local_machine.put(scn.LAUNCHER_PATH, scn.launcher)
                 scn.local_machine.start_user_session()
@@ -197,35 +222,44 @@ class Runner:
             scn.run()
             if not scn.has_passed():
                 self.failed = True
-                logger.error("[{}][{}] {} scenario has failed.".format(
-                    scn.mode, scn.releases, scn.name))
+                logger.error(
+                    "[{}][{}] {} scenario has failed.".format(
+                        scn.mode, scn.releases, scn.name
+                    )
+                )
                 if self.hold_on_fail:
                     if scn.mode == "remote":
                         msg = (
                             "You may hop onto the target machines by issuing "
                             "the following commands:\n{}\n{}\n"
-                            "Press enter to continue testing").format(
-                                scn.remote_machine.get_connecting_cmd(),
-                                scn.service_machine.get_connecting_cmd())
+                            "Press enter to continue testing"
+                        ).format(
+                            scn.remote_machine.get_connecting_cmd(),
+                            scn.service_machine.get_connecting_cmd(),
+                        )
                     elif scn.mode == "local":
                         msg = (
                             "You may hop onto the target machine by issuing "
                             "the following command:\n{}\n"
-                            "Press enter to continue testing").format(
-                                scn.local_machine.get_connecting_cmd())
+                            "Press enter to continue testing"
+                        ).format(scn.local_machine.get_connecting_cmd())
                     print(msg)
                     input()
             else:
-                logger.success("[{}][{}] {} scenario has passed.".format(
-                    scn.mode, scn.releases, scn.name))
+                logger.success(
+                    "[{}][{}] {} scenario has passed.".format(
+                        scn.mode, scn.releases, scn.name
+                    )
+                )
             self.machine_provider.cleanup()
         del self.machine_provider
         stopTime = time.perf_counter()
         timeTaken = stopTime - startTime
-        print('-' * 80)
+        print("-" * 80)
         total = len(self.scn_variants)
         status = "Ran {} scenario{} in {:.3f}s".format(
-            total, total != 1 and "s" or "", timeTaken)
+            total, total != 1 and "s" or "", timeTaken
+        )
         if self.wasSuccessful():
             logger.success(status)
         else:

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -287,8 +287,9 @@ class Runner:
         stopTime = time.perf_counter()
         timeTaken = stopTime - startTime
         print("-" * 80)
-        status = "Ran {} scenario{} in {:.3f}s".format(
-            total, total != 1 and "s" or "", timeTaken
+        form = "scenario" if total == 1 else "scenarios"
+        status = "Ran {} {} in {:.3f}s".format(
+            total, form, timeTaken
         )
         if self.wasSuccessful():
             logger.success(status)

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -52,13 +52,15 @@ class Scenario:
             cls.origins = ["source", "ppa", "classic-snap", "snap"]
         aggregator.add_scenario(cls)
 
-    def __init__(self, mode, *releases):
+    def __init__(self, mode, *releases, remote_revision="current", service_revision="current"):
         self.mode = mode
         self.releases = releases
         # machines set up by Runner.run()
         self.local_machine = None
         self.remote_machine = None
+        self.remote_revision = remote_revision
         self.service_machine = None
+        self.service_revision = service_revision
         self._checks = []
         self._ret_code = None
         self._stdout = ''


### PR DESCRIPTION
## Description

If a commit breaks the compatibility between two versions of checkbox (for example, remote-api compatibility) we have checks in place. Some of these checks rely on manually updated information (see: [Remote api bump by kissiel · Pull Request #566 · canonical/checkbox](https://github.com/canonical/checkbox/pull/566/commits/08c99cd65856b9f7adef9bb059887439825e6905))  but metabox can not catch if the information is not up to date right now because it only uses the current version of the code against itself. We should upgrade metabox to catch these kinds of problems.

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/CHECKBOX-694

## Documentation

N/A

## Tests

Metabox was run with the new feature enabled and disabled
