### PR TITLE
Fix checkbox runtime series16 snap (infra)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -144,10 +144,10 @@ parts:
     source-type: local
     stage-packages:
       - python3-dbus
+      - python3-dev
       - python3-evdev
       - python3-gi
       - python3-natsort
-      - python3-psutil
       - python3-requests-unixsocket
       - python3-serial
       - python3-setuptools
@@ -173,7 +173,10 @@ parts:
     override-pull: |
       snapcraftctl pull
     build-packages:
+      - gcc
       - libbluetooth-dev
+      - python3-dev
+      - python3-pip
     override-build: |
       # we need a new version of pip and setuptools + dependencies
       # these have an hardcoded version because we need a combination that is
@@ -200,6 +203,7 @@ parts:
       - python3-urwid
       - python3-xlsxwriter
       - python3-setuptools
+      - python3-dev
     python-packages:
       - tqdm
     after: [checkbox-support]

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -147,13 +147,15 @@ parts:
       - python3-systemd
       - python3-setuptools
       - libbluetooth3
-    python-packages:
-      - pynmea2
-      - pybluez
-    after: [acpi-tools]
+        #python-packages:
+        #- pynmea2
+        #- pybluez
     build-environment:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$PYTHONPATH
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
+    after:
+      - version-calculator
+      - acpi-tools
     override-stage: |
       snapcraftctl stage
       # The oneliner below was required in 2019 to fix an upstream bug:
@@ -162,9 +164,8 @@ parts:
       # when running lsb_release on ubuntu core
       # The fix was finally released with the distro 1.6 release available as of
       # 22.04 (i.e base: core22)
-      sed -i 's|except OSError:  # Command not found|except subprocess.CalledProcessError:  # Command not found|g' lib/python3.*/site-packages/**/**/distro.py
+      sed -i 's|except OSError:  # Command not found|except subprocess.CalledProcessError:  # Command not found|g' usr/local/lib/python3.5/dist-packages/distro.py
     override-pull: |
-      PYTHONHOME=/usr PYTHONUSERBASE=$SNAPCRAFT_PART_INSTALL $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install --upgrade 'pip; python_version >= "3.6"' 'pip<21; python_version < "3.6"' --user
       snapcraftctl pull
     build-packages:
       - libbluetooth-dev
@@ -172,21 +173,18 @@ parts:
       - python3-pip
     override-build: |
       # this is a bodge to be backward compatible
+      /usr/bin/pip3 install --prefix $SNAPCRAFT_PART_INSTALL --upgrade "pip==20.3.4" "setuptools<48" "setuptools_scm[toml]==3.4.3" "importlib_metadata==1.0.0" "zipp<2" "pynmea2" "pybluez"
       snapcraftctl build
-      # update pip and setuptools (+deps) because the directive
-      # is ignored in pyproject (and pip on xenial is preinstalled 8.x)
-      $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install "pip<21" "setuptools<48" "setuptools_scm[toml]>=3.4" "importlib_metadata==1.0.0" "zipp<2"
       # install the dependencies of checkbox-support itself because this
       # pip version  pyproject.toml dependencies
       $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install "pyparsing<3.0.0" "requests<2.26.0" "distro<1.7.0" "requests_unixsocket<=0.3.0" "importlib_metadata<=1.0.0"
-      # call pip again to actually install the module itself
-      $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install .
       # fix shebangs in bins.This is necessary because by calling pip via the
       # $SNAPCRAFT_PART_INSTALL path (to get the correct one) this path gets
       # propagated into bins. This path will be invalid once the snap is installed
       # so it must be changed to the appropriate one (/usr/bin/env python3) that
       # we could not use here
-      sed -iE 's|\#\!.*/usr/bin/python3$|#!/usr/bin/env python3|' $SNAPCRAFT_PART_INSTALL/usr/local/bin/*
+      sed -iE 's|\#\!.*/usr/bin/python3$|#!/usr/bin/env python3|' $SNAPCRAFT_PART_INSTALL/usr/bin/*
+      $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip uninstall -y pip
 ################################################################################
   checkbox-ng:
     plugin: python
