### PR TITLE
Checkbox rename outdated nomenclature (agent, controller) (Breaking)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,20 +67,21 @@ You should now be able to run checkbox, select a test plan and run it:
 ### Running/Testing checkbox remote
 
 By default `checkbox-cli` runs locally. If you want to run the [remote version]
-you have to activate the `checkbox-cli service` on the Machine under test:
+you have to activate the `checkbox-cli run-agent` on the Machine under test:
 
 ```bash
-(venv) # checkbox-cli service
+(venv) # checkbox-cli run-agent
 ```
-> Note: Keep in mind that service has to be run as root and needs the
+
+> Note: Keep in mind that run-agent has to be run as root and needs the
 > virtual env, you may have to re-enable/activate it after a `sudo -s`
 
-Now you can run the remote command to connect to it:
+Now you can run the control command to connect to it:
 ```bash
-(venv) $ checkbox-cli remote IP
+(venv) $ checkbox-cli control IP
 ```
 
-> Note: `service` and `remote` can both run on the same machine.
+> Note: `run-agent` and `control` can both run on the same machine.
 > in that situation, simply use `127.0.0.1`
 
 ### Writing and running unit tests for Checkbox

--- a/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
+++ b/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
@@ -43,8 +43,8 @@ from checkbox_ng.launcher.subcommands import (
 from checkbox_ng.launcher.check_config import CheckConfig
 from checkbox_ng.launcher.merge_reports import MergeReports
 from checkbox_ng.launcher.merge_submissions import MergeSubmissions
-from checkbox_ng.launcher.master import RemoteMaster
-from checkbox_ng.launcher.slave import RemoteSlave
+from checkbox_ng.launcher.controller import RemoteController
+from checkbox_ng.launcher.agent import RemoteAgent
 
 
 _ = gettext.gettext
@@ -73,12 +73,14 @@ def main():
         "merge-reports": MergeReports,
         "merge-submissions": MergeSubmissions,
         "tp-export": TestPlanExport,
-        "service": RemoteSlave,
-        "remote": RemoteMaster,
+        "run-agent": RemoteAgent,
+        "control": RemoteController,
     }
     deprecated_commands = {
-        "slave": "service",
-        "master": "remote",
+        "slave": "run-agent",
+        "service": "run-agent",
+        "master": "control",
+        "remote": "control"
     }
 
     known_cmds = list(commands.keys())
@@ -91,7 +93,8 @@ def main():
         if arg in deprecated_commands:
             sys.argv[i] = deprecated_commands[arg]
             logging.warning(
-                "%s is deprecated. Please use %s instead",
+                # "%s is deprecated. Please use %s instead",
+                "%s is deprecated and will be removed in the next major release of Checkbox. Please use %s instead",
                 arg,
                 deprecated_commands[arg],
             )

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -389,7 +389,7 @@ class Launcher(MainLoopStage, ReportsStage):
             title += " {}".format(app_version)
         runner_kwargs = {
             "normal_user_provider": lambda: self.configuration.get_value(
-                "daemon", "normal_user"
+                "agent", "normal_user"
             ),
             "password_provider": sudo_password_provider.get_sudo_password,
             "stdin": None,

--- a/checkbox-ng/checkbox_ng/launcher/test_agent.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_agent.py
@@ -18,17 +18,17 @@
 
 from unittest import TestCase, mock
 
-from checkbox_ng.launcher.slave import RemoteSlave
+from checkbox_ng.launcher.agent import RemoteAgent
 
 
-class SlaveTests(TestCase):
-    @mock.patch("checkbox_ng.launcher.slave._")
-    @mock.patch("checkbox_ng.launcher.slave._logger")
-    @mock.patch("checkbox_ng.launcher.slave.is_passwordless_sudo")
-    @mock.patch("checkbox_ng.launcher.slave.SessionAssistantSlave")
-    @mock.patch("checkbox_ng.launcher.slave.RemoteDebRestartStrategy")
-    @mock.patch("checkbox_ng.launcher.slave.RemoteSessionAssistant")
-    @mock.patch("checkbox_ng.launcher.slave.ThreadedServer")
+class AgentTests(TestCase):
+    @mock.patch("checkbox_ng.launcher.agent._")
+    @mock.patch("checkbox_ng.launcher.agent._logger")
+    @mock.patch("checkbox_ng.launcher.agent.is_passwordless_sudo")
+    @mock.patch("checkbox_ng.launcher.agent.SessionAssistantAgent")
+    @mock.patch("checkbox_ng.launcher.agent.RemoteDebRestartStrategy")
+    @mock.patch("checkbox_ng.launcher.agent.RemoteSessionAssistant")
+    @mock.patch("checkbox_ng.launcher.agent.ThreadedServer")
     @mock.patch("os.geteuid")
     @mock.patch("os.getenv")
     # used to load an empty launcher with no error
@@ -49,14 +49,14 @@ class SlaveTests(TestCase):
 
         self_mock = mock.MagicMock()
 
-        geteuid_mock.return_value = 0  # slave will not run as non-root
-        pwdless_sudo_mock.return_value = True  # slave needs pwd-less sudo
+        geteuid_mock.return_value = 0  # agent will not run as non-root
+        pwdless_sudo_mock.return_value = True  # agent needs pwd-less sudo
         getenv_mock.return_value = None
 
         with mock.patch("builtins.open"):
-            RemoteSlave.invoked(self_mock, ctx_mock)
+            RemoteAgent.invoked(self_mock, ctx_mock)
 
-        # slave server was created
+        # agent server was created
         self.assertTrue(threaded_server_mock.called)
         server = threaded_server_mock.return_value
         # the server was started

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -18,16 +18,16 @@
 
 from unittest import TestCase, mock
 
-from checkbox_ng.launcher.master import RemoteMaster
+from checkbox_ng.launcher.controller import RemoteController
 
 
-class MasterTests(TestCase):
+class ControllerTests(TestCase):
     @mock.patch("ipaddress.ip_address")
     @mock.patch("time.time")
     @mock.patch("builtins.print")
     @mock.patch("os.path.exists")
-    @mock.patch("checkbox_ng.launcher.master.Configuration.from_text")
-    @mock.patch("checkbox_ng.launcher.master._")
+    @mock.patch("checkbox_ng.launcher.controller.Configuration.from_text")
+    @mock.patch("checkbox_ng.launcher.controller._")
     # used to load an empty launcher with no error
     def test_invoked_ok(
         self,
@@ -57,11 +57,11 @@ class MasterTests(TestCase):
         with mock.patch("builtins.open") as mm:
             mm.return_value = mm
             mm.read.return_value = "[launcher]\nversion=0"
-            RemoteMaster.invoked(self_mock, ctx_mock)
+            RemoteController.invoked(self_mock, ctx_mock)
 
         self.assertTrue(self_mock.connect_and_run.called)
 
-    @mock.patch("checkbox_ng.launcher.master.RemoteSessionAssistant")
+    @mock.patch("checkbox_ng.launcher.controller.RemoteSessionAssistant")
     def test_check_remote_api_match_ok(self, remote_assistant_mock):
         """
         Test that the check_remote_api_match function does not fail/crash
@@ -74,9 +74,9 @@ class MasterTests(TestCase):
         remote_assistant_mock.REMOTE_API_VERSION = 0
         session_assistant_mock.get_remote_api_version.return_value = 0
 
-        RemoteMaster.check_remote_api_match(self_mock)
+        RemoteController.check_remote_api_match(self_mock)
 
-    @mock.patch("checkbox_ng.launcher.master.RemoteSessionAssistant")
+    @mock.patch("checkbox_ng.launcher.controller.RemoteSessionAssistant")
     def test_check_remote_api_match_fail(self, remote_assistant_mock):
         """
         Test that the check_remote_api_match function exits checkbox
@@ -91,7 +91,7 @@ class MasterTests(TestCase):
 
         with self.assertRaises(SystemExit):
             # this should exit checkbox because the two versions are different
-            RemoteMaster.check_remote_api_match(self_mock)
+            RemoteController.check_remote_api_match(self_mock)
 
         remote_assistant_mock.REMOTE_API_VERSION = 0
         session_assistant_mock.get_remote_api_version.return_value = 1
@@ -99,4 +99,4 @@ class MasterTests(TestCase):
         with self.assertRaises(SystemExit):
             # this should also exit checkbox because the two versions are
             # different
-            RemoteMaster.check_remote_api_match(self_mock)
+            RemoteController.check_remote_api_match(self_mock)

--- a/checkbox-ng/checkbox_ng/urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/urwid_ui.py
@@ -693,7 +693,7 @@ def interrupt_dialog(host):
     choices = [
         _("Nothing, continue testing (ESC)"),
         _("Stop the test case in progress and move on to the next"),
-        _("Disconnect but let the test session continue (CTRL+C)"),
+        _("Pause the test session and disconnect from the agent (CTRL+C)"),
         _("Exit and stop the Checkbox agent on the device at {}".format(host)),
         _("End this test session preserving its data and launch a new one"),
     ]

--- a/checkbox-ng/checkbox_ng/urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/urwid_ui.py
@@ -586,7 +586,7 @@ class TestPlanBrowser():
         urwid.Text("Exit (abandon session)          Ctrl+C")]))
 
     def __init__(self, title, test_plan_list, selection=None):
