### PR TITLE
Upgrade release docs canary

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,19 @@
+<!--
+Make sure that your PR title is clear and contains a traceability marker.
+
+Traceability Markers is what we use to understand the impact of your change at a glance.
+Pick one of the following:
+- Neutral (NE): Your change only includes documentation, comments, github actions or metabox
+- BugFix (BF): Your change fixes a bug
+- NewFeature (NF): Your chage is a new backward compatible feature, a new test/test plan/test inclusion
+- BreakingChange (BC): Your change breaks backward compatibility.
+    - This includes any API change to checkbox-ng/checkbox-support
+    - Changes to PXU grammar/field requirements
+    - Breaking changes to dependencies in snaps (fwts upgrade for example)
+If your change is to providers it can only be (NE, BF or NF)
+
+Example Title: Fixed bugged behaviour of checkbox load config (BF)
+-->
 ## Description
 
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,16 +3,16 @@ Make sure that your PR title is clear and contains a traceability marker.
 
 Traceability Markers is what we use to understand the impact of your change at a glance.
 Pick one of the following:
-- Neutral (NE): Your change only includes documentation, comments, github actions or metabox
-- BugFix (BF): Your change fixes a bug
-- NewFeature (NF): Your chage is a new backward compatible feature, a new test/test plan/test inclusion
-- BreakingChange (BC): Your change breaks backward compatibility.
+- Infra: Your change only includes documentation, comments, github actions or metabox
+- BugFix: Your change fixes a bug
+- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
+- Breaking: Your change breaks backward compatibility.
     - This includes any API change to checkbox-ng/checkbox-support
     - Changes to PXU grammar/field requirements
     - Breaking changes to dependencies in snaps (fwts upgrade for example)
-If your change is to providers it can only be (NE, BF or NF)
+If your change is to providers it can only be (Infra, BugFix or New)
 
-Example Title: Fixed bugged behaviour of checkbox load config (BF)
+Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
 -->
 ## Description
 

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -85,7 +85,7 @@ this is what that would look like:
   ```
 - Tag the release
   ```
-  git tag -s "v2.10.0" -m "Bump version: 2.9.1 → 2.10.0"
+  git tag -s "v2.10.0" -m "Beta promotion of: 2.9.1 → 2.10.0"
   ```
 - Push the tag to origin
   ```

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -4,6 +4,41 @@
 Sometimes, the builders will be down and this might prevent building the
 packages.
 
+## When can you relase a new beta candidate
+
+You can release a new beta candidate when you have at least one commit tagged
+by the verification process. This process will add a tag to the latest commit
+it can fetch with the version that is being verified and a
+`edge-validation-success` suffix. The verification process works as follows:
+
+```mermaid
+flowchart TD
+    A[Wait for specific time of the day] --New changes--> D
+    D[Build runtime/frontend snaps]
+    A --No new change--> A
+    D --Build failed--> E(Tag commit with: edge-validation-failed)
+    E --> A
+    D --Build ok--> F[Verify snaps via Metabox]
+    F --Validation ok--> G[Run canary testing via jenkins]
+    F --Validation failed --->E
+    G --Validation failed --->E
+    G --Validation ok--->H(Tag commit with: edge-validation-success)
+```
+
+> **_NOTE:_** This process is fully automated, you don't need to trigger it.
+
+If you want to verify the status of the latest edge build, run:
+```bash
+$ git fetch --tags
+$ git describe --tags --match "*edge-validation*" origin/main &&
+    git log -1 $(
+        git describe --tags --match "*edge-validation*" --abbrev=0 origin/main)
+```
+
+These commands will show you the latest tag that is in the repo and the commit
+it is associated with. If this tag ends with `edge-validation-success` you can
+proceed with the release.
+
 ## Promote the previous beta release to stable
 
 Internal teams (mostly QA and Certification) are using the version in the beta
@@ -39,7 +74,7 @@ Then, it's time to build the new beta version.
 
 ## How packages versions are generated?
 
-Both Debian packages and checkbox snaps rely on [setuptools_scm] to extract 
+Both Debian packages and checkbox snaps rely on [setuptools_scm] to extract
 package versions from git metadata.
 
 ```

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -9,7 +9,12 @@ packages.
 You can release a new beta candidate when you have at least one commit tagged
 by the verification process. This process will add a tag to the latest commit
 it can fetch with the version that is being verified and a
-`edge-validation-success` suffix. The verification process works as follows:
+`edge-validation-success` suffix. Note, any commit with that suffix is in theory
+a valid candidate for promotion but please, if any more recent commit is marked
+as `edge-validation-failed` investigate why, we may have upgraded the testing
+infra from one commit to the other!
+
+The verification process works as follows:
 
 ```mermaid
 flowchart TD
@@ -75,21 +80,29 @@ If the list includes:
 - New, backward compatible features: you have to increment the minor version
 - Non-backward compatible changes: you have to increment the major version
 
+All commit messages in the main history should have a postfix indicating what
+kind of change they are:
+- **Infra:** are changes to our testing infrastructure, you can safely ignore
+them
+- **Bugfix:** are bugfixes, increment patch version
+- **New:** are new backward compatible features, increment minor version
+- **Breaking:** are new breaking changes, increment major version
+
 If you were to be at at the tag `v2.9.1-edge-validation-success` and you
 had to release a new version with at least one backward compatible new feature,
-this is what that would look like:
+run the following commands:
 
 - Clone the repository
   ```
-  git clone git@github.com:canonical/checkbox.git
+  $ git clone git@github.com:canonical/checkbox.git
   ```
 - Tag the release
   ```
-  git tag -s "v2.10.0" -m "Beta promotion of: 2.9.1 → 2.10.0"
+  $ git tag -s "v2.10.0" -m "Beta promotion of: 2.9.1 → 2.10.0"
   ```
 - Push the tag to origin
   ```
-  git push --tags
+  $ git push --tags
   ```
 
 ## How packages versions are generated?


### PR DESCRIPTION
## Description

The new canary testing is ready to be integrated in the regular workflow but it is not yet completely documented in the release doc. We are also expecting whoever is doing the release to tag with a new version number but we do not explain what we expect that number to be.

This adds a handy guide on how edge validation works and how to know what the current status of edge is. This also includes an improved explanation on how to update the tag and how to decide the new value.

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/CHECKBOX-820 

## Documentation

N/A

## Tests

N/A
