### PR TITLE
Move to forked snapcraft build action (infra)

### DIFF
--- a/.github/workflows/checkbox-core-snap-beta-release.yml
+++ b/.github/workflows/checkbox-core-snap-beta-release.yml
@@ -33,7 +33,7 @@ jobs:
           echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
           git config --global user.email "robot@lists.canonical.com"
           git config --global user.name "Certification bot"
-      - uses: snapcore/action-build@v1
+      - uses: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
         id: snapcraft
         with:
           path: checkbox-core-snap/series${{ matrix.releases }}

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -56,7 +56,7 @@ jobs:
           git config --global user.name "Certification bot"
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
         with:
-          action: snapcore/action-build@v1
+          action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
           id: snapcraft
           attempt_delay: 600000 # 10min
           attempt_limit: 3

--- a/.github/workflows/checkbox-snap-beta-release.yml
+++ b/.github/workflows/checkbox-snap-beta-release.yml
@@ -34,7 +34,7 @@ jobs:
           echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
           git config --global user.email "robot@lists.canonical.com"
           git config --global user.name "Certification bot"
-      - uses: snapcore/action-build@v1
+      - uses: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
         id: snapcraft
         with:
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -57,7 +57,7 @@ jobs:
           git config --global user.name "Certification bot"
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
         with:
-          action: snapcore/action-build@v1
+          action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
           id: snapcraft
           attempt_delay: 600000 # 10min
           attempt_limit: 3


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

The current version of the action doesn't fail when snapcraft produces less than it expects (if snapcraft produces something, that is ok). This is not enough for us because that way we will never retry to build the snaps when some fail to build. 

I have forked the upstream version of the action and introduced a new check to monitor if snapcraft produced all that we need, else it will yield an error and fail. This moves our repository to my forked version of the action till a new release of the upstream action that contains this patch is released.

## Resolved issues

N/A

## Documentation

N/A

## Tests

N/A
