### PR TITLE
add venv installation to workflows so the doc Makefile works (Infra)

### DIFF
--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Install Aspell
         run: |
+          sudo apt update -qq
           sudo apt install -qq -y aspell aspell-en
 
       - name: Install the doc framework

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Install the doc framework
         working-directory: docs/
         run: |
+          sudo apt install -y -qq python3-venv
           make install
 
       - name: Build docs and run spelling checker
@@ -63,6 +64,7 @@ jobs:
       - name: Install the doc framework
         working-directory: docs/
         run: |
+          sudo apt install -y -qq python3-venv
           make install
 
       - name: Run linkchecker


### PR DESCRIPTION
## Description
The documentation workflows relied on the Makefile that assumed that the venv module is available, but it is not by default.
This patch adds installation of the python3-venv.
It also adds the `apt update` so we are ensured the cache is fresh.