### PR TITLE
Refine Canary test plan (BugFix)

### DIFF
--- a/providers/base/units/canary/test-plan.pxu
+++ b/providers/base/units/canary/test-plan.pxu
@@ -69,7 +69,6 @@ include:
  com.canonical.certification::cpu/topology
  com.canonical.certification::disk/detect
  com.canonical.certification::disk/stats_.*
- com.canonical.certification::disk/storage_device_.*
  com.canonical.certification::ethernet/detect
  com.canonical.certification::ethernet/ping_.*
  com.canonical.certification::i2c/i2c-bus-detect

--- a/providers/base/units/canary/test-plan.pxu
+++ b/providers/base/units/canary/test-plan.pxu
@@ -1,6 +1,6 @@
 id: canary
 unit: test plan
-_name: Checkbox release self-test
+_name: Checkbox release self-test (canary test plan)
 _description:
  This test plan is meant to run on Checkbox versions that are candidates for
  a release. The jobs included here are explicitly listed so the same jobs are
@@ -13,7 +13,6 @@ bootstrap_include:
  com.canonical.certification::bootloader
  com.canonical.certification::cpuinfo
  com.canonical.certification::device
- com.canonical.certification::graphics_card
  com.canonical.certification::interface
  com.canonical.certification::net_if_management
  com.canonical.certification::model_assertion
@@ -31,7 +30,6 @@ include:
  com.canonical.certification::lsusb_attachment
  com.canonical.certification::rtc
  com.canonical.certification::sleep
- com.canonical.certification::parts_meta_info_attachment
  com.canonical.certification::dkms_info_json
  com.canonical.certification::udev_json
  com.canonical.certification::package
@@ -74,11 +72,7 @@ include:
  com.canonical.certification::disk/storage_device_.*
  com.canonical.certification::ethernet/detect
  com.canonical.certification::ethernet/ping_.*
- com.canonical.certification::graphics/.*driver_version_.*
  com.canonical.certification::i2c/i2c-bus-detect
- com.canonical.certification::i2c/i2c-device-detect
- com.canonical.certification::ubuntu_core_features
- com.canonical.certification::kernel-snap/booted-kernel-matches-current-grub
  com.canonical.certification::location/status
  com.canonical.certification::memory/info
  com.canonical.certification::ipv6_detect
@@ -89,14 +83,6 @@ include:
  com.canonical.certification::power-management/cold-reboot
  com.canonical.certification::power-management/post-cold-reboot
  com.canonical.certification::snappy/snap-list
- com.canonical.certification::snappy/snap-search
- com.canonical.certification::snappy/snap-install
- com.canonical.certification::snappy/snap-refresh-automated
- com.canonical.certification::snappy/snap-revert-automated
- com.canonical.certification::snappy/snap-reupdate-automated
- com.canonical.certification::snappy/snap-remove
- com.canonical.certification::snappy/test-store-install-beta
- com.canonical.certification::snappy/test-store-install-edge
  com.canonical.certification::snappy/test-snap-confinement-mode
  com.canonical.certification::socketcan/modprobe_vcan
  com.canonical.certification::socketcan/send_packet_local_sff_virtual
@@ -109,10 +95,6 @@ include:
  com.canonical.certification::clevis-encrypt-tpm2/detect-ecc-capabilities
  com.canonical.certification::clevis-encrypt-tpm2/ecc
  com.canonical.certification::usb/storage-detect
- com.canonical.certification::watchdog/detect
- com.canonical.certification::watchdog/systemd-config
- com.canonical.certification::watchdog/trigger-system-reset-auto
- com.canonical.certification::watchdog/post-trigger-system-reset-auto
  com.canonical.certification::suspend/suspend_advanced_auto
  com.canonical.certification::after-suspend-audio/detect-playback-devices
  com.canonical.certification::after-suspend-audio/detect-capture-devices

--- a/providers/base/units/canary/test-plan.pxu
+++ b/providers/base/units/canary/test-plan.pxu
@@ -73,7 +73,6 @@ include:
  com.canonical.certification::ethernet/detect
  com.canonical.certification::ethernet/ping_.*
  com.canonical.certification::i2c/i2c-bus-detect
- com.canonical.certification::location/status
  com.canonical.certification::memory/info
  com.canonical.certification::ipv6_detect
  com.canonical.certification::ipv6_link_local_address_.*
@@ -101,5 +100,4 @@ include:
  com.canonical.certification::after-suspend-audio/alsa-loopback-automated
  com.canonical.certification::after-suspend-ethernet/detect
  com.canonical.certification::after-suspend-ethernet/ping_.*
- com.canonical.certification::after-suspend-location/status
  com.canonical.certification::after-suspend-usb/storage-detect


### PR DESCRIPTION
Remove a few jobs from the Canary test plan.

Some jobs are meant to be run on desktop images and do not run well (or at all) on Ubuntu Core:

- the graphics-related ones
- i2c/i2c-device-detect (although it could technically run on a desktop image, it requires a connected I²C device connected to run properly)

On the other hand, some jobs are meant to run on UC and not on desktop images:

- ubuntu_core_features
- kernel-snap/booted-kernel-matches-current-grub
- parts_meta_info_attachment

A lot of the snap-related tests make requests to the snap store, and it's preferable to avoid this to avoid false negative in the case where the snap store is not responding.

The watchdog tests are meant to be run only on devices where the watchdog device is enabled and properly setup. Watchdog is not part of the coverage for laptops and desktops.

This commit also renames the pxu file to be aligned with the convention used for other units in this provider.



## Resolved issues

Fix CHECKBOX-837

## Tests

Tested on

- an amd64 laptop running 22.04
- a Raspberry Pi 4 running Ubuntu Core 22
- a RPi3 running Ubuntu Core 16

using the latest checkbox from edge channel and the sideloaded base provider to test the changes in the canary test plan.

Results:

- [amd64 laptop, 22.04](https://certification.canonical.com/hardware/202203-30007/submission/331202/)
- [RPi4, UC22](https://certification.canonical.com/hardware/202212-30981/submission/331204/)
- [RPi3, UC16](https://certification.canonical.com/hardware/201908-27256/submission/331215/)