### PR TITLE
Fix retcode on fail

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
+++ b/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
@@ -160,4 +160,8 @@ def main():
     if args.debug:
         logging_level = logging.DEBUG
         logging.basicConfig(level=logging_level)
-    subcmd.invoked(ctx)
+    return subcmd.invoked(ctx)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/checkbox-ng/checkbox_ng/launcher/master.py
+++ b/checkbox-ng/checkbox_ng/launcher/master.py
@@ -159,7 +159,7 @@ class RemoteMaster(ReportsStage, MainLoopStage):
             )
         while time.time() < deadline:
             try:
-                self.connect_and_run(ctx.args.host, port)
+                return self.connect_and_run(ctx.args.host, port)
                 break
             except (ConnectionRefusedError, socket.timeout, OSError):
                 print(".", end="", flush=True)

--- a/metabox/metabox/metabox-provider/units/basic-tps.pxu
+++ b/metabox/metabox/metabox-provider/units/basic-tps.pxu
@@ -45,3 +45,10 @@ include:
  config-environ-source
  config-environ-vars
  config-environ-case
+
+unit: test plan
+id: pass-and-fail
+_name: Pass and Fail
+include:
+ basic-shell-passing
+ basic-shell-failing

--- a/metabox/metabox/scenarios/basic/return_codes.py
+++ b/metabox/metabox/scenarios/basic/return_codes.py
@@ -1,0 +1,46 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+
+from metabox.core.scenario import Scenario
+from metabox.core.actions import AssertRetCode, Start
+from metabox.core.utils import tag
+
+
+@tag("return-code", "basic")
+class ReturnCodeIsOneOnFail(Scenario):
+    """
+    Check that the return code is 1 when one of the tests included
+    in the test plan fails.
+    """
+
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification:: pass-and-fail
+        forced = yes
+        [test selection]
+        forced = yes
+        """
+    )
+    steps = [
+        Start(),
+        AssertRetCode(1),
+    ]

--- a/metabox/metabox/scenarios/basic/return_codes.py
+++ b/metabox/metabox/scenarios/basic/return_codes.py
@@ -34,10 +34,12 @@ class ReturnCodeIsOneOnFail(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification:: pass-and-fail
+        unit = 2021.com.canonical.certification::pass-and-fail
         forced = yes
         [test selection]
         forced = yes
+        [ui]
+        type = silent
         """
     )
     steps = [


### PR DESCRIPTION
## Description
This patch makes Checkbox return a valid return code depending on the outcome of the test plan being run.
Previously Checkbox remote always returned 0, even when some of the jobs failed. This patch makes checkbox return 0 only when **everything** passed.

## Tests

I'm providing a metabox test in this PR that checks this mechanic.