### PR TITLE
Pull fwts from the new github repo (infra)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -74,7 +74,7 @@ parts:
     source-tag: "V23.09.00"
     source-depth: 1
     plugin: autotools
-    source: git://git.launchpad.net/~firmware-testing-team/fwts/+git/fwts
+    source: https://github.com/fwts/fwts.git
     stage-packages:
       - libfdt1
       - libbsd0

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -78,7 +78,7 @@ parts:
     source-tag: "V23.09.00"
     source-depth: 1
     plugin: autotools
-    source: git://git.launchpad.net/~firmware-testing-team/fwts/+git/fwts
+    source: https://github.com/fwts/fwts.git
     stage-packages:
       - libfdt1
       - libbsd0

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -78,7 +78,7 @@ parts:
     source-tag: "V23.09.00"
     source-depth: 1
     plugin: autotools
-    source: git://git.launchpad.net/~firmware-testing-team/fwts/+git/fwts
+    source: https://github.com/fwts/fwts.git
     autotools-configure-parameters:
       - --prefix=/
     stage-packages:

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -82,7 +82,7 @@ parts:
     source-tag: "V23.09.00"
     source-depth: 1
     plugin: autotools
-    source: git://git.launchpad.net/~firmware-testing-team/fwts/+git/fwts
+    source: https://github.com/fwts/fwts.git
     autotools-configure-parameters:
       - --prefix=/
     stage-packages:


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

Fwts has a new repository on github as said [here](https://chat.canonical.com/canonical/pl/1tpa9qxah3ns3c7pf1erwa1sge). We have to update the recipe

## Resolved issues

Failing daily builds
Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-945

## Documentation

N/A

## Tests

Built `core22` via remote-build
