### PR TITLE
Update PyYAML to 6.0.1 avoiding failure to get requirements

### DIFF
--- a/checkbox-support/tox.ini
+++ b/checkbox-support/tox.ini
@@ -45,7 +45,7 @@ deps =
     requests == 2.25.1
     pyparsing == 2.4.7
     distro == 1.7.0
-    PyYAML == 5.4.1
+    PyYAML == 6.0.1
 
 [pytest]
 python_files = test_*.py

--- a/providers/base/tox.ini
+++ b/providers/base/tox.ini
@@ -73,4 +73,4 @@ deps =
     tqdm == 4.57.0
     pyparsing == 2.4.7
     distro == 1.7.0
-    PyYAML == 5.4.1
+    PyYAML == 6.0.1

--- a/providers/certification-client/tox.ini
+++ b/providers/certification-client/tox.ini
@@ -73,4 +73,4 @@ deps =
     tqdm == 4.57.0
     pyparsing == 2.4.7
     distro == 1.7.0
-    PyYAML == 5.4.1
+    PyYAML == 6.0.1

--- a/providers/certification-server/tox.ini
+++ b/providers/certification-server/tox.ini
@@ -73,4 +73,4 @@ deps =
     tqdm == 4.57.0
     pyparsing == 2.4.7
     distro == 1.7.0
-    PyYAML == 5.4.1
+    PyYAML == 6.0.1

--- a/providers/docker/tox.ini
+++ b/providers/docker/tox.ini
@@ -72,4 +72,4 @@ deps =
     tqdm == 4.57.0
     pyparsing == 2.4.7
     distro == 1.7.0
-    PyYAML == 5.4.1
+    PyYAML == 6.0.1

--- a/providers/gpgpu/tox.ini
+++ b/providers/gpgpu/tox.ini
@@ -73,4 +73,4 @@ deps =
     tqdm == 4.57.0
     pyparsing == 2.4.7
     distro == 1.7.0
-    PyYAML == 5.4.1
+    PyYAML == 6.0.1

--- a/providers/iiotg/tox.ini
+++ b/providers/iiotg/tox.ini
@@ -73,4 +73,4 @@ deps =
     tqdm == 4.57.0
     pyparsing == 2.4.7
     distro == 1.7.0
-    PyYAML == 5.4.1
+    PyYAML == 6.0.1

--- a/providers/resource/tox.ini
+++ b/providers/resource/tox.ini
@@ -65,4 +65,4 @@ deps =
     tqdm == 4.57.0
     pyparsing == 2.4.7
     distro == 1.7.0
-    PyYAML == 5.4.1
+    PyYAML == 6.0.1

--- a/providers/sru/tox.ini
+++ b/providers/sru/tox.ini
@@ -73,4 +73,4 @@ deps =
     tqdm == 4.57.0
     pyparsing == 2.4.7
     distro == 1.7.0
-    PyYAML == 5.4.1
+    PyYAML == 6.0.1

--- a/providers/tpm2/tox.ini
+++ b/providers/tpm2/tox.ini
@@ -70,4 +70,4 @@ deps =
     tqdm == 4.57.0
     pyparsing == 2.4.7
     distro == 1.7.0
-    PyYAML == 5.4.1
+    PyYAML == 6.0.1


### PR DESCRIPTION
## Description

See: https://github.com/yaml/pyyaml/issues/601

## Resolved issues

N/A

## Documentation

Documented why the version was changed

## Tests

N/A
