### PR TITLE
Select packages published in the last 4 weeks to copy from beta to stable (Infra)

### DIFF
--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -55,6 +55,9 @@ Therefore, if there has been no negative feedback from internal teams after a
 cycle of testing the beta release, run the [Stable release workflow] to copy deb
 packages to the stable PPA and promote all snaps to stable.
 
+> **_NOTE:_** Copy to the stable ppa only selects packages published in the last
+4 weeks.
+
 Then, it's time to build the new beta version.
 
 ## Tag the release

--- a/tools/release/lp-copy-packages.py
+++ b/tools/release/lp-copy-packages.py
@@ -45,7 +45,7 @@ dest_ppa = dest_owner.getPPAByName(name=dest_ppa_name)
 # Define the time period for package publication
 one_week_ago = datetime.datetime.utcnow().replace(
     tzinfo=datetime.timezone.utc
-) - datetime.timedelta(weeks=1)
+) - datetime.timedelta(weeks=4)
 
 # Get the packages in the source PPA that were published within the last week
 # and start with "checkbox"


### PR DESCRIPTION
## Description

Promoting packages from the testing (beta) ppa to stable is done by copies.
The filter only considers packages published to the archive in the last week.
This is sometime not enough and should be extended to a month.  

## Resolved issues

3.0.0 deb binaries were not copied over to stable ppa because they were published two weeks ago 

## Documentation

Note added to detail the copy criteria (packages published since a month)

## Tests

Tested the patched version to force the 3.0.0 release to stable.

