### PR TITLE
Add: cpu frequency governor cases for ARM device (new)

### DIFF
--- a/providers/base/bin/cpufreq_governors.py
+++ b/providers/base/bin/cpufreq_governors.py
@@ -1,0 +1,846 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Patrick Liu <patrick.liu@canonical.com>
+#   Rick Wu <rickwu4444@canonical.com>
+#
+# This is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this file.  If not, see <http://www.gnu.org/licenses/>.
+"""
+This program checks if the ARM system's CPU scaling works.
+"""
+
+import argparse
+import logging
+import os
+import re
+import subprocess
+import sys
+import time
+
+from multiprocessing import cpu_count
+from typing import List
+
+
+def init_logger():
+    """
+    Set the logger to log DEBUG and INFO to stdout, and
+    WARNING, ERROR, CRITICAL to stderr.
+    """
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    logger_format = "%(asctime)s %(levelname)-8s %(message)s"
+    date_format = "%Y-%m-%d %H:%M:%S"
+
+    # Log DEBUG and INFO to stdout, others to stderr
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stdout_handler.setLevel(logging.DEBUG)
+    stderr_handler.setLevel(logging.WARNING)
+
+    # Add a filter to the stdout handler to limit log records to
+    # INFO level and below
+    stdout_handler.addFilter(lambda record: record.levelno <= logging.INFO)
+
+    root_logger.addHandler(stderr_handler)
+    root_logger.addHandler(stdout_handler)
+
+    return root_logger
+
+
+class CPUScalingInfo:
+    """A class for gathering CPU scaling information."""
+
+    def __init__(self, policy=0):
+        """
+        Initialize the CPUScalingInfo object.
+
+        Args:
+            policy (int): The CPU policy number to be used (default is 0).
+        """
+        self.sys_cpu_dir = "/sys/devices/system/cpu"
+        self.policy = policy
+        self.cpu_policies = self.get_cpu_policies()
+        self.min_freq = self.get_min_frequency()
+        self.max_freq = self.get_max_frequency()
+        self.governors = self.get_supported_governors()
+        self.original_governor = self.get_governor()
+        self.affected_cpus = self.get_affected_cpus()
+
+    def get_cpu_policies(self) -> List:
+        """
+        Get a list of available CPU policies.
+
+        Returns:
+            List: A sorted list of available CPU policy numbers.
+        """
+        path = os.path.join(self.sys_cpu_dir, "cpufreq")
+        try:
+            policies = [
+                int(policy[6:])
+                for policy in os.listdir(path)
+                if re.match(r"policy\d+", policy)
+            ]
+        except IOError:
+            print("ERROR: Failed to get CPU policies from {}".format(path))
+            return []
+        if not policies:
+            print("ERROR: No CPU policies found in {}".format(path))
+            return []
+        return sorted(policies)
+
+    def get_scaling_driver(self, policy=0) -> str:
+        """
+        Get the scaling driver used by a specific CPU policy.
+
+        Args:
+            policy (int): The CPU policy number to query (default is 0).
+
+        Returns:
+            str: The name of the scaling driver for the specified policy.
+        """
+        path = os.path.join(
+            self.sys_cpu_dir,
+            "cpufreq",
+            "policy{}".format(policy),
+            "scaling_driver",
+        )
+        try:
+            with open(path, "r", encoding="UTF-8") as attr_file:
+                line = attr_file.read()
+                return line.strip()
+        except IOError:
+            print("ERROR: Fail to get scaling driver from {}".format(path))
+            return ""
+
+    def print_policies_list(self) -> bool:
+        """
+        Print the list of CPU policies and their corresponding scaling drivers
+
+        The output is in Checkbox resource job format.
+
+        Returns:
+            bool: True if the list is printed successfully, False otherwise.
+        """
+
+        if not self.cpu_policies:
+            return False
+        for policy in self.cpu_policies:
+            driver = self.get_scaling_driver(policy)
+            print("policy: {}".format(policy))
+            print("scaling_driver: {}".format(driver))
+            print()
+        return True
+
+    def get_attribute(self, attr) -> str:
+        """
+        Get the value of a specific attribute from the CPU sysfs.
+
+        Args:
+            attr (str): The name of the attribute to query.
+
+        Returns:
+            str: The value of the specified attribute.
+        """
+        logging.debug("Getting value from attribute '%s'", attr)
+        path = os.path.join(self.sys_cpu_dir, attr)
+        try:
+            with open(path, "r", encoding="UTF-8") as attr_file:
+                line = attr_file.read()
+                return line.strip()
+        except IOError:
+            logging.error("Fail to get attribute from %s", path)
+            return ""
+
+    def get_policy_attribute(self, attr) -> str:
+        """
+        Get the value of a specific attribute for the current CPU policy.
+
+        Args:
+            attr (str): The name of the attribute to query.
+
+        Returns:
+            str: The value of the specified attribute for the current policy.
+        """
+        return self.get_attribute(
+            "cpufreq/policy{}/{}".format(self.policy, attr)
+        )
+
+    def set_attribute(self, attr, value) -> bool:
+        """
+        Set the value of a specific attribute in the CPU sysfs.
+
+        Args:
+            attr (str): The name of the attribute to set.
+            value (str): The value to be set for the attribute.
+
+        Returns:
+            bool: True if the attribute is set successfully, False otherwise.
+        """
+        logging.debug("Setting value '%s' to attribute '%s'", value, attr)
+        path = os.path.join(self.sys_cpu_dir, attr)
+        try:
+            with open(path, "w", encoding="UTF-8") as attr_file:
+                attr_file.write(str(value))
+        except PermissionError:
+            logging.error("Permission denied when setting attribute %s", attr)
+            return False
+        except IOError:
+            logging.error("Fail to set '%s' to attribute %s", value, path)
+            return False
+        return True
+
+    def set_policy_attribute(self, attr, value) -> bool:
+        """
+        Set the value of a specific attribute for the current CPU policy.
+
+        Args:
+            attr (str): The name of the attribute to set.
+            value (str): The value to be set for the attribute.
+
+        Returns:
+            bool: True if the attribute is set successfully, False otherwise.
+        """
+        return self.set_attribute(
+            "cpufreq/policy{}/{}".format(self.policy, attr), value
+        )
+
+    def get_min_frequency(self) -> int:
+        """
+        Get the minimum CPU frequency for the current policy.
+
+        Returns:
+            int: The minimum CPU frequency in kHz.
+        """
+        frequency = self.get_policy_attribute("scaling_min_freq")
+        return int(frequency) if frequency else 0
+
+    def get_max_frequency(self) -> int:
+        """
+        Get the maximum CPU frequency for the current policy.
+
+        Returns:
+            int: The maximum CPU frequency in kHz.
+        """
+        frequency = self.get_policy_attribute("scaling_max_freq")
+        return int(frequency) if frequency else 0
+
+    def get_affected_cpus(self) -> List:
+        """
+        Get the list of affected CPUs for the current policy.
+
+        Returns:
+            List: A list of affected CPUs as strings.
+        """
+        values = self.get_policy_attribute("affected_cpus")
+        return values.split()
+
+    def get_supported_governors(self) -> List:
+        """
+        Get the list of supported governors for the current policy.
+
+        Returns:
+            List: A list of supported governors as strings.
+        """
+        values = self.get_policy_attribute("scaling_available_governors")
+        return values.split()
+
+    def get_governor(self) -> str:
+        """
+        Get the current governor for the current policy.
+
+        Returns:
+            str: The name of the current governor as a string.
+        """
+        return self.get_policy_attribute("scaling_governor")
+
+    def set_governor(self, governor) -> bool:
+        """
+        Set the governor for the current policy.
+
+        Args:
+            governor (str): The name of the governor to set.
+
+        Returns:
+            bool: True if the governor is set successfully, False otherwise.
+        """
+        return self.set_policy_attribute("scaling_governor", governor)
+
+    def set_frequency(self, frequency) -> bool:
+        """
+        Set the CPU frequency for the current policy.
+
+        Args:
+            frequency (int): The CPU frequency value to be set in kHz.
+
+        Returns:
+            bool: True if the frequency is set and verified successfully,
+                  False otherwise.
+        """
+        logging.debug("Setting Frequency to %s", frequency)
+        return self.set_policy_attribute("scaling_setspeed", frequency)
+
+
+class CPUScalingTest:
+    """A class for CPU scaling test operations."""
+
+    def __init__(self, policy=0):
+        """
+        Initialize the CPUScalingTest object.
+
+        Args:
+            policy (int): The CPU policy number to be used (default is 0).
+        """
+        self.policy = policy
+        self.info = CPUScalingInfo(policy=self.policy)
+
+    def stress_cpus(self) -> subprocess.Popen:
+        """
+        Stress the CPU cores by running multiple dd processes.
+
+        Returns:
+            subprocess.Popen: A list of Popen objects representing the
+                              dd processes spawned for each CPU core.
+        """
+        cpus_count = cpu_count()
+
+        cmd = ["dd", "if=/dev/zero", "of=/dev/null"]
+        processes = [subprocess.Popen(cmd) for _ in range(cpus_count)]
+        return processes
+
+    def stop_stress_cpus(self, processes):
+        """
+        Stop the CPU stress by terminating the specified dd processes.
+
+        Args:
+            processes (List[subprocess.Popen]): A list of Popen objects
+                                                representing the dd processes.
+        """
+        for p in processes:
+            p.terminate()
+            p.wait()
+
+    def print_policy_info(self):
+        """
+        Print information about the CPU frequency policy for the current CPU.
+        """
+        logging.info("## CPUfreq Policy%s Info ##", self.policy)
+        logging.info("Affected CPUs:")
+        if not self.info.governors:
+            logging.info("    None")
+        else:
+            for cpu in self.info.affected_cpus:
+                logging.info("    cpu%s", cpu)
+
+        logging.info(
+            "Supported CPU Frequencies: %s - %s MHz",
+            self.info.min_freq / 1000,
+            self.info.max_freq / 1000,
+        )
+
+        logging.info("Supported Governors:")
+        if not self.info.governors:
+            logging.info("    None")
+        else:
+            for governor in self.info.governors:
+                logging.info("    %s", governor)
+
+        logging.info("Current Governor: %s", self.info.original_governor)
+
+    def test_driver_detect(self) -> bool:
+        """
+        Print the unique scaling drivers used by available CPU policies.
+
+        If there are multiple drivers, they will be listed in a
+        space-separated format. Example:
+        "scaling_driver: driver_a driver_b"
+
+        Returns:
+            bool: True if the drivers are printed successfully,
+                  False otherwise.
+        """
+        if not self.info.cpu_policies:
+            return False
+        drivers = []
+        for policy in self.info.cpu_policies:
+            driver = self.info.get_scaling_driver(policy)
+            if driver and driver not in drivers:
+                drivers.append(driver)
+        if not drivers:
+            return False
+        else:
+            print("scaling_driver: {}".format(" ".join(drivers)))
+            return True
+
+    def test_userspace(self) -> bool:
+        """
+        Run the Userspace Governor Test.
+
+        Returns:
+            bool: True if the test passes, False otherwise.
+        """
+        logging.info("-------------------------------------------------")
+        logging.info("Running Userspace Governor Test")
+        success = True
+        governor = "userspace"
+        if governor not in self.info.governors:
+            if not self.probe_governor_module(governor):
+                return False
+
+        logging.info("Setting governor to %s", governor)
+        if not self.info.set_governor(governor):
+            success = False
+
+        # Set freq to minimum, verify
+        frequency = self.info.min_freq
+        logging.info(
+            "Setting CPU frequency to %u MHz", (int(frequency) / 1000)
+        )
+        if not self.info.set_frequency(frequency):
+            success = False
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        if not curr_freq or (self.info.min_freq != curr_freq):
+            logging.error(
+                "Could not verify that cpu frequency is set to the minimum"
+                " value of %s",
+                self.info.min_freq,
+            )
+            success = False
+
+        # Set freq to maximum, verify
+        frequency = self.info.max_freq
+        logging.info(
+            "Setting CPU frequency to %u MHz", (int(frequency) / 1000)
+        )
+        if not self.info.set_frequency(frequency):
+            success = False
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        if not curr_freq or (self.info.max_freq != curr_freq):
+            logging.error(
+                "Could not verify that cpu frequency is set to the maximum"
+                " value of %s",
+                self.info.max_freq,
+            )
+            success = False
+
+        if success:
+            logging.info("Userspace Governor Test: PASS")
+        return success
+
+    def test_performance(self) -> bool:
+        """
+        Run the Performance Governor Test.
+
+        Returns:
+            bool: True if the test passes, False otherwise.
+        """
+        logging.info("-------------------------------------------------")
+        logging.info("Running Performance Governor Test")
+        success = True
+        governor = "performance"
+        if governor not in self.info.governors:
+            if not self.probe_governor_module(governor):
+                return False
+
+        logging.info("Setting governor to %s", governor)
+        if not self.info.set_governor(governor):
+            success = False
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        logging.debug(
+            "Verifying current CPU frequency %s is close to max frequency",
+            curr_freq,
+        )
+        if not curr_freq or (
+            float(curr_freq) < 0.99 * float(self.info.max_freq)
+        ):
+            logging.error(
+                "Current cpu frequency of %s is not close enough to the "
+                "maximum value of %s",
+                curr_freq,
+                self.info.max_freq,
+            )
+            success = False
+
+        if success:
+            logging.info("Performance Governor Test: PASS")
+        return success
+
+    def test_powersave(self) -> bool:
+        """
+        Run the Powersave Governor Test.
+
+        Returns:
+            bool: True if the test passes, False otherwise.
+        """
+        logging.info("-------------------------------------------------")
+        logging.info("Running Powersave Governor Test")
+        success = True
+        governor = "powersave"
+        if governor not in self.info.governors:
+            if not self.probe_governor_module(governor):
+                return False
+
+        logging.info("Setting governor to %s", governor)
+        if not self.info.set_governor(governor):
+            success = False
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        logging.debug(
+            "Verifying current CPU frequency %s is close to min frequency",
+            curr_freq,
+        )
+        if not curr_freq or (
+            float(curr_freq) * 0.99 > float(self.info.min_freq)
+        ):
+            logging.error(
+                "Current cpu frequency of %s is not close enough to the "
+                "minimum value of %s",
+                curr_freq,
+                self.info.min_freq,
+            )
+            success = False
+
+        if success:
+            logging.info("Powersave Governor Test: PASS")
+        return success
+
+    def test_ondemand(self) -> bool:
+        """
+        Run the Ondemand Governor Test.
+
+        Returns:
+            bool: True if the test passes, False otherwise.
+        """
+        logging.info("-------------------------------------------------")
+        logging.info(
+            "Running Ondemand Governor Test on CPU policy%s", self.policy
+        )
+        success = True
+        governor = "ondemand"
+        if governor not in self.info.governors:
+            if not self.probe_governor_module(governor):
+                return False
+
+        logging.info("Setting governor to %s", governor)
+        if not self.info.set_governor(governor):
+            success = False
+
+        logging.info("Stressing CPUs...")
+        stress_process = self.stress_cpus()
+        time.sleep(5)
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
+        if (
+            not self.info.max_freq
+            or not curr_freq
+            or (self.info.max_freq != curr_freq)
+        ):
+            logging.error(
+                "Could not verify that cpu frequency has increased to the "
+                "maximum value"
+            )
+            success = False
+        else:
+            logging.info(
+                "Verified current CPU frequency is equal to the max frequency"
+            )
+
+        logging.info("Stop stressing CPUs...")
+        self.stop_stress_cpus(stress_process)
+        time.sleep(8)
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
+        if (
+            not self.info.min_freq
+            or not curr_freq
+            or (self.info.max_freq <= curr_freq)
+        ):
+            logging.error(
+                "Could not verify that cpu frequency has settled to a "
+                "lower frequency"
+            )
+            success = False
+        else:
+            logging.info(
+                "Verified current CPU frequency has settled to a "
+                "lower frequency"
+            )
+
+        if success:
+            logging.info("Ondemand Governor Test: PASS")
+        return success
+
+    def test_conservative(self) -> bool:
+        """
+        Run the Conservative Governor Test.
+
+        Returns:
+            bool: True if the test passes, False otherwise.
+        """
+        logging.info("-------------------------------------------------")
+        logging.info(
+            "Running Conservative Governor Test on CPU policy%s", self.policy
+        )
+        success = True
+        governor = "conservative"
+        if governor not in self.info.governors:
+            if not self.probe_governor_module(governor):
+                return False
+
+        logging.info("Setting governor to %s", governor)
+        if not self.info.set_governor(governor):
+            success = False
+
+        logging.info("Stressing CPUs...")
+        stress_process = self.stress_cpus()
+        time.sleep(5)
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
+        if (
+            not self.info.max_freq
+            or not curr_freq
+            or (self.info.max_freq != curr_freq)
+        ):
+            logging.error(
+                "Could not verify that cpu frequency has increased to the "
+                "maximum value"
+            )
+            success = False
+        else:
+            logging.info(
+                "Verified current CPU frequency is equal to the max frequency"
+            )
+
+        logging.info("Stop stressing CPUs...")
+        self.stop_stress_cpus(stress_process)
+        time.sleep(8)
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
+        if (
+            not self.info.min_freq
+            or not curr_freq
+            or (self.info.max_freq <= curr_freq)
+        ):
+            logging.error(
+                "Could not verify that cpu frequency has settled to a "
+                "lower frequency"
+            )
+            success = False
+        else:
+            logging.info(
+                "Verified current CPU frequency has settled to a "
+                "lower frequency"
+            )
+
+        if success:
+            logging.info("Conservative Governor Test: PASS")
+        return success
+
+    def test_schedutil(self) -> bool:
+        """
+        Run the Schedutil Governor Test.
+
+        Returns:
+            bool: True if the test passes, False otherwise.
+        """
+        logging.info("-------------------------------------------------")
+        logging.info(
+            "Running Schedutil Governor Test on CPU policy%s", self.policy
+        )
+        success = True
+        governor = "schedutil"
+        if governor not in self.info.governors:
+            if not self.probe_governor_module(governor):
+                return False
+
+        logging.info("Setting governor to %s", governor)
+        if not self.info.set_governor(governor):
+            success = False
+
+        logging.info("Stressing CPUs...")
+        stress_process = self.stress_cpus()
+        time.sleep(5)
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
+        if (
+            not self.info.max_freq
+            or not curr_freq
+            or (self.info.max_freq != curr_freq)
+        ):
+            logging.error(
+                "Could not verify that cpu frequency has increased to the "
+                "maximum value"
+            )
+            success = False
+        else:
+            logging.info(
+                "Verified current CPU frequency is equal to the max frequency"
+            )
+
+        logging.info("Stop stressing CPUs...")
+        self.stop_stress_cpus(stress_process)
+        time.sleep(8)
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
+        if (
+            not self.info.min_freq
+            or not curr_freq
+            or (self.info.max_freq <= curr_freq)
+        ):
+            logging.error(
+                "Could not verify that cpu frequency has settled to a "
+                "lower frequency"
+            )
+            success = False
+        else:
+            logging.info(
+                "Verified current CPU frequency has settled to a "
+                "lower frequency"
+            )
+
+        if success:
+            logging.info("Schedutil Governor Test: PASS")
+        return success
+
+    def restore_governor(self):
+        """
+        Restore the CPU governor to the original value.
+
+        This method sets the CPU governor to the original governor value
+        stored during initialization.
+        """
+        logging.info("-------------------------------------------------")
+        logging.info(
+            "Restoring original governor to %s",
+            self.info.original_governor
+        )
+        self.info.set_governor(self.info.original_governor)
+
+    def probe_governor_module(self, expected_governor) -> bool:
+        """
+        Probe the specific governor.
+
+        Args:
+            expected_governor (str): the name of governor
+
+        Returns:
+            bool: True if the governor be probed successfully, False otherwise
+        """
+        logging.info("Seems CPU frequency governors %s are not"
+                     " enable yet.", expected_governor)
+        module = ("cpufreq_{}".format(expected_governor))
+        logging.info("Attempting to probe %s ...", module)
+        cmd = ["modprobe", module]
+        try:
+            subprocess.run(
+                cmd,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8"
+            )
+            logging.info("Probe module Successfully!")
+            return True
+        except subprocess.CalledProcessError as err:
+            logging.error(err)
+            logging.error("%s governor not supported", expected_governor)
+            return False
+
+
+def main():
+    """
+    Execute the CPU scaling test based on the provided command-line arguments.
+
+    Command-line arguments:
+        -d, --debug: Turn on debug level output for extra info during the
+                     test run.
+        --policy-resource: Print the policies list in Checkbox resource job
+                           format.
+        --driver-detect: Print the CPU scaling driver.
+        --policy: Run the test on a specific CPU policy (default is policy 0).
+        --governor: Run a specific governor test.
+
+    Returns:
+        int: The exit code of the test execution, 0 if successful, 1 otherwise.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Turn on debug level output for extra info during test run.",
+    )
+    parser.add_argument(
+        "--policy-resource",
+        action="store_true",
+        help="Print the polices list in Checkbox resource job format.",
+    )
+    parser.add_argument(
+        "--driver-detect",
+        action="store_true",
+        help="Print the CPU scaling driver.",
+    )
+    parser.add_argument(
+        "--policy",
+        dest="policy",
+        help="Run test on specific policy",
+        default="0",
+    )
+    parser.add_argument(
+        "--governor",
+        dest="governor",
+        help="Run Specific Governor Test",
+    )
+    args = parser.parse_args()
+
+    logger = init_logger()
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+
+    info = CPUScalingInfo()
+    if args.policy_resource:
+        info.print_policies_list()
+        return 0
+
+    test = CPUScalingTest(policy=args.policy)
+    if args.driver_detect:
+        return 0 if test.test_driver_detect() else 1
+
+    exit_code = 0
+    try:
+        test.print_policy_info()
+        if not getattr(test, "test_{}".format(args.governor))():
+            exit_code = 1
+    except AttributeError:
+        logging.exception("Given governor is not supported")
+        return 1
+
+    test.restore_governor()
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/providers/base/tests/test_cpufreq_governors.py
+++ b/providers/base/tests/test_cpufreq_governors.py
@@ -1,0 +1,1201 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Rick Wu <rickwu4444@canonical.com>
+#   Patrick Chang <patrick.chang@canonical.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import subprocess
+import io
+import logging
+from unittest import mock
+import sys
+
+from cpufreq_governors import CPUScalingInfo, CPUScalingTest
+
+
+class TestCPUScalingTest(unittest.TestCase):
+    @mock.patch('cpufreq_governors.CPUScalingInfo',
+                return_value={})
+    def setUp(self, mock_cpuscalinginfo):
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+        # Create an instance of CPUScalingTest
+        self.cpu_scaling_test = CPUScalingTest()
+
+    @mock.patch('subprocess.run')
+    def test_probe_governor_module_success(self, mock_subprocess_run):
+        ''' Check if returns True while governor be probed successfully
+        '''
+        # Simulate a scenario governor module probe successfully.
+        governor = "test_governor"
+        mock_subprocess_run.returncode = 0
+        status = self.cpu_scaling_test.probe_governor_module(governor)
+        self.assertTrue(status)
+
+    @mock.patch('subprocess.run')
+    def test_probe_governor_module_fail(self, mock_subprocess_run):
+        ''' Check if returns False while governor cannot be probed
+        '''
+        # Simulate a scenario where the governors module probed fail.
+        # Create a mock subprocess.CompletedProcess object with a
+        # return code of SystemError
+        governor = "test_governor"
+        cmd = ["modprobe", governor]
+        mock_subprocess_run.side_effect = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=cmd,
+        )
+        status = self.cpu_scaling_test.probe_governor_module(governor)
+        self.assertFalse(status)
+
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_driver_detect_empty_cpu_policies(self, mock_cpuscalinginfo):
+        ''' Check if returns False while no cpu policy found
+        '''
+        mock_cpuscalinginfo.return_value.cpu_policies = []
+        instance = CPUScalingTest()
+        result = instance.test_driver_detect()
+        self.assertFalse(result)
+
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_driver_detect_single_policy(self, mock_cpuscalinginfo):
+        ''' Check if returns True while one cpu policy found
+        '''
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        # Return 'fake' string as driver name
+        mock_cpuscalinginfo.return_value.get_scaling_driver = lambda x: 'fake'
+        instance = CPUScalingTest()
+        result = instance.test_driver_detect()
+        self.assertTrue(result)
+
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_driver_detect_multiple_policies(self, mock_cpuscalinginfo):
+        ''' Check if returns True while multiple cpu policies found
+        '''
+        mock_cpuscalinginfo.return_value.cpu_policies = [
+            'policy0', 'policy1']
+        # Return 'fake' string as driver name
+        mock_cpuscalinginfo.return_value.get_scaling_driver = lambda x: 'fake'
+        instance = CPUScalingTest()
+        result = instance.test_driver_detect()
+        self.assertTrue(result)
+
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_driver_detect_no_driver(self, mock_cpuscalinginfo):
+        ''' Check if returns False while no driver found
+        '''
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.get_scaling_driver.return_value = []
+        instance = CPUScalingTest()
+        result = instance.test_driver_detect()
+        self.assertFalse(result)
+
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_userspace_success(self, mock_cpuscalinginfo):
+        ''' Check if CPU frequence can be set to the minimum and maximun while
+            using Userspce Governor
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['userspace']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor = lambda *args: True
+        minimum = 400000
+        mock_cpuscalinginfo.return_value.min_freq = minimum
+        maximum = 3600000
+        mock_cpuscalinginfo.return_value.max_freq = maximum
+        mock_cpuscalinginfo.return_value.get_policy_attribute.side_effect = [
+            minimum, maximum]
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_userspace()
+            # Expect True (Pass)
+            self.assertTrue(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Userspace Governor Test', lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to userspace', lc.output[2])
+            self.assertEqual(
+                'INFO:root:Setting CPU frequency to {} MHz'.format(
+                    int(minimum / 1000)), lc.output[3])
+            self.assertEqual(
+                'INFO:root:Setting CPU frequency to {} MHz'.format(
+                    int(maximum / 1000)), lc.output[4])
+            self.assertEqual(
+                'INFO:root:Userspace Governor Test: PASS', lc.output[5])
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_userspace_fails_to_set_as_minimum(self, mock_cpuscalinginfo):
+        ''' Check if CPU frequence cannot be set to the minimum value while
+            using Userspce Governor
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['userspace']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor = lambda *args: True
+        minimum = 400000
+        mock_cpuscalinginfo.return_value.min_freq = minimum
+        maximum = 3600000
+        mock_cpuscalinginfo.return_value.max_freq = maximum
+        # Mock the current value is 800000 after setting minimux to be 400000
+        mock_cpuscalinginfo.return_value.get_policy_attribute.side_effect = [
+            800000, maximum]
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_userspace()
+            # Expect False
+            self.assertFalse(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Userspace Governor Test', lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to userspace', lc.output[2])
+            self.assertEqual(
+                'INFO:root:Setting CPU frequency to {} MHz'.format(
+                    int(minimum / 1000)), lc.output[3])
+            self.assertEqual(
+                'ERROR:root:Could not verify that cpu frequency is set' +
+                ' to the minimum value of {}'.format(minimum),
+                lc.output[4])
+            self.assertEqual(
+                'INFO:root:Setting CPU frequency to {} MHz'.format(
+                    int(maximum / 1000)), lc.output[5])
+
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_userspace_fails_to_set_as_maximum(self, mock_cpuscalinginfo):
+        ''' Check if CPU frequence cannot be set to the maximum value while
+            using Userspce Governor
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['userspace']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor = lambda *args: True
+        minimum = 400000
+        mock_cpuscalinginfo.return_value.min_freq = 400000
+        maximum = 3600000
+        mock_cpuscalinginfo.return_value.max_freq = maximum
+        # Mock the current value is 2500000 after setting maximum to be 3600000
+        mock_cpuscalinginfo.return_value.get_policy_attribute.side_effect = [
+            minimum, 2500000]
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_userspace()
+            # Expect False
+            self.assertFalse(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Userspace Governor Test', lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to userspace', lc.output[2])
+            self.assertEqual(
+                'INFO:root:Setting CPU frequency to {} MHz'.format(
+                    int(minimum / 1000)), lc.output[3])
+            self.assertEqual(
+                'INFO:root:Setting CPU frequency to {} MHz'.format(
+                    int(maximum / 1000)), lc.output[4])
+            self.assertEqual(
+                'ERROR:root:Could not verify that cpu frequency is set' +
+                ' to the maximum value of {}'.format(maximum),
+                lc.output[5])
+
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_performance_success(self, mock_cpuscalinginfo):
+        ''' Check if CPU frequence is close to the maximum value (>99%) while
+            using Performance Governor
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['performance']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor = lambda *args: True
+        maximum = 3600000
+        mock_cpuscalinginfo.return_value.max_freq = maximum
+        # Mock the value of current frequency overs 99% of maximum
+        mock_cpuscalinginfo.return_value.get_policy_attribute.return_value = (
+            0.995 * float(maximum))
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_performance()
+            # Expect True (Pass)
+            self.assertTrue(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Performance Governor Test', lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to performance', lc.output[2])
+            self.assertEqual(
+                'DEBUG:root:Verifying current CPU frequency' +
+                ' {} is close to max frequency'.format(
+                    int(0.995 * float(maximum))),
+                lc.output[3]
+            )
+            self.assertEqual(
+                'INFO:root:Performance Governor Test: PASS', lc.output[4])
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_performance_fails_to_close_maximum(
+            self, mock_cpuscalinginfo):
+        ''' Check if CPU frequence is not close to the maximum value (<99%)
+            while using Performance Governor
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['performance']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor = lambda *args: True
+        maximum = 3600000
+        mock_cpuscalinginfo.return_value.max_freq = maximum
+        # Mock the value of current frequency overs 99% of maximum
+        mock_cpuscalinginfo.return_value.get_policy_attribute.return_value = (
+            0.989 * float(maximum))
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_performance()
+            # Expect False
+            self.assertFalse(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Performance Governor Test', lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to performance', lc.output[2])
+            self.assertEqual(
+                'DEBUG:root:Verifying current CPU frequency' +
+                ' {} is close to max frequency'.format(
+                    int(0.989 * float(maximum))),
+                lc.output[3]
+            )
+            self.assertEqual(
+                'ERROR:root:Current cpu frequency of' +
+                ' {} is not close'.format(int(0.989 * float(maximum))) +
+                ' enough to the maximum value of {}'.format(maximum),
+                lc.output[4]
+            )
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_powersave_success(self, mock_cpuscalinginfo):
+        ''' Check if current CPU frequence is very close to the minimum value
+            while using Powersave Governor
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['powersave']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor = lambda *args: True
+        minimum = 400000
+        mock_cpuscalinginfo.return_value.min_freq = minimum
+        # Mock the value of current frequency is over the minimum a little
+        mock_cpuscalinginfo.return_value.get_policy_attribute.return_value = (
+            float(minimum) * 100 / 99)
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_powersave()
+            # Expect True (Pass)
+            self.assertTrue(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Powersave Governor Test', lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to powersave', lc.output[2])
+            self.assertEqual(
+                'DEBUG:root:Verifying current CPU frequency' +
+                ' {} is close to min frequency'.format(
+                    int(float(minimum) * 100 / 99)),
+                lc.output[3]
+            )
+            self.assertEqual(
+                'INFO:root:Powersave Governor Test: PASS', lc.output[4])
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_powersave_fails_to_close_minimum(self, mock_cpuscalinginfo):
+        ''' Check if current CPU frequence is not very close to the minimum
+            value while using Powersave Governor
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['powersave']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor = lambda *args: True
+        minimum = 400000
+        mock_cpuscalinginfo.return_value.min_freq = minimum
+        # Mock the value of current frequency is over the minimum a little
+        mock_cpuscalinginfo.return_value.get_policy_attribute.return_value = (
+            float(minimum) * 100 / 98)
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_powersave()
+            # Expect False
+            self.assertFalse(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Powersave Governor Test', lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to powersave', lc.output[2])
+            self.assertEqual(
+                'DEBUG:root:Verifying current CPU frequency' +
+                ' {} is close to min frequency'.format(
+                    int(float(minimum) * 100 / 98)),
+                lc.output[3]
+            )
+            self.assertEqual(
+                'ERROR:root:Current cpu frequency of' +
+                ' {} is not close'.format(int(float(minimum) * 100 / 98)) +
+                ' enough to the minimum value of {}'.format(minimum),
+                lc.output[4]
+            )
+
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('time.sleep', return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stop_stress_cpus',
+        return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stress_cpus', return_value=None)
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_ondemand_success(
+        self,
+        mock_cpuscalinginfo,
+        mock_stress_cpus,
+        mock_stop_stress_cpus,
+        mock_time_sleep
+    ):
+        ''' Check if CPU frequence is able to be the maximun value while
+            stressing CPU and then down to lower frequency after stopping
+            stress and sleep for a while when using ondemand governor.
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['ondemand']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor.return_value = True
+        mock_cpuscalinginfo.return_value.min_freq = 400000
+        maximum = 3600000
+        mock_cpuscalinginfo.return_value.max_freq = maximum
+        # Mock the value of CPU frequency is maximum while stressing CPU, then
+        # down to the 60% of maximun after stopping stress and sleep for a
+        # while
+        mock_cpuscalinginfo.return_value.get_policy_attribute.side_effect = [
+            maximum, maximum * 0.6]
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_ondemand()
+            # Expect True (Pass)
+            self.assertTrue(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Ondemand Governor Test on CPU policy0',
+                lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to ondemand', lc.output[2])
+            self.assertEqual(
+                'INFO:root:Stressing CPUs...', lc.output[3])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum / 1000
+                ), lc.output[4])
+            self.assertEqual(
+                'INFO:root:Verified current CPU frequency is equal to the' +
+                ' max frequency', lc.output[5])
+            self.assertEqual('INFO:root:Stop stressing CPUs...', lc.output[6])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum * 0.6 / 1000
+                ), lc.output[7])
+            self.assertEqual(
+                'INFO:root:Verified current CPU frequency has ' +
+                'settled to a lower frequency', lc.output[8])
+
+            self.assertEqual(
+                'INFO:root:Ondemand Governor Test: PASS', lc.output[9])
+
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('time.sleep', return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stop_stress_cpus',
+        return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stress_cpus', return_value=None)
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_ondemand_fails_to_increase_frequency(
+        self,
+        mock_cpuscalinginfo,
+        mock_stress_cpus,
+        mock_stop_stress_cpus,
+        mock_time_sleep
+    ):
+        ''' Check if CPU frequence is unable to be incresed to the maximun
+            value after stressing CPU while using ondemand governor.
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['ondemand']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor.return_value = True
+        mock_cpuscalinginfo.return_value.min_freq = 400000
+        maximum = 3600000
+        mock_cpuscalinginfo.return_value.max_freq = maximum
+        # Mock the value of CPU frequency is not maximum even stress the CPU
+        # Set the second value to be same as origin since the value is not
+        # increased, we assume it's broken.
+        mock_cpuscalinginfo.return_value.get_policy_attribute.side_effect = [
+            maximum * 0.6, maximum * 0.6]
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_ondemand()
+            # Expect False (Pass)
+            self.assertFalse(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Ondemand Governor Test on CPU policy0',
+                lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to ondemand', lc.output[2])
+            self.assertEqual(
+                'INFO:root:Stressing CPUs...', lc.output[3])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum * 0.6 / 1000
+                ), lc.output[4])
+            self.assertEqual(
+                'ERROR:root:Could not verify that cpu frequency has ' +
+                'increased to the maximum value', lc.output[5])
+            self.assertEqual('INFO:root:Stop stressing CPUs...', lc.output[6])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum * 0.6 / 1000
+                ), lc.output[7])
+            self.assertEqual(
+                'INFO:root:Verified current CPU frequency has ' +
+                'settled to a lower frequency', lc.output[8])
+
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('time.sleep', return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stop_stress_cpus',
+        return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stress_cpus', return_value=None)
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_ondemand_fails_to_decrease_frequency(
+        self,
+        mock_cpuscalinginfo,
+        mock_stress_cpus,
+        mock_stop_stress_cpus,
+        mock_time_sleep
+    ):
+        ''' Check if CPU frequence is increased to the maximun value
+            after stressing CPU but cannot be decreased even after stopping
+            the stress and sleep for a while when using ondemand governor.
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['ondemand']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor.return_value = True
+        mock_cpuscalinginfo.return_value.min_freq = 400000
+        maximum = 3600000
+        mock_cpuscalinginfo.return_value.max_freq = maximum
+        # Mock the value of CPU frequency is to be maximum after stress the CPU
+        # Set the second value to be same as maximum since the value is not
+        # decreased, we assume it's broken.
+        mock_cpuscalinginfo.return_value.get_policy_attribute.side_effect = [
+            maximum, maximum]
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_ondemand()
+            # Expect False (Pass)
+            self.assertFalse(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Ondemand Governor Test on CPU policy0',
+                lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to ondemand', lc.output[2])
+            self.assertEqual(
+                'INFO:root:Stressing CPUs...', lc.output[3])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum / 1000
+                ), lc.output[4])
+            self.assertEqual(
+                'INFO:root:Verified current CPU frequency is equal to the' +
+                ' max frequency', lc.output[5])
+            self.assertEqual('INFO:root:Stop stressing CPUs...', lc.output[6])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum / 1000
+                ), lc.output[7])
+            self.assertEqual(
+                'ERROR:root:Could not verify that cpu frequency has ' +
+                'settled to a lower frequency', lc.output[8])
+
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('time.sleep', return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stop_stress_cpus',
+        return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stress_cpus', return_value=None)
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_conservative_success(
+        self,
+        mock_cpuscalinginfo,
+        mock_stress_cpus,
+        mock_stop_stress_cpus,
+        mock_time_sleep
+    ):
+        ''' Check if CPU frequence is able to be the maximun value while
+            stressing CPU and then down to lower frequency after stopping
+            stress and sleep for a while when using conservative governor.
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['conservative']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor.return_value = True
+        mock_cpuscalinginfo.return_value.min_freq = 400000
+        maximum = 3600000
+        mock_cpuscalinginfo.return_value.max_freq = maximum
+        # Mock the value of CPU frequency is maximum while stressing CPU, then
+        # down to the 60% of maximun after stopping stress and sleep for a
+        # while
+        mock_cpuscalinginfo.return_value.get_policy_attribute.side_effect = [
+            maximum, maximum * 0.6]
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_conservative()
+            # Expect True (Pass)
+            self.assertTrue(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Conservative Governor Test on CPU policy0',
+                lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to conservative', lc.output[2])
+            self.assertEqual(
+                'INFO:root:Stressing CPUs...', lc.output[3])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum / 1000
+                ), lc.output[4])
+            self.assertEqual(
+                'INFO:root:Verified current CPU frequency is equal to the' +
+                ' max frequency', lc.output[5])
+            self.assertEqual('INFO:root:Stop stressing CPUs...', lc.output[6])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum * 0.6 / 1000
+                ), lc.output[7])
+            self.assertEqual(
+                'INFO:root:Verified current CPU frequency has ' +
+                'settled to a lower frequency', lc.output[8])
+
+            self.assertEqual(
+                'INFO:root:Conservative Governor Test: PASS', lc.output[9])
+
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('time.sleep', return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stop_stress_cpus',
+        return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stress_cpus', return_value=None)
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_conservative_fails_to_increase_frequency(
+        self,
+        mock_cpuscalinginfo,
+        mock_stress_cpus,
+        mock_stop_stress_cpus,
+        mock_time_sleep
+    ):
+        ''' Check if CPU frequence is unable to be incresed to the maximun
+            value after stressing CPU while using conservative governor.
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['conservative']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor.return_value = True
+        mock_cpuscalinginfo.return_value.min_freq = 400000
+        maximum = 3600000
+        mock_cpuscalinginfo.return_value.max_freq = maximum
+        # Mock the value of CPU frequency is not maximum even stress the CPU
+        # Set the second value to be same as origin since the value is not
+        # increased, we assume it's broken.
+        mock_cpuscalinginfo.return_value.get_policy_attribute.side_effect = [
+            maximum * 0.6, maximum * 0.6]
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_conservative()
+            # Expect False (Pass)
+            self.assertFalse(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Conservative Governor Test on CPU policy0',
+                lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to conservative', lc.output[2])
+            self.assertEqual(
+                'INFO:root:Stressing CPUs...', lc.output[3])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum * 0.6 / 1000
+                ), lc.output[4])
+            self.assertEqual(
+                'ERROR:root:Could not verify that cpu frequency has ' +
+                'increased to the maximum value', lc.output[5])
+            self.assertEqual('INFO:root:Stop stressing CPUs...', lc.output[6])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum * 0.6 / 1000
+                ), lc.output[7])
+            self.assertEqual(
+                'INFO:root:Verified current CPU frequency has ' +
+                'settled to a lower frequency', lc.output[8])
+
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('time.sleep', return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stop_stress_cpus',
+        return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stress_cpus', return_value=None)
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_conservative_fails_to_decrease_frequency(
+        self,
+        mock_cpuscalinginfo,
+        mock_stress_cpus,
+        mock_stop_stress_cpus,
+        mock_time_sleep
+    ):
+        ''' Check if CPU frequence is increased to the maximun value
+            after stressing CPU but cannot be decreased even after stopping
+            the stress and sleep for a while when using conservative governor.
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['conservative']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor.return_value = True
+        mock_cpuscalinginfo.return_value.min_freq = 400000
+        maximum = 3600000
+        mock_cpuscalinginfo.return_value.max_freq = maximum
+        # Mock the value of CPU frequency is to be maximum after stress the CPU
+        # Set the second value to be same as maximum since the value is not
+        # decreased, we assume it's broken.
+        mock_cpuscalinginfo.return_value.get_policy_attribute.side_effect = [
+            maximum, maximum]
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_conservative()
+            # Expect False (Pass)
+            self.assertFalse(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Conservative Governor Test on CPU policy0',
+                lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to conservative', lc.output[2])
+            self.assertEqual(
+                'INFO:root:Stressing CPUs...', lc.output[3])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum / 1000
+                ), lc.output[4])
+            self.assertEqual(
+                'INFO:root:Verified current CPU frequency is equal to the' +
+                ' max frequency', lc.output[5])
+            self.assertEqual('INFO:root:Stop stressing CPUs...', lc.output[6])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum / 1000
+                ), lc.output[7])
+            self.assertEqual(
+                'ERROR:root:Could not verify that cpu frequency has ' +
+                'settled to a lower frequency', lc.output[8])
+
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('time.sleep', return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stop_stress_cpus',
+        return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stress_cpus', return_value=None)
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_schedutil_success(
+        self,
+        mock_cpuscalinginfo,
+        mock_stress_cpus,
+        mock_stop_stress_cpus,
+        mock_time_sleep
+    ):
+        ''' Check if CPU frequence is able to be the maximun value while
+            stressing CPU and then down to lower frequency after stopping
+            stress and sleep for a while when using schedutil governor.
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['schedutil']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor.return_value = True
+        mock_cpuscalinginfo.return_value.min_freq = 400000
+        maximum = 3600000
+        mock_cpuscalinginfo.return_value.max_freq = maximum
+        # Mock the value of CPU frequency is maximum while stressing CPU, then
+        # down to the 60% of maximun after stopping stress and sleep for a
+        # while
+        mock_cpuscalinginfo.return_value.get_policy_attribute.side_effect = [
+            maximum, maximum * 0.6]
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_schedutil()
+            # Expect True (Pass)
+            self.assertTrue(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Schedutil Governor Test on CPU policy0',
+                lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to schedutil', lc.output[2])
+            self.assertEqual(
+                'INFO:root:Stressing CPUs...', lc.output[3])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum / 1000
+                ), lc.output[4])
+            self.assertEqual(
+                'INFO:root:Verified current CPU frequency is equal to the' +
+                ' max frequency', lc.output[5])
+            self.assertEqual('INFO:root:Stop stressing CPUs...', lc.output[6])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum * 0.6 / 1000
+                ), lc.output[7])
+            self.assertEqual(
+                'INFO:root:Verified current CPU frequency has ' +
+                'settled to a lower frequency', lc.output[8])
+
+            self.assertEqual(
+                'INFO:root:Schedutil Governor Test: PASS', lc.output[9])
+
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('time.sleep', return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stop_stress_cpus',
+        return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stress_cpus', return_value=None)
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_schedutil_fails_to_increase_frequency(
+        self,
+        mock_cpuscalinginfo,
+        mock_stress_cpus,
+        mock_stop_stress_cpus,
+        mock_time_sleep
+    ):
+        ''' Check if CPU frequence is unable to be incresed to the maximun
+            value after stressing CPU while using schedutil governor.
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['schedutil']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor.return_value = True
+        mock_cpuscalinginfo.return_value.min_freq = 400000
+        maximum = 3600000
+        mock_cpuscalinginfo.return_value.max_freq = maximum
+        # Mock the value of CPU frequency is not maximum even stress the CPU
+        # Set the second value to be same as origin since the value is not
+        # increased, we assume it's broken.
+        mock_cpuscalinginfo.return_value.get_policy_attribute.side_effect = [
+            maximum * 0.6, maximum * 0.6]
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_schedutil()
+            # Expect False (Pass)
+            self.assertFalse(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Schedutil Governor Test on CPU policy0',
+                lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to schedutil', lc.output[2])
+            self.assertEqual(
+                'INFO:root:Stressing CPUs...', lc.output[3])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum * 0.6 / 1000
+                ), lc.output[4])
+            self.assertEqual(
+                'ERROR:root:Could not verify that cpu frequency has ' +
+                'increased to the maximum value', lc.output[5])
+            self.assertEqual('INFO:root:Stop stressing CPUs...', lc.output[6])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum * 0.6 / 1000
+                ), lc.output[7])
+            self.assertEqual(
+                'INFO:root:Verified current CPU frequency has ' +
+                'settled to a lower frequency', lc.output[8])
+
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    @mock.patch('time.sleep', return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stop_stress_cpus',
+        return_value=None)
+    @mock.patch(
+        'cpufreq_governors.CPUScalingTest.stress_cpus', return_value=None)
+    @mock.patch('cpufreq_governors.CPUScalingInfo')
+    def test_test_schedutil_fails_to_decrease_frequency(
+        self,
+        mock_cpuscalinginfo,
+        mock_stress_cpus,
+        mock_stop_stress_cpus,
+        mock_time_sleep
+    ):
+        ''' Check if CPU frequence is increased to the maximun value
+            after stressing CPU but cannot be decreased even after stopping
+            the stress and sleep for a while when using schedutil governor.
+        '''
+        mock_cpuscalinginfo.return_value.governors = ['schedutil']
+        mock_cpuscalinginfo.return_value.cpu_policies = ['policy0']
+        mock_cpuscalinginfo.return_value.set_governor.return_value = True
+        mock_cpuscalinginfo.return_value.min_freq = 400000
+        maximum = 3600000
+        mock_cpuscalinginfo.return_value.max_freq = maximum
+        # Mock the value of CPU frequency is to be maximum after stress the CPU
+        # Set the second value to be same as maximum since the value is not
+        # decreased, we assume it's broken.
+        mock_cpuscalinginfo.return_value.get_policy_attribute.side_effect = [
+            maximum, maximum]
+
+        with self.assertLogs(level='DEBUG') as lc:
+            # release stdout
+            sys.stdout = sys.__stdout__
+            logging.disable(logging.NOTSET)
+            instance = CPUScalingTest()
+            result = instance.test_schedutil()
+            # Expect False (Pass)
+            self.assertFalse(result)
+            # Check stdout
+            self.assertEqual(
+                'INFO:root:-------------------------------------------------',
+                lc.output[0]
+            )
+            self.assertEqual(
+                'INFO:root:Running Schedutil Governor Test on CPU policy0',
+                lc.output[1])
+            self.assertEqual(
+                'INFO:root:Setting governor to schedutil', lc.output[2])
+            self.assertEqual(
+                'INFO:root:Stressing CPUs...', lc.output[3])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum / 1000
+                ), lc.output[4])
+            self.assertEqual(
+                'INFO:root:Verified current CPU frequency is equal to the' +
+                ' max frequency', lc.output[5])
+            self.assertEqual('INFO:root:Stop stressing CPUs...', lc.output[6])
+            self.assertEqual(
+                'DEBUG:root:Current CPU frequency: {} MHz'.format(
+                    maximum / 1000
+                ), lc.output[7])
+            self.assertEqual(
+                'ERROR:root:Could not verify that cpu frequency has ' +
+                'settled to a lower frequency', lc.output[8])
+
+        # Supress stdout
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        # release stdout
+        sys.stdout = sys.__stdout__
+        logging.disable(logging.NOTSET)
+
+
+class TestCPUScalingInfo(unittest.TestCase):
+    @mock.patch('cpufreq_governors.CPUScalingInfo.__init__',
+                return_value=None)
+    def setUp(self,
+              mock_init):
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable(logging.CRITICAL)
+        CPUScalingInfo.__init__ = mock_init
+        # Create an instance of CPUScalingInfo
+        self.cpu_scaling_info = CPUScalingInfo()
+        self.cpu_scaling_info.sys_cpu_dir = "/sys/devices/system/cpu"
+
+    @mock.patch('os.listdir')
+    def test_get_cpu_policies_success(self, mock_listdir):
+        ''' Check if a sorted list contains cpu policy number can be returned
+            while policies exist.
+        '''
+        # Mock the listdir function to return a list of CPU policies
+        mock_listdir.return_value = ["policy0", "policy1", "policy2"]
+        # Call the get_cpu_policies function
+        policies = self.cpu_scaling_info.get_cpu_policies()
+
+        # Assert that the function returns the expected list of policies
+        self.assertEqual(policies, [0, 1, 2])
+
+    @mock.patch('os.listdir')
+    def test_get_cpu_policies_failure(self, mock_listdir):
+        ''' Check if an empty list be returned while OSError
+        '''
+        # Mock the listdir function to raise an OSError
+        mock_listdir.side_effect = OSError("OSError")
+        result = self.cpu_scaling_info.get_cpu_policies()
+        self.assertEqual(result, [])
+
+    @mock.patch('os.listdir')
+    def test_get_cpu_policies_failure_empty(self, mock_listdir):
+        ''' Check if an empty list be returned while no policy exists
+        '''
+        # Mock the listdir function to return an empty list
+        mock_listdir.return_value = []
+        result = self.cpu_scaling_info.get_cpu_policies()
+        self.assertEqual(result, [])
+
+    @mock.patch('builtins.open', mock.mock_open(read_data='Driver'))
+    def test_get_scaling_driver_success(self):
+        ''' Check if the name of driver be returned
+        '''
+        # Mock the open function to return a scaling driver
+        result = self.cpu_scaling_info.get_scaling_driver()
+        self.assertEqual(result, "Driver")
+
+    @mock.patch('builtins.open', side_effect=OSError)
+    def test_get_scaling_driver_oserror(self, mock_open):
+        ''' Check if an empty string be returned while OSError
+        '''
+        # Mock the open function to raise an OSError
+        result = self.cpu_scaling_info.get_scaling_driver()
+        self.assertEqual(result, "")
+
+    @mock.patch('builtins.open', mock.mock_open(read_data='Attribute_Value'))
+    def test_get_attribute_success(self):
+        ''' Check if get_attribute gets the contain of specific node
+        '''
+        # Mock the open function to return a attribute value
+        result = self.cpu_scaling_info.get_attribute("Attribute")
+        self.assertEqual(result, "Attribute_Value")
+
+    @mock.patch('builtins.open', side_effect=OSError)
+    def test_get_attribute_oserror(self, mock_open):
+        ''' Check if get_attribute gets an empty string while OSError occurs
+        '''
+        # Mock the open function to raise an OSError
+        result = self.cpu_scaling_info.get_attribute("Attribute")
+        self.assertEqual(result, "")
+
+    @mock.patch('builtins.open', new_callable=mock.mock_open, create=True)
+    def test_set_attribute_success(self, mock_open):
+        ''' Check if returns True while setting a value to a specific node
+        '''
+        mock_file = mock_open.return_value
+        result = self.cpu_scaling_info.set_attribute(
+            'attribute_name',
+            'new_value')
+        mock_file.write.assert_called_once_with('new_value')
+        self.assertTrue(result)
+
+    @mock.patch('builtins.open', side_effect=PermissionError)
+    def test_set_attribute_permissionerror(self, mock_open):
+        ''' Check if returns False while PermissionError occurs
+        '''
+        # Mock the open function to raise an PermissionError
+        result = self.cpu_scaling_info.set_attribute(
+            'attribute_name',
+            'new_value')
+        self.assertFalse(result)
+
+    @mock.patch('builtins.open', side_effect=OSError)
+    def test_set_attribute_oserror(self, mock_open):
+        ''' Check if returns False while OSError occurs
+        '''
+        # Mock the open function to raise an OSError
+        result = self.cpu_scaling_info.set_attribute(
+            'attribute_name',
+            'new_value')
+        self.assertFalse(result)
+
+    def tearDown(self):
+        # release stdout
+        sys.stdout = sys.__stdout__
+        logging.disable(logging.NOTSET)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/providers/base/units/cpu/jobs.pxu
+++ b/providers/base/units/cpu/jobs.pxu
@@ -290,3 +290,132 @@ _summary:
  cpufreq scaling test
 _description:
  Comprehensive testing of cpu scaling capabilities and directives via cpufreq.
+
+id: cpufreq_policy_list
+_summary: List the cpufreq policies
+_description:
+    List the cpufreq policies with the corresponding scaling drivers
+plugin: resource
+user: root
+category_id: com.canonical.plainbox::cpu
+estimated_duration: 1s
+command: cpufreq_governors.py --policy-resource
+
+id: cpu/cpufreq_driver_detect
+_summary: Detect if the CPU scaling driver exists
+plugin: shell
+user: root
+category_id: com.canonical.plainbox::cpu
+flags: also-after-suspend
+estimated_duration: 1s
+command: cpufreq_governors.py --driver-detect
+
+unit: template
+template-resource: cpufreq_policy_list
+template-unit: job
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+id: cpu/cpufreq-governor-performance-policy{policy}
+_summary: Test "performance" scaling governor on policy{policy}
+_description:
+    This job sets the governor to "performance" and 
+    verifies whether the frequency is maximum.
+plugin: shell
+user: root
+category_id: com.canonical.plainbox::cpu
+flags: also-after-suspend
+estimated_duration: 1s
+depends: cpu/cpufreq_driver_detect
+command: cpufreq_governors.py --policy {policy} --governor performance
+
+unit: template
+template-resource: cpufreq_policy_list
+template-unit: job
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+id: cpu/cpufreq-governor-powersave-policy{policy}
+_summary: Test "powersave" scaling governor on policy{policy}
+_description:
+    This job sets the governor to "powersave" and 
+    verifies whether the frequency is minimum.
+plugin: shell
+user: root
+category_id: com.canonical.plainbox::cpu
+flags: also-after-suspend
+estimated_duration: 1s
+depends: cpu/cpufreq_driver_detect
+command: cpufreq_governors.py --policy {policy} --governor powersave
+
+unit: template
+template-resource: cpufreq_policy_list
+template-unit: job
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+id: cpu/cpufreq-governor-userspace-policy{policy}
+_summary: Test "userspace" scaling governor on policy{policy}
+_description:
+    This job sets the governor to "userspace" and 
+    verifies the frequency when setting it to maximum
+    and minimum.
+plugin: shell
+user: root
+category_id: com.canonical.plainbox::cpu
+flags: also-after-suspend
+estimated_duration: 1s
+depends: cpu/cpufreq_driver_detect
+command: cpufreq_governors.py --policy {policy} --governor userspace
+
+unit: template
+template-resource: cpufreq_policy_list
+template-unit: job
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+id: cpu/cpufreq-governor-schedutil-policy{policy}
+_summary: Test "schedutil" scaling governor on policy{policy}
+_description:
+    This job sets the governor to "schedutil" and
+    verifies whether the frequency will be maximum
+    after stressing CPUs and settling down after
+    sleeping for a few seconds.
+plugin: shell
+user: root
+category_id: com.canonical.plainbox::cpu
+flags: also-after-suspend
+estimated_duration: 14s
+depends: cpu/cpufreq_driver_detect
+command: cpufreq_governors.py --policy {policy} --governor schedutil
+
+unit: template
+template-resource: cpufreq_policy_list
+template-unit: job
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+id: cpu/cpufreq-governor-ondemand-policy{policy}
+_summary: Test "ondemand" scaling governor on policy{policy}
+_description:
+    This job sets the governor to "ondemand" and
+    verifies whether the frequency will be maximum
+    after stressing CPUs and settling down after
+    sleeping for a few seconds.
+plugin: shell
+user: root
+category_id: com.canonical.plainbox::cpu
+flags: also-after-suspend
+estimated_duration: 14s
+depends: cpu/cpufreq_driver_detect
+command: cpufreq_governors.py --policy {policy} --governor ondemand
+
+unit: template
+template-resource: cpufreq_policy_list
+template-unit: job
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+id: cpu/cpufreq-governor-conservative-policy{policy}
+_summary: Test "conservative" scaling governor on policy{policy}
+_description:
+    This job sets the governor to "conservative" and
+    verifies whether the frequency will be maximum
+    after stressing CPUs and settling down after
+    sleeping for a few seconds.
+plugin: shell
+user: root
+category_id: com.canonical.plainbox::cpu
+flags: also-after-suspend
+estimated_duration: 14s
+depends: cpu/cpufreq_driver_detect
+command: cpufreq_governors.py --policy {policy} --governor conservative
+

--- a/providers/base/units/cpu/test-plan.pxu
+++ b/providers/base/units/cpu/test-plan.pxu
@@ -19,6 +19,8 @@ id: cpu-cert-automated
 unit: test plan
 _name: CPU tests (automated)
 _description: CPU tests (automated)
+bootstrap_include:
+    cpufreq_policy_list
 include:
     cpu/cstates                                    certification-status=blocker
     cpu/cstates_results.log
@@ -29,11 +31,20 @@ include:
     cpu/offlining_test                             certification-status=blocker
     cpu/topology                                   certification-status=blocker
     cpu/clocktest
+    cpu/cpufreq_driver_detect
+    cpu/cpufreq-governor-performance-.*
+    cpu/cpufreq-governor-powersave-.*
+    cpu/cpufreq-governor-userspace-.*
+    cpu/cpufreq-governor-schedutil-.*
+    cpu/cpufreq-governor-ondemand-.*
+    cpu/cpufreq-governor-conservative-.*
 
 id: after-suspend-cpu-cert-automated
 unit: test plan
 _name: CPU tests after suspend (automated)
 _description: CPU tests after suspend (automated)
+bootstrap_include:
+    cpufreq_policy_list
 include:
     after-suspend-cpu/cstates                      certification-status=blocker
     after-suspend-cpu/cstates_results.log
@@ -44,6 +55,13 @@ include:
     after-suspend-cpu/offlining_test                             certification-status=blocker
     after-suspend-cpu/topology                     certification-status=blocker
     after-suspend-cpu/clocktest
+    after-suspend-cpu/cpufreq_driver_detect
+    after-suspend-cpu/cpufreq-governor-performance-.*
+    after-suspend-cpu/cpufreq-governor-powersave-.*
+    after-suspend-cpu/cpufreq-governor-userspace-.*
+    after-suspend-cpu/cpufreq-governor-schedutil-.*
+    after-suspend-cpu/cpufreq-governor-ondemand-.*
+    after-suspend-cpu/cpufreq-governor-conservative-.*
 
 id: cpu-cert-blockers
 unit: test plan
@@ -77,6 +95,8 @@ id: cpu-automated
 unit: test plan
 _name: Automated CPU tests
 _description: Automated CPU tests for Snappy Ubuntu Core devices
+bootstrap_include:
+    cpufreq_policy_list
 include:
     cpu/scaling_test
     cpu/scaling_test-log-attach
@@ -88,6 +108,38 @@ include:
     cpu/arm_vfp_support_.*
     cpu/cstates
     cpu/cstates_results.log
+    cpu/cpufreq_driver_detect
+    cpu/cpufreq-governor-performance-.*
+    cpu/cpufreq-governor-powersave-.*
+    cpu/cpufreq-governor-userspace-.*
+    cpu/cpufreq-governor-schedutil-.*
+    cpu/cpufreq-governor-ondemand-.*
+    cpu/cpufreq-governor-conservative-.*
+
+id: after-suspend-cpu-automated
+unit: test plan
+_name: Automated CPU tests after suspend
+_description: Automated CPU tests for Snappy Ubuntu Core devices after suspend
+bootstrap_include:
+    cpufreq_policy_list
+include:
+    after-suspend-cpu/scaling_test
+    after-suspend-cpu/scaling_test-log-attach
+    after-suspend-cpu/maxfreq_test
+    after-suspend-cpu/maxfreq_test-log-attach
+    after-suspend-cpu/clocktest
+    after-suspend-cpu/offlining_test
+    after-suspend-cpu/topology
+    after-suspend-cpu/arm_vfp_support_.*
+    after-suspend-cpu/cstates
+    after-suspend-cpu/cstates_results.log
+    after-suspend-cpu/cpufreq_driver_detect
+    after-suspend-cpu/cpufreq-governor-performance-.*
+    after-suspend-cpu/cpufreq-governor-powersave-.*
+    after-suspend-cpu/cpufreq-governor-userspace-.*
+    after-suspend-cpu/cpufreq-governor-schedutil-.*
+    after-suspend-cpu/cpufreq-governor-ondemand-.*
+    after-suspend-cpu/cpufreq-governor-conservative-.*
 
 id: server-cpu
 unit: test plan

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu
@@ -147,6 +147,7 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
+  after-suspend-cpu-automated
 
 
 id: client-cert-iot-ubuntucore-22-stress


### PR DESCRIPTION
## Description
### Purpose

1. OEM-QA team designed the CPU frequency governor cases for ARM device

    - https://warthogs.atlassian.net/browse/CQT-1652

2. These cases are well tested on lots of ARM devices, therefore, it’s qualified to be merged back to Checkbox.
    - Migrate the test cases of CPU frequency governor from [CE-OEM](https://github.com/canonical/checkbox-provider-ce-oem/blob/main/checkbox-provider-ce-oem/units/cpu/test-plan.pxu#L19)

### Additional Information

These cases were designed by Patrick Liu for Baytown project at beginning.

- https://warthogs.atlassian.net/browse/CQT-1652
- https://warthogs.atlassian.net/browse/CQT-2906 

Then Rick improved it by adding the probe function and some unit test

- https://github.com/canonical/checkbox-provider-ce-oem/pull/51

## Resolved issues
Introduce the CPU Frequency Governor test cases for ARM device

### Project Test Results with [checkbox-ce-oem](https://github.com/canonical/checkbox-provider-ce-oem/blob/main/checkbox-provider-ce-oem/units/cpu/test-plan.pxu#L19) provider

- Baoshan
    - Server Image:
        - G1200: https://certification.canonical.com/hardware/202307-31862/submission/336991/test-results/?term=cpufreq
        - G700: https://certification.canonical.com/hardware/202303-31430/submission/337432/test-results/?term=cpufreq
        - G350: https://certification.canonical.com/hardware/202309-32029/submission/336706/test-results/?term=cpufreq
    - Desktop Image:
        - G1200: https://certification.canonical.com/hardware/202307-31858/submission/337434/test-results/?term=cpufreq
        - G700: https://certification.canonical.com/hardware/202308-31931/submission/337426/test-results/?term=cpufreq
- Shiner
    - Core Image: https://certification.canonical.com/hardware/202304-31535/submission/326030/test-results/?term=cpufreq
- Limerick:
    - Server Image: https://certification.canonical.com/hardware/202307-31903/submission/330308/test-results/?term=cpufreq

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests
### Sideload Test Results

- Baoshan (ARM)
    - Server Image on G1200 platform: https://certification.canonical.com/hardware/202307-31858/submission/337483/test-results/pass/?term=cpufreq
        - Run `client-cert-iot-server-22-04-automated` test plan
    - Desktop Image on G700 platform: https://certification.canonical.com/hardware/202308-31931/submission/337487/test-results/pass/?term=cpufreq
       - Run `client-cert-desktop-22-04-automated` test plan
- Dell (x86-64)
    - Jammy Desktop Image: https://certification.canonical.com/hardware/201712-26032/submission/337746/test-results/?term=cpufreq
         - Only cpufreq_driver_detect job be generated and executed, it means these CPU frequency governor test cases won’t affect the x86-64 platforms.
         - Run `client-cert-desktop-22-04-automated` test plan
