### PR TITLE
Fix the metabox trigger so that it is run to completion

### DIFF
--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -10,16 +10,19 @@ jobs:
   metabox_run_required:
     runs-on: ubuntu-latest
     name: Check for changes in metabox and checkbox-ng dirs
+    outputs:
+      required_run: ${{ steps.check_diff.outputs.required_run }}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Use git diff to see if there are any changes in the metabox and checkbox-ng directories
         id: check_diff
-        continue-on-error: true
         run: |
-          git diff --exit-code HEAD origin/main -- checkbox-ng metabox
-          if [[ $? -eq 0 ]]
+          # catch the return code in subshell to avoid github stopping the job 
+          # due to it being non-0, non-0 means: "found some diff"
+          SHOULD=$(git diff --exit-code HEAD origin/main -- checkbox-ng metabox 1>/dev/null 2>/dev/null; echo $?)
+          if [[ $SHOULD -eq 0 ]]
             then
               echo "No Metabox run required."
               echo "required_run=false" >> $GITHUB_OUTPUT
@@ -29,7 +32,7 @@ jobs:
           fi
 
   Metabox:
-    if: (github.event.review.state == 'approved' && needs.metabox_run_required.outputs.required_run == 'true') || github.event_name == 'workflow_dispatch'
+    if: (github.event.review.state == 'approved' && true == fromJSON(needs.metabox_run_required.outputs.required_run)) || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -19,10 +19,8 @@ jobs:
       - name: Use git diff to see if there are any changes in the metabox and checkbox-ng directories
         id: check_diff
         run: |
-          # catch the return code in subshell to avoid github stopping the job 
-          # due to it being non-0, non-0 means: "found some diff"
-          SHOULD=$(git diff --exit-code HEAD origin/main -- checkbox-ng metabox 1>/dev/null 2>/dev/null; echo $?)
-          if [[ $SHOULD -eq 0 ]]
+          DIFF_LENGTH=`git diff HEAD origin/main -- checkbox-ng metabox | wc -l`
+          if [[ $DIFF_LENGTH -eq 0 ]]
             then
               echo "No Metabox run required."
               echo "required_run=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

This fixes the metabox github action by catching the return code instead of letting github killing the job (namely, the `if` was never run when `$? != 0` because github would kill the job)

## Resolved issues

N/A

## Documentation

Added comment to document why/what the new thing does

## Tests

This was tested offline via [act](https://github.com/nektos/act) with the following simplified workflow:
```yaml
name: Run Metabox when PR is approved

on:
  pull_request_review:
    types: [submitted]
  # Allow manual trigger
  workflow_dispatch:

jobs:
  metabox_run_required:
    runs-on: ubuntu-latest
    name: Check for changes in metabox and checkbox-ng dirs
    outputs:
      required_run: ${{ steps.check_diff.outputs.required_run }}
    steps:
      - name: Use git diff to see if there are any changes in the metabox and checkbox-ng directories
        id: check_diff
        run: |
          #DIFF_LENGTH=`true | wc -l`
          DIFF_LENGTH=`echo | wc -l`
          if [[  $DIFF_LENGTH -eq 0 ]]
            then
              echo "No Metabox run required."
              echo "required_run=false" >> $GITHUB_OUTPUT
            else
              echo "Metabox run required!"
              echo "required_run=true" >> $GITHUB_OUTPUT
          fi

  Metabox:
    if: true == fromJSON(needs.metabox_run_required.outputs.required_run)
    runs-on: ubuntu-latest
    needs: metabox_run_required
    steps:
      - name: Run Metabox scenarios
        run: |
          echo "running"
```
