### PR TITLE
Fix checkbox16 runtime snap

### DIFF
--- a/checkbox-core-snap/common_files/config/wrapper_common
+++ b/checkbox-core-snap/common_files/config/wrapper_common
@@ -1,4 +1,3 @@
-
 function append_path() {
   local var="$1"
   local dir="$2"
@@ -23,6 +22,7 @@ else
   append_path GI_TYPELIB_PATH $RUNTIME/usr/lib/$ARCH/girepository-1.0
   append_path PATH $RUNTIME/bin
   append_path PATH $RUNTIME/usr/bin
+  append_path PATH $RUNTIME/usr/local/bin
   append_path PATH $RUNTIME/sbin
   append_path PATH $RUNTIME/usr/sbin
   append_path ALSA_CONFIG_PATH $RUNTIME/usr/share/alsa/alsa.conf

--- a/checkbox-core-snap/common_files/config/wrapper_common_classic
+++ b/checkbox-core-snap/common_files/config/wrapper_common_classic
@@ -1,4 +1,3 @@
-
 function append_path() {
   local var="$1"
   local dir="$2"
@@ -31,6 +30,7 @@ else
   append_path GI_TYPELIB_PATH $RUNTIME/usr/lib/$ARCH/girepository-1.0
   prepend_dir PATH $RUNTIME/bin
   prepend_dir PATH $RUNTIME/usr/bin
+  prepend_dir PATH $RUNTIME/usr/local/bin
   prepend_dir PATH $RUNTIME/sbin
   prepend_dir PATH $RUNTIME/usr/sbin
   prepend_dir PATH $RUNTIME/usr/lib/qt5/bin

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -168,6 +168,7 @@ parts:
       $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install "pip<21" "setuptools<48" "setuptools_scm[toml]>=3.4" "importlib_metadata==1.0.0" "zipp<2"
       # also, call pip again, this installs the module itself
       $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install .
+      sed -iE 's|#!\/root\/parts\/.*|#!/usr/bin/env python3|' $SNAPCRAFT_PART_INSTALL/usr/local/bin/*
 ################################################################################
   checkbox-ng:
     plugin: python

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -165,9 +165,9 @@ parts:
       # also use build to ensure install (pip is not compinat to pyproject)
       # on this version
       echo "from setuptools import setup; setup()" > setup.py
-      python3 -m pip install --force-reinstall "pip<21" "setuptools<48" "setuptools_scm[toml]>=3.4" "importlib_metadata==1.0.0" "zipp<2"
+      $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install "pip<21" "setuptools<48" "setuptools_scm[toml]>=3.4" "importlib_metadata==1.0.0" "zipp<2"
       # also, call pip again, this installs the module itself
-      python3 -m pip install .
+      $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install .
 ################################################################################
   checkbox-ng:
     plugin: python
@@ -197,9 +197,9 @@ parts:
       # also use build to ensure install (pip is not compinat to pyproject)
       # on this version
       echo "from setuptools import setup; setup()" > setup.py
-      python3 -m pip install --force-reinstall "pip<21" "setuptools<48" "setuptools_scm[toml]>=3.4" "importlib_metadata==1.0.0" "zipp<2"
+      $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install "pip<21" "setuptools<48" "setuptools_scm[toml]>=3.4" "importlib_metadata==1.0.0" "zipp<2"
       # also, call pip again, this installs the module itself
-      python3 -m pip install .
+      $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install .
 ################################################################################
   checkbox-provider-resource:
     plugin: dump

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -174,10 +174,11 @@ parts:
       # also use build to ensure install (pip is not compinat to pyproject)
       # on this version
       echo "from setuptools import setup; setup()" > setup.py
-      python3 -m pip install "build<0.4" "setuptools>=42,<51" setuptools>=42 setuptools_scm[toml]>=3.4 --force-reinstall
-      python3 -m build --no-isolation -x
+      python3 -m pip install -U "pip<21"
+      python3 -m pip install "setuptools>=42,<51" setuptools_scm[toml]>=3.4
       # also, call pip again, this installs the module itself
       python3 -m pip install .
+      python3 -m pip install importlib_metadata==1.0.0 "zipp<2"
 ################################################################################
   checkbox-ng:
     plugin: python
@@ -207,10 +208,11 @@ parts:
       # also use build to ensure install (pip is not compinat to pyproject)
       # on this version
       echo "from setuptools import setup; setup()" > setup.py
-      python3 -m pip install "build<0.4" "setuptools>=42,<51" setuptools>=42 setuptools_scm[toml]>=3.4 --force-reinstall
-      python3 -m build --no-isolation -x
+      python3 -m pip install -U "pip<21"
+      python3 -m pip install "setuptools>=42,<51" setuptools_scm[toml]>=3.4
       # also, call pip again, this installs the module itself
       python3 -m pip install .
+      python3 -m pip install importlib_metadata==1.0.0 "zipp<2"
 ################################################################################
   checkbox-provider-resource:
     plugin: dump

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -197,9 +197,17 @@ parts:
       # also use build to ensure install (pip is not compinat to pyproject)
       # on this version
       echo "from setuptools import setup; setup()" > setup.py
+      # setup the correct pip and related tools version
       $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install "pip<21" "setuptools<48" "setuptools_scm[toml]>=3.4" "importlib_metadata==1.0.0" "zipp<2"
-      # also, call pip again, this installs the module itself
+      # install checkbox-ng
       $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install .
+      # fix shebangs in bins.This is necessary because by calling pip via the
+      # $SNAPCRAFT_PART_INSTALL path (to get the correct one) this path gets
+      # propagated into bins. This path will be invalid once the snap is installed
+      # so it must be changed to the appropriate one (/usr/bin/env python3) that
+      # we could not use here
+      sed -iE 's|#!\/root\/parts\/.*|#!/usr/bin/env python3|' $SNAPCRAFT_PART_INSTALL/usr/local/bin/*
+      #sed -i "1s/.*/#!\/usr\/bin\/env python3/" $SNAPCRAFT_PART_INSTALL/usr/local/bin/*
 ################################################################################
   checkbox-provider-resource:
     plugin: dump

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -177,7 +177,7 @@ parts:
       $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install "pip<21" "setuptools<48" "setuptools_scm[toml]>=3.4" "importlib_metadata==1.0.0" "zipp<2"
       # also, call pip again, this installs the module itself
       $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install .
-      sed -iE 's|#!\/root\/parts\/.*|#!/usr/bin/env python3|' $SNAPCRAFT_PART_INSTALL/usr/local/bin/*
+      sed -iE 's|\#\!.*/usr/bin/python3$|#!/usr/bin/env python3|' $SNAPCRAFT_PART_INSTALL/usr/local/bin/*
 ################################################################################
   checkbox-ng:
     plugin: python
@@ -216,7 +216,7 @@ parts:
       # propagated into bins. This path will be invalid once the snap is installed
       # so it must be changed to the appropriate one (/usr/bin/env python3) that
       # we could not use here
-      sed -iE 's|#!\/root\/parts\/.*|#!/usr/bin/env python3|' $SNAPCRAFT_PART_INSTALL/usr/local/bin/*
+      sed -iE 's|\#\!.*/usr/bin/python3$|#!/usr/bin/env python3|' $SNAPCRAFT_PART_INSTALL/usr/local/bin/*
       #sed -i "1s/.*/#!\/usr\/bin\/env python3/" $SNAPCRAFT_PART_INSTALL/usr/local/bin/*
 ################################################################################
   checkbox-provider-resource:

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -152,15 +152,6 @@ parts:
     build-environment:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$PYTHONPATH
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
-    override-stage: |
-      snapcraftctl stage
-      # The oneliner below was required in 2019 to fix an upstream bug:
-      # https://github.com/python-distro/distro/issues/260
-      # This patch was meant to catch and ignore subprocess.CalledProcessError
-      # when running lsb_release on ubuntu core
-      # The fix was finally released with the distro 1.6 release available as of
-      # 22.04 (i.e base: core22)
-      sed -i 's|except OSError:  # Command not found|except subprocess.CalledProcessError:  # Command not found|g' lib/python3.*/site-packages/**/**/distro.py
     override-pull: |
       PYTHONHOME=/usr PYTHONUSERBASE=$SNAPCRAFT_PART_INSTALL $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install --upgrade 'pip; python_version >= "3.6"' 'pip<21; python_version < "3.6"' --user
       snapcraftctl pull
@@ -174,11 +165,9 @@ parts:
       # also use build to ensure install (pip is not compinat to pyproject)
       # on this version
       echo "from setuptools import setup; setup()" > setup.py
-      python3 -m pip install -U "pip<21"
-      python3 -m pip install "setuptools>=42,<51" setuptools_scm[toml]>=3.4
+      python3 -m pip install --force-reinstall "pip<21" "setuptools<48" "setuptools_scm[toml]>=3.4" "importlib_metadata==1.0.0" "zipp<2"
       # also, call pip again, this installs the module itself
       python3 -m pip install .
-      python3 -m pip install importlib_metadata==1.0.0 "zipp<2"
 ################################################################################
   checkbox-ng:
     plugin: python
@@ -208,11 +197,9 @@ parts:
       # also use build to ensure install (pip is not compinat to pyproject)
       # on this version
       echo "from setuptools import setup; setup()" > setup.py
-      python3 -m pip install -U "pip<21"
-      python3 -m pip install "setuptools>=42,<51" setuptools_scm[toml]>=3.4
+      python3 -m pip install --force-reinstall "pip<21" "setuptools<48" "setuptools_scm[toml]>=3.4" "importlib_metadata==1.0.0" "zipp<2"
       # also, call pip again, this installs the module itself
       python3 -m pip install .
-      python3 -m pip install importlib_metadata==1.0.0 "zipp<2"
 ################################################################################
   checkbox-provider-resource:
     plugin: dump
@@ -428,3 +415,4 @@ parts:
   common-config:
     plugin: dump
     source: config/
+    source-type: local

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -152,6 +152,15 @@ parts:
     build-environment:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$PYTHONPATH
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
+    override-stage: |
+      snapcraftctl stage
+      # The oneliner below was required in 2019 to fix an upstream bug:
+      # https://github.com/python-distro/distro/issues/260
+      # This patch was meant to catch and ignore subprocess.CalledProcessError
+      # when running lsb_release on ubuntu core
+      # The fix was finally released with the distro 1.6 release available as of
+      # 22.04 (i.e base: core22)
+      sed -i 's|except OSError:  # Command not found|except subprocess.CalledProcessError:  # Command not found|g' lib/python3.*/site-packages/**/**/distro.py
     override-pull: |
       PYTHONHOME=/usr PYTHONUSERBASE=$SNAPCRAFT_PART_INSTALL $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install --upgrade 'pip; python_version >= "3.6"' 'pip<21; python_version < "3.6"' --user
       snapcraftctl pull

--- a/checkbox-snap/series_classic16/launchers/configure
+++ b/checkbox-snap/series_classic16/launchers/configure
@@ -13,9 +13,12 @@ sys.path.append(os.path.expandvars("$SNAP/usr/lib/python3/dist-packages"))
 sitepkgpath = "$SNAP/lib/python3.5/site-packages"
 sys.path.append(os.path.expandvars(sitepkgpath))
 
-sys.path.append(os.path.expandvars(
-    "/snap/checkbox/current/usr/lib/python3/dist-packages"))
-runtimepath = "/snap/checkbox/current/lib/python3.5/site-packages"
+sys.path.append(
+    os.path.expandvars(
+        "/snap/checkbox16/current/usr/lib/python3/dist-packages"
+    )
+)
+runtimepath = "/snap/checkbox16/current/lib/python3.5/site-packages"
 sys.path.append(os.path.expandvars(runtimepath))
 
 try:
@@ -35,24 +38,26 @@ snap install checkbox16
 def main():
     # we need run as root to be able to write to /var/snap/...
     if os.geteuid() != 0:
-        print('You have to run this command with sudo')
+        print("You have to run this command with sudo")
         return
 
-    if len(sys.argv) > 1 and sys.argv[1] == '-l':
+    if len(sys.argv) > 1 and sys.argv[1] == "-l":
         print_checkbox_conf()
         return
 
     key_re = re.compile(r"^(?:[A-Z0-9]+_?)*[A-Z](?:_?[A-Z0-9])*$")
     vars_to_set = dict()
     for pair in sys.argv[1:]:
-        k, _, v = pair.partition('=')
+        k, _, v = pair.partition("=")
         if not key_re.match(k) or not v:
-            raise SystemExit("'%s' is not a valid configuration entry. "
-                             "Should be KEY=val" % pair)
-        k = k.replace('_', '-').lower()
+            raise SystemExit(
+                "'%s' is not a valid configuration entry. "
+                "Should be KEY=val" % pair
+            )
+        k = k.replace("_", "-").lower()
         vars_to_set[k] = v
     update_configuration(vars_to_set)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/checkbox-snap/series_classic16/snap/hooks/configure
+++ b/checkbox-snap/series_classic16/snap/hooks/configure
@@ -36,9 +36,12 @@ sys.path.append(os.path.expandvars("$SNAP/usr/lib/python3/dist-packages"))
 sitepkgpath = "$SNAP/lib/python3.5/site-packages"
 sys.path.append(os.path.expandvars(sitepkgpath))
 
-sys.path.append(os.path.expandvars(
-    "/snap/checkbox/current/usr/lib/python3/dist-packages"))
-runtimepath = "/snap/checkbox/current/lib/python3.5/site-packages"
+sys.path.append(
+    os.path.expandvars(
+        "/snap/checkbox16/current/usr/lib/python3/dist-packages"
+    )
+)
+runtimepath = "/snap/checkbox16/current/lib/python3.5/site-packages"
 sys.path.append(os.path.expandvars(runtimepath))
 
 try:


### PR DESCRIPTION
## Description

The checkbox16 runtime snap that is built from the current state of the repo is broken. To check that it is, one can install it from the edge channel or follow the snap building procedure and see that it will fail to launch, complaining that 
```
checkbox-cli was not found
```

I believe this is happens due to multiple reasons that this PR fixes:
1) The `checkbox-cli` bin is not correctly staged on xenial
2) When the `checkbox-cli` bin is correctly staged, the location it is put at is not in the snap PATH
3) When building with the correct python bin (fixing 1) the shebang in the bin files is wrong (pointing to the temporary "parts" bin instead of the actual location)

