### PR TITLE
An attempt at fixing a retry fail at the snap upload step (Infra)

### DIFF
--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -82,8 +82,8 @@ jobs:
           attempt_delay: 600000 # 10min
           attempt_limit: 3
           command: |
-            for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap \
+            for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap ; \
             do \
-              echo "Uploading $snap..." \
-              snapcraft upload $snap --release edge \
+              echo "Uploading $snap..." ; \
+              snapcraft upload $snap --release edge ; \
             done

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -82,8 +82,8 @@ jobs:
           attempt_delay: 600000 # 10min
           attempt_limit: 3
           command: |
-            for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap
-            do
-              echo "Uploading $snap..."
-              snapcraft upload $snap --release edge
+            for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap \
+            do \
+              echo "Uploading $snap..." \
+              snapcraft upload $snap --release edge \
             done

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -83,16 +83,16 @@ jobs:
           attempt_delay: 600000 # 10min
           attempt_limit: 3
           command: |
-            for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap \
+            for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap ; \
             do \
-              echo "Uploading $snap..." \
+              echo "Uploading $snap..." ; \
               if [[ ${{ matrix.type }} == 'classic' ]]; then \
                 if [[ ${{ matrix.releases }} == '22' ]]; then \
-                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge \
+                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge ; \
                 else \
-                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge \
+                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge ; \
                 fi \
               else \
-                snapcraft upload $snap --release ${{ matrix.type }}${{ matrix.releases }}/edge \
-              fi \
+                snapcraft upload $snap --release ${{ matrix.type }}${{ matrix.releases }}/edge ; \
+              fi ; \
             done

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -83,16 +83,16 @@ jobs:
           attempt_delay: 600000 # 10min
           attempt_limit: 3
           command: |
-            for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
-            do
-              echo "Uploading $snap..."
-              if [[ ${{ matrix.type }} == 'classic' ]]; then
-                if [[ ${{ matrix.releases }} == '22' ]]; then
-                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge
-                else
-                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge
-                fi
-              else
-                snapcraft upload $snap --release ${{ matrix.type }}${{ matrix.releases }}/edge
-              fi
+            for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap \
+            do \
+              echo "Uploading $snap..." \
+              if [[ ${{ matrix.type }} == 'classic' ]]; then \
+                if [[ ${{ matrix.releases }} == '22' ]]; then \
+                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge \
+                else \
+                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge \
+                fi \
+              else \
+                snapcraft upload $snap --release ${{ matrix.type }}${{ matrix.releases }}/edge \
+              fi \
             done


### PR DESCRIPTION
# Description

An attempted fix to https://github.com/canonical/checkbox/actions/runs/6621575266/job/17986706086#step:10:246

The command is not really multiline, it is collapsed to one line. This means that we need to delimit the subcommands via `;` to make them work

# Testing

I have executed a slightly modified version of the commands in a `sh` shell (that is what the workflow uses). 

To replicate: 
- Edit the conditions with either `[ ]` for false or `[ true ]` for true to check the branches
- Remove the interpolation `{{ }}` and replace it with working expandable paths where needed (in `for`)
- replace `snapcraft` with `echo`
