### PR TITLE
Remove useless HTML comment closing tag from PR template (Infra)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@ Signed commits are required.
   - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
     - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
 -->
--->
+
 ## Description
 
 <!--


### PR DESCRIPTION
Current PR template includes an extra HTML closing comment tag which ends up showing up in the issue if not taken care of manually.

This PR removes it.
