### PR TITLE
Calculate coverage unittests

### DIFF
--- a/checkbox-ng/.coveragerc
+++ b/checkbox-ng/.coveragerc
@@ -23,3 +23,4 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+show_missing = True

--- a/checkbox-ng/.coveragerc
+++ b/checkbox-ng/.coveragerc
@@ -1,20 +1,18 @@
 [run]
 branch = True
-source = checkbox_ng 
+source = checkbox_ng,plainbox
 omit =
-    checkbox_ng/tests.py
-    checkbox_ng/test_*.py
+    plainbox/vendor/*
+    plainbox/test_*
+    checkbox_ng/test_*
+    plainbox/impl/test_*
+    plainbox/testing_utils/*
+    plainbox/impl/unit/test_*
+    checkbox_ng/launcher/test_*
+    plainbox/impl/secure/test_*
+    plainbox/impl/session/test_*
     plainbox/impl/commands/test_*
     plainbox/impl/exporter/test_*
-    plainbox/impl/integration_tests.py
-    plainbox/impl/secure/test_*
-    plainbox/impl/test_*
-    plainbox/impl/transport/test_*
-    plainbox/setup.py
-    plainbox/test_*
-    plainbox/testing_utils/test_*
-    plainbox/tests.py
-    plainbox/vendor/*
 
 [report]
 exclude_lines =

--- a/checkbox-ng/tox.ini
+++ b/checkbox-ng/tox.ini
@@ -9,11 +9,14 @@ commands =
     {envpython} {envsitepackagesdir}/plainbox/impl/providers/categories/manage.py validate
     {envpython} {envsitepackagesdir}/plainbox/impl/providers/exporters/manage.py validate
     {envpython} {envsitepackagesdir}/plainbox/impl/providers/manifest/manage.py validate
-    {envpython} -m pytest
+    {envpython} -m coverage run -m pytest
+    {envpython} -m coverage report
 
 [testenv:py35]
 deps =
     pytest
+    coverage == 5.5
+    pytest-cov == 2.12.1
     requests == 2.9.1
     urwid == 1.3.1
     Jinja2 == 2.8
@@ -28,6 +31,8 @@ setenv=
 [testenv:py36]
 deps =
     pytest
+    coverage == 5.5
+    pytest-cov == 3.0.0
     requests == 2.18.4
     urwid == 2.0.1
     Jinja2 == 2.10
@@ -38,6 +43,8 @@ deps =
 [testenv:py38]
 deps =
     pytest
+    coverage == 7.3.0
+    pytest-cov == 4.1.0
     requests == 2.22.0
     urwid == 2.0.1
     Jinja2 == 2.10.1
@@ -48,6 +55,8 @@ deps =
 [testenv:py310]
 deps =
     pytest
+    coverage == 7.3.0
+    pytest-cov == 4.1.0
     requests == 2.25.1
     urwid == 2.1.2
     Jinja2 == 3.0.3

--- a/checkbox-support/.coveragerc
+++ b/checkbox-support/.coveragerc
@@ -1,0 +1,20 @@
+[run]
+branch = True
+source = checkbox_support
+omit =
+    checkbox_support/tests/*
+    checkbox_support/vendor/*
+    checkbox_support/parsers/tests/*
+    checkbox_support/scripts/tests/*
+    checkbox_support/snap_utils/tests/*
+    checkbox_support/heuristics/tests/*
+
+[report]
+exclude_lines =
+    @abc.abstractmethod
+    @abc.abstractproperty
+    @abstractmethod
+    @abstractproperty
+    @public
+    pragma: no cover
+    raise NotImplementedError

--- a/checkbox-support/.coveragerc
+++ b/checkbox-support/.coveragerc
@@ -18,3 +18,4 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+show_missing = True

--- a/checkbox-support/tox.ini
+++ b/checkbox-support/tox.ini
@@ -7,11 +7,14 @@ isolated_build = True
 commands =
     {envpython} -m pip install .
     {envpython} -m pip list
-    {envpython} -m pytest checkbox_support/
+    {envpython} -m coverage run -m pytest checkbox_support/
+    {envpython} -m coverage report
 
 [testenv:py35]
 deps =
     pytest
+    coverage == 5.5
+    pytest-cov == 2.12.1
     requests == 2.9.1
     pyparsing == 2.0.3
     distro == 1.0.1
@@ -25,6 +28,8 @@ setenv=
 [testenv:py36]
 deps =
     pytest
+    coverage == 5.5
+    pytest-cov == 3.0.0
     requests == 2.18.4
     pyparsing == 2.2.0
     distro == 1.0.1
@@ -34,6 +39,8 @@ deps =
 [testenv:py38]
 deps =
     pytest
+    coverage == 7.3.0
+    pytest-cov == 4.1.0
     requests == 2.22.0
     pyparsing == 2.4.6
     distro == 1.4.0
@@ -42,6 +49,8 @@ deps =
 [testenv:py310]
 deps =
     pytest
+    coverage == 7.3.0
+    pytest-cov == 4.1.0
     requests == 2.25.1
     pyparsing == 2.4.7
     distro == 1.7.0

--- a/providers/base/.coveragerc
+++ b/providers/base/.coveragerc
@@ -2,8 +2,7 @@
 branch = True
 source = bin,manage
 omit =
-  tests/*
-
+    tests/*
 
 [report]
 exclude_lines =
@@ -14,3 +13,4 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+show_missing = True

--- a/providers/base/.coveragerc
+++ b/providers/base/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+branch = True
+source = bin,manage
+omit =
+  tests/*
+
+
+[report]
+exclude_lines =
+    @abc.abstractmethod
+    @abc.abstractproperty
+    @abstractmethod
+    @abstractproperty
+    @public
+    pragma: no cover
+    raise NotImplementedError

--- a/providers/base/tox.ini
+++ b/providers/base/tox.ini
@@ -6,18 +6,20 @@ skipsdist=True
 [testenv]
 allowlist_externals = rm
 commands =
-    pip -q install ../../checkbox-ng
+    {envpython} -m pip -q install ../../checkbox-ng
     # Required because this provider depends on checkbox-support parsers & scripts
-    pip -q install ../../checkbox-support
+    {envpython} -m pip -q install ../../checkbox-support
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     # Required because this provider depends on the resource provider
-    {envbindir}/python3 ../resource/manage.py develop
-    {envbindir}/python3 manage.py validate
-    {envbindir}/python3 manage.py test
+    {envpython} ../resource/manage.py develop
+    {envpython} manage.py validate
+    {envpython} -m coverage run manage.py test
+    {envpython} -m coverage report
 
 [testenv:py35]
 deps =
     flake8
+    coverage == 5.5
     natsort == 4.0.3
     requests == 2.9.1
     urwid == 1.3.1
@@ -36,6 +38,7 @@ setenv=
 [testenv:py36]
 deps =
     flake8
+    coverage == 5.5
     natsort == 4.0.3
     requests == 2.18.4
     urwid == 2.0.1
@@ -50,6 +53,7 @@ deps =
 [testenv:py38]
 deps =
     flake8
+    coverage == 7.3.0
     natsort == 7.0.1
     requests == 2.22.0
     urwid == 2.0.1
@@ -64,6 +68,7 @@ deps =
 [testenv:py310]
 deps =
     flake8
+    coverage == 7.3.0
     natsort == 8.0.2
     requests == 2.25.1
     urwid == 2.1.2

--- a/providers/certification-client/.coveragerc
+++ b/providers/certification-client/.coveragerc
@@ -2,8 +2,7 @@
 branch = True
 source = bin,manage
 omit =
-  tests/*
-
+    tests/*
 
 [report]
 exclude_lines =
@@ -14,3 +13,4 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+show_missing = True

--- a/providers/certification-client/.coveragerc
+++ b/providers/certification-client/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+branch = True
+source = bin,manage
+omit =
+  tests/*
+
+
+[report]
+exclude_lines =
+    @abc.abstractmethod
+    @abc.abstractproperty
+    @abstractmethod
+    @abstractproperty
+    @public
+    pragma: no cover
+    raise NotImplementedError

--- a/providers/certification-client/tox.ini
+++ b/providers/certification-client/tox.ini
@@ -10,14 +10,16 @@ commands =
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
     # Required because this provider depends on the resource and base providers
-    {envbindir}/python3 ../resource/manage.py develop
-    {envbindir}/python3 ../base/manage.py develop
-    {envbindir}/python3 manage.py validate
-    {envbindir}/python3 manage.py test
+    {envpython} ../resource/manage.py develop
+    {envpython} ../base/manage.py develop
+    {envpython} manage.py validate
+    {envpython} -m coverage run manage.py test
+    {envpython} -m coverage report
 
 [testenv:py35]
 deps =
     flake8
+    coverage == 5.5
     natsort == 4.0.3
     requests == 2.9.1
     urwid == 1.3.1
@@ -36,6 +38,7 @@ setenv=
 [testenv:py36]
 deps =
     flake8
+    coverage == 7.3.0
     natsort == 4.0.3
     requests == 2.18.4
     urwid == 2.0.1
@@ -50,6 +53,7 @@ deps =
 [testenv:py38]
 deps =
     flake8
+    coverage == 7.3.0
     natsort == 7.0.1
     requests == 2.22.0
     urwid == 2.0.1
@@ -64,6 +68,7 @@ deps =
 [testenv:py310]
 deps =
     flake8
+    coverage == 5.5
     natsort == 8.0.2
     requests == 2.25.1
     urwid == 2.1.2

--- a/providers/certification-client/tox.ini
+++ b/providers/certification-client/tox.ini
@@ -38,7 +38,7 @@ setenv=
 [testenv:py36]
 deps =
     flake8
-    coverage == 7.3.0
+    coverage == 5.5
     natsort == 4.0.3
     requests == 2.18.4
     urwid == 2.0.1
@@ -68,7 +68,7 @@ deps =
 [testenv:py310]
 deps =
     flake8
-    coverage == 5.5
+    coverage == 7.3.0
     natsort == 8.0.2
     requests == 2.25.1
     urwid == 2.1.2

--- a/providers/certification-server/.coveragerc
+++ b/providers/certification-server/.coveragerc
@@ -2,8 +2,7 @@
 branch = True
 source = bin,manage
 omit =
-  tests/*
-
+    tests/*
 
 [report]
 exclude_lines =
@@ -14,3 +13,4 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+show_missing = True

--- a/providers/certification-server/.coveragerc
+++ b/providers/certification-server/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+branch = True
+source = bin,manage
+omit =
+  tests/*
+
+
+[report]
+exclude_lines =
+    @abc.abstractmethod
+    @abc.abstractproperty
+    @abstractmethod
+    @abstractproperty
+    @public
+    pragma: no cover
+    raise NotImplementedError

--- a/providers/certification-server/tox.ini
+++ b/providers/certification-server/tox.ini
@@ -10,14 +10,16 @@ commands =
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
     # Required because this provider depends on the resource and base providers
-    {envbindir}/python3 ../resource/manage.py develop
-    {envbindir}/python3 ../base/manage.py develop
-    {envbindir}/python3 manage.py validate
-    {envbindir}/python3 manage.py test
+    {envpython} ../resource/manage.py develop
+    {envpython} ../base/manage.py develop
+    {envpython} manage.py validate
+    {envpython} -m coverage run manage.py test
+    {envpython} -m coverage report
 
 [testenv:py35]
 deps =
     flake8
+    coverage == 5.5
     natsort == 4.0.3
     requests == 2.9.1
     urwid == 1.3.1
@@ -36,6 +38,7 @@ setenv=
 [testenv:py36]
 deps =
     flake8
+    coverage == 7.3.0
     natsort == 4.0.3
     requests == 2.18.4
     urwid == 2.0.1
@@ -50,6 +53,7 @@ deps =
 [testenv:py38]
 deps =
     flake8
+    coverage == 7.3.0
     natsort == 7.0.1
     requests == 2.22.0
     urwid == 2.0.1
@@ -64,6 +68,7 @@ deps =
 [testenv:py310]
 deps =
     flake8
+    coverage == 5.5
     natsort == 8.0.2
     requests == 2.25.1
     urwid == 2.1.2

--- a/providers/certification-server/tox.ini
+++ b/providers/certification-server/tox.ini
@@ -38,7 +38,7 @@ setenv=
 [testenv:py36]
 deps =
     flake8
-    coverage == 7.3.0
+    coverage == 5.5
     natsort == 4.0.3
     requests == 2.18.4
     urwid == 2.0.1
@@ -68,7 +68,7 @@ deps =
 [testenv:py310]
 deps =
     flake8
-    coverage == 5.5
+    coverage == 7.3.0
     natsort == 8.0.2
     requests == 2.25.1
     urwid == 2.1.2

--- a/providers/docker/tox.ini
+++ b/providers/docker/tox.ini
@@ -10,13 +10,14 @@ commands =
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
     # Required because this provider depends on the resource and base providers
-    {envbindir}/python3 ../resource/manage.py develop
-    {envbindir}/python3 ../base/manage.py develop
-    {envbindir}/python3 manage.py validate
+    {envpython} ../resource/manage.py develop
+    {envpython} ../base/manage.py develop
+    {envpython} manage.py validate
 
 [testenv:py35]
 deps =
     flake8
+    coverage == 5.5
     natsort == 4.0.3
     requests == 2.9.1
     urwid == 1.3.1
@@ -35,6 +36,7 @@ setenv=
 [testenv:py36]
 deps =
     flake8
+    coverage == 5.5
     natsort == 4.0.3
     requests == 2.18.4
     urwid == 2.0.1
@@ -49,6 +51,7 @@ deps =
 [testenv:py38]
 deps =
     flake8
+    coverage == 7.3.0
     natsort == 7.0.1
     requests == 2.22.0
     urwid == 2.0.1
@@ -63,6 +66,7 @@ deps =
 [testenv:py310]
 deps =
     flake8
+    coverage == 7.3.0
     natsort == 8.0.2
     requests == 2.25.1
     urwid == 2.1.2

--- a/providers/gpgpu/.coveragerc
+++ b/providers/gpgpu/.coveragerc
@@ -2,8 +2,7 @@
 branch = True
 source = bin,manage
 omit =
-  tests/*
-
+    tests/*
 
 [report]
 exclude_lines =
@@ -14,3 +13,4 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+show_missing = True

--- a/providers/gpgpu/.coveragerc
+++ b/providers/gpgpu/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+branch = True
+source = bin,manage
+omit =
+  tests/*
+
+
+[report]
+exclude_lines =
+    @abc.abstractmethod
+    @abc.abstractproperty
+    @abstractmethod
+    @abstractproperty
+    @public
+    pragma: no cover
+    raise NotImplementedError

--- a/providers/gpgpu/tox.ini
+++ b/providers/gpgpu/tox.ini
@@ -10,14 +10,16 @@ commands =
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
     # Required because this provider depends on the resource and base providers
-    {envbindir}/python3 ../resource/manage.py develop
-    {envbindir}/python3 ../base/manage.py develop
-    {envbindir}/python3 manage.py validate
-    {envbindir}/python3 manage.py test
+    {envpython} ../resource/manage.py develop
+    {envpython} ../base/manage.py develop
+    {envpython} manage.py validate
+    {envpython} -m coverage run manage.py test
+    {envpython} -m coverage report
 
 [testenv:py35]
 deps =
     flake8
+    coverage == 5.5
     natsort == 4.0.3
     requests == 2.9.1
     urwid == 1.3.1
@@ -36,6 +38,7 @@ setenv=
 [testenv:py36]
 deps =
     flake8
+    coverage == 7.3.0
     natsort == 4.0.3
     requests == 2.18.4
     urwid == 2.0.1
@@ -50,6 +53,7 @@ deps =
 [testenv:py38]
 deps =
     flake8
+    coverage == 7.3.0
     natsort == 7.0.1
     requests == 2.22.0
     urwid == 2.0.1
@@ -64,6 +68,7 @@ deps =
 [testenv:py310]
 deps =
     flake8
+    coverage == 5.5
     natsort == 8.0.2
     requests == 2.25.1
     urwid == 2.1.2

--- a/providers/gpgpu/tox.ini
+++ b/providers/gpgpu/tox.ini
@@ -38,7 +38,7 @@ setenv=
 [testenv:py36]
 deps =
     flake8
-    coverage == 7.3.0
+    coverage == 5.5
     natsort == 4.0.3
     requests == 2.18.4
     urwid == 2.0.1
@@ -68,7 +68,7 @@ deps =
 [testenv:py310]
 deps =
     flake8
-    coverage == 5.5
+    coverage == 7.3.0
     natsort == 8.0.2
     requests == 2.25.1
     urwid == 2.1.2

--- a/providers/iiotg/.coveragerc
+++ b/providers/iiotg/.coveragerc
@@ -2,8 +2,7 @@
 branch = True
 source = bin,manage
 omit =
-  tests/*
-
+    tests/*
 
 [report]
 exclude_lines =
@@ -14,3 +13,4 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+show_missing = True

--- a/providers/iiotg/.coveragerc
+++ b/providers/iiotg/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+branch = True
+source = bin,manage
+omit =
+  tests/*
+
+
+[report]
+exclude_lines =
+    @abc.abstractmethod
+    @abc.abstractproperty
+    @abstractmethod
+    @abstractproperty
+    @public
+    pragma: no cover
+    raise NotImplementedError

--- a/providers/iiotg/tox.ini
+++ b/providers/iiotg/tox.ini
@@ -10,14 +10,16 @@ commands =
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
     # Required because this provider depends on the resource and base providers
-    {envbindir}/python3 ../resource/manage.py develop
-    {envbindir}/python3 ../base/manage.py develop
-    {envbindir}/python3 manage.py validate
-    {envbindir}/python3 manage.py test
+    {envpython} ../resource/manage.py develop
+    {envpython} ../base/manage.py develop
+    {envpython} manage.py validate
+    {envpython} -m coverage run manage.py test
+    {envpython} -m coverage report
 
 [testenv:py35]
 deps =
     flake8
+    coverage == 5.5
     natsort == 4.0.3
     requests == 2.9.1
     urwid == 1.3.1
@@ -36,6 +38,7 @@ setenv=
 [testenv:py36]
 deps =
     flake8
+    coverage == 5.5
     natsort == 4.0.3
     requests == 2.18.4
     urwid == 2.0.1
@@ -50,6 +53,7 @@ deps =
 [testenv:py38]
 deps =
     flake8
+    coverage == 7.3.0
     natsort == 7.0.1
     requests == 2.22.0
     urwid == 2.0.1
@@ -64,6 +68,7 @@ deps =
 [testenv:py310]
 deps =
     flake8
+    coverage == 7.3.0
     natsort == 8.0.2
     requests == 2.25.1
     urwid == 2.1.2

--- a/providers/resource/.coveragerc
+++ b/providers/resource/.coveragerc
@@ -2,8 +2,7 @@
 branch = True
 source = bin,manage
 omit =
-  tests/*
-
+    tests/*
 
 [report]
 exclude_lines =
@@ -14,3 +13,4 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+show_missing = True

--- a/providers/resource/.coveragerc
+++ b/providers/resource/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+branch = True
+source = bin,manage
+omit =
+  tests/*
+
+
+[report]
+exclude_lines =
+    @abc.abstractmethod
+    @abc.abstractproperty
+    @abstractmethod
+    @abstractproperty
+    @public
+    pragma: no cover
+    raise NotImplementedError

--- a/providers/resource/tox.ini
+++ b/providers/resource/tox.ini
@@ -8,12 +8,14 @@ commands =
     pip -q install ../../checkbox-ng
     # Required because this provider depends on checkbox-support parsers & scripts
     pip -q install ../../checkbox-support
-    {envbindir}/python3 manage.py validate
-    {envbindir}/python3 manage.py test
+    {envpython} manage.py validate
+    {envpython} -m coverage run manage.py test
+    {envpython} -m coverage report
 
 [testenv:py35]
 deps =
     flake8
+    coverage == 5.5
     requests == 2.9.1
     urwid == 1.3.1
     Jinja2 == 2.8
@@ -31,6 +33,7 @@ setenv=
 [testenv:py36]
 deps =
     flake8
+    coverage == 5.5
     requests == 2.18.4
     urwid == 2.0.1
     Jinja2 == 2.10
@@ -44,6 +47,7 @@ deps =
 [testenv:py38]
 deps =
     flake8
+    coverage == 7.3.0
     requests == 2.22.0
     urwid == 2.0.1
     Jinja2 == 2.10.1
@@ -57,6 +61,7 @@ deps =
 [testenv:py310]
 deps =
     flake8
+    coverage == 7.3.0
     requests == 2.25.1
     urwid == 2.1.2
     Jinja2 == 3.0.3

--- a/providers/sru/.coveragerc
+++ b/providers/sru/.coveragerc
@@ -2,8 +2,7 @@
 branch = True
 source = bin,manage
 omit =
-  tests/*
-
+    tests/*
 
 [report]
 exclude_lines =
@@ -14,3 +13,4 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+show_missing = True

--- a/providers/sru/.coveragerc
+++ b/providers/sru/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+branch = True
+source = bin,manage
+omit =
+  tests/*
+
+
+[report]
+exclude_lines =
+    @abc.abstractmethod
+    @abc.abstractproperty
+    @abstractmethod
+    @abstractproperty
+    @public
+    pragma: no cover
+    raise NotImplementedError

--- a/providers/sru/tox.ini
+++ b/providers/sru/tox.ini
@@ -10,14 +10,16 @@ commands =
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
     # Required because this provider depends on the resource and base providers
-    {envbindir}/python3 ../resource/manage.py develop
-    {envbindir}/python3 ../base/manage.py develop
-    {envbindir}/python3 manage.py validate
-    {envbindir}/python3 manage.py test
+    {envpython} ../resource/manage.py develop
+    {envpython} ../base/manage.py develop
+    {envpython} manage.py validate
+    {envpython} -m coverage run manage.py test
+    {envpython} -m coverage report
 
 [testenv:py35]
 deps =
     flake8
+    coverage == 5.5
     natsort == 4.0.3
     requests == 2.9.1
     urwid == 1.3.1
@@ -36,6 +38,7 @@ setenv=
 [testenv:py36]
 deps =
     flake8
+    coverage == 5.5
     natsort == 4.0.3
     requests == 2.18.4
     urwid == 2.0.1
@@ -50,6 +53,7 @@ deps =
 [testenv:py38]
 deps =
     flake8
+    coverage == 7.3.0
     natsort == 7.0.1
     requests == 2.22.0
     urwid == 2.0.1
@@ -64,6 +68,7 @@ deps =
 [testenv:py310]
 deps =
     flake8
+    coverage == 7.3.0
     natsort == 8.0.2
     requests == 2.25.1
     urwid == 2.1.2

--- a/providers/tpm2/tox.ini
+++ b/providers/tpm2/tox.ini
@@ -9,8 +9,8 @@ commands =
     pip -q install ../../checkbox-ng
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     # Required because this provider depends on the resource provider
-    {envbindir}/python3 ../resource/manage.py develop
-    {envbindir}/python3 manage.py validate
+    {envpython} ../resource/manage.py develop
+    {envpython} manage.py validate
 
 [testenv:py35]
 deps =


### PR DESCRIPTION
## Description

We already run unit tests via tox + pytest. Right now we do not know what the test coverage is. We have to be able to get this metric up to at least (>0%) on every file because else tox does not recognize if a piece of grammar is unsupported for a given python version in non-imported files, but also, this is crucial for a robust software.

In order to collect coverage we have to add the pytest-cov + coverage dependency and use it as a part of the tox run. This implements this and setups `.coveragerc` files where they are needed.

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/CHECKBOX-798

## Documentation

N/A

## Tests

To run the tests locally you have to use tox. For example, if you want to test `checkbox-ng` tests out do the following:
```
$ cd checkbox-ng
$ tox 
```

This should run all tests for the installed python versions you have. After each run it will also produce a coverage report