### PR TITLE
fix reboot metabox scenario (BugFix)

### DIFF
--- a/metabox/metabox/scenarios/restart/launcher.py
+++ b/metabox/metabox/scenarios/restart/launcher.py
@@ -21,26 +21,28 @@ import textwrap
 
 from metabox.core.actions import AssertPrinted
 from metabox.core.scenario import Scenario
+from metabox.core.utils import tag
 
+
+@tag("reboot")
 class Reboot(Scenario):
-
-    modes = ['remote']
-    launcher = textwrap.dedent("""
-    [launcher]
-    launcher_version = 1
-    stock_reports = text
-    [test plan]
-    unit = com.canonical.certification::power-automated
-    forced = yes
-    [test selection]
-    forced = yes
-    exclude = .*cold.*
-    [ui]
-    type = silent
-    """)
+    modes = ["remote"]
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = com.canonical.certification::power-automated
+        forced = yes
+        [test selection]
+        forced = yes
+        exclude = .*cold.*
+        [ui]
+        type = silent
+        """
+    )
     steps = [
-        AssertPrinted('Connection lost!'),
-        AssertPrinted('Reconnecting'),
-        AssertPrinted("Reconnected\s+\(took"),
-        AssertPrinted('job passed   : Warm reboot'),
+        AssertPrinted("Connection lost!"),
+        AssertPrinted("job passed   : Warm reboot"),
     ]


### PR DESCRIPTION
## Description
The reboot metabox scenario asserted that the controller would write `Reconnecting` when the reboot happens, but on a very fast machine, the reboot happens so fast, that the controller doesn't have to wait even one sleep iteration making it not print out `Reconnecting` and just connecting immediately.

This patch removes the assertion for the reconnecting text.

The patch also improves the formatting and introduces a tag for the test.

## Tests
This patch fixes the test.