### PR TITLE
Fix snappy-snap-automated misplaced to manual plan (BugFix)

### DIFF
--- a/providers/certification-client/units/client-cert-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-22-04.pxu
@@ -42,7 +42,6 @@ nested_part:
     networking-cert-manual
     optical-cert-manual
     power-management-precheck-cert-manual
-    snappy-snap-automated
     touchpad-cert-manual
     touchscreen-cert-manual
     usb-cert-manual
@@ -117,6 +116,7 @@ nested_part:
     networking-cert-automated
     optical-cert-automated
     power-management-precheck-cert-automated
+    snappy-snap-automated
     touchpad-cert-automated
     touchscreen-cert-automated
     usb-cert-automated


### PR DESCRIPTION
## Description

`snappy-snap-automated` was added to client cert desktop plan with pull request https://github.com/canonical/checkbox/pull/663. 
When nesting to the desktop plan, it was misplaced to the manual plan on `client-cert-desktop-22-04.pxu`. 20-04 and 18-04 didn't misplace. This PR fixes it to move the `snappy-snap-automated` to the auto plan.

## Resolved issues
`snappy-snap-automated` misplaced to `client-cert-desktop-22-04-manual` test plan.
Should be placed in `client-cert-desktop-22-04-automated` test plan.

## Tests
Sideload list bootstrapped result:
```
patliu@:.../tmp/checkbox-providers$ checkbox.checkbox-cli list-bootstrapped com.canonical.certification::client-cert-desktop-22-04-automated | grep -i snappy
$PROVIDERPATH is defined, so following provider sources are ignored ['/home/patliu/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Using sideloaded provider: checkbox-provider-base, version 2.10.1 from /var/tmp/checkbox-providers/providers/base
Using sideloaded provider: checkbox-provider-certification-client, version 2.10.1 from /var/tmp/checkbox-providers/providers/certification-client
com.canonical.certification::snappy/snap-list
com.canonical.certification::snappy/snap-search
com.canonical.certification::snappy/snap-install
com.canonical.certification::snappy/snap-refresh-automated
com.canonical.certification::snappy/snap-revert-automated
com.canonical.certification::snappy/snap-reupdate-automated
com.canonical.certification::snappy/snap-remove
com.canonical.certification::snappy/test-store-install-beta
com.canonical.certification::snappy/test-store-install-edge
com.canonical.certification::snappy/test-system-confinement
com.canonical.certification::snappy/test-snaps-confinement
patliu@:.../tmp/checkbox-providers$ checkbox.checkbox-cli list-bootstrapped com.canonical.certification::client-cert-desktop-22-04-manual | grep -i snappy
$PROVIDERPATH is defined, so following provider sources are ignored ['/home/patliu/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Using sideloaded provider: checkbox-provider-base, version 2.10.1 from /var/tmp/checkbox-providers/providers/base
Using sideloaded provider: checkbox-provider-certification-client, version 2.10.1 from /var/tmp/checkbox-providers/providers/certification-client
patliu@:.../tmp/checkbox-providers$
```
