### PR TITLE
Fix flake8 error

### DIFF
--- a/providers/base/bin/accelerometer_test.py
+++ b/providers/base/bin/accelerometer_test.py
@@ -169,7 +169,7 @@ class AxisData(threading.Thread):
         for mapping, data in direction_map.items():
             reading = self.parse_reading(int(data), mapping)
 
-            if type(reading) == int:
+            if isinstance(reading, int):
                 return reading, mapping
 
         # Return nothing if threshold is not met
@@ -180,7 +180,7 @@ class AxisData(threading.Thread):
         while len(rem_tests) > 0:
             axis_data_bundle = self.grab_current_readings()
 
-            if type(axis_data_bundle) != list:
+            if not isinstance(axis_data_bundle, list):
                 logging.error("Failed to grab appropriate readings")
                 return 1
 

--- a/providers/base/bin/hotkey_tests.py
+++ b/providers/base/bin/hotkey_tests.py
@@ -372,7 +372,7 @@ class FauxKeyboard():
         while repetitions:
             if not modifiers.issubset({'alt', 'ctrl', 'shift', 'meta'}):
                 raise SystemExit('Unknown modifier')
-            if type(key_code) == KeyCodes:
+            if isinstance(key_code, KeyCodes):
                 key_code = key_code.value
             data = bytes()
             data += self.event_struct.pack(0, 0, 4, 4, key_code)

--- a/providers/base/bin/key_test.py
+++ b/providers/base/bin/key_test.py
@@ -165,7 +165,7 @@ class Reporter(object):
                 # Check for ESC key pressed
                 self.show_text(_("Test cancelled"))
                 self.quit()
-            elif 1 < code < 10 and type(self) == CLIReporter:
+            elif 1 < code < 10 and isinstance(self, CLIReporter):
                 # Check for number to skip
                 self.toggle_key(self.keys[code - 2])
             else:


### PR DESCRIPTION
## Description
Flake8 has been updated over the weekend: https://pypi.org/project/flake8/#history. 
As a result, some scripts in providers/base failed the Flake8 test. 
I'm not sure if specifying the flake version to run the tests is a good solution. So I changed those scripts under providers/base/bin/ to pass flake8 tests.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests
Create this PR see if provider-base could pass tox test in py38 env

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
-->
