### PR TITLE
Fix remote builds snaps

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -61,8 +61,9 @@ parts:
     plugin: dump
     source: .
     override-pull: |
-      # version.txt created by prepare.sh. Refer to it for more info
-      export version=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
+      snapcraftctl pull
+      # version.txt created by prepare.sh
+      export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
 ################################################################################

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -144,6 +144,7 @@ parts:
     after: [acpi-tools]
     build-environment:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$PYTHONPATH
+      - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     override-stage: |
       snapcraftctl stage
       # The oneliner below was required in 2019 to fix an upstream bug:
@@ -161,7 +162,6 @@ parts:
       - python3-dev
       - python3-pip
     override-build: |
-      export SETUPTOOLS_SCM_PRETEND_VERSION=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
       # this is a bodge to be backward compatible
       snapcraftctl build
       # also use build to ensure install (pip is not compinat to pyproject)
@@ -193,8 +193,8 @@ parts:
     after: [checkbox-support]
     build-environment:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$PYTHONPATH
+      - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     override-build: |
-      export SETUPTOOLS_SCM_PRETEND_VERSION=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
       # this is a bodge to be backward compatible
       snapcraftctl build
       # also use build to ensure install (pip is not compinat to pyproject)

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -65,8 +65,9 @@ parts:
     plugin: dump
     source: .
     override-pull: |
-      # version.txt created by prepare.sh.  Refer to it for more info
-      export version=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
+      snapcraftctl pull
+      # version.txt created by prepare.sh
+      export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
 ################################################################################

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -153,6 +153,8 @@ parts:
       - libbluetooth-dev
       - python3-dev
     after: [acpi-tools]
+    build-environment:
+      - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     override-stage: |
       snapcraftctl stage
       # The oneliner below was required in 2019 to fix an upstream bug:
@@ -163,7 +165,6 @@ parts:
       # 22.04 (i.e base: core22)
       sed -i 's|except OSError:  # Command not found|except subprocess.CalledProcessError:  # Command not found|g' $SNAPCRAFT_STAGE/lib/python3.*/site-packages/**/**/distro.py
     override-build: |
-      export SETUPTOOLS_SCM_PRETEND_VERSION=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
       # this is a bodge to be backward compatible
       echo "from setuptools import setup; setup()" > setup.py
       snapcraftctl build
@@ -189,9 +190,10 @@ parts:
       - python3-xlsxwriter
     python-packages:
       - tqdm
+    build-environment:
+      - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     after: [checkbox-support]
     override-build: |
-      export SETUPTOOLS_SCM_PRETEND_VERSION=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
       # this is a bodge to be backward compatible
       echo "from setuptools import setup; setup()" > setup.py
       snapcraftctl build

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -65,8 +65,9 @@ parts:
     plugin: dump
     source: .
     override-pull: |
-      # version.txt created by prepare.sh. Refer to it for more info
-      export version=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
+      snapcraftctl pull
+      # version.txt created by prepare.sh
+      export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
 ################################################################################

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -204,10 +204,10 @@ parts:
     build-environment:
       - C_INCLUDE_PATH: /usr/include/python3.8
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:${PYTHONPATH:-}
+      - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     override-build: |
-      export SETUPTOOLS_SCM_PRETEND_VERSION=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
       # this is a bodge to be backward compatible
-      echo "from setuptools import setup; import os; os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'] = '`cat $SNAPCRAFT_PROJECT_DIR/version.txt`'; setup();" > setup.py
+      echo "from setuptools import setup; setup();" > setup.py
       snapcraftctl build
 ################################################################################
   checkbox-ng:
@@ -249,10 +249,10 @@ parts:
     build-environment:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:${PYTHONPATH:-}
       - READTHEDOCS: 'True' # simplifies picamera install
+      - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     override-build: |
-      export SETUPTOOLS_SCM_PRETEND_VERSION=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
       # this is a bodge to be backward compatible
-      echo "from setuptools import setup; import os; os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'] = '`cat $SNAPCRAFT_PROJECT_DIR/version.txt`'; setup();" > setup.py
+      echo "from setuptools import setup; setup();" > setup.py
       snapcraftctl build
 ################################################################################
   checkbox-provider-resource:

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -65,8 +65,9 @@ parts:
     plugin: dump
     source: .
     override-pull: |
