### PR TITLE
Pass secrets to daily builds nested workflows (Bugfix)

### DIFF
--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -6,7 +6,10 @@ on:
 jobs:
   checkbox-core-snap-daily:
     uses: ./.github/workflows/checkbox-core-snap-daily-builds.yml
+    secrets: inherit
   checkbox-snap-daily:
     uses: ./.github/workflows/checkbox-snap-daily-builds.yml
+    secrets: inherit
   checkbox-deb-daily:
     uses: ./.github/workflows/deb-daily-builds.yml
+    secrets: inherit


### PR DESCRIPTION
https://github.com/canonical/checkbox/pull/772 (nested workflows) first [run](https://github.com/canonical/checkbox/actions/runs/6590285825/job/17906583944) failed with the following error:

```
Run tools/daily-builds/deb_daily_builds.py
Command './tools/release/lp-request-import.py ~checkbox-dev/checkbox/+git/checkbox' returned non-zero exit status 1.
Traceback (most recent call last):
  File "/home/runner/work/checkbox/checkbox/./tools/release/lp-request-import.py", line 67, in <module>
    sys.exit(main())
  File "/home/runner/work/checkbox/checkbox/./tools/release/lp-request-import.py", line 46, in main
    credentials = Credentials.from_string(os.getenv("LP_CREDENTIALS"))
  File "/usr/lib/python3/dist-packages/launchpadlib/credentials.py", line 151, in from_string
    credentials.load(StringIO(value))
  File "/usr/lib/python3/dist-packages/lazr/restfulclient/authorize/oauth.py", line 190, in load
    raise CredentialsFileError('No configuration for version %s' %
lazr.restfulclient.errors.CredentialsFileError: No configuration for version 1
```

## Resolved issues

This patch ensures that secrets available to the caller workflow are propagated to the 3 daily build workflows.
See https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows#passing-secrets-to-nested-workflows

## Documentation

N/A

## Tests

Tested from this branch: https://github.com/canonical/checkbox/actions/runs/6604664848/job/17939030901
