### PR TITLE
Split arch and name action as the build repo (infra)

### DIFF
--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -47,14 +47,20 @@ jobs:
           cd checkbox-core-snap/
           sudo apt update && sudo apt install -qq -y python3-setuptools-scm
           ./prepare.sh $SERIES
-      - name: add LP credentials
+      - name: Add LP credentials
         run: |
           mkdir -p ~/.local/share/snapcraft/provider/launchpad/
           echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
           git config --global user.email "robot@lists.canonical.com"
           git config --global user.name "Certification bot"
+      - name: Print Launchpad build repository
+        run: |
+          # snapcraft remote-build will create a repository with the name decided by the --build-id arg
+          # it is useful to have this URL to debug builds, note that it will not change if the same workflow is re-run
+          # as the run_id will not change
+          echo "Building at: https://git.launchpad.net/~ce-certification-qa/+git/checkbox${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}"
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
-        name: Building at: https://git.launchpad.net/~ce-certification-qa/+git/checkbox${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
+        name: Build Snap
         with:
           action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
           attempt_delay: 600000 # 10min
@@ -62,8 +68,10 @@ jobs:
           with: |
             path: checkbox-core-snap/series${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
+            # Note: if you change this --build-id arg, change it above as well and keep them consisten
             snapcraft-args: remote-build --build-on ${{ matrix.arch }} --launchpad-accept-public-upload --build-id checkbox${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
       - uses: actions/upload-artifact@v3
+        name: Upload logs on failure
         if: failure()
         with:
           name: snapcraft-log-series${{ matrix.releases }}
@@ -72,6 +80,7 @@ jobs:
             /home/runner/.local/state/snapcraft/log/
             checkbox-core-snap/series${{ matrix.releases }}/checkbox*.txt
       - uses: actions/upload-artifact@v3
+        name: Upload snaps as artifact
         with:
           name: series${{ matrix.releases }}
           path: checkbox-core-snap/series${{ matrix.releases }}/*.snap

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -30,14 +30,17 @@ jobs:
     strategy:
       matrix:
         releases: [16, 18, 20, 22]
-        arch: [amd64,arm64,armhf]
+        arch: [amd64, arm64, armhf]
     needs: check_history
     if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, linux, large]
     env:
       SERIES: series${{ matrix.releases }}
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
-    name: Runtime${{ matrix.releases }}-${{ matrix.arch }}
+      # snapcraft remote-build will create a repository with the name decided by the --build-id arg
+      # URL to this repo echoed below to help debug builds (does not change if the workflow is re-run)
+      SNAPCRAFT_BUILDER_ID: checkbox${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
+    name: Runtime (Core) ${{ matrix.releases }}-${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -55,20 +58,17 @@ jobs:
           git config --global user.name "Certification bot"
       - name: Print Launchpad build repository
         run: |
-          # snapcraft remote-build will create a repository with the name decided by the --build-id arg
-          # it is useful to have this URL to debug builds, note that it will not change if the same workflow is re-run
-          # as the run_id will not change
-          echo "Building at: https://git.launchpad.net/~ce-certification-qa/+git/checkbox${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}"
+          echo "Building at: https://git.launchpad.net/~ce-certification-qa/+git/$SNAPCRAFT_BUILDER_ID"
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
-        name: Build Snap
+        name: Build the snap
         with:
           action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
           attempt_delay: 600000 # 10min
-          attempt_limit: 3
+          attempt_limit: 5
           with: |
             path: checkbox-core-snap/series${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
-            snapcraft-args: remote-build --build-on ${{ matrix.arch }} --launchpad-accept-public-upload --build-id checkbox${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
+            snapcraft-args: remote-build --build-for ${{ matrix.arch }} --launchpad-accept-public-upload --build-id $SNAPCRAFT_BUILDER_ID
       - uses: actions/upload-artifact@v3
         name: Upload logs on failure
         if: failure()
@@ -79,15 +79,15 @@ jobs:
             /home/runner/.local/state/snapcraft/log/
             checkbox-core-snap/series${{ matrix.releases }}/checkbox*.txt
       - uses: actions/upload-artifact@v3
-        name: Upload snaps as artifact
+        name: Upload the snap as artifact
         with:
           name: series${{ matrix.releases }}
           path: checkbox-core-snap/series${{ matrix.releases }}/*.snap
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
-        name: Upload checkbox core snaps to the store
+        name: Upload the snap to the store
         with:
           attempt_delay: 600000 # 10min
-          attempt_limit: 3
+          attempt_limit: 10
           command: |
             for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap ; \
             do \

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -30,13 +30,14 @@ jobs:
     strategy:
       matrix:
         releases: [16, 18, 20, 22]
+        arch: [amd64,arm64,armhf]
     needs: check_history
     if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, linux, large]
     env:
       SERIES: series${{ matrix.releases }}
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
-    name: Checkbox Core snap for series ${{ matrix.releases }}
+    name: Runtime${{ matrix.releases }}-${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -53,15 +54,15 @@ jobs:
           git config --global user.email "robot@lists.canonical.com"
           git config --global user.name "Certification bot"
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+        name: Building at: https://git.launchpad.net/~ce-certification-qa/+git/checkbox${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
         with:
           action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
-          id: snapcraft
           attempt_delay: 600000 # 10min
           attempt_limit: 3
           with: |
             path: checkbox-core-snap/series${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
-            snapcraft-args: remote-build --build-on amd64,arm64,armhf --launchpad-accept-public-upload
+            snapcraft-args: remote-build --build-on ${{ matrix.arch }} --launchpad-accept-public-upload --build-id checkbox${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -68,7 +68,6 @@ jobs:
           with: |
             path: checkbox-core-snap/series${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
-            # Note: if you change this --build-id arg, change it above as well and keep them consisten
             snapcraft-args: remote-build --build-on ${{ matrix.arch }} --launchpad-accept-public-upload --build-id checkbox${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
       - uses: actions/upload-artifact@v3
         name: Upload logs on failure

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -31,13 +31,14 @@ jobs:
       matrix:
         type: [classic, uc]
         releases: [16, 18, 20, 22]
+        arch: [amd64, arm64, armhf]
     needs: check_history
     if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, linux, large]
     env:
       SERIES: series_${{ matrix.type }}${{ matrix.releases }}
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
-    name: Checkbox snap for series ${{ matrix.type }}${{ matrix.releases }}
+    name: Frontend ${{ matrix.type }}${{ matrix.releases }}-${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -54,15 +55,15 @@ jobs:
           git config --global user.email "robot@lists.canonical.com"
           git config --global user.name "Certification bot"
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+        name: Building at: https://git.launchpad.net/~ce-certification-qa/+git/checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
         with:
           action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
-          id: snapcraft
           attempt_delay: 600000 # 10min
           attempt_limit: 3
           with: |
             path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
-            snapcraft-args: remote-build --build-on amd64,arm64,armhf --launchpad-accept-public-upload
+            snapcraft-args: remote-build --build-on ${{ matrix.arch }} --launchpad-accept-public-upload --build-id checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -48,14 +48,20 @@ jobs:
           cd checkbox-snap/
           sudo apt update && sudo apt install -qq -y python3-setuptools-scm
           ./prepare_${{ matrix.type }}.sh $SERIES
-      - name: add LP credentials
+      - name: Add LP credentials
         run: |
           mkdir -p ~/.local/share/snapcraft/provider/launchpad/
           echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
           git config --global user.email "robot@lists.canonical.com"
           git config --global user.name "Certification bot"
+      - name: Print Launchpad build repository
+        run: |
+          # snapcraft remote-build will create a repository with the name decided by the --build-id arg
+          # it is useful to have this URL to debug builds, note that it will not change if the same workflow is re-run
+          # as the run_id will not change
+          echo "Building at: https://git.launchpad.net/~ce-certification-qa/+git/checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}"
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
-        name: Building at: https://git.launchpad.net/~ce-certification-qa/+git/checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
+        name: Build Snap
         with:
           action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
           attempt_delay: 600000 # 10min
@@ -63,8 +69,10 @@ jobs:
           with: |
             path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
+            # Note: if you change this --build-id arg, change it above as well and keep them consisten
             snapcraft-args: remote-build --build-on ${{ matrix.arch }} --launchpad-accept-public-upload --build-id checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
       - uses: actions/upload-artifact@v3
+        name: Upload logs on failure
         if: failure()
         with:
           name: snapcraft-log-series-${{ matrix.type }}${{ matrix.releases }}
@@ -73,11 +81,12 @@ jobs:
             /home/runner/.local/state/snapcraft/log/
             checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/checkbox*.txt
       - uses: actions/upload-artifact@v3
+        name: Upload snaps as artifact
         with:
           name: series_${{ matrix.type }}${{ matrix.releases }}
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
-        name: Upload checkbox snaps to the store
+        name: Upload Snap to the store
         with:
           attempt_delay: 600000 # 10min
           attempt_limit: 3

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -69,7 +69,6 @@ jobs:
           with: |
             path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
-            # Note: if you change this --build-id arg, change it above as well and keep them consisten
             snapcraft-args: remote-build --build-on ${{ matrix.arch }} --launchpad-accept-public-upload --build-id checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
       - uses: actions/upload-artifact@v3
         name: Upload logs on failure

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -31,14 +31,17 @@ jobs:
       matrix:
         type: [classic, uc]
         releases: [16, 18, 20, 22]
-        arch: [amd64, arm64, armhf]
     needs: check_history
     if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, linux, large]
     env:
       SERIES: series_${{ matrix.type }}${{ matrix.releases }}
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
-    name: Frontend ${{ matrix.type }}${{ matrix.releases }}-${{ matrix.arch }}
+      # snapcraft remote-build will create a repository with the name decided by the --build-id arg
+      # URL to this repo echoed below to help debug builds (does not change if the workflow is re-run)
+      # as the run_id will not change
+      SNAPCRAFT_BUILDER_ID: checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ github.run_id }}
+    name: Frontend ${{ matrix.type }}${{ matrix.releases }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -56,20 +59,17 @@ jobs:
           git config --global user.name "Certification bot"
       - name: Print Launchpad build repository
         run: |
-          # snapcraft remote-build will create a repository with the name decided by the --build-id arg
-          # it is useful to have this URL to debug builds, note that it will not change if the same workflow is re-run
-          # as the run_id will not change
-          echo "Building at: https://git.launchpad.net/~ce-certification-qa/+git/checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}"
+          echo "Building at: https://git.launchpad.net/~ce-certification-qa/+git/$SNAPCRAFT_BUILDER_ID"
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
-        name: Build Snap
+        name: Building the snaps
         with:
           action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
           attempt_delay: 600000 # 10min
-          attempt_limit: 3
+          attempt_limit: 5
           with: |
             path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
-            snapcraft-args: remote-build --build-on ${{ matrix.arch }} --launchpad-accept-public-upload --build-id checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
+            snapcraft-args: remote-build --build-for amd64,arm64,armhf --launchpad-accept-public-upload --build-id $SNAPCRAFT_BUILDER_ID
       - uses: actions/upload-artifact@v3
         name: Upload logs on failure
         if: failure()
@@ -80,15 +80,15 @@ jobs:
             /home/runner/.local/state/snapcraft/log/
             checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/checkbox*.txt
       - uses: actions/upload-artifact@v3
-        name: Upload snaps as artifact
+        name: Upload the snaps as artefacts
         with:
           name: series_${{ matrix.type }}${{ matrix.releases }}
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
-        name: Upload Snap to the store
+        name: Upload the snaps to the store
         with:
           attempt_delay: 600000 # 10min
-          attempt_limit: 3
+          attempt_limit: 10
           command: |
             for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap ; \
             do \


### PR DESCRIPTION
<!--
Make sure that your PR title is clear and contains a traceability marker.

Traceability Markers is what we use to understand the impact of your change at a glance.
Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)
If your change is to providers it can only be (Infra, BugFix or New)

Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)
-->
## Description

Building multiple arches per matrix expansion leads the workflow to hang waiting for slower archs even if a build failed and makes us unable to re-run the build for a specific arch if it failed. With this modification each arch is built with its own command.

> Note: this is the same PR I proposed previously but I have discovered that --build-id can be used to give the build an id and not only to recover a previously running build

Minor: This also includes a new step that dumps the build URL, this makes it way easier to debug the build if anything goes wrong at runtime
Minor: A few name changes (prettier output for the action menu)

## Resolved issues

The probability of a full build is hindered by the fact that every series either builds all arches or retries them all, this greatly increases the probability of retrying the individual arch because it goes from `P(arch_failure)` to `1-(1-P(arch_failure))**3`

## Documentation

This improves the build readability by providing the URL where the build repo is allowing for further debugging if needed without searching this information in the log at runtime

## Tests

Started the frontend workflow to see if it works at: https://github.com/canonical/checkbox/actions/runs/6652646495/job/18077062870