-      # version.txt created by prepare.sh. Refer to it for more info
-      export version=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
+      snapcraftctl pull
+      # version.txt created by prepare.sh
+      export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
 ################################################################################

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -142,7 +142,7 @@ parts:
 ################################################################################
   checkbox-support:
     plugin: python
-    source: checkbox-support
+    source: checkbox-support 
     source-type: local
     stage-packages:
       # actual requirements
@@ -176,10 +176,10 @@ parts:
     build-environment:
       - C_INCLUDE_PATH: /usr/include/python3.10
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:${PYTHONPATH:-}
+      - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     override-build: |
-      export SETUPTOOLS_SCM_PRETEND_VERSION=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
       # this is a bodge to be backward compatible
-      echo "from setuptools import setup; import os; os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'] = '`cat $SNAPCRAFT_PROJECT_DIR/version.txt`'; setup();" > setup.py
+      echo "from setuptools import setup; setup();" > setup.py
       snapcraftctl build
 ################################################################################
   checkbox-ng:
@@ -221,10 +221,10 @@ parts:
     build-environment:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:${PYTHONPATH:-}
       - READTHEDOCS: 'True' # simplifies picamera install
+      - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     override-build: |
-      export SETUPTOOLS_SCM_PRETEND_VERSION=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
       # this is a bodge to be backward compatible
-      echo "from setuptools import setup; import os; os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'] = '`cat $SNAPCRAFT_PROJECT_DIR/version.txt`'; setup();" > setup.py
+      echo "from setuptools import setup; setup();" > setup.py
       snapcraftctl build
 
 ################################################################################

--- a/checkbox-snap/series_classic16/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic16/snap/snapcraft.yaml
@@ -43,8 +43,9 @@ parts:
     plugin: dump
     source: .
     override-pull: |
+      snapcraftctl pull
       # version.txt created by prepare.sh
-      export version=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
+      export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
   launchers:

--- a/checkbox-snap/series_classic18/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic18/snap/snapcraft.yaml
@@ -46,8 +46,9 @@ parts:
     plugin: dump
     source: .
     override-pull: |
+      snapcraftctl pull
       # version.txt created by prepare.sh
-      export version=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
+      export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
   launchers:

--- a/checkbox-snap/series_classic20/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic20/snap/snapcraft.yaml
@@ -46,8 +46,9 @@ parts:
     plugin: dump
     source: .
     override-pull: |
+      snapcraftctl pull
       # version.txt created by prepare.sh
-      export version=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
+      export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
   launchers:

--- a/checkbox-snap/series_classic22/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic22/snap/snapcraft.yaml
@@ -46,8 +46,9 @@ parts:
     plugin: dump
     source: .
     override-pull: |
+      snapcraftctl pull
       # version.txt created by prepare.sh
-      export version=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
+      export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
   launchers:

--- a/checkbox-snap/series_uc16/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc16/snap/snapcraft.yaml
@@ -89,8 +89,9 @@ parts:
     plugin: dump
     source: .
     override-pull: |
+      snapcraftctl pull
       # version.txt created by prepare.sh
-      export version=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
+      export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
   launchers:

--- a/checkbox-snap/series_uc18/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc18/snap/snapcraft.yaml
@@ -93,8 +93,9 @@ parts:
     plugin: dump
     source: .
     override-pull: |
+      snapcraftctl pull
       # version.txt created by prepare.sh
-      export version=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
+      export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
   launchers:

--- a/checkbox-snap/series_uc20/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc20/snap/snapcraft.yaml
@@ -93,8 +93,9 @@ parts:
     plugin: dump
     source: .
     override-pull: |
+      snapcraftctl pull
       # version.txt created by prepare.sh
-      export version=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
+      export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
   launchers:

--- a/checkbox-snap/series_uc22/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc22/snap/snapcraft.yaml
@@ -93,8 +93,9 @@ parts:
     plugin: dump
     source: .
     override-pull: |
+      snapcraftctl pull
       # version.txt created by prepare.sh
-      export version=`cat $SNAPCRAFT_PROJECT_DIR/version.txt`
+      export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
   launchers:


### PR DESCRIPTION
## Description
SNAPCRAFT_REPO_ROOT seems to be empty in remote builds while the version file is staged and present in staging. This (should) fix snap daily and non dailiy builds.

## Resolved issues

N/A

## Documentation

N/A

## Tests

series22 and series16 were both ran. They implement the same thing and are two very different recipe, so this should work.
