### PR TITLE
Fixed sudo missing in apt get cmd

### DIFF
--- a/.github/workflows/checkbox-core-snap-beta-release.yml
+++ b/.github/workflows/checkbox-core-snap-beta-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Copy over the common files for series${{ matrix.releases }}
         run: |
           cd checkbox-core-snap/
-          apt install python3-setuptools-scm
+          sudo apt update && sudo apt install -qq -y python3-setuptools-scm
           ./prepare.sh $SERIES
       - name: add LP credentials
         run: |

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Copy over the common files for series ${{ matrix.releases }}
         run: |
           cd checkbox-core-snap/
-          apt install python3-setuptools-scm
+          sudo apt update && sudo apt install -qq -y python3-setuptools-scm
           ./prepare.sh $SERIES
       - name: add LP credentials
         run: |

--- a/.github/workflows/checkbox-snap-beta-release.yml
+++ b/.github/workflows/checkbox-snap-beta-release.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Copy over the common files for series ${{ matrix.type }}${{ matrix.releases }}
         run: |
           cd checkbox-snap/
+          sudo apt update && sudo apt install -qq -y python3-setuptools-scm
           ./prepare_${{ matrix.type }}.sh $SERIES
       - name: Remove '.dev' suffix from the version name
         run: |

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Copy over the common files for series ${{ matrix.type }}${{ matrix.releases }}
         run: |
           cd checkbox-snap/
+          sudo apt update && sudo apt install -qq -y python3-setuptools-scm
           ./prepare_${{ matrix.type }}.sh $SERIES
       - name: Add git short sha suffix to the version name
         run: |


### PR DESCRIPTION
## Description

https://github.com/canonical/checkbox/actions/runs/5422668047/jobs/9859603714 Failed due to missing `sudo` on `apt-get`

## Resolved issues

N/A

## Documentation

N/A

## Tests

N/A
