### PR TITLE
Fix docs makefile to use local copy of checkbox-ng for version info

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,7 +17,7 @@ help:
 install:
 	@echo "... setting up virtualenv"
 	python3 -m venv .sphinx/venv
-	. $(VENV); cd ..; pip install --upgrade -r docs/.sphinx/requirements.txt; pip install --upgrade checkbox-ng
+	. $(VENV); cd ..; pip install --upgrade -r docs/.sphinx/requirements.txt; pip install --upgrade ./checkbox-ng
 
 	@echo "\n" \
 		"--------------------------------------------------------------- \n" \


### PR DESCRIPTION


## Description

Install checkbox-ng from local repository rather than relying on outdated version in PyPI.


## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
-->

```
cd docs/
make install
make run
```

This works and return a live version of the documentation with the correct Checkbox version in the header.