### PR TITLE
Replace hardcoded path with find for distro.py (infra)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -169,7 +169,7 @@ parts:
       # when running lsb_release on ubuntu core
       # The fix was finally released with the distro 1.6 release available as of
       # 22.04 (i.e base: core22)
-      sed -i 's|except OSError:  # Command not found|except subprocess.CalledProcessError:  # Command not found|g' usr/local/lib/python3.5/dist-packages/distro.py
+      find -name distro.py | xargs sed -i 's|except OSError:  # Command not found|except subprocess.CalledProcessError:  # Command not found|g'
     override-pull: |
       snapcraftctl pull
     build-packages:

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -175,7 +175,7 @@ parts:
       # when running lsb_release on ubuntu core
       # The fix was finally released with the distro 1.6 release available as of
       # 22.04 (i.e base: core22)
-      sed -i 's|except OSError:  # Command not found|except subprocess.CalledProcessError:  # Command not found|g' $SNAPCRAFT_STAGE/lib/python3.*/site-packages/**/**/distro.py
+      find -name distro.py | xargs sed -i 's|except OSError:  # Command not found|except subprocess.CalledProcessError:  # Command not found|g'
     override-build: |
       snapcraftctl build
       # also use build to ensure install (pip is not compinat to pyproject)


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

This change is due to the distro module changing location every time the snap recipe is modified. The reason for this behaviour is currently unknown but it is happening in most builds/branches we do

## Resolved issues

As described, snaps builds fail seldom due to this changing location

## Documentation

The comment above this change is good enough to still encapsulate what it does, this does not change the what, it changes the how

## Tests

Manually built via `remote-bulds` both the runtime22 and runtime16 snaps
