### PR TITLE
Add: filter MTK video and image driver in udevadm (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/parsers/udevadm.py
+++ b/checkbox-support/checkbox_support/parsers/udevadm.py
@@ -561,9 +561,14 @@ class UdevadmDevice(object):
             if self._environment["SUBSYSTEM"] == "hidraw":
                 return "HIDRAW"
             if self._environment["SUBSYSTEM"] == "video4linux":
-                if self.driver not in ('bcm2835-codec', 'bcm2835-isp'):
-                    # Ignore raspberrypi memory to memory (M2M) devices,
-                    # for the video decoder, encoder, and ISP resize.
+                # Ignore raspberrypi memory to memory (M2M) devices,
+                # for the video decoder, encoder, and ISP resize.
+                # Ignore Mediatek v4l2 encoder, decoder, jpeg codec and
+                # image processor 3
+                driver_black_list = ('bcm2835-codec', 'bcm2835-isp',
+                                     'mtk-vcodec-enc', 'mtk-vcodec-dec',
+                                     'mtk-jpeg', 'mtk-mdp3')
+                if self.driver not in driver_black_list:
                     return "CAPTURE"
             # special device for PiCamera
             if self._environment["SUBSYSTEM"] == "vchiq":

--- a/checkbox-support/checkbox_support/parsers/udevadm.py
+++ b/checkbox-support/checkbox_support/parsers/udevadm.py
@@ -565,10 +565,10 @@ class UdevadmDevice(object):
                 # for the video decoder, encoder, and ISP resize.
                 # Ignore Mediatek v4l2 encoder, decoder, jpeg codec and
                 # image processor 3
-                driver_black_list = ('bcm2835-codec', 'bcm2835-isp',
+                drivers_blocklist = ('bcm2835-codec', 'bcm2835-isp',
                                      'mtk-vcodec-enc', 'mtk-vcodec-dec',
                                      'mtk-jpeg', 'mtk-mdp3')
-                if self.driver not in driver_black_list:
+                if self.driver not in drivers_blocklist:
                     return "CAPTURE"
             # special device for PiCamera
             if self._environment["SUBSYSTEM"] == "vchiq":


### PR DESCRIPTION
## Description
Mediatek contributes some drivers for video and image purpose. However, these drivers cause the Checkbox mistakes them for Camera jobs. In order to avoid this problem, filter those related drivers from udevadm is the way.

Drivers:
  - mtk-mdp3
    - MediaTek image processor 3 driver
  - mtk-jpeg
    - MediaTek JPEG codec driver
  - mtk-vcodec-enc
    - Mediatek video codec V4L2 encoder driver
  - mtk-vcodec-dec
    - Mediatek video codec V4L2 decoder driver
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

Avoid to generate the invalid camera jobs (Not physical camera). The following links are the test result after filtering those drivers from udevadm

- G350
  - Submission: https://certification.canonical.com/hardware/202202-29979/submission/331163/test-results/?term=camera
  - Environment: One physical MIPI ISP camera
  - Expectation: Only camera job for ISP camera

- G700
  - Submission: https://certification.canonical.com/hardware/202308-31931/submission/331160/test-results/?term=camera
  - Environment: No physical camera be connected
  - Expectation: No camera job be generated
 
- G1200
  - Submission: https://certification.canonical.com/hardware/202307-31864/submission/331161/test-results/?term=camera
  - Environment: One physical USB camera
  - Expectation: Only camera job for USB camera

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
