### PR TITLE
Install the gh command line tool (Infra)

### DIFF
--- a/.github/workflows/checkbox-stable-release.yml
+++ b/.github/workflows/checkbox-stable-release.yml
@@ -13,6 +13,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Install dependencies
+        run: |
+          sudo apt update -qq
+          sudo apt install -qq -y gh
       - name: Edit the draft release and publish it
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

The `gh` tool is not present on self hosted runners and it's required by the stable release workflow to update Github draft releases.



