### PR TITLE
Make ppa-dev-tools actually look for the correct package (infra)

### DIFF
--- a/tools/release/release_deb_monorepo.py
+++ b/tools/release/release_deb_monorepo.py
@@ -106,7 +106,7 @@ def main():
                     recipes_name, new_version),
                 shell=True, check=True).stdout.decode().rstrip()
             print(output)
-            to_check.append(recipes_name)
+            to_check.append(package_name)
 
     checked = [(name, check_build(name)) for name in to_check]
     for name, ok in checked:


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

ppa-dev-tools does not notice builds in the beta workflow but it does in the daily one. The reason is that the name it is looking for is wrong (it is looking for the name of the recipe instead of the package!)

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/CHECKBOX-701

## Documentation

N/A

## Tests

Comparing this with the beta workflow (`tools/deb_daily_builds.py`) it is clear that this is the only difference
