### PR TITLE
Fix EDID cycling test case

### DIFF
--- a/providers/base/bin/edid_cycle.py
+++ b/providers/base/bin/edid_cycle.py
@@ -20,11 +20,69 @@ from checkbox_support.scripts.zapper_proxy import (             # noqa: E402
 PATTERN = r"^HDMI-1.*\n.*^\s+(\d+x\d+).*\*"
 
 
+def _match(output):
+    """
+    Match the given randr output with a pattern to grab
+    the current resolution on HDMI-1.
+
+    Both gnome-randr and xrandr highlight the currently
+    selected resolution for each monitor with a `*`.
+
+    xrandr
+    >>> _match("Screen 0: minimum 320 x 200, current 1920 x 1080,"
+    ... " maximum 16384 x 16384i\\n"
+    ... "DPI-1 connected primary 1920x1080+0+0 (normal left inverted"
+    ... "   1920x1080     60.00*+  59.97    59.96    59.93    40.00\\n"
+    ... "HDMI-1 connected primary 1920x1080+0+0 (normal left inverted"
+    ... " right x axis y axis) 309mm x 174mm\\n"
+    ... "   1920x1080     60.00+  59.97    59.96    59.93    40.00\\n"
+    ... "   1680x1050     59.95    59.88\\n"
+    ... "   1600x1024     60.17*\\n")
+    '1600x1024'
+
+    xrandr, no output on HDMI-1
+    >>> _match("Screen 0: minimum 320 x 200, current 1920 x 1080,"
+    ... " maximum 16384 x 16384i\\n"
+    ... "DPI-1 connected primary 1920x1080+0+0 (normal left inverted"
+    ... "   1920x1080     60.00*+  59.97    59.96    59.93    40.00\\n"
+    ... "HDMI-1 connected primary 1920x1080+0+0 (normal left inverted"
+    ... " right x axis y axis) 309mm x 174mm\\n"
+    ... "   1920x1080     60.00+  59.97    59.96    59.93    40.00\\n"
+    ... "   1680x1050     59.95    59.88\\n")
+
+    xrandr, no HDMI-1 available
+    >>> _match("Screen 0: minimum 320 x 200, current 1920 x 1080,"
+    ... " maximum 16384 x 16384i\\n"
+    ... "DPI-1 connected primary 1920x1080+0+0 (normal left inverted"
+    ... "   1920x1080     60.00*+  59.97    59.96    59.93    40.00\\n")
+
+    gnome-randr
+    >>> _match("supports-mirroring: true\\n"
+    ... "layout-mode: physical\\n"
+    ... "supports-changing-layout-mode: false\\n"
+    ... "global-scale-required: false\\n"
+    ... "legacy-ui-scaling-factor: 1\\n"
+    ... 'renderer: "native"\\n\\n'
+    ... "logical monitor 0:\\n"
+    ... "x: 0, y: 0, scale: 1, rotation: normal, primary: yes\\n"
+    ... "associated physical monitors:\\n"
+    ... "	HDMI-1 DEL DELL U2722DE 4M9KFH3\\n\\n"
+    ... "HDMI-1 DEL DELL U2722DE 4M9KFH3\\n"
+    ... "              2560x1440@59.951	2560x1440 	59.95+"
+    ... "[x1.00+, x2.00, x3.00]\\n"
+    ... "              2048x1080@23.997	2048x1080 	24.00*"
+    ... "[x1.00+, x2.00]\\n")
+    '2048x1080'
+    """
+    match = re.search(PATTERN, output, re.MULTILINE | re.DOTALL)
+    if match:
+        return match.group(1)
+    return None
+
+
 def check_resolution():
     """
     Check output resolution on HDMI using randr.
-    Both gnome-randr and xrandr highlight the currently
-    selected resolution for each monitor with a `*`.
     """
     if os.getenv('XDG_SESSION_TYPE') == 'wayland':
         cmd = "gnome-randr"
@@ -35,10 +93,7 @@ def check_resolution():
         [cmd],
         universal_newlines=True, encoding="utf-8")
 
-    match = re.search(PATTERN, randr_output, re.MULTILINE | re.DOTALL)
-    if match:
-        return match.group(1)
-    return None
+    return _match(randr_output)
 
 
 def change_edid(host, edid_file):

--- a/providers/base/bin/edid_cycle.py
+++ b/providers/base/bin/edid_cycle.py
@@ -17,11 +17,15 @@ import time
 from checkbox_support.scripts.zapper_proxy import (             # noqa: E402
     zapper_run)
 
