### PR TITLE
Fix connecting by hostname (BugFix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -152,7 +152,8 @@ class RemoteController(ReportsStage, MainLoopStage):
         timeout = 600
         deadline = time.time() + timeout
         port = ctx.args.port
-        if not ipaddress.ip_address(ctx.args.host).is_loopback:
+
+        if not is_hostname_a_loopback(ctx.args.host):
             print(
                 _("Connecting to {}:{}. Timeout: {}s").format(
                     ctx.args.host, port, timeout
@@ -810,3 +811,14 @@ class RemoteController(ReportsStage, MainLoopStage):
                     break
             if next_job:
                 continue
+
+
+def is_hostname_a_loopback(hostname):
+    """
+    Check if hostname is a loopback address
+    """
+    try:
+        ip_address = ipaddress.ip_address(socket.gethostbyname(hostname))
+    except socket.gaierror:
+        return False
+    return ip_address.is_loopback

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -63,6 +63,42 @@ class ControllerTests(TestCase):
 
         self.assertTrue(self_mock.connect_and_run.called)
 
+    @mock.patch("checkbox_ng.launcher.controller.is_hostname_a_loopback")
+    @mock.patch("time.time")
+    @mock.patch("builtins.print")
+    @mock.patch("os.path.exists")
+    @mock.patch("checkbox_ng.launcher.controller.Configuration.from_text")
+    @mock.patch("checkbox_ng.launcher.controller._")
+    def test_invoked_ok_for_localhost(
+        self,
+        gettext_mock,
+        configuration_mock,
+        path_exists_mock,
+        print_mock,
+        time_mock,
+        loopback_check,
+    ):
+        ctx_mock = mock.MagicMock()
+        ctx_mock.args.launcher = "example"
+        ctx_mock.args.user = "some username"
+        ctx_mock.args.host = "undertest@local"
+        ctx_mock.args.port = "9999"
+        loopback_check.return_value = True
+
+        self_mock = mock.MagicMock()
+
+        # make the check if launcher is there go through
+        path_exists_mock.return_value = True
+        # avoid monitoring time (no timeout in this test)
+        time_mock.return_value = 0
+
+        with mock.patch("builtins.open") as mm:
+            mm.return_value = mm
+            mm.read.return_value = "[launcher]\nversion=0"
+            RemoteController.invoked(self_mock, ctx_mock)
+
+        self.assertTrue(self_mock.connect_and_run.called)
+
     @mock.patch("checkbox_ng.launcher.controller.RemoteSessionAssistant")
     def test_check_remote_api_match_ok(self, remote_assistant_mock):
         """

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -26,7 +26,7 @@ from checkbox_ng.launcher.controller import is_hostname_a_loopback
 
 
 class ControllerTests(TestCase):
-    @mock.patch("ipaddress.ip_address")
+    @mock.patch("checkbox_ng.launcher.controller.is_hostname_a_loopback")
     @mock.patch("time.time")
     @mock.patch("builtins.print")
     @mock.patch("os.path.exists")
@@ -40,16 +40,14 @@ class ControllerTests(TestCase):
         path_exists_mock,
         print_mock,
         time_mock,
-        ip_address_mock,
+        loopback_check,
     ):
         ctx_mock = mock.MagicMock()
         ctx_mock.args.launcher = "example"
         ctx_mock.args.user = "some username"
         ctx_mock.args.host = "undertest@local"
         ctx_mock.args.port = "9999"
-
-        ip_address_mock.return_value = ip_address_mock
-        ip_address_mock.is_loopback = False
+        loopback_check.return_value = False
 
         self_mock = mock.MagicMock()
 

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -216,6 +216,24 @@ class IsHostnameALoopbackTests(TestCase):
         self.assertTrue(is_hostname_a_loopback("foobar"))
 
     @mock.patch("socket.gethostbyname")
+    @mock.patch("ipaddress.ip_address")
+    def test_is_hostname_a_loopback_false_case(
+        self, ip_address_mock, gethostbyname_mock
+    ):
+        """
+        Test that the is_hostname_a_loopback function returns False
+        when the ip_address claims it is not a loopback
+        """
+        gethostbyname_mock.return_value = "127.0.0.1"
+        # we still can't just use 127.0.0.1 and assume it's a loopback
+        # because that address is just a convention and it could be
+        # changed by the user, and also this is a thing just for IPv4
+        # so we need to mock the ip_address as well
+        ip_address_mock.return_value = ip_address_mock
+        ip_address_mock.is_loopback = False
+        self.assertFalse(is_hostname_a_loopback("foobar"))
+
+    @mock.patch("socket.gethostbyname")
     def test_is_hostname_a_loopback_socket_raises(self, gethostbyname_mock):
         """
         Test that the is_hostname_a_loopback function returns False


### PR DESCRIPTION
## Description
This fixes a bug where only IP addresses could be used as targets for controller.
The 4df48633 introduced a bug where using hostname as a target for the
control subcommand would yield a traceback. Usually that's not a problem
because we specify agents using IP addresses, but 'localhost' is a great
hostname that should work :)

While fixing this I outlined this check to a function, and ...

## Tests

... wrote tests for the function.