### PR TITLE
New checkbox-ng unittests (>0%)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/test_check_config.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_check_config.py
@@ -1,0 +1,51 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase, mock
+
+from checkbox_ng.launcher.check_config import CheckConfig
+from plainbox.impl.config import Configuration
+
+
+class CheckConfigTests(TestCase):
+    @mock.patch("builtins.print")
+    @mock.patch("checkbox_ng.launcher.check_config.load_configs")
+    def test_invoked_ok(self, mock_load_configs, mock_print):
+        # this is the default configuration
+        mock_load_configs.return_value = Configuration()
+
+        ret_val = CheckConfig.invoked(...)
+
+        mock_print.assert_any_call("Configuration files:")
+        mock_print.assert_any_call("No problems with config(s) found!")
+        self.assertEqual(ret_val, 0)
+
+    @mock.patch("builtins.print")
+    @mock.patch("checkbox_ng.launcher.check_config.load_configs")
+    def test_invoked_has_problems(self, mock_load_configs, mock_print):
+        # this is the default configuration
+        conf = Configuration()
+        conf.notice_problem("Test problem")
+        mock_load_configs.return_value = conf
+
+        ret_val = CheckConfig.invoked(...)
+
+        mock_print.assert_any_call("Configuration files:")
+        mock_print.assert_any_call("Problems:")
+        mock_print.assert_any_call("- ", "Test problem")
+        self.assertEqual(ret_val, 1)

--- a/checkbox-ng/checkbox_ng/launcher/test_checkbox_cli.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_checkbox_cli.py
@@ -1,0 +1,48 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections import namedtuple
+from unittest import TestCase, mock
+
+from checkbox_ng.launcher.checkbox_cli import main
+
+
+class CheckboxCliTests(TestCase):
+    @mock.patch("sys.argv")
+    @mock.patch("argparse.ArgumentParser.parse_args")
+    @mock.patch("checkbox_ng.launcher.checkbox_cli.Launcher")
+    def test_launcher_ok(
+        self,
+        launcher_mock,
+        parse_args_mock,
+        sys_argv_mock,
+    ):
+        # Add here necessary fake args to provide
+        ns_parse_args_type = namedtuple(
+            "ParseArgsNamespace", ["subcommand", "debug", "verbose"]
+        )
+        parse_args_mock.return_value = ns_parse_args_type(
+            subcommand="launcher", debug=False, verbose=False
+        )
+        # for simplicitys sake, launcher_mock returns itself when constructed
+        launcher_mock.return_value = launcher_mock
+
+        main()
+
+        launcher_mock.assert_called_once()
+        launcher_mock.invoked.assert_called_once()

--- a/checkbox-ng/checkbox_ng/launcher/test_master.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_master.py
@@ -1,0 +1,62 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase, mock
+
+from checkbox_ng.launcher.master import RemoteMaster
+
+
+class MasterTests(TestCase):
+    @mock.patch("ipaddress.ip_address")
+    @mock.patch("time.time")
+    @mock.patch("builtins.print")
+    @mock.patch("os.path.exists")
+    @mock.patch("checkbox_ng.launcher.master.Configuration.from_text")
+    @mock.patch("checkbox_ng.launcher.master._")
+    # used to load an empty launcher with no error
+    def test_invoked_ok(
+        self,
+        gettext_mock,
+        configuration_mock,
+        path_exists_mock,
+        print_mock,
+        time_mock,
+        ip_address_mock,
+    ):
+        ctx_mock = mock.MagicMock()
+        ctx_mock.args.launcher = "example"
+        ctx_mock.args.user = "some username"
+        ctx_mock.args.host = "undertest@local"
+        ctx_mock.args.port = "9999"
+
+        ip_address_mock.return_value = ip_address_mock
+        ip_address_mock.is_loopback = False
+
+        self_mock = mock.MagicMock()
+
+        # make the check if launcher is there go through
+        path_exists_mock.return_value = True
+        # avoid monitoring time (no timeout in this test)
+        time_mock.return_value = 0
+
+        with mock.patch("builtins.open") as mm:
+            mm.return_value = mm
+            mm.read.return_value = "[launcher]\nversion=0"
+            RemoteMaster.invoked(self_mock, ctx_mock)
+
+        self_mock.connect_and_run.assert_called_once()

