### PR TITLE
Re-delete the apste_support job from the server-disk test plan after it (BugFix)

### DIFF
--- a/providers/base/units/disk/test-plan.pxu
+++ b/providers/base/units/disk/test-plan.pxu
@@ -80,4 +80,3 @@ include:
     disk/fstrim_.*                             certification-status=non-blocker
     disk/disk_stress_ng_.*                     certification-status=blocker
     disk/disk_cpu_load_.*                      certification-status=blocker
-    disk/apste_support_on_.*                   certification-status=non-blocker


### PR DESCRIPTION
Re-delete the apste_support job that was mistakenly re-added by another commit.

resolves SHENG-2304 SERVCERT-1260 #698 

