### PR TITLE
Add: snaps confinement test (new)

### DIFF
--- a/providers/base/bin/snap_confinement_test.py
+++ b/providers/base/bin/snap_confinement_test.py
@@ -105,15 +105,21 @@ class SnapsConfinement:
     Test the confinement status of all installed snaps.
 
     Attributes:
-        whitelist_snaps (list): A list of snap names or regex patterns
-            that are exempted from the confinement check.
+        allowlist_snaps (list): A list of snap names or regex patterns
+            that are exempted from the confinement check. To match the
+            entire snap name, use the pattern "^<snap_name>$". For
+            example, "bugit" matches only "bugit". To match multiple
+            snaps with similar names, use ".*" suffixes. For instance,
+            "checkbox.*" matches all snap names starting with "checkbox".
+            Customize this list to exclude specific snaps from the
+            confinement checks based on their names or patterns.
     """
 
-    whitelist_snaps = [
-        "bugit",
+    allowlist_snaps = [
+        r"^bugit$",
         r"checkbox.*",
-        "mir-test-tools",
-        "graphics-test-tools",
+        r"^mir-test-tools$",
+        r"^graphics-test-tools$",
     ]
 
     def invoked(self):
@@ -138,10 +144,11 @@ class SnapsConfinement:
             if snap_name is None:
                 logging.error("Snap 'name' not found in the snap data.")
                 exit_code = 1
+                continue  # Skipping following checks if snap_name not found
 
             if any(
                 re.match(pattern, snap_name)
-                for pattern in self.whitelist_snaps
+                for pattern in self.allowlist_snaps
             ):
                 print("Skipping whitelisted snap: {}".format(snap_name))
                 continue
@@ -182,7 +189,7 @@ def main():
     }
     parser = argparse.ArgumentParser()
     parser.add_argument("subcommand", type=str, choices=sub_commands)
-    args = parser.parse_args(sys.argv[1:2])
+    args = parser.parse_args()
     return sub_commands[args.subcommand]().invoked()
 
 

--- a/providers/base/bin/snap_confinement_test.py
+++ b/providers/base/bin/snap_confinement_test.py
@@ -56,7 +56,7 @@ class SystemConfinement:
 
         Returns:
             str: A detailed output of the system's confinement and
-                sandbox features in JSON format.
+                 sandbox features in JSON format.
         """
         data = Snapd().get_system_info()
 
@@ -125,7 +125,7 @@ class SnapsConfinement:
 
         Returns:
             int: Exit code. 0 if the test passes for all snaps,
