### PR TITLE
Catch error of kind/type parsers and not crash (Bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/config.py
+++ b/checkbox-ng/plainbox/impl/config.py
@@ -173,7 +173,7 @@ class Configuration:
                     self._origins[section] = dict()
             self.sections[section][name] = value
             self._origins[section][name] = origin
-        except TypeError:
+        except (TypeError, ValueError):
             problem = (
                 "Problem with setting field {} in section [{}] "
                 "'{}' cannot be used as {}. Origin: {}"

--- a/checkbox-ng/plainbox/impl/test_config.py
+++ b/checkbox-ng/plainbox/impl/test_config.py
@@ -21,7 +21,7 @@ This module contains tests for the new Checkbox Config module
 from contextlib import contextmanager
 import logging
 from unittest import TestCase
-from unittest.mock import mock_open, patch
+from unittest.mock import mock_open, patch, MagicMock
 
 from plainbox.impl.config import Configuration
 
@@ -139,3 +139,30 @@ class ConfigurationTests(TestCase):
         with patch("builtins.open", mock_open(read_data=ini_data)):
             cfg = Configuration.from_path("unit test")
         self.assertEqual(cfg.get_value("agent", "normal_user"), "testuser")
+
+    def test_parse_error_noticed(self):
+        """
+        The following configuration should yield problems
+        and not crash checkbox on parsing failure
+
+        [ui]
+        max_attempts = invalid_int
+        [test selection]
+        exclude = test # we can't parse this because
+        # the comments are not supported on the same
+        # line, therefore the ' is interpreted as an
+        # opened but unclosed period
+        """
+        self_mock = MagicMock()
+        with muted_logging():
+            Configuration.set_value(
+                self_mock, "ui", "max_attempts", "invalid_int", "test_body"
+            )
+            Configuration.set_value(
+                self_mock,
+                "test selection",
+                "exclude",
+                "test # we can't parse this",
+                "test_body",
+            )
+        self.assertEqual(self_mock.notice_problem.call_count, 2)


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

From the linked issue:
> Given that setup of a launcher file is a "user" action it might be nice to provide a user-friendly response when a badly formatted launcher file is supplied. 

We already have such a mechanism but it fails to notice when a value that it is trying to parse is not parsable (for example "abc" for an int/float value or a non-valid `shlex.split` input as in the linked issue).

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/752

## Documentation

N/A

## Tests

I have run tox and metabox on this branch 
