### PR TITLE
Remove fan stress test from test plan(BugFix)

### DIFF
--- a/providers/base/units/miscellanea/test-plan.pxu
+++ b/providers/base/units/miscellanea/test-plan.pxu
@@ -31,7 +31,6 @@ include:
     firmware/fwts_uefirtvariable.*                 certification-status=blocker
     miscellanea/oops                               certification-status=blocker
     miscellanea/oops_results.log
-    miscellanea/fan_stress_reaction
     miscellanea/debsums                            certification-status=blocker
     miscellanea/check_prerelease                   certification-status=blocker
     miscellanea/ubuntu-desktop-recommends          certification-status=blocker

--- a/providers/sru/units/sru.pxu
+++ b/providers/sru/units/sru.pxu
@@ -56,7 +56,6 @@ include:
     audio/alsa_record_playback_automated
     install/apt-get-gets-updates
     miscellanea/dkms_build_validation
-    miscellanea/fan_stress_reaction
     networking/http
     networking/gateway_ping
     thunderbolt3/storage-preinserted
@@ -142,7 +141,6 @@ include:
     1_screenshot_fullscreen_video_.*.jpg
     install/apt-get-gets-updates
     miscellanea/dkms_build_validation
-    miscellanea/fan_stress_reaction
     networking/http
     networking/gateway_ping
     thunderbolt3/storage-preinserted


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description
This change is to fix: https://github.com/canonical/checkbox/issues/697

QA team notice fan stress test is marginal pass/fail, Issac has conducted experiments to prove that fan RPM is controlled by the EC not the OS. They found that CPU loading is not the only factor affecting fan RPM, but also the thermal design of the form factor. Therefore, the QA team has proposed to remove the fan test from the test plan, and Sylvain has approved it.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
https://warthogs.atlassian.net/browse/CHECKBOX-940
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
