### PR TITLE
Adjust the wwan, watchdog and alsa-loopback test cases. (BugFix)

### DIFF
--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -755,25 +755,6 @@ estimated_duration: 5
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_audio_loopback_connector == 'True'
 
-id: audio/alsa-loopback
-_summary: Captured sound matches played one
-_purpose:
- Check if sound that is 'hearable' by capture device
-_steps:
- 1. Connect line-out to line-in (plug the loop-back cable)
- 2. Commence the test
- 3. Observe command's output
-_verification:
- Is the reported frequency in the 438 - 442 range
-plugin: user-interact-verify
-depends: audio/detect-playback-devices audio/detect-capture-devices
-user: root
-environ: ALSA_CONFIG_PATH LD_LIBRARY_PATH ALSADEVICE
-flags: also-after-suspend
-command: alsa_test loopback -d 5
-category_id: com.canonical.plainbox::audio
-estimated_duration: 30
-
 id: audio/pa-record-internal-mic
 _summary: Record a wav file and check it using pulseaudio - internal mic
 _purpose:

--- a/providers/base/units/audio/test-plan.pxu
+++ b/providers/base/units/audio/test-plan.pxu
@@ -107,7 +107,6 @@ _name: Manual audio tests
 _description: Manual audio tests for Snappy Ubuntu Core devices
 include:
     audio/alsa-playback
-    audio/alsa-loopback
 
 id: audio-pa-manual
 unit: test plan
@@ -144,7 +143,6 @@ _name: Manual audio tests (after suspend)
 _description: Manual audio tests for Snappy Ubuntu Core devices
 include:
     after-suspend-audio/alsa-playback
-    after-suspend-audio/alsa-loopback
 
 id: after-suspend-audio-pa-manual
 unit: test plan

--- a/providers/base/units/watchdog/jobs.pxu
+++ b/providers/base/units/watchdog/jobs.pxu
@@ -15,27 +15,6 @@ flags: simple
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_hardware_watchdog == 'True'
 
-id: watchdog/trigger-system-reset
-depends: watchdog/systemd-config
-_summary: Test that the watchdog module can trigger a system reset
-_purpose:
- The watchdog module should be capable of issuing a hard reset of the SUT.
-_steps:
- 1. Commence the test to trigger a SysRq.
- 2. Once the watchdog timeout has expired (10s) the SUT should reset itself.
- 3. The board will reboot and the user should resume the test session.
-_verification:
- Did the board reset itself?
-command:
-  echo 1 > /proc/sys/kernel/sysrq
-  echo 0 > /proc/sys/kernel/panic
-  echo c > /proc/sysrq-trigger
-flags: noreturn preserve-locale
-user: root
-plugin: user-interact-verify
-category_id: com.canonical.plainbox::power-management
-estimated_duration: 60
-
 id: watchdog/trigger-system-reset-auto
 depends: watchdog/systemd-config
 _summary: Test that the watchdog module can trigger a system reset

--- a/providers/base/units/watchdog/test-plan.pxu
+++ b/providers/base/units/watchdog/test-plan.pxu
@@ -7,6 +7,12 @@ nested_part:
     watchdog-manual
     watchdog-automated
 
+id: watchdog-manual
+unit: test plan
+_name: Manual watchdog tests
+_description: Manual watchdog tests for Ubuntu Core devices
+include:
+
 id: watchdog-automated
 unit: test plan
 _name: Automated watchdog tests

--- a/providers/base/units/watchdog/test-plan.pxu
+++ b/providers/base/units/watchdog/test-plan.pxu
@@ -7,13 +7,6 @@ nested_part:
     watchdog-manual
     watchdog-automated
 
-id: watchdog-manual
-unit: test plan
-_name: Manual watchdog tests
-_description: Manual watchdog tests for Ubuntu Core devices
-include:
-    watchdog/trigger-system-reset
-
 id: watchdog-automated
 unit: test plan
 _name: Automated watchdog tests

--- a/providers/base/units/wwan/test-plan.pxu
+++ b/providers/base/units/wwan/test-plan.pxu
@@ -47,6 +47,7 @@ _description: Manual wwan tests for Snappy Ubuntu Core devices
 include:
     wwan/detect-manual
     wwan/scan-networks-manual
+    wwan/check-sim-present-manual
     wwan/gsm-connection-interrupted-manual
 
 id: after-suspend-wwan-manual
@@ -56,4 +57,5 @@ _description: Manual wwan tests for Snappy Ubuntu Core devices
 include:
     after-suspend-wwan/detect-manual
     after-suspend-wwan/scan-networks-manual
+    after-suspend-wwan/check-sim-present-manual
     after-suspend-wwan/gsm-connection-interrupted-manual

--- a/providers/base/units/wwan/test-plan.pxu
+++ b/providers/base/units/wwan/test-plan.pxu
@@ -46,8 +46,6 @@ _name: Manual wwan tests
 _description: Manual wwan tests for Snappy Ubuntu Core devices
 include:
     wwan/detect-manual
