### PR TITLE
Enforce coverage requirement and reporting via codecov

### DIFF
--- a/.github/workflows/tox-checkbox-ng.yaml
+++ b/.github/workflows/tox-checkbox-ng.yaml
@@ -30,3 +30,5 @@ jobs:
         run: pip install tox
       - name: Run tox
         run: tox
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/tox-checkbox-support.yaml
+++ b/.github/workflows/tox-checkbox-support.yaml
@@ -30,3 +30,5 @@ jobs:
         run: pip install tox
       - name: Run tox
         run: tox
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/tox-provider-base.yaml
+++ b/.github/workflows/tox-provider-base.yaml
@@ -30,3 +30,5 @@ jobs:
         run: pip install tox
       - name: Run tox
         run: tox
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/tox-provider-certification-client.yaml
+++ b/.github/workflows/tox-provider-certification-client.yaml
@@ -30,3 +30,5 @@ jobs:
         run: pip install tox
       - name: Run tox
         run: tox
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/tox-provider-certification-server.yaml
+++ b/.github/workflows/tox-provider-certification-server.yaml
@@ -30,3 +30,5 @@ jobs:
         run: pip install tox
       - name: Run tox
         run: tox
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/tox-provider-gpgpu.yaml
+++ b/.github/workflows/tox-provider-gpgpu.yaml
@@ -30,3 +30,5 @@ jobs:
         run: pip install tox
       - name: Run tox
         run: tox
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/tox-provider-iiotg.yaml
+++ b/.github/workflows/tox-provider-iiotg.yaml
@@ -30,3 +30,5 @@ jobs:
         run: pip install tox
       - name: Run tox
         run: tox
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/tox-provider-resource.yaml
+++ b/.github/workflows/tox-provider-resource.yaml
@@ -30,3 +30,5 @@ jobs:
         run: pip install tox
       - name: Run tox
         run: tox
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/tox-provider-sru.yaml
+++ b/.github/workflows/tox-provider-sru.yaml
@@ -30,3 +30,5 @@ jobs:
         run: pip install tox
       - name: Run tox
         run: tox
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ Note that every part of this repository has a `.coveragerc` file, they should
 already include anything you may want to see in the report. If something is
 missing you can edit it but please, consult with the team before doing so.
 Tests are intentionally excluded from the coverage report, this is because
