### PR TITLE
sanitize output printed by loguru so it doesn't crash on backtraces

### DIFF
--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -276,9 +276,12 @@ class Runner:
             if not scn.has_passed():
                 self.failed = True
                 logger.error(scenario_description + " scenario has failed.")
-                logger.error(
-                    "Scenario output:\n" + scn.get_output_streams().strip()
-                )
+
+                # let's strip < from the output to avoid confusing loguru
+                # loguru assumes that <> is used for colorizing
+                output = scn.get_output_streams().strip().replace("<", "\<")
+
+                logger.error("Scenario output:\n" + output)
                 if self.hold_on_fail:
                     if scn.mode == "remote":
                         msg = (


### PR DESCRIPTION
## Description

This patch makes sure that we don't send unescaped `<` characters to loguru (the other end is not needed to be sanitized).
This helps develop metabox scenarios (that may crash during development).