### PR TITLE
Fixed typo in codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ coverage:
     patch:
       default:
         target: 90%
-flag_manageemnt:
+flag_management:
   default_rules:
     # carryforward means if a test was not run again, use the previous
     # coverage result for the current flag (part)


### PR DESCRIPTION
## Description

The current `codecov.yml` is actually broken due to a typo. This fixes said typo

## Resolved issues

N/A

## Documentation

N/A

## Tests

The config can be verified with:
```
$ curl --data-binary @codecov.yml https://codecov.io/validate
```
