### PR TITLE
Fix: support v4l2_cap_streaming for camera/detect

### DIFF
--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -211,7 +211,8 @@ class CameraTest:
             resolutions = resolutions.replace("Format:", "    Format:")
             print(resolutions)
 
-            if cp.capabilities & V4L2_CAP_VIDEO_CAPTURE:
+            if cp.capabilities & V4L2_CAP_VIDEO_CAPTURE or \
+                    cp.capabilities & V4L2_CAP_STREAMING:
                 cap_status = 0
         return dev_status | cap_status
 


### PR DESCRIPTION
## Description

Some camera devices' driver only support V4L2_CAP_STREAMING flag, however, the camera/detect job only allows V4L2_CAP_VIDEO_CAPTURE flag currently.

It causes all camera related jobs be skipped since they are depend on camera/detect job. Therefore, I update this script to support V4L2_CAP_STREAMING flag.

Ref:
  - https://www.kernel.org/doc/html/v5.15/userspace-api/media/v4l/vidioc-querycap.html?highlight=vidioc_querycap
  - https://www.kernel.org/doc/html/v5.15/userspace-api/media/v4l/mmap.html#mmap

## Resolved issues

### Baoshan Project
  - This submission shows that the MIPI ISP camera supports V4L2_CAP_STREAMING flag only
    - https://certification.canonical.com/hardware/202202-29979/submission/295167/test-results/?term=camera

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
