### PR TITLE
Move and fix release note generation (infra)

### DIFF
--- a/.github/workflows/checkbox-stable-release.yml
+++ b/.github/workflows/checkbox-stable-release.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Install dependencies
         run: |
           which curl || (sudo apt update && sudo apt install curl -y)
-          curl https://cli.github.com/packages/githubcli-archive-keyring.gpg --output /usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo curl https://cli.github.com/packages/githubcli-archive-keyring.gpg --output /usr/share/keyrings/githubcli-archive-keyring.gpg
           sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-          sudo gpg --import /usr/share/keyrings/githubcli-archive-keyring.gpg
+          gpg --import /usr/share/keyrings/githubcli-archive-keyring.gpg
           gpg --fingerprint "2C6106201985B60E6C7AC87323F3D4EA75716059"
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
           sudo apt update -qq

--- a/.github/workflows/checkbox-stable-release.yml
+++ b/.github/workflows/checkbox-stable-release.yml
@@ -19,7 +19,6 @@ jobs:
           curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
           sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          sudo apt update
           gpg --fingerprint "2C6106201985B60E6C7AC87323F3D4EA75716059"
           sudo apt update -qq
           sudo apt install -qq -y gh

--- a/.github/workflows/checkbox-stable-release.yml
+++ b/.github/workflows/checkbox-stable-release.yml
@@ -15,11 +15,12 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: |
-          type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          which curl || (sudo apt update && sudo apt install curl -y)
+          curl https://cli.github.com/packages/githubcli-archive-keyring.gpg --output /usr/share/keyrings/githubcli-archive-keyring.gpg
           sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo gpg --import /usr/share/keyrings/githubcli-archive-keyring.gpg
           gpg --fingerprint "2C6106201985B60E6C7AC87323F3D4EA75716059"
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
           sudo apt update -qq
           sudo apt install -qq -y gh
       - name: Edit the draft release and publish it

--- a/.github/workflows/checkbox-stable-release.yml
+++ b/.github/workflows/checkbox-stable-release.yml
@@ -15,6 +15,12 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: |
+          type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt update
+          gpg --fingerprint "2C6106201985B60E6C7AC87323F3D4EA75716059"
           sudo apt update -qq
           sudo apt install -qq -y gh
       - name: Edit the draft release and publish it

--- a/.github/workflows/deb-beta-release.yml
+++ b/.github/workflows/deb-beta-release.yml
@@ -31,10 +31,3 @@ jobs:
           attempt_limit: 3
           command: |
             tools/release/release_deb_monorepo.py
-      - name: Generate the github release note
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
-          CHECKBOX_REPO: ${{ github.repository }}
-        run: |
-          gh release create $(git describe --tags --abbrev=0 --match v*) -d --generate-notes

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -14,9 +14,9 @@ jobs:
       - name: Setup the gh repository and install gh
         run: |
           which curl || (sudo apt update && sudo apt install curl -y)
-          curl https://cli.github.com/packages/githubcli-archive-keyring.gpg --output /usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo curl https://cli.github.com/packages/githubcli-archive-keyring.gpg --output /usr/share/keyrings/githubcli-archive-keyring.gpg
           sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-          sudo gpg --import /usr/share/keyrings/githubcli-archive-keyring.gpg
+          gpg --import /usr/share/keyrings/githubcli-archive-keyring.gpg
           gpg --fingerprint "2C6106201985B60E6C7AC87323F3D4EA75716059"
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
           sudo apt update -qq

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -17,8 +17,8 @@ jobs:
           curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
           sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          sudo apt update
           gpg --fingerprint "2C6106201985B60E6C7AC87323F3D4EA75716059"
+          sudo apt update
           sudo apt install gh -y
       - name: Generate the github release note
         env:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -18,8 +18,8 @@ jobs:
           sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
           gpg --fingerprint "2C6106201985B60E6C7AC87323F3D4EA75716059"
-          sudo apt update
-          sudo apt install gh -y
+          sudo apt update -qq
+          sudo apt install -y -qq gh
       - name: Generate the github release note
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,29 @@
+name: Beta release notes
+run-name: Beta release notes for ${{ github.ref_name }}
+
+on:
+  push:
+    tags:
+        - "v*"
+  workflow_dispatch:
+
+jobs:
+  Release:
+    runs-on: [self-hosted, linux, large]
+    steps:
+      - name: Setup the gh repository and install gh
+        run: |
+          type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt update
+          gpg --fingerprint "2C6106201985B60E6C7AC87323F3D4EA75716059"
+          sudo apt install gh -y
+      - name: Generate the github release note
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
+          CHECKBOX_REPO: ${{ github.repository }}
+        run: |
+          gh release create $(git describe --tags --abbrev=0 --match v*) -d --generate-notes

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -13,13 +13,14 @@ jobs:
     steps:
       - name: Setup the gh repository and install gh
         run: |
-          type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          which curl || (sudo apt update && sudo apt install curl -y)
+          curl https://cli.github.com/packages/githubcli-archive-keyring.gpg --output /usr/share/keyrings/githubcli-archive-keyring.gpg
           sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo gpg --import /usr/share/keyrings/githubcli-archive-keyring.gpg
           gpg --fingerprint "2C6106201985B60E6C7AC87323F3D4EA75716059"
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
           sudo apt update -qq
-          sudo apt install -y -qq gh
+          sudo apt install -qq -y gh
       - name: Generate the github release note
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This sets-up the environment and installs gh, generating the release note after. This also moves the action to a new workflow for release note generation

## Resolved issues

gh is missing from the image on SHR, we need to install it first. 

## Documentation

N/A

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

