### PR TITLE
Add tracers tests (New)

### DIFF
--- a/providers/base/src/EXECUTABLES
+++ b/providers/base/src/EXECUTABLES
@@ -1,3 +1,4 @@
 alsa_test
 clocktest
 threaded_memtest
+ptrace_test

--- a/providers/base/src/Makefile
+++ b/providers/base/src/Makefile
@@ -1,9 +1,9 @@
 .PHONY:
-all: alsa_test clocktest threaded_memtest
+all: alsa_test clocktest threaded_memtest ptrace_test
 
 .PHONY: clean
 clean:
-	rm -f alsa_test clocktest threaded_memtest
+	rm -f alsa_test clocktest threaded_memtest ptrace_test
 
 threaded_memtest: CFLAGS += -pthread
 threaded_memtest: CFLAGS += -Wno-unused-but-set-variable

--- a/providers/base/src/ptrace_test.c
+++ b/providers/base/src/ptrace_test.c
@@ -1,0 +1,11 @@
+#include <sys/ptrace.h>
+#include <stdio.h>
+
+int main() {
+    if (ptrace(PTRACE_TRACEME, 0, 1, 0) < 0) {
+        // if ptrace() call return a negative value -> fail (or program is already beeing ptraced?)
+        return 1;
+    }
+
+    return 0;
+}

--- a/providers/base/units/tracers/jobs.pxu
+++ b/providers/base/units/tracers/jobs.pxu
@@ -29,6 +29,8 @@ _summary:
  Tests ftrace kernel tracing infrastructure is enable
 _description:
  Check if kernel configuration item CONFIG_FTRACE bool is set to 'y'.
+requires:
+  kernel_config_file.detected == 'true'
 
 id: tracers/tracefs
 plugin: shell

--- a/providers/base/units/tracers/jobs.pxu
+++ b/providers/base/units/tracers/jobs.pxu
@@ -13,3 +13,19 @@ _summary:
  Tests the ptrace tracer availability
 _description:
  The test initiates tracing using the ptrace syscall with ptrace_test binary (c source code).
+
+id: tracers/ftrace
+plugin: shell
+command: 
+  if grep -q -e "^CONFIG_FTRACE=y" /boot/config-"$(uname -r)"
+  then
+      echo "ftrace: supported"
+      exit 0
+  else
+      echo "ftrace: unsupported"
+      exit 1
+  fi
+_summary:
+ Tests ftrace kernel tracing infrastructure is enable
+_description:
+ Check if kernel configuration item CONFIG_FTRACE bool is set to 'y'.

--- a/providers/base/units/tracers/jobs.pxu
+++ b/providers/base/units/tracers/jobs.pxu
@@ -29,3 +29,19 @@ _summary:
  Tests ftrace kernel tracing infrastructure is enable
 _description:
  Check if kernel configuration item CONFIG_FTRACE bool is set to 'y'.
+
+id: tracers/tracefs
+plugin: shell
+command: 
+  if mount | grep -q tracefs
+  then
+      echo "tracefs: supported"
+      exit 0
+  else
+      echo "ftracefs: unsupported"
+      exit 1
+  fi
+_summary:
+ Tests the tracefs file system availability
+_description:
+ Check if the tracefs is mounted on a system using the mount command.

--- a/providers/base/units/tracers/jobs.pxu
+++ b/providers/base/units/tracers/jobs.pxu
@@ -1,0 +1,15 @@
+id: tracers/ptrace
+plugin: shell
+command:
+  if ptrace_test
+  then
+      echo "ptrace: supported"
+      exit 0
+  else
+      echo "ptrace: unsupported"
+      exit 1
+  fi
+_summary:
+ Tests the ptrace tracer availability
+_description:
+ The test initiates tracing using the ptrace syscall with ptrace_test binary (c source code).

--- a/providers/base/units/tracers/resource.pxu
+++ b/providers/base/units/tracers/resource.pxu
@@ -1,0 +1,12 @@
+id: kernel_config_file
+plugin: resource
+_summary:
+ Kernel config file resource
+command:
+ if [[ -f "/boot/config-$(uname -r)" ]]
+ then
+     echo "detected: true"
+ else
+     echo "detected: false"
+ fi
+_description: Check existence of kernel config file

--- a/providers/base/units/tracers/test-plan.pxu
+++ b/providers/base/units/tracers/test-plan.pxu
@@ -1,0 +1,7 @@
+id: tracers
+unit: test plan
+_name: Tracers tests
+_description:
+ Tracers tests
+include:
+    tracers/ptrace

--- a/providers/base/units/tracers/test-plan.pxu
+++ b/providers/base/units/tracers/test-plan.pxu
@@ -4,4 +4,5 @@ _name: Tracers tests
 _description:
  Tracers tests
 include:
+    tracers/ftrace
     tracers/ptrace

--- a/providers/base/units/tracers/test-plan.pxu
+++ b/providers/base/units/tracers/test-plan.pxu
@@ -7,3 +7,5 @@ include:
     tracers/ftrace
     tracers/ptrace
     tracers/tracefs
+bootstrap_include:
+    kernel_config_file

--- a/providers/base/units/tracers/test-plan.pxu
+++ b/providers/base/units/tracers/test-plan.pxu
@@ -6,3 +6,4 @@ _description:
 include:
     tracers/ftrace
     tracers/ptrace
+    tracers/tracefs


### PR DESCRIPTION
This is an attempt to add `ptrace` and `ftrace` tests in checkbox.

## Description

For a specific project at Canonical we are using checkbox and we need to check for the availability of user-space `ptrace` and `ftrace` tools in our images. Thus, we want to add a dedicated test to check this and since it could be relevant to other, this might be into base checkbox test plan.

This, PR:
 - Introduces a new dedicated unit for tracers.
 - Introduces a specific binary tool: `ptrace_test` (source code in C) that aims to test the `ptrace()` system call availability.
 - Introduces the associated test with `ptrace_test`.
 - Introduces a new test to check `ftrace` availability (based on the availability of `tracefs`).

A potential alternative to the usage of specific `ptrace_test` binary: parsing `/proc/kallsyms` got identified but not developed.

## Resolved issues

[Associated Jira ticket](https://warthogs.atlassian.net/browse/ERL-358)

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
