### PR TITLE
fix mocking of Remote Session Assistant (BugFix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -533,9 +533,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         self.run_jobs()
 
     def _handle_last_job_after_resume(self, resumed_session_info):
-        if self.launcher.get_value("ui", "type") == "silent":
-            time.sleep(20)
-        else:
+        if self.launcher.get_value("ui", "type") != "silent":
             resume_dialog(10)
         jobs_repr = json.loads(
             self.sa.get_jobs_repr([resumed_session_info["last_job"]])

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -156,3 +156,39 @@ class ControllerTests(TestCase):
         RemoteController.finish_session(self_mock)
 
         self.assertTrue(self_mock._has_anything_failed)
+
+    @mock.patch("checkbox_ng.launcher.controller.SimpleUI")
+    @mock.patch("checkbox_ng.launcher.controller.resume_dialog")
+    def test__handle_last_job_after_resume_when_silent(self, res_dia_mock, _):
+        self_mock = mock.MagicMock()
+        self_mock.launcher = mock.MagicMock()
+        self_mock.launcher.get_value.return_value = "silent"
+        self_mock.sa.get_jobs_repr.return_value = [
+            {"name": "job", "category_name": "category", "id": "job_id"}
+        ]
+        with mock.patch("json.loads") as _:
+            with mock.patch("builtins.print") as print_mock:
+                RemoteController._handle_last_job_after_resume(
+                    self_mock, {"last_job": "job_id"}
+                )
+
+        self.assertFalse(res_dia_mock.called)
+
+    @mock.patch("checkbox_ng.launcher.controller.SimpleUI")
+    @mock.patch("checkbox_ng.launcher.controller.resume_dialog")
+    def test__handle_last_job_after_resume_when_not_silent(
+        self, res_dia_mock, _
+    ):
+        self_mock = mock.MagicMock()
+        self_mock.launcher = mock.MagicMock()
+        self_mock.launcher.get_value.return_value = "loud"
+        self_mock.sa.get_jobs_repr.return_value = [
+            {"name": "job", "category_name": "category", "id": "job_id"}
+        ]
+        with mock.patch("json.loads") as _:
+            with mock.patch("builtins.print") as print_mock:
+                RemoteController._handle_last_job_after_resume(
+                    self_mock, {"last_job": "job_id"}
+                )
+
+        self.assertTrue(res_dia_mock.called)

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -596,7 +596,16 @@ class RemoteSessionAssistant:
             # it is already determined
             return
         if not result:
-            result = self._be.wait().get_result()
+            if not self._be:
+                # the job is considered done and there's no background
+                # executor, because the job was auto-passed from the session
+                # resume mechanism after a no-return job has been run
+                result = result_builder = JobResultBuilder(
+                    outcome=IJobResult.OUTCOME_PASS,
+                    comments="Automatically passed while resuming",
+                ).get_result()
+            else:
+                result = self._be.wait().get_result()
         self._sa.use_job_result(self._currently_running_job, result)
         if self._state != Bootstrapping:
             if not self._sa.get_dynamic_todo_list():

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -18,6 +18,7 @@
 
 from unittest import TestCase, mock
 
+from plainbox.abc import IJobResult
 from plainbox.impl.session import remote_assistant
 
 
@@ -27,7 +28,8 @@ class RemoteAssistantTests(TestCase):
         allowed_when = remote_assistant.RemoteSessionAssistant.allowed_when
 
         @allowed_when(remote_assistant.Idle)
-        def allowed(self, *args): ...
+        def allowed(self, *args):
+            ...
 
         self_mock._state = remote_assistant.Idle
         allowed(self_mock)
@@ -37,8 +39,33 @@ class RemoteAssistantTests(TestCase):
         allowed_when = remote_assistant.RemoteSessionAssistant.allowed_when
 
         @allowed_when(remote_assistant.Idle)
-        def not_allowed(self, *args): ...
+        def not_allowed(self, *args):
+            ...
 
         self_mock._state = remote_assistant.Started
         with self.assertRaises(AssertionError):
             not_allowed(self_mock)
+
+
+class RemoteAssistantFinishJobTests(TestCase):
+    def setUp(self):
+        self.rsa = remote_assistant.RemoteSessionAssistant("")
+        self.rsa._sa = mock.Mock()
+        self.rsa._be = None
+
+    @mock.patch("plainbox.impl.session.remote_assistant.JobResultBuilder")
+    def test_no_result_after_auto_resume(self, MockJobResultBuilder):
+        self.rsa._currently_running_job = "job_id"
+        mock_job = mock.Mock()
+        mock_job.plugin = "shell"
+        mock_builder = MockJobResultBuilder.return_value
+        mock_builder.get_result.return_value = IJobResult.OUTCOME_PASS
+
+        result = self.rsa.finish_job()
+
+        self.rsa._sa.use_job_result.assert_called_with("job_id", "pass")
+        self.assertEqual(result, IJobResult.OUTCOME_PASS)
+        MockJobResultBuilder.assert_called_with(
+            outcome=IJobResult.OUTCOME_PASS,
+            comments="Automatically passed while resuming",
+        )

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -81,6 +81,6 @@ class RemoteAssistantFinishJobTests(TestCase):
 
         result = self.rsa.finish_job()
 
-        self.rsa._be.wait.assert_called()
-        self.rsa._be.wait().get_result.assert_called()
+        self.assertTrue(self.rsa._be.wait.called)
+        self.assertTrue(self.rsa._be.wait().get_result)
         self.assertEqual(result, IJobResult.OUTCOME_PASS)

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -69,3 +69,18 @@ class RemoteAssistantFinishJobTests(TestCase):
             outcome=IJobResult.OUTCOME_PASS,
             comments="Automatically passed while resuming",
         )
+
+    def test_no_result_with_be(self):
+        self.rsa._currently_running_job = "job_id"
+        self.rsa._be = mock.Mock()
+        wait_res = mock.Mock()
+        self.rsa._be.wait.return_value = wait_res
+        wait_get_result_res = mock.Mock()
+        self.rsa._be.wait().get_result = wait_get_result_res
+        wait_get_result_res.return_value = IJobResult.OUTCOME_PASS
+
+        result = self.rsa.finish_job()
+
+        self.rsa._be.wait.assert_called()
+        self.rsa._be.wait().get_result.assert_called()
+        self.assertEqual(result, IJobResult.OUTCOME_PASS)

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -49,7 +49,7 @@ class RemoteAssistantTests(TestCase):
 
 class RemoteAssistantFinishJobTests(TestCase):
     def setUp(self):
-        self.rsa = remote_assistant.RemoteSessionAssistant("")
+        self.rsa = mock.MagicMock()
         self.rsa._sa = mock.Mock()
         self.rsa._be = None
 
@@ -61,7 +61,7 @@ class RemoteAssistantFinishJobTests(TestCase):
         mock_builder = MockJobResultBuilder.return_value
         mock_builder.get_result.return_value = IJobResult.OUTCOME_PASS
 
-        result = self.rsa.finish_job()
+        result = remote_assistant.RemoteSessionAssistant.finish_job(self.rsa)
 
         self.rsa._sa.use_job_result.assert_called_with("job_id", "pass")
         self.assertEqual(result, IJobResult.OUTCOME_PASS)
@@ -79,7 +79,7 @@ class RemoteAssistantFinishJobTests(TestCase):
         self.rsa._be.wait().get_result = wait_get_result_res
         wait_get_result_res.return_value = IJobResult.OUTCOME_PASS
 
-        result = self.rsa.finish_job()
+        result = remote_assistant.RemoteSessionAssistant.finish_job(self.rsa)
 
         self.assertTrue(self.rsa._be.wait.called)
         self.assertTrue(self.rsa._be.wait().get_result)


### PR DESCRIPTION
## Description

Fix the unit tests not fully mocking parts of the remote assistant object, which made it run subprocess in the host system.
