### PR TITLE
use strict POSIX shell syntax (Infra)

### DIFF
--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap
           changes=$(git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap)
-          if [[ -z $changes ]]
+          if [ -z $changes ]
             then
               echo "should_run=false" >> $GITHUB_OUTPUT
             else
@@ -86,8 +86,8 @@ jobs:
             for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap ; \
             do \
               echo "Uploading $snap..." ; \
-              if [[ ${{ matrix.type }} == 'classic' ]]; then \
-                if [[ ${{ matrix.releases }} == '22' ]]; then \
+              if [ ${{ matrix.type }} = 'classic' ]; then \
+                if [ ${{ matrix.releases }} = '22' ]; then \
                   snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge ; \
                 else \
                   snapcraft upload $snap --release ${{ matrix.releases }}.04/edge ; \


### PR DESCRIPTION
## Description
This patch fixes the daily snap builds workflow by switching from bash syntax to a more compliant strict POSIX syntax for the shell code.
