### PR TITLE
Readable metabox output in CI

### DIFF
--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -65,4 +65,4 @@ jobs:
       - name: Install Metabox
         run: python3 -m pip install -e .
       - name: Run Metabox scenarios
-        run: metabox configs/${{ matrix.mode }}-source-${{ matrix.os }}.py --log INFO
+        run: metabox configs/${{ matrix.mode }}-source-${{ matrix.os }}.py

--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -65,4 +65,4 @@ jobs:
       - name: Install Metabox
         run: python3 -m pip install -e .
       - name: Run Metabox scenarios
-        run: metabox configs/${{ matrix.mode }}-source-${{ matrix.os }}.py --log TRACE
+        run: metabox configs/${{ matrix.mode }}-source-${{ matrix.os }}.py --log INFO

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -35,7 +35,6 @@ logger = logger.opt(colors=True)
 class Runner:
     """Metabox scenario discovery and runner."""
 
-
     def __init__(self, args):
         self.args = args
         # logging
@@ -135,15 +134,22 @@ class Runner:
         scenarios_modes_origins = (
             (scenario_cls, mode, origin)
             for scenario_cls in self.scenarios
-            for (mode, origin) in product(scenario_cls.modes, scenario_cls.origins)
+            for (mode, origin) in product(
+                scenario_cls.modes, scenario_cls.origins
+            )
         )
         for scenario_cls, mode, origin in scenarios_modes_origins:
             if mode not in self.config:
-                logger.debug("Skipping a scenario: [{}] {}", mode, scenario_cls.name)
+                logger.debug(
+                    "Skipping a scenario: [{}] {}", mode, scenario_cls.name
+                )
                 continue
             if origin != self.config[mode]["origin"]:
                 logger.debug(
-                    "Skipping a scenario: [{}][{}] {}", mode, origin, scenario_cls.name
+                    "Skipping a scenario: [{}][{}] {}",
+                    mode,
+                    origin,
+                    scenario_cls.name,
                 )
                 continue
             scn_config = scenario_cls.config_override
