### PR TITLE
Strip the executable stack bit on libde265.so.0.1.1, armhf only (BugFix)

### DIFF
--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -273,6 +273,12 @@ parts:
       python3 manage.py validate
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-base --root="$SNAPCRAFT_PART_INSTALL"
+      # Strip the executable stack bit on libde265.so.0.1.1
+      # Only armhf requires this modification, arm64 and amd64 both pass the
+      # automated store validation (i.e review-tools.snap-review)
+      if [ $SNAPCRAFT_TARGET_ARCH = "armhf" ]; then
+        execstack --clear-execstack $SNAPCRAFT_PART_INSTALL/usr/lib/*/libde265.so.0.1.1
+      fi
     stage-packages:
       - bc
       - bluez-tests
@@ -346,6 +352,7 @@ parts:
       - on arm64:
         - python3-rpi.gpio # only in focal
     build-packages:
+      - execstack
       - libasound2-dev
       - libcap-dev
     organize:


### PR DESCRIPTION
## Description

On armhf, libde265.so.0.1.1 triggers a review-tools warning about the executable stack (PROT_EXEC).
This patch strips it with 'execstack --clear-execstack'

## Resolved issues

Uploads to the store are blocked for the checkbox22 snap because of the following warning during automated reviews:
`Found files with executable stack. This adds PROT_EXEC to mmap(2) during mediation which may cause security denials. Either adjust your program to not require an executable stack, strip it with 'execstack --clear-execstack ...' or remove the affected file from your snap. Affected files: usr/lib/arm-linux-gnueabihf/libde265.so.0.1.1 functional-snap-v2_execstack`

## Documentation

N/A

## Tests

Tested using `snapcraft remote-build --build-on amd64,arm64,armhf`

Review tools passed:
```
$ review-tools.snap-review ./checkbox22_3.0.1.dev18+gc8878e24a.d20231120_armhf.snap
./checkbox22_3.0.1.dev18+gc8878e24a.d20231120_armhf.snap: pass
```

