### PR TITLE
Adds retries to daily builds (Infra)

### DIFF
--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -54,12 +54,16 @@ jobs:
           echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
           git config --global user.email "robot@lists.canonical.com"
           git config --global user.name "Certification bot"
-      - uses: snapcore/action-build@v1
-        id: snapcraft
+      - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # 1.3.0
         with:
-          path: checkbox-core-snap/series${{ matrix.releases }}
-          snapcraft-channel: 7.x/stable
-          snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
+          action: snapcore/action-build@v1
+          id: snapcraft
+          attempt_delay: 600000 # 10min
+          attempt_limit: 3
+          with: |
+            path: checkbox-core-snap/series${{ matrix.releases }}
+            snapcraft-channel: 7.x/stable
+            snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
@@ -72,10 +76,14 @@ jobs:
         with:
           name: series${{ matrix.releases }}
           path: checkbox-core-snap/series${{ matrix.releases }}/*.snap
-      - name: Upload checkbox core snaps to the store
-        run: |
-          for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap
-          do
-            echo "Uploading $snap..."
-            snapcraft upload $snap --release edge
-          done
+      - uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        with:
+          name: Upload checkbox core snaps to the store
+          retry_wait_seconds: 600 # 10min
+          max_attempts: 3
+          run: |
+            for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap
+            do
+              echo "Uploading $snap..."
+              snapcraft upload $snap --release edge
+            done

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -81,7 +81,7 @@ jobs:
           name: Upload checkbox core snaps to the store
           retry_wait_seconds: 600 # 10min
           max_attempts: 3
-          run: |
+          command: |
             for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap
             do
               echo "Uploading $snap..."

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -54,7 +54,7 @@ jobs:
           echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
           git config --global user.email "robot@lists.canonical.com"
           git config --global user.name "Certification bot"
-      - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # 1.3.0
+      - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
         with:
           action: snapcore/action-build@v1
           id: snapcraft
@@ -76,12 +76,11 @@ jobs:
         with:
           name: series${{ matrix.releases }}
           path: checkbox-core-snap/series${{ matrix.releases }}/*.snap
-      - uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+      - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
         name: Upload checkbox core snaps to the store
         with:
-          retry_wait_seconds: 600 # 10min
-          max_attempts: 3
-          timeout_minutes: 480 # 8h
+          attempt_delay: 600000 # 10min
+          attempt_limit: 3
           command: |
             for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap
             do

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -77,8 +77,8 @@ jobs:
           name: series${{ matrix.releases }}
           path: checkbox-core-snap/series${{ matrix.releases }}/*.snap
       - uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        name: Upload checkbox core snaps to the store
         with:
-          name: Upload checkbox core snaps to the store
           retry_wait_seconds: 600 # 10min
           max_attempts: 3
           command: |

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -81,6 +81,7 @@ jobs:
         with:
           retry_wait_seconds: 600 # 10min
           max_attempts: 3
+          timeout_minutes: 480 # 8h
           command: |
             for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap
             do

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -55,12 +55,16 @@ jobs:
           echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
           git config --global user.email "robot@lists.canonical.com"
           git config --global user.name "Certification bot"
-      - uses: snapcore/action-build@v1
-        id: snapcraft
+      - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # 1.3.0
         with:
-          path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}
-          snapcraft-channel: 7.x/stable
-          snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
+          action: snapcore/action-build@v1
+          id: snapcraft
+          attempt_delay: 600000 # 10min
+          attempt_limit: 3
+          with: |
+            path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}
+            snapcraft-channel: 7.x/stable
+            snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
@@ -73,18 +77,22 @@ jobs:
         with:
           name: series_${{ matrix.type }}${{ matrix.releases }}
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
-      - name: Upload checkbox snaps to the store
-        run: |
-          for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
-          do
-            echo "Uploading $snap..."
-            if [[ ${{ matrix.type }} == 'classic' ]]; then
-              if [[ ${{ matrix.releases }} == '22' ]]; then
-                snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge
+      - uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        with:
+          name: Upload checkbox snaps to the store
+          retry_wait_seconds: 600 # 10min
+          max_attempts: 3
+          run: |
+            for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
+            do
+              echo "Uploading $snap..."
+              if [[ ${{ matrix.type }} == 'classic' ]]; then
+                if [[ ${{ matrix.releases }} == '22' ]]; then
+                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge
+                else
+                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge
+                fi
               else
-                snapcraft upload $snap --release ${{ matrix.releases }}.04/edge
+                snapcraft upload $snap --release ${{ matrix.type }}${{ matrix.releases }}/edge
               fi
-            else
-              snapcraft upload $snap --release ${{ matrix.type }}${{ matrix.releases }}/edge
-            fi
-          done
+            done

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -82,7 +82,7 @@ jobs:
           name: Upload checkbox snaps to the store
           retry_wait_seconds: 600 # 10min
           max_attempts: 3
-          run: |
+          command: |
             for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
             do
               echo "Uploading $snap..."

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -55,7 +55,7 @@ jobs:
           echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
           git config --global user.email "robot@lists.canonical.com"
           git config --global user.name "Certification bot"
-      - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # 1.3.0
+      - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
         with:
           action: snapcore/action-build@v1
           id: snapcraft
@@ -77,12 +77,11 @@ jobs:
         with:
           name: series_${{ matrix.type }}${{ matrix.releases }}
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
-      - uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+      - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
         name: Upload checkbox snaps to the store
         with:
-          retry_wait_seconds: 600 # 10min
-          max_attempts: 3
-          timeout_minutes: 480 # 8h
+          attempt_delay: 600000 # 10min
+          attempt_limit: 3
           command: |
             for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
             do

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           retry_wait_seconds: 600 # 10min
           max_attempts: 3
+          timeout_minutes: 480 # 8h
           command: |
             for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
             do

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -78,8 +78,8 @@ jobs:
           name: series_${{ matrix.type }}${{ matrix.releases }}
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
       - uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        name: Upload checkbox snaps to the store
         with:
-          name: Upload checkbox snaps to the store
           retry_wait_seconds: 600 # 10min
           max_attempts: 3
           command: |

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -51,5 +51,5 @@ jobs:
           name: Check for new commits, push build and wait result
           retry_wait_seconds: 600 # 10min
           max_attempts: 3
-          run: |
+          command: |
             tools/daily-builds/deb_daily_builds.py

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -44,11 +44,11 @@ jobs:
         with:
           fetch-depth: 0
       - uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        name: Check for new commits, push build and wait result
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
           PYTHONUNBUFFERED: 1
         with:
-          name: Check for new commits, push build and wait result
           retry_wait_seconds: 600 # 10min
           max_attempts: 3
           command: |

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -43,9 +43,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Check for new commits, push build and wait result
+      - uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
           PYTHONUNBUFFERED: 1
-        run: |
-          tools/daily-builds/deb_daily_builds.py
+        with:
+          name: Check for new commits, push build and wait result
+          retry_wait_seconds: 600 # 10min
+          max_attempts: 3
+          run: |
+            tools/daily-builds/deb_daily_builds.py

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -43,14 +43,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+      - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
         name: Check for new commits, push build and wait result
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
           PYTHONUNBUFFERED: 1
         with:
-          retry_wait_seconds: 600 # 10min
-          max_attempts: 3
-          timeout_minutes: 480 # 8h
+          attempt_delay: 600000 # 10min
+          attempt_limit: 3
           command: |
             tools/daily-builds/deb_daily_builds.py

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -51,5 +51,6 @@ jobs:
         with:
           retry_wait_seconds: 600 # 10min
           max_attempts: 3
+          timeout_minutes: 480 # 8h
           command: |
             tools/daily-builds/deb_daily_builds.py


### PR DESCRIPTION
Adds retries to launchpad / snapcraft remote-build dependent steps / actions to daily builds.
Implemented using Wandalen/wretry.action@v1.3.0 (after first trying out `nick-fields/retry@v2.9.0` which would only work for steps and not actions, and also awkwardly required a timeout in minutes or seconds, neither of which is useful for the purpose).

## Tests

- `Wandalen/wretry.action@v1.3.0` tested out via https://github.com/canonical/self-hosted-runner-test/actions/runs/6619138089/job/17979029650?pr=9
- `nick-fields/retry@v2.9.0` retry step tested via https://github.com/canonical/self-hosted-runner-test: https://github.com/canonical/self-hosted-runner-test/actions/runs/6618945826/job/17978468555

