### PR TITLE
Removed category flags (Infra)

### DIFF
--- a/.github/workflows/tox-checkbox-ng.yaml
+++ b/.github/workflows/tox-checkbox-ng.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,checkbox-ng
+          flags: checkbox-ng

--- a/.github/workflows/tox-checkbox-support.yaml
+++ b/.github/workflows/tox-checkbox-support.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,checkbox-support
+          flags: checkbox-support

--- a/.github/workflows/tox-provider-base.yaml
+++ b/.github/workflows/tox-provider-base.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,providers,provider-base
+          flags: provider-base

--- a/.github/workflows/tox-provider-certification-client.yaml
+++ b/.github/workflows/tox-provider-certification-client.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,providers,provider-certification-client
+          flags: provider-certification-client

--- a/.github/workflows/tox-provider-certification-server.yaml
+++ b/.github/workflows/tox-provider-certification-server.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,providers,provider-certification-server
+          flags: provider-certification-server

--- a/.github/workflows/tox-provider-gpgpu.yaml
+++ b/.github/workflows/tox-provider-gpgpu.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,providers,provider-gpgpu
+          flags: provider-gpgpu

--- a/.github/workflows/tox-provider-iiotg.yaml
+++ b/.github/workflows/tox-provider-iiotg.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,providers,provider-iiotg
+          flags: provider-iiotg

--- a/.github/workflows/tox-provider-resource.yaml
+++ b/.github/workflows/tox-provider-resource.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,providers,provider-resource
+          flags: provider-resource

--- a/.github/workflows/tox-provider-sru.yaml
+++ b/.github/workflows/tox-provider-sru.yaml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests,providers,provider-sru
+          flags: provider-sru


### PR DESCRIPTION
## Description

Codecov.io carryover does not seem to support partial carry over. What this would do is make our tests fail due to dropping coverage on "categories" flags (for example, unittest) due to the fact that if any coverage for a category is submitted, it is assumed as the overall coverage of the flag. 

This removes category flags leaving just the leaf flags for each part on the monorepo

## Resolved issues

See: https://github.com/canonical/checkbox/pull/690, unittest coverage is marked as -58% but this is not actually the case, `unittest` is just a category that includes one of the tests that were run

## Documentation

N/A

## Tests

N/A
