### PR TITLE
Add missing build dep pybuild plugin pyproject

### DIFF
--- a/checkbox-support/debian/control
+++ b/checkbox-support/debian/control
@@ -6,6 +6,7 @@ Uploaders: Sylvain Pineau <sylvain.pineau@canonical.com>
 Build-Depends:
  debhelper (>= 9),
  dh-python,
+ pybuild-plugin-pyproject,
  python3-all,
  python3-bluez,
  python3-dbus,


### PR DESCRIPTION
## Description

pybuild explicitly needs a build-dep on  pybuild-plugin-pyproject to process pyproject instead of setup.py 

## Resolved issues

checkbox-support FTBFS

## Documentation

N/A

## Tests

tested source package builds in a jammy container: 

````
$ dpkg-buildpackage -S
dpkg-buildpackage: info: source package checkbox-support
dpkg-buildpackage: info: source version 2.8
dpkg-buildpackage: info: source distribution UNRELEASED
dpkg-buildpackage: info: source changed by Devices Certification Bot <robot@canonical.com>
 dpkg-source --before-build .
 fakeroot debian/rules clean
dh clean --sourcedirectory=checkbox-support --with=python3 --buildsystem=pybuild
   dh_auto_clean -O--sourcedirectory=checkbox-support -O--buildsystem=pybuild
   dh_autoreconf_clean -O--sourcedirectory=checkbox-support -O--buildsystem=pybuild
   dh_clean -O--sourcedirectory=checkbox-support -O--buildsystem=pybuild
 dpkg-source -b .
dpkg-source: info: using source format '3.0 (native)'
dpkg-source: info: building checkbox-support in checkbox-support_2.8.tar.xz
dpkg-source: info: building checkbox-support in checkbox-support_2.8.dsc
 dpkg-genbuildinfo --build=source -O../checkbox-support_2.8_source.buildinfo
 dpkg-genchanges --build=source -O../checkbox-support_2.8_source.changes
dpkg-genchanges: info: including full source code in upload
 dpkg-source --after-build .
dpkg-buildpackage: info: source-only upload: Debian-native package
dpkg-buildpackage: warning: not signing UNRELEASED build; use --force-sign to override
````
