### PR TITLE
Move deb commit checking to the edge workflow (infra)

### DIFF
--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Check for checkbox projects new commits
         id: check_log
         run: |
-          git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap
-          changes=$(git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap)
+          git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap
+          changes=$(git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap)
           if [[ -z $changes ]]
             then
               echo "should_run=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Check for checkbox snap new commits
         id: check_log
         run: |
-          git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-snap
-          changes=$(git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-snap)
+          git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap
+          changes=$(git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap)
           if [[ -z $changes ]]
             then
               echo "should_run=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -7,8 +7,31 @@ on:
   workflow_call:
 
 jobs:
+  check_history:
+    runs-on: ubuntu-latest
+    name: Check for new commits
+    outputs:
+      should_run: ${{ steps.check_log.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check for new commits to any deb
+        id: check_log
+        run: |
+          git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers
+          changes=$(git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers)
+          if [[ -z $changes ]]
+            then
+              echo "should_run=false" >> $GITHUB_OUTPUT
+            else
+              echo "should_run=true" >> $GITHUB_OUTPUT
+          fi
+
   deb_daily_builds:
     name: Debian packages daily build
+    needs: check_history
+    if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Check for new commits to any deb
         id: check_log
         run: |
-          git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers
-          changes=$(git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers)
+          git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap
+          changes=$(git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap)
           if [[ -z $changes ]]
             then
               echo "should_run=false" >> $GITHUB_OUTPUT

--- a/tools/daily-builds/deb_daily_builds.py
+++ b/tools/daily-builds/deb_daily_builds.py
@@ -34,20 +34,22 @@ CONFIG_PPA_DEV_TOOLS = """{{
 }}
 """
 
+
 def run(*args, **kwargs):
     """wrapper for subprocess.run."""
     try:
         return subprocess.run(
-            *args, **kwargs,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT)
+            *args, **kwargs, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
     except subprocess.CalledProcessError as e:
-        print('{}\n{}'.format(e, e.output.decode()))
+        print("{}\n{}".format(e, e.output.decode()))
         raise SystemExit(1)
+
 
 def _del_file(path):
     with suppress(FileNotFoundError):
         os.remove(path)
+
 
 def check_build(name) -> bool:
     """
@@ -65,44 +67,58 @@ def check_build(name) -> bool:
                 "wait",
                 "ppa:checkbox-dev/ppa",
                 "-C",
-                path
+                path,
             ]
         )
         return True
     return False
 
+
 def main():
     """Parse the checkbox monorepo to trigger deb daily builds in Launchpad."""
     # First request code import (GitHub -> Launchpad)
     run(
-       "./tools/release/lp-request-import.py "
-       "~checkbox-dev/checkbox/+git/checkbox",
-       shell=True, check=True)
+        "./tools/release/lp-request-import.py "
+        "~checkbox-dev/checkbox/+git/checkbox",
+        shell=True,
+        check=True,
+    )
     projects = {}
-    for path, dirs, files in os.walk('.'):
+    for path, dirs, files in os.walk("."):
         if "debian" in dirs:
             project_path = os.path.relpath(path)
             # Tweak the provider paths to get names in the following form:
             # providers/base -> checkbox-provider-base
-            project_name = project_path.replace('s/', '-')
-            if project_name.startswith('provider'):
-                project_name = "checkbox-"+project_name
+            project_name = project_path.replace("s/", "-")
+            if project_name.startswith("provider"):
+                project_name = "checkbox-" + project_name
             projects[project_name] = project_path
     to_check = []
     # Find projects new commits from the last 24 hours
     for name, path in sorted(projects.items(), key=lambda i: i[1]):
-        new_commits = int(run(
-            'git rev-list --count HEAD --not '
-            '$(git rev-list -n1 --before="24 hours" '
-            '--first-parent HEAD) -- :{}'.format(path),
-            shell=True, check=True).stdout.decode().rstrip())
+        new_commits = int(
+            run(
+                "git rev-list --count HEAD --not "
+                '$(git rev-list -n1 --before="24 hours" '
+                "--first-parent HEAD) -- :{}".format(path),
+                shell=True,
+                check=True,
+            )
+            .stdout.decode()
+            .rstrip()
+        )
         # Kick off daily builds if the new commits got merged into main
         if new_commits:
-            output = run(
-                "./tools/release/lp-recipe-update-build.py checkbox "
-                "--recipe {} -n {}".format(
-                    name+'-daily', get_version()),
-                shell=True, check=True).stdout.decode().rstrip()
+            output = (
+                run(
+                    "./tools/release/lp-recipe-update-build.py checkbox "
+                    "--recipe {} -n {}".format(name + "-daily", get_version()),
+                    shell=True,
+                    check=True,
+                )
+                .stdout.decode()
+                .rstrip()
+            )
             print(output)
             # We have started the build, store it here so it can
             # be checked after.
@@ -112,7 +128,7 @@ def main():
     for name, ok in checked:
         if not ok:
             print("Failed to build:", name)
-    if any(not ok for (_,ok) in checked):
+    if any(not ok for (_, ok) in checked):
         raise SystemExit(1)
 
 


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

Right now we can not force a deb build, additionally, the workflow will only try to build packages that did change in the last24 hours. This leads to the pipeline being impossible to retry if nothing landed in the last 24 hours and version numbers of packages being out of sync. 

## Resolved issues

N/A

## Documentation

N/A

## Tests

N/A
