### PR TITLE
Add ptrace tracer test (New)

### DIFF
--- a/providers/base/src/EXECUTABLES
+++ b/providers/base/src/EXECUTABLES
@@ -1,3 +1,4 @@
 alsa_test
 clocktest
 threaded_memtest
+ptrace-test

--- a/providers/base/src/Makefile
+++ b/providers/base/src/Makefile
@@ -1,9 +1,9 @@
 .PHONY:
-all: alsa_test clocktest threaded_memtest
+all: alsa_test clocktest threaded_memtest ptrace-test
 
 .PHONY: clean
 clean:
-	rm -f alsa_test clocktest threaded_memtest
+	rm -f alsa_test clocktest threaded_memtest ptrace_test
 
 threaded_memtest: CFLAGS += -pthread
 threaded_memtest: CFLAGS += -Wno-unused-but-set-variable

--- a/providers/base/src/ptrace_test.c
+++ b/providers/base/src/ptrace_test.c
@@ -1,0 +1,13 @@
+#include <sys/ptrace.h>
+#include <stdio.h>
+
+int main() {
+    if (ptrace(PTRACE_TRACEME, 0, 1, 0) < 0) {
+        // if ptrace() call return a negative value -> fail (or program is already beeing ptraced?)
+        printf("NOK");
+        return 1;
+    }
+
+    printf("OK");
+    return 0;
+}

--- a/providers/base/units/tracers/jobs.pxu
+++ b/providers/base/units/tracers/jobs.pxu
@@ -1,0 +1,7 @@
+plugin: shell
+id: tracers/ptrace
+command: ptrace_test
+_summary:
+ Tests the ptrace tracer availability
+_description:
+ Runs a test for ptrace tracer availability.

--- a/providers/base/units/tracers/test-plan.pxu
+++ b/providers/base/units/tracers/test-plan.pxu
@@ -1,0 +1,7 @@
+id: tracers
+unit: test plan
+_name: Tracers tests
+_description:
+ Tracers tests
+include:
+    tracers/ptrace


### PR DESCRIPTION
This is a draft attempt to add `ptrace` test in checkbox.

## Description

For a specific project at Canonical we are using checkbox and we need to check for the availability of user-space `ptrace` tools in our images. Thus, we want to add a dedicated test to check this and since it could be relevant to other, this might be into base checkbox test plan.

We also plan to add dedicated `ftrace` test later so we created the `tracers` unit.

This, this PR:
 - Introduces a new dedicated unit for tracers
 - Introduces a specific binary tool: `ptrace_test` (source code in C) that aims to test the `ptrace()` system call availability.
 - Introduces the associated test with `ptrace_test`.

An potential alternative to the usage of specific `ptrace_test` binary: parsing `/proc/kallsyms` got identified but not developed.

## Resolved issues

[Associated Jira ticket](https://warthogs.atlassian.net/browse/ERL-358)

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