--- a/checkbox-ng/checkbox_ng/launcher/test_merge_reports.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_merge_reports.py
@@ -1,0 +1,73 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase, mock
+from functools import partial
+
+from checkbox_ng.launcher.merge_reports import MergeReports
+
+
+class MergeReportsTests(TestCase):
+    @mock.patch("checkbox_ng.launcher.merge_reports.TemporaryDirectory")
+    @mock.patch("checkbox_ng.launcher.merge_reports.SessionManager")
+    @mock.patch("checkbox_ng.launcher.merge_reports.JobDefinition")
+    @mock.patch("checkbox_ng.launcher.merge_reports.CategoryUnit")
+    @mock.patch("builtins.print")
+    @mock.patch("tarfile.open")
+    @mock.patch("json.load")
+    # used to load an empty launcher with no error
+    def test_invoked_ok(
+        self,
+        json_mock,
+        tarfile_mock,
+        print_mock,
+        category_mock,
+        job_definition_mock,
+        session_manager_mock,
+        temp_dir_mock,
+    ):
+        ctx_mock = mock.MagicMock()
+        ctx_mock.args.submission = ["submission"]
+        ctx_mock.args.output_file = "file_location"
+
+        self_mock = mock.MagicMock()
+        self_mock._parse_submission = partial(
+            MergeReports._parse_submission, self_mock
+        )
+
+        basic_job_info = {
+            "name": "test_name",
+            "id": "test_id",  # note: no :: to fetch the default ns
+        }
+        sub_to_read = {
+            "title": "report title",
+            "results": [basic_job_info],
+            "resource-results": [basic_job_info],
+            "attachment-results": [basic_job_info],
+            "category_map": {"test_category": "test_name"},
+        }
+        json_mock.return_value = sub_to_read
+
+        with mock.patch("builtins.open"):
+            MergeReports.invoked(self_mock, ctx_mock)
+
+        # output path was printed
+        print_mock.assert_any_call(ctx_mock.args.output_file)
+        exporter = self_mock._create_exporter.return_value
+        # exporter was created and dumped
+        exporter.dump_from_session_manager_list.assert_called_once()

--- a/checkbox-ng/checkbox_ng/launcher/test_merge_submissions.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_merge_submissions.py
@@ -1,0 +1,52 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase, mock
+from functools import partial
+
+from checkbox_ng.launcher.merge_submissions import MergeSubmissions
+
+
+class MergeSubmissionsTests(TestCase):
+    @mock.patch("checkbox_ng.launcher.merge_submissions.TemporaryDirectory")
+    @mock.patch("checkbox_ng.launcher.merge_submissions.SessionManager")
+    @mock.patch("checkbox_ng.launcher.merge_submissions.MergeReports")
+    @mock.patch("builtins.print")
+    @mock.patch("tarfile.open")
+    @mock.patch("json.load")
+    # used to load an empty launcher with no error
+    def test_invoked_ok(
+        self,
+        json_mock,
+        tarfile_mock,
+        print_mock,
+        merge_reports_mock,
+        session_manager_mock,
+        temporary_directory_mock,
+    ):
+        ctx_mock = mock.MagicMock()
+        ctx_mock.args.submission = ["submission"]
+        ctx_mock.args.output_file = "file_location"
+
+        self_mock = mock.MagicMock()
+
+        with mock.patch("builtins.open"):
+            MergeSubmissions.invoked(self_mock, ctx_mock)
+
+        # output path was printed
+        print_mock.assert_any_call(ctx_mock.args.output_file)

