### PR TITLE
Change: read ubuntu_dist_channel first then media-info (#754) (BugFix)

### DIFF
--- a/providers/base/units/info/jobs.pxu
+++ b/providers/base/units/info/jobs.pxu
@@ -366,14 +366,14 @@ command:
             exit 1
         fi
     {% else -%}
-        if [ -s /var/log/installer/media-info ]; then  # Stock installer info
+        if [ -s /var/lib/ubuntu_dist_channel ]; then  # PC projects
+            cat /var/lib/ubuntu_dist_channel
+        elif [ -s /var/log/installer/media-info ]; then  # Stock installer info
             cat /var/log/installer/media-info
         elif [ -s /.disk/info ]; then
             cat /.disk/info
         elif [ -s /etc/media-info ]; then
             cat /etc/media-info
-        elif [ -s /var/lib/ubuntu_dist_channel ]; then  # PC projects
-            cat /var/lib/ubuntu_dist_channel
         else
             exit 1
         fi


### PR DESCRIPTION
On Somerville platforms, media-info provides the build stamp of the base image and ubuntu_dist_channel provides the base image and platform image information. 

`u@u:~$ cat /var/log/installer/media-info`
`Ubuntu 22.04 LTS "Jammy Jellyfish" - somerville-jammy-amd64-20220504-33`

`u@u:~$ cat /var/lib/ubuntu_dist_channel`
`# This is the distribution channel descriptor for the OEM CDs`
`# For more information see http://wiki.ubuntu.com/DistributionChannelDescriptor`
`canonical-oem-somerville-jammy-amd64-20220504-33+jellyfish-rattata+X94`

The patch changed the order of reading content of ubuntu_dist_channel first then media-info as buildstamp info.