### PR TITLE
Fix metabox test RunFailingTestplan (infra)

### DIFF
--- a/metabox/metabox/scenarios/basic/run-invocation.py
+++ b/metabox/metabox/scenarios/basic/run-invocation.py
@@ -1,14 +1,14 @@
 # This file is part of Checkbox.
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # Written by:
 #   Maciej Kisielewski <maciej.kisielewski@canonical.com>
 #   Sylvain Pineau <sylvain.pineau@canonical.com>
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
 # as published by the Free Software Foundation.
-
 #
 # Checkbox is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -18,59 +18,63 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 import metabox.core.keys as keys
-from metabox.core.actions import AssertPrinted
-from metabox.core.actions import AssertRetCode
-from metabox.core.actions import Expect
-from metabox.core.actions import Send
-from metabox.core.actions import Start
+from metabox.core.actions import (
+    AssertPrinted,
+    AssertRetCode,
+    Expect,
+    Send,
+    Start,
+)
 from metabox.core.scenario import Scenario
 
 
 class RunTestplan(Scenario):
-
-    modes = ['local']
-    config_override = {'local': {'releases': ['bionic']}}
+    modes = ["local"]
+    config_override = {"local": {"releases": ["bionic"]}}
     steps = [
-        Start('run 2021.com.canonical.certification::'
-              'basic-automated-passing', timeout=30),
-        AssertRetCode(0)
+        Start(
+            "run 2021.com.canonical.certification::basic-automated-passing",
+            timeout=30,
+        ),
+        AssertRetCode(0),
     ]
 
 
 class RunFailingTestplan(Scenario):
-
-    modes = ['local']
+    modes = ["local"]
     steps = [
-        Start('run 2021.com.canonical.certification::'
-              'basic-automated-failing', timeout=30),
-        AssertRetCode(0)
+        Start(
+            "run 2021.com.canonical.certification::basic-automated-failing",
+            timeout=30,
+        ),
+        AssertRetCode(0),
     ]
 
 
 class RunTestplanWithEnvvar(Scenario):
-
-    modes = ['local']
-    environment = {'foo': 42}
+    modes = ["local"]
+    environment = {"foo": 42}
     steps = [
-        Start('run 2021.com.canonical.certification::basic-automated',
-              timeout=30),
+        Start(
+            "run 2021.com.canonical.certification::basic-automated", timeout=30
+        ),
         AssertPrinted("foo: 42"),
     ]
 
 
 class RunManualplan(Scenario):
-
-    modes = ['local']
+    modes = ["local"]
     steps = [
-        Start('run 2021.com.canonical.certification::basic-manual'),
-        Expect('Pick an action'),
+        Start("run 2021.com.canonical.certification::basic-manual"),
+        Expect("Pick an action"),
         Send(keys.KEY_ENTER),
-        Expect('Pick an action', timeout=30),
-        Send('p' + keys.KEY_ENTER),
-        Expect('Pick an action'),
+        Expect("Pick an action", timeout=30),
+        Send("p" + keys.KEY_ENTER),
+        Expect("Pick an action"),
         Send(keys.KEY_ENTER),
-        Expect('Pick an action'),
-        Send('p' + keys.KEY_ENTER),
-        Expect(' [32;1m☑ [0m: '
-               'A simple user interaction and verification job'),
+        Expect("Pick an action"),
+        Send("p" + keys.KEY_ENTER),
+        Expect(
+            " [32;1m☑ [0m: A simple user interaction and verification job"
+        ),
     ]

--- a/metabox/metabox/scenarios/basic/run-invocation.py
+++ b/metabox/metabox/scenarios/basic/run-invocation.py
@@ -47,7 +47,7 @@ class RunFailingTestplan(Scenario):
             "run 2021.com.canonical.certification::basic-automated-failing",
             timeout=30,
         ),
-        AssertRetCode(0),
+        AssertRetCode(1),
     ]
 
 


### PR DESCRIPTION
## Description

Fixing the return code of the run command makes the metabox scenario that tested it (somewhat wrongly) fail. This fixes it

## Resolved issues

N/A

## Documentation

I think this is the expected behavior (test fails, `exit(1)`), we don't need any new documentation

## Tests

To run the test you can run the following:
```
$ metabox local-source-16.04.py --tag RunFailingTestplan
$ metabox local-source-18.04.py --tag RunFailingTestplan
$ metabox local-source-20.04.py --tag RunFailingTestplan
$ metabox local-source-22.04.py --tag RunFailingTestplan
```
