### PR TITLE
Removed future and quoted type hint

### DIFF
--- a/checkbox-ng/checkbox_ng/config.py
+++ b/checkbox-ng/checkbox_ng/config.py
@@ -21,7 +21,6 @@
 :mod:`checkbox_ng.config` -- CheckBoxNG configuration
 =====================================================
 """
-from __future__ import annotations
 import gettext
 import logging
 import os
@@ -48,7 +47,7 @@ def expand_all(path):
     return os.path.expandvars(os.path.expanduser(path))
 
 
-def _search_configs_by_name(name: str) -> list[str]:
+def _search_configs_by_name(name: str) -> "list[str]":
     """
     Returns all well known config locations that have a `name` file
     in them


### PR DESCRIPTION
## Description

Once we deprecate all py<2.9 we can use actual type hints, until that point this will remain quoted

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/597

## Documentation

Documented the change in commit message

## Tests

N/A