-    wwan/gsm-connection-manual
-    wwan/check-sim-present-manual
     wwan/scan-networks-manual
     wwan/gsm-connection-interrupted-manual
 
@@ -57,7 +55,5 @@ _name: Manual wwan tests (after suspend)
 _description: Manual wwan tests for Snappy Ubuntu Core devices
 include:
     after-suspend-wwan/detect-manual
-    after-suspend-wwan/gsm-connection-manual
-    after-suspend-wwan/check-sim-present-manual
     after-suspend-wwan/scan-networks-manual
     after-suspend-wwan/gsm-connection-interrupted-manual

--- a/providers/certification-client/units/client-cert-desktop-18-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-18-04.pxu
@@ -34,7 +34,7 @@ nested_part:
     misc-client-cert-manual
     mediacard-cert-manual
     memory-manual
-    mobilebroadband-cert-manual
+    wwan-manual
     ethernet-cert-manual
     networking-cert-manual
     optical-cert-manual
@@ -104,7 +104,7 @@ nested_part:
     mediacard-cert-automated
     mediacard-automated
     memory-automated
-    mobilebroadband-cert-automated
+    wwan-automated
     ethernet-cert-automated
     networking-cert-automated
     optical-cert-automated
@@ -129,6 +129,7 @@ nested_part:
     after-suspend-touchscreen-cert-automated
     after-suspend-wireless-cert-automated
     after-suspend-bluetooth-cert-automated
+    after-suspend-wwan-automated
     # The following tests should run BEFORE the automated tests. The reboot and
     # power off tests will also give us a clean system to start the stress run
     # with.

--- a/providers/certification-client/units/client-cert-desktop-20-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-20-04.pxu
@@ -37,7 +37,7 @@ nested_part:
     led-cert-manual
     mediacard-cert-manual
     memory-manual
-    mobilebroadband-cert-manual
+    wwan-manual
     ethernet-cert-manual
     networking-cert-manual
     optical-cert-manual
@@ -107,7 +107,7 @@ nested_part:
     mediacard-cert-automated
     mediacard-automated
     memory-automated
-    mobilebroadband-cert-automated
+    wwan-automated
     ethernet-cert-automated
     networking-cert-automated
     optical-cert-automated
@@ -132,6 +132,7 @@ nested_part:
     after-suspend-touchscreen-cert-automated
     after-suspend-wireless-cert-automated
     after-suspend-bluetooth-cert-automated
+    after-suspend-wwan-automated
     # The following tests should run BEFORE the automated tests. The reboot and
     # power off tests will also give us a clean system to start the stress run
     # with.

--- a/providers/certification-client/units/client-cert-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-22-04.pxu
@@ -37,7 +37,7 @@ nested_part:
     led-cert-manual
     mediacard-cert-manual
     memory-manual
-    mobilebroadband-cert-manual
+    wwan-manual
     ethernet-cert-manual
     networking-cert-manual
     optical-cert-manual
@@ -112,7 +112,7 @@ nested_part:
     mediacard-cert-automated
     mediacard-automated
     memory-automated
-    mobilebroadband-cert-automated
+    wwan-automated
     ethernet-cert-automated
     networking-cert-automated
     optical-cert-automated
@@ -137,7 +137,7 @@ nested_part:
     after-suspend-cpu-cert-automated
     after-suspend-input-cert-automated
     after-suspend-disk-cert-automated
-    after-suspend-mobilebroadband-cert-automated
+    after-suspend-wwan-automated
     after-suspend-ethernet-cert-automated
     after-suspend-networking-cert-automated
     after-suspend-optical-cert-automated


### PR DESCRIPTION

1.   The commit is for the alsa-loopback test case.
    
    Actually, the alsa-loopback-automated test case does the same
    thing with alsa-loopback. When we test iot project machines,
    the alsa-loopback-automated needs to be tested. I guess we
    could do the alsa-loopback-automated only in the future.

2.   This commit to modify the watchdog test cases.
    
    The watchdog-automated's test items have included watchdog-maunal
    so I remove the watchdog-manual test case;

3.   Modify the wwan related test cases in desktop pxus.
    
    The mobilebroadband-cert-automated test case is only
    part of the wwan test plan. We hope to replace
    mobilebroadband-cert-automated with wwan-automated.
    
    The relevant test plans we currently use include:
    client-cert-desktop-22-04-automated
    client-cert-desktop-20-04-automated
    client-cert-desktop-18-04-automated
    I have replaced mobilebroadband-cert-automated in them
    with wwan-automated, and added after-sudpend-wwan-
    automated to ensure that wwan is tested before and after
    suspend.
    
    In addition, for mobilebroadband-cert-manual in the Manual
    test plan, when the SIM is inserted into the prototype in the
    desktop, the system should automatically recognize wwan and
    SIM card, and we do not need to perform manual testing. So I
    deleted mobilebroadband-cert-manual in the relevant test
    plans. At the same time, since wwan-automated already
    contains wwan-manual cases, I deleted the wwan-manual in
    these test plans:
    client-cert-desktop-22-04-manual
    client-cert-desktop-20-04-manual
    client-cert-desktop-18-04-manual





