### PR TITLE
Check for new commits from the main daily workflow (Infra)

### DIFF
--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -5,34 +5,11 @@ on:
   workflow_call:
 
 jobs:
-  check_history:
-    runs-on: [self-hosted, linux, large]
-    name: Check for new commits
-    outputs:
-      should_run: ${{ steps.check_log.outputs.should_run }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Check for checkbox projects new commits
-        id: check_log
-        run: |
-          git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap
-          changes=$(git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap)
-          if [[ -z $changes ]]
-            then
-              echo "should_run=false" >> $GITHUB_OUTPUT
-            else
-              echo "should_run=true" >> $GITHUB_OUTPUT
-          fi
-
   snap:
     strategy:
       matrix:
         releases: [16, 18, 20, 22]
         arch: [amd64, arm64, armhf]
-    needs: check_history
-    if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, linux, large]
     env:
       SERIES: series${{ matrix.releases }}

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -5,34 +5,11 @@ on:
   workflow_call:
 
 jobs:
-  check_history:
-    runs-on: [self-hosted, linux, large]
-    name: Check for new commits
-    outputs:
-      should_run: ${{ steps.check_log.outputs.should_run }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Check for checkbox snap new commits
-        id: check_log
-        run: |
-          git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap
-          changes=$(git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap)
-          if [ -z $changes ]
-            then
-              echo "should_run=false" >> $GITHUB_OUTPUT
-            else
-              echo "should_run=true" >> $GITHUB_OUTPUT
-          fi
-
   snap:
     strategy:
       matrix:
         type: [classic, uc]
         releases: [16, 18, 20, 22]
-    needs: check_history
-    if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, linux, large]
     env:
       SERIES: series_${{ matrix.type }}${{ matrix.releases }}

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -6,12 +6,35 @@ on:
   workflow_dispatch:
 
 jobs:
+  check_for_commits:
+    runs-on: [self-hosted, linux, large]
+    name: Check for commits
+    outputs:
+      new_commit_count: ${{ steps.commit_check.outputs.new_commit_count }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check for commits
+        id: commit_check
+        run: |
+          commit_count=$(git log --since="24 hours ago" --oneline -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap | wc -l)
+          echo "new_commit_count=$commit_count" | tee $GITHUB_OUTPUT
+
   checkbox-core-snap-daily:
+    needs: check_for_commits
+    if: ${{ needs.check_for_commits.outputs.new_commit_count > 0 || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/checkbox-core-snap-daily-builds.yml
     secrets: inherit
+
   checkbox-snap-daily:
+    needs: check_for_commits
+    if: ${{ needs.check_for_commits.outputs.new_commit_count > 0 || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/checkbox-snap-daily-builds.yml
     secrets: inherit
+
   checkbox-deb-daily:
+    needs: check_for_commits
+    if: ${{ needs.check_for_commits.outputs.new_commit_count > 0 || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/deb-daily-builds.yml
     secrets: inherit

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -5,31 +5,8 @@ on:
   workflow_call:
 
 jobs:
-  check_history:
-    runs-on: ubuntu-latest
-    name: Check for new commits
-    outputs:
-      should_run: ${{ steps.check_log.outputs.should_run }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Check for new commits to any deb
-        id: check_log
-        run: |
-          git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap
-          changes=$(git rev-list --abbrev-commit --pretty=oneline HEAD --not $(git rev-list -n1 --before="24 hours" --first-parent HEAD) -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap)
-          if [[ -z $changes ]]
-            then
-              echo "should_run=false" >> $GITHUB_OUTPUT
-            else
-              echo "should_run=true" >> $GITHUB_OUTPUT
-          fi
-
   deb_daily_builds:
     name: Debian packages daily build
-    needs: check_history
-    if: ${{ needs.check_history.outputs.should_run != 'false' }} || github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, linux, large]
     steps:
       - name: Install dependencies


### PR DESCRIPTION
## Description

Move the check for new commits from the 3 daily workflows to the top / caller workflow.

## Resolved issues

The workflow event type does not seem to be set to workflow_call thus triggering builds every day.
Problem is that ppa uploads are refused if the same version already exists in the ppa. 

Similar issue: https://github.com/actions/runner/discussions/1884

## Documentation

N/A

## Test

The manual workflow dispatch from this branch:
https://github.com/canonical/checkbox/actions/runs/6893400460
