### PR TITLE
Fix config options are now case insensitive

### DIFF
--- a/checkbox-ng/plainbox/impl/config.py
+++ b/checkbox-ng/plainbox/impl/config.py
@@ -240,6 +240,9 @@ class Configuration:
         """
         cfg = Configuration(origin)
         parser = ConfigParser(delimiters="=")
+        # make the option names case sensitive
+        # else envvars are broken
+        parser.optionxform = str
         parser.read_string(ini_file.read())
         for sect_name, section in parser.items():
             if sect_name == "DEFAULT":

--- a/metabox/metabox/metabox-provider/units/basic-jobs.pxu
+++ b/metabox/metabox/metabox-provider/units/basic-jobs.pxu
@@ -21,6 +21,11 @@ flags: simple
 command: echo variables: $var1 $var2 $var3 $var4 $var_launcher
 environ: var1 var2 var3 var4
 
+id: config-environ-case
+flags: simple
+command: echo variables: $Case $CASE $case
+environ: Case CASE case
+
 id: stub/manual
 _summary: A simple manual job
 _description:

--- a/metabox/metabox/metabox-provider/units/basic-tps.pxu
+++ b/metabox/metabox/metabox-provider/units/basic-tps.pxu
@@ -44,3 +44,4 @@ _name: Checkbox Configuration Tests
 include:
  config-environ-source
  config-environ-vars
+ config-environ-case

--- a/metabox/metabox/scenarios/config/environment.py
+++ b/metabox/metabox/scenarios/config/environment.py
@@ -25,6 +25,31 @@ from metabox.core.actions import AssertPrinted, Start, MkTree, Put
 from .config_files import environment
 
 
+class CheckboxConfEnvvarCaseSensitive(Scenario):
+    """
+    Check that environment variables are case sensitive
+    """
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::config-automated
+        forced = yes
+        [test selection]
+        forced = yes
+        [environment]
+        CASE = CASE
+        Case = Case
+        case = case
+        """)
+    steps = [
+        AssertPrinted("CASE"),
+        AssertPrinted("Case"),
+        AssertPrinted("case"),
+    ]
+
+
 class CheckboxConfXDG(Scenario):
     """
     Check that environment variables are read from the XDG directory when


### PR DESCRIPTION
## Description

The config refactor made all config options case insensitive. This is not a huge problem for most of them but environment variables can not work with this change (given that all options are flattened to lower case and envvars are case sensitive).

#### Example:
GIven the following launcher:
```
[environment]
ABC=123
```
This test case will fail:
```
id: config-environ-case
flags: simple
command: [ $ABC ]
environ: ABC
```

The reason is that the launcher will try to supply a variable named `abc` and not `ABC`

## Resolved issues

Resolves: https://github.com/canonical/checkbox/issues/651

## Documentation

The change seems a bit strange so I have added a small comment above it. Note that it is what the configparser documentation suggests: [ConfigParser.optionxform](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.optionxform)

## Tests

This also adds a metabox test to verify/non-regress this behaviour. Note that this was not caught before because all `environment` section used in tests defined lower case variables! 

To run the new test use the following:
```
(metabox) $ metabox --tag CheckboxConfEnvvarCaseSensitive -- remote-source-22.04.py
``` 
