### PR TITLE
Dont require gpg pass when running tests (BugFix)

### DIFF
--- a/checkbox-ng/plainbox/test_provider_manager.py
+++ b/checkbox-ng/plainbox/test_provider_manager.py
@@ -240,7 +240,8 @@ class ProviderManagerToolTests(TestCase):
         """
         verify that ``sdist`` creates a proper tarball
         """
-        self.tool.main(["sdist"])
+        with mock.patch('subprocess.call'):
+            self.tool.main(["sdist"])
         tarball = os.path.join(
             self.tmpdir, "dist", "com.example.test-1.0.tar.gz")
         self.assertTarballContent(
@@ -259,7 +260,8 @@ class ProviderManagerToolTests(TestCase):
         even if some files are missing
         """
         shutil.rmtree(os.path.join(self.tmpdir, "jobs"))
-        self.tool.main(["sdist"])
+        with mock.patch('subprocess.call'):
+            self.tool.main(["sdist"])
         tarball = os.path.join(
             self.tmpdir, "dist", "com.example.test-1.0.tar.gz")
         self.assertNoTarballContent(


### PR DESCRIPTION
## Description

Previously when the tests run, if the host had a GPG key in its databse that was protected by a password, the operator was asked to provide the password. This was due to subprocess.call not being mocked properly in the provider_manager tests.


## Tests

The test module is what gets fixed here.
