### PR TITLE
Migrate pulseaudio to pipewire (New)

### DIFF
--- a/providers/base/bin/check_audio_deamon.sh
+++ b/providers/base/bin/check_audio_deamon.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ -z "$(command -v pactl)" ]; then
+    if [ -n "$(command -v pw-cli)" ] ;then
+        echo "Daemon is pipewire, use pipewire function"
+        exit 0
+    else
+        # shouldn't be here,
+        # if requires: package.name in ['pulseaudio-utils', 'pipewire']
+        echo "No pipewire or pulseaudio installed!! Stop test"
+        exit 2
+    fi
+elif pactl info | grep -iq pipewire ; then
+    echo "Daemon is pipewire, use pipeiwre function"
+    exit 0
+else
+    echo "Daemon is pulseaudio, use pulseaudio function"
+    exit 1
+fi

--- a/providers/base/bin/pipewire_test.py
+++ b/providers/base/bin/pipewire_test.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Hanhsuan Lee <hanhsuan.lee@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import division, print_function
+import argparse
+import collections
+import json
+import logging
+import math
+import re
+import subprocess
+import sys
+import time
+try:
+    import gi
+    gi.require_version('GLib', '2.0')
+    gi.require_version('Gst', '1.0')
+    from gi.repository import GObject
+    from gi.repository import Gst
+    from gi.repository import GLib
+    Gst.init(None)  # This has to be done very early so it can find elements
+except ImportError:
+    print("Can't import module: %s. it may not be available for this"
+          "version of Python, which is: " % sys.exc_info()[1], file=sys.stderr)
+    print((sys.version), file=sys.stderr)
+    sys.exit(127)
+
+
+# Frequency bands for FFT
+BINS = 256
+# How often to take a sample and do FFT on it.
+FFT_INTERVAL = 100000000  # In nanoseconds, so this is every 1/10th second
+# Sampling frequency. The effective maximum frequency we can analyze is
+# half of this (see Nyquist's theorem)
+SAMPLING_FREQUENCY = 44100
+# The default test frequency is in the middle of the band that contains 5000Hz
+# This frequency was determined experimentally to be high enough but more
+# reliable than others we tried.
+DEFAULT_TEST_FREQUENCY = 5035
+# only sample a signal when peak level is in this range (in dB attenuation,
+# 0 means no attenuation (and horrible clipping).
+REC_LEVEL_RANGE = (-2.0, -12.0)
+# For our test signal to be considered present, it has to be this much higher
+# than the base level (minimum magnitude). This is in dB.
+MAGNITUDE_THRESHOLD = 2.5
+# Volume for the sample tone (in %)
+PLAY_VOLUME = 70
+
+
+class PIDController(object):
+    """ A Proportional-Integrative-Derivative controller (PID) controls a
+    process's output to try to maintain a desired output value (known as
+    'setpoint', by continually adjusting the process's input.
+
+    It does so by calculating the "error" (difference between output and
+    setpoint) and attempting to minimize it manipulating the input.
+
+    The desired change to the input is calculated based on error and three
+    constants (kp, ki and kd).  These values can be interpreted in terms of
+    time: P depends on the present error, I on the accumulation of past errors,
+    and D is a prediction of future errors, based on current rate of change.
+    The weighted sum of these three actions is used to adjust the process via a
+    control element.
+
+    In practice, kp, ki and kd are process-dependent and usually have to
+    be tweaked by hand, but once reasonable constants are arrived at, they
+    can apply to a particular process without further modification.
+
+    """
+    def __init__(self, kp, ki, kd, setpoint=0):
+        """ Creates a PID controller with given constants and setpoint.
+
+           Arguments:
+           kp, ki, kd: PID constants, see class description.
+           setpoint: desired output value; calls to input_change with
+                     a process output reading will return a desired change
+                     to the input to attempt matching output to this value.
+        """
+        self.setpoint = setpoint
+        self.kp = kp
+        self.ki = ki
+        self.kd = kd
+        self._integral = 0
+        self._previous_error = 0
+        self._change_limit = 0
+
+    def input_change(self, process_feedback, dt):
+        """ Calculates desired input value change.
+
+            Based on process feedback and time interval (dt).
+        """
+        error = self.setpoint - process_feedback
+        self._integral = self._integral + (error * dt)
+        derivative = (error - self._previous_error) / dt
+        self._previous_error = error
+        input_change = (self.kp * error) + \
+                       (self.ki * self._integral) + \
+                       (self.kd * derivative)
+        if self._change_limit and abs(input_change) > abs(self._change_limit):
+            sign = input_change / abs(input_change)
+            input_change = sign * self._change_limit
+        return input_change
+
+    def set_change_limit(self, limit):
+        """Ensures that input value changes are lower than limit.
+
+           Setting limit of zero disables this.
+        """
+        self._change_limit = limit
+
+
+class VolumeController(object):
+    pw_types = {'input': 'SOURCE', 'output': 'SINK'}
+
+    def __init__(self, type, logger=None):
+        """Initializes the volume controller.
+
+           Arguments:
+           type: either input or output
+
+        """
+        self.type = type
+        self._volume = None
+        self.identifier = None
+        self.logger = logger
+
+    def set_volume(self, volume):
+        if not 0 <= volume <= 100:
+            return False
+        command = [
+            "wpctl",
+            "set-volume",
+            "@DEFAULT_AUDIO_%s@" % (self.pw_types[self.type]),
+            str(int(volume)) + "%",
+        ]
+        self._wpctl_output(command)
+        self._volume = volume
+        return True
+
+    def get_volume(self):
+        return self._volume
+
+    def mute(self, mute):
+        mute = str(int(mute))
+        command = [
+            "wpctl",
+            "set-mute",
+            "@DEFAULT_AUDIO_%s@" % (self.pw_types[self.type]),
+            mute,
+        ]
+        self._wpctl_output(command)
+        return True
+
+    def _wpctl_output(self, command):
+        # This method mainly calls wpctl (hence the name). Since wpctl may
+        # return a failure if the audio layer is not yet initialized, we will
+        # try running a few times in case of failure. All our invocations of
+        # wpctl should be "idempotent" so repeating them should not have
+        # any bad effects.
+        for attempt in range(0, 3):
+            try:
+                return subprocess.check_output(command,
+                                               universal_newlines=True)
+            except (subprocess.CalledProcessError):
+                time.sleep(5)
+            except FileNotFoundError:
+                break
+        self.logger.error("Fail to execute: {}".format(command))
+        sys.exit(1)
+
+
+class FileDumper(object):
+    def write_to_file(self, filename, data):
+        try:
+            with open(filename, "w") as f:
+                for i in data:
+                    print(i, file=f)
+            return_value = True
+        except (TypeError, IOError):
+            return_value = False
+        return return_value
+
+
+class SpectrumAnalyzer(object):
+    def __init__(self, points, sampling_frequency=44100,
+                 wanted_samples=50):
+        self.spectrum = [0] * points
+        self.number_of_samples = 0
+        self.wanted_samples = wanted_samples
+        self.sampling_frequency = sampling_frequency
+        # Frequencies should contain *real* frequency which is half of
+        # the sampling frequency
+        self.frequencies = [((sampling_frequency / 2.0) / points) * i
+                            for i in range(points)]
+
+    def _average(self):
+        return sum(self.spectrum) / len(self.spectrum)
+
+    def sample(self, sample):
+        if len(sample) != len(self.spectrum):
+            return
+        self.spectrum = [((old * self.number_of_samples) + new) /
+                         (self.number_of_samples + 1)
+                         for old, new in zip(self.spectrum, sample)]
+        self.number_of_samples += 1
+
+    def frequencies_with_peak_magnitude(self, threshold=1.0):
+        # First establish the base level
+        per_magnitude_bins = collections.defaultdict(int)
+        for magnitude in self.spectrum:
+            per_magnitude_bins[magnitude] += 1
+        base_level = max(per_magnitude_bins,
+                         key=lambda x: per_magnitude_bins[x])
+        # Now return all values that are higher (more positive)
+        # than base_level + threshold
+        peaks = []
+        for i in range(1, len(self.spectrum) - 1):
+            first_index = i - 1
+            last_index = i + 1
+            if self.spectrum[first_index] < self.spectrum[i] and \
+                    self.spectrum[last_index] < self.spectrum[i] and \
+                    self.spectrum[i] > base_level + threshold:
+                peaks.append(i)
+
+        return peaks
+
+    def frequency_band_for(self, frequency):
+        """Convenience function to tell me which band
+           a frequency is contained in
+        """
+        # Note that actual frequencies are half of what the sampling
+        # frequency would tell us. If SF is 44100 then maximum actual
+        # frequency is 22050, and if I have 10 frequency bins each will
+        # contain only 2205 Hz, not 4410 Hz.
+        max_frequency = self.sampling_frequency / 2
+        if frequency > max_frequency or frequency < 0:
+            return None
+        band = float(frequency) / (max_frequency / len(self.spectrum))
+        return int(math.ceil(band)) - 1
+
+    def frequencies_for_band(self, band):
+        """Convenience function to tell me the delimiting frequencies
+           for a band
+        """
+        if band >= len(self.spectrum) or band < 0:
+            return None
+        lower = self.frequencies[band]
+        upper = lower + ((self.sampling_frequency / 2.0) / len(self.spectrum))
+        return (lower, upper)
+
+    def sampling_complete(self):
+        return self.number_of_samples >= self.wanted_samples
+
+
+class GStreamerMessageHandler(object):
+    def __init__(self, rec_level_range, logger, volumecontroller,
+                 pidcontroller, spectrum_analyzer):
+        """Initializes the message handler. It knows how to handle
+           spectrum and level gstreamer messages.
+
+           Arguments:
+           rec_level_range: tuple with acceptable recording level
+                            ranges
+           logger: logging object with debug, info, error methods.
+           volumecontroller: an instance of VolumeController to use
+                             to adjust RECORDING level
+           pidcontroller: a PID controller instance which helps control
+                          volume
+           spectrum_analyzer: instance of SpectrumAnalyzer to collect
+                              data from spectrum messages
+
+        """
+        self.current_level = sys.maxsize
+        self.logger = logger
+        self.pid_controller = pidcontroller
+        self.rec_level_range = rec_level_range
+        self.spectrum_analyzer = spectrum_analyzer
+        self.volume_controller = volumecontroller
+
+    def set_quit_method(self, method):
+        """ Method that will be called when sampling is complete."""
+        self._quit_method = method
+
+    def bus_message_handler(self, bus, message):
+        if message.type == Gst.MessageType.ELEMENT:
+            message_name = message.get_structure().get_name()
+            if message_name == 'spectrum':
+                # TODO: Due to an upstream bug, a structure's get_value method
+                # doesn't work if the value in question is an array (as is the
+                # case with the magnitudes).
+                # https://bugzilla.gnome.org/show_bug.cgi?id=693168
+                # We have to resort to parsing the string representation of the
+                # structure. It's an ugly hack but it works.
+                # Ideally we'd be able to say this to get fft_magnitudes:
+                # message.get_structure.get_value('magnitude').
+                # If an upstream fix ever makes it into gstreamer,
+                # remember to remove this hack and the parse_spectrum method
+                struct_string = message.get_structure().to_string()
+                structure = parse_spectrum_message_structure(struct_string)
+                fft_magnitudes = structure['magnitude']
+                self.spectrum_method(self.spectrum_analyzer, fft_magnitudes)
+
+            if message_name == 'level':
+                # peak_value is our process feedback
+                # It's returned as an array, so I need the first (and only)
+                # element
+                peak_value = message.get_structure().get_value('peak')[0]
+                self.level_method(peak_value, self.pid_controller,
+                                  self.volume_controller)
+
+    # Adjust recording level
+    def level_method(self, level, pid_controller, volume_controller):
+        # If volume controller doesn't return a valid volume,
+        # we can't control it :(
+        current_volume = volume_controller.get_volume()
+        if current_volume is None:
+            self.logger.error("Unable to control recording volume. "
+                              "Test results may be wrong")
+            return
+        self.current_level = level
+        change = pid_controller.input_change(level, 0.10)
+        if self.logger:
+            self.logger.debug(
+                        "Peak level: %(peak_level).2f, "
+                        "volume: %(volume)d%%, Volume change: %(change)f%%" % {
+                            'peak_level': level,
+                            'change': change,
+                            'volume': current_volume})
+        volume_controller.set_volume(current_volume + change)
+
+    # Only sample if level is within the threshold
+    def spectrum_method(self, analyzer, spectrum):
+        if self.rec_level_range[1] <= self.current_level \
+           or self.current_level <= self.rec_level_range[0]:
+            self.logger.debug(
+                "Sampling, recorded %d samples" % analyzer.number_of_samples)
+            analyzer.sample(spectrum)
+        if analyzer.sampling_complete() and self._quit_method:
+            self.logger.info("Sampling complete, ending process")
+            self._quit_method()
+
+
+class GstAudioObject(object):
+    def __init__(self):
+        self.class_name = self.__class__.__name__
+
+    def _set_state(self, state, description):
+        self.pipeline.set_state(state)
+        message = "%s: %s" % (self.class_name, description)
+        if self.logger:
+            self.logger.info(message)
+
+    def start(self):
+        self._set_state(Gst.State.PLAYING, "Starting")
+
+    def stop(self):
+        self._set_state(Gst.State.NULL, "Stopping")
+
+
+class Player(GstAudioObject):
+    def __init__(self, frequency=DEFAULT_TEST_FREQUENCY, logger=None):
+        super(Player, self).__init__()
+        self.pipeline_description = (
+            "audiotestsrc wave=sine freq=%s "
+            "! audioconvert "
+            "! audioresample "
+            "! autoaudiosink" % int(frequency))
+        self.logger = logger
+        if self.logger:
+            self.logger.debug(self.pipeline_description)
+        self.pipeline = Gst.parse_launch(self.pipeline_description)
+
+
+class Recorder(GstAudioObject):
+    def __init__(self, output_file, bins=BINS,
+                 sampling_frequency=SAMPLING_FREQUENCY,
+                 fft_interval=FFT_INTERVAL, logger=None):
+        super(Recorder, self).__init__()
+        pipeline_description = ('''autoaudiosrc
+        ! queue
+        ! level message=true
+        ! audioconvert
+        ! audio/x-raw, channels=1, rate=(int)%(rate)s
+        ! audioresample
+        ! spectrum interval=%(fft_interval)s bands = %(bands)s
+        ! wavenc
+        ! filesink location=%(file)s''' % {
+            'bands': bins,
+            'rate': sampling_frequency,
+            'fft_interval': fft_interval,
+            'file': output_file})
+        self.logger = logger
+        if self.logger:
+            self.logger.debug(pipeline_description)
+        self.pipeline = Gst.parse_launch(pipeline_description)
+
+    def register_message_handler(self, handler_method):
+        if self.logger:
+            message = "Registering message handler: %s" % handler_method
+            self.logger.debug(message)
+        self.bus = self.pipeline.get_bus()
+        self.bus.add_signal_watch()
+        self.bus.connect('message', handler_method)
+
+
+def parse_spectrum_message_structure(struct_string):
+    # First let's jsonize this
+    # This is the message name, which we don't need
+    text = struct_string.replace("spectrum, ", "")
+    # name/value separator in json is : and not =
+    text = text.replace("=", ": ")
+    # Mutate the {} array notation from the structure to
+    # [] notation for json.
+    text = text.replace("{", "[")
+    text = text.replace("}", "]")
+    # Remove a few stray semicolons that aren't needed
+    text = text.replace(";", "")
+    # Remove the data type fields, as json doesn't need them
+    text = re.sub(r"\(.+?\)", "", text)
+    # double-quote the identifiers
+    text = re.sub(r"([\w-]+):", r'"\1":', text)
+    # Wrap the whole thing in brackets
+    text = ("{"+text+"}")
+    # Try to parse and return something sensible here, even if
+    # the data was unparsable.
+    try:
+        return json.loads(text)
+    except ValueError:
+        return None
+
+
+def process_arguments(args=sys.argv[1:]):
+    description = """
+        Plays a single frequency through the default output, then records on
+        the default input device. Analyzes the recorded signal to test for
+        presence of the played frequency, if present it exits with success.
+    """
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+            "-t", "--time",
+            dest='test_duration',
+            action='store',
+            default=30,
+            type=int,
+            help="""Maximum test duration, default %(default)s seconds.
+                    It may exit sooner if it determines it has enough data.""")
+    parser.add_argument(
+            "-a", "--audio",
+            action='store',
+            default="/dev/null",
+            type=str,
+            help="File to save recorded audio in .wav format")
+    parser.add_argument(
+            "-q", "--quiet",
+            action='store_true',
+            default=False,
+            help="Be quiet, no output unless there's an error.")
+    parser.add_argument(
+            "-d", "--debug",
+            action='store_true',
+            default=False,
+            help="Debugging output")
+    parser.add_argument(
+            "-f", "--frequency",
+            action='store',
+            default=DEFAULT_TEST_FREQUENCY,
+            type=int,
+            help="Frequency for test signal, default %(default)s Hz")
+    parser.add_argument(
+            "-u", "--spectrum",
+            action='store',
+            type=str,
+            help="""File to save spectrum information for plotting
+                    (one frequency/magnitude pair per line)""")
+    return parser.parse_args(args)
+
+
+def run_test(args):
+
+    # Setup logging
+    level = logging.INFO
+    if args.debug:
+        level = logging.DEBUG
+    if args.quiet:
+        level = logging.ERROR
+    logging.basicConfig(level=level)
+    try:
+        # Launches recording pipeline. I need to hook up into the gst
+        # messages.
+        recorder = Recorder(output_file=args.audio, logger=logging)
+        # Just launches the playing pipeline
+        player = Player(frequency=args.frequency, logger=logging)
+    except GObject.GError as excp:
+        logging.critical("Unable to initialize GStreamer pipelines: %s", excp)
+        sys.exit(127)
+
+    # This just receives a process feedback and tells me how much to change to
+    # achieve the setpoint
+    pidctrl = PIDController(kp=0.7, ki=.01, kd=0.01,
+                            setpoint=REC_LEVEL_RANGE[0])
+    pidctrl.set_change_limit(5)
+    # This  gathers spectrum data.
+    analyzer = SpectrumAnalyzer(points=BINS,
+                                sampling_frequency=SAMPLING_FREQUENCY)
+
+    recorder.volumecontroller = VolumeController(type='input',
+                                                 logger=logging)
+    recorder.volumecontroller.set_volume(0)
+    recorder.volumecontroller.mute(False)
+
+    player.volumecontroller = VolumeController(type='output',
+                                               logger=logging)
+    player.volumecontroller.set_volume(PLAY_VOLUME)
+    player.volumecontroller.mute(False)
+
+    # This handles the messages from gstreamer and orchestrates
+    # the passed volume controllers, pid controller and spectrum analyzer
+    # accordingly.
+    gmh = GStreamerMessageHandler(rec_level_range=REC_LEVEL_RANGE,
+                                  logger=logging,
+                                  volumecontroller=recorder.volumecontroller,
+                                  pidcontroller=pidctrl,
+                                  spectrum_analyzer=analyzer)
+
+    # I need to tell the recorder which method will handle messages.
+    recorder.register_message_handler(gmh.bus_message_handler)
+
+    # Create the loop and add a few triggers
+    loop = GLib.MainLoop()
+    GLib.timeout_add_seconds(0, player.start)
+    GLib.timeout_add_seconds(0, recorder.start)
+    GLib.timeout_add_seconds(args.test_duration, loop.quit)
+
+    # Tell the gmh which method to call when enough samples are collected
+    gmh.set_quit_method(loop.quit)
+
+    loop.run()
+
+    # When the loop ends, set things back to reasonable states
+    player.stop()
+    recorder.stop()
+    player.volumecontroller.set_volume(50)
+    recorder.volumecontroller.set_volume(10)
+
+    # See if data gathering was successful.
+    test_band = analyzer.frequency_band_for(args.frequency)
+    candidate_bands = analyzer.frequencies_with_peak_magnitude(
+        MAGNITUDE_THRESHOLD)
+    for band in candidate_bands:
+        logging.debug("Band (%.2f,%.2f) contains a magnitude peak" %
+                      analyzer.frequencies_for_band(band))
+    if test_band in candidate_bands:
+        freqs_for_band = analyzer.frequencies_for_band(test_band)
+        logging.info(
+            "PASS: Test frequency of %s in band (%.2f, %.2f) "
+            "which contains a magnitude peak" %
+            ((args.frequency,) + freqs_for_band))
+        return_value = 0
+    else:
+        logging.info(
+            "FAIL: Test frequency of %s is not in one of the "
+            "bands with magnitude peaks" % args.frequency)
+        return_value = 1
+    # Is the microphone broken?
+    if len(set(analyzer.spectrum)) <= 1:
+        logging.info("WARNING: Microphone seems broken, didn't even "
+                     "record ambient noise")
+
+    if args.spectrum:
+        logging.info("Saving spectrum data for plotting as %s" %
+                     args.spectrum)
+        if (
+            not FileDumper().write_to_file(
+                args.spectrum,
+                ["%s,%s" % t for t in zip(
+                    analyzer.frequencies, analyzer.spectrum)])
+        ):
+            logging.error("Couldn't save spectrum data for plotting",
+                          file=sys.stderr)
+
+    return return_value
+
+
+def main():
+    # Get arguments.
+    args = process_arguments()
+
+    return run_test(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/providers/base/bin/pipewire_test.py
+++ b/providers/base/bin/pipewire_test.py
@@ -192,7 +192,8 @@ class FileDumper(object):
                 for i in data:
                     print(i, file=f)
             return_value = True
-        except (TypeError, IOError):
+        except (TypeError, IOError) as e:
+            logging.error(repr(e))
             return_value = False
         return return_value
 
@@ -441,7 +442,8 @@ def parse_spectrum_message_structure(struct_string):
     # the data was unparsable.
     try:
         return json.loads(text)
-    except ValueError:
+    except ValueError as e:
+        logging.error(repr(e))
         return None
 
 

--- a/providers/base/bin/pipewire_utils.py
+++ b/providers/base/bin/pipewire_utils.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Hanhsuan Lee <hanhsuan.lee@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from enum import IntEnum
+import subprocess
+import argparse
+import logging
+import time
+import json
+import sys
+import re
+import gi
+gi.require_version('Gst', '1.0')
+gi.require_version('GLib', '2.0')
+from gi.repository import Gst        # noqa: E402
+from gi.repository import GLib       # noqa: E402
+
+
+class PipewireTestError(IntEnum):
+    """
+    A class used to define PipewireTest Error code
+
+    :attr NO_ERROR: process success
+    :type NO_ERROR: int
+
+    :attr NOT_DETECTED: couldn't find specific device
+    :type NOT_DETECTED: int
+
+    :attr NO_AVAILABLE_PORT: couldn't find available port
+    :type NO_AVAILABLE_PORT: int
+
+    :attr NO_SPECIFIC_DEVICE: couldn't find specific device
+    :type NO_SPECIFIC_DEVICE: int
+
+    :attr PIPELINE_PROCESS_FAIL: gst pipeline process failed
+    :type PIPELINE_PROCESS_FAIL: int
+    """
+    NO_ERROR = 0
+    NOT_DETECTED = -1
+    NO_AVAILABLE_PORT = -2
+    NO_SPECIFIC_DEVICE = -3
+    PIPELINE_PROCESS_FAIL = -4
+    NO_CHANGE_DETECTED = -5
+
+
+class PipewireTest:
+    """
+    A class used to test pipewire functions
+
+    """
+    logger = logging.getLogger()
+
+    def _get_pw_type(self, media_class) -> str:
+        """
+        convert sink to Output and source to Input
+
+        :param media_class: sink(s) or source(s)
+        :type media_class: str
+        """
+        if re.match('sinks*', media_class, re.IGNORECASE):
+            return "Output"
+        elif re.match('sources*', media_class, re.IGNORECASE):
+            return "Input"
+        else:
+            self.logger.info("Media class:[{}] is unknown".format(media_class))
+            return "UNKNOWN CLASS"
+
+    def _get_pw_dump(self, p_type) -> dict:
+        """
+        Use to convert the json output of pw-dump to dict object
+        """
+        pw_dump = subprocess.check_output("pw-dump {}".format(p_type),
+                                          shell=True,
+                                          universal_newlines=True)
+        try:
+            return json.loads(pw_dump)
+        except (ValueError, TypeError):
+            self.logger.error("pw-dump {} failed !!!".format(p_type))
+            return {}
+
+    def generate_pw_media_class(self, media_type, media_class) -> str:
+        """
+        Combine media_type and media_class to pw-dump format,
+        such as "Audio/Sink".
+
+        :param media_type: For now only support Audio or Video
+        :type media_type: str
+
+        :param media_class: For now only support Sinks* or Sources*
+        :type media_class: str
+        """
+        if re.fullmatch('audio', media_type, re.IGNORECASE):
+            mtype = "Audio"
+        elif re.fullmatch('video', media_type, re.IGNORECASE):
+            mtype = "Video"
+        else:
+            self.logger.info("Media type:[{}] is unknown".format(media_type))
+            return "UNKNOWN TYPE"
+
+        if re.fullmatch('sinks*', media_class, re.IGNORECASE):
+            return "{}/Sink".format(mtype)
+        elif re.fullmatch('sources*', media_class, re.IGNORECASE):
+            return "{}/Source".format(mtype)
+        else:
+            self.logger.info("Media class:[{}] is unknown".format(media_class))
+            return "UNKNOWN CLASS"
+
+    def detect_device(self, media_type, media_class) -> int:
+        """
+        detect specific device is on this system or not.
+        This function parse output of pw-dump to check, the device type
+        equals PipeWire:Interface:Node and media.class equals args.
+
+        :param media_type: For now only support Audio or Video
+        :type media_type: str
+
+        :param media_class: For now only support Sinks* or Sources*
+        :type media_class: str
+        """
+        mclass = self.generate_pw_media_class(media_type, media_class)
+        if mclass in ["UNKNOWN CLASS", "UNKNOWN TYPE"]:
+            return PipewireTestError.NOT_DETECTED
+        clients = self._get_pw_dump("Node")
+
+        detected_flag = False
+        for client in clients:
+            props = client["info"]["props"]
+            if mclass == props.get("media.class"):
+                self.logger.info("device id:[{}] media.class:[{}]"
+                                 " node.name:[{}]"
+                                 .format(client["id"], mclass,
+                                         props.get("node.name")))
+                detected_flag = True
+        if detected_flag:
+            return PipewireTestError.NO_ERROR
+        self.logger.info("media.class:[{}] couldn't find".format(mclass))
+        return PipewireTestError.NOT_DETECTED
+
+    def select_device(self, media_type, media_class, device):
+        """
+        Set desired device as default
+        This function parse output of pw-dump to find, the device type
+        equals PipeWire:Interface:Node and media.class equals args.
+
+        :param media_type: For now only support Audio or Video
+        :type media_type: str
+
+        :param media_class: For now only support Sinks* or Sources*
+        :type media_class: str
+
+        :param device: device type, such as hdmi, usb and bluez etc.
+        :type devide: str
+        """
+        mclass = self.generate_pw_media_class(media_type, media_class)
+        if mclass in ["UNKNOWN CLASS", "UNKNOWN TYPE"]:
+            return PipewireTestError.NO_AVAILABLE_PORT
+        clients = self._get_pw_dump("Node")
+
+        available_nodes = {}
+        for client in clients:
+            props = client["info"]["props"]
+            name = props.get("node.name")
+            if (mclass == props.get("media.class")
+                    and device in name):
+                available_nodes[client["id"]] = (client)
+
+        if len(available_nodes) < 1:
+            self.logger.error("No available {} found".format(mclass))
+            return PipewireTestError.NO_AVAILABLE_PORT
+        self.logger.info("Available {}:".format(mclass))
+        for i in available_nodes:
+            n = available_nodes[i]
+            desc = n["info"]["props"].get("node.description")
+            self.logger.info("Id:[{}], device:[{}]"
+                             .format(n["id"], desc))
+
+        chosen = False
+        node_id = None
+        while not chosen:
+            self.logger.info("Which {} would you like to test?"
+                             " -1 means don't change".format(mclass))
+            self.logger.info("    {} id:".format(mclass))
+            node_id = input()
+            try:
+                chosen = int(node_id) in available_nodes
+            except ValueError:
+                chosen = False
+            if chosen:
+                cmd = "wpctl set-default {}".format(node_id)
+                subprocess.check_output(cmd, shell=True,
+                                        universal_newlines=True)
+            elif node_id == "-1":
+                chosen = True
+            else:
+                self.logger.info("    [{}] isn't existed!"
+                                 .format(node_id))
+        return PipewireTestError.NO_ERROR
+
+    def _check_state(self, device) -> bool:
+        """
+        Checks whether the sink is available for the given device.
+        This function parse output of pw-dump to find the device type
+        equals PipeWire:Interface:Device and media.class equals Audio/Device.
+        For pipewire, the active port will be listed under info.params.Route.
+        Therefore, you could check this object to know the state of it.
+
+        :param device: device you would like to check
+        :type device: str
+        """
+        clients = self._get_pw_dump("Device")
+        try:
+            for client in clients:
+                mclass = client["info"]["props"].get("media.class")
+                if mclass == "Audio/Device":
+                    for route in client["info"]["params"]["Route"]:
+                        name = route["name"]
+                        available = route["available"]
+                        if (device in name
+                                and "output" in name
+                                and available in ["unknown", "yes"]):
+                            self.logger.info(
+                                    "[ Audio sink ]".center(80, '='))
+                            self.logger.info(
+                                    "Device: [{}] availavle: [{}]"
+                                    .format(route["description"],
+                                            available))
+                            return True
+            raise ValueError('No abailable output device for {}'
+                             .format(device))
+        except (IndexError, ValueError) as e:
+            logging.error(str(e))
+            return False
+
+    def gst_pipeline(self, pipe, timeout, device) -> int:
+        """
+        Simple GStreamer pipeline player
+
+        :param pipe: Quoted GStreamer pipeline to launch
+        :type pipe: str
+
+        :param timeout: Timeout for running the pipeline
+        :type timeout: int
+
+        :param device: device type, such as hdmi etc.
+        :type devide: str
+        """
+        if device:
+            if not self._check_state(device):
+                return PipewireTestError.NO_SPECIFIC_DEVICE
+
+        Gst.init(None)
+        try:
+            self.logger.info("Attempting to initialize Gstreamer pipeline: {}"
+                             .format(pipe))
+            element = Gst.parse_launch(pipe)
+        except GLib.GError as error:
+            self.logger.info("Specified pipeline couldn't be processed.")
+            self.logger.info("Error when processing pipeline: {}"
+                             .format(error))
+            # Exit harmlessly
+            return PipewireTestError.PIPELINE_PROCESS_FAIL
+        self.logger.info("Pipeline initialized, now starting playback.")
+        element.set_state(Gst.State.PLAYING)
+
+        if timeout:
+            time.sleep(timeout)
+
+        element.set_state(Gst.State.NULL)
+
+        return PipewireTestError.NO_ERROR
+
+    def _get_audio_config(self, mode) -> set:
+        """
+        Get simple audio configuration
+        This function parse output of pw-dump to find the device type
+        equals PipeWire:Interface:Device and media.class equals Audio/Device.
+        For pipewire, the active port will be listed under info.params.Route.
+        Therefore, you could check this object to know the state of it.
+
+        :param mode: sink or source
+        :type mode: str
+        """
+        clients = self._get_pw_dump("Device")
+        cfg = set()
+        for client in clients:
+            active_ports = None
+            mclass = client["info"]["props"].get("media.class")
+            if mclass == "Audio/Device":
+                active_ports = client["info"]["params"]["Route"]
+            if active_ports:
+                for p in active_ports:
+                    if p["direction"] == self._get_pw_type(mode):
+                        cfg.add(("{} #{}".format(mode, client["id"]),
+                                p["name"], p["available"]))
+        return cfg
+
+    def monitor_active_port_change(self, timeout, mode) -> int:
+        """
+        Monitoring Audio active port changing
+        This script checks if the active port on either sinks
+        (speakers or headphones) or sources (microphones, webcams)
+        is changed after an appropriate device is plugged into the DUT.
+        The script is fully automatic and either times out after or
+        returns as soon as the change is detected.
+
+        :param timeout: Timeout after which the script fails
+        :type timeout: int
+
+        :param mode: Monitor either sinks or sources
+        :type mode: str
+        """
+        initial_cfg = self._get_audio_config(mode)
+        self.logger.info("Starting with config: {}".format(initial_cfg))
+        self.logger.info("You have {} seconds to plug the item in"
+                         .format(timeout))
+
+        for _ in range(int(timeout)):
+            new_cfg = self._get_audio_config(mode)
+            if new_cfg != initial_cfg:
+                self.logger.info("Now using config: {}".format(new_cfg))
+                self.logger.info("It seems to work!")
+                return PipewireTestError.NO_ERROR
+            time.sleep(1)
+        self.logger.info("Couldn't detect active port change!")
+        return PipewireTestError.NO_CHANGE_DETECTED
+
+    def go_through_ports(self, cmd, mode):
+        """
+        Go through available ports for testing
+        This script checks if the ports on either sinks
+        (speakers or headphones) or sources (microphones, webcams)
+        is available and working on the DUT.
+
+        :param cmd: command for testing
+        :type cmd: str
+
+        :param mode: Monitor either sinks or sources
+        :type mode: str
+        """
+        clients = self._get_pw_dump("Device")
+        for client in clients:
+            ports = None
+            mclass = client["info"]["props"].get("media.class")
+            if mclass == "Audio/Device":
+                ports = client["info"]["params"]["EnumRoute"]
+            if ports:
+                for p in ports:
+                    chosen = None
+                    if (p["direction"] == self._get_pw_type(mode)
+                            and p["available"] in ["yes", "unknown"]):
+                        while chosen != "yes":
+                            self.logger.info("Please select [{}] for "
+                                             "testing (if selected, "
+                                             "please enter 'yes')"
+                                             .format(p["description"]))
+
+                            chosen = input()
+                        checked = None
+                        while checked != "yes":
+                            with subprocess.Popen(cmd, shell=True,
+                                                  stdout=subprocess.PIPE,
+                                                  universal_newlines=True
+                                                  ) as p:
+                                while p.poll() is None:
+                                    line = p.stdout.readline().strip()
+                                    self.logger.info(line)
+                                p.kill()
+                            self.logger.info("Is working ?  "
+                                             "please enter 'yes' "
+                                             "to leave")
+
+                            checked = input()
+
+    def _args_parsing(self, args=sys.argv[1:]):
+        parser = argparse.ArgumentParser(
+                prog="Pipewire validator",
+                description="using for pipewire to valid system functions")
+
+        subparsers = parser.add_subparsers(dest='test_type')
+        subparsers.required = True
+
+        # Add parser for detecting audio/video function
+        parser_detect = subparsers.add_parser(
+                'detect', help='Detect audio/video devices on this system')
+        parser_detect.add_argument(
+                "-t", "--type", type=str, default="Audio",
+                help="device type such as Audio "
+                "or Video (default: %(default)s)"
+                )
+        parser_detect.add_argument(
+                "-c", "--clazz", type=str, default="Sink",
+                help="device type such as Sink or "
+                "Source (default: %(default)s)"
+                )
+
+        # Add parser for selecting audio/video function
+        parser_select = subparsers.add_parser(
+                'select', help='Select audio/video devices on this system')
+        parser_select.add_argument(
+                "-t", "--type", type=str, default="Audio",
+                help="device type such as Audio "
+                "or Video (default: %(default)s)"
+                )
+        parser_select.add_argument(
+                "-c", "--clazz", type=str, default="Sink",
+                help="device type such as Sink or "
+                "Source (default: %(default)s)"
+                )
+        parser_select.add_argument(
+                "-d", "--device", type=str, default="",
+                help="device type such as hdmi or "
+                "bluz (default: %(default)s)"
+                )
+
+        # Add parser for gst pipeline function(Audio only)
+        parser_gst = subparsers.add_parser(
+                'gst', help='Simple GStreamer pipeline player')
+        parser_gst.add_argument(
+                "PIPELINE",
+                help="Quoted GStreamer pipeline to launch")
+        parser_gst.add_argument(
+                "-t", "--timeout", type=int, required=True,
+                help="Timeout for running the pipeline")
+        parser_gst.add_argument(
+                "-d", "--device", type=str,
+                help="Device to check for status")
+
+        # Add parser for monitor function(Audio only)
+        parser_monitor = subparsers.add_parser(
+                'monitor', help='Monitoring Audio active port changing')
+        parser_monitor.add_argument(
+                "-t", "--timeout", type=int, required=True,
+                help="Timeout after which the script fails")
+        parser_monitor.add_argument(
+                "-m", "--mode", type=str,
+                help="Monitor either sinks or sources")
+
+        # Add parser for go through function
+        parser_through = subparsers.add_parser(
+                'through', help='Go through available ports for testing')
+        parser_through.add_argument(
+                "-c", "--command", type=str, required=True,
+                help="command for testing")
+        parser_through.add_argument(
+                "-m", "--mode", type=str,
+                help="Either sinks or sources")
+
+        return parser.parse_args(args)
+
+    def function_select(self, args):
+        if args.test_type == 'detect':
+            # detect_device("audio", "sink")
+            return self.detect_device(args.type, args.clazz)
+        elif args.test_type == 'select':
+            # select_device("audio", "sink", "hdmi")
+            return self.select_device(args.type, args.clazz, args.device)
+        elif args.test_type == 'gst':
+            # gst_pipeline(PIPELINE, "30", "hdmi")
+            return self.gst_pipeline(args.PIPELINE, args.timeout, args.device)
+        elif args.test_type == "monitor":
+            # monitor_active_port_change("30", "sink")
+            return self.monitor_active_port_change(args.timeout, args.mode)
+        elif args.test_type == "through":
+            # go_through_ports("speaker-test -c 2 -l 1 -t wav", "sink")
+            return self.go_through_ports(args.command, args.mode)
+
+    def main(self) -> int:
+        """
+        main function for command line processing
+        """
+        # create logger formatter
+        log_formatter = logging.Formatter(fmt='%(message)s')
+
+        # set log level
+        self.logger.setLevel(logging.INFO)
+
+        # create console handler
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(log_formatter)
+
+        # Add console handler to logger
+        self.logger.addHandler(console_handler)
+
+        return self.function_select(self._args_parsing())
+
+
+if __name__ == "__main__":
+    sys.exit(PipewireTest().main())

--- a/providers/base/bin/show_default_audio_device.sh
+++ b/providers/base/bin/show_default_audio_device.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-echo "Default output device:"
-wpctl inspect @DEFAULT_AUDIO_SINK@ | grep "node.description" | cut -d '=' -f 2
-echo "Default input device:"
-wpctl inspect @DEFAULT_AUDIO_SOURCE@ | grep "node.description" | cut -d '=' -f 2
-echo "If these are not you would like to test, please change them before testing"

--- a/providers/base/bin/show_default_audio_device.sh
+++ b/providers/base/bin/show_default_audio_device.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Default output device:"
+wpctl inspect @DEFAULT_AUDIO_SINK@ | grep "node.description" | cut -d '=' -f 2
+echo "Default input device:"
+wpctl inspect @DEFAULT_AUDIO_SOURCE@ | grep "node.description" | cut -d '=' -f 2
+echo "If these are not you would like to test, please change them before testing"

--- a/providers/base/tests/test_pipewire_test.py
+++ b/providers/base/tests/test_pipewire_test.py
@@ -1,0 +1,321 @@
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Hanhsuan Lee <hanhsuan.lee@canonical.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import sys
+from unittest.mock import MagicMock
+from unittest.mock import Mock, patch, mock_open, call
+try:
+    sys.modules["gi"] = MagicMock()
+    sys.modules["gi.repository"] = MagicMock()
+    from pipewire_test import *
+except ImportError:
+    sys.exit(127)
+
+
+class PIDControllerTests(unittest.TestCase):
+
+    def test_input_change(self):
+        pc = PIDController(kp=0.7, ki=.01, kd=0.01,
+                           setpoint=REC_LEVEL_RANGE[0])
+        self.assertEqual(0.7, pc.kp)
+        self.assertEqual(0.01, pc.ki)
+        self.assertEqual(0.01, pc.kd)
+        self.assertEqual(0, pc._integral)
+        self.assertEqual(0, pc._previous_error)
+        self.assertEqual(0, pc._change_limit)
+        self.assertAlmostEqual(-2.403, pc.input_change(1, 0.10))
+
+    def test_set_change_limit(self):
+        pc = PIDController(kp=0.7, ki=.01, kd=0.01,
+                           setpoint=REC_LEVEL_RANGE[0])
+        pc.set_change_limit(0.5)
+        self.assertEqual(0.5, pc._change_limit)
+        self.assertAlmostEqual(-0.5, pc.input_change(1, 0.10))
+
+
+class VolumeControllerTests(unittest.TestCase):
+
+    def test_set_volume(self):
+        vc = VolumeController(type='input', logger=None)
+        self.assertEqual('input', vc.type)
+        self.assertEqual(None, vc._volume)
+        self.assertEqual(None, vc.identifier)
+        self.assertEqual(None, vc.logger)
+
+    @patch("pipewire_test.VolumeController._wpctl_output")
+    def test_set_get_mute_volume(self, mock_wpctl):
+        vc = VolumeController(type='input', logger=None)
+
+        # over range
+        self.assertEqual(False, vc.set_volume(101))
+        self.assertEqual(False, vc.set_volume(-1))
+
+        mock_wpctl.return_value = None
+
+        # set correctly
+        self.assertEqual(True, vc.set_volume(5))
+        self.assertEqual(5, vc._volume)
+
+        # get correctly
+        self.assertEqual(5, vc.get_volume())
+
+        # mute
+        self.assertEqual(True, vc.mute(True))
+        self.assertEqual(True, vc.mute(False))
+
+    @patch("subprocess.check_output")
+    def test_wpctl_output_succ(self, mock_checkout):
+        vc = VolumeController(type='input', logger=None)
+        mock_checkout.return_value = None
+        vc.set_volume(5)
+        mock_checkout.assert_called_with(['wpctl',
+                                          'set-volume',
+                                          '@DEFAULT_AUDIO_SOURCE@',
+                                          '5%'],
+                                         universal_newlines=True)
+        vc.mute(True)
+        mock_checkout.assert_called_with(['wpctl',
+                                          'set-mute',
+                                          '@DEFAULT_AUDIO_SOURCE@',
+                                          '1'],
+                                         universal_newlines=True)
+
+    @patch("subprocess.check_output")
+    def test_wpctl_output_fail(self, mock_checkout):
+        vc = VolumeController(type='input', logger=MagicMock())
+        mock_checkout.side_effect = subprocess.CalledProcessError(2, "echo")
+        with self.assertRaises(SystemExit) as cm:
+            vc.set_volume(5)
+        self.assertEqual(cm.exception.code, 1)
+
+        mock_checkout.side_effect = FileNotFoundError
+        with self.assertRaises(SystemExit) as cm:
+            vc.set_volume(5)
+        self.assertEqual(cm.exception.code, 1)
+
+
+class FileDumperTests(unittest.TestCase):
+
+    def test_write_to_file(self):
+        open_mock = mock_open()
+        with patch("pipewire_test.open",
+                   open_mock, create=True):
+            self.assertEqual(True,
+                             FileDumper().write_to_file("test.txt",
+                                                        "test-data"))
+            open_mock.assert_called_with("test.txt", "w")
+            open_mock.return_value.write.assert_has_calls([call("t"),
+                                                           call("\n"),
+                                                           call("e"),
+                                                           call("\n"),
+                                                           call("s"),
+                                                           call("\n"),
+                                                           call("t"),
+                                                           call("\n"),
+                                                           call("-"),
+                                                           call("\n"),
+                                                           call("d"),
+                                                           call("\n"),
+                                                           call("a"),
+                                                           call("\n"),
+                                                           call("t"),
+                                                           call("\n"),
+                                                           call("a"),
+                                                           call("\n")])
+
+    def test_write_to_file_except(self):
+        open_mock = mock_open()
+        with patch("pipewire_test.open",
+                   open_mock, create=True):
+            open_mock.side_effect = TypeError
+            self.assertEqual(False,
+                             FileDumper().write_to_file("test.txt",
+                                                        "test-data"))
+            open_mock.side_effect = IOError
+            self.assertEqual(False,
+                             FileDumper().write_to_file("test.txt",
+                                                        "test-data"))
+
+
+class SpectrumAnalyzerTests(unittest.TestCase):
+
+    def test_init(self):
+        sa = SpectrumAnalyzer(points=256)
+        self.assertEqual([0] * 256, sa.spectrum)
+        self.assertEqual(0, sa.number_of_samples)
+        self.assertEqual(50, sa.wanted_samples)
+        self.assertEqual(44100, sa.sampling_frequency)
+        self.assertEqual([((44100 / 2.0) / 256) * i
+                          for i in range(256)], sa.frequencies)
+
+    def test_average(self):
+        sa = SpectrumAnalyzer(points=256)
+        self.assertEqual(0, sa._average())
+
+    def test_sample(self):
+        sa = SpectrumAnalyzer(points=256)
+        sa.sample(sa.spectrum)
+        self.assertEqual([0] * 256, sa.spectrum)
+        self.assertEqual(1, sa.number_of_samples)
+
+        # data type error
+        self.assertEqual(None, sa.sample(""))
+
+    def test_frequencies_with_peak_magnitude(self):
+        sa = SpectrumAnalyzer(points=256)
+        self.assertEqual([], sa.frequencies_with_peak_magnitude())
+
+    def test_frequency_band_for(self):
+        sa = SpectrumAnalyzer(points=256)
+        self.assertEqual(2, sa.frequency_band_for(220))
+
+        # frequency > max_frequency
+        self.assertEqual(None, sa.frequency_band_for(22000000))
+
+        # frequency < 0
+        self.assertEqual(None, sa.frequency_band_for(-1))
+
+    def test_frequencies_for_band(self):
+        sa = SpectrumAnalyzer(points=256)
+        self.assertEqual((18949.21875, 19035.3515625),
+                         sa.frequencies_for_band(220))
+
+        # band >= len(self.spectrum)
+        self.assertEqual(None, sa.frequencies_for_band(280))
+
+        # band < 0
+        self.assertEqual(None, sa.frequencies_for_band(-1))
+
+    def test_sampling_complete(self):
+
+        # true
+        sa = SpectrumAnalyzer(points=256, wanted_samples=0)
+        self.assertEqual(True, sa.sampling_complete())
+
+        # false
+        sa = SpectrumAnalyzer(points=256)
+        self.assertEqual(False, sa.sampling_complete())
+
+
+class GStreamerMessageHandlerTests(unittest.TestCase):
+    analyzer = SpectrumAnalyzer(points=256)
+    vc = VolumeController(type='input', logger=MagicMock())
+    pc = PIDController(kp=0.7, ki=.01, kd=0.01,
+                       setpoint=REC_LEVEL_RANGE[0])
+    gmh = GStreamerMessageHandler(rec_level_range=REC_LEVEL_RANGE,
+                                  logger=MagicMock(),
+                                  volumecontroller=vc,
+                                  pidcontroller=pc,
+                                  spectrum_analyzer=analyzer)
+
+    def test_bus_message_handler_type_error(self):
+        struct = Gst.Structure().new_from_string("test")
+        message = Gst.Message().new_element(None, struct)
+        bus = Gst.Bus()
+        self.gmh.bus_message_handler(bus, message)
+        self.assertEqual(0, self.analyzer.number_of_samples)
+        self.assertEqual(None, self.vc._volume)
+
+    def test_bus_message_handler_name_error(self):
+        struct = Gst.Structure().new_from_string("test")
+        message = Gst.Message().new_element(None, struct)
+        message.type = Gst.MessageType.ELEMENT
+        bus = Gst.Bus()
+        self.gmh.bus_message_handler(bus, message)
+        self.assertEqual(0, self.analyzer.number_of_samples)
+        self.assertEqual(None, self.vc._volume)
+
+    def test_level_method_none(self):
+        self.gmh.level_method(1, self.pc, self.vc)
+        self.assertEqual(None, self.vc._volume)
+
+    @patch("pipewire_test.VolumeController._wpctl_output")
+    def test_level_method_zore(self, mock_wpctl):
+        self.vc.set_volume(0)
+        self.gmh.level_method(1, self.pc, self.vc)
+        self.assertEqual(0, self.vc._volume)
+
+    def test_spectrum_method(self):
+        self.gmh.spectrum_method(self.analyzer, [-0, -10])
+        self.assertEqual(0, self.analyzer.number_of_samples)
+
+
+class GstAudioObjectTests(unittest.TestCase):
+
+    def test_init(self):
+        gao = GstAudioObject()
+        self.assertEqual("GstAudioObject", gao.class_name)
+
+
+class ParseSpectrumMessageStructureTests(unittest.TestCase):
+    ss = "spectrum, endtime=(guint64)5000000000,"\
+         " timestamp=(guint64)4900000000,"\
+         " stream-time=(guint64)4900000000,"\
+         " running-time=(guint64)4900000000,"\
+         " duration=(guint64)100000000,"\
+         " magnitude=(float){ -60, -60 };"
+    ans = '{"endtime": 5000000000, "timestamp": 4900000000,'\
+          ' "stream-time": 4900000000, "running-time": 4900000000,'\
+          ' "duration": 100000000, "magnitude": [-60, -60]}'
+
+    def test_succ(self):
+        json_string = parse_spectrum_message_structure(self.ss)
+        self.assertEqual(self.ans, json.dumps(json_string))
+
+    def test_non_josn(self):
+        self.assertEqual(None, parse_spectrum_message_structure("test"))
+
+
+class ProcessArgumentsTests(unittest.TestCase):
+
+    args = [
+            "-t", "10",
+            "-a", "audio",
+            "-f", "8",
+            "-u", "u"
+           ]
+
+    def test_succ(self):
+        rv = process_arguments(self.args)
+        self.assertEqual(rv.test_duration, 10)
+        self.assertEqual(rv.audio, "audio")
+        self.assertEqual(rv.quiet, False)
+        self.assertEqual(rv.debug, False)
+        self.assertEqual(rv.frequency, 8)
+        self.assertEqual(rv.spectrum, "u")
+
+
+class RunTestTests(unittest.TestCase):
+
+    @patch("pipewire_test.VolumeController._wpctl_output")
+    def test_succ(self, mock_wpctl):
+        self.assertEqual(1, run_test(process_arguments([])))
+
+    @patch("pipewire_test.SpectrumAnalyzer.frequencies_for_band")
+    @patch("pipewire_test.SpectrumAnalyzer.frequencies_with_peak_magnitude")
+    @patch("pipewire_test.SpectrumAnalyzer.frequency_band_for")
+    @patch("pipewire_test.VolumeController._wpctl_output")
+    def test_with_bands(self, mock_wpctl, mock_band, mock_peak, mock_rb):
+        mock_rb.return_value = (1, 2)
+        mock_band.return_value = 5035
+        mock_peak.return_value = [5035]
+        self.assertEqual(0, run_test(process_arguments(["--debug"])))
+
+    @patch("pipewire_test.VolumeController._wpctl_output")
+    def test_with_spectrum(self, mock_wpctl):
+        self.assertEqual(1,
+                         run_test(process_arguments(["-u", "8", "--quiet"])))

--- a/providers/base/tests/test_pipewire_test.py
+++ b/providers/base/tests/test_pipewire_test.py
@@ -18,12 +18,9 @@ import unittest
 import sys
 from unittest.mock import MagicMock
 from unittest.mock import Mock, patch, mock_open, call
-try:
-    sys.modules["gi"] = MagicMock()
-    sys.modules["gi.repository"] = MagicMock()
-    from pipewire_test import *
-except ImportError:
-    sys.exit(127)
+sys.modules["gi"] = MagicMock()
+sys.modules["gi.repository"] = MagicMock()
+from pipewire_test import *
 
 
 def sorting(item):

--- a/providers/base/tests/test_pipewire_utils.py
+++ b/providers/base/tests/test_pipewire_utils.py
@@ -16,9 +16,7 @@
 
 # There are some issue with assertLog for python version lower than 3.10,
 # https://github.com/python/cpython/commit/6fdfcec5b11f44f27aae3d53ddeb004150ae1f61
-# and make some duplicate code in this script.
-# Therefore, please don't add new test cases of assertLog
-# and the old one might be removed in the future.
+# Therefore, please don't add new test cases of assertLog.
 
 import unittest
 import sys
@@ -112,59 +110,41 @@ class GeneratePwMediaClassTests(unittest.TestCase):
         pt = PipewireTest()
 
         # return UNKNOWN TYPE
-        if sys.version_info < (3, 10):
-            wrong_type1 = "videog"
-            wrong_type2 = "xxxx"
-            self.assertEqual("UNKNOWN TYPE",
-                             pt.generate_pw_media_class(wrong_type1,
-                                                        "source"))
-            self.assertEqual("UNKNOWN TYPE",
-                             pt.generate_pw_media_class(wrong_type2,
-                                                        "sources"))
-            return
+        wrong_type1 = "videog"
+        wrong_type2 = "xxxx"
+        self.assertEqual("UNKNOWN TYPE",
+                         pt.generate_pw_media_class(wrong_type1,
+                                                    "source"))
+        self.assertEqual("UNKNOWN TYPE",
+                         pt.generate_pw_media_class(wrong_type2,
+                                                    "sources"))
 
-        with self.assertLogs("root", level="INFO") as cm:
-            wrong_type1 = "videog"
-            wrong_type2 = "xxxx"
-            self.assertEqual("UNKNOWN TYPE",
-                             pt.generate_pw_media_class(wrong_type1,
-                                                        "source"))
-            self.assertEqual("UNKNOWN TYPE",
-                             pt.generate_pw_media_class(wrong_type2,
-                                                        "sources"))
-            # check log output
-            self.assertEqual(cm.output,
-                             ["INFO:root:Media type:[{}] is unknown"
-                              .format(wrong_type1),
-                              "INFO:root:Media type:[{}] is unknown"
-                              .format(wrong_type2)])
+        # example code for testing log output in python 3.10 and above
+        # with self.assertLogs("root", level="INFO") as cm:
+        #     wrong_type1 = "videog"
+        #     wrong_type2 = "xxxx"
+        #     self.assertEqual("UNKNOWN TYPE",
+        #                      pt.generate_pw_media_class(wrong_type1,
+        #                                                 "source"))
+        #     self.assertEqual("UNKNOWN TYPE",
+        #                      pt.generate_pw_media_class(wrong_type2,
+        #                                                 "sources"))
+        #     # check log output
+        #     self.assertEqual(cm.output,
+        #                      ["INFO:root:Media type:[{}] is unknown"
+        #                       .format(wrong_type1),
+        #                       "INFO:root:Media type:[{}] is unknown"
+        #                       .format(wrong_type2)])
 
         # return UNKNOWN CLASS
-        if sys.version_info < (3, 10):
-            wrong_class1 = "sourceg"
-            wrong_class2 = "sinkf"
-            self.assertEqual("UNKNOWN CLASS",
-                             pt.generate_pw_media_class("video",
-                                                        wrong_class1))
-            self.assertEqual("UNKNOWN CLASS",
-                             pt.generate_pw_media_class("video",
-                                                        wrong_class2))
-            return
-        with self.assertLogs("root", level="INFO") as cm:
-            wrong_class1 = "sourceg"
-            wrong_class2 = "sinkf"
-            self.assertEqual("UNKNOWN CLASS",
-                             pt.generate_pw_media_class("video",
-                                                        wrong_class1))
-            self.assertEqual("UNKNOWN CLASS",
-                             pt.generate_pw_media_class("video",
-                                                        wrong_class2))
-            # check log output
-            self.assertEqual(cm.output,
-                             ["INFO:root:Media class:[{}] is unknown"
-                              .format(wrong_class1),
-                              "INFO:root:Media class:[{}] is unknown"
-                              .format(wrong_class2)])
+        wrong_class1 = "sourceg"
+        wrong_class2 = "sinkf"
+        self.assertEqual("UNKNOWN CLASS",
+                         pt.generate_pw_media_class("video",
+                                                    wrong_class1))
+        self.assertEqual("UNKNOWN CLASS",
+                         pt.generate_pw_media_class("video",
+                                                    wrong_class2))
 
 
 class DetectDeviceTests(unittest.TestCase):
@@ -242,80 +222,34 @@ class DetectDeviceTests(unittest.TestCase):
     def test_succ(self, mock_checkout):
         pt = PipewireTest()
 
-        if sys.version_info < (3, 10):
-            # detect audio sink succ
-            mock_checkout.return_value = self.sink_audio_node
-            self.assertEqual(PipewireTestError.NO_ERROR,
-                             pt.detect_device("audio", "sink"))
+        # detect audio sink succ
+        mock_checkout.return_value = self.sink_audio_node
+        self.assertEqual(PipewireTestError.NO_ERROR,
+                         pt.detect_device("audio", "sink"))
 
-            # detect audio source succ
-            mock_checkout.return_value = self.source_audio_node
-            self.assertEqual(PipewireTestError.NO_ERROR,
-                             pt.detect_device("audio", "source"))
-            return
-        with self.assertLogs("root", level="INFO") as cm:
-            # detect audio sink succ
-            mock_checkout.return_value = self.sink_audio_node
-            self.assertEqual(PipewireTestError.NO_ERROR,
-                             pt.detect_device("audio", "sink"))
-
-            # detect audio source succ
-            mock_checkout.return_value = self.source_audio_node
-            self.assertEqual(PipewireTestError.NO_ERROR,
-                             pt.detect_device("audio", "source"))
-
-            # check log output
-            self.assertEqual(cm.output,
-                             ["INFO:root:device id:[29]"
-                              " media.class:[Audio/Sink]"
-                              " node.name:[Freewheel-Driver]",
-                              "INFO:root:device id:[30]"
-                              " media.class:[Audio/Source]"
-                              " node.name:[Freewheel-Driver]"])
+        # detect audio source succ
+        mock_checkout.return_value = self.source_audio_node
+        self.assertEqual(PipewireTestError.NO_ERROR,
+                         pt.detect_device("audio", "source"))
 
     @patch("subprocess.check_output")
     def test_fail(self, mock_checkout):
         pt = PipewireTest()
 
-        if sys.version_info < (3, 10):
-            # detect audio sink fail
-            mock_checkout.return_value = self.source_audio_node
-            self.assertEqual(PipewireTestError.NOT_DETECTED,
-                             pt.detect_device("audio", "sink"))
+        # detect audio sink fail
+        mock_checkout.return_value = self.source_audio_node
+        self.assertEqual(PipewireTestError.NOT_DETECTED,
+                         pt.detect_device("audio", "sink"))
 
-            # detect audio source fail
-            mock_checkout.return_value = self.sink_audio_node
-            self.assertEqual(PipewireTestError.NOT_DETECTED,
-                             pt.detect_device("audio", "source"))
+        # detect audio source fail
+        mock_checkout.return_value = self.sink_audio_node
+        self.assertEqual(PipewireTestError.NOT_DETECTED,
+                         pt.detect_device("audio", "source"))
 
-            # wrong media class
-            mock_checkout.return_value = self.sink_audio_node
-            self.assertEqual(PipewireTestError.NOT_DETECTED,
-                             pt.detect_device("xxx", "ooo"))
-            return
-        with self.assertLogs("root", level="INFO") as cm:
-            # detect audio sink fail
-            mock_checkout.return_value = self.source_audio_node
-            self.assertEqual(PipewireTestError.NOT_DETECTED,
-                             pt.detect_device("audio", "sink"))
-
-            # detect audio source fail
-            mock_checkout.return_value = self.sink_audio_node
-            self.assertEqual(PipewireTestError.NOT_DETECTED,
-                             pt.detect_device("audio", "source"))
-
-            # wrong media class
-            mock_checkout.return_value = self.sink_audio_node
-            self.assertEqual(PipewireTestError.NOT_DETECTED,
-                             pt.detect_device("xxx", "ooo"))
-
-            # check log output
-            self.assertEqual(cm.output,
-                             ["INFO:root:"
-                              "media.class:[Audio/Sink] couldn't find",
-                              "INFO:root:"
-                              "media.class:[Audio/Source] couldn't find",
-                              "INFO:root:Media type:[xxx] is unknown"])
+        # wrong media class
+        mock_checkout.return_value = self.sink_audio_node
+        self.assertEqual(PipewireTestError.NOT_DETECTED,
+                         pt.detect_device("xxx", "ooo"))
 
 
 class SelectDeviceTests(unittest.TestCase):
@@ -360,20 +294,9 @@ class SelectDeviceTests(unittest.TestCase):
     def test_wrong_pw_dump(self, mock_checkout):
         pt = PipewireTest()
 
-        if sys.version_info < (3, 10):
-            mock_checkout.return_value = "xxxx"
-            self.assertEqual(PipewireTestError.NO_AVAILABLE_PORT,
-                             pt.select_device("video", "sink", "hdmi"))
-            return
-        with self.assertLogs("root", level="INFO") as cm:
-            mock_checkout.return_value = "xxxx"
-            self.assertEqual(PipewireTestError.NO_AVAILABLE_PORT,
-                             pt.select_device("video", "sink", "hdmi"))
-
-            # check log output
-            self.assertEqual(cm.output,
-                             ["ERROR:root:pw-dump Node failed !!!",
-                              "ERROR:root:No available Video/Sink found"])
+        mock_checkout.return_value = "xxxx"
+        self.assertEqual(PipewireTestError.NO_AVAILABLE_PORT,
+                         pt.select_device("video", "sink", "hdmi"))
 
     @patch("subprocess.check_output")
     def test_no_available_node(self, mock_checkout):
@@ -385,19 +308,9 @@ class SelectDeviceTests(unittest.TestCase):
         self.assertEqual(PipewireTestError.NO_AVAILABLE_PORT,
                          pt.select_device("video", "xxx", "hdmi"))
 
-        if sys.version_info < (3, 10):
-            mock_checkout.return_value = self.sink_audio_node
-            self.assertEqual(PipewireTestError.NO_AVAILABLE_PORT,
-                             pt.select_device("video", "sink", "hdmi"))
-            return
-        with self.assertLogs("root", level="INFO") as cm:
-            mock_checkout.return_value = self.sink_audio_node
-            self.assertEqual(PipewireTestError.NO_AVAILABLE_PORT,
-                             pt.select_device("video", "sink", "hdmi"))
-
-            # check log output
-            self.assertEqual(cm.output,
-                             ["ERROR:root:No available Video/Sink found"])
+        mock_checkout.return_value = self.sink_audio_node
+        self.assertEqual(PipewireTestError.NO_AVAILABLE_PORT,
+                         pt.select_device("video", "sink", "hdmi"))
 
     @patch("builtins.input")
     @patch("subprocess.check_output")
@@ -465,48 +378,19 @@ class GstPipeLineTests(unittest.TestCase):
     def test_wrong_gst_pipeline_device(self, mock_checkout):
         pt = PipewireTest()
 
-        if sys.version_info < (3, 10):
-            mock_checkout.return_value = self.device
-            self.assertEqual(PipewireTestError.NO_SPECIFIC_DEVICE,
-                             pt.gst_pipeline("pipe", 10, "qoo"))
-            return
-        with self.assertLogs("root", level="INFO") as cm:
-            mock_checkout.return_value = self.device
-            self.assertEqual(PipewireTestError.NO_SPECIFIC_DEVICE,
-                             pt.gst_pipeline("pipe", 10, "qoo"))
-
-            # check log output
-            self.assertEqual(cm.output,
-                             ["ERROR:root:No abailable output device for qoo"])
+        mock_checkout.return_value = self.device
+        self.assertEqual(PipewireTestError.NO_SPECIFIC_DEVICE,
+                         pt.gst_pipeline("pipe", 10, "qoo"))
 
     @patch("subprocess.check_output")
     def test_gst_pipeline(self, mock_checkout):
         pt = PipewireTest()
 
-        if sys.version_info < (3, 10):
-            mock_checkout.return_value = self.device
-            self.assertEqual(PipewireTestError.NO_ERROR,
-                             pt.gst_pipeline("audiotestsrc wave=sine freq=512"
-                                             " ! audioconvert ! audioresample"
-                                             " ! autoaudiosink", 2, "hdmi"))
-            return
-        with self.assertLogs("root", level="INFO") as cm:
-            mock_checkout.return_value = self.device
-            self.assertEqual(PipewireTestError.NO_ERROR,
-                             pt.gst_pipeline("audiotestsrc wave=sine freq=512"
-                                             " ! audioconvert ! audioresample"
-                                             " ! autoaudiosink", 2, "hdmi"))
-
-            # check log output
-            self.assertEqual(cm.output,
-                             ["INFO:root:" + "[ Audio sink ]".center(80, '='),
-                              "INFO:root:Device: [hdmi demo output] "
-                              "availavle: [yes]",
-                              "INFO:root:Attempting to initialize Gstreamer "
-                              "pipeline: audiotestsrc wave=sine freq=512 ! "
-                              "audioconvert ! audioresample ! autoaudiosink",
-                              "INFO:root:Pipeline initialized, now starting "
-                              "playback."])
+        mock_checkout.return_value = self.device
+        self.assertEqual(PipewireTestError.NO_ERROR,
+                         pt.gst_pipeline("audiotestsrc wave=sine freq=512"
+                                         " ! audioconvert ! audioresample"
+                                         " ! autoaudiosink", 2, "hdmi"))
 
 
 class MonitorActivePortTests(unittest.TestCase):
@@ -599,47 +483,17 @@ class MonitorActivePortTests(unittest.TestCase):
     def test_couldnt_detect_change(self, mock_checkout):
         pt = PipewireTest()
 
-        if sys.version_info < (3, 10):
-            mock_checkout.return_value = self.before_device
-            self.assertEqual(PipewireTestError.NO_CHANGE_DETECTED,
-                             pt.monitor_active_port_change(2, "sink"))
-            return
-        with self.assertLogs("root", level="INFO") as cm:
-            mock_checkout.return_value = self.before_device
-            self.assertEqual(PipewireTestError.NO_CHANGE_DETECTED,
-                             pt.monitor_active_port_change(2, "sink"))
-
-            # check log output
-            self.assertEqual(cm.output,
-                             ["INFO:root:Starting with config: "
-                              "{('sink #29', 'hdmi_demo_output', 'yes')}",
-                              "INFO:root:"
-                              "You have 2 seconds to plug the item in",
-                              "INFO:root:Couldn't detect active port change!"])
+        mock_checkout.return_value = self.before_device
+        self.assertEqual(PipewireTestError.NO_CHANGE_DETECTED,
+                         pt.monitor_active_port_change(2, "sink"))
 
     @patch("subprocess.check_output")
     def test_could_detect_change(self, mock_checkout):
         pt = PipewireTest()
 
-        if sys.version_info < (3, 10):
-            mock_checkout.side_effect = [self.before_device, self.after_device]
-            self.assertEqual(PipewireTestError.NO_ERROR,
-                             pt.monitor_active_port_change(2, "sink"))
-            return
-        with self.assertLogs("root", level="INFO") as cm:
-            mock_checkout.side_effect = [self.before_device, self.after_device]
-            self.assertEqual(PipewireTestError.NO_ERROR,
-                             pt.monitor_active_port_change(2, "sink"))
-
-            # check log output
-            self.assertEqual(cm.output,
-                             ["INFO:root:Starting with config: "
-                              "{('sink #29', 'hdmi_demo_output', 'yes')}",
-                              "INFO:root:"
-                              "You have 2 seconds to plug the item in",
-                              "INFO:root:Now using config: "
-                              "{('sink #29', 'hdmi_after_output', 'yes')}",
-                              "INFO:root:It seems to work!"])
+        mock_checkout.side_effect = [self.before_device, self.after_device]
+        self.assertEqual(PipewireTestError.NO_ERROR,
+                         pt.monitor_active_port_change(2, "sink"))
 
 
 class GoThroughPortTests(unittest.TestCase):
@@ -691,23 +545,9 @@ class GoThroughPortTests(unittest.TestCase):
     def test_though(self, mock_checkout, mock_input):
         pt = PipewireTest()
 
-        if sys.version_info < (3, 10):
-            mock_checkout.return_value = self.device
-            mock_input.side_effect = ["yes", "yes"]
-            self.assertEqual(None, pt.go_through_ports("echo test", "sink"))
-            return
-        with self.assertLogs("root", level="INFO") as cm:
-            mock_checkout.return_value = self.device
-            mock_input.side_effect = ["yes", "yes"]
-            self.assertEqual(None, pt.go_through_ports("echo test", "sink"))
-
-            # check log output
-            self.assertEqual(cm.output,
-                             [("INFO:root:Please select [hdmi demo output] "
-                              "for testing (if selected, please enter 'yes')"),
-                              "INFO:root:test",
-                              ("INFO:root:"
-                               "Is working ?  please enter 'yes' to leave")])
+        mock_checkout.return_value = self.device
+        mock_input.side_effect = ["yes", "yes"]
+        self.assertEqual(None, pt.go_through_ports("echo test", "sink"))
 
 
 class ArgsParsingTests(unittest.TestCase):

--- a/providers/base/tests/test_pipewire_utils.py
+++ b/providers/base/tests/test_pipewire_utils.py
@@ -150,73 +150,75 @@ class GeneratePwMediaClassTests(unittest.TestCase):
 class DetectDeviceTests(unittest.TestCase):
 
     # Correct Node
-    sink_audio_node = '[{\
-                        "id": 29,\
-                        "type": "PipeWire:Interface:Node",\
-                        "version": 3,\
-                        "permissions": [ "r", "w", "x", "m" ],\
-                        "info": {\
-                          "max-input-ports": 0,\
-                          "max-output-ports": 0,\
-                          "change-mask": [ "input-ports",\
-                                           "output-ports",\
-                                           "state", "props",\
-                                           "params" ],\
-                          "n-input-ports": 0,\
-                          "n-output-ports": 0,\
-                          "state": "suspended",\
-                          "error": null,\
-                          "props": {\
-                            "media.class": "Audio/Sink",\
-                            "factory.name": "support.node.driver",\
-                            "node.name": "Freewheel-Driver",\
-                            "priority.driver": 19000,\
-                            "node.group": "pipewire.freewheel",\
-                            "node.freewheel": true,\
-                            "factory.id": 10,\
-                            "clock.quantum-limit": 8192,\
-                            "node.driver": true,\
-                            "object.id": 29,\
-                            "object.serial": 29\
-                          },\
-                          "params": {\
-                          }\
-                        }\
-                      }]'
+    sink_audio_node = """
+                       [{
+                        "id": 29,
+                        "type": "PipeWire:Interface:Node",
+                        "version": 3,
+                        "permissions": [ "r", "w", "x", "m" ],
+                        "info": {
+                          "max-input-ports": 0,
+                          "max-output-ports": 0,
+                          "change-mask": [ "input-ports",
+                                           "output-ports",
+                                           "state", "props",
+                                           "params" ],
+                          "n-input-ports": 0,
+                          "n-output-ports": 0,
+                          "state": "suspended",
+                          "error": null,
+                          "props": {
+                            "media.class": "Audio/Sink",
+                            "factory.name": "support.node.driver",
+                            "node.name": "Freewheel-Driver",
+                            "priority.driver": 19000,
+                            "node.group": "pipewire.freewheel",
+                            "node.freewheel": true,
+                            "factory.id": 10,
+                            "clock.quantum-limit": 8192,
+                            "node.driver": true,
+                            "object.id": 29,
+                            "object.serial": 29
+                          },
+                          "params": {
+                          }
+                        }
+                      }]"""
 
-    source_audio_node = '[{\
-                           "id": 30,\
-                           "type": "PipeWire:Interface:Node",\
-                           "version": 3,\
-                           "permissions": [ "r", "w", "x", "m" ],\
-                           "info": {\
-                             "max-input-ports": 0,\
-                             "max-output-ports": 0,\
-                             "change-mask": [ "input-ports",\
-                                              "output-ports",\
-                                              "state", "props",\
-                                              "params" ],\
-                             "n-input-ports": 0,\
-                             "n-output-ports": 0,\
-                             "state": "suspended",\
-                             "error": null,\
-                             "props": {\
-                               "media.class": "Audio/Source",\
-                               "factory.name": "support.node.driver",\
-                               "node.name": "Freewheel-Driver",\
-                               "priority.driver": 19000,\
-                               "node.group": "pipewire.freewheel",\
-                               "node.freewheel": true,\
-                               "factory.id": 10,\
-                               "clock.quantum-limit": 8192,\
-                               "node.driver": true,\
-                               "object.id": 29,\
-                               "object.serial": 29\
-                             },\
-                             "params": {\
-                             }\
-                           }\
-                         }]'
+    source_audio_node = """
+                         [{
+                           "id": 30,
+                           "type": "PipeWire:Interface:Node",
+                           "version": 3,
+                           "permissions": [ "r", "w", "x", "m" ],
+                           "info": {
+                             "max-input-ports": 0,
+                             "max-output-ports": 0,
+                             "change-mask": [ "input-ports",
+                                              "output-ports",
+                                              "state", "props",
+                                              "params" ],
+                             "n-input-ports": 0,
+                             "n-output-ports": 0,
+                             "state": "suspended",
+                             "error": null,
+                             "props": {
+                               "media.class": "Audio/Source",
+                               "factory.name": "support.node.driver",
+                               "node.name": "Freewheel-Driver",
+                               "priority.driver": 19000,
+                               "node.group": "pipewire.freewheel",
+                               "node.freewheel": true,
+                               "factory.id": 10,
+                               "clock.quantum-limit": 8192,
+                               "node.driver": true,
+                               "object.id": 29,
+                               "object.serial": 29
+                             },
+                             "params": {
+                             }
+                           }
+                         }]"""
 
     @patch("subprocess.check_output")
     def test_succ(self, mock_checkout):
@@ -255,40 +257,41 @@ class DetectDeviceTests(unittest.TestCase):
 class SelectDeviceTests(unittest.TestCase):
 
     # Correct Node
-    sink_audio_node = '[{\
-                        "id": 29,\
-                        "type": "PipeWire:Interface:Node",\
-                        "version": 3,\
-                        "permissions": [ "r", "w", "x", "m" ],\
-                        "info": {\
-                          "max-input-ports": 0,\
-                          "max-output-ports": 0,\
-                          "change-mask": [ "input-ports",\
-                                           "output-ports",\
-                                           "state", "props",\
-                                           "params" ],\
-                          "n-input-ports": 0,\
-                          "n-output-ports": 0,\
-                          "state": "suspended",\
-                          "error": null,\
-                          "props": {\
-                            "media.class": "Audio/Sink",\
-                            "factory.name": "support.node.driver",\
-                            "node.name": "demo-hdmi",\
-                            "node.description": "unit test",\
-                            "priority.driver": 19000,\
-                            "node.group": "pipewire.freewheel",\
-                            "node.freewheel": true,\
-                            "factory.id": 10,\
-                            "clock.quantum-limit": 8192,\
-                            "node.driver": true,\
-                            "object.id": 29,\
-                            "object.serial": 29\
-                          },\
-                          "params": {\
-                          }\
-                        }\
-                      }]'
+    sink_audio_node = """
+                       [{
+                        "id": 29,
+                        "type": "PipeWire:Interface:Node",
+                        "version": 3,
+                        "permissions": [ "r", "w", "x", "m" ],
+                        "info": {
+                          "max-input-ports": 0,
+                          "max-output-ports": 0,
+                          "change-mask": [ "input-ports",
+                                           "output-ports",
+                                           "state", "props",
+                                           "params" ],
+                          "n-input-ports": 0,
+                          "n-output-ports": 0,
+                          "state": "suspended",
+                          "error": null,
+                          "props": {
+                            "media.class": "Audio/Sink",
+                            "factory.name": "support.node.driver",
+                            "node.name": "demo-hdmi",
+                            "node.description": "unit test",
+                            "priority.driver": 19000,
+                            "node.group": "pipewire.freewheel",
+                            "node.freewheel": true,
+                            "factory.id": 10,
+                            "clock.quantum-limit": 8192,
+                            "node.driver": true,
+                            "object.id": 29,
+                            "object.serial": 29
+                          },
+                          "params": {
+                          }
+                        }
+                      }]"""
 
     @patch("subprocess.check_output")
     def test_wrong_pw_dump(self, mock_checkout):
@@ -334,45 +337,46 @@ class SelectDeviceTests(unittest.TestCase):
 class GstPipeLineTests(unittest.TestCase):
 
     # Correct Device
-    device = '[{\
-                 "id": 29,\
-                 "type": "PipeWire:Interface:Device",\
-                 "version": 3,\
-                 "permissions": [ "r", "w", "x", "m" ],\
-                 "info": {\
-                   "max-input-ports": 0,\
-                   "max-output-ports": 0,\
-                   "change-mask": [ "input-ports",\
-                                    "output-ports",\
-                                    "state", "props",\
-                                    "params" ],\
-                   "n-input-ports": 0,\
-                   "n-output-ports": 0,\
-                   "state": "suspended",\
-                   "error": null,\
-                   "props": {\
-                     "media.class": "Audio/Device",\
-                     "factory.name": "support.node.driver",\
-                     "node.name": "Freewheel-Driver",\
-                     "node.description": "unit test",\
-                     "priority.driver": 19000,\
-                     "node.group": "pipewire.freewheel",\
-                     "node.freewheel": true,\
-                     "factory.id": 10,\
-                     "clock.quantum-limit": 8192,\
-                     "node.driver": true,\
-                     "object.id": 29,\
-                     "object.serial": 29\
-                   },\
-                   "params": {\
-                       "Route": [{\
-                           "name": "hdmi_demo_output",\
-                           "available": "yes",\
-                           "description": "hdmi demo output"\
-                       }]\
-                   }\
-                 }\
-                }]'
+    device = """
+              [{
+               "id": 29,
+               "type": "PipeWire:Interface:Device",
+               "version": 3,
+               "permissions": [ "r", "w", "x", "m" ],
+               "info": {
+                 "max-input-ports": 0,
+                 "max-output-ports": 0,
+                 "change-mask": [ "input-ports",
+                                  "output-ports",
+                                  "state", "props",
+                                  "params" ],
+                 "n-input-ports": 0,
+                 "n-output-ports": 0,
+                 "state": "suspended",
+                 "error": null,
+                 "props": {
+                   "media.class": "Audio/Device",
+                   "factory.name": "support.node.driver",
+                   "node.name": "Freewheel-Driver",
+                   "node.description": "unit test",
+                   "priority.driver": 19000,
+                   "node.group": "pipewire.freewheel",
+                   "node.freewheel": true,
+                   "factory.id": 10,
+                   "clock.quantum-limit": 8192,
+                   "node.driver": true,
+                   "object.id": 29,
+                   "object.serial": 29
+                 },
+                 "params": {
+                     "Route": [{
+                         "name": "hdmi_demo_output",
+                         "available": "yes",
+                         "description": "hdmi demo output"
+                     }]
+                 }
+               }
+              }]"""
 
     @patch("subprocess.check_output")
     def test_wrong_gst_pipeline_device(self, mock_checkout):
@@ -396,88 +400,90 @@ class GstPipeLineTests(unittest.TestCase):
 class MonitorActivePortTests(unittest.TestCase):
 
     # Correct Device
-    before_device = '[{\
-                 "id": 29,\
-                 "type": "PipeWire:Interface:Device",\
-                 "version": 3,\
-                 "permissions": [ "r", "w", "x", "m" ],\
-                 "info": {\
-                   "max-input-ports": 0,\
-                   "max-output-ports": 0,\
-                   "change-mask": [ "input-ports",\
-                                    "output-ports",\
-                                    "state", "props",\
-                                    "params" ],\
-                   "n-input-ports": 0,\
-                   "n-output-ports": 0,\
-                   "state": "suspended",\
-                   "error": null,\
-                   "props": {\
-                     "media.class": "Audio/Device",\
-                     "factory.name": "support.node.driver",\
-                     "node.name": "Freewheel-Driver",\
-                     "node.description": "unit test",\
-                     "priority.driver": 19000,\
-                     "node.group": "pipewire.freewheel",\
-                     "node.freewheel": true,\
-                     "factory.id": 10,\
-                     "clock.quantum-limit": 8192,\
-                     "node.driver": true,\
-                     "object.id": 29,\
-                     "object.serial": 29\
-                   },\
-                   "params": {\
-                       "Route": [{\
-                           "name": "hdmi_demo_output",\
-                           "available": "yes",\
-                           "direction": "Output",\
-                           "description": "hdmi demo output"\
-                       }]\
-                   }\
-                 }\
-                }]'
+    before_device = """
+                     [{
+                       "id": 29,
+                       "type": "PipeWire:Interface:Device",
+                       "version": 3,
+                       "permissions": [ "r", "w", "x", "m" ],
+                       "info": {
+                         "max-input-ports": 0,
+                         "max-output-ports": 0,
+                         "change-mask": [ "input-ports",
+                                          "output-ports",
+                                          "state", "props",
+                                          "params" ],
+                         "n-input-ports": 0,
+                         "n-output-ports": 0,
+                         "state": "suspended",
+                         "error": null,
+                         "props": {
+                           "media.class": "Audio/Device",
+                           "factory.name": "support.node.driver",
+                           "node.name": "Freewheel-Driver",
+                           "node.description": "unit test",
+                           "priority.driver": 19000,
+                           "node.group": "pipewire.freewheel",
+                           "node.freewheel": true,
+                           "factory.id": 10,
+                           "clock.quantum-limit": 8192,
+                           "node.driver": true,
+                           "object.id": 29,
+                           "object.serial": 29
+                         },
+                         "params": {
+                             "Route": [{
+                                 "name": "hdmi_demo_output",
+                                 "available": "yes",
+                                 "direction": "Output",
+                                 "description": "hdmi demo output"
+                             }]
+                         }
+                       }
+                      }]"""
 
     # Correct Device
-    after_device = '[{\
-                 "id": 29,\
-                 "type": "PipeWire:Interface:Device",\
-                 "version": 3,\
-                 "permissions": [ "r", "w", "x", "m" ],\
-                 "info": {\
-                   "max-input-ports": 0,\
-                   "max-output-ports": 0,\
-                   "change-mask": [ "input-ports",\
-                                    "output-ports",\
-                                    "state", "props",\
-                                    "params" ],\
-                   "n-input-ports": 0,\
-                   "n-output-ports": 0,\
-                   "state": "suspended",\
-                   "error": null,\
-                   "props": {\
-                     "media.class": "Audio/Device",\
-                     "factory.name": "support.node.driver",\
-                     "node.name": "Freewheel-Driver",\
-                     "node.description": "unit test",\
-                     "priority.driver": 19000,\
-                     "node.group": "pipewire.freewheel",\
-                     "node.freewheel": true,\
-                     "factory.id": 10,\
-                     "clock.quantum-limit": 8192,\
-                     "node.driver": true,\
-                     "object.id": 29,\
-                     "object.serial": 29\
-                   },\
-                   "params": {\
-                       "Route": [{\
-                           "name": "hdmi_after_output",\
-                           "available": "yes",\
-                           "direction": "Output",\
-                           "description": "hdmi after output"\
-                       }]\
-                   }\
-                 }\
-                }]'
+    after_device = """
+                    [{
+                      "id": 29,
+                      "type": "PipeWire:Interface:Device",
+                      "version": 3,
+                      "permissions": [ "r", "w", "x", "m" ],
+                      "info": {
+                        "max-input-ports": 0,
+                        "max-output-ports": 0,
+                        "change-mask": [ "input-ports",
+                                         "output-ports",
+                                         "state", "props",
+                                         "params" ],
+                        "n-input-ports": 0,
+                        "n-output-ports": 0,
+                        "state": "suspended",
+                        "error": null,
+                        "props": {
+                          "media.class": "Audio/Device",
+                          "factory.name": "support.node.driver",
+                          "node.name": "Freewheel-Driver",
+                          "node.description": "unit test",
+                          "priority.driver": 19000,
+                          "node.group": "pipewire.freewheel",
+                          "node.freewheel": true,
+                          "factory.id": 10,
+                          "clock.quantum-limit": 8192,
+                          "node.driver": true,
+                          "object.id": 29,
+                          "object.serial": 29
+                        },
+                        "params": {
+                            "Route": [{
+                                "name": "hdmi_after_output",
+                                "available": "yes",
+                                "direction": "Output",
+                                "description": "hdmi after output"
+                            }]
+                        }
+                      }
+                     }]"""
 
     @patch("subprocess.check_output")
     def test_couldnt_detect_change(self, mock_checkout):
@@ -499,46 +505,46 @@ class MonitorActivePortTests(unittest.TestCase):
 class GoThroughPortTests(unittest.TestCase):
 
     # Correct Device
-    device = '[{\
-                 "id": 29,\
-                 "type": "PipeWire:Interface:Device",\
-                 "version": 3,\
-                 "permissions": [ "r", "w", "x", "m" ],\
-                 "info": {\
-                   "max-input-ports": 0,\
-                   "max-output-ports": 0,\
-                   "change-mask": [ "input-ports",\
-                                    "output-ports",\
-                                    "state", "props",\
-                                    "params" ],\
-                   "n-input-ports": 0,\
-                   "n-output-ports": 0,\
-                   "state": "suspended",\
-                   "error": null,\
-                   "props": {\
-                     "media.class": "Audio/Device",\
-                     "factory.name": "support.node.driver",\
-                     "node.name": "Freewheel-Driver",\
-                     "node.description": "unit test",\
-                     "priority.driver": 19000,\
-                     "node.group": "pipewire.freewheel",\
-                     "node.freewheel": true,\
-                     "factory.id": 10,\
-                     "clock.quantum-limit": 8192,\
-                     "node.driver": true,\
-                     "object.id": 29,\
-                     "object.serial": 29\
-                   },\
-                   "params": {\
-                       "EnumRoute": [{\
-                           "name": "hdmi_demo_output",\
-                           "available": "yes",\
-                           "direction": "Output",\
-                           "description": "hdmi demo output"\
-                       }]\
-                   }\
-                 }\
-                }]'
+    device = """[{
+                 "id": 29,
+                 "type": "PipeWire:Interface:Device",
+                 "version": 3,
+                 "permissions": [ "r", "w", "x", "m" ],
+                 "info": {
+                   "max-input-ports": 0,
+                   "max-output-ports": 0,
+                   "change-mask": [ "input-ports",
+                                    "output-ports",
+                                    "state", "props",
+                                    "params" ],
+                   "n-input-ports": 0,
+                   "n-output-ports": 0,
+                   "state": "suspended",
+                   "error": null,
+                   "props": {
+                     "media.class": "Audio/Device",
+                     "factory.name": "support.node.driver",
+                     "node.name": "Freewheel-Driver",
+                     "node.description": "unit test",
+                     "priority.driver": 19000,
+                     "node.group": "pipewire.freewheel",
+                     "node.freewheel": true,
+                     "factory.id": 10,
+                     "clock.quantum-limit": 8192,
+                     "node.driver": true,
+                     "object.id": 29,
+                     "object.serial": 29
+                   },
+                   "params": {
+                       "EnumRoute": [{
+                           "name": "hdmi_demo_output",
+                           "available": "yes",
+                           "direction": "Output",
+                           "description": "hdmi demo output"
+                       }]
+                   }
+                 }
+                }]"""
 
     @patch("builtins.input")
     @patch("subprocess.check_output")
@@ -549,6 +555,36 @@ class GoThroughPortTests(unittest.TestCase):
         mock_input.side_effect = ["yes", "yes"]
         self.assertEqual(None, pt.go_through_ports("echo test", "sink"))
 
+
+class ShowDefaultDeviceTests(unittest.TestCase):
+
+    def test_device_type_error(self):
+        pt = PipewireTest()
+
+        with self.assertRaises(ValueError):
+            pt.show_default_device("XXX")
+
+    @patch("subprocess.check_output")
+    def test_video_sink_not_call(self, mock_check):
+        pt = PipewireTest()
+
+        mock_check.side_effect = ["node.description=xxx",
+                                  "node.description=ooo"]
+        pt.show_default_device("VIDEO")
+        mock_check.assert_called_with(["wpctl", "inspect",
+                                       "@DEFAULT_VIDEO_SOURCE@"],
+                                      universal_newlines=True)
+
+    @patch("subprocess.check_output")
+    def test_audio(self, mock_check):
+        pt = PipewireTest()
+
+        mock_check.side_effect = ["node.description=xxx",
+                                  "node.description=ooo"]
+        pt.show_default_device("AUDIO")
+        mock_check.assert_called_with(["wpctl", "inspect",
+                                       "@DEFAULT_AUDIO_SINK@"],
+                                      universal_newlines=True)
 
 class ArgsParsingTests(unittest.TestCase):
     def test_success(self):
@@ -594,6 +630,10 @@ class ArgsParsingTests(unittest.TestCase):
         self.assertEqual(rv.command, "echo")
         self.assertEqual(rv.mode, "mode")
 
+        args = ["show", "-t", "AUDIO"]
+        rv = pt._args_parsing(args)
+        self.assertEqual(rv.type, "AUDIO")
+
 
 class FunctionSelectTests(unittest.TestCase):
 
@@ -632,3 +672,10 @@ class FunctionSelectTests(unittest.TestCase):
         args = ["through", "-c", "echo", "-m", "mode"]
         rv = pt.function_select(pt._args_parsing(args))
         self.assertEqual(rv, 55)
+
+    @patch("pipewire_utils.PipewireTest.show_default_device", return_value=44)
+    def test_through(self, mock_monitor):
+        pt = PipewireTest()
+        args = ["show", "-t", "AUDIO"]
+        rv = pt.function_select(pt._args_parsing(args))
+        self.assertEqual(rv, 44)

--- a/providers/base/tests/test_pipewire_utils.py
+++ b/providers/base/tests/test_pipewire_utils.py
@@ -1,0 +1,695 @@
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Hanhsuan Lee <hanhsuan.lee@canonical.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import sys
+from unittest.mock import MagicMock
+sys.modules["gi"] = MagicMock()
+sys.modules["gi.repository"] = MagicMock()
+from unittest.mock import Mock, patch
+from pipewire_utils import *
+
+
+class GetPwTypeTests(unittest.TestCase):
+
+    def test_succ(self):
+        pt = PipewireTest()
+
+        # return Output
+        self.assertEqual("Output",
+                         pt._get_pw_type("sinks"))
+        self.assertEqual("Output",
+                         pt._get_pw_type("Sinks"))
+        self.assertEqual("Output",
+                         pt._get_pw_type("Sink"))
+
+        # return Input
+        self.assertEqual("Input",
+                         pt._get_pw_type("sources"))
+        self.assertEqual("Input",
+                         pt._get_pw_type("Sources"))
+        self.assertEqual("Input",
+                         pt._get_pw_type("Source"))
+
+        # return UNKNOWN CLASS
+        self.assertEqual("UNKNOWN CLASS",
+                         pt._get_pw_type("xxxx"))
+
+
+class GeneratePwMediaClassTests(unittest.TestCase):
+
+    def test_succ(self):
+        pt = PipewireTest()
+
+        # return Audio/Sink
+        self.assertEqual("Audio/Sink",
+                         pt.generate_pw_media_class("audio", "sink"))
+        self.assertEqual("Audio/Sink",
+                         pt.generate_pw_media_class("audio", "Sink"))
+        self.assertEqual("Audio/Sink",
+                         pt.generate_pw_media_class("Audio", "sink"))
+        self.assertEqual("Audio/Sink",
+                         pt.generate_pw_media_class("Audio", "Sink"))
+        self.assertEqual("Audio/Sink",
+                         pt.generate_pw_media_class("Audio", "Sinks"))
+
+        # return Audio/Source
+        self.assertEqual("Audio/Source",
+                         pt.generate_pw_media_class("audio", "source"))
+        self.assertEqual("Audio/Source",
+                         pt.generate_pw_media_class("audio", "Source"))
+        self.assertEqual("Audio/Source",
+                         pt.generate_pw_media_class("Audio", "source"))
+        self.assertEqual("Audio/Source",
+                         pt.generate_pw_media_class("Audio", "Source"))
+        self.assertEqual("Audio/Source",
+                         pt.generate_pw_media_class("Audio", "Sources"))
+
+        # return Video/Sink
+        self.assertEqual("Video/Sink",
+                         pt.generate_pw_media_class("video", "sink"))
+        self.assertEqual("Video/Sink",
+                         pt.generate_pw_media_class("video", "Sink"))
+        self.assertEqual("Video/Sink",
+                         pt.generate_pw_media_class("Video", "sink"))
+        self.assertEqual("Video/Sink",
+                         pt.generate_pw_media_class("Video", "Sink"))
+        self.assertEqual("Video/Sink",
+                         pt.generate_pw_media_class("Video", "Sinks"))
+
+        # return Video/Source
+        self.assertEqual("Video/Source",
+                         pt.generate_pw_media_class("video", "source"))
+        self.assertEqual("Video/Source",
+                         pt.generate_pw_media_class("video", "Source"))
+        self.assertEqual("Video/Source",
+                         pt.generate_pw_media_class("Video", "source"))
+        self.assertEqual("Video/Source",
+                         pt.generate_pw_media_class("Video", "Source"))
+        self.assertEqual("Video/Source",
+                         pt.generate_pw_media_class("Video", "Sources"))
+
+    def test_fail(self):
+        pt = PipewireTest()
+
+        # return UNKNOWN TYPE
+        with self.assertLogs("root", level="INFO") as cm:
+            wrong_type1 = "videog"
+            wrong_type2 = "xxxx"
+            self.assertEqual("UNKNOWN TYPE",
+                             pt.generate_pw_media_class(wrong_type1,
+                                                        "source"))
+            self.assertEqual("UNKNOWN TYPE",
+                             pt.generate_pw_media_class(wrong_type2,
+                                                        "sources"))
+            # check log output
+            self.assertEqual(cm.output,
+                             ["INFO:root:Media type:[{}] is unknown"
+                              .format(wrong_type1),
+                              "INFO:root:Media type:[{}] is unknown"
+                              .format(wrong_type2)])
+
+        # return UNKNOWN CLASS
+        with self.assertLogs("root", level="INFO") as cm:
+            wrong_class1 = "sourceg"
+            wrong_class2 = "sinkf"
+            self.assertEqual("UNKNOWN CLASS",
+                             pt.generate_pw_media_class("video",
+                                                        wrong_class1))
+            self.assertEqual("UNKNOWN CLASS",
+                             pt.generate_pw_media_class("video",
+                                                        wrong_class2))
+            # check log output
+            self.assertEqual(cm.output,
+                             ["INFO:root:Media class:[{}] is unknown"
+                              .format(wrong_class1),
+                              "INFO:root:Media class:[{}] is unknown"
+                              .format(wrong_class2)])
+
+
+class DetectDeviceTests(unittest.TestCase):
+
+    # Correct Node
+    sink_audio_node = '[{\
+                        "id": 29,\
+                        "type": "PipeWire:Interface:Node",\
+                        "version": 3,\
+                        "permissions": [ "r", "w", "x", "m" ],\
+                        "info": {\
+                          "max-input-ports": 0,\
+                          "max-output-ports": 0,\
+                          "change-mask": [ "input-ports",\
+                                           "output-ports",\
+                                           "state", "props",\
+                                           "params" ],\
+                          "n-input-ports": 0,\
+                          "n-output-ports": 0,\
+                          "state": "suspended",\
+                          "error": null,\
+                          "props": {\
+                            "media.class": "Audio/Sink",\
+                            "factory.name": "support.node.driver",\
+                            "node.name": "Freewheel-Driver",\
+                            "priority.driver": 19000,\
+                            "node.group": "pipewire.freewheel",\
+                            "node.freewheel": true,\
+                            "factory.id": 10,\
+                            "clock.quantum-limit": 8192,\
+                            "node.driver": true,\
+                            "object.id": 29,\
+                            "object.serial": 29\
+                          },\
+                          "params": {\
+                          }\
+                        }\
+                      }]'
+
+    source_audio_node = '[{\
+                           "id": 30,\
+                           "type": "PipeWire:Interface:Node",\
+                           "version": 3,\
+                           "permissions": [ "r", "w", "x", "m" ],\
+                           "info": {\
+                             "max-input-ports": 0,\
+                             "max-output-ports": 0,\
+                             "change-mask": [ "input-ports",\
+                                              "output-ports",\
+                                              "state", "props",\
+                                              "params" ],\
+                             "n-input-ports": 0,\
+                             "n-output-ports": 0,\
+                             "state": "suspended",\
+                             "error": null,\
+                             "props": {\
+                               "media.class": "Audio/Source",\
+                               "factory.name": "support.node.driver",\
+                               "node.name": "Freewheel-Driver",\
+                               "priority.driver": 19000,\
+                               "node.group": "pipewire.freewheel",\
+                               "node.freewheel": true,\
+                               "factory.id": 10,\
+                               "clock.quantum-limit": 8192,\
+                               "node.driver": true,\
+                               "object.id": 29,\
+                               "object.serial": 29\
+                             },\
+                             "params": {\
+                             }\
+                           }\
+                         }]'
+
+    @patch("subprocess.check_output")
+    def test_succ(self, mock_checkout):
+        pt = PipewireTest()
+
+        with self.assertLogs("root", level="INFO") as cm:
+            # detect audio sink succ
+            mock_checkout.return_value = self.sink_audio_node
+            self.assertEqual(PipewireTestError.NO_ERROR,
+                             pt.detect_device("audio", "sink"))
+
+            # detect audio source succ
+            mock_checkout.return_value = self.source_audio_node
+            self.assertEqual(PipewireTestError.NO_ERROR,
+                             pt.detect_device("audio", "source"))
+            # check log output
+            self.assertEqual(cm.output,
+                             ["INFO:root:device id:[29]"
+                              " media.class:[Audio/Sink]"
+                              " node.name:[Freewheel-Driver]",
+                              "INFO:root:device id:[30]"
+                              " media.class:[Audio/Source]"
+                              " node.name:[Freewheel-Driver]"])
+
+    @patch("subprocess.check_output")
+    def test_fail(self, mock_checkout):
+        pt = PipewireTest()
+
+        with self.assertLogs("root", level="INFO") as cm:
+            # detect audio sink fail
+            mock_checkout.return_value = self.source_audio_node
+            self.assertEqual(PipewireTestError.NOT_DETECTED,
+                             pt.detect_device("audio", "sink"))
+
+            # detect audio source fail
+            mock_checkout.return_value = self.sink_audio_node
+            self.assertEqual(PipewireTestError.NOT_DETECTED,
+                             pt.detect_device("audio", "source"))
+
+            # wrong media class
+            mock_checkout.return_value = self.sink_audio_node
+            self.assertEqual(PipewireTestError.NOT_DETECTED,
+                             pt.detect_device("xxx", "ooo"))
+            # check log output
+            self.assertEqual(cm.output,
+                             ["INFO:root:"
+                              "media.class:[Audio/Sink] couldn't find",
+                              "INFO:root:"
+                              "media.class:[Audio/Source] couldn't find",
+                              "INFO:root:Media type:[xxx] is unknown"])
+
+
+class SelectDeviceTests(unittest.TestCase):
+
+    # Correct Node
+    sink_audio_node = '[{\
+                        "id": 29,\
+                        "type": "PipeWire:Interface:Node",\
+                        "version": 3,\
+                        "permissions": [ "r", "w", "x", "m" ],\
+                        "info": {\
+                          "max-input-ports": 0,\
+                          "max-output-ports": 0,\
+                          "change-mask": [ "input-ports",\
+                                           "output-ports",\
+                                           "state", "props",\
+                                           "params" ],\
+                          "n-input-ports": 0,\
+                          "n-output-ports": 0,\
+                          "state": "suspended",\
+                          "error": null,\
+                          "props": {\
+                            "media.class": "Audio/Sink",\
+                            "factory.name": "support.node.driver",\
+                            "node.name": "demo-hdmi",\
+                            "node.description": "unit test",\
+                            "priority.driver": 19000,\
+                            "node.group": "pipewire.freewheel",\
+                            "node.freewheel": true,\
+                            "factory.id": 10,\
+                            "clock.quantum-limit": 8192,\
+                            "node.driver": true,\
+                            "object.id": 29,\
+                            "object.serial": 29\
+                          },\
+                          "params": {\
+                          }\
+                        }\
+                      }]'
+
+    @patch("subprocess.check_output")
+    def test_wrong_pw_dump(self, mock_checkout):
+        pt = PipewireTest()
+
+        with self.assertLogs("root", level="INFO") as cm:
+            mock_checkout.return_value = "xxxx"
+            self.assertEqual(PipewireTestError.NO_AVAILABLE_PORT,
+                             pt.select_device("video", "sink", "hdmi"))
+            # check log output
+            self.assertEqual(cm.output,
+                             ["ERROR:root:pw-dump Node failed !!!",
+                              "ERROR:root:No available Video/Sink found"])
+
+    @patch("subprocess.check_output")
+    def test_no_available_node(self, mock_checkout):
+        pt = PipewireTest()
+
+        # parameters error
+        self.assertEqual(PipewireTestError.NO_AVAILABLE_PORT,
+                         pt.select_device("xxx", "sink", "hdmi"))
+        self.assertEqual(PipewireTestError.NO_AVAILABLE_PORT,
+                         pt.select_device("video", "xxx", "hdmi"))
+
+        with self.assertLogs("root", level="INFO") as cm:
+            mock_checkout.return_value = self.sink_audio_node
+            self.assertEqual(PipewireTestError.NO_AVAILABLE_PORT,
+                             pt.select_device("video", "sink", "hdmi"))
+            # check log output
+            self.assertEqual(cm.output,
+                             ["ERROR:root:No available Video/Sink found"])
+
+    @patch("builtins.input")
+    @patch("subprocess.check_output")
+    def test_succ(self, mock_checkout, mock_input):
+        mock_checkout.return_value = self.sink_audio_node
+        mock_input.side_effect = ["t", 29]
+        pt = PipewireTest()
+        self.assertEqual(PipewireTestError.NO_ERROR,
+                         pt.select_device("audio", "sink", "hdmi"))
+
+    @patch("builtins.input")
+    @patch("subprocess.check_output")
+    def test_exit(self, mock_checkout, mock_input):
+        mock_checkout.return_value = self.sink_audio_node
+        mock_input.side_effect = ["t", "-1"]
+        pt = PipewireTest()
+        self.assertEqual(PipewireTestError.NO_ERROR,
+                         pt.select_device("audio", "sink", "hdmi"))
+
+
+class GstPipeLineTests(unittest.TestCase):
+
+    # Correct Device
+    device = '[{\
+                 "id": 29,\
+                 "type": "PipeWire:Interface:Device",\
+                 "version": 3,\
+                 "permissions": [ "r", "w", "x", "m" ],\
+                 "info": {\
+                   "max-input-ports": 0,\
+                   "max-output-ports": 0,\
+                   "change-mask": [ "input-ports",\
+                                    "output-ports",\
+                                    "state", "props",\
+                                    "params" ],\
+                   "n-input-ports": 0,\
+                   "n-output-ports": 0,\
+                   "state": "suspended",\
+                   "error": null,\
+                   "props": {\
+                     "media.class": "Audio/Device",\
+                     "factory.name": "support.node.driver",\
+                     "node.name": "Freewheel-Driver",\
+                     "node.description": "unit test",\
+                     "priority.driver": 19000,\
+                     "node.group": "pipewire.freewheel",\
+                     "node.freewheel": true,\
+                     "factory.id": 10,\
+                     "clock.quantum-limit": 8192,\
+                     "node.driver": true,\
+                     "object.id": 29,\
+                     "object.serial": 29\
+                   },\
+                   "params": {\
+                       "Route": [{\
+                           "name": "hdmi_demo_output",\
+                           "available": "yes",\
+                           "description": "hdmi demo output"\
+                       }]\
+                   }\
+                 }\
+                }]'
+
+    @patch("subprocess.check_output")
+    def test_wrong_gst_pipeline_device(self, mock_checkout):
+        pt = PipewireTest()
+
+        with self.assertLogs("root", level="INFO") as cm:
+            mock_checkout.return_value = self.device
+            self.assertEqual(PipewireTestError.NO_SPECIFIC_DEVICE,
+                             pt.gst_pipeline("pipe", 10, "qoo"))
+            # check log output
+            self.assertEqual(cm.output,
+                             ["ERROR:root:No abailable output device for qoo"])
+
+    @patch("subprocess.check_output")
+    def test_gst_pipeline(self, mock_checkout):
+        pt = PipewireTest()
+
+        with self.assertLogs("root", level="INFO") as cm:
+            mock_checkout.return_value = self.device
+            self.assertEqual(PipewireTestError.NO_ERROR,
+                             pt.gst_pipeline("audiotestsrc wave=sine freq=512"
+                                             " ! audioconvert ! audioresample"
+                                             " ! autoaudiosink", 2, "hdmi"))
+            # check log output
+            self.assertEqual(cm.output,
+                             ["INFO:root:" + "[ Audio sink ]".center(80, '='),
+                              "INFO:root:Device: [hdmi demo output] "
+                              "availavle: [yes]",
+                              "INFO:root:Attempting to initialize Gstreamer "
+                              "pipeline: audiotestsrc wave=sine freq=512 ! "
+                              "audioconvert ! audioresample ! autoaudiosink",
+                              "INFO:root:Pipeline initialized, now starting "
+                              "playback."])
+
+
+class MonitorActivePortTests(unittest.TestCase):
+
+    # Correct Device
+    before_device = '[{\
+                 "id": 29,\
+                 "type": "PipeWire:Interface:Device",\
+                 "version": 3,\
+                 "permissions": [ "r", "w", "x", "m" ],\
+                 "info": {\
+                   "max-input-ports": 0,\
+                   "max-output-ports": 0,\
+                   "change-mask": [ "input-ports",\
+                                    "output-ports",\
+                                    "state", "props",\
+                                    "params" ],\
+                   "n-input-ports": 0,\
+                   "n-output-ports": 0,\
+                   "state": "suspended",\
+                   "error": null,\
+                   "props": {\
+                     "media.class": "Audio/Device",\
+                     "factory.name": "support.node.driver",\
+                     "node.name": "Freewheel-Driver",\
+                     "node.description": "unit test",\
+                     "priority.driver": 19000,\
+                     "node.group": "pipewire.freewheel",\
+                     "node.freewheel": true,\
+                     "factory.id": 10,\
+                     "clock.quantum-limit": 8192,\
+                     "node.driver": true,\
+                     "object.id": 29,\
+                     "object.serial": 29\
+                   },\
+                   "params": {\
+                       "Route": [{\
+                           "name": "hdmi_demo_output",\
+                           "available": "yes",\
+                           "direction": "Output",\
+                           "description": "hdmi demo output"\
+                       }]\
+                   }\
+                 }\
+                }]'
+
+    # Correct Device
+    after_device = '[{\
+                 "id": 29,\
+                 "type": "PipeWire:Interface:Device",\
+                 "version": 3,\
+                 "permissions": [ "r", "w", "x", "m" ],\
+                 "info": {\
+                   "max-input-ports": 0,\
+                   "max-output-ports": 0,\
+                   "change-mask": [ "input-ports",\
+                                    "output-ports",\
+                                    "state", "props",\
+                                    "params" ],\
+                   "n-input-ports": 0,\
+                   "n-output-ports": 0,\
+                   "state": "suspended",\
+                   "error": null,\
+                   "props": {\
+                     "media.class": "Audio/Device",\
+                     "factory.name": "support.node.driver",\
+                     "node.name": "Freewheel-Driver",\
+                     "node.description": "unit test",\
+                     "priority.driver": 19000,\
+                     "node.group": "pipewire.freewheel",\
+                     "node.freewheel": true,\
+                     "factory.id": 10,\
+                     "clock.quantum-limit": 8192,\
+                     "node.driver": true,\
+                     "object.id": 29,\
+                     "object.serial": 29\
+                   },\
+                   "params": {\
+                       "Route": [{\
+                           "name": "hdmi_after_output",\
+                           "available": "yes",\
+                           "direction": "Output",\
+                           "description": "hdmi after output"\
+                       }]\
+                   }\
+                 }\
+                }]'
+
+    @patch("subprocess.check_output")
+    def test_couldnt_detect_change(self, mock_checkout):
+        pt = PipewireTest()
+
+        with self.assertLogs("root", level="INFO") as cm:
+            mock_checkout.return_value = self.before_device
+            self.assertEqual(PipewireTestError.NO_CHANGE_DETECTED,
+                             pt.monitor_active_port_change(2, "sink"))
+            # check log output
+            self.assertEqual(cm.output,
+                             ["INFO:root:Starting with config: "
+                              "{('sink #29', 'hdmi_demo_output', 'yes')}",
+                              "INFO:root:"
+                              "You have 2 seconds to plug the item in",
+                              "INFO:root:Couldn't detect active port change!"])
+
+    @patch("subprocess.check_output")
+    def test_could_detect_change(self, mock_checkout):
+        pt = PipewireTest()
+
+        with self.assertLogs("root", level="INFO") as cm:
+            mock_checkout.side_effect = [self.before_device, self.after_device]
+            self.assertEqual(PipewireTestError.NO_ERROR,
+                             pt.monitor_active_port_change(2, "sink"))
+            # check log output
+            self.assertEqual(cm.output,
+                             ["INFO:root:Starting with config: "
+                              "{('sink #29', 'hdmi_demo_output', 'yes')}",
+                              "INFO:root:"
+                              "You have 2 seconds to plug the item in",
+                              "INFO:root:Now using config: "
+                              "{('sink #29', 'hdmi_after_output', 'yes')}",
+                              "INFO:root:It seems to work!"])
+
+
+class GoThroughPortTests(unittest.TestCase):
+
+    # Correct Device
+    device = '[{\
+                 "id": 29,\
+                 "type": "PipeWire:Interface:Device",\
+                 "version": 3,\
+                 "permissions": [ "r", "w", "x", "m" ],\
+                 "info": {\
+                   "max-input-ports": 0,\
+                   "max-output-ports": 0,\
+                   "change-mask": [ "input-ports",\
+                                    "output-ports",\
+                                    "state", "props",\
+                                    "params" ],\
+                   "n-input-ports": 0,\
+                   "n-output-ports": 0,\
+                   "state": "suspended",\
+                   "error": null,\
+                   "props": {\
+                     "media.class": "Audio/Device",\
+                     "factory.name": "support.node.driver",\
+                     "node.name": "Freewheel-Driver",\
+                     "node.description": "unit test",\
+                     "priority.driver": 19000,\
+                     "node.group": "pipewire.freewheel",\
+                     "node.freewheel": true,\
+                     "factory.id": 10,\
+                     "clock.quantum-limit": 8192,\
+                     "node.driver": true,\
+                     "object.id": 29,\
+                     "object.serial": 29\
+                   },\
+                   "params": {\
+                       "EnumRoute": [{\
+                           "name": "hdmi_demo_output",\
+                           "available": "yes",\
+                           "direction": "Output",\
+                           "description": "hdmi demo output"\
+                       }]\
+                   }\
+                 }\
+                }]'
+
+    @patch("builtins.input")
+    @patch("subprocess.check_output")
+    def test_though(self, mock_checkout, mock_input):
+        pt = PipewireTest()
+
+        with self.assertLogs("root", level="INFO") as cm:
+            mock_checkout.return_value = self.device
+            mock_input.side_effect = ["yes", "yes"]
+            self.assertEqual(None, pt.go_through_ports("echo test", "sink"))
+
+            # check log output
+            self.assertEqual(cm.output,
+                             [("INFO:root:Please select [hdmi demo output] "
+                              "for testing (if selected, please enter 'yes')"),
+                              "INFO:root:test",
+                              ("INFO:root:"
+                               "Is working ?  please enter 'yes' to leave")])
+
+
+class ArgsParsingTests(unittest.TestCase):
+    def test_success(self):
+        pt = PipewireTest()
+
+        # no argument, load default
+        args = ["detect"]
+        rv = pt._args_parsing(args)
+        self.assertEqual(rv.type, "Audio")
+        self.assertEqual(rv.clazz, "Sink")
+
+        args = ["select"]
+        rv = pt._args_parsing(args)
+        self.assertEqual(rv.type, "Audio")
+        self.assertEqual(rv.clazz, "Sink")
+        self.assertEqual(rv.device, "")
+
+        # set argument
+        args = ["detect", "-t", "unit", "-c", "test"]
+        rv = pt._args_parsing(args)
+        self.assertEqual(rv.type, "unit")
+        self.assertEqual(rv.clazz, "test")
+
+        args = ["select", "-t", "unit", "-c", "test", "-d", "device"]
+        rv = pt._args_parsing(args)
+        self.assertEqual(rv.type, "unit")
+        self.assertEqual(rv.clazz, "test")
+        self.assertEqual(rv.device, "device")
+
+        args = ["gst", "-t", "30", "-d", "device", "PIPELINE"]
+        rv = pt._args_parsing(args)
+        self.assertEqual(rv.timeout, 30)
+        self.assertEqual(rv.PIPELINE, "PIPELINE")
+        self.assertEqual(rv.device, "device")
+
+        args = ["monitor", "-t", "30", "-m", "mode"]
+        rv = pt._args_parsing(args)
+        self.assertEqual(rv.timeout, 30)
+        self.assertEqual(rv.mode, "mode")
+
+        args = ["through", "-c", "echo", "-m", "mode"]
+        rv = pt._args_parsing(args)
+        self.assertEqual(rv.command, "echo")
+        self.assertEqual(rv.mode, "mode")
+
+
+class FunctionSelectTests(unittest.TestCase):
+
+    @patch("pipewire_utils.PipewireTest.detect_device", return_value=99)
+    def test_detect(self, mock_detect):
+        pt = PipewireTest()
+        args = ["detect", "-t", "unit", "-c", "test"]
+        rv = pt.function_select(pt._args_parsing(args))
+        self.assertEqual(rv, 99)
+
+    @patch("pipewire_utils.PipewireTest.select_device", return_value=88)
+    def test_select(self, mock_select):
+        pt = PipewireTest()
+        args = ["select", "-t", "unit", "-c", "test"]
+        rv = pt.function_select(pt._args_parsing(args))
+        self.assertEqual(rv, 88)
+
+    @patch("pipewire_utils.PipewireTest.gst_pipeline", return_value=77)
+    def test_gst(self, mock_gst):
+        pt = PipewireTest()
+        args = ["gst", "-t", "30", "-d", "device", "PIPELINE"]
+        rv = pt.function_select(pt._args_parsing(args))
+        self.assertEqual(rv, 77)
+
+    @patch("pipewire_utils.PipewireTest.monitor_active_port_change",
+           return_value=66)
+    def test_monitor(self, mock_monitor):
+        pt = PipewireTest()
+        args = ["monitor", "-t", "30", "-m", "mode"]
+        rv = pt.function_select(pt._args_parsing(args))
+        self.assertEqual(rv, 66)
+
+    @patch("pipewire_utils.PipewireTest.go_through_ports", return_value=55)
+    def test_through(self, mock_monitor):
+        pt = PipewireTest()
+        args = ["through", "-c", "echo", "-m", "mode"]
+        rv = pt.function_select(pt._args_parsing(args))
+        self.assertEqual(rv, 55)

--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -39,13 +39,19 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
-  audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-  audio_settings.py set --device=pci --volume=50
-  gst_pipeline_test.py -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
-  EXIT_CODE=$?
-  audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --device=pci --volume=50
+    gst_pipeline_test.py -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
   exit $EXIT_CODE
 _description:
  PURPOSE:
@@ -71,15 +77,21 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 flags: also-after-suspend
 command:
- audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --verbose --device=hdmi --volume=50
- gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
- EXIT_CODE=$?
- audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- exit $EXIT_CODE
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --verbose --device=hdmi --volume=50
+    gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
+  exit $EXIT_CODE
 _purpose:
     HDMI audio interface verification
 _steps:
@@ -101,15 +113,21 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 flags: also-after-suspend
 command:
- audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --verbose --device=hdmi --volume=50
- gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
- EXIT_CODE=$?
- audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- exit $EXIT_CODE
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --verbose --device=hdmi --volume=50
+    gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
+  exit $EXIT_CODE
 _purpose:
     DisplayPort audio interface verification
 _steps:
@@ -131,15 +149,21 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 flags: also-after-suspend
 command:
- audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --verbose --device=hdmi --volume=50
- gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
- EXIT_CODE=$?
- audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- exit $EXIT_CODE
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --verbose --device=hdmi --volume=50
+    gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
+  exit $EXIT_CODE
 _purpose:
     Thunderbolt audio interface verification
 _steps:
@@ -161,15 +185,21 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 flags: also-after-suspend
 command:
- audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --verbose --device=hdmi --volume=50
- gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
- EXIT_CODE=$?
- audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- exit $EXIT_CODE
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --verbose --device=hdmi --volume=50
+    gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
+  exit $EXIT_CODE
 _purpose:
     Thunderbolt audio interface verification
 _steps:
@@ -191,15 +221,21 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 flags: also-after-suspend
 command:
- audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --verbose --device=hdmi --volume=50
- gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
- EXIT_CODE=$?
- audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- exit $EXIT_CODE
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --verbose --device=hdmi --volume=50
+    gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
+  exit $EXIT_CODE
 _purpose:
     DisplayPort audio via USB Type-C port interface verification
 _steps:
@@ -221,15 +257,21 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 flags: also-after-suspend
 command:
- audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --verbose --device=hdmi --volume=50
- gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
- EXIT_CODE=$?
- audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- exit $EXIT_CODE
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --verbose --device=hdmi --volume=50
+    gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
+  exit $EXIT_CODE
 _purpose:
     HDMI audio via USB Type-C port interface verification
 _steps:
@@ -248,13 +290,19 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
-  audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-  audio_settings.py set --device=pci --volume=50
-  gst_pipeline_test.py -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
-  EXIT_CODE=$?
-  audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --device=pci --volume=50
+    gst_pipeline_test.py -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
   exit $EXIT_CODE
 _description:
  PURPOSE:
@@ -274,14 +322,20 @@ depends: audio/playback_auto
 requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
- package.name == 'pulseaudio-utils'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
-  audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-  audio_settings.py set --device=pci --volume=50
-  alsa_record_playback.sh
-  EXIT_CODE=$?
-  audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    alsa_record_playback.sh
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --device=pci --volume=50
+    alsa_record_playback.sh
+    EXIT_CODE=$?
+    audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
   exit $EXIT_CODE
 _description:
  PURPOSE:
@@ -302,15 +356,21 @@ depends: audio/playback_headphones
 requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
- package.name == 'pulseaudio-utils'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
- audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --device=pci --volume=50
- alsa_record_playback.sh
- EXIT_CODE=$?
- audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- exit $EXIT_CODE
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    alsa_record_playback.sh
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --device=pci --volume=50
+    alsa_record_playback.sh
+    EXIT_CODE=$?
+    audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
+  exit $EXIT_CODE
 _description:
  PURPOSE:
      This test will check that recording sound using an external microphone works correctly
@@ -328,14 +388,19 @@ estimated_duration: 120.0
 requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
- package.name == 'pulseaudio-utils'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
-  audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-  audio_settings.py set --device=usb --volume=50
-  alsa_record_playback.sh
-  EXIT_CODE=$?
-  audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  if check_audio_deamon.sh ; then
+    alsa_record_playback.sh
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --device=usb --volume=50
+    alsa_record_playback.sh
+    EXIT_CODE=$?
+    audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
   exit $EXIT_CODE
 _description:
  PURPOSE:
@@ -358,10 +423,16 @@ requires:
  package.name == 'gir1.2-gstreamer-1.0'
  package.name == 'libgstreamer1.0-0'
  package.name == 'gstreamer1.0-plugins-good'
- package.name == 'gstreamer1.0-pulseaudio'
+ package.name in ['gstreamer1.0-pulseaudio', 'gstreamer1.0-pipewire']
  package.name == 'alsa-base'
  device.category == 'AUDIO'
-command: audio_test.py
+ package.name in ['pulseaudio-utils', 'pipewire']
+command: 
+  if check_audio_deamon.sh ; then
+    pipewire_test.py
+  else
+    audio_test.py
+  fi
 _description:
  Play back a sound on the default output and listen for it on the
  default input.
@@ -373,10 +444,14 @@ flags: also-after-suspend
 estimated_duration: 1.0
 imports: from com.canonical.plainbox import manifest
 requires:
-  package.name == 'pulseaudio-utils'
+  package.name in ['pulseaudio-utils', 'pipewire']
   manifest.has_audio_playback == 'True'
 command:
-  pactl_list.sh sinks
+  if check_audio_deamon.sh ; then
+    pipewire_utils.py detect -t audio -c sinks
+  else
+    pactl_list.sh sinks
+  fi
 _description:
   Test to detect if there's available sinks
 
@@ -387,10 +462,14 @@ id: audio/detect_sources
 estimated_duration: 1.0
 imports: from com.canonical.plainbox import manifest
 requires:
-  package.name == 'pulseaudio-utils'
+  package.name in ['pulseaudio-utils', 'pipewire']
   manifest.has_audio_capture == 'True'
 command:
-  pactl_list.sh sources
+  if check_audio_deamon.sh ; then
+    pipewire_utils.py detect -t audio -c sources
+  else
+    pactl_list.sh sources
+  fi
 _description:
   Test to detect if there's available sources.
 
@@ -471,14 +550,20 @@ requires:
  dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower','Space-saving','All In One','All-In-One','AIO']
  device.category == 'AUDIO'
  package.name == 'alsa-base'
- package.name == 'pulseaudio-utils'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
-  audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-  audio_settings.py set --device=pci --volume=50
-  alsa_record_playback.sh
-  EXIT_CODE=$?
-  audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    alsa_record_playback.sh
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --device=pci --volume=50
+    alsa_record_playback.sh
+    EXIT_CODE=$?
+    audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
   exit $EXIT_CODE
 _description:
  PURPOSE:
@@ -497,8 +582,13 @@ flags: also-after-suspend
 estimated_duration: 60.0
 requires:
  device.category == 'AUDIO'
- package.name == 'pulseaudio-utils'
-command: pulse_active_port_change.py sinks
+ package.name in ['pulseaudio-utils', 'pipewire']
+command: 
+  if check_audio_deamon.sh ; then
+    pipewire_utils.py monitor -t 30 -m sinks
+  else
+    pulse_active_port_change.py sinks
+  fi
 _description:
  PURPOSE:
      Check that system detects speakers or headphones being plugged in
@@ -519,8 +609,13 @@ flags: also-after-suspend
 estimated_duration: 60.0
 requires:
  device.category == 'AUDIO'
- package.name == 'pulseaudio-utils'
-command: pulse_active_port_change.py sources
+ package.name in ['pulseaudio-utils', 'pipewire']
+command: 
+  if check_audio_deamon.sh ; then
+    pipewire_utils.py monitor -t 30 -m sources
+  else
+    pulse_active_port_change.py sources
+  fi
 _description:
  PURPOSE:
      Check that system detects a microphone being plugged in
@@ -544,14 +639,20 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 10 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
     audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
     audio_settings.py set --device=pci --volume=50
     gst_pipeline_test.py -t 10 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
     audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-    exit $EXIT_CODE
+  fi
+  exit $EXIT_CODE
 _description:
  PURPOSE:
      Check that balance control works correctly on internal speakers
@@ -573,13 +674,19 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
-  audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-  audio_settings.py set --device=pci --volume=50
-  gst_pipeline_test.py -t 10 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
-  EXIT_CODE=$?
-  audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 10 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --device=pci --volume=50
+    gst_pipeline_test.py -t 10 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
   exit $EXIT_CODE
 _description:
  PURPOSE:
@@ -612,13 +719,19 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
-  audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-  audio_settings.py set --device=pci --volume=50
-  gst_pipeline_test.py -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
-  EXIT_CODE=$?
-  audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --device=pci --volume=50
+    gst_pipeline_test.py -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
   exit $EXIT_CODE
 _description:
  PURPOSE:
@@ -641,10 +754,16 @@ requires:
  package.name == 'gir1.2-gstreamer-1.0'
  package.name == 'libgstreamer1.0-0'
  package.name == 'gstreamer1.0-plugins-good'
- package.name == 'gstreamer1.0-pulseaudio'
+ package.name in ['gstreamer1.0-pulseaudio', 'gstreamer1.0-pipewire']
  package.name == 'alsa-base'
+ package.name in ['pulseaudio-utils', 'pipewire']
  device.category == 'AUDIO'
 command: audio_test.py
+  if check_audio_deamon.sh ; then
+    pipewire_test.py
+  else
+    audio_test.py
+  fi
 _description:
  Play back a sound on the default output and listen for it on the
  default input, after suspending 30 times.
@@ -654,9 +773,13 @@ category_id: com.canonical.plainbox::audio
 id: audio/detect_sinks_sources_after_suspend_30_cycles
 estimated_duration: 1.0
 requires:
-  package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
-  pactl_list.sh
+  if check_audio_deamon.sh ; then
+    pipewire_utils.py detect -t audio -c sinks
+  else
+    pactl.sh sinks
+  fi
 _description:
   Test to detect if there's available sources and sinks after suspending 30 times.
 

--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -42,7 +42,7 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -81,7 +81,7 @@ requires:
 flags: also-after-suspend
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -117,7 +117,7 @@ requires:
 flags: also-after-suspend
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -153,7 +153,7 @@ requires:
 flags: also-after-suspend
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -189,7 +189,7 @@ requires:
 flags: also-after-suspend
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -225,7 +225,7 @@ requires:
 flags: also-after-suspend
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -261,7 +261,7 @@ requires:
 flags: also-after-suspend
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -293,7 +293,7 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -326,7 +326,7 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     alsa_record_playback.sh
     EXIT_CODE=$?
   else
@@ -360,7 +360,7 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     alsa_record_playback.sh
     EXIT_CODE=$?
   else
@@ -554,7 +554,7 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     alsa_record_playback.sh
     EXIT_CODE=$?
   else
@@ -642,7 +642,7 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 10 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -677,7 +677,7 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 10 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -722,7 +722,7 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else

--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -105,7 +105,7 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -454,7 +454,7 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     alsa_record_playback.sh
     EXIT_CODE=$?
   else

--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -102,15 +102,22 @@ estimated_duration: 120.0
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_bt_smart == 'True'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
-  audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-  idx=$(pactl list cards short | awk '/bluez/{print $1}')
-  bt_sink=$(pactl list sinks short | awk '/bluez/{print $2}')
-  pactl set-card-profile "$idx" a2dp
-  pactl set-default-sink "$bt_sink"
-  gst_pipeline_test.py -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
-  EXIT_CODE=$?
-  audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    idx=$(pactl list cards short | awk '/bluez/{print $1}')
+    bt_sink=$(pactl list sinks short | awk '/bluez/{print $2}')
+    pactl set-card-profile "$idx" a2dp
+    pactl set-default-sink "$bt_sink"
+    gst_pipeline_test.py -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
   exit $EXIT_CODE
 _description:
  PURPOSE:
@@ -444,26 +451,33 @@ flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_bt_smart == 'True'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
-  audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-  idx=$(pactl list cards short | awk '/bluez/{print $1}')
-  if [ "$idx" = "" ]; then
-    echo "Please enable and pair the bluetooth headset device"
-    exit 1
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    alsa_record_playback.sh
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    idx=$(pactl list cards short | awk '/bluez/{print $1}')
+    if [ "$idx" = "" ]; then
+      echo "Please enable and pair the bluetooth headset device"
+      exit 1
+    fi
+    bt_sink=$(pactl list sinks short | awk '/bluez/{print $2}')
+    bt_profile=$(pactl list cards | awk -v RS='' '/bluez/' | awk -F':' '{print $1}' | awk '/head_unit/{print $1}')
+    pactl set-card-profile "$idx" "$bt_profile"
+    pactl set-default-sink "$bt_sink"
+    bt_source=$(pactl list sources short | awk '/bluez_source/{print $2}')
+    if [ "$bt_source" = "" ]; then
+      echo "Please check your bluetooth support HSP/HFP profile"
+      exit 1
+    fi
+    pactl set-default-source "$bt_source"
+    alsa_record_playback.sh
+    EXIT_CODE=$?
+    audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
   fi
-  bt_sink=$(pactl list sinks short | awk '/bluez/{print $2}')
-  bt_profile=$(pactl list cards | awk -v RS='' '/bluez/' | awk -F':' '{print $1}' | awk '/head_unit/{print $1}')
-  pactl set-card-profile "$idx" "$bt_profile"
-  pactl set-default-sink "$bt_sink"
-  bt_source=$(pactl list sources short | awk '/bluez_source/{print $2}')
-  if [ "$bt_source" = "" ]; then
-    echo "Please check your bluetooth support HSP/HFP profile"
-    exit 1
-  fi
-  pactl set-default-source "$bt_source"
-  alsa_record_playback.sh
-  EXIT_CODE=$?
-  audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
   exit $EXIT_CODE
 _purpose:
      This test will check the Headset Head Unit (HSP/HFP) capability of your Bluetooth device,

--- a/providers/base/units/dock/jobs.pxu
+++ b/providers/base/units/dock/jobs.pxu
@@ -260,7 +260,7 @@ flags: also-after-suspend
 estimated_duration: 30.0
 command:
  if check_audio_deamon.sh ; then
-   show_default_audio_device.sh
+   pipewire_utils.py show -t audio
    pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
    EXIT_CODE=$?
  else
@@ -294,7 +294,7 @@ flags: also-after-suspend
 estimated_duration: 30.0
 command:
  if check_audio_deamon.sh ; then
-   show_default_audio_device.sh
+   pipewire_utils.py show -t audio
    pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
    EXIT_CODE=$?
  else
@@ -329,7 +329,7 @@ plugin: user-interact-verify
 estimated_duration: 30.0
 command:
  if check_audio_deamon.sh ; then
-   show_default_audio_device.sh
+   pipewire_utils.py show -t audio
    pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
    EXIT_CODE=$?
  else
@@ -365,7 +365,7 @@ flags: also-after-suspend
 estimated_duration: 30.0
 command:
  if check_audio_deamon.sh ; then
-   show_default_audio_device.sh
+   pipewire_utils.py show -t audio
    pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
    EXIT_CODE=$?
  else
@@ -401,7 +401,7 @@ flags: also-after-suspend
 estimated_duration: 30.0
 command:
  if check_audio_deamon.sh ; then
-   show_default_audio_device.sh
+   pipewire_utils.py show -t audio
    pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
    EXIT_CODE=$?
  else
@@ -436,7 +436,7 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
  if check_audio_deamon.sh ; then
-   show_default_audio_device.sh
+   pipewire_utils.py show -t audio
    pipewire_utils.py gst -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
    EXIT_CODE=$?
  else
@@ -471,7 +471,7 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
  if check_audio_deamon.sh ; then
-   show_default_audio_device.sh
+   pipewire_utils.py show -t audio
    alsa_record_playback.sh
    EXIT_CODE=$?
  else
@@ -545,7 +545,7 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
  if check_audio_deamon.sh ; then
-   show_default_audio_device.sh
+   pipewire_utils.py show -t audio
    alsa_record_playback.sh
    EXIT_CODE=$?
  else
@@ -1194,7 +1194,7 @@ flags: also-after-suspend
 estimated_duration: 30.0
 command:
  if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
  else
@@ -1228,7 +1228,7 @@ flags: also-after-suspend
 estimated_duration: 30.0
 command:
  if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
  else
@@ -1262,7 +1262,7 @@ flags: also-after-suspend
 estimated_duration: 30.0
 command:
  if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
  else
@@ -1296,7 +1296,7 @@ flags: also-after-suspend
 estimated_duration: 30.0
 command:
  if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
  else
@@ -2895,7 +2895,7 @@ requires:
     package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     pipewire_utils.py gst -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -2972,7 +2972,7 @@ requires:
     package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_deamon.sh ; then
-    show_default_audio_device.sh
+    pipewire_utils.py show -t audio
     alsa_record_playback.sh
     EXIT_CODE=$?
   else

--- a/providers/base/units/dock/jobs.pxu
+++ b/providers/base/units/dock/jobs.pxu
@@ -253,17 +253,23 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 _summary: HDMI audio test
 plugin: user-interact-verify
 flags: also-after-suspend
 estimated_duration: 30.0
 command:
- audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --verbose --device=hdmi --volume=50
- gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
- EXIT_CODE=$?
- audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ if check_audio_deamon.sh ; then
+   show_default_audio_device.sh
+   pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+   EXIT_CODE=$?
+ else
+   audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+   audio_settings.py set --verbose --device=hdmi --volume=50
+   gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+   EXIT_CODE=$?
+   audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ fi
  exit $EXIT_CODE
 _purpose:
     Dock HDMI audio interface verification
@@ -281,17 +287,23 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 _summary: DisplayPort audio test
 plugin: user-interact-verify
 flags: also-after-suspend
 estimated_duration: 30.0
 command:
- audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --verbose --device=hdmi --volume=50
- gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
- EXIT_CODE=$?
- audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ if check_audio_deamon.sh ; then
+   show_default_audio_device.sh
+   pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+   EXIT_CODE=$?
+ else
+   audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+   audio_settings.py set --verbose --device=hdmi --volume=50
+   gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+   EXIT_CODE=$?
+   audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ fi
  exit $EXIT_CODE
 _purpose:
     Dock DisplayPort audio interface verification
@@ -311,16 +323,22 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 _summary: HDMI audio test
 plugin: user-interact-verify
 estimated_duration: 30.0
 command:
- audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --verbose --device=hdmi --volume=50
- gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
- EXIT_CODE=$?
- audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ if check_audio_deamon.sh ; then
+   show_default_audio_device.sh
+   pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+   EXIT_CODE=$?
+ else
+   audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+   audio_settings.py set --verbose --device=hdmi --volume=50
+   gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+   EXIT_CODE=$?
+   audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ fi
  exit $EXIT_CODE
 _purpose:
     Dock USB Type-C HDMI audio interface verification
@@ -340,17 +358,23 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 _summary: HDMI audio test
 plugin: user-interact-verify
 flags: also-after-suspend
 estimated_duration: 30.0
 command:
- audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --verbose --device=hdmi --volume=50
- gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
- EXIT_CODE=$?
- audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ if check_audio_deamon.sh ; then
+   show_default_audio_device.sh
+   pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+   EXIT_CODE=$?
+ else
+   audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+   audio_settings.py set --verbose --device=hdmi --volume=50
+   gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+   EXIT_CODE=$?
+   audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ fi
  exit $EXIT_CODE
 _purpose:
     Dock USB Type-C Displayport audio interface verification
@@ -369,18 +393,24 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
  manifest.has_thunderbolt3 == 'True'
 _summary: DisplayPort audio test
 plugin: user-interact-verify
 flags: also-after-suspend
 estimated_duration: 30.0
 command:
- audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --verbose --device=hdmi --volume=50
- gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
- EXIT_CODE=$?
- audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ if check_audio_deamon.sh ; then
+   show_default_audio_device.sh
+   pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+   EXIT_CODE=$?
+ else
+   audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+   audio_settings.py set --verbose --device=hdmi --volume=50
+   gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+   EXIT_CODE=$?
+   audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ fi
  exit $EXIT_CODE
 _purpose:
     Dock Thunderbolt3 audio interface verification
@@ -403,14 +433,20 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
-  audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-  audio_settings.py set --device=pci --volume=50
-  gst_pipeline_test.py -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
-  EXIT_CODE=$?
-  audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-  exit $EXIT_CODE
+ if check_audio_deamon.sh ; then
+   show_default_audio_device.sh
+   pipewire_utils.py gst -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+   EXIT_CODE=$?
+ else
+   audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+   audio_settings.py set --device=pci --volume=50
+   gst_pipeline_test.py -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+   EXIT_CODE=$?
+   audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ fi
+ exit $EXIT_CODE
 _purpose:
     This test will check that headphones connector works correctly.
     (Skip this test if there is no headphone connector on the dock)
@@ -431,14 +467,20 @@ depends: dock/audio-playback-headphones
 requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
- package.name == 'pulseaudio-utils'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
- audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --device=pci --volume=50
- alsa_record_playback.sh
- EXIT_CODE=$?
- audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ if check_audio_deamon.sh ; then
+   show_default_audio_device.sh
+   alsa_record_playback.sh
+   EXIT_CODE=$?
+ else
+   audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+   audio_settings.py set --device=pci --volume=50
+   alsa_record_playback.sh
+   EXIT_CODE=$?
+   audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ fi
  exit $EXIT_CODE
 _purpose:
     This test will check that recording sound using an external microphone works correctly
@@ -499,15 +541,21 @@ _summary: Line-in connection test
 requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
- package.name == 'pulseaudio-utils'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
-  audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-  audio_settings.py set --device=pci --volume=50
-  alsa_record_playback.sh
-  EXIT_CODE=$?
-  audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-  exit $EXIT_CODE
+ if check_audio_deamon.sh ; then
+   show_default_audio_device.sh
+   alsa_record_playback.sh
+   EXIT_CODE=$?
+ else
+   audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+   audio_settings.py set --device=pci --volume=50
+   alsa_record_playback.sh
+   EXIT_CODE=$?
+   audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ fi
+ exit $EXIT_CODE
 _purpose:
     Check that external line-in connection works correctly
     (Skip this test if the dock does not have a line in connector)
@@ -526,8 +574,13 @@ estimated_duration: 60.0
 _summary: Headphones recognized when plugged to the dock test
 requires:
  device.category == 'AUDIO'
- package.name == 'pulseaudio-utils'
-command: pulse_active_port_change.py sinks
+ package.name in ['pulseaudio-utils', 'pipewire']
+command:
+  if check_audio_deamon.sh ; then
+    pipewire_utils.py monitor -t 30 -m sinks
+  else
+    pulse_active_port_change.py sinks
+  fi
 _purpose:
     Check that system detects speakers or headphones being plugged in
     (Skip this test if the dock does not have headphones connector)
@@ -549,8 +602,13 @@ estimated_duration: 60.0
 _summary: Microphone recognized when plugged to the dock test
 requires:
  device.category == 'AUDIO'
- package.name == 'pulseaudio-utils'
-command: pulse_active_port_change.py sources
+ package.name in ['pulseaudio-utils', 'pipewire']
+command:
+  if check_audio_deamon.sh ; then
+    pipewire_utils.py monitor -t 30 -m sources
+  else
+    pulse_active_port_change.py sources
+  fi
 _purpose:
     Check that system detects a microphone being plugged in
     (Skip this test if the dock does not have a microphone connector)
@@ -1129,17 +1187,23 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 _summary: HDMI audio test
 plugin: user-interact-verify
 flags: also-after-suspend
 estimated_duration: 30.0
 command:
- audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --verbose --device=hdmi --volume=50
- gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
- EXIT_CODE=$?
- audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+ else
+    audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --verbose --device=hdmi --volume=50
+    gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ fi
  exit $EXIT_CODE
 _purpose:
     Dock USB Type-C Displayport audio interface verification
@@ -1157,17 +1221,23 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 _summary: HDMI audio test
 plugin: user-interact-verify
 flags: also-after-suspend
 estimated_duration: 30.0
 command:
- audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --verbose --device=hdmi --volume=50
- gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
- EXIT_CODE=$?
- audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+ else
+    audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --verbose --device=hdmi --volume=50
+    gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ fi
  exit $EXIT_CODE
 _purpose:
     Dock Thunderbolt3 audio interface verification
@@ -1185,17 +1255,23 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 _summary: DisplayPort audio test
 plugin: user-interact-verify
 flags: also-after-suspend
 estimated_duration: 30.0
 command:
- audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --verbose --device=hdmi --volume=50
- gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
- EXIT_CODE=$?
- audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+ else
+    audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --verbose --device=hdmi --volume=50
+    gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ fi
  exit $EXIT_CODE
 _purpose:
     Dock DisplayPort audio interface verification
@@ -1213,17 +1289,23 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 _summary: HDMI audio test
 plugin: user-interact-verify
 flags: also-after-suspend
 estimated_duration: 30.0
 command:
- audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --verbose --device=hdmi --volume=50
- gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
- EXIT_CODE=$?
- audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+ else
+    audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --verbose --device=hdmi --volume=50
+    gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+ fi
  exit $EXIT_CODE
 _purpose:
     Dock HDMI audio interface verification
@@ -1742,10 +1824,16 @@ requires:
  package.name == 'gir1.2-gstreamer-1.0'
  package.name == 'libgstreamer1.0-0'
  package.name == 'gstreamer1.0-plugins-good'
- package.name == 'gstreamer1.0-pulseaudio'
+ package.name in ['gstreamer1.0-pulseaudio', 'gstreamer1.0-pipewire']
  package.name == 'alsa-base'
+ package.name in ['pulseaudio-utils', 'pipewire']
  device.category == 'AUDIO'
-command: audio_test.py
+command:
+  if check_audio_deamon.sh ; then
+    pipewire_test.py
+  else
+    audio_test.py
+  fi
 _description:
  This will check to make sure that your audio device works properly after a suspend and resume.  This may work fine with speakers and onboard microphone, however, it works best if used with a cable connecting the audio-out jack to the audio-in jack.
 
@@ -2452,19 +2540,24 @@ id: dock/all-init-monitor-multi-head-audio-playback
 category_id: dock-audio
 requires:
     device.category == 'AUDIO'
+    package.name in ['pulseaudio-utils', 'pipewire']
 _summary: Multiple monitor audio test
 plugin: user-interact-verify
 estimated_duration: 60.0
 command:
-    indexes=$(pacmd list-sinks | grep -e 'index' -e 'available' | grep -B 1 -e 'available: unknown' -e 'available: yes' | grep index | awk '{print $NF}')
-    for index in $indexes
-    do
-            pacmd set-default-sink "$index"
-            audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/dockaudio_settings
-            pacmd set-sink-volume "$index" 65536
-            speaker-test -c 2 -l 1 -t wav
-            audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/dockaudio_settings
-    done
+    if check_audio_deamon.sh ; then
+        pipewire_utils.py through -m sink -c "speaker-test -c 2 -l 1 -t wav"
+    else
+        indexes=$(pacmd list-sinks | grep -e 'index' -e 'available' | grep -B 1 -e 'available: unknown' -e 'available: yes' | grep index | awk '{print $NF}')
+        for index in $indexes
+        do
+                pacmd set-default-sink "$index"
+                audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/dockaudio_settings
+                pacmd set-sink-volume "$index" 65536
+                speaker-test -c 2 -l 1 -t wav
+                audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/dockaudio_settings
+        done
+    fi
 _purpose:
     This test is to check if every external monitor on the dock can play sound.
 _steps:
@@ -2763,8 +2856,13 @@ estimated_duration: 60.0
 _summary: Headphones recognized when plugged to the dock test
 requires:
  device.category == 'AUDIO'
- package.name == 'pulseaudio-utils'
-command: pulse_active_port_change.py sinks
+ package.name in ['pulseaudio-utils', 'pipewire']
+command:
+  if check_audio_deamon.sh ; then
+    pipewire_utils.py monitor -t 30 -m sinks
+  else
+    pulse_active_port_change.py sinks
+  fi
 _purpose:
     Check that system detects speakers or headphones being plugged in.
     (Skip this test if the dock does not have headphones connector)
@@ -2794,14 +2892,20 @@ requires:
     device.category == 'AUDIO'
     package.name == 'alsa-base'
     package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
-    package.name == 'pulseaudio-utils'
+    package.name in ['pulseaudio-utils', 'pipewire']
 command:
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    pipewire_utils.py gst -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
     audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
     audio_settings.py set --device=pci --volume=50
     gst_pipeline_test.py -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
     audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-    exit $EXIT_CODE
+  fi
+  exit $EXIT_CODE
 _purpose:
     This test will check that headphones connector works correctly.
     (Skip this test if there is no headphone connector on the dock)
@@ -2828,8 +2932,13 @@ estimated_duration: 60.0
 _summary: Microphone recognized when plugged to the dock test
 requires:
  device.category == 'AUDIO'
- package.name == 'pulseaudio-utils'
-command: pulse_active_port_change.py sources
+ package.name in ['pulseaudio-utils', 'pipewire']
+command:
+  if check_audio_deamon.sh ; then
+    pipewire_utils.py monitor -t 30 -m sources
+  else
+    pulse_active_port_change.py sources
+  fi
 _purpose:
     Check that system detects a microphone being plugged in.
     (Skip this test if the dock does not have a microphone connector)
@@ -2859,15 +2968,21 @@ depends: dock/all-init-audio-microphone-plug-detection
 requires:
     device.category == 'AUDIO'
     package.name == 'alsa-base'
-    package.name == 'pulseaudio-utils'
     package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
+    package.name in ['pulseaudio-utils', 'pipewire']
 command:
+  if check_audio_deamon.sh ; then
+    show_default_audio_device.sh
+    alsa_record_playback.sh
+    EXIT_CODE=$?
+  else
     audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
     audio_settings.py set --device=pci --volume=50
     alsa_record_playback.sh
     EXIT_CODE=$?
     audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
-    exit $EXIT_CODE
+  fi
+  exit $EXIT_CODE
 _purpose:
     This test will check that recording sound using an external microphone works correctly.
     (Skip this test if the dock does not have a microphone connector)

--- a/providers/base/units/suspend/suspend.pxu
+++ b/providers/base/units/suspend/suspend.pxu
@@ -31,8 +31,14 @@ estimated_duration: 1.0
 requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
+ package.name in ['pulseaudio-utils', 'pipewire']
 _summary: Record mixer settings before suspending.
-command: audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/audio_settings_before_suspend
+command:
+  if check_audio_deamon.sh ; then
+    wpctl status | sed 's/pid:.*/]/g' > "$PLAINBOX_SESSION_SHARE"/audio_settings_before_suspend
+  else
+    audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/audio_settings_before_suspend
+  fi
 
 plugin: shell
 category_id: com.canonical.plainbox::suspend
@@ -432,10 +438,15 @@ estimated_duration: 1.0
 requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
+ package.name in ['pulseaudio-utils', 'pipewire']
 depends: suspend/suspend_advanced_auto suspend/audio_before_suspend
 _description: Verify that mixer settings after suspend are the same as before suspend.
 command:
-  audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/audio_settings_after_suspend
+  if check_audio_deamon.sh ; then
+      wpctl status | sed 's/pid:.*/]/g' > "$PLAINBOX_SESSION_SHARE"/audio_settings_after_suspend
+  else
+      audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/audio_settings_after_suspend
+  fi
   diff "$PLAINBOX_SESSION_SHARE"/audio_settings_before_suspend "$PLAINBOX_SESSION_SHARE"/audio_settings_after_suspend
 
 plugin: shell
@@ -445,10 +456,15 @@ estimated_duration: 1.2
 requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
+ package.name in ['pulseaudio-utils', 'pipewire']
 depends: suspend/suspend_advanced_auto suspend/audio_before_suspend
 _description: Verify that mixer settings after suspend are the same as before suspend.
 command:
-  audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/audio_settings_after_suspend
+  if check_audio_deamon.sh ; then
+    wpctl status | sed 's/pid:.*/]/g' > "$PLAINBOX_SESSION_SHARE"/audio_settings_after_suspend
+  else
+    audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/audio_settings_after_suspend
+  fi
   diff "$PLAINBOX_SESSION_SHARE"/audio_settings_before_suspend "$PLAINBOX_SESSION_SHARE"/audio_settings_after_suspend
 
 plugin: user-interact


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->
1. using `check_audio_deamon.sh` to check what environment is under testing to use right function for testing
2. Under pipewire, using `pw-dump` and `wpctl` to replace `pactl` command to collect information and settings.
3. the output of `pw-dump` is json format, therefore `pactl.py` isn't needed a alternative for pipewire.
4. `audio_settings.py` is buggy for selecting right device, change to use `show_default_audio_device.sh` to show the default device and let user to check.
5. using `wpctl status` to replace `audio_settings.py store` command

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

#327
After Ubuntu 22.04, the audio will change from pulseaudio to pipewire. Therefore, the old test case should be migrated from pulseaudio to pipewire.

[JIRA](https://warthogs.atlassian.net/browse/CQT-2094)

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
[Jira Card CQT-2396](https://warthogs.atlassian.net/browse/CQT-2396)

