### PR TITLE
Limit tox run to the env of the current matrix (infra)

### DIFF
--- a/.github/workflows/tox-checkbox-ng.yaml
+++ b/.github/workflows/tox-checkbox-ng.yaml
@@ -20,6 +20,15 @@ jobs:
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]
+        include:
+          - python: "3.5"
+            tox_env_name: "py35"
+          - python: "3.6"
+            tox_env_name: "py36"
+          - python: "3.8"
+            tox_env_name: "py38"
+          - python: "3.10"
+            tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -29,7 +38,7 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run tox
-        run: tox
+        run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tox-checkbox-support.yaml
+++ b/.github/workflows/tox-checkbox-support.yaml
@@ -20,6 +20,15 @@ jobs:
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]
+        include:
+          - python: "3.5"
+            tox_env_name: "py35"
+          - python: "3.6"
+            tox_env_name: "py36"
+          - python: "3.8"
+            tox_env_name: "py38"
+          - python: "3.10"
+            tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -29,7 +38,7 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run tox
-        run: tox
+        run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tox-provider-base.yaml
+++ b/.github/workflows/tox-provider-base.yaml
@@ -20,6 +20,15 @@ jobs:
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]
+        include:
+          - python: "3.5"
+            tox_env_name: "py35"
+          - python: "3.6"
+            tox_env_name: "py36"
+          - python: "3.8"
+            tox_env_name: "py38"
+          - python: "3.10"
+            tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -29,7 +38,7 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run tox
-        run: tox
+        run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tox-provider-certification-client.yaml
+++ b/.github/workflows/tox-provider-certification-client.yaml
@@ -20,6 +20,15 @@ jobs:
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]
+        include:
+          - python: "3.5"
+            tox_env_name: "py35"
+          - python: "3.6"
+            tox_env_name: "py36"
+          - python: "3.8"
+            tox_env_name: "py38"
+          - python: "3.10"
+            tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -29,7 +38,7 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run tox
-        run: tox
+        run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tox-provider-certification-server.yaml
+++ b/.github/workflows/tox-provider-certification-server.yaml
@@ -20,6 +20,15 @@ jobs:
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]
+        include:
+          - python: "3.5"
+            tox_env_name: "py35"
+          - python: "3.6"
+            tox_env_name: "py36"
+          - python: "3.8"
+            tox_env_name: "py38"
+          - python: "3.10"
+            tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -29,7 +38,7 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run tox
-        run: tox
+        run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tox-provider-docker.yaml
+++ b/.github/workflows/tox-provider-docker.yaml
@@ -20,6 +20,15 @@ jobs:
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]
+        include:
+          - python: "3.5"
+            tox_env_name: "py35"
+          - python: "3.6"
+            tox_env_name: "py36"
+          - python: "3.8"
+            tox_env_name: "py38"
+          - python: "3.10"
+            tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -29,4 +38,4 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run tox
-        run: tox
+        run: tox -e${{ matrix.tox_env_name }}

--- a/.github/workflows/tox-provider-gpgpu.yaml
+++ b/.github/workflows/tox-provider-gpgpu.yaml
@@ -20,6 +20,15 @@ jobs:
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]
+        include:
+          - python: "3.5"
+            tox_env_name: "py35"
+          - python: "3.6"
+            tox_env_name: "py36"
+          - python: "3.8"
+            tox_env_name: "py38"
+          - python: "3.10"
+            tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -29,7 +38,7 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run tox
-        run: tox
+        run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tox-provider-iiotg.yaml
+++ b/.github/workflows/tox-provider-iiotg.yaml
@@ -20,6 +20,15 @@ jobs:
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]
+        include:
+          - python: "3.5"
+            tox_env_name: "py35"
+          - python: "3.6"
+            tox_env_name: "py36"
+          - python: "3.8"
+            tox_env_name: "py38"
+          - python: "3.10"
+            tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -29,7 +38,7 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run tox
-        run: tox
+        run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tox-provider-resource.yaml
+++ b/.github/workflows/tox-provider-resource.yaml
@@ -20,6 +20,15 @@ jobs:
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]
+        include:
+          - python: "3.5"
+            tox_env_name: "py35"
+          - python: "3.6"
+            tox_env_name: "py36"
+          - python: "3.8"
+            tox_env_name: "py38"
+          - python: "3.10"
+            tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -29,7 +38,7 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run tox
-        run: tox
+        run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tox-provider-sru.yaml
+++ b/.github/workflows/tox-provider-sru.yaml
@@ -20,6 +20,15 @@ jobs:
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]
+        include:
+          - python: "3.5"
+            tox_env_name: "py35"
+          - python: "3.6"
+            tox_env_name: "py36"
+          - python: "3.8"
+            tox_env_name: "py38"
+          - python: "3.10"
+            tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -29,7 +38,7 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run tox
-        run: tox
+        run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tox-provider-tpm2.yaml
+++ b/.github/workflows/tox-provider-tpm2.yaml
@@ -20,6 +20,15 @@ jobs:
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]
+        include:
+          - python: "3.5"
+            tox_env_name: "py35"
+          - python: "3.6"
+            tox_env_name: "py36"
+          - python: "3.8"
+            tox_env_name: "py38"
+          - python: "3.10"
+            tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -29,4 +38,4 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run tox
-        run: tox
+        run: tox -e${{ matrix.tox_env_name }}


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

Currently tox is run on a machine without limiting the environment it is meant to cover. When this is done, tox selects any environment that it is able to run so, if an image contains more than a version of python, tox will in a single action for multiple versions of python.

See for example this [action run](https://github.com/canonical/checkbox/actions/runs/6184293747/job/16787663978), the python3.6 environment contains both python3.6 and python3.8. 

This makes the output very long and hard to read, the failure here is at line [1399](https://github.com/canonical/checkbox/actions/runs/6184293747/job/16787663978#step:5:1400), that would be at the end of the log, but it is not because right after 3.6, 3.8 is tested. This also means that tests are run multiple times with the same python, wasting a lot of resources/time.

## Resolved issues

Fixes: [CHECKBOX-870](https://warthogs.atlassian.net/browse/CHECKBOX-870)

## Documentation

N/A

## Tests

N/A


[CHECKBOX-870]: https://warthogs.atlassian.net/browse/CHECKBOX-870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