### PR TITLE
Fixed all tox files with new setuptools_scm bodge and avoid editable

### DIFF
--- a/providers/base/tox.ini
+++ b/providers/base/tox.ini
@@ -6,9 +6,9 @@ skipsdist=True
 [testenv]
 allowlist_externals = rm
 commands =
-    pip -q install -e ../../checkbox-ng
+    pip -q install ../../checkbox-ng
     # Required because this provider depends on checkbox-support parsers & scripts
-    pip -q install -e ../../checkbox-support
+    pip -q install ../../checkbox-support
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     # Required because this provider depends on the resource provider
     {envbindir}/python3 ../resource/manage.py develop
@@ -28,6 +28,10 @@ deps =
     pyparsing == 2.0.3
     distro == 1.0.1
     PyYAML == 3.11
+setenv=
+# we do not care about the package version in tox
+#  but it breaks some old python3.5 builds
+    SETUPTOOLS_SCM_PRETEND_VERSION=0.0
 
 [testenv:py36]
 deps =

--- a/providers/certification-client/tox.ini
+++ b/providers/certification-client/tox.ini
@@ -6,7 +6,7 @@ skipsdist=True
 [testenv]
 allowlist_externals = rm
 commands =
-    pip -q install -e ../../checkbox-ng
+    pip -q install ../../checkbox-ng
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
     # Required because this provider depends on the resource and base providers
@@ -28,6 +28,10 @@ deps =
     pyparsing == 2.0.3
     distro == 1.0.1
     PyYAML == 3.11
+setenv=
+# we do not care about the package version in tox
+#  but it breaks some old python3.5 builds
+    SETUPTOOLS_SCM_PRETEND_VERSION=0.0
 
 [testenv:py36]
 deps =

--- a/providers/certification-server/tox.ini
+++ b/providers/certification-server/tox.ini
@@ -6,7 +6,7 @@ skipsdist=True
 [testenv]
 allowlist_externals = rm
 commands =
-    pip -q install -e ../../checkbox-ng
+    pip -q install ../../checkbox-ng
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
     # Required because this provider depends on the resource and base providers
@@ -28,6 +28,10 @@ deps =
     pyparsing == 2.0.3
     distro == 1.0.1
     PyYAML == 3.11
+setenv=
+# we do not care about the package version in tox
+#  but it breaks some old python3.5 builds
+    SETUPTOOLS_SCM_PRETEND_VERSION=0.0
 
 [testenv:py36]
 deps =

--- a/providers/docker/tox.ini
+++ b/providers/docker/tox.ini
@@ -6,7 +6,7 @@ skipsdist=True
 [testenv]
 allowlist_externals = rm
 commands =
-    pip -q install -e ../../checkbox-ng
+    pip -q install ../../checkbox-ng
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
     # Required because this provider depends on the resource and base providers
@@ -27,6 +27,10 @@ deps =
     pyparsing == 2.0.3
     distro == 1.0.1
     PyYAML == 3.11
+setenv=
+# we do not care about the package version in tox
+#  but it breaks some old python3.5 builds
+    SETUPTOOLS_SCM_PRETEND_VERSION=0.0
 
 [testenv:py36]
 deps =

--- a/providers/gpgpu/tox.ini
+++ b/providers/gpgpu/tox.ini
@@ -6,7 +6,7 @@ skipsdist=True
 [testenv]
 allowlist_externals = rm
 commands =
-    pip -q install -e ../../checkbox-ng
+    pip -q install ../../checkbox-ng
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
     # Required because this provider depends on the resource and base providers
@@ -28,6 +28,10 @@ deps =
     pyparsing == 2.0.3
     distro == 1.0.1
     PyYAML == 3.11
+setenv=
+# we do not care about the package version in tox
+#  but it breaks some old python3.5 builds
+    SETUPTOOLS_SCM_PRETEND_VERSION=0.0
 
 [testenv:py36]
 deps =

--- a/providers/iiotg/tox.ini
+++ b/providers/iiotg/tox.ini
@@ -6,7 +6,7 @@ skipsdist=True
 [testenv]
 allowlist_externals = rm
 commands =
-    pip -q install -e ../../checkbox-ng
+    pip -q install ../../checkbox-ng
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
     # Required because this provider depends on the resource and base providers
@@ -28,6 +28,10 @@ deps =
     pyparsing == 2.0.3
     distro == 1.0.1
     PyYAML == 3.11
+setenv=
+# we do not care about the package version in tox
+#  but it breaks some old python3.5 builds
+    SETUPTOOLS_SCM_PRETEND_VERSION=0.0
 
 [testenv:py36]
 deps =

--- a/providers/resource/tox.ini
+++ b/providers/resource/tox.ini
@@ -5,9 +5,9 @@ skipsdist=True
 
 [testenv]
 commands =
-    pip -q install -e ../../checkbox-ng
+    pip -q install ../../checkbox-ng
     # Required because this provider depends on checkbox-support parsers & scripts
-    pip -q install -e ../../checkbox-support
+    pip -q install ../../checkbox-support
     {envbindir}/python3 manage.py validate
     {envbindir}/python3 manage.py test
 
@@ -23,6 +23,10 @@ deps =
     pyparsing == 2.0.3
     distro == 1.0.1
     PyYAML == 3.11
+setenv=
+# we do not care about the package version in tox
+#  but it breaks some old python3.5 builds
+    SETUPTOOLS_SCM_PRETEND_VERSION=0.0
 
 [testenv:py36]
 deps =

--- a/providers/sru/tox.ini
+++ b/providers/sru/tox.ini
@@ -6,7 +6,7 @@ skipsdist=True
 [testenv]
 allowlist_externals = rm
 commands =
-    pip -q install -e ../../checkbox-ng
+    pip -q install ../../checkbox-ng
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
     # Required because this provider depends on the resource and base providers
@@ -28,6 +28,10 @@ deps =
     pyparsing == 2.0.3
     distro == 1.0.1
     PyYAML == 3.11
+setenv=
+# we do not care about the package version in tox
+#  but it breaks some old python3.5 builds
+    SETUPTOOLS_SCM_PRETEND_VERSION=0.0
 
 [testenv:py36]
 deps =

--- a/providers/tpm2/tox.ini
+++ b/providers/tpm2/tox.ini
@@ -6,7 +6,7 @@ skipsdist=True
 [testenv]
 allowlist_externals = rm
 commands =
-    pip -q install -e ../../checkbox-ng
+    pip -q install ../../checkbox-ng
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     # Required because this provider depends on the resource provider
     {envbindir}/python3 ../resource/manage.py develop
@@ -25,6 +25,10 @@ deps =
     pyparsing == 2.0.3
     distro == 1.0.1
     PyYAML == 3.11
+setenv=
+# we do not care about the package version in tox
+#  but it breaks some old python3.5 builds
+    SETUPTOOLS_SCM_PRETEND_VERSION=0.0
 
 [testenv:py36]
 deps =


### PR DESCRIPTION
## Description
All providers had their own tox file that was not up-to-date with the new SETUPTOOLS_SCM bodge, this fixes this problem

## Resolved issues

Broken build: https://github.com/canonical/checkbox/actions/runs/5453276521/jobs/9921895043

## Documentation

Commented on top of the "hack"

## Tests
N/A