@@ -213,21 +211,17 @@ parts:
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     override-build: |
       # this is a bodge to be backward compatible
+      /usr/bin/pip3 install --prefix $SNAPCRAFT_PART_INSTALL --upgrade "pip==20.3.4" "setuptools<48" "setuptools_scm[toml]==3.4.3" "importlib_metadata==1.0.0" "zipp<2"
       snapcraftctl build
-      # update pip and setuptools (+deps) because the directive
-      # is ignored in pyproject (and pip on xenial is preinstalled 8.x)
-      $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install "pip<21" "setuptools<48" "setuptools_scm[toml]>=3.4" "importlib_metadata==1.0.0" "zipp<2"
       # install the dependencies of checkbox-support itself because this
       # pip version  pyproject.toml dependencies
       $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install "packaging<21.0" "psutil<=5.9.5" "requests<2.26.0" "urwid<=2.1.2" "Jinja2<=2.11.3" "XlsxWriter<=3.0.3" "tqdm<4.65.0" "importlib_metadata<=1.0.0"
-      # call pip again to actually install the module itself
-      $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install .
       # fix shebangs in bins.This is necessary because by calling pip via the
       # $SNAPCRAFT_PART_INSTALL path (to get the correct one) this path gets
       # propagated into bins. This path will be invalid once the snap is installed
       # so it must be changed to the appropriate one (/usr/bin/env python3) that
       # we could not use here
-      sed -iE 's|\#\!.*/usr/bin/python3$|#!/usr/bin/env python3|' $SNAPCRAFT_PART_INSTALL/usr/local/bin/*
+      sed -iE 's|\#\!.*/usr/bin/python3$|#!/usr/bin/env python3|' $SNAPCRAFT_PART_INSTALL/usr/bin/*
 ################################################################################
   checkbox-provider-resource:
     plugin: dump
@@ -248,6 +242,8 @@ parts:
       python3 manage.py validate
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-resource --root="$SNAPCRAFT_PART_INSTALL"
+    stage:
+      - providers
     build-packages:
       - autoconf
       - automake
@@ -266,6 +262,8 @@ parts:
       python3 manage.py validate
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-base --root="$SNAPCRAFT_PART_INSTALL"
+    stage:
+      - providers
     stage-packages:
       - bc
       - bluez-tests

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -143,16 +143,24 @@ parts:
     source: checkbox-support
     source-type: local
     stage-packages:
+      - python3-dbus
+      - python3-evdev
+      - python3-gi
+      - python3-natsort
+      - python3-psutil
       - python3-requests-unixsocket
-      - python3-systemd
+      - python3-serial
       - python3-setuptools
+      - python3-systemd
+      - python3-yaml
+      - pyotherside
       - libbluetooth3
     build-environment:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$PYTHONPATH
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     after:
       - version-calculator
-      - acpi-tools
+        #- acpi-tools
     override-stage: |
       snapcraftctl stage
       # The oneliner below was required in 2019 to fix an upstream bug:
@@ -166,8 +174,6 @@ parts:
       snapcraftctl pull
     build-packages:
       - libbluetooth-dev
-      - python3-dev
-      - python3-pip
     override-build: |
       # this is a bodge to be backward compatible
       /usr/bin/pip3 install --prefix $SNAPCRAFT_PART_INSTALL --upgrade "pip==20.3.4" "setuptools<48" "setuptools_scm[toml]==3.4.3" "importlib_metadata==1.0.0" "zipp<2" "pynmea2" "pybluez"
@@ -175,15 +181,6 @@ parts:
       # install the dependencies of checkbox-support itself because this
       # pip version  pyproject.toml dependencies
       $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install "pyparsing<3.0.0" "requests<2.26.0" "distro<1.7.0" "requests_unixsocket<=0.3.0" "importlib_metadata<=1.0.0"
