### PR TITLE
use noninteractive apt in workflows (Infra)

### DIFF
--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install Aspell
         run: |
-          sudo apt-get install aspell aspell-en
+          sudo apt install -qq -y aspell aspell-en
 
       - name: Install the doc framework
         working-directory: docs/


### PR DESCRIPTION
## Description
The spelling workflow failed because it used an interactive invocation of apt.
This patch adds `-y -qq` to the invocation.