### PR TITLE
make the config chains scenario in metabox local-only

### DIFF
--- a/metabox/metabox/scenarios/config/chains.py
+++ b/metabox/metabox/scenarios/config/chains.py
@@ -32,7 +32,9 @@ from metabox.core.utils import tag
 from .config_files import chains
 
 
+@tag("config-chains")
 class ConfigChainsPriority(Scenario):
+    modes = ["local"]
     etc_checkbox = read_text(chains, "etc_checkbox.conf")
     etc_checkbox_includes_includes = read_text(
         chains, "etc_checkbox_includes_includes.conf"


### PR DESCRIPTION
This should never have run via remote because:
- the configs on the controller are not taken into account
- the agent runs as root, so configs for the `ubuntu` user are pointless

There is more that we can improve in this test, but this patch at least fixes the metabox runs.
