### PR TITLE
Only stage version.txt in version-calculator

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -66,6 +66,8 @@ parts:
       export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
+    stage:
+      - version.txt
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/hwe/fwts.git/plain/snapcraft.yaml
   fwts:

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -70,6 +70,8 @@ parts:
       export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
+    stage:
+      - version.txt
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/hwe/fwts.git/plain/snapcraft.yaml
   fwts:

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -70,6 +70,8 @@ parts:
       export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
+    stage:
+      - version.txt
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/hwe/fwts.git/plain/snapcraft.yaml
   fwts:

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -70,6 +70,8 @@ parts:
       export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
+    stage:
+      - version.txt
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/hwe/fwts.git/plain/snapcraft.yaml
   fwts:


### PR DESCRIPTION
## Description

The version-calculator part stages every dir/file in the root of the build. This is undesirable and wrong because it creates a bigger snap that contains a lot of unrelated/sort of related and ok files, but all in the wrong location. For example searching for `checkbox-cli.py` in the current `edge` snap yields the following:
```
/snap/checkbox22$ find . -name checkbox_cli.py
./x1/checkbox-ng/build/lib/checkbox_ng/launcher/checkbox_cli.py
./x1/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
./x1/lib/python3.10/site-packages/build/lib/checkbox_ng/launcher/checkbox_cli.py
./x1/lib/python3.10/site-packages/checkbox_ng/launcher/checkbox_cli.py
```

When it should actually yield something like this (v2.8):
```
snap/checkbox22/current$ find . -name checkbox_cli.py
./lib/python3.10/site-packages/checkbox_ng/launcher/checkbox_cli.py
```

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/CHECKBOX-780

## Documentation

N/A

## Tests

The new build was executed and tested. This creates a working snap with no weird files in the root. 
