### PR TITLE
Move the error to the exception to give non-0 return

### DIFF
--- a/metabox/metabox/core/configuration.py
+++ b/metabox/metabox/core/configuration.py
@@ -33,16 +33,11 @@ def read_config(filename):
     a configuration object or raise SystemExit on problems.
     """
 
-    try:
-        mod_spec = importlib.util.spec_from_file_location(
-            'config_file', filename)
-        module = importlib.util.module_from_spec(mod_spec)
-        mod_spec.loader.exec_module(module)
-        config = module.configuration
-        return config
-    except (AttributeError, SyntaxError, FileNotFoundError) as exc:
-        logger.critical(exc)
-        raise SystemExit()
+    mod_spec = importlib.util.spec_from_file_location("config_file", filename)
+    module = importlib.util.module_from_spec(mod_spec)
+    mod_spec.loader.exec_module(module)
+    config = module.configuration
+    return config
 
 
 def guess_source_uri(config):
@@ -55,11 +50,12 @@ def guess_source_uri(config):
             if "uri" not in config[kind]:
                 logger.info("Config: No 'uri' element defined.")
                 # e.g. '/mnt/documents/dev/work/checkbox/metabox/metabox'
-                metabox_pkg_path = files('metabox')
+                metabox_pkg_path = files("metabox")
                 uri = metabox_pkg_path.parent.parent
                 logger.info("Config: Setting 'uri' to '{}'.", uri)
                 config[kind]["uri"] = str(uri)
     return config
+
 
 def validate_config(config):
     """
@@ -67,23 +63,23 @@ def validate_config(config):
     Raises SystemExit when a problem is found.
     """
     if not _has_local_or_remote_declaration(config):
-        logger.critical(
+        raise SystemExit(
             "Configuration has to define at least one way of running checkbox."
-            "Define 'local' or 'service' and 'remote'.")
-        raise SystemExit()
+            "Define 'local' or 'service' and 'remote'."
+        )
     for kind in config:
-        if kind not in ('local', 'service', 'remote'):
-            logger.critical(
+        if kind not in ("local", "service", "remote"):
+            raise SystemExit(
                 "Configuration has to define at least one way "
                 "of running checkbox."
-                "Define 'local' or 'service' and 'remote'.")
-            raise SystemExit()
+                "Define 'local' or 'service' and 'remote'."
+            )
         for decl in config[kind]:
             if not _decl_has_a_valid_origin(config[kind]):
-                logger.critical(
+                raise SystemExit(
                     "Missing or invalid origin for the {} "
-                    "declaration in config!", kind)
-                raise SystemExit()
+                    "declaration in config!".format(kind)
+                )
 
 
 def _has_local_or_remote_declaration(config):
@@ -108,8 +104,7 @@ def _has_local_or_remote_declaration(config):
     True
     """
 
-    return bool(config.get('local') or (
-        config.get('service') and config.get('remote')))
+    return bool(config.get("local") or (config.get("service") and config.get("remote")))
 
 
 def _decl_has_a_valid_origin(decl):
@@ -130,20 +125,20 @@ def _decl_has_a_valid_origin(decl):
     >>> _decl_has_a_valid_origin(decl)
     False
     """
-    if 'origin' not in decl:
+    if "origin" not in decl:
         return False
-    if decl['origin'] == 'snap':
+    if decl["origin"] == "snap":
         return True
-    elif decl['origin'] == 'classic-snap':
+    elif decl["origin"] == "classic-snap":
         return True
-    elif decl['origin'] == 'ppa':
+    elif decl["origin"] == "ppa":
         return True
-    elif decl['origin'] == 'source':
-        source = Path(decl['uri']).expanduser()
+    elif decl["origin"] == "source":
+        source = Path(decl["uri"]).expanduser()
         if not source.is_dir():
             logger.error("{} doesn't look like a directory", source)
             return False
-        setup_file_location = source / 'checkbox-ng'
+        setup_file_location = source / "checkbox-ng"
         if not setup_file_location.exists():
             logger.error("{} not found", setup_file)
             return False
@@ -157,12 +152,14 @@ def _decl_has_a_valid_origin(decl):
             #       may still be errors (like missing dependencies)
             package_dry_install_log = subprocess.check_output(
                 ["python3", "-m", "pip", "install", "--dry-run", "."],
-                cwd=setup_file_location, text=True, stderr=subprocess.DEVNULL
+                cwd=setup_file_location,
+                text=True,
+                stderr=subprocess.DEVNULL,
             )
         except subprocess.CalledProcessError:
             logger.error("Failed to dry-run install {}", setup_file_location)
             return False
-        if 'checkbox-ng' not in package_dry_install_log:
+        if "checkbox-ng" not in package_dry_install_log:
             logger.error("{} must be a fork of gh:canonical/checkbox", source)
             return False
         return True

--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -321,8 +321,7 @@ class LxdMachineProvider:
             if res.exit_code:
                 msg = "Failed to run command in the container! Command: \n"
                 msg += cmd + '\n' + res.stdout + '\n' + res.stderr
-                logger.critical(msg)
-                raise SystemExit()
+                raise SystemExit(msg)
 
     def _store_config(self, machine):
         machine._container.files.put(


### PR DESCRIPTION
## Description
This replaces all logger critical and empty SystemExit w/ a SystemExit with the logged message so that we get it AND a non-0 return code. This was done because else, for example, github actions pass due to metabox returning 0 if it fails to start.

## Resolved issues

N/A

## Documentation

N/A

## Tests

I have run metabox locally, it will fail in github due to another problem related to https://github.com/canonical/checkbox/actions/runs/5543583811/
