### PR TITLE
Revert "Increase timeout of lid_close_suspend_open.sh (#575)"

### DIFF
--- a/providers/base/bin/lid_close_suspend_open.sh
+++ b/providers/base/bin/lid_close_suspend_open.sh
@@ -4,7 +4,7 @@ echo "Number of successful suspends until now: $prev_suspend_number"
 echo "Please close the lid and wait for 5 sec to make it suspend~"
 echo "============================================================="
 echo ""
-runTime="20 second"
+runTime="10 second"
 endTimeout=$(date -d "$runTime" +%s)
 echo "Wait for lid close ..."
 echo "-------------------------------------------------------------"


### PR DESCRIPTION
This reverts commit 32081dff35b19ea163cae66238c4867bc000ed18.

## Description


Revert https://github.com/canonical/checkbox/pull/575.
Increasing the timeout might lost track on the DUT which is slow on suspend/resume.

## Resolved issues


## Documentation
Launchpad bug: https://bugs.launchpad.net/stella/+bug/2019302

## Tests