-# randr highlights the currently used resolution with a *
 PATTERN = "^HDMI-1.*\n.* (\\d+x\\d+).*\\*"
 
 
 def check_resolution():
+    """
+    Check output resolution on HDMI using randr.
+    Both gnome-randr and xrandr highlight the currently
+    selected resolution for each monitor with a `*`.
+    """
     if os.getenv('XDG_SESSION_TYPE') == 'wayland':
         cmd = "gnome-randr"
     else:
@@ -39,6 +43,9 @@ def check_resolution():
 
 
 def change_edid(host, edid_file):
+    """Clear EDID and then 'plug' back a new monitor."""
+    zapper_run(host, "change_edid", None)
+    time.sleep(1)
     with open(edid_file, 'rb') as f:
         zapper_run(host, "change_edid", f.read())
 

--- a/providers/base/bin/edid_cycle.py
+++ b/providers/base/bin/edid_cycle.py
@@ -17,7 +17,7 @@ import time
 from checkbox_support.scripts.zapper_proxy import (             # noqa: E402
     zapper_run)
 
-PATTERN = "^HDMI-1.*\n.* (\\d+x\\d+).*\\*"
+PATTERN = r"^HDMI-1.*\n.*^\s+(\d+x\d+).*\*"
 
 
 def check_resolution():

--- a/providers/base/bin/edid_cycle.py
+++ b/providers/base/bin/edid_cycle.py
@@ -31,15 +31,14 @@ def check_resolution():
     else:
         cmd = "xrandr"
 
-    randr_output = subprocess.check_output([cmd],
+    randr_output = subprocess.check_output(
+        [cmd],
         universal_newlines=True, encoding="utf-8")
 
     match = re.search(PATTERN, randr_output, re.MULTILINE | re.DOTALL)
     if match:
         return match.group(1)
-    else:
-        return None
-
+    return None
 
 
 def change_edid(host, edid_file):

--- a/providers/base/bin/monitor_hotplug.py
+++ b/providers/base/bin/monitor_hotplug.py
@@ -15,7 +15,7 @@ from checkbox_support.scripts.zapper_proxy import (  # noqa: E402
     zapper_run)
 
 
-def _check_connected(device):
+def check_connected(device):
     if os.getenv('XDG_SESSION_TYPE') == 'wayland':
         xrandr_output = subprocess.check_output(
             ["gnome-randr", "query", device],
@@ -56,7 +56,7 @@ def main():
 
     print("unplugging {}... ".format(args.peripheral), end="")
     _change_fn[args.peripheral](args.host, "disconnected")
-    if _check_connected(device) is False:
+    if check_connected(device) is False:
         print("PASS")
     else:
         failed = True
@@ -64,7 +64,7 @@ def main():
 
     print("plugging {}... ".format(args.peripheral), end="")
     _change_fn[args.peripheral](args.host, "connected")
-    if _check_connected(device) is True:
+    if check_connected(device) is True:
         print("PASS")
     else:
         failed = True
@@ -72,7 +72,7 @@ def main():
 
     print("unplugging {}... ".format(args.peripheral), end="")
     _change_fn[args.peripheral](args.host, "disconnected")
-    if _check_connected(device) is False:
+    if check_connected(device) is False:
         print("PASS")
     else:
         failed = True


### PR DESCRIPTION
## Description

EDID cycling testcase has always failed in our lab. The reason is that on laptops (and in general extended monitors) the resolution retrieved using `xdpyinfo` is considering the whole setup, not the single outputs.

With this PR, tools like `xrandr` and `gnome-randr` are used instead: they display for each available outputs the possible resolutions, the preferred one (+) and the one in use (*).

Also, since I've experimented some noise moving directly from one EDID to another, I added an "unplug" step between every new EDID. 

## Resolved issues

Fixes [ZAP-516](https://warthogs.atlassian.net/browse/ZAP-516)

## Documentation

The script was quite poor in terms of docstrings, I added a couple of them.

## Tests

Successful runs:
- X11: http://10.102.156.15:8080/job/cert-hp-probook-440-g9/370
- Wayland (locally, on NUC): 
```
$ XDG_SESSION_TYPE="wayland" DISPLAY=:0 checkbox-cli run com.canonical.certification::monitor/edid
Using sideloaded provider: checkbox-provider-base, version 2.7 from /var/tmp/checkbox-providers/base
[...]
changing EDID to 2560x1440
checking resolution... PASS
changing EDID to 1920x1080
checking resolution... PASS
changing EDID to 1280x1024
checking resolution... PASS
[...]
 ☑ : Check if the system automatically changes the resolution based on EDID
```


[ZAP-516]: https://warthogs.atlassian.net/browse/ZAP-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