### PR TITLE
Add the app_context module (New)

### DIFF
--- a/checkbox-ng/checkbox_ng/app_context.py
+++ b/checkbox-ng/checkbox_ng/app_context.py
@@ -1,0 +1,56 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+This module provides functions helping in determining how and where Checkbox
+is being run.
+"""
+
+import os
+
+from functools import lru_cache
+
+
+@lru_cache
+def on_core():
+    """
+    Return True if we are running on Ubuntu Core. False otherwise.
+
+    If we get an exception while trying to read the file, we let it bubble up.
+    """
+
+    with open("/etc/os-release") as os_release_file:
+        return any(
+            line.startswith("NAME=Ubuntu Core") for line in os_release_file
+        )
+
+
+def application_name():
+    """
+    Return the name of the application.
+
+    In case of snaps this means the full name of current snap. For example:
+    checkbox-acme
+
+    If the snap is just a generic checkbox snap, then the name will be just
+    checkbox.
+
+    If we're running from within a deb package, then the name will always be
+    checkbox, as the project-specific providers don't change the name of the
+    checkbox application.
+    """
+
+    return os.environ.get("SNAP_NAME", "checkbox")

--- a/checkbox-ng/checkbox_ng/app_context.py
+++ b/checkbox-ng/checkbox_ng/app_context.py
@@ -33,9 +33,8 @@ def on_core():
     """
 
     with open("/etc/os-release") as os_release_file:
-        return any(
-            line.startswith("NAME=Ubuntu Core") for line in os_release_file
-        )
+        contents = os_release_file.readlines()
+        return any(line.startswith("NAME=Ubuntu Core") for line in contents)
 
 
 def application_name():

--- a/checkbox-ng/checkbox_ng/app_context.py
+++ b/checkbox-ng/checkbox_ng/app_context.py
@@ -24,7 +24,7 @@ import os
 from functools import lru_cache
 
 
-@lru_cache
+@lru_cache(maxsize=1)
 def on_core():
     """
     Return True if we are running on Ubuntu Core. False otherwise.

--- a/checkbox-ng/checkbox_ng/test_app_context.py
+++ b/checkbox-ng/checkbox_ng/test_app_context.py
@@ -1,0 +1,66 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for app_context module."""
+
+from unittest import TestCase
+from unittest.mock import mock_open, patch
+
+from checkbox_ng.app_context import application_name, on_core
+
+
+class OnCoreTests(TestCase):
+    def test_really_on_core(self):
+        on_core.cache_clear()
+        the_mock = mock_open(read_data="NAME=Ubuntu Core")
+
+        with patch("builtins.open", the_mock):
+            self.assertEqual(on_core(), True)
+
+    def test_not_on_core(self):
+        on_core.cache_clear()
+        the_mock = mock_open(read_data="NAME=Ubuntu")
+
+        with patch("builtins.open", the_mock):
+            self.assertEqual(on_core(), False)
+
+    def test_really_on_core_second_line(self):
+        on_core.cache_clear()
+        the_mock = mock_open(read_data="foobar\nNAME=Ubuntu Core")
+
+        with patch("builtins.open", the_mock):
+            self.assertEqual(on_core(), True)
+
+    def test_not_on_core_empty_os_release(self):
+        on_core.cache_clear()
+        the_mock = mock_open(read_data="")
+
+        with patch("builtins.open", the_mock):
+            self.assertEqual(on_core(), False)
+
+
+class ApplicationNameTests(TestCase):
+    def test_snap_name(self):
+        with patch.dict("os.environ", {"SNAP_NAME": "checkbox-acme"}):
+            self.assertEqual(application_name(), "checkbox-acme")
+
+    def test_snap_name_generic(self):
+        with patch.dict("os.environ", {"SNAP_NAME": "checkbox"}):
+            self.assertEqual(application_name(), "checkbox")
+
+    def test_deb_package(self):
+        with patch.dict("os.environ", {}, clear=True):
+            self.assertEqual(application_name(), "checkbox")


### PR DESCRIPTION
## Description
The function checking if we're running on Ubuntu Core was previously defined very deep in the unit definition module. This module exposes it for all interested callers. 
Similarly I'm adding a unified way of checking what is the name of the snap we're running from so it's easier to determine so called "app_id" later on (which is used by session assistant to filter out sessions, for instance).

## Tests
The proposed module is mirrored by the test_app_context.py with unit tests.