### PR TITLE
Add testcase to check power-mode before and after suspend

### DIFF
--- a/providers/base/units/suspend/suspend.pxu
+++ b/providers/base/units/suspend/suspend.pxu
@@ -48,6 +48,16 @@ estimated_duration: 1.2
 _summary: Dumps memory info to a file for comparison after suspend
 command: meminfo_resource.py > "$PLAINBOX_SESSION_SHARE"/meminfo_before_suspend
 
+plugin: shell
+category_id: com.canonical.plainbox::suspend
+id: suspend/power_mode_before_suspend
+estimated_duration: 1.2
+requires:
+  module.name == 'platform_profile'
+  package.name == 'power-profiles-daemon'
+_summary: Dumps power_mode info to a file for comparison after suspend
+command: power_mode_resource.py > "$PLAINBOX_SESSION_SHARE"/power_mode_before_suspend
+
 unit: template
 template-resource: device
 template-filter: device.category == 'NETWORK'
@@ -582,6 +592,30 @@ depends: suspend/suspend_advanced_auto suspend/memory_before_suspend
 _description:
  Verify that all memory is available after resuming from suspend.
 command: meminfo_resource.py | diff "$PLAINBOX_SESSION_SHARE"/meminfo_before_suspend -
+
+plugin: shell
+category_id: com.canonical.plainbox::suspend
+id: suspend/power_mode_after_suspend
+estimated_duration: 1.2
+requires:
+  module.name == 'platform_profile'
+  package.name == 'power-profiles-daemon'
+depends: suspend/suspend_advanced_auto suspend/power_mode_before_suspend
+_description:
+ Verify that power mode is changed after resuming from suspend.
+command: power_mode_resource.py | diff "$PLAINBOX_SESSION_SHARE"/power_mode_before_suspend -
+
+plugin: shell
+category_id: com.canonical.plainbox::suspend
+id: suspend/power_mode_after_suspend_auto
+estimated_duration: 1.2
+requires:
+  module.name == 'platform_profile'
+  package.name == 'power-profiles-daemon'
+depends: suspend/suspend_advanced_auto suspend/power_mode_before_suspend
+_description:
+ Verify that power mode is changed after resuming from suspend.
+command: power_mode_resource.py | diff "$PLAINBOX_SESSION_SHARE"/power_mode_before_suspend -
 
 plugin: manual
 category_id: com.canonical.plainbox::suspend

--- a/providers/resource/bin/power_mode_resource.py
+++ b/providers/resource/bin/power_mode_resource.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+#
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Modules providing a function running os or sys commands."""
+import sys
+import os
+
+
+def main():
+    """Dump the power mode."""
+    sysfs_root = "/sys/firmware/acpi/"
+    if not os.path.isdir(sysfs_root):
+        return 1
+
+    profile_filename = os.path.join(sysfs_root, "platform_profile")
+    if (not os.path.isfile(profile_filename) or
+            not os.access(profile_filename, os.R_OK)):
+        return 1
+
+    with open(profile_filename, "rt", encoding="utf-8") as stream:
+        profile = stream.read().strip().split()
+        if len(profile) < 1:
+            return 1
+        else:
+            print(profile[0])
+            # uncomment the following line to do local testing
+            #os.system(f"powerprofilesctl set power-saver")
+            return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

With Platform Profile (low-power, balanced, performance) support being added to the kernel and GNOME we'd like this to be tested to confirm it is working during HW enablement/certification.
It is expected functionality on these platforms and we need to highlight any issues with it not working to the FW team so it can be fixed before preload signoff.

## Resolved issues

Original bug: https://bugs.launchpad.net/sutton/+bug/2036435

## Documentation
This testcase could help verify power mode can stay in the chosen setting after suspend.

## Tests
```
Outcome: job passed
==============[ Running job 6 / 7. Estimated time left: 0:00:02 ]===============
--------[ Dumps power_mode info to a file for comparison after suspend ]--------
ID: com.canonical.certification::suspend/power_mode_before_suspend
Category: com.canonical.plainbox::suspend
... 8< -------------------------------------------------------------------------
------------------------------------------------------------------------- >8 ---
Outcome: job passed
==============[ Running job 7 / 7. Estimated time left: 0:00:01 ]===============
----------------------[ suspend/power_mode_after_suspend ]----------------------
ID: com.canonical.certification::suspend/power_mode_after_suspend
Category: com.canonical.plainbox::suspend
... 8< -------------------------------------------------------------------------
------------------------------------------------------------------------- >8 ---
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2023-11-10T11.52.36
==================================[ Results ]===================================
 ☑ : Create resource info for supported sleep states
 ☑ : Creates resource info for RTC
 ☑ : Automated test of suspend function
 ☑ : Collect information about kernel modules
 ☑ : Collect information about installed software packages
 ☑ : Dumps power_mode info to a file for comparison after suspend
 ☑ : suspend/power_mode_after_suspend
```
