### PR TITLE
Fix clocktest.c complie warning and add more error handling (BugFix)

### DIFF
--- a/providers/base/src/Makefile
+++ b/providers/base/src/Makefile
@@ -7,7 +7,7 @@ clean:
 
 threaded_memtest: CFLAGS += -pthread
 threaded_memtest: CFLAGS += -Wno-unused-but-set-variable
-clocktest: CFLAGS += -D_POSIX_C_SOURCE=199309L -D_BSD_SOURCE
+clocktest: CFLAGS += -D_POSIX_C_SOURCE=199309L -D_DEFAULT_SOURCE
 clocktest: LDLIBS += -lrt
 alsa_test: CXXFLAGS += -std=c++11
 alsa_test: LDLIBS += -lasound -pthread


### PR DESCRIPTION
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->
1.`_BSD_SOURCE` is deprecated when [glibc 2.20](https://sourceware.org/legacy-ml/libc-alpha/2014-09/msg00088.html) was released at 2014/09/08.
It should be fine to change `_BSD_SOURCE` to `_DEFAULT_SOURCE`.

2.If `num_cpus` is [`-1`](https://www.gnu.org/software/libc/manual/html_node/Sysconf-Definition.html), it will make garbage value for `time` to calculate `jitter`.
Adding to check `num_cpus` shouldn't be `-1`.

3.malloc won't be always return success.
Adding to check the return value shouldn't be `NULL`.

4.After `malloc` memory for `time`, it is never released.
Adding `free` before return.

5.Change `tab` to `space`

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
This commit makes the code more robust only.

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
-->
This change has been tested to compile and run on Ubuntu 22.04 and 16.04 without any issue.

```sh
u@u-Inspiron-5594:/dev/shm$ ./clocktest
Testing for clock jitter on 8 cpus
PASSED: largest jitter seen was 0.000620

Testing clock direction for 5 minutes...
PASSED: Iteration 0 delta: 0.000466
PASSED: Iteration 1 delta: 0.000514
PASSED: Iteration 2 delta: 0.000463
PASSED: Iteration 3 delta: 0.000298
PASSED: Iteration 4 delta: 0.000404
clock direction test: sleeptime 60 sec per iteration, failed iterations: 0
u@u-Inspiron-5594:/dev/shm$ ./clocktest-m 
Testing for clock jitter on 8 cpus
PASSED: largest jitter seen was 0.000605

Testing clock direction for 5 minutes...
PASSED: Iteration 0 delta: 0.000163
PASSED: Iteration 1 delta: 0.000096
PASSED: Iteration 2 delta: 0.001384
PASSED: Iteration 3 delta: 0.000346
PASSED: Iteration 4 delta: 0.000537
clock direction test: sleeptime 60 sec per iteration, failed iterations: 0
```


