### PR TITLE
Add link to existing documentation issues in "give feedback" (infra)

### DIFF
--- a/docs/.sphinx/_static/github_issue_links.js
+++ b/docs/.sphinx/_static/github_issue_links.js
@@ -10,6 +10,15 @@ window.onload = function() {
         + "&body=*Please describe the question or issue you're facing with "
         + `"${document.title}"`
         + ".*"
+        + "%0A%0A"
+        + "<!-- "
+        + "%0A"
+        + "Please check if your question or issue is not already listed here: "
+        + "%0A"
+        + github_url
+        + "/labels/documentation"
+        + "%0A"
+        + "-->"
         + "%0A%0A%0A%0A%0A"
         + "---"
         + "%0A"


### PR DESCRIPTION
## Description

When clicking on "Give feedback" in the upper right of any documentation page, a GitHub issue is created. Its body now includes a text inviting the user to check
https://github.com/canonical/checkbox/labels/documentation before raising their issue or question.



<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

CHECKBOX-847



## Tests

1. Deploy the docs locally using `make run` in the `docs/` dir
2. Click the "Give feedback" button on any page of the documentation
3. Make sure the issue description now includes:

```
<!-- 
Please check if your question or issue is not already listed here: 
https://github.com/canonical/checkbox/labels/documentation
-->
```
