### PR TITLE
Added automated testplan to SRU (New)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/zapper_proxy.py
+++ b/checkbox-support/checkbox_support/scripts/zapper_proxy.py
@@ -21,7 +21,6 @@ It uses internal Zapper Control RPyC API.
 """
 import argparse
 import os
-import sys
 import time
 
 from importlib import import_module
@@ -109,4 +108,4 @@ def main(arguments):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/checkbox-support/checkbox_support/scripts/zapper_proxy.py
+++ b/checkbox-support/checkbox_support/scripts/zapper_proxy.py
@@ -21,6 +21,7 @@ It uses internal Zapper Control RPyC API.
 """
 import argparse
 import os
+import sys
 import time
 
 from importlib import import_module
@@ -84,7 +85,7 @@ def get_capabilities(host):
     print("\n\n".join(stringify_cap(cap) for cap in capabilities))
 
 
-def main():
+def main(arguments):
     """Entry point."""
 
     parser = argparse.ArgumentParser()
@@ -98,13 +99,7 @@ def main():
     )
     parser.add_argument("cmd")
     parser.add_argument("args", nargs="*")
-    args = parser.parse_args()
-
-    if args.host is None:
-        raise SystemExit(
-            "You have to provide Zapper host, either via '--host' or via "
-            "ZAPPER_HOST environment variable"
-        )
+    args = parser.parse_args(arguments)
 
     if args.cmd == "get_capabilities":
         get_capabilities(args.host)
@@ -114,4 +109,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])

--- a/checkbox-support/checkbox_support/scripts/zapper_proxy.py
+++ b/checkbox-support/checkbox_support/scripts/zapper_proxy.py
@@ -84,7 +84,7 @@ def get_capabilities(host):
     print("\n\n".join(stringify_cap(cap) for cap in capabilities))
 
 
-def main(arguments):
+def main(arguments=None):
     """Entry point."""
 
     parser = argparse.ArgumentParser()

--- a/providers/base/units/zapper/jobs.pxu
+++ b/providers/base/units/zapper/jobs.pxu
@@ -106,6 +106,7 @@ command: bt_a2dp.py "$ZAPPER_HOST"
 depends: bluetooth/detect-output
 
 id: input/zapper-keyboard
+requires: zapper_capabilities.capability == 'hid'
 category_id: com.canonical.plainbox::input
 plugin: shell
 user: root

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu
@@ -138,6 +138,7 @@ nested_part:
   wireless-automated
   wireless-wifi-master-mode-auto
   wwan-automated
+  zapper-enabled-automated
   after-suspend-audio-automated
   after-suspend-bluez-automated
   after-suspend-ethernet-automated

--- a/providers/sru/units/sru-ubuntucore.pxu
+++ b/providers/sru/units/sru-ubuntucore.pxu
@@ -84,7 +84,6 @@ include:
     wireless/wireless_connection_open_ac_nm_.*
 #     suspend/audio_before_suspend
     bluetooth4/beacon_eddystone_url_.*
-    zapper-enabled-automated
     cpu/cpuinfo_before_suspend
 #    suspend/network_before_suspend
     memory/meminfo_before_suspend

--- a/providers/sru/units/sru-ubuntucore.pxu
+++ b/providers/sru/units/sru-ubuntucore.pxu
@@ -84,6 +84,7 @@ include:
     wireless/wireless_connection_open_ac_nm_.*
 #     suspend/audio_before_suspend
     bluetooth4/beacon_eddystone_url_.*
+    zapper-enabled-automated
     cpu/cpuinfo_before_suspend
 #    suspend/network_before_suspend
     memory/meminfo_before_suspend

--- a/providers/sru/units/sru.pxu
+++ b/providers/sru/units/sru.pxu
@@ -86,7 +86,6 @@ nested_part:
     usb-cert-automated
     usb-automated
     wireless-cert-automated
-    zapper-enabled-automated
     # start of suspend related tests
     before-suspend-reference-cert-full
     # suspend point

--- a/providers/sru/units/sru.pxu
+++ b/providers/sru/units/sru.pxu
@@ -86,6 +86,7 @@ nested_part:
     usb-cert-automated
     usb-automated
     wireless-cert-automated
+    zapper-enabled-automated
     # start of suspend related tests
     before-suspend-reference-cert-full
     # suspend point
@@ -150,6 +151,7 @@ nested_part:
     monitor-discrete-gpu-cert-automated
     graphics-integrated-gpu-cert-automated
     graphics-discrete-gpu-cert-automated
+    zapper-enabled-automated
     # start of suspend related tests
     before-suspend-reference-cert-full
     # suspend point


### PR DESCRIPTION
## Description

The testplan `enabled-automated` includes jobs like USB hotplugging, EDID cycling, etc. and with this PR will be included in our SRU Desktop testplan and in iot-server/core testplans.

Every job is depending on the corresponding capabilities which are fetched by the `capabilities` job. This PR updates this job so that it doesn't fail when the IP is not provided or the host is non responding correctly: by default, every assisted job will be skipped in that case.

## Resolved issues

Resolves [ZAP-578](https://warthogs.atlassian.net/browse/ZAP-578)

## Documentation

- Changes are only related to the host and its inclusion in SRU, not sure we can disclosure much about it in public documentation
- Changes (and existing code) are now tested with 100% test coverage

## Tests
For what concerns `capabilities` changes:

Without providing the IP address variable:
```
checkbox.checkbox-cli run com.canonical.certification::enabled-automated
```
will result in
```
==================================[ Results ]===================================
 ☑ : Get setup capabilities
 ☑ : Collect information about installed snap packages
 ☑ : Collect information about hardware devices (udev)
 ☑ : Collect information about installed software packages
 ☑ : bluetooth/detect-output
 ☐ : Check if the system can connect to a Bluetooth speaker using A2DP profile
 ☐ : Check if the system recognizes keyboard events
 ☐ : Check if the system automatically changes the resolution based on EDID
 ☑ : Hardware Manifest
 ☐ : Check if the system recognizes hotplug events on HDMI
```
where `capabilities` succeeded but every job was skipped.

On the other hand, passing IP address will result in:
```
==================================[ Results ]===================================
 ☑ : Collect information about installed snap packages
 ☑ : Collect information about hardware devices (udev)
 ☑ : Collect information about installed software packages
 ☑ : bluetooth/detect-output
 ☑ : Get setup capabilities
 ☑ : Check if the system can connect to a Bluetooth speaker using A2DP profile
 ☑ : Check if the system recognizes keyboard events
 ☑ : Check if the system automatically changes the resolution based on EDID
 ☑ : Hardware Manifest
 ☑ : Check if the system recognizes hotplug events on HDMI
 ☑ : Collect information about supported types of USB
 ☑ : USB 3.0 insertion test on port 1
 ☑ : USB 3.0 removal test on port 1
```
where, depending on the capabilites, some jobs run.


[ZAP-578]: https://warthogs.atlassian.net/browse/ZAP-578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