### PR TITLE
Add checkbox-provider-gpgpu as recommends for checkbox-provider-certification-server (new)

### DIFF
--- a/providers/certification-server/debian/control
+++ b/providers/certification-server/debian/control
@@ -16,6 +16,7 @@ Architecture: all
 Depends: checkbox-provider-base, ${plainbox:Depends}
 Recommends: bonnie++,
             canonical-certification-submit,
+            checkbox-provider-gpgpu,
             cpu-checker,
             freeipmi-tools,
             fwts (>=16.02.00-0ubuntu1~),


### PR DESCRIPTION
## Description

Just adding checkbox-provider-gpgpu as a recommends for checkbox-provider-certification-server so that installing that is no longer a separate manual step. The package is extremely small so installing that on every cert deployment is negligible.

## Resolved issues

Resolves: SERVCERT-242

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
