### PR TITLE
move toxing to self-hosted runners

### DIFF
--- a/.github/workflows/tox-checkbox-ng.yaml
+++ b/.github/workflows/tox-checkbox-ng.yaml
@@ -16,7 +16,7 @@ jobs:
     defaults:
       run:
         working-directory: checkbox-ng
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, large]
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]

--- a/.github/workflows/tox-checkbox-support.yaml
+++ b/.github/workflows/tox-checkbox-support.yaml
@@ -16,7 +16,7 @@ jobs:
     defaults:
       run:
         working-directory: checkbox-support
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, large]
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]

--- a/.github/workflows/tox-provider-base.yaml
+++ b/.github/workflows/tox-provider-base.yaml
@@ -16,7 +16,7 @@ jobs:
     defaults:
       run:
         working-directory: providers/base
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, large]
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]

--- a/.github/workflows/tox-provider-certification-client.yaml
+++ b/.github/workflows/tox-provider-certification-client.yaml
@@ -16,7 +16,7 @@ jobs:
     defaults:
       run:
         working-directory: providers/certification-client
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, large]
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]

--- a/.github/workflows/tox-provider-certification-server.yaml
+++ b/.github/workflows/tox-provider-certification-server.yaml
@@ -16,7 +16,7 @@ jobs:
     defaults:
       run:
         working-directory: providers/certification-server
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, large]
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]

--- a/.github/workflows/tox-provider-docker.yaml
+++ b/.github/workflows/tox-provider-docker.yaml
@@ -16,7 +16,7 @@ jobs:
     defaults:
       run:
         working-directory: providers/docker
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, large]
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]

--- a/.github/workflows/tox-provider-gpgpu.yaml
+++ b/.github/workflows/tox-provider-gpgpu.yaml
@@ -16,7 +16,7 @@ jobs:
     defaults:
       run:
         working-directory: providers/gpgpu
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, large]
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]

--- a/.github/workflows/tox-provider-iiotg.yaml
+++ b/.github/workflows/tox-provider-iiotg.yaml
@@ -16,7 +16,7 @@ jobs:
     defaults:
       run:
         working-directory: providers/iiotg
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, large]
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]

--- a/.github/workflows/tox-provider-resource.yaml
+++ b/.github/workflows/tox-provider-resource.yaml
@@ -16,7 +16,7 @@ jobs:
     defaults:
       run:
         working-directory: providers/resource
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, large]
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]

--- a/.github/workflows/tox-provider-sru.yaml
+++ b/.github/workflows/tox-provider-sru.yaml
@@ -16,7 +16,7 @@ jobs:
     defaults:
       run:
         working-directory: providers/sru
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, large]
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]

--- a/.github/workflows/tox-provider-tpm2.yaml
+++ b/.github/workflows/tox-provider-tpm2.yaml
@@ -16,7 +16,7 @@ jobs:
     defaults:
       run:
         working-directory: providers/tpm2
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, linux, large]
     strategy:
       matrix:
         python: ["3.5", "3.6", "3.8", "3.10"]


### PR DESCRIPTION
## Description
This PR switches the runners that run tox testing from the GH provided 20.04 ones to the ones we host.
