### PR TITLE
Update rules to translate from dpkg to PEP440 version (infra)

### DIFF
--- a/checkbox-ng/debian/rules
+++ b/checkbox-ng/debian/rules
@@ -5,12 +5,21 @@ export LANGUAGE=
 export NO_PNG_PKG_MANGLE=1
 export SRCTOP=checkbox-ng
 
+# DEBVER is the latest version as declared by the changelog
+#   it is in this form pkg_version~ubuntu(ubuntu_version)
+# pkg_version = setuptools_scm where .dev -> ~dev (to make this a valid dpkg version)
+# This is not a valid python version, remove the ~ubuntu(ubuntu_version)
+# replace ~dev -> .dev as PEP440 mandates
+DEBVER := $(shell dpkg-parsechangelog -SVersion)
+PYTHON_VERSION := $(shell echo $(DEBVER) | sed 's/.ubuntu.\+//' | sed 's/~dev/.dev/')
+export SETUPTOOLS_SCM_PRETEND_VERSION=$(PYTHON_VERSION)
+
 %:
 	dh $@ --sourcedirectory=$(SRCTOP) --with=python3 --buildsystem=pybuild
 
 # Override dh_install to ensure that console_scripts are in the
 # checkbox-ng package and not in the python3-checkbox-ng package.
-# Also move the data and test-data directories to usr/share and provide 
+# Also move the data and test-data directories to usr/share and provide
 # symlinks (via python3-checkbox-ng.links) for everything to work.
 override_dh_install:
 	dh_install

--- a/checkbox-support/debian/rules
+++ b/checkbox-support/debian/rules
@@ -2,5 +2,14 @@
 export PYBUILD_NAME=checkbox-support
 export SRCTOP=checkbox-support
 
+# DEBVER is the latest version as declared by the changelog
+#   it is in this form pkg_version~ubuntu(ubuntu_version)
+# pkg_version = setuptools_scm where .dev -> ~dev (to make this a valid dpkg version)
+# This is not a valid python version, remove the ~ubuntu(ubuntu_version)
+# replace ~dev -> .dev as PEP440 mandates
+DEBVER := $(shell dpkg-parsechangelog -SVersion)
+PYTHON_VERSION := $(shell echo $(DEBVER) | sed 's/.ubuntu.\+//' | sed 's/~dev/.dev/')
+export SETUPTOOLS_SCM_PRETEND_VERSION=$(PYTHON_VERSION)
+
 %:
 	dh $@ --sourcedirectory=$(SRCTOP) --with=python3 --buildsystem=pybuild


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

The checkbox deb version is currently formed by: 
- `X.Y.Z`: version of checkbox as calculated by setuptootls_scm
- `~devXX...`: (if included by setuptools_scm) `.` -> `~` to adhere to the dpkg version standard (see: https://github.com/canonical/checkbox/pull/714)
- `-ubuntuA.B.C`: automatically included by launchpad (dpkg's debian version)

The package installs a module (checkbox-ng) that uses the same version.

This version schema is not compatible with [PEP440](https://peps.python.org/pep-0440/), this was not a problem in the past but now it is making daily builds fail on lunar and mantic because this string is now validated against the PEP (see: [LP_LOG](https://launchpad.net/~checkbox-dev/+archive/ubuntu/testing/+packages))

The `-ubuntu`  postfix can be safely removed from the python package version. The dev annotation has to be translated back to a valid PEP440 annotation (`~dev` -> `.dev`).


## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/709
Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-859

## Documentation

The replacement is documented above the rule in a comment. 

## Tests

To test this PR first create a lunar container, run the following to install the build dependency:
```
$ sudo apt install debhelper dh-python python3-all python3-distutils-extra python3-docutils python3-jinja2 python3-packaging python3-padme python3-pkg-resources python3-psutil python3-requests python3-requests-oauthlib python3-setuptools python3-sphinx python3-tk python3-tqdm pybuild-plugin-pyproject python3-setuptools-scm
```

Then run the following to create the environment:
```
$ git clone https://github.com/canonical/checkbox -b fix_modules_versioning
$ cd checkbox
$ mv checkbox-ng/debian . # <- change to checkbox-support if you want to build that
```

Edit the changelog to have the version that is currently causing problems
```
$ cat debian/changelog | sed 's/2\.8/2.10.1~dev4+g471dc2cca.d20230914~ubuntu23.4/' > debian/changelog
```

Finally, build the package
```
$ dpkg-buildpackage -us -uc -b -rfakeroot
```

This should create in your parent directory a `.deb` package with a new build of checkbox's deb