### PR TITLE
Make the remote api mismatch message clearer

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/master.py
+++ b/checkbox-ng/checkbox_ng/launcher/master.py
@@ -180,7 +180,7 @@ class RemoteMaster(ReportsStage, MainLoopStage):
         #  check if ever disconnected
         ever_disconnected = False
         #  this to animate the dash
-        spinner = itertools.cycle('-\\|/')
+        spinner = itertools.cycle("-\\|/")
         #  this tracks the disconnection time
         disconnection_time = 0
         while True:
@@ -235,12 +235,22 @@ class RemoteMaster(ReportsStage, MainLoopStage):
                     )
                 master_api_version = RemoteSessionAssistant.REMOTE_API_VERSION
                 if slave_api_version != master_api_version:
-                    raise SystemExit(
-                        _(
-                            "Remote API version mismatch. Service "
-                            "uses: {}. Remote uses: {}"
-                        ).format(slave_api_version, master_api_version)
+                    problem_msg = (
+                        "You are trying to connect to an incompatible "
+                        "checkbox agent! To solve this, upgrade the {} to the "
+                        "{} version. (Agent version: {}, Controller "
+                        "version {})"
                     )
+                    if master_api_version > slave_api_version:
+                        solution = ("agent", "controller")
+                    else:
+                        solution = ("controller", "agent")
+
+                    problem_msg = problem_msg.format(
+                        *solution, slave_api_version, master_api_version
+                    )
+
+                    raise SystemExit(_(problem_msg))
                 state, payload = self.sa.whats_up()
                 _logger.info("remote: Main dispatch with state: %s", state)
                 if printed_reconnecting and ever_disconnected:
@@ -297,7 +307,7 @@ class RemoteMaster(ReportsStage, MainLoopStage):
                     ever_disconnected = True
                     printed_reconnecting = True
                 print(next(spinner), end="\b", flush=True)
-                time.sleep(.25)
+                time.sleep(0.25)
             except KeyboardInterrupt:
                 interrupted = True
 

--- a/checkbox-ng/checkbox_ng/launcher/master.py
+++ b/checkbox-ng/checkbox_ng/launcher/master.py
@@ -235,19 +235,27 @@ class RemoteMaster(ReportsStage, MainLoopStage):
                     )
                 master_api_version = RemoteSessionAssistant.REMOTE_API_VERSION
                 if slave_api_version != master_api_version:
