### PR TITLE
Fixed USB-C OTG cleanup job was unexpectedly executed (BugFix)

### DIFF
--- a/providers/base/units/usb/usb-c.pxu
+++ b/providers/base/units/usb/usb-c.pxu
@@ -251,6 +251,8 @@ _siblings: [
        "_summary": "Cleanup USB OTG serial interface setup after serial device test (after suspend)",
        "after": "after-suspend-usb-c-otg/g_serial"
      }]
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_usbc_otg == 'True'
 
 id: usb-c-otg/g_mass_storage
 _summary: Check DUT can be detected as a mass storage device
@@ -298,6 +300,8 @@ _siblings: [
        "_summary": "Cleanup mass storage setup after mass storage device test (after suspend)",
        "after": "after-suspend-usb-c-otg/g_mass_storage"
      }]
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_usbc_otg == 'True'
 
 id: usb-c-otg/g_ether
 _summary: Check DUT can be detected as USB ethernet device
@@ -346,3 +350,5 @@ _siblings: [
        "_summary": "Cleanup USB OTG ethernet interface setup after ethernet device test (after suspend)",
        "after": "after-suspend-usb-c-otg/g_ether"
      }]
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_usbc_otg == 'True'


### PR DESCRIPTION
The USB-C OTG cleanup job was unexpectedly executed. It was executed even if the test job had been skipped because the manifest entry was not supported.

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
Add a manifest to the USB-C OTG clean-up jobs to ensure that those jobs will be skipped if USB-C OTG is not supported in the manifest menu.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
The USB-C OTG cleanup job was unexpectedly executed. It was executed even if the test job had been skipped because the manifest entry was not supported.
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
The manifest entry for USB-C OTG indicates 'not supported' for side loading."
https://pastebin.canonical.com/p/yWJfdkq4fq/
https://pastebin.canonical.com/p/4Pb5tny86G/
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests
1. Side loading this branch
2. Run checkbox-cli and select test plan "com.canonical.certification::usb-c-manual "
3. Select "usb-c-otg" related jobs
4. Select "No" for the manifest entry "Does the platform support USB-C OTG?"
5. Run the test and all select jobs should be skipped due to the manifest entry is no.
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