#### To fix 1

This happens because calling `python3` in the `override-build` of `checkbox-ng`/`checkbox-support`, does not call the correct python, rather the builder machine python, leading to the bins being created in the wrong location. 

This was fixed calling python via `$SNAPCRAFT_PART_INSTALL/usr/bin/python3`. 
> Note: this fixes all bins, turns out most of them were missing

#### To fix 2

This happens because instead of installing to `/bin` or `/usr/bin`, bins are installed in `/usr/local/bin`. 

This was fixed adding the new location to the path.

#### To fix 3

This happens because the python path is specified explicitly (the fix for 1), but I'm not sure if there is any way to avoid it.

To fix this I have replaced all shebang of bins in `/usr/local/bin` that start with `/root/parts` with an invocation of `/usr/bin/env python3`. This is not great but it should not break anything that is not broken already at least. `/root/parts` is not a valid path once the snap is installed, so that will cause problems either way.

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/CHECKBOX-781

## Documentation

The most complicated thing to understand in this PR I think is the `sed` who was documented in a big comment above it. Also, the build process now uses a standard `pip install` instead of the complicated combination of pip and build that were there before, I think this greatly improves the readability of the recipe

## Tests

In `checkbox-core-snap` run: 
```
$ ./prepare.sh series16
[...]
$ cd series16
# pick one or the other, refresh if you have snapcraft installed. Look out! this will downgrade your snapcraft
$ snap install snapcraft --channel=4.x OR snap refresh snapcraft --channel=4.x 
$ snapcraft --use-lxd
```

Once the process is done run:
```
$ snap install checkbox16_[...].snap --dangerous
$ snap install checkbox --channel=16.04/edge --classic
```

You should be now able to run `checkbox.checkbox-cli`!

This was also tested by creating a modified version of the checkbox runtime (that includes the metabox provider) and the following metabox config: 
> Note: in order to actually execute this config, a few modifications have to be made to metabox
```
configuration = {
    "local": {
        "origin": "classic-snap",
        "checkbox_core_snap": {"uri": "~/checkbox16.snap"},
        "checkbox_snap": {"risk": "edge"},
        "releases": ["xenial"],
    },
    "remote": {
        "origin": "classic-snap",
        "checkbox_core_snap": {"uri": "~/checkbox16.snap"},
        "checkbox_snap": {"risk": "edge"},
        "releases": ["xenial"],
    },
    "service": {
        "origin": "classic-snap",
        "checkbox_core_snap": {"uri": "~/checkbox16.snap"},
        "checkbox_snap": {"risk": "edge"},
        "releases": ["xenial"],
    },
}
```
