### PR TITLE
Override the version number using the SETUPTOOLS_SCM_PRETEND_VERSION

### DIFF
--- a/checkbox-ng/debian/rules
+++ b/checkbox-ng/debian/rules
@@ -4,6 +4,7 @@ export LANG=
 export LANGUAGE=
 export NO_PNG_PKG_MANGLE=1
 export SRCTOP=checkbox-ng
+export SETUPTOOLS_SCM_PRETEND_VERSION=$(shell dpkg-parsechangelog -S version)
 
 %:
 	dh $@ --sourcedirectory=$(SRCTOP) --with=python3,sphinxdoc --buildsystem=pybuild

--- a/checkbox-support/debian/rules
+++ b/checkbox-support/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 export PYBUILD_NAME=checkbox-support
 export SRCTOP=checkbox-support
+export SETUPTOOLS_SCM_PRETEND_VERSION=$(shell dpkg-parsechangelog -S version)
 
 %:
 	dh $@ --sourcedirectory=$(SRCTOP) --with=python3 --buildsystem=pybuild


### PR DESCRIPTION

## Description

checkbox-ng and checkbox-support deb packages are getting a 0.0.0 or 0.1.dev version number for the source package otherwise

## Resolved issues

the PKG_INFO file of the python packages is useless if not correctly generated by setuptools_scm

## Documentation

N/A

## Tests

Tested the `git-build-recipe `locally, the wheel version is correct:
```
adding 'checkbox_ng-2.9.dev24+g20dd6acc0.dist-info/COPYING'
adding 'checkbox_ng-2.9.dev24+g20dd6acc0.dist-info/METADATA'
adding 'checkbox_ng-2.9.dev24+g20dd6acc0.dist-info/WHEEL'
adding 'checkbox_ng-2.9.dev24+g20dd6acc0.dist-info/entry_points.txt'
adding 'checkbox_ng-2.9.dev24+g20dd6acc0.dist-info/top_level.txt'
adding 'checkbox_ng-2.9.dev24+g20dd6acc0.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Successfully built checkbox_ng-2.9.dev24+g20dd6acc0-py3-none-any.whl
I: pybuild plugin_pyproject:118: Unpacking wheel built for python3.8 with "installer" module
```

