### PR TITLE
Carryover codecov coverage (fixed typo)

### DIFF
--- a/.github/workflows/tox-checkbox-ng.yaml
+++ b/.github/workflows/tox-checkbox-ng.yaml
@@ -32,3 +32,6 @@ jobs:
         run: tox
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests,checkbox-ng

--- a/.github/workflows/tox-checkbox-support.yaml
+++ b/.github/workflows/tox-checkbox-support.yaml
@@ -32,3 +32,6 @@ jobs:
         run: tox
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests,checkbox-support

--- a/.github/workflows/tox-provider-base.yaml
+++ b/.github/workflows/tox-provider-base.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,providers,base
+          flags: unittests,providers,provider-base

--- a/.github/workflows/tox-provider-base.yaml
+++ b/.github/workflows/tox-provider-base.yaml
@@ -32,3 +32,6 @@ jobs:
         run: tox
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests,providers,base

--- a/.github/workflows/tox-provider-certification-client.yaml
+++ b/.github/workflows/tox-provider-certification-client.yaml
@@ -32,3 +32,6 @@ jobs:
         run: tox
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests,providers,certification-client

--- a/.github/workflows/tox-provider-certification-client.yaml
+++ b/.github/workflows/tox-provider-certification-client.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,providers,certification-client
+          flags: unittests,providers,provider-certification-client

--- a/.github/workflows/tox-provider-certification-server.yaml
+++ b/.github/workflows/tox-provider-certification-server.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,providers,certification-server
+          flags: unittests,providers,provider-certification-server

--- a/.github/workflows/tox-provider-certification-server.yaml
+++ b/.github/workflows/tox-provider-certification-server.yaml
@@ -32,3 +32,6 @@ jobs:
         run: tox
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests,providers,certification-server

--- a/.github/workflows/tox-provider-gpgpu.yaml
+++ b/.github/workflows/tox-provider-gpgpu.yaml
@@ -32,3 +32,6 @@ jobs:
         run: tox
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests,providers,gpgpu

--- a/.github/workflows/tox-provider-gpgpu.yaml
+++ b/.github/workflows/tox-provider-gpgpu.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,providers,gpgpu
+          flags: unittests,providers,provider-gpgpu

--- a/.github/workflows/tox-provider-iiotg.yaml
+++ b/.github/workflows/tox-provider-iiotg.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,providers,iiotg
+          flags: unittests,providers,provider-iiotg

--- a/.github/workflows/tox-provider-iiotg.yaml
+++ b/.github/workflows/tox-provider-iiotg.yaml
@@ -32,3 +32,6 @@ jobs:
         run: tox
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests,providers,iiotg

--- a/.github/workflows/tox-provider-resource.yaml
+++ b/.github/workflows/tox-provider-resource.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,providers,resource
+          flags: unittests,providers,provider-resource

--- a/.github/workflows/tox-provider-resource.yaml
+++ b/.github/workflows/tox-provider-resource.yaml
@@ -32,3 +32,6 @@ jobs:
         run: tox
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests,providers,resource

--- a/.github/workflows/tox-provider-sru.yaml
+++ b/.github/workflows/tox-provider-sru.yaml
@@ -32,3 +32,6 @@ jobs:
         run: tox
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests,providers,sru

--- a/.github/workflows/tox-provider-sru.yaml
+++ b/.github/workflows/tox-provider-sru.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,providers,sru
+          flags: unittests,providers,provider-sru

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,8 @@ coverage:
     patch:
       default:
         target: 90%
+flag_manageemnt:
+  default_rules:
+    # carryforward means if a test was not run again, use the previous
+    # coverage result for the current flag (part)
+    carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ coverage:
     patch:
       default:
         target: 90%
-flag_manageemnt:
+flag_management:
   default_rules:
     # carryforward means if a test was not run again, use the previous
     # coverage result for the current flag (part)


### PR DESCRIPTION
## Description
Given that we have a monorepo, we have several "parts" that are independent in the same spot. Every time a change is pushed to a pr or main, if a part was changed, it is tested. Once a part is tested the coverage results are pushed to codecov.io.

This fixes this issue by enabling carryover and flagging the parts. Carryover basically means that if a flag (part) is not updated in a submission, the previous value is used instead. Flags are how codecov identifies the parts, this creates one per part + one for all unittests

## Resolved issues
The issue that we are having is that if a part is not tested in a submission (for example, because it was not changed), codecov "forgets" it existed right now, leading to the coverage values that are not reflecting of reality.

## Documentation
This adds a new flag per part, this should make the output more readable without any need for additional documentation.

## Tests
See the codecov bot comment to get to the dashboard, it should now have a "flags" section that lists the coverage of each part