### PR TITLE
Improve warn message for skipped file at provider loading (Bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
@@ -23,6 +23,7 @@ Test definitions for plainbox.impl.secure.providers.v1 module
 """
 
 from unittest import TestCase
+import os
 
 from plainbox.impl.job import JobDefinition
 from plainbox.impl.secure.config import Unset
@@ -103,11 +104,11 @@ class ProviderContentLoaderTests(TestCase):
 
     def test_warn_ignored_file_warns_about_skipped_files(self):
         filenames = [
-            '/'.join([self.units_path, 'unitfile']),
-            '/'.join([self.jobs_path, 'jobfile']),
-            '/'.join([self.data_path, 'datafile']),
-            '/'.join([self.bin_path, 'binfile']),
-            '/'.join([self.locale_path, 'localefile']),
+            os.path.join(self.units_path, 'unitfile'),
+            os.path.join(self.jobs_path, 'jobfile'),
+            os.path.join(self.data_path, 'datafile'),
+            os.path.join(self.bin_path, 'binfile'),
+            os.path.join(self.locale_path, 'localefile'),
         ]
         for filename in filenames:
             with self.subTest(filename=filename):
@@ -118,7 +119,7 @@ class ProviderContentLoaderTests(TestCase):
         #   - contain the skipped filename
         #   - contain the reason to skip
         #   - be clear on skipping
-        filename = '/'.join([self.units_path, 'unitsfile'])
+        filename = os.path.join(self.units_path, 'unitsfile')
         with self.assertLogs(level='WARNING') as log_recorder:
             self.loader._warn_ignored_file(filename)
 
@@ -128,7 +129,7 @@ class ProviderContentLoaderTests(TestCase):
 
     def test_warn_ignored_file_does_not_log_files_outside_provider_dirs(self):
         outside_path = '/not/a/provider/path'
-        filename = '/'.join([outside_path, 'unitsfile'])
+        filename = os.path.join(outside_path, 'unitsfile')
         with self.assertLogs(level='WARNING') as log_recorder:
             logger.warning("Dummy warning")
             self.loader._warn_ignored_file(filename)

--- a/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
@@ -56,7 +56,7 @@ class ProviderContentLoaderTests(TestCase):
 
     def assertLogsInline(self, function, *args, **kwargs):
         '''
-        Asserts that a callable logs a message when called with args and/or kwargs. This methos is meant to be used where assertLogs context manager would decrease readability.
+        Asserts that a callable logs a message when called with args and/or kwargs. This method is meant to be used where assertLogs context manager would decrease readability.
 
         :param function:
             callable to be tested

--- a/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
@@ -89,7 +89,7 @@ class ProviderContentLoaderTests(TestCase):
 
     def setUp(self):
         patcher = mock.patch(
-            'plainbox.impl.secure.providers.v1.ProviderContentLoader',
+            'plainbox.impl.secure.providers.v1.Provider1',
             autospec=True,
         )
         self.provider_mock = patcher.start()

--- a/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
@@ -123,9 +123,9 @@ class ProviderContentLoaderTests(TestCase):
         with self.assertLogs(level='WARNING') as log_recorder:
             self.loader._warn_ignored_file(filename)
 
-            self.assertRegex(log_recorder.output[0], filename)
-            self.assertRegex(log_recorder.output[0], '(?i)executable')
-            self.assertRegex(log_recorder.output[0], '(?i)skip')
+            self.assertIn(filename, log_recorder.output[0])
+            self.assertIn('executable', log_recorder.output[0])
+            self.assertIn('skip', log_recorder.output[0])
 
     def test_warn_ignored_file_does_not_log_files_outside_provider_dirs(self):
         outside_path = '/not/a/provider/path'

--- a/checkbox-ng/plainbox/impl/secure/providers/v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/v1.py
@@ -592,12 +592,13 @@ class ProviderContentLoader:
         Do not print warning for all skipped files, do it only for file that is located
         inside a official provider folder (bin, data, units, ..).
         """
-        if ((self.provider.units_dir and filename.startswith(self.provider.units_dir))
-            or (self.provider.jobs_dir and filename.startswith(self.provider.jobs_dir))
-            or (self.provider.data_dir and filename.startswith(self.provider.data_dir))
-            or (self.provider.bin_dir and filename.startswith(self.provider.bin_dir))
-            or (self.provider.locale_dir and filename.startswith(self.provider.locale_dir))):
-            logger.warn("File %s is not executable, skipping", filename)
+        file_is_in_units_dir = self.provider.units_dir and filename.startswith(self.provider.units_dir)
+        file_is_in_jobs_dir = self.provider.jobs_dir and filename.startswith(self.provider.jobs_dir)
+        file_is_in_data_dir = self.provider.data_dir and filename.startswith(self.provider.data_dir)
+        file_is_in_bin_dir = self.provider.bin_dir and filename.startswith(self.provider.bin_dir)
+        file_is_in_locale_dir = self.provider.locale_dir and filename.startswith(self.provider.locale_dir)
+        if any([file_is_in_units_dir, file_is_in_jobs_dir, file_is_in_data_dir, file_is_in_bin_dir, file_is_in_locale_dir]):
+            logger.warning("File %s is not executable, skipping", filename)
 
     def _load_file(self, filename, text, plugin_kwargs):
         # NOTE: text is lazy, call str() or iter() to see the real content This

--- a/checkbox-ng/plainbox/impl/secure/providers/v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/v1.py
@@ -592,12 +592,14 @@ class ProviderContentLoader:
         Do not print warning for all skipped files, do it only for file that is located
         inside a official provider folder (bin, data, units, ..).
         """
-        file_is_in_units_dir = self.provider.units_dir and filename.startswith(self.provider.units_dir)
-        file_is_in_jobs_dir = self.provider.jobs_dir and filename.startswith(self.provider.jobs_dir)
-        file_is_in_data_dir = self.provider.data_dir and filename.startswith(self.provider.data_dir)
-        file_is_in_bin_dir = self.provider.bin_dir and filename.startswith(self.provider.bin_dir)
-        file_is_in_locale_dir = self.provider.locale_dir and filename.startswith(self.provider.locale_dir)
-        if any([file_is_in_units_dir, file_is_in_jobs_dir, file_is_in_data_dir, file_is_in_bin_dir, file_is_in_locale_dir]):
+        provider_folders = [
+            self.provider.units_dir,
+            self.provider.jobs_dir,
+            self.provider.data_dir,
+            self.provider.bin_dir,
+            self.provider.locale_dir
+        ]
+        if any(location and filename.startswith(location) for location in provider_folders):
             logger.warning("File %s is not executable, skipping", filename)
 
     def _load_file(self, filename, text, plugin_kwargs):

--- a/checkbox-ng/plainbox/impl/secure/providers/v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/v1.py
@@ -597,7 +597,7 @@ class ProviderContentLoader:
             or (self.provider.data_dir and filename.startswith(self.provider.data_dir))
             or (self.provider.bin_dir and filename.startswith(self.provider.bin_dir))
             or (self.provider.locale_dir and filename.startswith(self.provider.locale_dir))):
-            logger.warn("Skipped file: %s", filename)
+            logger.warn("File %s is not executable, skipping", filename)
 
     def _load_file(self, filename, text, plugin_kwargs):
         # NOTE: text is lazy, call str() or iter() to see the real content This


### PR DESCRIPTION
The warn message informs about the file being skipped without the reason it happens. This will add that the file is not executable (hence will be skipped).