--- a/checkbox-ng/checkbox_ng/launcher/test_provider_tools.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_provider_tools.py
@@ -1,0 +1,49 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase, mock
+
+from checkbox_ng.launcher.provider_tools import main
+
+
+class ProviderToolsTests(TestCase):
+    @mock.patch("importlib.util.spec_from_file_location")
+    @mock.patch("importlib.util.module_from_spec")
+    @mock.patch("os.path.exists")
+    def test_ok(self, path_exists_mock, module_fs_mock, spec_from_file_mock):
+        # this loads the manage.py from cwd checking before
+        # make this check pass
+        path_exists_mock.return_value = True
+        main()
+        # manage.py was loaded as spec
+        spec_from_file_mock.assert_called_once()
+        spec_mock = spec_from_file_mock.return_value
+        # mange.py was turned into a module
+        module_fs_mock.assert_called_once()
+        module_mock = module_fs_mock.return_value
+        # and it was launched
+        spec_mock.loader.exec_module.assert_called_with(module_mock)
+
+    @mock.patch("importlib.util.spec_from_file_location")
+    @mock.patch("importlib.util.module_from_spec")
+    @mock.patch("os.path.exists")
+    def test_fail(self, path_exists_mock, module_fs_mock, spec_from_file_mock):
+        # this loads the manage.py from cwd checking before
+        path_exists_mock.return_value = False
+        with self.assertRaises(SystemExit):
+            main()

--- a/checkbox-ng/checkbox_ng/launcher/test_slave.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_slave.py
@@ -1,0 +1,63 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase, mock
+
+from checkbox_ng.launcher.slave import RemoteSlave
+
+
+class SlaveTests(TestCase):
+    @mock.patch("checkbox_ng.launcher.slave._")
+    @mock.patch("checkbox_ng.launcher.slave._logger")
+    @mock.patch("checkbox_ng.launcher.slave.is_passwordless_sudo")
+    @mock.patch("checkbox_ng.launcher.slave.SessionAssistantSlave")
+    @mock.patch("checkbox_ng.launcher.slave.RemoteDebRestartStrategy")
+    @mock.patch("checkbox_ng.launcher.slave.RemoteSessionAssistant")
+    @mock.patch("checkbox_ng.launcher.slave.ThreadedServer")
+    @mock.patch("os.geteuid")
+    @mock.patch("os.getenv")
+    # used to load an empty launcher with no error
+    def test_invoked_ok(
+        self,
+        getenv_mock,
+        geteuid_mock,
+        threaded_server_mock,
+        remote_assistant_mock,
+        remote_strategy_mock,
+        session_assistant_mock,
+        pwdless_sudo_mock,
+        logger_mock,
+        gettext_mock,
+    ):
+        ctx_mock = mock.MagicMock()
+        ctx_mock.args.resume = False
+
+        self_mock = mock.MagicMock()
+
+        geteuid_mock.return_value = 0  # slave will not run as non-root
+        pwdless_sudo_mock.return_value = True  # slave needs pwd-less sudo
+        getenv_mock.return_value = None
+
+        with mock.patch("builtins.open"):
+            RemoteSlave.invoked(self_mock, ctx_mock)
+
+        # slave server was created
+        threaded_server_mock.assert_called_once()
+        server = threaded_server_mock.return_value
+        # the server was started
+        server.start.assert_called_once()

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -1,6 +1,6 @@
 # This file is part of Checkbox.
 #
-# Copyright 2015 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # Written by:
 #   Massimiliano Girardi <massimiliano.girardi@canonical.com>
 #


### PR DESCRIPTION
## Description

There are some files in checkbox-ng that are not even invoked in test runs via tox. This leads to several problems, like files with unsupported syntax going through the tox check due to them not being imported anywhere.

This creates a unittest per file who was missing any coverage. Additionally, this greately increases the overall coverage of the checkbox-ng module, given that the new unit tests actually cover the most important function of all the files (mostly `invoke` or `main`).

> Note: After this PR all files in checkbox-ng must have a coverage >0%

## Resolved issues

Along with https://github.com/canonical/checkbox/pull/675 this
Resolves: https://warthogs.atlassian.net/browse/CHECKBOX-740

## Documentation

N/A

## Tests

To run the new tests do the following:
```
$ cd checkbox/checkbox-ng/checkbox_ng
$ pytest . -vvv
```
