### PR TITLE
Exclude python main starting code from coverage report (infra)

### DIFF
--- a/checkbox-ng/.coveragerc
+++ b/checkbox-ng/.coveragerc
@@ -23,4 +23,5 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+    if __name__ == .__main__.:
 show_missing = True

--- a/checkbox-support/.coveragerc
+++ b/checkbox-support/.coveragerc
@@ -18,4 +18,5 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+    if __name__ == .__main__.:
 show_missing = True

--- a/providers/base/.coveragerc
+++ b/providers/base/.coveragerc
@@ -13,4 +13,5 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+    if __name__ == .__main__.:
 show_missing = True

--- a/providers/certification-client/.coveragerc
+++ b/providers/certification-client/.coveragerc
@@ -13,4 +13,5 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+    if __name__ == .__main__.:
 show_missing = True

--- a/providers/certification-server/.coveragerc
+++ b/providers/certification-server/.coveragerc
@@ -13,4 +13,5 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+    if __name__ == .__main__.:
 show_missing = True

--- a/providers/gpgpu/.coveragerc
+++ b/providers/gpgpu/.coveragerc
@@ -13,4 +13,5 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+    if __name__ == .__main__.:
 show_missing = True

--- a/providers/resource/.coveragerc
+++ b/providers/resource/.coveragerc
@@ -13,4 +13,5 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+    if __name__ == .__main__.:
 show_missing = True

--- a/providers/sru/.coveragerc
+++ b/providers/sru/.coveragerc
@@ -13,4 +13,5 @@ exclude_lines =
     @public
     pragma: no cover
     raise NotImplementedError
+    if __name__ == .__main__.:
 show_missing = True


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

Most python scripts call main via the idiom 
```
if __name__ == "__main__":
  exit(main())
```
or something similar. 

These lines are not significant most of the times and can be safely ignored in the coverage report else they will (sometimes heavily) make the coverage requirement harder to hit for new small scripts.

## Resolved issues

N/A

## Documentation

N/A

## Tests

The snippet was taken from the coverage official documentation [(here)](https://coverage.readthedocs.io/en/stable/excluding.html#advanced-exclusion). Note that we use `exclude_lines` instead of `exclude_also` because that keyword in not supported for older releases of coverage.py (anything <3.8)
