### PR TITLE
Exclude the debian directory from source dist and wheel packages

### DIFF
--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -178,6 +178,7 @@ parts:
       - -bin/activate*
       - -**/RECORD
       - -**/__pycache__
+      - -debian
     build-environment:
       - C_INCLUDE_PATH: /usr/include/python3.8
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:${PYTHONPATH:-}
@@ -186,13 +187,6 @@ parts:
       # this is a bodge to be backward compatible
       echo "from setuptools import setup; setup();" > setup.py
       snapcraftctl build
-      # This is a bodge to avoid conflicts with checkbox-ng and checkbox-support
-      # these files should not be necessary either way
-      rm -f $SNAPCRAFT_PART_INSTALL/lib/python3.8/site-packages/debian/changelog
-      rm -f $SNAPCRAFT_PART_INSTALL/lib/python3.8/site-packages/debian/compat
-      rm -f $SNAPCRAFT_PART_INSTALL/lib/python3.8/site-packages/debian/control
-      rm -f $SNAPCRAFT_PART_INSTALL/lib/python3.8/site-packages/debian/copyright
-      rm -f $SNAPCRAFT_PART_INSTALL/lib/python3.8/site-packages/debian/rules
 ################################################################################
   checkbox-ng:
     plugin: python
@@ -230,6 +224,7 @@ parts:
       - -bin/activate*
       - -**/RECORD
       - -**/__pycache__
+      - -debian
     build-environment:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:${PYTHONPATH:-}
       - READTHEDOCS: 'True' # simplifies picamera install
@@ -238,13 +233,6 @@ parts:
       # this is a bodge to be backward compatible
       echo "from setuptools import setup; setup();" > setup.py
       snapcraftctl build
-      # This is a bodge to avoid conflicts with checkbox-ng and checkbox-support
-      # these files should not be necessary either way
-      rm -f $SNAPCRAFT_PART_INSTALL/lib/python3.8/site-packages/debian/changelog
-      rm -f $SNAPCRAFT_PART_INSTALL/lib/python3.8/site-packages/debian/compat
-      rm -f $SNAPCRAFT_PART_INSTALL/lib/python3.8/site-packages/debian/control
-      rm -f $SNAPCRAFT_PART_INSTALL/lib/python3.8/site-packages/debian/copyright
-      rm -f $SNAPCRAFT_PART_INSTALL/lib/python3.8/site-packages/debian/rules
 ################################################################################
   checkbox-provider-resource:
     plugin: dump

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -173,6 +173,7 @@ parts:
       - -bin/activate*
       - -**/RECORD
       - -**/__pycache__
+      - -debian
     build-environment:
       - C_INCLUDE_PATH: /usr/include/python3.10
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:${PYTHONPATH:-}
@@ -218,6 +219,7 @@ parts:
       - -bin/activate*
       - -**/RECORD
       - -**/__pycache__
+      - -debian
     build-environment:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:${PYTHONPATH:-}
       - READTHEDOCS: 'True' # simplifies picamera install
@@ -226,7 +228,6 @@ parts:
       # this is a bodge to be backward compatible
       echo "from setuptools import setup; setup();" > setup.py
       snapcraftctl build
-
 ################################################################################
   checkbox-provider-resource:
     plugin: dump

--- a/checkbox-ng/MANIFEST.in
+++ b/checkbox-ng/MANIFEST.in
@@ -33,3 +33,4 @@ recursive-exclude daily-package-testing *
 recursive-include contrib *.policy
 recursive-include docs *.rst *.py *.html *.conf
 recursive-include plainbox/test-data *.json *.html *.tar.xz
+recursive-exclude debian *

--- a/checkbox-ng/pyproject.toml
+++ b/checkbox-ng/pyproject.toml
@@ -45,6 +45,8 @@
   dynamic = ["version"]
 [tool.setuptools_scm]
   root=".."
+[tool.setuptools.packages.find]
+  exclude = ["debian*"]
 [project.scripts]
   checkbox-cli = "checkbox_ng.launcher.checkbox_cli:main"
   checkbox-provider-tools = "checkbox_ng.launcher.provider_tools:main"

--- a/checkbox-support/MANIFEST.in
+++ b/checkbox-support/MANIFEST.in
@@ -7,3 +7,4 @@ recursive-include checkbox_support/parsers/tests/fixtures *.txt
 recursive-include checkbox_support/parsers/tests/pactl_data *.txt
 recursive-include checkbox_support/parsers/tests/udevadm_data *.txt *.lsblk
 recursive-include checkbox_support/snap_utils/tests/asserts_data *.txt
+recursive-exclude debian *

--- a/checkbox-support/pyproject.toml
+++ b/checkbox-support/pyproject.toml
@@ -22,6 +22,8 @@
   long_description_content_type='text/x-rst'
 [tool.setuptools_scm]
   root=".."
+[tool.setuptools.packages.find]
+  exclude = ["debian*"]
 [project.scripts]
   checkbox-support-run_watcher = "checkbox_support.scripts.run_watcher:main"
   checkbox-support-fwts_test = "checkbox_support.scripts.fwts_test:main"


### PR DESCRIPTION
## Description

Python wheel packagse created using the python build module include the debian packaging subdir

## Resolved issues

checkbox core snap builds are failing to stage checkbox-ng and checkbox-support since they both copied their respective debian subdir to the staging location.

## Documentation

N/A

## Tests

Tested both chgeckbox-ng and checkbox-support wheel packages, they don't include debian dirs:

`python3 -m build --no-isolation --wheel --outdir /tmp/`
