### PR TITLE
A daily release pipeline to trigger the package specific dialy pipelines (Infra)

### DIFF
--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '00 04 * * *'
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   check_history:

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '00 04 * * *'
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   check_history:

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -1,0 +1,12 @@
+name: Daily builds
+
+on:
+  workflow_dispatch:
+
+jobs:
+  checkbox-core-snap-daily:
+    uses: ./.github/workflows/checkbox-core-snap-daily-builds.yml
+  checkbox-snap-daily:
+    uses: ./.github/workflows/checkbox-snap-daily-builds.yml
+  checkbox-deb-daily:
+    uses: ./.github/workflows/deb-daily-builds.yml

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '00 04 * * *'
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   deb_daily_builds:


### PR DESCRIPTION
## Description

A `workflow_dispatch` activated release pipeline for dailies following instructions from https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow to the best of my understanding. This should call the three necessary build pipelines at the same git ref as the pipeline calling is at.

## Resolved issues

Does not resolve any tracked issue, associated with making release build debugging (https://warthogs.atlassian.net/browse/CHECKBOX-945) more convenient, so we get all the builds with one button press built at the same git ref predictably.

## Documentation

A reference to this being available needed in the release process docs.

## Tests

I have not dared pressed the button, please finish this to a workable state ok baiii