@@ -183,13 +189,17 @@ class Runner:
                 raise ValueError("Unknown mode {}".format(mode))
             for args, kwargs in releases:
                 logger.debug(
-                    "Adding scenario: [{}][{}] {}", mode, origin, scenario_cls.name
+                    "Adding scenario: [{}][{}] {}",
+                    mode,
+                    origin,
+                    scenario_cls.name,
                 )
                 self.scn_variants.append(scenario_cls(*args, **kwargs))
         if self.args.tags or self.args.exclude_tags:
             if self.args.tags:
                 logger.info(
-                    "Including scenario tag(s): %s" % ", ".join(sorted(self.args.tags))
+                    "Including scenario tag(s): %s"
+                    % ", ".join(sorted(self.args.tags))
                 )
             if self.args.exclude_tags:
                 logger.info(
@@ -215,7 +225,9 @@ class Runner:
         config = self.config[mode].copy()
         config["alias"] = release_alias
         config["role"] = mode
-        return self.machine_provider.get_machine_by_config(MachineConfig(mode, config))
+        return self.machine_provider.get_machine_by_config(
+            MachineConfig(mode, config)
+        )
 
     def _get_scenario_description(self, scn):
         scenario_description_fmt = "[{mode}][{release_version}] {name}"
@@ -256,12 +268,17 @@ class Runner:
 
             scenario_description = self._get_scenario_description(scn)
             logger.info(
-                "Starting scenario ({}/{}): {}".format(idx, total, scenario_description)
+                "Starting scenario ({}/{}): {}".format(
+                    idx, total, scenario_description
+                )
             )
             scn.run()
             if not scn.has_passed():
                 self.failed = True
                 logger.error(scenario_description + " scenario has failed.")
+                logger.error(
+                    "Scenario output:\n" + scn.get_output_streams().strip()
+                )
                 if self.hold_on_fail:
                     if scn.mode == "remote":
                         msg = (
@@ -288,9 +305,7 @@ class Runner:
         timeTaken = stopTime - startTime
         print("-" * 80)
         form = "scenario" if total == 1 else "scenarios"
-        status = "Ran {} {} in {:.3f}s".format(
-            total, form, timeTaken
-        )
+        status = "Ran {} {} in {:.3f}s".format(total, form, timeTaken)
         if self.wasSuccessful():
             logger.success(status)
         else:

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -72,12 +72,13 @@ class Scenario:
         self._ret_code = None
         self._stdout = ""
         self._stderr = ""
+        self._oudstr_full = ""
         self._pts = None
 
     def get_output_streams(self):
         if self._pts:
             return self._pts.stdout_data_full.decode("utf-8")
-        return self._stdout + self._stderr
+        return self._outstr_full
 
     def has_passed(self):
         """Check whether all the assertions passed."""
@@ -111,11 +112,12 @@ class Scenario:
             # getting empty log trace events
             self._pts.verbose = False
 
-    def _assign_outcome(self, ret_code, stdout, stderr):
+    def _assign_outcome(self, ret_code, stdout, stderr, outstr_full):
         """Store remnants of a machine that run the scenario."""
         self._ret_code = ret_code
         self._stdout = stdout
         self._stderr = stderr
+        self._outstr_full = outstr_full
 
     # TODO: add storing of what actually failed in the assert methods
     def assert_printed(self, pattern):

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -32,14 +32,15 @@ from metabox.core.aggregator import aggregator
 
 class Scenario:
     """Definition of how to run a Checkbox session."""
+
     config_override = {}
     environment = {}
     launcher = None
-    LAUNCHER_PATH = '/home/ubuntu/launcher.checkbox'
+    LAUNCHER_PATH = "/home/ubuntu/launcher.checkbox"
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        cls.name = '{}.{}'.format(cls.__module__, cls.__name__)
+        cls.name = "{}.{}".format(cls.__module__, cls.__name__)
         # If a scenario does not declare the modes it should run in,
         # assume it will run in both local and remote modes.
         if not hasattr(cls, "modes"):
@@ -52,7 +53,13 @@ class Scenario:
             cls.origins = ["source", "ppa", "classic-snap", "snap"]
         aggregator.add_scenario(cls)
 
-    def __init__(self, mode, *releases, remote_revision="current", service_revision="current"):
+    def __init__(
+        self,
+        mode,
+        *releases,
+        remote_revision="current",
+        service_revision="current"
+    ):
         self.mode = mode
         self.releases = releases
         # machines set up by Runner.run()
@@ -63,9 +70,14 @@ class Scenario:
         self.service_revision = service_revision
         self._checks = []
         self._ret_code = None
-        self._stdout = ''
-        self._stderr = ''
+        self._stdout = ""
+        self._stderr = ""
         self._pts = None
+
+    def get_output_streams(self):
+        if self._pts:
+            return self._pts.stdout_data_full.decode("utf-8")
+        return self._stdout + self._stderr
 
     def has_passed(self):
         """Check whether all the assertions passed."""
@@ -81,13 +93,13 @@ class Scenario:
                 interactive = False
                 # CHECK if any EXPECT/SEND command follows
                 # w/o a new call to START before it
-                for next_step in self.steps[i + 1:]:
+                for next_step in self.steps[i + 1 :]:
                     if isinstance(next_step, Start):
                         break
                     if isinstance(next_step, (Expect, Send, SelectTestPlan)):
                         interactive = True
                         break
-                step.kwargs['interactive'] = interactive
+                step.kwargs["interactive"] = interactive
             try:
                 step(self)
             except TimeoutError:
@@ -114,7 +126,8 @@ class Scenario:
         """
         regex = re.compile(pattern)
         self._checks.append(
-            bool(regex.search(self._stdout)) or bool(regex.search(self._stderr))
+            bool(regex.search(self._stdout))
+            or bool(regex.search(self._stderr))
         )
 
     def assert_not_printed(self, pattern):
@@ -125,10 +138,8 @@ class Scenario:
         """
         regex = re.compile(pattern)
         if self._pts:
-            found = (
-                regex.search(
-                    self._pts.stdout_data_full.decode('utf-8', errors='ignore')
-                )
+            found = regex.search(
+                self._pts.stdout_data_full.decode("utf-8", errors="ignore")
             )
         else:
             found = regex.search(self._stdout) or regex.search(self._stderr)
@@ -147,8 +158,8 @@ class Scenario:
     def assertNotEqual(self, first, second):
         self._checks.append(first != second)
 
-    def start(self, cmd='', interactive=False, timeout=0):
-        if self.mode == 'remote':
+    def start(self, cmd="", interactive=False, timeout=0):
+        if self.mode == "remote":
             outcome = self.start_all(interactive=interactive, timeout=timeout)
             if interactive:
                 self._pts = outcome
@@ -158,8 +169,11 @@ class Scenario:
             if self.launcher:
                 cmd = self.LAUNCHER_PATH
             outcome = self.local_machine.start(
-                cmd=cmd, env=self.environment,
-                interactive=interactive, timeout=timeout)
+                cmd=cmd,
+                env=self.environment,
+                interactive=interactive,
+                timeout=timeout,
+            )
             if interactive:
                 self._pts = outcome
             else:
@@ -176,8 +190,11 @@ class Scenario:
 
     def start_remote(self, interactive=False, timeout=0):
         outcome = self.remote_machine.start_remote(
-            self.service_machine.address, self.LAUNCHER_PATH, interactive,
-            timeout=timeout)
+            self.service_machine.address,
+            self.LAUNCHER_PATH,
+            interactive,
+            timeout=timeout,
+        )
         if interactive:
             self._pts = outcome
         else:
@@ -188,31 +205,31 @@ class Scenario:
         return self.service_machine.start_service(force)
 
     def expect(self, data, timeout=60):
-        assert(self._pts is not None)
+        assert self._pts is not None
         outcome = self._pts.expect(data, timeout)
         self._checks.append(outcome)
 
     def send(self, data):
-        assert(self._pts is not None)
-        self._pts.send(data.encode('utf-8'), binary=True)
+        assert self._pts is not None
+        self._pts.send(data.encode("utf-8"), binary=True)
 
     def sleep(self, secs):
         time.sleep(secs)
 
     def signal(self, signal):
-        assert(self._pts is not None)
+        assert self._pts is not None
         self._pts.send_signal(signal)
 
     def select_test_plan(self, testplan_id, timeout=60):
-        assert(self._pts is not None)
+        assert self._pts is not None
         outcome = self._pts.select_test_plan(testplan_id, timeout)
         self._checks.append(outcome)
 
-    def run_cmd(self, cmd, env={}, interactive=False, timeout=0, target='all'):
-        if self.mode == 'remote':
-            if target == 'remote':
+    def run_cmd(self, cmd, env={}, interactive=False, timeout=0, target="all"):
+        if self.mode == "remote":
+            if target == "remote":
                 self.remote_machine.run_cmd(cmd, env, interactive, timeout)
-            elif target == 'service':
+            elif target == "service":
                 self.service_machine.run_cmd(cmd, env, interactive, timeout)
             else:
                 self.remote_machine.run_cmd(cmd, env, interactive, timeout)
@@ -220,11 +237,11 @@ class Scenario:
         else:
             self.local_machine.run_cmd(cmd, env, interactive, timeout)
 
-    def reboot(self, timeout=0, target='all'):
-        if self.mode == 'remote':
-            if target == 'remote':
+    def reboot(self, timeout=0, target="all"):
+        if self.mode == "remote":
+            if target == "remote":
                 self.remote_machine.reboot(timeout)
-            elif target == 'service':
+            elif target == "service":
                 self.service_machine.reboot(timeout)
             else:
                 self.remote_machine.reboot(timeout)
@@ -232,11 +249,11 @@ class Scenario:
         else:
             self.local_machine.reboot(timeout)
 
-    def put(self, filepath, data, mode=None, uid=1000, gid=1000, target='all'):
-        if self.mode == 'remote':
-            if target == 'remote':
+    def put(self, filepath, data, mode=None, uid=1000, gid=1000, target="all"):
+        if self.mode == "remote":
+            if target == "remote":
                 self.remote_machine.put(filepath, data, mode, uid, gid)
-            elif target == 'service':
+            elif target == "service":
                 self.service_machine.put(filepath, data, mode, uid, gid)
             else:
                 self.remote_machine.put(filepath, data, mode, uid, gid)
@@ -244,11 +261,11 @@ class Scenario:
         else:
             self.local_machine.put(filepath, data, mode, uid, gid)
 
-    def switch_on_networking(self, target='all'):
-        if self.mode == 'remote':
-            if target == 'remote':
+    def switch_on_networking(self, target="all"):
+        if self.mode == "remote":
+            if target == "remote":
                 self.remote_machine.switch_on_networking()
-            elif target == 'service':
+            elif target == "service":
                 self.service_machine.switch_on_networking()
             else:
                 self.remote_machine.switch_on_networking()
@@ -256,11 +273,11 @@ class Scenario:
         else:
             self.local_machine.switch_on_networking()
 
-    def switch_off_networking(self, target='all'):
-        if self.mode == 'remote':
-            if target == 'remote':
+    def switch_off_networking(self, target="all"):
+        if self.mode == "remote":
+            if target == "remote":
                 self.remote_machine.switch_off_networking()
-            elif target == 'service':
+            elif target == "service":
                 self.service_machine.switch_off_networking()
             else:
                 self.remote_machine.switch_off_networking()
@@ -277,7 +294,7 @@ class Scenario:
     def is_service_active(self):
         return self.service_machine.is_service_active()
 
-    def mktree(self, path, privileged=False, timeout=0, target='all'):
+    def mktree(self, path, privileged=False, timeout=0, target="all"):
         """
         Creates a directory including any missing parent
         """

--- a/metabox/metabox/core/utils.py
+++ b/metabox/metabox/core/utils.py
@@ -17,30 +17,32 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 import re
-from typing import IO, NamedTuple
+from typing import NamedTuple
 
-__all__ = ('tag', 'ExecuteResult')
+__all__ = ("tag", "ExecuteResult")
 
 
 def tag(*tags):
     """Decorator to add tags to a scenario class."""
+
     def decorator(obj):
-        setattr(obj, 'tags', set(tags))
+        setattr(obj, "tags", set(tags))
         return obj
+
     return decorator
 
 
 class ExecuteResult(NamedTuple):
-
     exit_code: int
-    stdout: IO
-    stderr: IO
+    stdout: str
+    stderr: str
+    outstr_full: str
 
 
 class _re:
     def __init__(self, pattern, flags=0):
         self._raw_pattern = pattern
-        self._pattern = re.compile(pattern.encode('utf-8'), flags)
+        self._pattern = re.compile(pattern.encode("utf-8"), flags)
 
     def __repr__(self):
         return f"Regex {self._raw_pattern}"

--- a/metabox/metabox/main.py
+++ b/metabox/metabox/main.py
@@ -40,37 +40,53 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        'config', metavar='CONFIG', type=Path,
-        help='Metabox configuration file'
+        "config",
+        metavar="CONFIG",
+        type=Path,
+        help="Metabox configuration file",
     )
     parser.add_argument(
-        '--tag', action='append', dest='tags',
-        help='Run only scenario with the specified tag. '
-             'Can be used multiple times.',
+        "--tag",
+        action="append",
+        dest="tags",
+        help="Run only scenario with the specified tag. "
+        "Can be used multiple times.",
     )
     parser.add_argument(
-        '--exclude-tag', action='append', dest='exclude_tags',
-        help='Do not run scenario with the specified tag. '
-             'Can be used multiple times.',
+        "--exclude-tag",
+        action="append",
+        dest="exclude_tags",
+        help="Do not run scenario with the specified tag. "
+        "Can be used multiple times.",
     )
     parser.add_argument(
-        "--log", dest="log_level", choices=Core().levels.keys(),
-        default='SUCCESS',
+        "--log",
+        dest="log_level",
+        choices=Core().levels.keys(),
+        default="INFO",
         help="Set the logging level",
     )
     parser.add_argument(
-        '--do-not-dispose', action='store_true',
-        help="Do not delete LXD containers after the run")
+        "--do-not-dispose",
+        action="store_true",
+        help="Do not delete LXD containers after the run",
+    )
     parser.add_argument(
-        '--use-existing', action='store_true',
-        help="Use existing containers updating the source inside them")
+        "--use-existing",
+        action="store_true",
+        help="Use existing containers updating the source inside them",
+    )
     parser.add_argument(
-        '--hold-on-fail', action='store_true',
-        help="Pause testing when a scenario fails")
+        "--hold-on-fail",
+        action="store_true",
+        help="Pause testing when a scenario fails",
+    )
     parser.add_argument(
-        '--debug-machine-setup', action='store_true',
+        "--debug-machine-setup",
+        action="store_true",
         help="Turn on verbosity during machine setup. "
-             "Only works with --log TRACE")
+        "Only works with --log TRACE",
+    )
     logging.basicConfig(handlers=[InterceptHandler()], level=0, force=True)
     # Ignore warnings issued by pylxd/models/operation.py
     with warnings.catch_warnings():
@@ -81,5 +97,5 @@ def main():
         raise SystemExit(not runner.wasSuccessful())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Description

Right now when a metabox action fails on github it is very tedious to recover why it did. This is due to one fact: the amount of output metabox produces. Metabox is very verbose in CI because we need to launch it with log level TRACE, else it will not print any stdout/stderr of the scenarios that it is testing and that would be useless (we would know that a test failed but not why). 

This PR does two things:
**Raises the log level to INFO:** This should make the log informative (giving testing progress for example via `Starting scenario` prompts) but way more concise (skipping all debug messages and all outputs produced by successful jobs)
**stdout/stderr in log in failure:** When a scenario fails, metabox will now always log at the error level the fact that it did

## Resolved issues

N/A

## Documentation

N/A

## Tests

I have forced a local(manual + auto) and a remote(manual + auto) test to fail to see the new output 
