### PR TITLE
Fix UnboundLocalError in subcommands.py (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -295,7 +295,7 @@ class Launcher(MainLoopStage, ReportsStage):
             _ = detect_restart_strategy(session_type="local")
         except LookupError as exc:
             _logger.warning(exc)
-            _logger.warning(_("Automatic restart disabled!"))
+            _logger.warning(gettext.gettext("Automatic restart disabled!"))
             return
 
         snap_name = os.getenv("SNAP_NAME")

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -77,6 +77,7 @@ class TestLauncher(TestCase):
 class TestLauncherReturnCodes(TestCase):
     def setUp(self):
         self.launcher = Launcher()
+        self.launcher._maybe_rerun_jobs = Mock(return_value=False)
         self.launcher._maybe_resume_session = Mock(return_value=False)
         self.launcher._start_new_session = Mock()
         self.launcher._pick_jobs_to_run = Mock()


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

The pybuild tester fails to test every package because an `_` assignment is shadowing the global  `_`. 
Marking the variable as `nonlocal` or `global` is not enough in the context of the exception handler because that leads the first assignment to fail, I decided to just use the function directly to fix the issue.

Additionally, once that is fixed, the tests fail (and this is a difference between pytest and uniitest). I have fixed this by mocking also the function call that causes this to happen

## Resolved issues

Fixes: https://launchpadlibrarian.net/692605124/buildlog_ubuntu-mantic-amd64.checkbox-ng_2.10.2~dev27+g1aa81f06a~ubuntu23.10.1_BUILDING.txt.gz

## Documentation

N/A

## Tests

I have verified this via `pytest`, `unittest` and by locally re-building the package using `dpkg-buildpackage` on jammy
