### PR TITLE
Port pinned version from canonical/sphinx-docs-starter-pack

### DIFF
--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -1,7 +1,7 @@
 psutil
 urwid
 tqdm
-sphinx
+sphinx==7.1.2
 sphinx-autobuild
 sphinx-design
 furo


### PR DESCRIPTION
## Description

As described in https://github.com/canonical/sphinx-docs-starter-pack/pull/76 sphinx updated and broke some of the plugins that we use in the starter pack. We are going to pin the version for now, this should make the docs job work again (confirmend also here: [link](https://chat.canonical.com/canonical/pl/6rd9iiziz7bxfmsch19ymmjppr))

## Resolved issues

Docs RTD job is currently failing 

## Documentation

N/A

## Tests

To build the docs do the following:
```
$ cd docs
$ make install
$ make run
```

This should start a webserver, open the doc at: http://127.0.0.1:8000