-      # fix shebangs in bins.This is necessary because by calling pip via the
-      # $SNAPCRAFT_PART_INSTALL path (to get the correct one) this path gets
-      # propagated into bins. This path will be invalid once the snap is installed
-      # so it must be changed to the appropriate one (/usr/bin/env python3) that
-      # we could not use here
-      sed -iE 's|\#\!.*/usr/bin/python3$|#!/usr/bin/env python3|' $SNAPCRAFT_PART_INSTALL/usr/bin/*
-      # remove pip from this part because else snapcraft considers it
-      # clashing with the one that checkbox-ng installs
-      $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip uninstall -y pip
 ################################################################################
   checkbox-ng:
     plugin: python
@@ -201,7 +198,6 @@ parts:
       - python3-urwid
       - python3-xlsxwriter
       - python3-setuptools
-      - python3-dev
     python-packages:
       - tqdm
     after: [checkbox-support]
@@ -215,12 +211,6 @@ parts:
       # install the dependencies of checkbox-support itself because this
       # pip version  pyproject.toml dependencies
       $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip install "packaging<21.0" "psutil<=5.9.5" "requests<2.26.0" "urwid<=2.1.2" "Jinja2<=2.11.3" "XlsxWriter<=3.0.3" "tqdm<4.65.0" "importlib_metadata<=1.0.0"
-      # fix shebangs in bins.This is necessary because by calling pip via the
-      # $SNAPCRAFT_PART_INSTALL path (to get the correct one) this path gets
-      # propagated into bins. This path will be invalid once the snap is installed
-      # so it must be changed to the appropriate one (/usr/bin/env python3) that
-      # we could not use here
-      sed -iE 's|\#\!.*/usr/bin/python3$|#!/usr/bin/env python3|' $SNAPCRAFT_PART_INSTALL/usr/bin/*
 ################################################################################
   checkbox-provider-resource:
     plugin: dump
@@ -232,17 +222,14 @@ parts:
       - dmidecode
       - libjson-xs-perl
       - pciutils
-      - python3-requests-unixsocket
       - smartmontools
     override-build: |
       cd src && autoreconf -i && cd -
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.8/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.5/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-resource --root="$SNAPCRAFT_PART_INSTALL"
-    stage:
-      - providers
     build-packages:
       - autoconf
       - automake
@@ -256,13 +243,11 @@ parts:
     source: providers/base
     source-type: local
     override-build: |
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.8/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.5/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-base --root="$SNAPCRAFT_PART_INSTALL"
-    stage:
-      - providers
     stage-packages:
       - bc
       - bluez-tests
@@ -310,14 +295,6 @@ parts:
       - parted
       - pciutils
       - pulseaudio-utils
-      - pyotherside
-      - python3-dbus
-      - python3-evdev
-      - python3-gi
-      - python3-natsort
-      - python3-psutil
-      - python3-serial
-      - python3-yaml
       - qml-module-qtquick-controls
       - qml-module-qtquick-layouts
       - qmlscene
@@ -340,7 +317,7 @@ parts:
     source: providers/docker
     source-type: local
     override-build: |
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.8/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.5/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -354,7 +331,7 @@ parts:
     source: providers/tpm2
     source-type: local
     override-build: |
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.8/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.5/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -366,7 +343,7 @@ parts:
     source: providers/sru
     source-type: local
     override-build: |
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.8/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.5/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -378,7 +355,7 @@ parts:
     source: providers/gpgpu
     source-type: local
     override-build: |
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.8/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.5/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -390,7 +367,7 @@ parts:
     source: providers/certification-client
     source-type: local
     override-build: |
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.8/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.5/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -402,7 +379,7 @@ parts:
     source: providers/certification-server
     source-type: local
     override-build: |
-      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.8/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$SNAPCRAFT_STAGE/lib/python3.5/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$SNAPCRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -160,7 +160,7 @@ parts:
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     after:
       - version-calculator
