### PR TITLE
Fixed remote nomenclature and service name (infra)

### DIFF
--- a/docs/tutorial/using-checkbox/remote.rst
+++ b/docs/tutorial/using-checkbox/remote.rst
@@ -33,8 +33,8 @@ You should see something like this:
           Tasks: 1 (limit: 19014)
          Memory: 69.7M
             CPU: 2.537s
-         CGroup: /system.slice/snap.checkbox.service.service
-                 └─1411 python3 /snap/checkbox22/current/bin/checkbox-cli service
+         CGroup: /system.slice/snap.checkbox.agent.service
+                 └─1411 python3 /snap/checkbox22/current/bin/checkbox-cli run-agent
 
     Jul 21 13:38:48 coltrane systemd[1]: Started Service for snap application checkbox.service.
     (...)

--- a/docs/tutorial/using-checkbox/remote.rst
+++ b/docs/tutorial/using-checkbox/remote.rst
@@ -20,13 +20,13 @@ Run the following command:
 
 .. code-block:: none
 
-    systemctl status snap.checkbox.service.service
+    systemctl status snap.checkbox.agent.service
 
 You should see something like this:
 
 .. code-block:: none
 
-    ● snap.checkbox.service.service - Service for snap application checkbox.service
+    ● snap.checkbox.agent.service - Service for snap application checkbox.service
          Loaded: loaded (/etc/systemd/system/snap.checkbox.service.service; enabled; vendor preset: enabled)
          Active: active (running) since Fri 2023-07-21 13:38:48 CST; 1h 29min ago
        Main PID: 1411 (python3)
@@ -46,14 +46,14 @@ For the sake of this tutorial, let's stop this service for the moment:
 
 .. code-block:: none
 
-    sudo systemctl stop snap.checkbox.service.service
+    sudo systemctl stop snap.checkbox.agent.service
 
 Now, open two terminal windows using ``Ctrl+Alt+T``. In the first one,
 start the Checkbox agent:
 
 .. code-block:: none
 
-    sudo checkbox.checkbox-cli agent
+    sudo checkbox.checkbox-cli run-agent
 
 In the second one, run Checkbox as a controller to connect to the agent:
 
@@ -107,11 +107,11 @@ restart the Checkbox agent service with:
 
 .. code-block:: none
 
-    sudo systemctl start snap.checkbox.service.service
+    sudo systemctl start snap.checkbox.agent.service
 
 If you have another device running Ubuntu, you can try to install Checkbox on
 it, then connect to it using your own computer with the ``checkbox.checkbox-cli
-remote x.x.x.x`` command, replacing ``x.x.x.x`` by the IP address of the
+control x.x.x.x`` command, replacing ``x.x.x.x`` by the IP address of the
 other device.
 
 Launchers in remote mode
@@ -123,7 +123,7 @@ local mode. If you still have the launcher file you created in the
 
 .. code-block:: none
 
-    checkbox.checkbox-cli remote 127.0.0.1 mylauncher
+    checkbox.checkbox-cli control 127.0.0.1 mylauncher
 
 This will start a remote test session with the configuration defined in
 your launcher.
@@ -136,7 +136,7 @@ of them is the interrupt screen. Run Checkbox remote:
 
 .. code-block:: none
 
-    checkbox.checkbox-cli remote 127.0.0.1
+    checkbox.checkbox-cli control 127.0.0.1
 
 Select the "Checkbox Base Tutorial" test plan, leave all the jobs selected,
 and press ``T`` to start the testing session.
@@ -169,7 +169,7 @@ see the Checkbox agent Systemd service is not running anymore:
 
 .. code-block:: none
 
-    systemctl is-active snap.checkbox.service.service
+    systemctl is-active snap.checkbox.agent.service
     inactive
 
 If you try reconnecting to the agent, the controller will wait 5 minutes
@@ -177,7 +177,7 @@ for the agent to be reactivated, after what it will time out:
 
 .. code-block:: none
 
-    checkbox.checkbox-cli remote 127.0.0.1
+    checkbox.checkbox-cli control 127.0.0.1
     .....
     Connection timed out.
 
@@ -185,7 +185,7 @@ Restart the agent by typing:
 
 .. code-block:: none
 
-    sudo systemctl start snap.checkbox.service.service
+    sudo systemctl start snap.checkbox.agent.service
 
 Wrapping up
 ===========


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The remote documentation is not completely up to date, a few names and commands are still the old one.

## Resolved issues

N/A

## Documentation

N/A

## Tests

```
> make install && make run
```

