### PR TITLE
Check the installed package instead of from ubuntu-archive (BugFix)

### DIFF
--- a/providers/base/bin/check-ubuntu-desktop-recommends.sh
+++ b/providers/base/bin/check-ubuntu-desktop-recommends.sh
@@ -3,13 +3,16 @@ set -euo pipefail
 IFS=$'\n\t'
 
 noninstalled=()
+target_version="$(dpkg-query --showformat='${Version}' --show ubuntu-desktop)"
+apt_show_ud="$(apt-cache show ubuntu-desktop="$target_version")"
+recommends="$(echo "${apt_show_ud}"| grep ^Recommends | head -n 1)"
 while read -r pkg; do
     # libreoffice-impress provides libreoffice-ogltrans, and libreoffice-ogltrans becomes a transitional package on Ubuntu 20.04.
     # shellcheck disable=SC2016
     if ! dpkg-query -W -f='${Status}\n' "$pkg" 2>&1 | grep "install ok installed" >/dev/null 2>&1 && [ "$pkg" != "libreoffice-ogltrans" ]; then
         noninstalled+=("$pkg")
     fi
-done < <(apt-cache show ubuntu-desktop | grep ^Recommends | head -n 1 | cut -d : -f 2- | xargs | sed 's/ //g' | tr , $'\n')
+done < <(echo "$recommends"| cut -d : -f 2-| xargs| sed 's/ //g'| tr , $'\n')
 
 if [ -n "${noninstalled[*]}" ]; then
     IFS=' '


### PR DESCRIPTION
…e instead of from ubuntu-archive (LP: #2027655)

## Description

The current test case checks the recommended packages of ubuntu-desktop which is the version from ubuntu-archive.
However, we need to check the package we currently installed on the system.

## Resolved issues

Fixes: the tool part from https://bugs.launchpad.net/stella/+bug/2027655

## Documentation

## Tests

Tested-by: [andy.chi@canonical.com](mailto:andy.chi@canonical.com)