-test files tend to inflationate the coverage with no real benefit, so don't
+test files tend to inflate the coverage with no real benefit, so don't
 worry if you can not spot yours in the report.
 
 Of course, you may only be interested in the coverage of your patch (for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,15 +72,15 @@ you have to activate the `checkbox-cli service` on the Machine under test:
 ```bash
 (venv) # checkbox-cli service
 ```
-> Note: Keep in mind that service has to be run as root and needs the 
+> Note: Keep in mind that service has to be run as root and needs the
 > virtual env, you may have to re-enable/activate it after a `sudo -s`
 
 Now you can run the remote command to connect to it:
 ```bash
-(venv) $ checkbox-cli remote IP 
+(venv) $ checkbox-cli remote IP
 ```
 
-> Note: `service` and `remote` can both run on the same machine. 
+> Note: `service` and `remote` can both run on the same machine.
 > in that situation, simply use `127.0.0.1`
 
 ### Writing and running unit tests for Checkbox
@@ -102,6 +102,40 @@ Run checks for code quality of provider hosted scripts and any unit
 tests for providers:
 
     $ ./manage.py test
+
+### Coverage requirements
+
+In Checkbox we have a coverage requirement for new PRs. This is to ensure
+that if anyone has to edit the source in the future we have a reliable way
+to determine if the edits are changing the meaning of it. Remember, it may be very
+clear to you now, but what about tomorrow? Given this objective, try to
+create your tests in a way that captures this spirit, it is not about having
+a patch coverage of 80% or 81%. It is better to have a very clean and clear
+test collection that covers a little bit less of your patch than a
+monstrosity of mocks and patches that are just there to reach the coverage
+quota.
+
+To collect your coverage you can run the following:
+```
+$ python -m pip install coverage pytest pytest-cov
+# cd to where your test is
+$ python -m coverage run -m pytest .
+```
+Note that every part of this repository has a `.coveragerc` file, they should
+already include anything you may want to see in the report. If something is
+missing you can edit it but please, consult with the team before doing so.
+Tests are intentionally excluded from the coverage report, this is because
+test files tend to inflationate the coverage with no real benefit, so don't
+worry if you can not spot yours in the report.
+
+Of course, you may only be interested in the coverage of your patch (for
+example, if you change a file that has a very low coverage, we do not want
+you to take up the challenge of testing it all if you don't want to!). The
+easiest way to get this measurement is to open a new PR and connect it with
+your branch. The `codecov.io` Bot should comment on it as soon as the `tox`
+job relevant to your change is finished, giving you a handy report. Note
+that the bot will tell you what you should improve to meet the requirements,
+the constraints are listed in `codecov.yaml` in the repo root.
 
 ## Version control recommendations
 

--- a/checkbox-ng/tox.ini
+++ b/checkbox-ng/tox.ini
@@ -11,6 +11,7 @@ commands =
     {envpython} {envsitepackagesdir}/plainbox/impl/providers/manifest/manage.py validate
     {envpython} -m coverage run -m pytest
     {envpython} -m coverage report
+    {envpython} -m coverage xml
 
 [testenv:py35]
 deps =

--- a/checkbox-support/tox.ini
+++ b/checkbox-support/tox.ini
@@ -9,6 +9,7 @@ commands =
     {envpython} -m pip list
     {envpython} -m coverage run -m pytest checkbox_support/
     {envpython} -m coverage report
+    {envpython} -m coverage xml
 
 [testenv:py35]
 deps =

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 80%

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,4 +2,4 @@ coverage:
   status:
     patch:
       default:
-        target: 80%
+        target: 90%

--- a/providers/base/tox.ini
+++ b/providers/base/tox.ini
@@ -15,6 +15,7 @@ commands =
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
+    {envpython} -m coverage xml
 
 [testenv:py35]
 deps =

--- a/providers/certification-client/tox.ini
+++ b/providers/certification-client/tox.ini
@@ -15,6 +15,7 @@ commands =
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
+    {envpython} -m coverage xml
 
 [testenv:py35]
 deps =

--- a/providers/certification-server/tox.ini
+++ b/providers/certification-server/tox.ini
@@ -15,6 +15,7 @@ commands =
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
+    {envpython} -m coverage xml
 
 [testenv:py35]
 deps =

--- a/providers/gpgpu/tox.ini
+++ b/providers/gpgpu/tox.ini
@@ -15,6 +15,7 @@ commands =
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
+    {envpython} -m coverage xml
 
 [testenv:py35]
 deps =

--- a/providers/iiotg/tox.ini
+++ b/providers/iiotg/tox.ini
@@ -15,6 +15,7 @@ commands =
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
+    {envpython} -m coverage xml
 
 [testenv:py35]
 deps =

--- a/providers/resource/tox.ini
+++ b/providers/resource/tox.ini
@@ -11,6 +11,7 @@ commands =
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
+    {envpython} -m coverage xml
 
 [testenv:py35]
 deps =

--- a/providers/sru/tox.ini
+++ b/providers/sru/tox.ini
@@ -15,6 +15,7 @@ commands =
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
+    {envpython} -m coverage xml
 
 [testenv:py35]
 deps =


### PR DESCRIPTION
## Description

This upgrades our coverage reporting by uploading to codecov.io. Using the features of said service, this also starts to enforce a patch based coverage requirement (for now just hardcoded at 80%).

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/CHECKBOX-799

## Documentation

This adds a new section to the contributing guide that explains how to get a local coverage report, why we want a coverage constraint and how we enforce it. This section also points to where the coverage constraint is specified and how it is reported io PRs (the pointer is there because in the future we may want to change the requirement, we don't want to have to update this file with the new one!)

## Tests

N/A