-            otherwise 1.
+                 otherwise 1.
         """
         data = Snapd().list()
         exit_code = 0

--- a/providers/base/bin/snap_confinement_test.py
+++ b/providers/base/bin/snap_confinement_test.py
@@ -82,19 +82,19 @@ class SystemConfinement:
 
         if missing_features:
             logging.error(
-                "Cannot find '{}' in apparmor".format(missing_features)
+                "Cannot find '%s' in apparmor", missing_features
             )
 
         categories_to_check = ["mount", "udev"]
         for category in categories_to_check:
             if category not in sandbox_features:
                 logging.error(
-                    "Cannot find '{}' in sandbox-features".format(category)
+                    "Cannot find '%s' in sandbox-features", category
                 )
                 break
             for feature in sandbox_features[category]:
                 if "cgroup-v2" in feature:
-                    logging.error("cgroup({}) must NOT be v2".format(feature))
+                    logging.error("cgroup(%s) must NOT be v2", feature)
 
         return sandbox_features_output
 

--- a/providers/base/bin/snap_confinement_test.py
+++ b/providers/base/bin/snap_confinement_test.py
@@ -17,64 +17,98 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
+import argparse
 import json
 import logging
 import sys
 from checkbox_support.snap_utils.snapd import Snapd
 
-features_should_include = [
-    "kernel:caps",
-    "kernel:dbus",
-    "kernel:domain",
-    "kernel:file",
-    "kernel:mount",
-    "kernel:namespaces",
-    "kernel:network",
-    "kernel:ptrace",
-    "kernel:signal",
-    "parser:unsafe",
-]
+
+class SystemConfinement:
+    """
+    Check the confinement status and sandbox features of the system.
+
+    Attributes:
+        features_should_include (list): A list of sandbox features that
+            must be present in the 'apparmor' category.
+    """
+    features_should_include = [
+        "kernel:caps",
+        "kernel:dbus",
+        "kernel:domain",
+        "kernel:file",
+        "kernel:mount",
+        "kernel:namespaces",
+        "kernel:network",
+        "kernel:ptrace",
+        "kernel:signal",
+        "parser:unsafe",
+    ]
+
+    def invoked(self):
+        """
+        Check the confinement and sandbox features of the system.
+
+        This test checks if the system's confinement is 'strict'. If it
+        is 'strict', the test passes; otherwise, it checks the presence
+        of required features and prints out errors for any missing ones.
+
+        Returns:
+            str: A detailed output of the system's confinement and
+                sandbox features in JSON format.
+        """
+        data = Snapd().get_system_info()
+
+        confinement = data["confinement"]
+        if confinement == "strict":
+            print("System confinement is \"strict\"")
+            print("Test PASS")
+            return 0
+
+        sandbox_features = data["sandbox-features"]
+        sandbox_features_output = (
+            "\nOUTPUT: confinement: {}\nOUTPUT: sandbox-features:\n{}".format(
+                confinement, json.dumps(sandbox_features, indent=2)
+            )
+        )
+
+        missing_features = []
+        if "apparmor" not in sandbox_features:
+            logging.error("Cannot find 'apparmor' in sandbox-features")
+        else:
+            for feature in self.features_should_include:
+                if feature not in sandbox_features["apparmor"]:
+                    missing_features.append(feature)
+
+        if missing_features:
+            logging.error(
+                "Cannot find '{}' in apparmor".format(missing_features)
+            )
+
+        categories_to_check = ["mount", "udev"]
+        for category in categories_to_check:
+            if category not in sandbox_features:
+                logging.error(
+                    "Cannot find '{}' in sandbox-features".format(category)
+                )
+                break
+            for feature in sandbox_features[category]:
+                if "cgroup-v2" in feature:
+                    logging.error("cgroup({}) must NOT be v2".format(feature))
+
+        return sandbox_features_output
 
 
 def main():
-
-    data = Snapd().get_system_info()
-
-    confinement = data["confinement"]
-    if confinement == "strict":
-        print("Test PASS")
-        return 0
-
-    sandbox_features = data["sandbox-features"]
-    sandbox_features_output = (
-        "\nOUTPUT: confinement: {}\nOUTPUT: sandbox-features:\n{}".format(
-            confinement, json.dumps(sandbox_features, indent=2)
-        )
-    )
-
-    missing_features = []
-    if "apparmor" not in sandbox_features:
-        logging.error("Cannot find 'apparmor' in sandbox-features")
-    else:
-        for feature in features_should_include:
-            if feature not in sandbox_features["apparmor"]:
-                missing_features.append(feature)
-
-    if missing_features:
-        logging.error("Cannot find '{}' in apparmor".format(missing_features))
-
-    categories_to_check = ["mount", "udev"]
-    for category in categories_to_check:
-        if category not in sandbox_features:
-            logging.error(
-                "Cannot find '{}' in sandbox-features".format(category)
-            )
-            break
-        for feature in sandbox_features[category]:
-            if "cgroup-v2" in feature:
-                logging.error("cgroup({}) must NOT be v2".format(feature))
-
-    return sandbox_features_output
+    logging.basicConfig(format='%(levelname)s: %(message)s')
+    sub_commands = {
+        "system": SystemConfinement,
+        # "snaps": SnapsConfinement,
+    }
+    parser = argparse.ArgumentParser()
+    parser.add_argument("subcommand", type=str, choices=sub_commands)
+    args = parser.parse_args(sys.argv[1:2])
+    return sub_commands[args.subcommand]().invoked()
 
 
 if __name__ == "__main__":

--- a/providers/base/units/snapd/snapd.pxu
+++ b/providers/base/units/snapd/snapd.pxu
@@ -274,13 +274,12 @@ category_id: snapd
 estimated_duration: 1.0
 flags: preserve-locale
 
-id: snappy/test-snap-confinement-mode
-_summary: Test if the snap confinement mode is strict
+id: snappy/test-system-confinement
+_summary: Test if the system confinement is strict
 _purpose:
- Test if the snap confinement mode is `strict`
- If not, list the missing features
+  Test if the system confinement is "strict"
+  If not, list the missing features
 plugin: shell
-command: snap_confinement_test.py
-user: root
+command: snap_confinement_test.py system
 category_id: snapd
-estimated_duration: 1s
+estimated_duration: 2s

--- a/providers/base/units/snapd/snapd.pxu
+++ b/providers/base/units/snapd/snapd.pxu
@@ -283,3 +283,14 @@ plugin: shell
 command: snap_confinement_test.py system
 category_id: snapd
 estimated_duration: 2s
+
+id: snappy/test-snaps-confinement
+_summary: Test all the snaps' confinement
+_purpose:
+  Test all the snaps' confinement, devmode, revision.
+  Make sure the confinement is "strict", devmode is "False",
+  and revision should not be sideloded.
+plugin: shell
+command: snap_confinement_test.py snaps
+category_id: snapd
+estimated_duration: 3s

--- a/providers/base/units/snapd/test-plan.pxu
+++ b/providers/base/units/snapd/test-plan.pxu
@@ -68,7 +68,7 @@ include:
     snappy/test-store-install-beta
     snappy/test-store-install-edge
     snappy/test-store-config-.*
-    snappy/test-snap-confinement-mode
+    snappy/test-system-confinement
 mandatory_include:
     snap
 bootstrap_include:

--- a/providers/base/units/snapd/test-plan.pxu
+++ b/providers/base/units/snapd/test-plan.pxu
@@ -69,6 +69,7 @@ include:
     snappy/test-store-install-edge
     snappy/test-store-config-.*
     snappy/test-system-confinement
+    snappy/test-snaps-confinement
 mandatory_include:
     snap
 bootstrap_include:

--- a/providers/certification-client/units/client-cert-desktop-18-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-18-04.pxu
@@ -109,6 +109,7 @@ nested_part:
     networking-cert-automated
     optical-cert-automated
     power-management-precheck-cert-automated
+    snappy-snap-automated
     touchpad-cert-automated
     touchscreen-cert-automated
     usb-cert-automated

--- a/providers/certification-client/units/client-cert-desktop-20-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-20-04.pxu
@@ -112,6 +112,7 @@ nested_part:
     networking-cert-automated
     optical-cert-automated
     power-management-precheck-cert-automated
+    snappy-snap-automated
     touchpad-cert-automated
     touchscreen-cert-automated
     usb-cert-automated

--- a/providers/certification-client/units/client-cert-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-22-04.pxu
@@ -42,6 +42,7 @@ nested_part:
     networking-cert-manual
     optical-cert-manual
     power-management-precheck-cert-manual
+    snappy-snap-automated
     touchpad-cert-manual
     touchscreen-cert-manual
     usb-cert-manual

--- a/providers/certification-client/units/client-cert-odm-desktop-18-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-desktop-18-04.pxu
@@ -26,6 +26,7 @@ nested_part:
     networking-cert-manual
     optical-cert-manual
     power-management-precheck-cert-manual
+    snappy-snap-automated
     # touchpad-cert-manual
     # touchscreen-cert-manual
     usb-cert-manual

--- a/providers/certification-client/units/client-cert-odm-desktop-20-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-desktop-20-04.pxu
@@ -27,6 +27,7 @@ nested_part:
     networking-cert-manual
     optical-cert-manual
     power-management-precheck-cert-manual
+    snappy-snap-automated
     # touchpad-cert-manual
     # touchscreen-cert-manual
     usb-cert-manual

--- a/providers/certification-client/units/client-cert-odm-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-desktop-22-04.pxu
@@ -27,6 +27,7 @@ nested_part:
     networking-cert-manual
     optical-cert-manual
     power-management-precheck-cert-manual
+    snappy-snap-automated
     # touchpad-cert-manual
     # touchscreen-cert-manual
     usb-cert-manual


### PR DESCRIPTION
## Resolved issues
Jira task https://warthogs.atlassian.net/browse/CQT-2907

## Rational
Murcia project's customer asked us to include 2 snaps in the GM image. One of the snap is `strict` confined and installed in devmode, the other one is `devmode` confined and also installed in devmode.[1]

Recently this problem was found. For security reason, this should not be allowed on the image we delivered.
So we were asked to create a test case to catch this in the future.

[1] snap confinement document https://snapcraft.io/docs/snap-confinement

## Information
We originally have a test case called `snappy/test-snap-confinement-mode`. It checks the confinement and sandbox features of the system, if the system confinement is not `strict`, the test case will print out the missing requirements (e.g. sandbox features or cgroup version). Therefore, this test is testing the confinement of the system. We don't actually test the snap confinements of each installed snap.

In the problematic image of Murcia project, there are 2 snaps sideloaded at the last stage of image installation.

Name | Version | Revision |   | Confinement | Devmode |   |  
-- | -- | -- | -- | -- | -- | -- | --
gcap | 1.0.0 | x1 |   | strict | True |   | July 14, 2023
litebmc-fwupd | 2.6 | x1 |   | devmode | True |   | July 14, 2023

## Requirement
After checking with OEM SWE team, the requriments of this test are checking the following things for each installed snap,
1. Check the revision should NOT be sideloaded like `x1`.
2. Check the confinement should be `strict`. `classic` and `devmode` confinement are not allowed.
3. Check the `installed in devmode` should be `False`.
4. This test should be executed on all desktop, server, and core images.

## What are implemented in this pull request?
1. Refactor the original script. Splitting them to `SystemConfinement` class and `SnapsConfinement` class corresponding to the system confinement test and snap confinement test(the new test created)
2. Whitelisted the snaps that are installed in devmode for testing. Including `bugit`, `checkboxXX`, `mir-test-tools`, `graphic-test-tools`.
3. Implement the requirements above.
4. Add `snappy/test-system-confinement` and `snappy/test-snaps-confinement` to snappy-snap-automated test plan.
5. Add snappy-snap-automated test plan to desktop test plans. As we are thinking desktop image should also test the snap features including install, refresh, revert ...etc.

## Sideload test results
* Tested on a Ubuntu Desktop 22.04 laptop
https://pastebin.canonical.com/p/hsyFyRVtVQ/
* Tested on a Ubuntu Core 22 device with sideloading stress-ng snap
https://pastebin.canonical.com/p/CngKh9fNyD/
* Tested on that problematic machine (Desktop image on IoT device)
https://pastebin.canonical.com/p/gT8WNzbjbt/