-        #- acpi-tools
+      - acpi-tools
     override-stage: |
       snapcraftctl stage
       # The oneliner below was required in 2019 to fix an upstream bug:
@@ -175,7 +175,9 @@ parts:
     build-packages:
       - libbluetooth-dev
     override-build: |
-      # this is a bodge to be backward compatible
+      # we need a new version of pip and setuptools + dependencies
+      # these have an hardcoded version because we need a combination that is
+      # compatible with python 3.5.1 (note the `.1`)
       /usr/bin/pip3 install --prefix $SNAPCRAFT_PART_INSTALL --upgrade "pip==20.3.4" "setuptools<48" "setuptools_scm[toml]==3.4.3" "importlib_metadata==1.0.0" "zipp<2" "pynmea2" "pybluez"
       snapcraftctl build
       # install the dependencies of checkbox-support itself because this
@@ -205,7 +207,9 @@ parts:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$PYTHONPATH
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
     override-build: |
-      # this is a bodge to be backward compatible
+      # we need a new version of pip and setuptools + dependencies
+      # these have an hardcoded version because we need a combination that is
+      # compatible with python 3.5.1 (note the `.1`)
       /usr/bin/pip3 install --prefix $SNAPCRAFT_PART_INSTALL --upgrade "pip==20.3.4" "setuptools<48" "setuptools_scm[toml]==3.4.3" "importlib_metadata==1.0.0" "zipp<2"
       snapcraftctl build
       # install the dependencies of checkbox-support itself because this

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -147,9 +147,6 @@ parts:
       - python3-systemd
       - python3-setuptools
       - libbluetooth3
-        #python-packages:
-        #- pynmea2
-        #- pybluez
     build-environment:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$PYTHONPATH
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
@@ -184,6 +181,8 @@ parts:
       # so it must be changed to the appropriate one (/usr/bin/env python3) that
       # we could not use here
       sed -iE 's|\#\!.*/usr/bin/python3$|#!/usr/bin/env python3|' $SNAPCRAFT_PART_INSTALL/usr/bin/*
+      # remove pip from this part because else snapcraft considers it
+      # clashing with the one that checkbox-ng installs
       $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m pip uninstall -y pip
 ################################################################################
   checkbox-ng:


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

Currently the series16 snap fails to build (see: https://github.com/canonical/checkbox/actions/runs/6154735028).

This happens because the setuptools (and pip) version in the snap when running the start of the build-override section are very old. They were upgraded after the `snapcraft-build` step and this did not cause any issue because that step would not try to install the module as we had removed the setup.py file (and these old versions of pip/setuptools would just ignore the command). Since the file was re-introduced the build now fails because it tries to install using the backend declared in `pyproject.toml` (`setuptools.build_meta`, as you can see from the error) that is not present in this old version of setuptools.

This PR fixes the problem by preparing  the environment so that  the `snapcraft-build` is able to install the modules in both parts. 

## Resolved issues

(see: https://github.com/canonical/checkbox/actions/runs/6154735028).

## Documentation

This removes most hacks in the recipe and updates the comments in the overwritten build to be more significant

## Tests

Run the following to get a snap: (or refer to the snap building guide)
```
$ cd checkbox-core-snap
$ ./prepare.sh series16
$ cd series16
$ snapcraft remote-build 
```

Use the following config to test the snap via metabox:
```
configuration = {
    "local": {
        "origin": "classic-snap",
        "checkbox_core_snap": {
            "uri": "~/checkbox16.snap"
        },
        "checkbox_snap": {"risk": "edge"},
        "releases": ["xenial"],
    },
    "remote": {
        "origin": "classic-snap",
        "checkbox_core_snap": {
            "uri": "~/checkbox16.snap"
        },
        "checkbox_snap": {"risk": "edge"},
        "releases": ["xenial"],
    },
    "service": {
        "origin": "classic-snap",
        "checkbox_core_snap": {
            "uri": "~/checkbox16.snap"
        },
        "checkbox_snap": {"risk": "edge"},
        "releases": ["xenial"],
    },
}
```