### PR TITLE
Fix crash (TypeError exception) when resuming a session

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -290,7 +290,7 @@ class Launcher(MainLoopStage, ReportsStage):
 
     def _configure_restart(self, ctx):
         try:
-            strategy = detect_restart_strategy(session_type="local")
+            _ = detect_restart_strategy(session_type="local")
         except LookupError as exc:
             _logger.warning(exc)
             _logger.warning(_("Automatic restart disabled!"))

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -308,8 +308,13 @@ class Launcher(MainLoopStage, ReportsStage):
         if ctx.args.launcher:
             respawn_cmd.append(os.path.abspath(ctx.args.launcher))
         respawn_cmd.append("--resume")
+        def join_cmd(args):
+            try:
+                return shlex.join(args)
+            except AttributeError:
+                return " ".join(shlex.quote(x) for x in args)
         ctx.sa.configure_application_restart(
-            lambda session_id: [shlex.join(respawn_cmd + [session_id])]
+            lambda session_id: [join_cmd(respawn_cmd + [session_id])]
         )
 
     def _maybe_resume_session(self):

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -309,7 +309,7 @@ class Launcher(MainLoopStage, ReportsStage):
             respawn_cmd.append(os.path.abspath(ctx.args.launcher))
         respawn_cmd.append("--resume")
         ctx.sa.configure_application_restart(
-            lambda session_id: [shlex.join(respawn_cmd.append(session_id))]
+            lambda session_id: [shlex.join(respawn_cmd + [session_id])]
         )
 
     def _maybe_resume_session(self):

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -38,7 +38,6 @@ class TestLauncher(TestCase):
         abspath_mock.return_value = "launcher_path"
 
         Launcher._configure_restart(tested_self, ctx_mock)
-        ctx_mock.sa.configure_application_restart.assert_called()
         (
             get_restart_cmd_f,
         ) = ctx_mock.sa.configure_application_restart.call_args[0]
@@ -62,7 +61,6 @@ class TestLauncher(TestCase):
         abspath_mock.return_value = "launcher_path"
 
         Launcher._configure_restart(tested_self, ctx_mock)
-        ctx_mock.sa.configure_application_restart.assert_called()
         (
             get_restart_cmd_f,
         ) = ctx_mock.sa.configure_application_restart.call_args[0]

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -1,0 +1,76 @@
+# This file is part of Checkbox.
+#
+# Copyright 2015 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest import TestCase
+from unittest.mock import patch, Mock
+
+from checkbox_ng.launcher.subcommands import Launcher
+
+
+class TestLauncher(TestCase):
+    @patch("checkbox_ng.launcher.subcommands.detect_restart_strategy")
+    @patch("os.getenv")
+    @patch("sys.argv")
+    @patch("os.path.abspath")
+    def test__configure_restart(
+        self, abspath_mock, sys_argv_mock, mock_getenv, mock_rs
+    ):
+        tested_self = Mock()
+        ctx_mock = Mock()
+        mock_getenv.return_value = ""
+        sys_argv_mock.__getitem__.return_value = "unittest"
+        abspath_mock.return_value = "launcher_path"
+
+        Launcher._configure_restart(tested_self, ctx_mock)
+        ctx_mock.sa.configure_application_restart.assert_called()
+        (
+            get_restart_cmd_f,
+        ) = ctx_mock.sa.configure_application_restart.call_args[0]
+        restart_cmd = get_restart_cmd_f("session_id")
+        self.assertEqual(
+            restart_cmd,
+            ["unittest launcher launcher_path --resume session_id"],
+        )
+
+    @patch("checkbox_ng.launcher.subcommands.detect_restart_strategy")
+    @patch("os.getenv")
+    @patch("sys.argv")
+    @patch("os.path.abspath")
+    def test__configure_restart_snap(
+        self, abspath_mock, sys_argv_mock, mock_getenv, mock_rs
+    ):
+        tested_self = Mock()
+        ctx_mock = Mock()
+        mock_getenv.return_value = "snap_name"
+        sys_argv_mock.__getitem__.return_value = "unittest"
+        abspath_mock.return_value = "launcher_path"
+
+        Launcher._configure_restart(tested_self, ctx_mock)
+        ctx_mock.sa.configure_application_restart.assert_called()
+        (
+            get_restart_cmd_f,
+        ) = ctx_mock.sa.configure_application_restart.call_args[0]
+        restart_cmd = get_restart_cmd_f("session_id")
+        self.assertEqual(
+            restart_cmd,
+            [
+                "/snap/bin/snap_name.checkbox-cli launcher "
+                "launcher_path --resume session_id"
+            ],
+        )


### PR DESCRIPTION
## Description

`shlex.join()` takes an iterable as a parameter. However, when using the `append()` function from a list, nothing is returned, so `shlex.join()` will raise the following exception:

```
TypeError: 'NoneType' object is not iterable
```

Instead, use the + operator to join two lists to avoid the problem.





<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

Fix #654
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Tests

Built an amd64 and an arm64 snaps using this branch, and tested them in two different ways:

1. ssh-ed into an arm64 device, installed the snap and ran checkbox local using `client-cert-iot-server-22-04-stress`, keeping only `cold-boot-loop-reboot1` and `cold-boot-loop-test1`, all OK: https://certification.canonical.com/hardware/202306-31692/submission/326073/
1. used the same test plan/test jobs on an amd64 device using checkbox remote, and got the same results
