### PR TITLE
Fix: Assign bitrate and loopback on for Socketcan

### DIFF
--- a/providers/base/units/socketcan/jobs.pxu
+++ b/providers/base/units/socketcan/jobs.pxu
@@ -101,7 +101,7 @@ command:
   set -ex
   ip link set {interface} down
   ip link set dev {interface} mtu 16
-  ip link set {interface} type can bitrate 100000 loopback on
+  ip link set {interface} type can bitrate 1000000 loopback on
   ip link set {interface} up
   socketcan_test.py {interface} 111
 
@@ -126,7 +126,7 @@ command:
   set -ex
   ip link set {interface} down
   ip link set dev {interface} mtu 16
-  ip link set {interface} type can bitrate 100000 loopback on
+  ip link set {interface} type can bitrate 1000000 loopback on
   ip link set {interface} up
   socketcan_test.py {interface} FA123 --effid
 

--- a/providers/base/units/socketcan/jobs.pxu
+++ b/providers/base/units/socketcan/jobs.pxu
@@ -101,6 +101,7 @@ command:
   set -ex
   ip link set {interface} down
   ip link set dev {interface} mtu 16
+  ip link set {interface} type can bitrate 100000 loopback on
   ip link set {interface} up
   socketcan_test.py {interface} 111
 
@@ -125,6 +126,7 @@ command:
   set -ex
   ip link set {interface} down
   ip link set dev {interface} mtu 16
+  ip link set {interface} type can bitrate 100000 loopback on
   ip link set {interface} up
   socketcan_test.py {interface} FA123 --effid
 
@@ -150,7 +152,7 @@ command:
   ip link set {interface} down
   # Following command is only supported configuration method when using the
   # IXXAT driver from HMS
-  ip link set {interface} type can bitrate 1000000 dbitrate 2000000 fd on
+  ip link set {interface} type can bitrate 1000000 dbitrate 2000000 fd on loopback on
   ip link set {interface} up
   socketcan_test.py {interface} 1B --fdmode
 


### PR DESCRIPTION
## Description

Two changes are made in this commit.
1. For most of devices with Can hardware component, the Can interface cannot be brought up if the bitrate is not given. Therefore, I assign the bitrate for eff and sff local socketcan tests like what the remote socketcan tests do.
2. For local Socketcan test, loopback is the must need parameter be assigned before bringing the Can interface up.

## Resolved issues

### _No_ `Bitrate` & _No_ `Loopback on`:

- Limeric Project
    - Submission: https://certification.canonical.com/hardware/202304-31517/submission/323234/test-results/fail/?term=socketcan
      - FD mode is not supported which be confirmed by customer ([LP#2022014](https://bugs.launchpad.net/limerick/+bug/2022014)), so please ignore the failed result of local fd mode
      - Customer mentioned that bitrate and loopback on are needed before bringing up ([LP#2025450](https://bugs.launchpad.net/limerick/+bug/2025450/comments/5))

- Baoshan Project
    - Submission: https://certification.canonical.com/hardware/202307-31858/submission/326108/test-results/fail/?term=socketcan 
      - For local eff and sff Socketcan test, the can0 interface cannot be brought up if there's no `bitrate` be assigned.
      - For local fd Socketcan test, timeout occurs if the `loopback on` isn't given.

### _With_ `Bitrate` and `Loopback on`:

- Baoshan Project
  - Sideload result: https://certification.canonical.com/hardware/202307-31858/submission/326402/test-results/?term=local
  
- Baytown Project
  - Submission: https://certification.canonical.com/hardware/202212-30955/submission/309730/test-results/?term=packet_local

- Limeric Project
  - VCK190 Submission: https://certification.canonical.com/hardware/202210-30706/submission/305486/test-results/?term=socket
  - ZCU106 Submission: https://certification.canonical.com/hardware/202210-30688/submission/290344/test-results/?term=socket

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
-->
