### PR TITLE
fix: sleep for 10s between connection retries in BT A2DP test

### DIFF
--- a/providers/base/bin/bt_a2dp.py
+++ b/providers/base/bin/bt_a2dp.py
@@ -60,6 +60,10 @@ def main():
                 break
             except bluetooth.btcommon.BluetoothError as exc:
                 print("Failed to connect. {}".format(exc))
+                # the sleep below lets the Bluetooth stack react to the
+                # changing environment. Without it the retries may happen
+                # too quickly
+                time.sleep(10)
         else:
             raise SystemExit("Failed to connect to Zapper via BT")
 


### PR DESCRIPTION
## Description
Previously it was only a second which meant that the temporary radio blackouts may have been responsible for failing the test. This patch makes the testing script wait for quite a bit longer between retries.

Landing this for the second time. After the first time it got reverted because of unrelated issue.
Let's hope this will stick better :-)
