### PR TITLE
Always allow manual triggering of daily builds

### DIFF
--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         releases: [16, 18, 20, 22]
     needs: check_history
-    if: ${{ needs.check_history.outputs.should_run != 'false' }}
+    if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       SERIES: series${{ matrix.releases }}

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -33,7 +33,7 @@ jobs:
         type: [classic, uc]
         releases: [16, 18, 20, 22]
     needs: check_history
-    if: ${{ needs.check_history.outputs.should_run != 'false' }}
+    if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       SERIES: series_${{ matrix.type }}${{ matrix.releases }}


### PR DESCRIPTION
## Description

The manual triggering of daily builds for snaps still checks for changes in the previous 24h. 

This makes it do it either way, given that we are manually triggering it, we want it to run. 

## Resolved issues

Today we want to re-run daily builds because one of them failed and the changes are not detected by the workflow anymore. (This is another thing that needs fixing, but it is outside of this PR scope)

## Documentation

N/A (arguably, this is the behavior one would expect from a manual run of the workflow)

## Tests

N/A
