### PR TITLE
Add launcher cli arg to check_config (New)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/check_config.py
+++ b/checkbox-ng/checkbox_ng/launcher/check_config.py
@@ -24,9 +24,9 @@ class CheckConfig:
     """Implementation of the `check-config` sub-command."""
 
     @staticmethod
-    def invoked(_):
+    def invoked(context):
         """Function that's run with `check-config` invocation."""
-        config = load_configs()
+        config = load_configs(context.args.launcher)
         print("Configuration files:")
         for source in config.sources:
             print(" - {}".format(source))
@@ -50,4 +50,6 @@ class CheckConfig:
         return 1
 
     def register_arguments(self, parser):
-        """Register extra args for this subcmd. No extra args ATM."""
+        parser.add_argument(
+            "launcher", nargs="?", help="launcher definition file to use"
+        )

--- a/checkbox-ng/checkbox_ng/launcher/test_check_config.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_check_config.py
@@ -27,10 +27,12 @@ class CheckConfigTests(TestCase):
     @mock.patch("builtins.print")
     @mock.patch("checkbox_ng.launcher.check_config.load_configs")
     def test_invoked_ok(self, mock_load_configs, mock_print):
+        args_mock = MagicMock()
+        args_mock.args.launcher = None
         # this is the default configuration
         mock_load_configs.return_value = Configuration()
 
-        ret_val = CheckConfig.invoked(...)
+        ret_val = CheckConfig.invoked(args_mock)
 
         mock_print.assert_any_call("Configuration files:")
         mock_print.assert_any_call("No problems with config(s) found!")
@@ -39,21 +41,23 @@ class CheckConfigTests(TestCase):
     @mock.patch("builtins.print")
     @mock.patch("checkbox_ng.launcher.check_config.load_configs")
     def test_invoked_has_problems(self, mock_load_configs, mock_print):
+        args_mock = MagicMock()
+        args_mock.args.launcher = None
         # this is the default configuration
         conf = Configuration()
         conf.notice_problem("Test problem")
         mock_load_configs.return_value = conf
 
-        ret_val = CheckConfig.invoked(...)
+        ret_val = CheckConfig.invoked(args_mock)
 
         mock_print.assert_any_call("Configuration files:")
         mock_print.assert_any_call("Problems:")
         mock_print.assert_any_call("- ", "Test problem")
         self.assertEqual(ret_val, 1)
 
-    def test_register_argument(self):
+    def test_register_arguments(self):
         self_mock = MagicMock()
         parser_mock = MagicMock()
-        CheckConfig.register_argument(self_mock, parser_mock)
+        CheckConfig.register_arguments(self_mock, parser_mock)
 
         self.assertTrue(parser_mock.add_argument.called)

--- a/checkbox-ng/checkbox_ng/launcher/test_check_config.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_check_config.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
-from unittest import TestCase, mock
+from unittest import TestCase, mock, MagicMock
 
 from checkbox_ng.launcher.check_config import CheckConfig
 from plainbox.impl.config import Configuration
@@ -49,3 +49,10 @@ class CheckConfigTests(TestCase):
         mock_print.assert_any_call("Problems:")
         mock_print.assert_any_call("- ", "Test problem")
         self.assertEqual(ret_val, 1)
+
+    def test_register_argument(self):
+        self_mock = MagicMock()
+        parser_mock = MagicMock()
+        CheckConfig.register_argument(self_mock, parser_mock)
+
+        self.assertTrue(parser_mock.add_argument.called)

--- a/checkbox-ng/checkbox_ng/launcher/test_check_config.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_check_config.py
@@ -16,7 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
-from unittest import TestCase, mock, MagicMock
+from unittest import TestCase, mock
+from unittest.mock import MagicMock
 
 from checkbox_ng.launcher.check_config import CheckConfig
 from plainbox.impl.config import Configuration

--- a/docs/tutorial/using-checkbox/launcher.rst
+++ b/docs/tutorial/using-checkbox/launcher.rst
@@ -244,8 +244,8 @@ and where it comes from. Run the following command:
 
 .. code-block:: none
 
-    $ checkbox.checkbox-cli check-config
-    Configuration files:
+   $ checkbox.checkbox-cli check-config
+   Configuration files:
      - /var/snap/checkbox/2799/checkbox.conf
      - /home/user/.config/checkbox.conf
        [config]
@@ -285,6 +285,43 @@ looking at the output above, I can see that the ``STRESS_S3_WAIT_DELAY``
 environment variable is set to ``120`` because it is specified in
 a Checkbox configuration that comes with the snap version I'm using
 (``/var/snap/checkbox/2799/checkbox.conf``).
+
+If you want to debug a Checkbox run that involves a ``launcher``, fear not.
+The ``check-config`` command works with launchers as well. Try the previous
+command with the ``launcher`` we created before:
+
+.. code-block:: none
+    :emphasize-lines: 8,14,17-18,21,28
+
+    $ checkbox.checkbox-cli check-config mylauncher
+    Configuration files:
+     - /var/snap/checkbox/2799/checkbox.conf
+     - /home/user/.config/checkbox.conf
+       [config]
+         config_filename=checkbox.conf      (Default)
+       [launcher]
+         app_id=com.canonical.certification:tutorial From config file: /home/user/mylauncher
+         app_version=                       (Default)
+         launcher_version=1                 From config file: /home/user/.config/checkbox.conf
+         local_submission=True              (Default)
+         session_desc=                      (Default)
+         session_title=session title        (Default)
+         stock_reports=text, submission_files From config file: /home/user/mylauncher
+       [test plan]
+         filter=*                           (Default)
+         forced=True                        From config file: /home/user/mylauncher
+         unit=com.canonical.certification::tutorial-base From config file: /home/user/mylauncher
+       [test selection]
+         exclude=                           (Default)
+         forced=True                        From config file: /home/user/mylauncher
+       (...)
+       [environment]
+         STRESS_S3_WAIT_DELAY=120           From config file: /var/snap/checkbox/2799/checkbox.conf
+       (...)
+         TUTO=tutorial                      From config file: /home/user/.config/checkbox.conf
+       (...)
+         TUTORIAL=Value from my launcher!   From config file: /home/user/mylauncher
+    No problems with config(s) found!
 
 Create an executable launcher
 =============================


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

We have a `check-config` command that is very useful to debug a config/check it before using it. This command does not support checking a launcher directly. 

## Resolved issues

N/A

## Documentation

Added the documentation for this option in the correct place of the tutorial (where it is originally introduced) with an example run

## Tests

Added a new test that covers the addition of the parameter, the other part was already well tested.
