### PR TITLE
Fix: wireless_scanning needs to be run as root while run it remotely. (BugFix)

### DIFF
--- a/providers/base/units/wireless/jobs.pxu
+++ b/providers/base/units/wireless/jobs.pxu
@@ -16,6 +16,7 @@ template-filter: device.category == 'WIRELESS' and device.interface != 'UNKNOWN'
 template-engine: jinja2
 template-unit: job
 id: wireless/wireless_scanning_{{ interface }}
+user: root
 _summary: Test system can discover Wi-Fi networks on {{ interface }}
 command:
   net_driver_info.py "$NET_DRIVER_INFO"


### PR DESCRIPTION
## Description

During the setup of Denver Keurig project, I found that when I run the test from Jenkins, wireless_scanning_wlan0 will fail, but when I run the test from the DUT directly, it will pass.
According to past experience, it should be the issue which the test case didn't indicate the user: root.

## Resolved issues

Please refer to the failure from [Jenkins job](http://10.102.156.15:8080/job/cert-denver-kdrp-hmi-10-avnet-avt-iiotg20-kernel-latest-beta/10/testReport/junit/com.canonical/certification__wireless_wireless_scanning_wlan0/com_canonical_certification__wireless_wireless_scanning_wlan0/)


## Documentation
N/A

## Tests

```
Connecting to 10.102.160.91:18871. Timeout: 600s
============[ Bootstrap com.canonical.certification::device (1/1) ]=============
-----------------------------[ Running job 3 / 3 ]------------------------------
--------------[ Test system can discover Wi-Fi networks on wlan0 ]--------------
ID: com.canonical.certification::wireless/wireless_scanning_wlan0
Category: Wireless networking tests
--------------------------------------------------------------------------------
Interface wlan0 using module brcmfmac
  Parameters:
    alternative_fw_path:
    debug: 0
    roamoff: 0

Checking kernel ring buffer for brcmfmac messages:


Interface eth0 using module r8152

Checking kernel ring buffer for r8152 messages:


## Cleaning up NM connections
+ nmcli -t -f TYPE,UUID,NAME c

## Calling a rescan
+ nmcli d wifi rescan
Error: Scanning not allowed immediately following previous scan.
Scan request failed, allow other operations to complete (15s)

## List APs
+ nmcli -t -f SSID,CHAN,FREQ,SIGNAL d wifi list ifname wlan0
SSID: cert-bg-open-tel-l5-01 Chan: 6 Freq: 2437 MHz Signal: 100
SSID: Canonical Chan: 11 Freq: 2462 MHz Signal: 95
SSID:  Chan: 1 Freq: 2412 MHz Signal: 92
SSID: ttttttttttttttttttttttt Chan: 9 Freq: 2452 MHz Signal: 87
SSID:  Chan: 1 Freq: 2412 MHz Signal: 84
SSID: Canonical Chan: 6 Freq: 2437 MHz Signal: 84
SSID: Canonical-Guest Chan: 6 Freq: 2437 MHz Signal: 80
SSID:  Chan: 6 Freq: 2437 MHz Signal: 80
SSID: Canonical-Doorbell Chan: 6 Freq: 2437 MHz Signal: 79
SSID: Canonical Chan: 1 Freq: 2412 MHz Signal: 75
SSID: Canonical Chan: 1 Freq: 2412 MHz Signal: 75
SSID: cert-bg-wpa-tel-l3-01 Chan: 11 Freq: 2462 MHz Signal: 75
SSID: Canonical Chan: 11 Freq: 2462 MHz Signal: 74
SSID: cert-n-open-tel-l3-01 Chan: 1 Freq: 2412 MHz Signal: 70
SSID:  Chan: 11 Freq: 2462 MHz Signal: 70
SSID: cert-bg-open-tel-l3-01 Chan: 1 Freq: 2412 MHz Signal: 69
SSID: cert-n-wpa-tel-l3-01 Chan: 1 Freq: 2412 MHz Signal: 67
SSID:  Chan: 6 Freq: 2437 MHz Signal: 62
SSID:  Chan: 6 Freq: 2437 MHz Signal: 54
SSID: Canonical Chan: 1 Freq: 2412 MHz Signal: 50
SSID: Canonical Chan: 6 Freq: 2437 MHz Signal: 45
SSID:  Chan: 6 Freq: 2437 MHz Signal: 42

Found 22 access points
--------------------------------------------------------------------------------
Outcome: job passed
```