-        self.master_list = sorted(
+        self.controller_list = sorted(
             test_plan_list, key=lambda tp_info: tp_info.get('name'))
         # Header
         self.header = urwid.Padding(urwid.Text(title), left=1)
@@ -594,7 +594,7 @@ class TestPlanBrowser():
         self.radio_button_group = []
         self.button_pile = None
         self._preselected_tp = selection
-        self._update_button_pile(self.master_list)
+        self._update_button_pile(self.controller_list)
         listbox_content = [
             urwid.Divider(),
             urwid.Padding(self.button_pile, left=4, right=3, min_width=13),
@@ -644,10 +644,10 @@ class TestPlanBrowser():
                     filter_str = self.filter_footer.get_edit_text()
                     self.radio_button_group = []
                     if filter_str == '':
-                        self._update_button_pile(self.master_list)
+                        self._update_button_pile(self.controller_list)
                     else:
                         self._update_button_pile(
-                            [x for x in self.master_list
+                            [x for x in self.controller_list
                              if filter_str in x.get('name')])
                 if key in ('esc', 'enter'):
                     self.frame.contents['footer'] = (self.default_footer, None)
@@ -693,8 +693,8 @@ def interrupt_dialog(host):
     choices = [
         _("Nothing, continue testing (ESC)"),
         _("Stop the test case in progress and move on to the next"),
-        _("Pause the test session and disconnect from the agent (CTRL+C)"),
-        _("Exit and stop the Checkbox service on the testbed at {}".format(host)),
+        _("Disconnect but let the test session continue (CTRL+C)"),
+        _("Exit and stop the Checkbox agent on the device at {}".format(host)),
         _("End this test session preserving its data and launch a new one"),
     ]
     footer_text = [
@@ -739,7 +739,7 @@ def interrupt_dialog(host):
         index = next(
             radio_button_group.index(i) for i in radio_button_group if i.state)
         return ['cancel', 'kill-command', 'kill-controller',
-                'kill-service', 'abandon'][index]
+                'kill-agent', 'abandon'][index]
     except StopIteration:
         return None
 
@@ -912,7 +912,7 @@ def resume_dialog(duration):
     timer = CountdownWidget(duration)
     timer_pad = urwid.Padding(timer, align='center', width='clip')
     timer_fill = urwid.Filler(timer_pad)
-    title = _("Checkbox slave is about to resume the session!")
+    title = _("Checkbox agent is about to resume the session!")
     header = urwid.AttrWrap(urwid.Padding(urwid.Text(title), left=1), 'header')
     footer = urwid.AttrWrap(
         urwid.Padding(urwid.Text(footer_text), left=1), 'foot')

--- a/checkbox-ng/debian/checkbox-ng.service
+++ b/checkbox-ng/debian/checkbox-ng.service
@@ -3,7 +3,7 @@ Description=Checkbox Remote Service
 Wants=network.target
 
 [Service]
-ExecStart=/usr/bin/checkbox-cli service
+ExecStart=/usr/bin/checkbox-cli run-agent
 SyslogIdentifier=checkbox-ng.service
 Environment="XDG_CACHE_HOME=/var/cache/"
 Restart=on-failure

--- a/checkbox-ng/plainbox/impl/config.py
+++ b/checkbox-ng/plainbox/impl/config.py
@@ -40,6 +40,11 @@ class Configuration:
     For instance what reports to generate, should the session be interactive,
     and many others. Look at CONFIG_SPEC for details.
     """
+
+    DEPRECATED_SECTION_NAMES = {
+        "daemon": "agent"
+    }
+
     def __init__(self, source=None):
         """Create a new configuration object filled with default values."""
         self.sections = OrderedDict()
@@ -253,6 +258,14 @@ class Configuration:
                     ).format(var_name)
                     cfg.notice_problem(problem)
                 continue
+
+            if sect_name in cls.DEPRECATED_SECTION_NAMES:
+                current_name = cls.DEPRECATED_SECTION_NAMES[sect_name]
+                logger.warning(
+                    "Config: %s section name is deprecated. Use %s instead.",
+                    sect_name, current_name
+                )
+                sect_name = current_name
             if ":" in sect_name:
                 for var_name, var in section.items():
                     cfg.set_value(sect_name, var_name, var, origin)
@@ -410,7 +423,7 @@ CONFIG_SPEC = [
         },
     ),
     (
-        "daemon",
+        "agent",
         {
             "normal_user": VarSpec(
                 str, "", "Username to use for jobs that don't specify user."

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -248,17 +248,10 @@ class SessionAssistant:
         """
         UsageExpectation.of(self).enforce()
         if self._restart_strategy is None:
-            # 'checkbox-slave' is deprecated, it's here so people can resume
-            # old session, the next if statement can be changed to just checking
-            # for 'remote' type
-            # session_type = 'remote' if self._metadata.title == 'remote'
-            #                         else 'local'
-            # with the next release or when we do inclusive naming refactor
-            # or roughly after April of 2022
             # TODO: REMOTE API RAPI:
             # this heuristic of guessing session type from the title
             # should be changed to a proper arg/flag with the Remote API bump
-            remote_types = ("remote", "checkbox-slave")
+            remote_types = ("remote", "checkbox-agent")
             session_type = "local"
             try:
                 app_blob = json.loads(self._metadata.app_blob.decode("UTF-8"))

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -251,13 +251,9 @@ class SessionAssistant:
             # TODO: REMOTE API RAPI:
             # this heuristic of guessing session type from the title
             # should be changed to a proper arg/flag with the Remote API bump
-            remote_types = ("remote", "checkbox-agent")
-            session_type = "local"
             try:
                 app_blob = json.loads(self._metadata.app_blob.decode("UTF-8"))
                 session_type = app_blob["type"]
-                if session_type in remote_types:
-                    session_type = "remote"
             except (AttributeError, ValueError, KeyError):
                 session_type = "local"
             self._restart_strategy = detect_restart_strategy(

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -86,7 +86,7 @@ class BufferedUI(SilentUI):
             try:
                 self._output.write(stream_name + line.decode("UTF-8"))
             except UnicodeDecodeError:
-                # Don't start a slave->master transfer for binary attachments
+                # Don't start a agent->controller transfer for binary attachments
                 self._output.write("hidden(Hiding binary test output)\n")
                 self.got_program_output = self._ignore_program_output
 
@@ -154,7 +154,7 @@ class RemoteSessionAssistant:
         self._input_piping = os.pipe()
         self._passwordless_sudo = is_passwordless_sudo()
         self.terminate_cb = None
-        self._pipe_from_master = open(self._input_piping[1], "w")
+        self._pipe_from_controller = open(self._input_piping[1], "w")
         self._pipe_to_subproc = open(self._input_piping[0])
         self._reset_sa()
         self._currently_running_job = None
@@ -303,7 +303,7 @@ class RemoteSessionAssistant:
             )
 
         self._sa.use_alternate_configuration(self._launcher)
-        self._normal_user = self._launcher.get_value("daemon", "normal_user")
+        self._normal_user = self._launcher.get_value("agent", "normal_user")
         if self._normal_user:
             if not check_user_exists(self._normal_user):
                 raise RuntimeError(
@@ -358,7 +358,7 @@ class RemoteSessionAssistant:
         self._sa.select_test_plan(test_plan_id)
         # TODO: REMOTE API RAPI: Change this API on the next RAPI bump
         # previously the function returned bool signifying the need for sudo
-        # password. With slave being guaranteed to never need it anymor
+        # password. With agent being guaranteed to never need it anymor
         # we can make this funciton return nothing
         return False
 
@@ -698,7 +698,7 @@ class RemoteSessionAssistant:
 
         self._normal_user = app_blob.get(
             "effective_normal_user",
-            self._launcher.get_value("daemon", "normal_user"),
+            self._launcher.get_value("agent", "normal_user"),
         )
         _logger.info(
             "normal_user after loading metadata: %r", self._normal_user
@@ -757,10 +757,10 @@ class RemoteSessionAssistant:
 
     def transmit_input(self, text):
         if not text:
-            self._pipe_from_master.close()
+            self._pipe_from_controller.close()
             return
-        self._pipe_from_master.write(text)
-        self._pipe_from_master.flush()
+        self._pipe_from_controller.write(text)
+        self._pipe_from_controller.flush()
 
     def send_signal(self, signal):
         if not self._currently_running_job:
@@ -775,7 +775,7 @@ class RemoteSessionAssistant:
     @property
     def passwordless_sudo(self):
         # TODO: REMOTE API RAPI: Remove this API on the next RAPI bump
-        # if the slave is still running it means it's very passwordless
+        # if the agent is still running it means it's very passwordless
         return True
 
     @property

--- a/checkbox-ng/plainbox/impl/session/restart.py
+++ b/checkbox-ng/plainbox/impl/session/restart.py
@@ -269,13 +269,7 @@ def detect_restart_strategy(session=None, session_type=None) -> IRestartStrategy
     :raises LookupError:
         When no such object can be found.
     """
-    # debian and unconfined checkbox-ng.service
-    # 'checkbox-slave' is deprecated, it's here so people can resume old
-    # session, but the next line should become:
-    #  session_type == 'remote':
-    # with the next release or when we do inclusive naming refactor
-    # or roughly after April of 2022
-    if session_type in ('remote', 'checkbox-slave'):
+    if session_type in ('remote', 'checkbox-agent'):
         try:
             env = os.environ
             env["SYSTEMD_IGNORE_CHROOT"] = "1"
@@ -295,9 +289,9 @@ def detect_restart_strategy(session=None, session_type=None) -> IRestartStrategy
     # set by the launcher script
     if on_ubuntucore():
         try:
-            slave_status = subprocess.check_output(
-                ['snapctl', 'get', 'slave'], universal_newlines=True).rstrip()
-            if slave_status == 'disabled':
+            agent_status = subprocess.check_output(
+                ['snapctl', 'get', 'agent'], universal_newlines=True).rstrip()
+            if agent_status == 'disabled':
                 return SnappyRestartStrategy()
             else:
                 return RemoteSnappyRestartStrategy()
@@ -317,18 +311,12 @@ def detect_restart_strategy(session=None, session_type=None) -> IRestartStrategy
     # Classic snaps
     snap_data = os.getenv('SNAP_DATA')
     if snap_data:
-        # Classic snaps w/ remote service enabled and in use
-        # 'checkbox-slave' is deprecated, it's here so people can resume old
-        # session, but the next line should become:
-        #  session_type == 'remote':
-        # with the next release or when we do inclusive naming refactor
-        # or roughly after April of 2022
-        if session_type in ('remote', 'checkbox-slave'):
+        if session_type in ('remote', 'checkbox-agent'):
             try:
-                slave_status = subprocess.check_output(
-                    ['snapctl', 'get', 'slave'],
+                agent_status = subprocess.check_output(
+                    ['snapctl', 'get', 'agent'],
                     universal_newlines=True).rstrip()
-                if slave_status == 'enabled':
+                if agent_status == 'enabled':
                     return RemoteSnappyRestartStrategy()
             except subprocess.CalledProcessError:
                 pass

--- a/checkbox-ng/plainbox/impl/session/restart.py
+++ b/checkbox-ng/plainbox/impl/session/restart.py
@@ -269,7 +269,7 @@ def detect_restart_strategy(session=None, session_type=None) -> IRestartStrategy
     :raises LookupError:
         When no such object can be found.
     """
-    if session_type in ('remote', 'checkbox-agent'):
+    if session_type == 'remote':
         try:
             env = os.environ
             env["SYSTEMD_IGNORE_CHROOT"] = "1"
@@ -311,7 +311,7 @@ def detect_restart_strategy(session=None, session_type=None) -> IRestartStrategy
     # Classic snaps
     snap_data = os.getenv('SNAP_DATA')
     if snap_data:
-        if session_type in ('remote', 'checkbox-agent'):
+        if session_type == 'remote':
             try:
                 agent_status = subprocess.check_output(
                     ['snapctl', 'get', 'agent'],

--- a/checkbox-ng/plainbox/impl/test_config.py
+++ b/checkbox-ng/plainbox/impl/test_config.py
@@ -44,7 +44,7 @@ class ConfigurationTests(TestCase):
         cfg = Configuration()
         self.assertEqual(cfg.get_value("test plan", "filter"), ["*"])
         self.assertTrue(cfg.get_value("launcher", "local_submission"))
-        self.assertEqual(cfg.get_value("daemon", "normal_user"), "")
+        self.assertEqual(cfg.get_value("agent", "normal_user"), "")
 
     @patch("os.path.isfile", return_value=True)
     def test_one_var_overwrites(self, _):
@@ -62,8 +62,8 @@ class ConfigurationTests(TestCase):
             cfg = Configuration.from_path("unit test")
         self.assertEqual(cfg.get_value("test plan", "filter"), ["*"])
         self.assertTrue(cfg.get_value("launcher", "local_submission"))
-        self.assertEqual(cfg.get_value("daemon", "normal_user"), "")
-        self.assertEqual(cfg.get_origin("daemon", "normal_user"), "")
+        self.assertEqual(cfg.get_value("agent", "normal_user"), "")
+        self.assertEqual(cfg.get_origin("agent", "normal_user"), "")
         self.assertEqual(cfg.get_value("launcher", "stock_reports"), ["text"])
         self.assertEqual(
             cfg.get_origin("launcher", "stock_reports"), "unit test"
@@ -129,3 +129,13 @@ class ConfigurationTests(TestCase):
         with muted_logging():
             cfg = Configuration.from_path("invalid path")
         self.assertEqual(len(cfg.get_problems()), 1)
+
+    @patch("os.path.isfile", return_value=True)
+    def test_depracated_section_name_works(self, _):
+        ini_data = """
+        [daemon]
+        normal_user = testuser
+        """
+        with patch("builtins.open", mock_open(read_data=ini_data)):
+            cfg = Configuration.from_path("unit test")
+        self.assertEqual(cfg.get_value("agent", "normal_user"), "testuser")

--- a/checkbox-snap/common_series_classic/snap/hooks/install
+++ b/checkbox-snap/common_series_classic/snap/hooks/install
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 set -e
-snapctl set slave=enabled
+snapctl set agent=enabled
 
 echo "ubuntu ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/checkbox
 

--- a/checkbox-snap/series_classic16/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic16/snap/snapcraft.yaml
@@ -24,9 +24,9 @@ apps:
     command: bin/client-cert-iot-server
   configure:
     command: bin/configure
-  service:
+  agent:
     command-chain: [bin/wrapper_local]
-    command: bin/checkbox-cli-wrapper service
+    command: bin/checkbox-cli-wrapper run-agent
     daemon: simple
     restart-condition: on-failure
   shell:

--- a/checkbox-snap/series_classic18/launchers/odm-certification-app
+++ b/checkbox-snap/series_classic18/launchers/odm-certification-app
@@ -21,4 +21,4 @@ else
     print_usage
 fi
 
-exec checkbox-cli remote "$1" "$SNAP"/bin/odm-certification
+exec checkbox-cli controller "$1" "$SNAP"/bin/odm-certification

--- a/checkbox-snap/series_classic18/launchers/odm-certification-app
+++ b/checkbox-snap/series_classic18/launchers/odm-certification-app
@@ -21,4 +21,4 @@ else
     print_usage
 fi
 
-exec checkbox-cli controller "$1" "$SNAP"/bin/odm-certification
+exec checkbox-cli control "$1" "$SNAP"/bin/odm-certification

--- a/checkbox-snap/series_classic18/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic18/snap/snapcraft.yaml
@@ -27,9 +27,9 @@ apps:
     command: bin/odm-certification-app
   configure:
     command: bin/configure
-  service:
+  agent:
     command-chain: [bin/wrapper_local]
-    command: bin/checkbox-cli-wrapper service
+    command: bin/checkbox-cli-wrapper run-agent
     daemon: simple
     restart-condition: on-failure
   shell:

--- a/checkbox-snap/series_classic20/launchers/odm-certification-app
+++ b/checkbox-snap/series_classic20/launchers/odm-certification-app
@@ -21,4 +21,4 @@ else
     print_usage
 fi
 
-exec checkbox-cli remote "$1" "$SNAP"/bin/odm-certification
+exec checkbox-cli controller "$1" "$SNAP"/bin/odm-certification

--- a/checkbox-snap/series_classic20/launchers/odm-certification-app
+++ b/checkbox-snap/series_classic20/launchers/odm-certification-app
@@ -21,4 +21,4 @@ else
     print_usage
 fi
 
-exec checkbox-cli controller "$1" "$SNAP"/bin/odm-certification
+exec checkbox-cli control "$1" "$SNAP"/bin/odm-certification

--- a/checkbox-snap/series_classic20/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic20/snap/snapcraft.yaml
@@ -27,9 +27,9 @@ apps:
     command: bin/odm-certification-app
   configure:
     command: bin/configure
-  service:
+  agent:
     command-chain: [bin/wrapper_local]
-    command: bin/checkbox-cli-wrapper service
+    command: bin/checkbox-cli-wrapper run-agent
     daemon: simple
     restart-condition: on-failure
   shell:

--- a/checkbox-snap/series_classic22/launchers/odm-certification-app
+++ b/checkbox-snap/series_classic22/launchers/odm-certification-app
@@ -21,4 +21,4 @@ else
     print_usage
 fi
 
-exec checkbox-cli remote "$1" "$SNAP"/bin/odm-certification
+exec checkbox-cli controller "$1" "$SNAP"/bin/odm-certification

--- a/checkbox-snap/series_classic22/launchers/odm-certification-app
+++ b/checkbox-snap/series_classic22/launchers/odm-certification-app
@@ -21,4 +21,4 @@ else
     print_usage
 fi
 
-exec checkbox-cli controller "$1" "$SNAP"/bin/odm-certification
+exec checkbox-cli control "$1" "$SNAP"/bin/odm-certification

--- a/checkbox-snap/series_classic22/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic22/snap/snapcraft.yaml
@@ -27,9 +27,9 @@ apps:
     command: bin/odm-certification-app
   configure:
     command: bin/configure
-  service:
+  agent:
     command-chain: [bin/wrapper_local]
-    command: bin/checkbox-cli-wrapper service
+    command: bin/checkbox-cli-wrapper run-agent
     daemon: simple
     restart-condition: on-failure
   shell:

--- a/checkbox-snap/series_uc16/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc16/snap/snapcraft.yaml
@@ -68,9 +68,9 @@ apps:
     plugs: *standard
   configure:
     command: bin/configure
-  service:
+  agent:
     command-chain: [bin/wrapper_local]
-    command: bin/checkbox-cli-wrapper service
+    command: bin/checkbox-cli-wrapper run-agent
     daemon: simple
     restart-condition: on-failure
     plugs: *standard

--- a/checkbox-snap/series_uc18/launchers/odm-certification-app
+++ b/checkbox-snap/series_uc18/launchers/odm-certification-app
@@ -21,4 +21,4 @@ else
     print_usage
 fi
 
-exec checkbox-cli remote "$1" "$SNAP"/bin/odm-certification
+exec checkbox-cli controller "$1" "$SNAP"/bin/odm-certification

--- a/checkbox-snap/series_uc18/launchers/odm-certification-app
+++ b/checkbox-snap/series_uc18/launchers/odm-certification-app
@@ -21,4 +21,4 @@ else
     print_usage
 fi
 
-exec checkbox-cli controller "$1" "$SNAP"/bin/odm-certification
+exec checkbox-cli control "$1" "$SNAP"/bin/odm-certification

--- a/checkbox-snap/series_uc18/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc18/snap/snapcraft.yaml
@@ -72,9 +72,9 @@ apps:
     plugs: *standard
   configure:
     command: bin/configure
-  service:
+  agent:
     command-chain: [bin/wrapper_local]
-    command: bin/checkbox-cli-wrapper service
+    command: bin/checkbox-cli-wrapper run-agent
     daemon: simple
     restart-condition: on-failure
     plugs: *standard

--- a/checkbox-snap/series_uc20/launchers/odm-certification-app
+++ b/checkbox-snap/series_uc20/launchers/odm-certification-app
@@ -21,4 +21,4 @@ else
     print_usage
 fi
 
-exec checkbox-cli remote "$1" "$SNAP"/bin/odm-certification
+exec checkbox-cli controller "$1" "$SNAP"/bin/odm-certification

--- a/checkbox-snap/series_uc20/launchers/odm-certification-app
+++ b/checkbox-snap/series_uc20/launchers/odm-certification-app
@@ -21,4 +21,4 @@ else
     print_usage
 fi
 
-exec checkbox-cli controller "$1" "$SNAP"/bin/odm-certification
+exec checkbox-cli control "$1" "$SNAP"/bin/odm-certification

--- a/checkbox-snap/series_uc20/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc20/snap/snapcraft.yaml
@@ -72,9 +72,9 @@ apps:
     plugs: *standard
   configure:
     command: bin/configure
-  service:
+  agent:
     command-chain: [bin/wrapper_local]
-    command: bin/checkbox-cli-wrapper service
+    command: bin/checkbox-cli-wrapper run-agent
     daemon: simple
     restart-condition: on-failure
     plugs: *standard

--- a/checkbox-snap/series_uc22/launchers/odm-certification-app
+++ b/checkbox-snap/series_uc22/launchers/odm-certification-app
@@ -21,4 +21,4 @@ else
     print_usage
 fi
 
-exec checkbox-cli remote "$1" "$SNAP"/bin/odm-certification
+exec checkbox-cli controller "$1" "$SNAP"/bin/odm-certification

--- a/checkbox-snap/series_uc22/launchers/odm-certification-app
+++ b/checkbox-snap/series_uc22/launchers/odm-certification-app
@@ -21,4 +21,4 @@ else
     print_usage
 fi
 
-exec checkbox-cli controller "$1" "$SNAP"/bin/odm-certification
+exec checkbox-cli control "$1" "$SNAP"/bin/odm-certification

--- a/checkbox-snap/series_uc22/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc22/snap/snapcraft.yaml
@@ -72,9 +72,9 @@ apps:
     plugs: *standard
   configure:
     command: bin/configure
-  service:
+  agent:
     command-chain: [bin/wrapper_local]
-    command: bin/checkbox-cli-wrapper service
+    command: bin/checkbox-cli-wrapper run-agent
     daemon: simple
     restart-condition: on-failure
     plugs: *standard

--- a/metabox/README.md
+++ b/metabox/README.md
@@ -139,7 +139,7 @@ configuration = {
         'uri': '~/checkbox',
         'releases': ['jammy', 'focal', 'bionic'],
     },
-    'service': {
+    'agent': {
         'origin': 'source',
         'uri': '~/checkbox',
         'releases': ['jammy', 'focal', 'bionic'],

--- a/metabox/configs/checkbox-core-snap-classic-beta-config.py
+++ b/metabox/configs/checkbox-core-snap-classic-beta-config.py
@@ -5,13 +5,13 @@ configuration = {
         'checkbox_snap': {'risk': 'stable'},
         'releases': ['bionic', 'focal'],
     },
-    'remote': {
+    'controller': {
         'origin': 'classic-snap',
         'checkbox_core_snap': {'risk': 'beta'},
         'checkbox_snap': {'risk': 'stable'},
         'releases': ['focal'],
     },
-    'service': {
+    'agent': {
         'origin': 'classic-snap',
         'checkbox_core_snap': {'risk': 'beta'},
         'checkbox_snap': {'risk': 'stable'},

--- a/metabox/configs/dev-ppa-config.py
+++ b/metabox/configs/dev-ppa-config.py
@@ -4,12 +4,12 @@ configuration = {
         'uri': 'ppa:checkbox-dev/ppa',
         'releases': ['bionic', 'focal'],
     },
-    'remote': {
+    'controller': {
         'origin': 'ppa',
         'uri': 'ppa:checkbox-dev/ppa',
         'releases': ['focal'],
     },
-    'service': {
+    'agent': {
         'origin': 'ppa',
         'uri': 'ppa:checkbox-dev/ppa',
         'releases': ['bionic', 'focal'],

--- a/metabox/configs/remote-source-16.04.py
+++ b/metabox/configs/remote-source-16.04.py
@@ -1,11 +1,11 @@
 configuration = {
-    'remote': {
+    'controller': {
         # Metabox can run tests from a local directory containing a copy of
         # the Checkbox source code repository.
         'origin': 'source',
         'releases': ['xenial'],
     },
-    'service': {
+    'agent': {
         'origin': 'source',
         'releases': ['xenial'],
     },

--- a/metabox/configs/remote-source-18.04.py
+++ b/metabox/configs/remote-source-18.04.py
@@ -1,11 +1,11 @@
 configuration = {
-    'remote': {
+    'controller': {
         # Metabox can run tests from a local directory containing a copy of
         # the Checkbox source code repository.
         'origin': 'source',
         'releases': ['bionic'],
     },
-    'service': {
+    'agent': {
         'origin': 'source',
         'releases': ['bionic'],
     },

--- a/metabox/configs/remote-source-20.04.py
+++ b/metabox/configs/remote-source-20.04.py
@@ -1,11 +1,11 @@
 configuration = {
-    'remote': {
+    'controller': {
         # Metabox can run tests from a local directory containing a copy of
         # the Checkbox source code repository.
         'origin': 'source',
         'releases': ['focal'],
     },
-    'service': {
+    'agent': {
         'origin': 'source',
         'releases': ['focal'],
     },

--- a/metabox/configs/remote-source-22.04.py
+++ b/metabox/configs/remote-source-22.04.py
@@ -1,11 +1,11 @@
 configuration = {
-    'remote': {
+    'controller': {
         # Metabox can run tests from a local directory containing a copy of
         # the Checkbox source code repository.
         'origin': 'source',
         'releases': ['jammy'],
     },
-    'service': {
+    'agent': {
         'origin': 'source',
         'releases': ['jammy'],
     },

--- a/metabox/configs/source-remote-config.py
+++ b/metabox/configs/source-remote-config.py
@@ -1,10 +1,10 @@
 configuration = {
-    'remote': {
+    'controller': {
         'origin': 'source',
         'uri': '~/dev/work/checkbox',
         'releases': ['focal'],
     },
-    'service': {
+    'agent': {
         'origin': 'source',
         'uri': '~/dev/work/checkbox',
         'releases': ['focal'],

--- a/metabox/configs/testing-ppa-config.py
+++ b/metabox/configs/testing-ppa-config.py
@@ -4,12 +4,12 @@ configuration = {
         'uri': 'ppa:checkbox-dev/testing',
         'releases': ['focal', 'jammy'],
     },
-    'remote': {
+    'controller': {
         'origin': 'ppa',
         'uri': 'ppa:checkbox-dev/testing',
         'releases': ['focal'],
     },
-    'service': {
+    'agent': {
         'origin': 'ppa',
         'uri': 'ppa:checkbox-dev/testing',
         'releases': ['focal', 'jammy'],

--- a/metabox/metabox/core/actions.py
+++ b/metabox/metabox/core/actions.py
@@ -24,7 +24,7 @@ This module defines the Actions classes.
 __all__ = [
     "Start", "Expect", "Send", "SelectTestPlan",
     "AssertPrinted", "AssertNotPrinted", "AssertRetCode",
-    "AssertServiceActive", "Sleep", "RunCmd", "Signal", "Reboot",
+    "AssertAgentActive", "Sleep", "RunCmd", "Signal", "Reboot",
     "NetUp", "NetDown", "Put", "MkTree"
 ]
 
@@ -69,8 +69,8 @@ class AssertRetCode(ActionBase):
     handler = 'assert_ret_code'
 
 
-class AssertServiceActive(ActionBase):
-    handler = 'is_service_active'
+class AssertAgentActive(ActionBase):
+    handler = 'is_agent_active'
 
 
 class Sleep(ActionBase):

--- a/metabox/metabox/core/configuration.py
+++ b/metabox/metabox/core/configuration.py
@@ -65,14 +65,14 @@ def validate_config(config):
     if not _has_local_or_remote_declaration(config):
         raise SystemExit(
             "Configuration has to define at least one way of running checkbox."
-            "Define 'local' or 'service' and 'remote'."
+            "Define 'local' or 'agent' and 'controller'."
         )
     for kind in config:
-        if kind not in ("local", "service", "remote"):
+        if kind not in ("local", "agent", "controller"):
             raise SystemExit(
                 "Configuration has to define at least one way "
                 "of running checkbox."
-                "Define 'local' or 'service' and 'remote'."
+                "Define 'local' or 'agent' and 'controller'."
             )
         for decl in config[kind]:
             if not _decl_has_a_valid_origin(config[kind]):
@@ -93,18 +93,19 @@ def _has_local_or_remote_declaration(config):
     >>> config = {'local': []}
     >>> _has_local_or_remote_declaration(config)
     False
-    >>> config = {'service': 'something'}
+    >>> config = {'agent': 'something'}
     >>> _has_local_or_remote_declaration(config)
     False
-    >>> config = {'remote': 'something'}
+    >>> config = {'controller': 'something'}
     >>> _has_local_or_remote_declaration(config)
     False
-    >>> config = {'remote': 'something', 'service': 'somethig_else'}
+    >>> config = {'controller': 'something', 'agent': 'somethig_else'}
     >>> _has_local_or_remote_declaration(config)
     True
     """
 
-    return bool(config.get("local") or (config.get("service") and config.get("remote")))
+    return bool(config.get('local') or (
+        config.get('agent') and config.get('controller')))
 
 
 def _decl_has_a_valid_origin(decl):

--- a/metabox/metabox/core/machine.py
+++ b/metabox/metabox/core/machine.py
@@ -519,7 +519,7 @@ class ContainerSnapMachine(ContainerBaseMachine):
                 [Unit]
                 Description=Checkbox Overlay Service
                 Wants=network.target
-                Before=snap.{name}.service.service
+                Before=snap.{name}.agent.service
 
                 [Service]
                 ExecStart={cmd}
@@ -557,7 +557,7 @@ class ContainerSnapMachine(ContainerBaseMachine):
             "sudo systemctl daemon-reload",
             "sudo systemctl enable overlay-checkbox.service --now",
             install_metabox_provider,
-            "sudo systemctl restart snap.{}.service.service".format(
+            "sudo systemctl restart snap.{}.agent.service".format(
                 self._snap_name
             ),
         ]
@@ -607,7 +607,7 @@ class ContainerSnapMachine(ContainerBaseMachine):
         if force:
             return run_or_raise(
                 self._container,
-                "sudo systemctl start snap.{}.service.service".format(
+                "sudo systemctl start snap.{}.agent.service".format(
                     self._snap_name
                 ),
             )
@@ -616,7 +616,7 @@ class ContainerSnapMachine(ContainerBaseMachine):
         assert self.config.role == "agent"
         return run_or_raise(
             self._container,
-            "sudo systemctl stop snap.{}.service.service".format(
+            "sudo systemctl stop snap.{}.agent.service".format(
                 self._snap_name
             ),
         )
@@ -626,7 +626,7 @@ class ContainerSnapMachine(ContainerBaseMachine):
         return (
             run_or_raise(
                 self._container,
-                "systemctl is-active snap.{}.service.service".format(
+                "systemctl is-active snap.{}.agent.service".format(
                     self._snap_name
                 ),
             ).stdout

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -79,7 +79,7 @@ class Runner:
                 controller_release, agent_release = v.releases
                 controller_config["alias"] = controller_release
                 agent_config["alias"] = agent_release
-                revisions = self._get_revisions_jobs() # DIO what does revisions jobs do?
+                revisions = self._get_revisions_jobs()
                 for controller_revision, agent_revision in revisions:
                     controller_config["revision"] = controller_revision
                     self.combo.add(MachineConfig("controller", controller_config))
@@ -140,12 +140,12 @@ class Runner:
         )
 
         for scenario_cls, mode, origin in scenarios_modes_origins:
-            mode_to_any_role = {
+            mode_to_role = {
                 "remote": "controller",
                 "local": "local",
                 "agent": "agent"
             }
-            role = mode_to_any_role[mode]
+            role = mode_to_role[mode]
             if role not in self.config:
                 logger.debug(
                     "Skipping a scenario: [{}] {}", mode, scenario_cls.name
@@ -170,8 +170,8 @@ class Runner:
                 releases = list(
                     (mode, r_alias, s_alias)
                     for (r_alias, s_alias) in product(
-                        self.config["controller"]["releases"],
-                        self.config["agent"]["releases"],
+                        controller_releases,
+                        agent_releases,
                     )
                 )
                 revisions = self._get_revisions_jobs()

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -74,17 +74,17 @@ class Runner:
     def _gather_all_machine_spec(self):
         for v in self.scn_variants:
             if v.mode == "remote":
-                remote_config = self.config["remote"].copy()
-                service_config = self.config["service"].copy()
-                remote_release, service_release = v.releases
-                remote_config["alias"] = remote_release
-                service_config["alias"] = service_release
-                revisions = self._get_revisions_jobs()
-                for remote_revision, service_revision in revisions:
-                    remote_config["revision"] = remote_revision
-                    self.combo.add(MachineConfig("remote", remote_config))
-                    service_config["revision"] = service_revision
-                    self.combo.add(MachineConfig("service", service_config))
+                controller_config = self.config["controller"].copy()
+                agent_config = self.config["agent"].copy()
+                controller_release, agent_release = v.releases
+                controller_config["alias"] = controller_release
+                agent_config["alias"] = agent_release
+                revisions = self._get_revisions_jobs() # DIO what does revisions jobs do?
+                for controller_revision, agent_revision in revisions:
+                    controller_config["revision"] = controller_revision
+                    self.combo.add(MachineConfig("controller", controller_config))
+                    agent_config["revision"] = agent_revision
+                    self.combo.add(MachineConfig("agent", agent_config))
             elif v.mode == "local":
                 local_config = self.config["local"].copy()
                 local_config["alias"] = v.releases[0]
@@ -117,15 +117,15 @@ class Runner:
     def _get_revisions_jobs(self):
         """
         If revision testing is requested, returns revisions to test
-        for remote or/and service
+        for controller or/and agent
         """
-        remote_revisions = ["current"]
-        service_revisions = ["current"]
-        if self.config["remote"].get("revision_testing", False):
-            remote_revisions.append("origin/main")
-        if self.config["service"].get("revision_testing", False):
-            service_revisions.append("origin/main")
-        return product(remote_revisions, service_revisions)
+        controller_revisions = ["current"]
+        agent_revisions = ["current"]
+        if self.config["controller"].get("revision_testing", False):
+            controller_revisions.append("origin/main")
+        if self.config["agent"].get("revision_testing", False):
+            agent_revisions.append("origin/main")
+        return product(controller_revisions, agent_revisions)
 
     def setup(self):
         self.scenarios = aggregator.all_scenarios()
@@ -138,13 +138,20 @@ class Runner:
                 scenario_cls.modes, scenario_cls.origins
             )
         )
+
         for scenario_cls, mode, origin in scenarios_modes_origins:
-            if mode not in self.config:
+            mode_to_any_role = {
+                "remote": "controller",
+                "local": "local",
+                "agent": "agent"
+            }
+            role = mode_to_any_role[mode]
+            if role not in self.config:
                 logger.debug(
                     "Skipping a scenario: [{}] {}", mode, scenario_cls.name
                 )
                 continue
-            if origin != self.config[mode]["origin"]:
+            if origin != self.config[role]["origin"]:
                 logger.debug(
                     "Skipping a scenario: [{}][{}] {}",
                     mode,
@@ -154,27 +161,27 @@ class Runner:
                 continue
             scn_config = scenario_cls.config_override
             if mode == "remote":
-                remote_releases = self._override_filter_or_get(
-                    scn_config, "remote", "releases"
+                controller_releases = self._override_filter_or_get(
+                    scn_config, "controller", "releases"
                 )
-                service_releases = self._override_filter_or_get(
-                    scn_config, "service", "releases"
+                agent_releases = self._override_filter_or_get(
+                    scn_config, "agent", "releases"
                 )
                 releases = list(
                     (mode, r_alias, s_alias)
                     for (r_alias, s_alias) in product(
-                        self.config["remote"]["releases"],
-                        self.config["service"]["releases"],
+                        self.config["controller"]["releases"],
+                        self.config["agent"]["releases"],
                     )
                 )
                 revisions = self._get_revisions_jobs()
                 # names to kwargs
                 revisions = (
                     {
-                        "remote_revision": remote_revision,
-                        "service_revision": service_revision,
+                        "controller_revision": controller_revision,
+                        "agent_revision": agent_revision,
                     }
-                    for (remote_revision, service_revision) in revisions
+                    for (controller_revision, agent_revision) in revisions
                 )
                 releases = product(releases, revisions)
             elif mode == "local":
@@ -235,15 +242,15 @@ class Runner:
             return scenario_description_fmt.format(
                 mode=scn.mode, release_version=scn.releases, name=scn.name
             )
-        remote_rv = scn.releases[0]
-        service_rv = scn.releases[1]
-        if scn.remote_revision != "current":
-            remote_rv += " {}".format(scn.remote_revision)
-        if scn.service_revision != "current":
-            service_rv += " {}".format(scn.service_revision)
+        controller_rv = scn.releases[0]
+        agent_rv = scn.releases[1]
+        if scn.controller_revision != "current":
+            controller_rv += " {}".format(scn.controller_revision)
+        if scn.agent_revision != "current":
+            agent_rv += " {}".format(scn.agent_revision)
         return scenario_description_fmt.format(
             mode=scn.mode,
-            release_version="({}, {})".format(remote_rv, service_rv),
+            release_version="({}, {})".format(controller_rv, agent_rv),
             name=scn.name,
         )
 
@@ -252,13 +259,13 @@ class Runner:
         total = len(self.scn_variants)
         for idx, scn in enumerate(self.scn_variants, 1):
             if scn.mode == "remote":
-                scn.remote_machine = self._load("remote", scn.releases[0])
-                scn.service_machine = self._load("service", scn.releases[1])
-                scn.remote_machine.rollback_to("provisioned")
-                scn.service_machine.rollback_to("provisioned")
+                scn.controller_machine = self._load("controller", scn.releases[0])
+                scn.agent_machine = self._load("agent", scn.releases[1])
+                scn.controller_machine.rollback_to("provisioned")
+                scn.agent_machine.rollback_to("provisioned")
                 if scn.launcher:
-                    scn.remote_machine.put(scn.LAUNCHER_PATH, scn.launcher)
-                scn.service_machine.start_user_session()
+                    scn.controller_machine.put(scn.LAUNCHER_PATH, scn.launcher)
+                scn.agent_machine.start_user_session()
             elif scn.mode == "local":
                 scn.local_machine = self._load("local", scn.releases[0])
                 scn.local_machine.rollback_to("provisioned")
@@ -286,8 +293,8 @@ class Runner:
                             "the following commands:\n{}\n{}\n"
                             "Press enter to continue testing"
                         ).format(
-                            scn.remote_machine.get_connecting_cmd(),
-                            scn.service_machine.get_connecting_cmd(),
+                            scn.controller_machine.get_connecting_cmd(),
+                            scn.agent_machine.get_connecting_cmd(),
                         )
                     elif scn.mode == "local":
                         msg = (

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -57,17 +57,17 @@ class Scenario:
         self,
         mode,
         *releases,
-        remote_revision="current",
-        service_revision="current"
+        controller_revision="current",
+        agent_revision="current"
     ):
         self.mode = mode
         self.releases = releases
         # machines set up by Runner.run()
         self.local_machine = None
-        self.remote_machine = None
-        self.remote_revision = remote_revision
-        self.service_machine = None
-        self.service_revision = service_revision
+        self.controller_machine = None
+        self.controller_revision = controller_revision
+        self.agent_machine = None
+        self.agent_revision = agent_revision
         self._checks = []
         self._ret_code = None
         self._stdout = ""
@@ -160,8 +160,8 @@ class Scenario:
     def assertNotEqual(self, first, second):
         self._checks.append(first != second)
 
-    def start(self, cmd="", interactive=False, timeout=0):
-        if self.mode == "remote":
+    def start(self, cmd='', interactive=False, timeout=0):
+        if self.mode == 'remote':
             outcome = self.start_all(interactive=interactive, timeout=timeout)
             if interactive:
                 self._pts = outcome
@@ -182,17 +182,17 @@ class Scenario:
                 self._assign_outcome(*outcome)
 
     def start_all(self, interactive=False, timeout=0):
-        self.start_service()
-        outcome = self.start_remote(interactive, timeout)
+        self.start_agent()
+        outcome = self.start_controller(interactive, timeout)
         if interactive:
             self._pts = outcome
         else:
             self._assign_outcome(*outcome)
         return outcome
 
-    def start_remote(self, interactive=False, timeout=0):
-        outcome = self.remote_machine.start_remote(
-            self.service_machine.address,
+    def start_controller(self, interactive=False, timeout=0):
+        outcome = self.controller_machine.start_controller(
+            self.agent_machine.address,
             self.LAUNCHER_PATH,
             interactive,
             timeout=timeout,
@@ -203,8 +203,8 @@ class Scenario:
             self._assign_outcome(*outcome)
         return outcome
 
-    def start_service(self, force=False):
-        return self.service_machine.start_service(force)
+    def start_agent(self, force=False):
+        return self.agent_machine.start_service(force)
 
     def expect(self, data, timeout=60):
         assert self._pts is not None
@@ -229,72 +229,72 @@ class Scenario:
 
     def run_cmd(self, cmd, env={}, interactive=False, timeout=0, target="all"):
         if self.mode == "remote":
-            if target == "remote":
-                self.remote_machine.run_cmd(cmd, env, interactive, timeout)
-            elif target == "service":
-                self.service_machine.run_cmd(cmd, env, interactive, timeout)
+            if target == "controller":
+                self.controller_machine.run_cmd(cmd, env, interactive, timeout)
+            elif target == "agent":
+                self.agent_machine.run_cmd(cmd, env, interactive, timeout)
             else:
-                self.remote_machine.run_cmd(cmd, env, interactive, timeout)
-                self.service_machine.run_cmd(cmd, env, interactive, timeout)
+                self.controller_machine.run_cmd(cmd, env, interactive, timeout)
+                self.agent_machine.run_cmd(cmd, env, interactive, timeout)
         else:
             self.local_machine.run_cmd(cmd, env, interactive, timeout)
 
     def reboot(self, timeout=0, target="all"):
         if self.mode == "remote":
-            if target == "remote":
-                self.remote_machine.reboot(timeout)
-            elif target == "service":
-                self.service_machine.reboot(timeout)
+            if target == "controller":
+                self.controller_machine.reboot(timeout)
+            elif target == "agent":
+                self.agent_machine.reboot(timeout)
             else:
-                self.remote_machine.reboot(timeout)
-                self.service_machine.reboot(timeout)
+                self.controller_machine.reboot(timeout)
+                self.agent_machine.reboot(timeout)
         else:
             self.local_machine.reboot(timeout)
 
     def put(self, filepath, data, mode=None, uid=1000, gid=1000, target="all"):
         if self.mode == "remote":
-            if target == "remote":
-                self.remote_machine.put(filepath, data, mode, uid, gid)
-            elif target == "service":
-                self.service_machine.put(filepath, data, mode, uid, gid)
+            if target == "controller":
+                self.controller_machine.put(filepath, data, mode, uid, gid)
+            elif target == "agent":
+                self.agent_machine.put(filepath, data, mode, uid, gid)
             else:
-                self.remote_machine.put(filepath, data, mode, uid, gid)
-                self.service_machine.put(filepath, data, mode, uid, gid)
+                self.controller_machine.put(filepath, data, mode, uid, gid)
+                self.agent_machine.put(filepath, data, mode, uid, gid)
         else:
             self.local_machine.put(filepath, data, mode, uid, gid)
 
     def switch_on_networking(self, target="all"):
         if self.mode == "remote":
-            if target == "remote":
-                self.remote_machine.switch_on_networking()
-            elif target == "service":
-                self.service_machine.switch_on_networking()
+            if target == "controller":
+                self.controller_machine.switch_on_networking()
+            elif target == "agent":
+                self.agent_machine.switch_on_networking()
             else:
-                self.remote_machine.switch_on_networking()
-                self.service_machine.switch_on_networking()
+                self.controller_machine.switch_on_networking()
+                self.agent_machine.switch_on_networking()
         else:
             self.local_machine.switch_on_networking()
 
     def switch_off_networking(self, target="all"):
         if self.mode == "remote":
-            if target == "remote":
-                self.remote_machine.switch_off_networking()
-            elif target == "service":
-                self.service_machine.switch_off_networking()
+            if target == "controller":
+                self.controller_machine.switch_off_networking()
+            elif target == "agent":
+                self.agent_machine.switch_off_networking()
             else:
-                self.remote_machine.switch_off_networking()
-                self.service_machine.switch_off_networking()
+                self.controller_machine.switch_off_networking()
+                self.agent_machine.switch_off_networking()
         else:
             self.local_machine.switch_off_networking()
 
-    def stop_service(self):
-        return self.service_machine.stop_service()
+    def stop_agent(self):
+        return self.agent_machine.stop_agent()
 
-    def reboot_service(self):
-        return self.service_machine.reboot_service()
+    def reboot_agent(self):
+        return self.agent_machine.reboot_agent()
 
-    def is_service_active(self):
-        return self.service_machine.is_service_active()
+    def is_agent_active(self):
+        return self.agent_machine.is_agent_active()
 
     def mktree(self, path, privileged=False, timeout=0, target="all"):
         """

--- a/metabox/metabox/scenarios/basic/run-invocation.py
+++ b/metabox/metabox/scenarios/basic/run-invocation.py
@@ -20,6 +20,7 @@
 import metabox.core.keys as keys
 from metabox.core.actions import (
     AssertPrinted,
+    AssertNotPrinted,
     AssertRetCode,
     Expect,
     Send,
@@ -77,4 +78,56 @@ class RunManualplan(Scenario):
         Expect(
             " [32;1m☑ [0m: A simple user interaction and verification job"
         ),
+    ]
+
+
+class RunSlave(Scenario):
+
+    modes = ['local']
+    steps = [
+        Start('slave'),
+        AssertPrinted("slave is deprecated and will be removed in the next major release of Checkbox. Please use run-agent instead")
+    ]
+
+
+class RunMaster(Scenario):
+
+    modes = ['local']
+    steps = [
+        Start('master'),
+        AssertPrinted("master is deprecated and will be removed in the next major release of Checkbox. Please use control instead")
+    ]
+
+
+class RunService(Scenario):
+
+    modes = ['local']
+    steps = [
+        Start('service'),
+        AssertPrinted("service is deprecated and will be removed in the next major release of Checkbox. Please use run-agent instead")
+    ]
+
+class RunRemote(Scenario):
+
+    modes = ['local']
+    steps = [
+        Start('remote'),
+        AssertPrinted("remote is deprecated and will be removed in the next major release of Checkbox. Please use control instead")
+    ]
+
+
+class RunRunAgent(Scenario):
+
+    modes = ['local']
+    steps = [
+        Start('run-agent'),
+        AssertNotPrinted("Unable to load launcher 'run-agent'. File not found!")
+    ]
+
+class RunControl(Scenario):
+
+    modes = ['local']
+    steps = [
+        Start('control'),
+        AssertNotPrinted("Unable to load launcher 'control'. File not found!")
     ]

--- a/metabox/metabox/scenarios/config/chains.py
+++ b/metabox/metabox/scenarios/config/chains.py
@@ -42,7 +42,7 @@ class ConfigChainsPriority(Scenario):
     home_checkbox_includes = read_text(chains, "home_checkbox_includes.conf")
     etc_checkbox_includes = read_text(chains, "etc_checkbox_includes.conf")
     home_checkbox = read_text(chains, "home_checkbox.conf")
-
+    modes = ['local']
     steps = [
         Put("/etc/xdg/checkbox.conf", etc_checkbox),
         Put("/etc/xdg/includes.conf", etc_checkbox_includes),

--- a/metabox/metabox/scenarios/config/chains.py
+++ b/metabox/metabox/scenarios/config/chains.py
@@ -42,7 +42,7 @@ class ConfigChainsPriority(Scenario):
     home_checkbox_includes = read_text(chains, "home_checkbox_includes.conf")
     etc_checkbox_includes = read_text(chains, "etc_checkbox_includes.conf")
     home_checkbox = read_text(chains, "home_checkbox.conf")
-    modes = ['local']
+
     steps = [
         Put("/etc/xdg/checkbox.conf", etc_checkbox),
         Put("/etc/xdg/includes.conf", etc_checkbox_includes),

--- a/metabox/metabox/scenarios/config/daemon.py
+++ b/metabox/metabox/scenarios/config/daemon.py
@@ -52,7 +52,7 @@ class DaemonNormalUserSetInConfig(Scenario):
         """
     )
     steps = [
-        Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="service"),
+        Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="agent"),
         RunCmd("sudo useradd config_user"),
         Start(),
         AssertPrinted("user:config_user"),
@@ -78,7 +78,7 @@ class DaemonNormalUserOverwittenByLauncher(Scenario):
         """
     )
     steps = [
-        Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="service"),
+        Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="agent"),
         RunCmd("sudo useradd launcher_user"),
         Start(),
         AssertPrinted("user:launcher_user"),
@@ -127,3 +127,48 @@ class DaemonNormalUserDoesntExist(Scenario):
         Start(),
         AssertPrinted("User 'testuser' doesn't exist!"),
     ]
+
+@tag("daemon", "agent", "normal_user")
+class NewNameForDaemonWorks(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::whoami_as_user_tp
+        forced = yes
+        [test selection]
+        forced = yes
+        [agent]
+        normal_user = testuser
+        """
+    )
+    steps = [
+        Start(),
+        AssertPrinted("User 'testuser' doesn't exist!"),
+    ]
+
+@tag("daemon", "agent", "normal_user")
+class DeprecatedDaemon(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::whoami_as_user_tp
+        forced = yes
+        [test selection]
+        forced = yes
+        [daemon]
+        normal_user = testuser
+        """
+    )
+    steps = [
+        Start(),
+        AssertPrinted("Config: daemon section name is deprecated. Use agent instead."),
+    ]
+

--- a/metabox/metabox/scenarios/config/environment.py
+++ b/metabox/metabox/scenarios/config/environment.py
@@ -263,12 +263,12 @@ class CheckboxConfLocalResolutionOrder(Scenario):
     ]
 
 
-class CheckboxConfRemoteServiceResolutionOrder(Scenario):
+class CheckboxConfRemoteAgentResolutionOrder(Scenario):
     """
     According to the documentation, when the Checkbox Remote starts, it looks
     for config files in the same places that local Checkbox session would look
-    (on the Service side). If the Remote uses a Launcher, then the values from
-    that Launcher take precedence over the values from configs on the Service
+    (on the Agent side). If the Remote uses a Launcher, then the values from
+    that Launcher take precedence over the values from configs on the Agent
     side.
 
     This scenario sets 3 environment variables in different config locations
@@ -291,10 +291,10 @@ class CheckboxConfRemoteServiceResolutionOrder(Scenario):
         """
     )
     steps = [
-        Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="service"),
+        Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="agent"),
         MkTree("/root/.config", privileged=True),
         Put(
-            "/root/.config/checkbox.conf", checkbox_conf_home, target="service"
+            "/root/.config/checkbox.conf", checkbox_conf_home, target="agent"
         ),
         Start(),
         AssertPrinted("variables: HOME LAUNCHER XDG"),

--- a/metabox/metabox/scenarios/config/test_selection.py
+++ b/metabox/metabox/scenarios/config/test_selection.py
@@ -152,11 +152,11 @@ class RemoteTestSelectionResolution(Scenario):
         forced = yes
         """)
     steps = [
-        MkTree("/home/ubuntu/.config", target="service"),
+        MkTree("/home/ubuntu/.config", target="agent"),
         Put("/home/ubuntu/.config/checkbox.conf", checkbox_conf_home,
-            target="service"),
+            target="agent"),
         Put("/etc/xdg/checkbox.conf", checkbox_conf_etc,
-            target="service"),
+            target="agent"),
         Start(),
         AssertPrinted(".*config-environ-source.*"),
     ]
@@ -183,11 +183,11 @@ class TestPlanSelectionSkip(Scenario):
         forced = yes
         """)
     steps = [
-        MkTree("/home/ubuntu/.config", target="service"),
+        MkTree("/home/ubuntu/.config", target="agent"),
         Put("/home/ubuntu/.config/checkbox.conf",
-            checkbox_conf, target="service"),
+            checkbox_conf, target="agent"),
         Put("/etc/xdg/checkbox.conf", checkbox_conf,
-            target = "service"),
+            target = "agent"),
         Start(),
         # Assert that we have reached test selection
         Expect("Choose tests to run on your system")
@@ -216,11 +216,11 @@ class TestPlanPreselected(Scenario):
         unit = com.canonical.certification::smoke
         """)
     steps = [
-        MkTree("/home/ubuntu/.config", target="service"),
+        MkTree("/home/ubuntu/.config", target="agent"),
         Put("/home/ubuntu/.config/checkbox.conf",
-            checkbox_conf, target="service"),
+            checkbox_conf, target="agent"),
         Put("/etc/xdg/checkbox.conf", checkbox_conf,
-            target = "service"),
+            target = "agent"),
         Start(),
         #( ) Some other test
         #(X) All Smoke Tests

--- a/metabox/metabox/scenarios/config/transport.py
+++ b/metabox/metabox/scenarios/config/transport.py
@@ -73,7 +73,7 @@ class TransportSecureIDSetInConfigOnly(Scenario):
         """
     )
     steps = [
-        Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="service"),
+        Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="agent"),
         Start(),
         AssertPrinted("config is not a valid secure_id"),
     ]
@@ -106,7 +106,7 @@ class TransportSecureIDOverwrittenByLauncher(Scenario):
         """
     )
     steps = [
-        Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="service"),
+        Put("/etc/xdg/checkbox.conf", checkbox_conf_xdg, target="agent"),
         Start(),
         AssertPrinted("launcher is not a valid secure_id"),
     ]


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

This is based on the work in https://github.com/canonical/checkbox/pull/606, it expands on it fixing the last few problems and rebasing on the current state of `main`

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/CHECKBOX-657
Resolves: https://warthogs.atlassian.net/browse/CHECKBOX-901

## Documentation

The old names are still supported but yield a deprecation warning for now 

## Tests

This was tested using metabox with source, classic-snap runs and canary with a raspberrypi
