### PR TITLE
Add miscellanea/ubuntu-desktop-minimal-recommends job (New)

### DIFF
--- a/providers/base/bin/check-ubuntu-desktop-recommends.sh
+++ b/providers/base/bin/check-ubuntu-desktop-recommends.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+target_package=${1:-ubuntu-desktop}
+
 noninstalled=()
 while read -r pkg; do
     # libreoffice-impress provides libreoffice-ogltrans, and libreoffice-ogltrans becomes a transitional package on Ubuntu 20.04.
@@ -9,7 +11,7 @@ while read -r pkg; do
     if ! dpkg-query -W -f='${Status}\n' "$pkg" 2>&1 | grep "install ok installed" >/dev/null 2>&1 && [ "$pkg" != "libreoffice-ogltrans" ]; then
         noninstalled+=("$pkg")
     fi
-done < <(apt-cache show ubuntu-desktop | grep ^Recommends | head -n 1 | cut -d : -f 2- | xargs | sed 's/ //g' | tr , $'\n')
+done < <(apt-cache show "${target_package}" | grep ^Recommends | head -n 1 | cut -d : -f 2- | xargs | sed 's/ //g' | tr , $'\n')
 
 if [ -n "${noninstalled[*]}" ]; then
     IFS=' '
@@ -17,5 +19,5 @@ if [ -n "${noninstalled[*]}" ]; then
     exit 1
 fi
 
-echo "All packages in Recommends of ubuntu-desktop are installed."
+echo "All packages in Recommends of ${target_package} are installed."
 exit 0

--- a/providers/base/units/miscellanea/jobs.pxu
+++ b/providers/base/units/miscellanea/jobs.pxu
@@ -486,12 +486,19 @@ _description: Verify installed Debian package files against MD5 checksum lists f
 
 plugin: shell
 category_id: com.canonical.plainbox::miscellanea
-estimated_duration: 60
+estimated_duration: 1
 id: miscellanea/ubuntu-desktop-recommends
 requires: package.name == 'ubuntu-desktop'
 command: check-ubuntu-desktop-recommends.sh
-_summary: Check if Debian packages in Recommends of ubuntu-desktop are installed
-_description: Check if Debian packages in Recommends of ubuntu-desktop are installed
+_summary: Check that all the recommended packages for ubuntu-desktop are installed
+
+plugin: shell
+category_id: com.canonical.plainbox::miscellanea
+estimated_duration: 1
+id: miscellanea/ubuntu-desktop-minimal-recommends
+requires: package.name == 'ubuntu-desktop-minimal'
+command: check-ubuntu-desktop-recommends.sh ubuntu-desktop-minimal
+_summary: Check that all the recommended packages for ubuntu-desktop-minimal are installed
 
 plugin: shell
 category_id: com.canonical.plainbox::miscellanea


### PR DESCRIPTION
## Description

For certain IoT Desktop images, the default installation is the ubuntu-desktop-minimal package. Therefore, it is necessary to check whether its recommended packages have been installed.

Ref: https://packages.ubuntu.com/jammy/ubuntu-desktop-minimal

## Resolved issues

N/A

## Documentation

N/A

## Tests

Sideload result on Baoshan Project and the information of `apt-cache show ubuntu-desktop-minimal`:

- https://pastebin.canonical.com/p/Kh94grNfYr/

CID: 202309-32022
Image: iot-baoshan-classic-desktop-2204-genio-desktop-09-01-20230908-116
