### PR TITLE
Let system handle ethtool location

### DIFF
--- a/providers/base/bin/network_device_info.py
+++ b/providers/base/bin/network_device_info.py
@@ -39,7 +39,7 @@ class Utils():
     @staticmethod
     def get_ethtool_info(interface, key):
         """Return ethtool information identified by key"""
-        cmd = ['/sbin/ethtool', interface]
+        cmd = ['ethtool', interface]
         try:
             output = check_output(cmd, stderr=STDOUT, universal_newlines=True)
         except CalledProcessError:


### PR DESCRIPTION
## Description

Trying to call `/sbin/ethtool` causes our job `networking/info_device(number)_(interface)` to fail loading additional information when Checkbox is installed as a snap, because in this case the location of ethtool is `/snap/checkbox22/current/sbin/ethtool`.

Calling ethtool directly to let the system handle the tool location.

## Resolved issues

Fix #508

## Tests

Tested the change locally in a venv:

```
./network_device_info.py info NETWORK --interface enp0s31f6
Category: NETWORK
Interface: enp0s31f6
Product: Ethernet Connection (16) I219-LM
Vendor: Intel Corporation
Driver: e1000e
Driver Version: 
Path: /devices/pci0000:00/0000:00:1f.6
Id: [8086:1a1e]
Subsystem Id: [1028:0b08]
Mac: 00:be:43:42:6a:36
Carrier Status: Connected
Ipv4: 10.102.88.116
Ipv6: fe80::cd42:fe94:9a6d:7719/64
Speed: 1000
Supported Modes: 
	10baseT/Half 10baseT/Full
	100baseT/Half 100baseT/Full
	1000baseT/Full
Advertised Modes: 
	10baseT/Half 10baseT/Full
	100baseT/Half 100baseT/Full
	1000baseT/Full
Partner Modes: 
```

In the checkbox22 snap, ethtool resides in `/snap/checkbox22/current/sbin/ethtool`. Calling it directly rather that with `/sbin/ethtool` will fix the issue.
