### PR TITLE
Build one arch per matrix expansion (infra)

### DIFF
--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -32,6 +32,7 @@ jobs:
     strategy:
       matrix:
         releases: [16, 18, 20, 22]
+        arch: [amd64, arm64, armhf, i386]
     needs: check_history
     if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -63,7 +64,7 @@ jobs:
           with: |
             path: checkbox-core-snap/series${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
-            snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
+            snapcraft-args: remote-build --build-on ${{ matrix.arch }} --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -39,7 +39,7 @@ jobs:
     env:
       SERIES: series${{ matrix.releases }}
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
-    name: Checkbox Core snap for series ${{ matrix.releases }}
+    name: Runtime (${{ matrix.releases }}, ${{ matrix.arch }})
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -64,7 +64,7 @@ jobs:
           with: |
             path: checkbox-core-snap/series${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
-            snapcraft-args: remote-build --build-on ${{ matrix.arch }} --launchpad-accept-public-upload
+            snapcraft-args: remote-build --build-for ${{ matrix.arch }} --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -58,7 +58,6 @@ jobs:
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
         with:
           action: snapcore/action-build@v1
-          id: snapcraft
           attempt_delay: 600000 # 10min
           attempt_limit: 3
           with: |

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         releases: [16, 18, 20, 22]
-        arch: [amd64, arm64, armhf, i386]
+        arch: [amd64, arm64, armhf]
     needs: check_history
     if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         type: [classic, uc]
         releases: [16, 18, 20, 22]
-        arch: [amd64,arm64,armhf,i386]
+        arch: [amd64,arm64,armhf]
     needs: check_history
     if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         type: [classic, uc]
         releases: [16, 18, 20, 22]
+        arch: [amd64,arm64,armhf,i386]
     needs: check_history
     if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -64,7 +65,7 @@ jobs:
           with: |
             path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
-            snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
+            snapcraft-args: remote-build --build-on ${{ matrix.arch }} --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
@@ -86,8 +87,8 @@ jobs:
             for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap ; \
             do \
               echo "Uploading $snap..." ; \
-              if [[ ${{ matrix.type }} == 'classic' ]]; then \
-                if [[ ${{ matrix.releases }} == '22' ]]; then \
+              if [ ${{ matrix.type }} = 'classic' ]; then \
+                if [ ${{ matrix.releases }} = '22' ]; then \
                   snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge ; \
                 else \
                   snapcraft upload $snap --release ${{ matrix.releases }}.04/edge ; \

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -40,7 +40,7 @@ jobs:
     env:
       SERIES: series_${{ matrix.type }}${{ matrix.releases }}
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
-    name: Checkbox snap for series ${{ matrix.type }}${{ matrix.releases }}
+    name: Frontend (${{ matrix.type }}${{ matrix.releases }}, ${{ matrix.arch}})
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -65,7 +65,7 @@ jobs:
           with: |
             path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
-            snapcraft-args: remote-build --build-on ${{ matrix.arch }} --launchpad-accept-public-upload
+            snapcraft-args: remote-build --build-for ${{ matrix.arch }} --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -59,7 +59,6 @@ jobs:
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
         with:
           action: snapcore/action-build@v1
-          id: snapcraft
           attempt_delay: 600000 # 10min
           attempt_limit: 3
           with: |


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description
Building multiple arches per matrix expansion leads the workflow to hang waiting for slower archs even if a build failed and makes us unable to re-run the build for a specific arch if it failed. With this modification each arch is built with its own command. 

Minor: This also fixes sh compatibility
Minor: build-for is now the correct way to call build-on

## Tests

I have re-checked the `[[` vs `[` thing and it should now work. The matrix expansion should be ok but I'm unable to run act at the moment.
