### PR TITLE
Install and require cuda-toolkit metapackage instead of the cuda metapackage fixes: #748 (BugFix)

### DIFF
--- a/providers/gpgpu/tools/gpu-setup
+++ b/providers/gpgpu/tools/gpu-setup
@@ -59,7 +59,7 @@ add-apt-repository -y "deb http://developer.download.nvidia.com/compute/cuda/rep
 echo "*  Installing necessary pacakges"
 apt install -y build-essential git
 ## need to break this out to fix issue where cuda installs gdm3
-apt install -y --no-install-recommends cuda
+apt install -y --no-install-recommends cuda-toolkit
 
 #fix the path to get nvcc from the cuda package
 CUDA_PATH=$(find /usr/local -maxdepth 1 -type d -iname "cuda*")/bin

--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -3,6 +3,6 @@ category_id: gpgpu
 plugin: shell
 estimated_duration: 300
 requires:
-    package.name == 'cuda'
+    package.name == 'cuda-toolkit'
 _summary: GPGPU stress testing
 command: cd /opt/gpu-burn/ && ./gpu_burn 14400 | grep -v -e '^[[:space:]]*$' -e "errors:" -e "Summary at"


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

previously we just installed the cuda metapacakge. That works fine until you want to test using Canonical packaged NVIDIA drivers.  one of the dependencies in the cuda chain removes our drivers and force installs the ones from the NVIDIA repos and there's no way to reverse that without breaking other things.  however, all we need for this test is the cuda-toolkit to compile GPU burn.  After some testing, we find that installing just the cuda-toolkit metapackage will get us the toolkit and libraries needed without forcing the NVIDIA driver to also be installed.  Thus we can now test linux-nvidia and the nvidia drivers installed using the ubuntu-drivers tool safely.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
#748 
SERVCERT-517

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->
No docs impact
## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
install ubuntu server
install NVIDIA drivers using ubuntu-drivers
install canonical-certification-server and checkbox-provider-gpgpu
reboot to ensure drivers are loaded
run gpu-setup
observe that the drivers installed by ubuntu-drivers are not removed when installing the cuda toolkit.