### PR TITLE
New plainbox unittests (>0%)

### DIFF
--- a/checkbox-ng/plainbox/impl/commands/test_cmd_session.py
+++ b/checkbox-ng/plainbox/impl/commands/test_cmd_session.py
@@ -1,0 +1,34 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase, mock
+
+from plainbox.impl.commands.cmd_session import SessionCommand
+
+
+class SessionCommandTests(TestCase):
+    @mock.patch(
+        "plainbox.impl.commands.cmd_session.SessionCommand.add_subcommand"
+    )
+    def test_register_parser(self, add_sc):
+        subparser_mock = mock.MagicMock()
+
+        session_command = SessionCommand([])
+        session_command.register_parser(subparser_mock)
+        add_sc.assert_called()
+        self.assertEqual(add_sc.return_value.prog, "plainbox session")

--- a/checkbox-ng/plainbox/impl/commands/test_cmd_session.py
+++ b/checkbox-ng/plainbox/impl/commands/test_cmd_session.py
@@ -30,5 +30,5 @@ class SessionCommandTests(TestCase):
 
         session_command = SessionCommand([])
         session_command.register_parser(subparser_mock)
-        add_sc.assert_called()
+        self.assertTrue(add_sc.called)
         self.assertEqual(add_sc.return_value.prog, "plainbox session")

--- a/checkbox-ng/plainbox/impl/commands/test_deprecated.py
+++ b/checkbox-ng/plainbox/impl/commands/test_deprecated.py
@@ -23,9 +23,9 @@ class DeprecatedTests(TestCase):
     @mock.patch("warnings.warn")
     def test_parse_warning(self, warn_mock):
         import plainbox.impl.commands.parse
-        warn_mock.assert_called()
+        self.assertTrue(warn_mock.called)
 
     @mock.patch("warnings.warn")
     def test_session_warning(self, warn_mock):
         import plainbox.impl.commands.session
-        warn_mock.assert_called()
+        self.assertTrue(warn_mock.called)

--- a/checkbox-ng/plainbox/impl/commands/test_deprecated.py
+++ b/checkbox-ng/plainbox/impl/commands/test_deprecated.py
@@ -1,0 +1,31 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase, mock
+
+
+class DeprecatedTests(TestCase):
+    @mock.patch("warnings.warn")
+    def test_parse_warning(self, warn_mock):
+        import plainbox.impl.commands.parse
+        warn_mock.assert_called()
+
+    @mock.patch("warnings.warn")
+    def test_session_warning(self, warn_mock):
+        import plainbox.impl.commands.session
+        warn_mock.assert_called()

--- a/checkbox-ng/plainbox/impl/commands/test_inv_session.py
+++ b/checkbox-ng/plainbox/impl/commands/test_inv_session.py
@@ -36,4 +36,4 @@ class SessionInvocationTests(TestCase):
         session_command = SessionInvocation(ns, None)
         session_command.show_session()
 
-        print_mock.assert_called()
+        self.assertTrue(print_mock.called)

--- a/checkbox-ng/plainbox/impl/commands/test_inv_session.py
+++ b/checkbox-ng/plainbox/impl/commands/test_inv_session.py
@@ -1,0 +1,39 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase, mock
+
+from plainbox.impl.commands.inv_session import SessionInvocation
+
+
+class SessionInvocationTests(TestCase):
+    @mock.patch(
+        "plainbox.impl.commands.inv_session.SessionInvocation._lookup_storage"
+    )
+    @mock.patch(
+        "builtins.print"
+    )
+    def test_register_parser_none(self, print_mock, lookup_mock):
+        lookup_mock.return_value = None
+        ns = mock.MagicMock()
+        ns.session_id_list = range(1)
+
+        session_command = SessionInvocation(ns, None)
+        session_command.show_session()
+
+        print_mock.assert_called()

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -1,0 +1,44 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase, mock
+
+from plainbox.impl.session import remote_assistant
+
+
+class RemoteAssistantTests(TestCase):
+    def test_allowed_when_ok(self):
+        self_mock = mock.MagicMock()
+        allowed_when = remote_assistant.RemoteSessionAssistant.allowed_when
+
+        @allowed_when(remote_assistant.Idle)
+        def allowed(self, *args): ...
+
+        self_mock._state = remote_assistant.Idle
+        allowed(self_mock)
+
+    def test_allowed_when_fail(self):
+        self_mock = mock.MagicMock()
+        allowed_when = remote_assistant.RemoteSessionAssistant.allowed_when
+
+        @allowed_when(remote_assistant.Idle)
+        def not_allowed(self, *args): ...
+
+        self_mock._state = remote_assistant.Started
+        with self.assertRaises(AssertionError):
+            not_allowed(self_mock)

--- a/checkbox-ng/tox.ini
+++ b/checkbox-ng/tox.ini
@@ -24,6 +24,7 @@ deps =
     MarkupSafe == 0.23
     XlsxWriter == 0.7.3
     tqdm == 4.19.5
+    psutil == 5.9.5
 setenv=
 # we do not care about the package version in tox
 #  but it breaks some old python3.5 builds
@@ -40,6 +41,7 @@ deps =
     MarkupSafe == 1.1.0
     XlsxWriter == 0.9.6
     tqdm == 4.19.5
+    psutil == 5.9.5
 
 [testenv:py38]
 deps =
@@ -52,6 +54,7 @@ deps =
     MarkupSafe == 1.1.0
     XlsxWriter == 1.1.2
     tqdm == 4.30.0
+    psutil == 5.9.5
 
 [testenv:py310]
 deps =
@@ -64,3 +67,4 @@ deps =
     MarkupSafe == 2.0.1
     XlsxWriter == 3.0.2
     tqdm == 4.57.0
+    psutil == 5.9.5


### PR DESCRIPTION
## Description

This PR aims to make every module in plainbox at least imported by the unittests. This allows tox, pytest and any other static analysis tool we may want to start using to analyze them.

I have used this occasion to try to produce some reasonable unittests, so that we get also some value more than just a plain include. 

## Resolved issues

This is part of: https://warthogs.atlassian.net/browse/CHECKBOX-740

## Documentation

N/A

## Tests

To run the tests run the following
```
$ cd checkbox/checkbox-ng/plainbox
$ pytest . -vvv
```
