### PR TITLE
Remove i386 builds from the workflows (infra)

### DIFF
--- a/.github/workflows/checkbox-core-snap-beta-release.yml
+++ b/.github/workflows/checkbox-core-snap-beta-release.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           path: checkbox-core-snap/series${{ matrix.releases }}
           snapcraft-channel: 7.x/stable
-          snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
+          snapcraft-args: remote-build --build-on amd64,arm64,armhf --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
@@ -54,21 +54,10 @@ jobs:
       - name: Check that snapcraft built the expected amount of snaps
         run: |
           NB_SNAPS=$(find checkbox-core-snap/series${{ matrix.releases }} -maxdepth 1 -type f -name *.snap | wc -l)
-          # Expecting 3 snaps for checkbox20 and checkbox22 (amd64, armhf, arm64)
-          # and 4 snaps for checkbox16 and checkbox18 (i386, amd64, armhf, arm64)
-          if [ ${{ matrix.releases }} == "16" ] || [ ${{ matrix.releases }} == "18" ]
+          if [ ${NB_SNAPS} != "3" ]
           then
-            if [ ${NB_SNAPS} != "4" ]
-            then
-              echo "Error: Snapcraft should have produced 4 snaps, found ${NB_SNAPS} instead."
-                exit 1
-            fi
-          else
-            if [ ${NB_SNAPS} != "3" ]
-            then
-              echo "Error: Snapcraft should have produced 3 snaps, found ${NB_SNAPS} instead."
-              exit 1
-            fi
+            echo "Error: Snapcraft should have produced 3 snaps, found ${NB_SNAPS} instead."
+            exit 1
           fi
       - name: Upload checkbox core snaps to the store
         run: |

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -63,7 +63,7 @@ jobs:
           with: |
             path: checkbox-core-snap/series${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
-            snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
+            snapcraft-args: remote-build --build-on amd64,arm64,armhf --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/checkbox-snap-beta-release.yml
+++ b/.github/workflows/checkbox-snap-beta-release.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}
           snapcraft-channel: 7.x/stable
-          snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
+          snapcraft-args: remote-build --build-on amd64,arm64,armhf --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
@@ -55,21 +55,10 @@ jobs:
       - name: Check that snapcraft built the expected amount of snaps
         run: |
           NB_SNAPS=$(find checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }} -maxdepth 1 -type f -name *.snap | wc -l)
-          # Expecting 3 snaps for 20 and 22 releases (amd64, armhf, arm64)
-          # and 4 snaps for 16 and 18 releases (i386, amd64, armhf, arm64)
-          if [ ${{ matrix.releases }} == "16" ] || [ ${{ matrix.releases }} == "18" ]
+          if [ ${NB_SNAPS} != "3" ]
           then
-            if [ ${NB_SNAPS} != "4" ]
-            then
-              echo "Error: Snapcraft should have produced 4 snaps, found ${NB_SNAPS} instead."
-                exit 1
-            fi
-          else
-            if [ ${NB_SNAPS} != "3" ]
-            then
-              echo "Error: Snapcraft should have produced 3 snaps, found ${NB_SNAPS} instead."
-              exit 1
-            fi
+            echo "Error: Snapcraft should have produced 3 snaps, found ${NB_SNAPS} instead."
+            exit 1
           fi
       - name: Upload checkbox snaps to the store
         run: |

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -64,7 +64,7 @@ jobs:
           with: |
             path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
-            snapcraft-args: remote-build --build-on amd64,arm64,armhf,i386 --launchpad-accept-public-upload
+            snapcraft-args: remote-build --build-on amd64,arm64,armhf --launchpad-accept-public-upload
       - uses: actions/upload-artifact@v3
         if: failure()
         with:


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

We don't need `i386` builds anymore, they can be removed from all automated builders

## Resolved issues

N/A

## Documentation

N/A

## Tests

N/A
