### PR TITLE
Fix start remote cmd arg

### DIFF
--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -32,14 +32,15 @@ from metabox.core.aggregator import aggregator
 
 class Scenario:
     """Definition of how to run a Checkbox session."""
+
     config_override = {}
     environment = {}
     launcher = None
-    LAUNCHER_PATH = '/home/ubuntu/launcher.checkbox'
+    LAUNCHER_PATH = "/home/ubuntu/launcher.checkbox"
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        cls.name = '{}.{}'.format(cls.__module__, cls.__name__)
+        cls.name = "{}.{}".format(cls.__module__, cls.__name__)
         # If a scenario does not declare the modes it should run in,
         # assume it will run in both local and remote modes.
         if not hasattr(cls, "modes"):
@@ -52,7 +53,9 @@ class Scenario:
             cls.origins = ["source", "ppa", "classic-snap", "snap"]
         aggregator.add_scenario(cls)
 
-    def __init__(self, mode, *releases, remote_revision="current", service_revision="current"):
+    def __init__(
+        self, mode, *releases, remote_revision="current", service_revision="current"
+    ):
         self.mode = mode
         self.releases = releases
         # machines set up by Runner.run()
@@ -63,8 +66,8 @@ class Scenario:
         self.service_revision = service_revision
         self._checks = []
         self._ret_code = None
-        self._stdout = ''
-        self._stderr = ''
+        self._stdout = ""
+        self._stderr = ""
         self._pts = None
 
     def has_passed(self):
@@ -81,13 +84,13 @@ class Scenario:
                 interactive = False
                 # CHECK if any EXPECT/SEND command follows
                 # w/o a new call to START before it
-                for next_step in self.steps[i + 1:]:
+                for next_step in self.steps[i + 1 :]:
                     if isinstance(next_step, Start):
                         break
                     if isinstance(next_step, (Expect, Send, SelectTestPlan)):
                         interactive = True
                         break
-                step.kwargs['interactive'] = interactive
+                step.kwargs["interactive"] = interactive
             try:
                 step(self)
             except TimeoutError:
