### PR TITLE
Validate pr title for traceability markers (infra)

### DIFF
--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -14,4 +14,15 @@ jobs:
     - name: Checking the presence of the Traceability Marker in the PR title
       env:
         PR_TITLE: ${{ github.event.pull_request.title }}
-      run: echo "$PR_TITLE" | grep -iP "(infra|bugfix|new|breaking)\)?$"
+      run: |
+        if echo "$PR_TITLE" | grep -iqP "\((infra|bugfix|new|breaking)\)$"; then
+          echo "PR title contains the traceability marker"
+          exit 0
+        else
+          echo "Traceability marker missing"
+          echo "Update your title with one of the following postfix"
+          echo "(Infra,Bugfix,New,Breaking)"
+          echo
+          echo "e.g. $PR_TITLE (BugFix)"
+          exit 1
+        fi


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

We have a new traceability system for PR titles but we have no way to actually enforce it right now beside manually checking. 

This changes that by adding a new GH Action that validates the title to check that it actually ends with a traceability marker. To make them not too invasive and hard on contributors, these markers are case insensitive and optionally enclosed in brackets.

## Resolved issues

N/A

## Documentation

N/A

## Tests

This PR was created with a title that does not contain any marker. The job should fail. Once that happens it will be edited to the correct title and it should pass.

Failure: https://github.com/canonical/checkbox/actions/runs/6223347828/job/16889096967?pr=732
Passing: https://github.com/canonical/checkbox/actions/runs/6223329257/job/16889036066?pr=732