### PR TITLE
virtualization/verify_lxd_vm requires lxd versions only available as snaps (BugFix)

### DIFF
--- a/providers/base/units/virtualization/jobs.pxu
+++ b/providers/base/units/virtualization/jobs.pxu
@@ -5,7 +5,7 @@ environ: LXD_TEMPLATE KVM_IMAGE
 estimated_duration: 60.0
 requires:
  executable.name == 'lxc'
- package.name == 'lxd' or snap.name == 'lxd'
+ snap.name == 'lxd'
 command: virtualization.py --debug lxdvm
 _description:
  Verifies that an LXD Virtual Machine can be created and launched


### PR DESCRIPTION
…snaps

lxd virtual machine support was added in 4.0, but there are no debs for lxd >= 4 in the Ubuntu ecosystem. bionic systems deploy with an old 3.x lxd deb, so testing with that installed results in a false alarm.

DEBUG:root:Attempting to initialize LXD
DEBUG:root:Command lxd init --auto:
DEBUG:root: Command returned no output
DEBUG:root:Launching Virtual Machine
DEBUG:root:No local image available, attempting to import from default remote. ERROR:root:Command lxc init ubuntu:18.04 testbed --vm  returned a code of 1 ERROR:root: STDOUT:
ERROR:root: STDERR: Error: unknown flag: --vm

Fixes #684
