### PR TITLE
fix resultbuilder being None on autoresume (BugFix)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -596,7 +596,7 @@ class RemoteSessionAssistant:
             # it is already determined
             return
         if not result:
-            if not self._be:
+            if not self._be or not self._be.wait():
                 # the job is considered done and there's no background
                 # executor, because the job was auto-passed from the session
                 # resume mechanism after a no-return job has been run


### PR DESCRIPTION
## Description
As a followup to the race condition fix [submitted last week](https://github.com/canonical/checkbox/pull/774) this also covers result builder not being instantiated (there can be no command to be run, or that has to be run).

## Resolved issues
Fixes: https://github.com/canonical/checkbox/issues/75

## Tests
I've added tests that check this circumstance.
