### PR TITLE
fix `pip install -e .` for focal (older pip) (Infra)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -173,8 +173,6 @@ parts:
     override-build: |
       # this is a bodge to be backward compatible
       snapcraftctl build
-      # setup.py is necessary for this old pip verision
-      echo "from setuptools import setup; setup()" > setup.py
       # update pip and setuptools (+deps) because the directive
       # is ignored in pyproject (and pip on xenial is preinstalled 8.x)
       $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install "pip<21" "setuptools<48" "setuptools_scm[toml]>=3.4" "importlib_metadata==1.0.0" "zipp<2"
@@ -216,8 +214,6 @@ parts:
     override-build: |
       # this is a bodge to be backward compatible
       snapcraftctl build
-      # setup.py is necessary for this old pip verision
-      echo "from setuptools import setup; setup()" > setup.py
       # update pip and setuptools (+deps) because the directive
       # is ignored in pyproject (and pip on xenial is preinstalled 8.x)
       $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install "pip<21" "setuptools<48" "setuptools_scm[toml]>=3.4" "importlib_metadata==1.0.0" "zipp<2"

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -177,8 +177,6 @@ parts:
       # 22.04 (i.e base: core22)
       sed -i 's|except OSError:  # Command not found|except subprocess.CalledProcessError:  # Command not found|g' $SNAPCRAFT_STAGE/lib/python3.*/site-packages/**/**/distro.py
     override-build: |
-      # this is a bodge to be backward compatible
-      echo "from setuptools import setup; setup()" > setup.py
       snapcraftctl build
       # also use build to ensure install (pip is not compinat to pyproject)
       # on this version
@@ -206,8 +204,6 @@ parts:
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     after: [checkbox-support]
     override-build: |
-      # this is a bodge to be backward compatible
-      echo "from setuptools import setup; setup()" > setup.py
       snapcraftctl build
       # also use build to ensure install (pip is not compinat to pyproject)
       # on this version

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -186,8 +186,6 @@ parts:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:${PYTHONPATH:-}
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     override-build: |
-      # this is a bodge to be backward compatible
-      echo "from setuptools import setup; setup();" > setup.py
       snapcraftctl build
 ################################################################################
   checkbox-ng:
@@ -232,8 +230,6 @@ parts:
       - READTHEDOCS: 'True' # simplifies picamera install
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     override-build: |
-      # this is a bodge to be backward compatible
-      echo "from setuptools import setup; setup();" > setup.py
       snapcraftctl build
 ################################################################################
   checkbox-provider-resource:

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -190,8 +190,6 @@ parts:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:${PYTHONPATH:-}
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     override-build: |
-      # this is a bodge to be backward compatible
-      echo "from setuptools import setup; setup();" > setup.py
       snapcraftctl build
 ################################################################################
   checkbox-ng:
@@ -236,8 +234,6 @@ parts:
       - READTHEDOCS: 'True' # simplifies picamera install
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     override-build: |
-      # this is a bodge to be backward compatible
-      echo "from setuptools import setup; setup();" > setup.py
       snapcraftctl build
 ################################################################################
   checkbox-provider-resource:

--- a/checkbox-ng/setup.py
+++ b/checkbox-ng/setup.py
@@ -1,0 +1,6 @@
+# This helps older pip version properly install editable version of checkbox
+# inside the venv with `pip install -e .`
+
+from setuptools import setup
+
+setup()

--- a/checkbox-support/setup.py
+++ b/checkbox-support/setup.py
@@ -1,0 +1,6 @@
+# This helps older pip version properly install editable version of checkbox
+# inside the venv with `pip install -e .`
+
+from setuptools import setup
+
+setup()

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -308,16 +308,13 @@ class ContainerSourceMachine(ContainerBaseMachine):
 
     def _get_install_source_cmds(self):
         if self.config.alias in ["xenial", "bionic"]:
-            # pip<20 does not support editable install without a setup.py file
             return [
                 (
                     "bash -c 'pushd /home/ubuntu/checkbox/checkbox-ng ; "
-                    'echo "from setuptools import setup; setup()" > setup.py;'
                     "sudo python3 -m pip install -e .'"
                 ),
                 (
                     "bash -c 'pushd /home/ubuntu/checkbox/checkbox-support ; "
-                    'echo "from setuptools import setup; setup()" > setup.py;'
                     "sudo python3 -m pip install -e .'"
                 ),
                 # ensure these two are at the correct version to support xenial


### PR DESCRIPTION
## Description
PIP, when run in editable mode requires the projects to have `setup.py`, it cannot do it just with setup.cfg and pyproject.toml.

This patch makes it so checkbox can be deployed and used from source.

## Resolved issues
This partially fixes [Checkbox-841](https://warthogs.atlassian.net/browse/CHECKBOX-841)

## Tests
Tested on: Bionic, Focal, Jammy, and Lunar