### PR TITLE
Replace generic GH runner with the self-hosted (Infra)

### DIFF
--- a/.github/workflows/checkbox-core-snap-beta-release.yml
+++ b/.github/workflows/checkbox-core-snap-beta-release.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         releases: [16, 18, 20, 22]
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       SERIES: series${{ matrix.releases }}
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
@@ -79,7 +79,7 @@ jobs:
           done
 
   changelog:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: checkbox-snap changelog (${{ github.ref_name }})
     if: ${{ github.event_name == 'push' }}
     steps:

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check_history:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Check for new commits
     outputs:
       should_run: ${{ steps.check_log.outputs.should_run }}
@@ -34,7 +34,7 @@ jobs:
         releases: [16, 18, 20, 22]
     needs: check_history
     if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       SERIES: series${{ matrix.releases }}
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}

--- a/.github/workflows/checkbox-snap-beta-release.yml
+++ b/.github/workflows/checkbox-snap-beta-release.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         type: [classic, uc]
         releases: [16, 18, 20, 22]
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       SERIES: series_${{ matrix.type }}${{ matrix.releases }}
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
@@ -88,7 +88,7 @@ jobs:
           done
 
   changelog:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: checkbox-snap changelog (${{ github.ref_name }})
     if: ${{ github.event_name == 'push' }}
     steps:

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check_history:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Check for new commits
     outputs:
       should_run: ${{ steps.check_log.outputs.should_run }}
@@ -35,7 +35,7 @@ jobs:
         releases: [16, 18, 20, 22]
     needs: check_history
     if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       SERIES: series_${{ matrix.type }}${{ matrix.releases }}
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}

--- a/.github/workflows/checkbox-stable-release.yml
+++ b/.github/workflows/checkbox-stable-release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     name: Publish the release
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout checkbox monorepo
         uses: actions/checkout@v3
@@ -21,7 +21,7 @@ jobs:
 
   checkbox_deb_packages:
     name: Checkbox Debian packages
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Install dependencies
         run: |
@@ -39,7 +39,7 @@ jobs:
 
   checkbox_core_snap:
     name: Checkbox core snap packages
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
     steps:
@@ -59,7 +59,7 @@ jobs:
 
   checkbox_snap:
     name: Checkbox snap packages
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
     steps:

--- a/.github/workflows/deb-beta-release.yml
+++ b/.github/workflows/deb-beta-release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Release:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -32,7 +32,7 @@ jobs:
     name: Debian packages daily build
     needs: check_history
     if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/documentation-build-readthedocs.io.yml
+++ b/.github/workflows/documentation-build-readthedocs.io.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   if_merged:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
     - run: |
         curl -X POST -d "branches=latest" -d "token=${{ secrets.RTD_TOKEN }}" https://readthedocs.org/api/v2/webhook/checkbox/137367/

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   spellcheck:
     name: Spelling check
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     defaults:
       run:
         working-directory: docs
@@ -37,7 +37,7 @@ jobs:
 
   woke:
     name: Inclusive language check
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -52,7 +52,7 @@ jobs:
 
   linkcheck:
     name: Link check
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     defaults:
       run:
         working-directory: docs

--- a/.github/workflows/issues_to_jira.yaml
+++ b/.github/workflows/issues_to_jira.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   update:
     name: Update Issue
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Create JIRA ticket
         env:

--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   metabox_run_required:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Check for changes in metabox and checkbox-ng dirs
     outputs:
       required_run: ${{ steps.check_diff.outputs.required_run }}

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -9,7 +9,7 @@ on:
       - edited
 jobs:
   validate_title:
-    runs-on: self-hosted
+    runs-on: [self-hosted, linux, X64, two-xlarge]
     steps:
     - name: Checking the presence of the Traceability Marker in the PR title
       env:

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -9,7 +9,7 @@ on:
       - edited
 jobs:
   validate_title:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
     - name: Checking the presence of the Traceability Marker in the PR title
       env:


### PR DESCRIPTION
## Description

This PR replaces the use of "ubuntu-latest" github runners in favour of the self-hosted ones. 
This targets only the `ubuntu-latest` as this matches what we offer with self-hosted (we have Jammy runners only).
