### PR TITLE
udevadm: recognize 8086:a780 as a VIDEO device (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/parsers/udevadm.py
+++ b/checkbox-support/checkbox_support/parsers/udevadm.py
@@ -1430,7 +1430,7 @@ def known_to_be_video_device(vendor_id, product_id, pci_class, pci_subclass):
         # older GPUs have subdevices with OTHER which are uninteresting. If
         # Intel, we only consider OTHER devices as VIDEO if they are in this
         # explicit list
-        return product_id in [0x0152, 0x0412, 0x0402]
+        return product_id in [0x0152, 0x0412, 0x0402, 0xa780]
 
 
 def parse_udevadm_output(output, lsblk=None, list_partitions=False, bits=None):


### PR DESCRIPTION
## Description

Add 8086:a780, which is "Raptor Lake-S UHD Graphics", as a recognized video device.

## Tests

`checkbox-cli run com.canonical.certification::graphics_card` now shows:

```yaml
bus: pci
category: VIDEO
driver: i915
gpu_count: 2
index: 1
path: /devices/pci0000:00/0000:00:02.0
prime_gpu_offload: Off
product: PCI ID 0xa780
product_id: 42880
product_slug: PCI_ID_0xa780
subproduct_id: 3024
subvendor_id: 4136
switch_to_cmd: false
vendor: Intel Corporation
vendor_id: 32902
vendor_slug: Intel_Corporation
```

Where previously it would not show that GPU.