-                    problem_msg = (
-                        "You are trying to connect to an incompatible "
-                        "checkbox agent! To solve this, upgrade the {} to the "
-                        "{} version. (Agent version: {}, Controller "
-                        "version {})"
+                    template_msg = (
+                        "The controller that you are using is {} than the agent "
+                        "you are trying to connect to.\n"
+                        "To solve this, upgrade the {} to the "
+                        "{} version.\n"
+                        "If you are unsure about the nomenclature see:\n"
+                        "https://checkbox.readthedocs.io/en/latest/reference"
+                        "/glossary.html\n\n"
+                        "Error: (Agent version: {}, Controller version {})"
                     )
                     if master_api_version > slave_api_version:
+                        problem = "newer"
                         solution = ("agent", "controller")
                     else:
+                        problem = "older"
                         solution = ("controller", "agent")
-
-                    problem_msg = problem_msg.format(
-                        *solution, slave_api_version, master_api_version
+                    problem_msg = template_msg.format(
+                        problem,
+                        *solution,
+                        slave_api_version,
+                        master_api_version
                     )
 
                     raise SystemExit(_(problem_msg))

--- a/checkbox-ng/checkbox_ng/launcher/master.py
+++ b/checkbox-ng/checkbox_ng/launcher/master.py
@@ -173,33 +173,40 @@ class RemoteMaster(ReportsStage, MainLoopStage):
         """
         agent_api_version = self.sa.get_remote_api_version()
         controller_api_version = RemoteSessionAssistant.REMOTE_API_VERSION
+
         if agent_api_version == controller_api_version:
             return
-        template_msg = (
-            "The controller that you are using is {} than the agent "
+
+        newer_msg = _(
+            "The controller that you are using is newer than the agent "
             "you are trying to connect to.\n"
-            "To solve this, upgrade the {} to the "
-            "{} version.\n"
-            "If you are unsure about the nomenclature see:\n"
-            "https://checkbox.readthedocs.io/en/latest/reference"
-            "/glossary.html\n\n"
+            "To solve this, upgrade the agent to the controller version.\n"
+            "If you are unsure about the nomenclature or what any of this "
+            "means, see:\n"
+            "https://checkbox.readthedocs.io/en/latest/reference/"
+            "glossary.html\n\n"
             "Error: (Agent version: {}, Controller version {})"
         )
-        if controller_api_version > agent_api_version:
-            problem = "newer"
-            solution = ("agent", "controller")
-        else:
-            problem = "older"
-            solution = ("controller", "agent")
-        problem_msg = template_msg.format(
-            problem,
-            *solution,
-            agent_api_version,
-            controller_api_version
+
+        older_msg = _(
+            "The controller that you are using is older than the agent "
+            "you are trying to connect to.\n"
+            "To solve this, upgrade the controller to the agent version.\n"
+            "If you are unsure about the nomenclature or what any of this "
+            "means, see:\n"
+            "https://checkbox.readthedocs.io/en/latest/reference/"
+            "glossary.html\n\n"
+            "Error: (Agent version: {}, Controller version {})"
         )
 
-        raise SystemExit(_(problem_msg))
+        if controller_api_version > agent_api_version:
+            problem_msg = newer_msg
+        else:
+            problem_msg = older_msg
 
+        raise SystemExit(
+            problem_msg.format(agent_api_version, controller_api_version)
+        )
 
     def connect_and_run(self, host, port=18871):
         config = rpyc.core.protocol.DEFAULT_CONFIG.copy()

--- a/checkbox-ng/checkbox_ng/launcher/test_master.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_master.py
@@ -62,10 +62,7 @@ class MasterTests(TestCase):
         self.assertTrue(self_mock.connect_and_run.called)
 
     @mock.patch("checkbox_ng.launcher.master.RemoteSessionAssistant")
-    @mock.patch("checkbox_ng.launcher.master._")
-    def test_check_remote_api_match_ok(
-        self, gettext_mock, remote_assistant_mock
-    ):
+    def test_check_remote_api_match_ok(self, remote_assistant_mock):
         """
         Test that the check_remote_api_match function does not fail/crash
         if the two versions match
@@ -78,14 +75,9 @@ class MasterTests(TestCase):
         session_assistant_mock.get_remote_api_version.return_value = 0
 
         RemoteMaster.check_remote_api_match(self_mock)
-        # assert this runs with no problem, the two versions are the same
-        self.assertTrue(True)
 
     @mock.patch("checkbox_ng.launcher.master.RemoteSessionAssistant")
-    @mock.patch("checkbox_ng.launcher.master._")
-    def test_check_remote_api_match_fail(
-        self, gettext_mock, remote_assistant_mock
-    ):
+    def test_check_remote_api_match_fail(self, remote_assistant_mock):
         """
         Test that the check_remote_api_match function exits checkbox
         if the two versions don't match

--- a/checkbox-ng/checkbox_ng/launcher/test_master.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_master.py
@@ -60,3 +60,51 @@ class MasterTests(TestCase):
             RemoteMaster.invoked(self_mock, ctx_mock)
 
         self.assertTrue(self_mock.connect_and_run.called)
+
+    @mock.patch("checkbox_ng.launcher.master.RemoteSessionAssistant")
+    @mock.patch("checkbox_ng.launcher.master._")
+    def test_check_remote_api_match_ok(
+        self, gettext_mock, remote_assistant_mock
+    ):
+        """
+        Test that the check_remote_api_match function does not fail/crash
+        if the two versions match
+        """
+        self_mock = mock.MagicMock()
+        session_assistant_mock = mock.MagicMock()
+        self_mock.sa = session_assistant_mock
+
+        remote_assistant_mock.REMOTE_API_VERSION = 0
+        session_assistant_mock.get_remote_api_version.return_value = 0
+
+        RemoteMaster.check_remote_api_match(self_mock)
+        # assert this runs with no problem, the two versions are the same
+        self.assertTrue(True)
+
+    @mock.patch("checkbox_ng.launcher.master.RemoteSessionAssistant")
+    @mock.patch("checkbox_ng.launcher.master._")
+    def test_check_remote_api_match_fail(
+        self, gettext_mock, remote_assistant_mock
+    ):
+        """
+        Test that the check_remote_api_match function exits checkbox
+        if the two versions don't match
+        """
+        self_mock = mock.MagicMock()
+        session_assistant_mock = mock.MagicMock()
+        self_mock.sa = session_assistant_mock
+
+        remote_assistant_mock.REMOTE_API_VERSION = 1
+        session_assistant_mock.get_remote_api_version.return_value = 0
+
+        with self.assertRaises(SystemExit):
+            # this should exit checkbox because the two versions are different
+            RemoteMaster.check_remote_api_match(self_mock)
+
+        remote_assistant_mock.REMOTE_API_VERSION = 0
+        session_assistant_mock.get_remote_api_version.return_value = 1
+
+        with self.assertRaises(SystemExit):
+            # this should also exit checkbox because the two versions are
+            # different
+            RemoteMaster.check_remote_api_match(self_mock)


### PR DESCRIPTION
## Description

As a step to make the release (aftermath) smoother, we have to improve how errors are communicated to the users. Checkbox remote does not start if both agent and controller are compatible but the current message is not very clear. 

This updates that message with hopefully clearer wording and a link to the docs.

The new error message looks like this:
```
The controller that you are using is newer than the agent you are trying to connect to.
To solve this, upgrade the agent to the controller version.
If you are unsure about the nomenclature see:
https://checkbox.readthedocs.io/en/latest/reference/glossary.html

Error: (Agent version: 11, Controller version 13)
```

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/659
Part of: https://warthogs.atlassian.net/browse/CHECKBOX-820

## Documentation

This separates the check into a function with a new docstring to explain what the purpose of it is

## Tests

This move the checking into a new function and tests it via two new unit tests. To run them:
```
$ cd checkbox_ng/launcher
$ pytest test_master.py
```
