### PR TITLE
Check for required Python lib in snap preparation scripts

### DIFF
--- a/checkbox-core-snap/prepare.sh
+++ b/checkbox-core-snap/prepare.sh
@@ -47,12 +47,18 @@ echo "Copying over checkbox-ng to $series"
 rsync -r --links ../checkbox-ng $series/
 echo "Copying over checkbox-support to $series"
 rsync -r --links ../checkbox-support $series
-echo "Dumping version in version file for $series"
-# setuptools_scm fetches the version calculating it from the latest tag.
-# We use the default setuptools_scm schema refert to:
-# https://pypi.org/project/setuptools-scm/ for more infos. Generally:
-# no distance and clean: {tag}
-# distance and clean: {next_version}.dev{distance}+{scm letter}{revision hash}
-# no distance and not clean: {tag}+dYYYYMMDD
-# distance and not clean: {next_version}.dev{distance}+{scm letter}{revision hash}.dYYYYMMDD
-(cd .. && python3 -m setuptools_scm | grep -oP "\S+$") 2>/dev/null 1>$series/version.txt
+echo "Dumping version in version file for $series..."
+if python3 -c 'import setuptools_scm' &> /dev/null; then
+	# setuptools_scm fetches the version calculating it from the latest tag.
+	# We use the default setuptools_scm schema refert to:
+	# https://pypi.org/project/setuptools-scm/ for more infos. Generally:
+	# no distance and clean: {tag}
+	# distance and clean: {next_version}.dev{distance}+{scm letter}{revision hash}
+	# no distance and not clean: {tag}+dYYYYMMDD
+	# distance and not clean: {next_version}.dev{distance}+{scm letter}{revision hash}.dYYYYMMDD
+	(cd .. && python3 -m setuptools_scm | grep -oP "\S+$") 2>/dev/null 1>$series/version.txt
+else
+	echo "Error: Python package 'setuptools-scm' not available."
+	echo "Please install it and try again."
+	exit 1
+fi

--- a/checkbox-snap/prepare_classic.sh
+++ b/checkbox-snap/prepare_classic.sh
@@ -41,6 +41,18 @@ fi
 
 echo "Copying over common_series_classic/* to $series"
 rsync -r --links common_series_classic/ $series/
-echo "Dumping version in version file for $series"
-(cd .. && python3 -m setuptools_scm | grep -oP "\S+$") 2>/dev/null 1>$series/version.txt
-
+echo "Dumping version in version file for $series..."
+if python3 -c 'import setuptools_scm' &> /dev/null; then
+	# setuptools_scm fetches the version calculating it from the latest tag.
+	# We use the default setuptools_scm schema refert to:
+	# https://pypi.org/project/setuptools-scm/ for more infos. Generally:
+	# no distance and clean: {tag}
+	# distance and clean: {next_version}.dev{distance}+{scm letter}{revision hash}
+	# no distance and not clean: {tag}+dYYYYMMDD
+	# distance and not clean: {next_version}.dev{distance}+{scm letter}{revision hash}.dYYYYMMDD
+	(cd .. && python3 -m setuptools_scm | grep -oP "\S+$") 2>/dev/null 1>$series/version.txt
+else
+	echo "Error: Python package 'setuptools-scm' not available."
+	echo "Please install it and try again."
+	exit 1
+fi

--- a/checkbox-snap/prepare_uc.sh
+++ b/checkbox-snap/prepare_uc.sh
@@ -41,6 +41,18 @@ fi
 
 echo "Copying over common_series_uc/* to $series"
 rsync -r --links common_series_uc/ $series/
-echo "Dumping version in version file for $series"
-(cd .. && python3 -m setuptools_scm | grep -oP "\S+$") 2>/dev/null 1>$series/version.txt
-
+echo "Dumping version in version file for $series..."
+if python3 -c 'import setuptools_scm' &> /dev/null; then
+	# setuptools_scm fetches the version calculating it from the latest tag.
+	# We use the default setuptools_scm schema refert to:
+	# https://pypi.org/project/setuptools-scm/ for more infos. Generally:
+	# no distance and clean: {tag}
+	# distance and clean: {next_version}.dev{distance}+{scm letter}{revision hash}
+	# no distance and not clean: {tag}+dYYYYMMDD
+	# distance and not clean: {next_version}.dev{distance}+{scm letter}{revision hash}.dYYYYMMDD
+	(cd .. && python3 -m setuptools_scm | grep -oP "\S+$") 2>/dev/null 1>$series/version.txt
+else
+	echo "Error: Python package 'setuptools-scm' not available."
+	echo "Please install it and try again."
+	exit 1
+fi


### PR DESCRIPTION
The prepare*.sh scripts will fail to put the version number in the version.txt file if setuptools-scm package is not present on the system.

Add a check to make sure it is, and a hint if it's not.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
-->

Ran the prepare.sh scripts for checkbox-core-snap and checkbox-snap, and made sure the version number in generated version.txt file was as expected.

```
pieq@rahsaan ~/d/w/c/checkbox-core-snap (fix-prepare-scripts)> ./prepare.sh series22
Copying over common_files/* to series22
Copying over providers to series22
Copying over checkbox-ng to series22
Copying over checkbox-support to series22
Dumping version in version file for series22...
Error: Python package 'setuptools-scm' not available.
Please install it and try again.
pieq@rahsaan ~/d/w/c/checkbox-core-snap (fix-prepare-scripts) [1]> sudo apt install python3-setuptools-scm
(...)
Unpacking python3-setuptools-scm (7.1.0-3) ...
Setting up python3-setuptools-scm (7.1.0-3) ...
pieq@rahsaan ~/d/w/c/checkbox-core-snap (fix-prepare-scripts)> ./prepare.sh series22
Copying over common_files/* to series22
Copying over providers to series22
Copying over checkbox-ng to series22
Copying over checkbox-support to series22
Dumping version in version file for series22...
pieq@rahsaan ~/d/w/c/checkbox-core-snap (fix-prepare-scripts)> cat series22/version.txt 
2.9.dev50+g451ab9feb
```