@@ -125,10 +128,8 @@ class Scenario:
         """
         regex = re.compile(pattern)
         if self._pts:
-            found = (
-                regex.search(
-                    self._pts.stdout_data_full.decode('utf-8', errors='ignore')
-                )
+            found = regex.search(
+                self._pts.stdout_data_full.decode("utf-8", errors="ignore")
             )
         else:
             found = regex.search(self._stdout) or regex.search(self._stderr)
@@ -147,37 +148,53 @@ class Scenario:
     def assertNotEqual(self, first, second):
         self._checks.append(first != second)
 
-    def start(self, cmd='', interactive=False, timeout=0):
-        if self.mode == 'remote':
-            outcome = self.start_all(interactive=interactive, timeout=timeout)
-            if interactive:
-                self._pts = outcome
-            else:
-                self._assign_outcome(*outcome)
+    def start(self, cmd="", interactive=False, timeout=0):
+        if self.mode == "remote":
+            outcome = self.start_all(
+                cmd=cmd, interactive=interactive, timeout=timeout
+            )
         else:
-            if self.launcher:
-                cmd = self.LAUNCHER_PATH
-            outcome = self.local_machine.start(
-                cmd=cmd, env=self.environment,
-                interactive=interactive, timeout=timeout)
-            if interactive:
-                self._pts = outcome
-            else:
-                self._assign_outcome(*outcome)
+            outcome = self.start_local(
+                cmd=cmd, interactive=interactive, timeout=timeout
+            )
 
-    def start_all(self, interactive=False, timeout=0):
+        if interactive:
+            self._pts = outcome
+        else:
+            self._assign_outcome(*outcome)
+
+    def start_local(self, cmd="", interactive=False, timeout=0):
+        cmd_arr = []
+        if cmd:
+            cmd_arr = shlex.split(cmd)
+        if self.launcher:
+            cmd_arr.append(self.LAUNCHER_PATH)
+        cmd_str = shlex.join(cmd_arr)
+
+        return self.local_machine.start(
+            cmd=cmd_str,
+            env=self.environment,
+            interactive=interactive,
+            timeout=timeout,
+        )
+
+    def start_all(self, cmd="", interactive=False, timeout=0):
         self.start_service()
-        outcome = self.start_remote(interactive, timeout)
+        outcome = self.start_remote(cmd=cmd, interactive=interactive, timeout=timeout)
         if interactive:
             self._pts = outcome
         else:
             self._assign_outcome(*outcome)
         return outcome
 
-    def start_remote(self, interactive=False, timeout=0):
+    def start_remote(self, cmd="", interactive=False, timeout=0):
         outcome = self.remote_machine.start_remote(
-            self.service_machine.address, self.LAUNCHER_PATH, interactive,
-            timeout=timeout)
+            self.service_machine.address,
+            self.LAUNCHER_PATH,
+            cmd=cmd,
+            interactive=interactive,
+            timeout=timeout,
+        )
         if interactive:
             self._pts = outcome
         else:
@@ -188,31 +205,31 @@ class Scenario:
         return self.service_machine.start_service(force)
 
     def expect(self, data, timeout=60):
-        assert(self._pts is not None)
+        assert self._pts is not None
         outcome = self._pts.expect(data, timeout)
         self._checks.append(outcome)
 
     def send(self, data):
-        assert(self._pts is not None)
-        self._pts.send(data.encode('utf-8'), binary=True)
+        assert self._pts is not None
+        self._pts.send(data.encode("utf-8"), binary=True)
 
     def sleep(self, secs):
         time.sleep(secs)
 
     def signal(self, signal):
-        assert(self._pts is not None)
+        assert self._pts is not None
         self._pts.send_signal(signal)
 
     def select_test_plan(self, testplan_id, timeout=60):
-        assert(self._pts is not None)
+        assert self._pts is not None
         outcome = self._pts.select_test_plan(testplan_id, timeout)
         self._checks.append(outcome)
 
-    def run_cmd(self, cmd, env={}, interactive=False, timeout=0, target='all'):
-        if self.mode == 'remote':
-            if target == 'remote':
+    def run_cmd(self, cmd, env={}, interactive=False, timeout=0, target="all"):
+        if self.mode == "remote":
+            if target == "remote":
                 self.remote_machine.run_cmd(cmd, env, interactive, timeout)
-            elif target == 'service':
+            elif target == "service":
                 self.service_machine.run_cmd(cmd, env, interactive, timeout)
             else:
                 self.remote_machine.run_cmd(cmd, env, interactive, timeout)
@@ -220,11 +237,11 @@ class Scenario:
         else:
             self.local_machine.run_cmd(cmd, env, interactive, timeout)
 
-    def reboot(self, timeout=0, target='all'):
-        if self.mode == 'remote':
-            if target == 'remote':
+    def reboot(self, timeout=0, target="all"):
+        if self.mode == "remote":
+            if target == "remote":
                 self.remote_machine.reboot(timeout)
-            elif target == 'service':
+            elif target == "service":
                 self.service_machine.reboot(timeout)
             else:
                 self.remote_machine.reboot(timeout)
@@ -232,11 +249,11 @@ class Scenario:
         else:
             self.local_machine.reboot(timeout)
 
-    def put(self, filepath, data, mode=None, uid=1000, gid=1000, target='all'):
-        if self.mode == 'remote':
-            if target == 'remote':
+    def put(self, filepath, data, mode=None, uid=1000, gid=1000, target="all"):
+        if self.mode == "remote":
+            if target == "remote":
                 self.remote_machine.put(filepath, data, mode, uid, gid)
-            elif target == 'service':
+            elif target == "service":
                 self.service_machine.put(filepath, data, mode, uid, gid)
             else:
                 self.remote_machine.put(filepath, data, mode, uid, gid)
@@ -244,11 +261,11 @@ class Scenario:
         else:
             self.local_machine.put(filepath, data, mode, uid, gid)
 
-    def switch_on_networking(self, target='all'):
-        if self.mode == 'remote':
-            if target == 'remote':
+    def switch_on_networking(self, target="all"):
+        if self.mode == "remote":
+            if target == "remote":
                 self.remote_machine.switch_on_networking()
-            elif target == 'service':
+            elif target == "service":
                 self.service_machine.switch_on_networking()
             else:
                 self.remote_machine.switch_on_networking()
@@ -256,11 +273,11 @@ class Scenario:
         else:
             self.local_machine.switch_on_networking()
 
-    def switch_off_networking(self, target='all'):
-        if self.mode == 'remote':
-            if target == 'remote':
+    def switch_off_networking(self, target="all"):
+        if self.mode == "remote":
+            if target == "remote":
                 self.remote_machine.switch_off_networking()
-            elif target == 'service':
+            elif target == "service":
                 self.service_machine.switch_off_networking()
             else:
                 self.remote_machine.switch_off_networking()
@@ -277,7 +294,7 @@ class Scenario:
     def is_service_active(self):
         return self.service_machine.is_service_active()
 
-    def mktree(self, path, privileged=False, timeout=0, target='all'):
+    def mktree(self, path, privileged=False, timeout=0, target="all"):
         """
         Creates a directory including any missing parent
         """

--- a/metabox/metabox/scenarios/config/chains.py
+++ b/metabox/metabox/scenarios/config/chains.py
@@ -33,6 +33,8 @@ from .config_files import chains
 
 
 class ConfigChainsPriority(Scenario):
+    modes = ["local"]
+
     etc_checkbox = read_text(chains, "etc_checkbox.conf")
     etc_checkbox_includes_includes = read_text(
         chains, "etc_checkbox_includes_includes.conf"


### PR DESCRIPTION
## Description

This fixes the start cmd using it as intended (similarly to the other two kwargs).

This also fixes the ConfigChains scenario, limiting it to local because we do not yet support `check-config` for remote

## Resolved issues

N/A

## Documentation

This also adds a comment to explain how cmd is used/augmented by the remote start

## Tests

Metabox run with remote22 and local22 config
