### PR TITLE
Don't use '-A' in network.py on non-numa systems (BugFix)

### DIFF
--- a/providers/base/tests/test_network.py
+++ b/providers/base/tests/test_network.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import patch, mock_open
+
+from network import IPerfPerformanceTest
+
+class IPerfPerfomanceTestTests(unittest.TestCase):
+
+    def test_find_numa_reports_node(self):
+        with patch('builtins.open', mock_open(read_data="1")) as mo:
+            returned = IPerfPerformanceTest.find_numa(None, "device")
+            self.assertEqual(returned, 1)
+
+    def test_find_numa_minus_one_from_sysfs(self):
+        with patch('builtins.open', mock_open(read_data="-1")) as mo:
+            returned = IPerfPerformanceTest.find_numa(None, "device")
+            self.assertEqual(returned, -1)
+    def test_find_numa_numa_node_not_found(self):
+        with patch('builtins.open', mock_open()) as mo:
+            mo.side_effect = FileNotFoundError
+            returned = IPerfPerformanceTest.find_numa(None, "device")
+            self.assertEqual(returned, -1)


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description
This PR fixes bug #570, which can cause the CPU load to spike if the CPU affinity is set incorrectly on systems that don't support NUMA features.

The fix involves identifying systems that lack NUMA support and _not_ passing the -A {nodes} option to iperf3 on such systems.


<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

Resolves bug #570

Jira card: https://warthogs.atlassian.net/browse/SERVCERT-1183

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

No documentation changes required.
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

Tested on lloobee (my own ARM64-based development system), which exhibited the bug. The new version drops the CPU load from 90%+ to about 35-40%, and increases the throughput by about 5% (from 88% to 93%, give or take a percent or two).

I've also tested on two servers in the Server Certification pool, torchtusk and whomp, to be sure the script doesn't create problems on systems that DO support NUMA. No unexpected problems arose. The change should result in exactly the same iperf3 command being used on such systems as the previous version of the script. Such systems were unaffected by the bug to begin with.

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
