### PR TITLE
Add missing package data in the checkbox-support MANIFEST.in

### DIFF
--- a/checkbox-support/MANIFEST.in
+++ b/checkbox-support/MANIFEST.in
@@ -1,7 +1,9 @@
 global-include COPYING
 global-include README*
 include checkbox_support/parsers/cputable
+recursive-include checkbox_support/parsers/tests/cpuinfo_data *.txt
+recursive-include checkbox_support/parsers/tests/dmidecode_data *.txt
 recursive-include checkbox_support/parsers/tests/fixtures *.txt
 recursive-include checkbox_support/parsers/tests/pactl_data *.txt
-recursive-include checkbox_support/parsers/tests/cpuinfo_data *.txt
-recursive-include checkbox_support/parsers/tests/udevadm_data *.txt
+recursive-include checkbox_support/parsers/tests/udevadm_data *.txt *.lsblk
+recursive-include checkbox_support/snap_utils/tests/asserts_data *.txt


### PR DESCRIPTION
## Description

pyproject does not include the whole tree structure of the checkbox_support folder and several package data files are missing causing unit tests failures while building debs in launchpad.

## Resolved issues

checkbox-support binary deb packages can't build for all releases (because of unit tests, failing due to missing data files)
See https://code.launchpad.net/~checkbox-dev/+recipe/checkbox-support-daily

## Documentation

N/A

## Tests

https://launchpad.net/~sylvain-pineau/+archive/ubuntu/sylvain.pineau/+build/26375248
