### PR TITLE
Version calculator script (infra)

### DIFF
--- a/tools/release/get_version.py
+++ b/tools/release/get_version.py
@@ -39,7 +39,7 @@ from enum import Enum
 from collections import namedtuple
 from subprocess import check_output
 
-logger = None
+logger = logging.getLogger(__name__)
 
 
 class TraceabilityEnum(Enum):
@@ -199,8 +199,6 @@ def setup_logger(log_level: str):
     """
     Sets up the global logger to the provider log_level
     """
-    global logger
-    logger = logging.getLogger(__name__)
     logger.setLevel(getattr(logging, log_level))
 
 

--- a/tools/release/get_version.py
+++ b/tools/release/get_version.py
@@ -189,7 +189,7 @@ def bump_version(version: str, needed_bump: TraceabilityEnum) -> str:
         case TraceabilityEnum.BUGFIX:
             patch += 1
         case TraceabilityEnum.INFRA:
-            ...
+            pass
         case _:
             raise ValueError(f"Unknown traceability marker {needed_bump}")
     return f"v{major}.{minor}.{patch}"
@@ -200,7 +200,7 @@ def setup_logger(verbose: bool):
     Sets up the global logger to the provider log_level
     """
     if verbose:
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.INFO)
     else:
         logger.setLevel(logging.WARNING)
 

--- a/tools/release/get_version.py
+++ b/tools/release/get_version.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+import sys
+import logging
+import argparse
+import textwrap
+
+from enum import Enum
+from collections import namedtuple
+from subprocess import check_output
+
+logger = None
+
+
+class TraceabilityEnum(Enum):
+    BREAKING = "breaking"
+    NEW = "new"
+    BUGFIX = "bugfix"
+    INFRA = "infra"
+
+    @classmethod
+    def parse(cls, trace):
+        # traceability text is in the form (trace). To be robust and
+        # not too pedantic, the string is case insensitive
+        return cls(trace.replace("(", "").replace(")", "").lower())
+
+
+FailedCategory = namedtuple("FailedCategory", ["commit", "pr"])
+
+
+def get_last_stable_release(repo_path: str) -> str:
+    """
+    Returns the last stable release (vM.m.p)
+
+    The naming convention postfixes every channel promotion with the channel
+    name and validation status except stable, we don't have any other tag in
+    the repo so to fetch the last stable release version we can get the latest
+    tag that ends with a number
+    """
+    return check_output(
+        [
+            "git",
+            "describe",
+            "--tags",
+            "--match",
+            "*[0123456789]",
+            "--abbrev=0",
+            "origin/main",
+        ],
+        cwd=repo_path,
+        text=True,
+    ).strip()
+
+
+def get_history_since(tag: str, repo_path: str) -> list[str]:
+    period = f"{tag}..HEAD"
+    # get all commit hash short descriptions in the period
+    return check_output(
+        ["git", "log", "--pretty=format:%s", period], cwd=repo_path, text=True
+    ).splitlines()
+
+
+def get_most_severe(
+    trace_one: TraceabilityEnum, trace_other: TraceabilityEnum
+) -> TraceabilityEnum:
+    severity = [
+        TraceabilityEnum.BREAKING,
+        TraceabilityEnum.NEW,
+        TraceabilityEnum.BUGFIX,
+        TraceabilityEnum.INFRA,
+    ]
+    trace_one_severity = severity.index(trace_one)
+    trace_other_severity = severity.index(trace_other)
+    return severity[min(trace_one_severity, trace_other_severity)]
+
+
+def get_needed_bump(history: list[str]) -> TraceabilityEnum:
+    """
+    Get what version number should be bumped using traceability postfixes
+
+    Breaking -> Major bump
+    New -> Minor bump
+    BugFix -> Patch bump
+    Infra -> No bump
+
+    Note: This yields a warning for commit messages are not in the format
+        Message (Traceability) (#PR)
+    """
+
+    needed_bump = TraceabilityEnum.INFRA
+    failed_category = []
+
+    # categorize all commits in the history
+    for commit_message in history:
+        *_, trace_str, pr = commit_message.rsplit(" ", 2)
+        try:
+            current_trace = TraceabilityEnum.parse(trace_str)
+        except ValueError:
+            # clean up the pr so that we can use it in the warning
+            pr = pr.replace("(", "").replace(")", "").replace("#", "")
+            failed_category.append(
+                FailedCategory(commit=commit_message, pr=pr)
+            )
+            continue
+        needed_bump = get_most_severe(needed_bump, current_trace)
+
+    # report commits that were not automatically categorized
+    if failed_category:
+        logger.warning("Failed to categorize:")
+    for failure in failed_category:
+        warning_failure_text = textwrap.dedent(
+            f"""
+            {failure.commit}
+            Check: https://github.com/canonical/checkbox/pull/{failure.pr}
+            """
+        ).strip()
+        logger.warning(warning_failure_text)
+
+    return needed_bump
+
+
+def add_dev_suffix(version: str, history_len: int):
+    return f"{version}-dev{history_len}"
+
+
+def get_bumped_version(version: str, needed_bump: TraceabilityEnum) -> str:
+    version_no_v = version.replace("v", "")
+    major, minor, patch = (int(n) for n in version_no_v.split("."))
+    if needed_bump == TraceabilityEnum.BREAKING:
+        major += 1
+        minor = 0
+        patch = 0
+    elif needed_bump == TraceabilityEnum.NEW:
+        minor += 1
+        patch = 0
+    elif needed_bump == TraceabilityEnum.BUGFIX:
+        patch += 1
+    else:
+        ...
+    return f"v{major}.{minor}.{patch}"
+
+
+def describe_bump(needed_bump: TraceabilityEnum) -> str:
+    if needed_bump == TraceabilityEnum.BREAKING:
+        return "major"
+    elif needed_bump == TraceabilityEnum.NEW:
+        return "minor"
+    elif needed_bump == TraceabilityEnum.BUGFIX:
+        return "patch"
+    return "none"
+
+
+def setup_logger(log_level: str):
+    """
+    Sets up the global logger to the provider log_level
+    """
+    global logger
+    logger = logging.getLogger(__name__)
+    logger.setLevel(getattr(logging, log_level))
+
+
+def get_cli_args(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--log",
+        choices=["ERROR", "WARNING", "INFO"],
+        help="set the log level (default: %(default)s)",
+        default="WARNING",
+    )
+    parser.add_argument(
+        "--dev-suffix",
+        action="store_true",
+        help=(
+            "add a -devXX suffix to the version where XX is the count "
+            "of commits since the latest tag"
+        ),
+    )
+    parser.add_argument(
+        "repo_path", nargs="?", help="location of the repo (default: cwd)"
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv):
+    args = get_cli_args(argv)
+    setup_logger(args.log)
+
+    last_stable_release = get_last_stable_release(args.repo_path)
+    logger.info("Last stable release:", last_stable_release)
+    history = get_history_since(last_stable_release, args.repo_path)
+    needed_bump = get_needed_bump(history)
+    if needed_bump == TraceabilityEnum.INFRA:
+        raise SystemExit("Could not detect any release worthy commit!")
+
+    final_version = bumped_version = get_bumped_version(
+        last_stable_release, needed_bump
+    )
+    if args.dev_suffix:
+        final_version = add_dev_suffix(bumped_version, len(history))
+
+    bump_reason = describe_bump(needed_bump)
+    logger.info(f"Detected necessary bump: {bump_reason}")
+    logger.info("Proposed new version:")
+
+    print(final_version)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tools/release/get_version.py
+++ b/tools/release/get_version.py
@@ -178,19 +178,20 @@ def bump_version(version: str, needed_bump: TraceabilityEnum) -> str:
     """
     version_no_v = version.replace("v", "")
     major, minor, patch = (int(n) for n in version_no_v.split("."))
-    if needed_bump == TraceabilityEnum.BREAKING:
-        major += 1
-        minor = 0
-        patch = 0
-    elif needed_bump == TraceabilityEnum.NEW:
-        minor += 1
-        patch = 0
-    elif needed_bump == TraceabilityEnum.BUGFIX:
-        patch += 1
-    elif needed_bump == TraceabilityEnum.INFRA:
-        ...
-    else:
-        raise ValueError(f"Unknown traceability marker {needed_bump}")
+    match needed_bump:
+        case TraceabilityEnum.BREAKING:
+            major += 1
+            minor = 0
+            patch = 0
+        case TraceabilityEnum.NEW:
+            minor += 1
+            patch = 0
+        case TraceabilityEnum.BUGFIX:
+            patch += 1
+        case TraceabilityEnum.INFRA:
+            ...
+        case _:
+            raise ValueError(f"Unknown traceability marker {needed_bump}")
     return f"v{major}.{minor}.{patch}"
 
 

--- a/tools/release/get_version.py
+++ b/tools/release/get_version.py
@@ -195,20 +195,22 @@ def bump_version(version: str, needed_bump: TraceabilityEnum) -> str:
     return f"v{major}.{minor}.{patch}"
 
 
-def setup_logger(log_level: str):
+def setup_logger(verbose: bool):
     """
     Sets up the global logger to the provider log_level
     """
-    logger.setLevel(getattr(logging, log_level))
+    if verbose:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.WARNING)
 
 
 def get_cli_args(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--log",
-        choices=["ERROR", "WARNING", "INFO"],
-        help="set the log level (default: %(default)s)",
-        default="WARNING",
+        "-v",
+        help="increase verbosity, describing each step",
+        action="store_true",
     )
     parser.add_argument(
         "--dev-suffix",
@@ -225,17 +227,17 @@ def get_cli_args(argv):
 
 
 def get_version(
-    dev_suffix: bool, log_level: str = "WARNING", repo_path: str = None
+    dev_suffix: bool, verbose: bool = False, repo_path: str = None
 ) -> str:
     """
     Gets the next version string after calculting the current using tags.
     When dev_suffix is true, this new version string will also include a
     suffix that indicates the number of commits since the latest tag.
     """
-    setup_logger(log_level)
+    setup_logger(verbose)
 
     last_stable_release = get_last_stable_release(repo_path)
-    logger.info("Last stable release:", last_stable_release)
+    logger.info(f"Last stable release: {last_stable_release}")
     history = get_history_since(last_stable_release, repo_path)
     needed_bump = get_needed_bump(history)
     if needed_bump == TraceabilityEnum.INFRA:
@@ -256,7 +258,7 @@ def get_version(
 
 def main(argv):
     args = get_cli_args(argv)
-    version = get_version(args.dev_suffix, args.log, args.repo_path)
+    version = get_version(args.dev_suffix, args.v, args.repo_path)
     print(version)
 
 

--- a/tools/release/get_version.py
+++ b/tools/release/get_version.py
@@ -162,7 +162,7 @@ def add_dev_suffix(version: str, history_len: int):
     return f"{version}-dev{history_len}"
 
 
-def get_bumped_version(version: str, needed_bump: TraceabilityEnum) -> str:
+def bump_version(version: str, needed_bump: TraceabilityEnum) -> str:
     """
     Increases to the correct version part given the traceability
     """
@@ -177,8 +177,10 @@ def get_bumped_version(version: str, needed_bump: TraceabilityEnum) -> str:
         patch = 0
     elif needed_bump == TraceabilityEnum.BUGFIX:
         patch += 1
-    else:
+    elif needed_bump == TraceabilityEnum.INFRA:
         ...
+    else:
+        raise ValueError(f"Unknown traceability marker {needed_bump}")
     return f"v{major}.{minor}.{patch}"
 
 
@@ -240,7 +242,7 @@ def get_version(
     if needed_bump == TraceabilityEnum.INFRA:
         raise SystemExit("Could not detect any release worthy commit!")
 
-    final_version = bumped_version = get_bumped_version(
+    final_version = bumped_version = bump_version(
         last_stable_release, needed_bump
     )
     if dev_suffix:

--- a/tools/release/get_version.py
+++ b/tools/release/get_version.py
@@ -54,6 +54,16 @@ class TraceabilityEnum(Enum):
         # not too pedantic, the string is case insensitive
         return cls(trace.replace("(", "").replace(")", "").lower())
 
+    def describe(self) -> str:
+        description = "none"
+        if self == TraceabilityEnum.BREAKING:
+            description = "major"
+        elif self == TraceabilityEnum.NEW:
+            description = "minor"
+        elif self == TraceabilityEnum.BUGFIX:
+            description = "patch"
+        return description
+
 
 FailedCategory = namedtuple("FailedCategory", ["commit", "pr"])
 
@@ -184,16 +194,6 @@ def bump_version(version: str, needed_bump: TraceabilityEnum) -> str:
     return f"v{major}.{minor}.{patch}"
 
 
-def describe_bump(needed_bump: TraceabilityEnum) -> str:
-    if needed_bump == TraceabilityEnum.BREAKING:
-        return "major"
-    elif needed_bump == TraceabilityEnum.NEW:
-        return "minor"
-    elif needed_bump == TraceabilityEnum.BUGFIX:
-        return "patch"
-    return "none"
-
-
 def setup_logger(log_level: str):
     """
     Sets up the global logger to the provider log_level
@@ -248,7 +248,7 @@ def get_version(
     if dev_suffix:
         final_version = add_dev_suffix(bumped_version, len(history))
 
-    bump_reason = describe_bump(needed_bump)
+    bump_reason = needed_bump.describe()
     logger.info(f"Detected necessary bump: {bump_reason}")
     logger.info("Proposed new version:")
 

--- a/tools/release/get_version.py
+++ b/tools/release/get_version.py
@@ -180,13 +180,12 @@ def get_cli_args(argv):
     return parser.parse_args(argv)
 
 
-def main(argv):
-    args = get_cli_args(argv)
-    setup_logger(args.log)
+def get_version(repo_path: str, dev_suffix: bool, log_level: str):
+    setup_logger(log_level)
 
-    last_stable_release = get_last_stable_release(args.repo_path)
+    last_stable_release = get_last_stable_release(repo_path)
     logger.info("Last stable release:", last_stable_release)
-    history = get_history_since(last_stable_release, args.repo_path)
+    history = get_history_since(last_stable_release, repo_path)
     needed_bump = get_needed_bump(history)
     if needed_bump == TraceabilityEnum.INFRA:
         raise SystemExit("Could not detect any release worthy commit!")
@@ -194,14 +193,20 @@ def main(argv):
     final_version = bumped_version = get_bumped_version(
         last_stable_release, needed_bump
     )
-    if args.dev_suffix:
+    if dev_suffix:
         final_version = add_dev_suffix(bumped_version, len(history))
 
     bump_reason = describe_bump(needed_bump)
     logger.info(f"Detected necessary bump: {bump_reason}")
     logger.info("Proposed new version:")
 
-    print(final_version)
+    return final_version
+
+
+def main(argv):
+    args = get_cli_args(argv)
+    version = get_version(args.repo_path, args.dev_suffix, args.log)
+    print(version)
 
 
 if __name__ == "__main__":

--- a/tools/release/test_get_version.py
+++ b/tools/release/test_get_version.py
@@ -111,7 +111,7 @@ class MainTests(unittest.TestCase):
             "v1.2.3",
             "a (new) #1\nb (breaking) #2\nc (infra) #3",
         ]
-        get_version.main(["--dev-suffix", "--log", "WARNING"])
+        get_version.main(["--dev-suffix", "-v"])
         self.assertEqual(print_mock.call_count, 1)
         # last version is v1.2.3
         # we had at least 1 breaking change, we should get v2.0.0
@@ -126,7 +126,7 @@ class MainTests(unittest.TestCase):
             "v1.2.3",
             "a (new) #1\nb (new) #2\nc (infra) #3",
         ]
-        get_version.main(["--log", "WARNING"])
+        get_version.main([])
         self.assertEqual(print_mock.call_count, 1)
         # last version is v1.2.3
         # we had at least 1 new feature, we should get v1.3.0
@@ -140,7 +140,7 @@ class MainTests(unittest.TestCase):
             "v1.2.3",
             "a (bugfix) #1\nb (infra) #2\nc (infra) #3",
         ]
-        get_version.main(["--log", "WARNING"])
+        get_version.main([])
         self.assertEqual(print_mock.call_count, 1)
         # last version is v1.2.3
         # we had at least 1 bugfix, we should get v1.2.4
@@ -157,7 +157,7 @@ class MainTests(unittest.TestCase):
         # last version is v1.2.3
         # this should fail because we didn't have any release worthy commit
         with self.assertRaises(SystemExit):
-            get_version.main(["--log", "WARNING"])
+            get_version.main([])
 
         check_output_mock.side_effect = [
             "v1.2.3",
@@ -167,4 +167,4 @@ class MainTests(unittest.TestCase):
         # this should fail because we are on a tagged commit
         # (so nothing to release here)
         with self.assertRaises(SystemExit):
-            get_version.main(["--log", "WARNING"])
+            get_version.main([])

--- a/tools/release/test_get_version.py
+++ b/tools/release/test_get_version.py
@@ -1,0 +1,170 @@
+import shlex
+import unittest
+
+from unittest.mock import MagicMock, patch, call
+
+import get_version
+from get_version import TraceabilityEnum
+
+
+@patch("get_version.logger", new=MagicMock())
+class GetVersionTests(unittest.TestCase):
+    @patch("get_version.check_output")
+    def test_get_last_stable_release(self, check_output_mock):
+        check_output_mock.return_value = "vX.Y.Z\n  "
+
+        fetched_version = get_version.get_last_stable_release("")
+
+        self.assertTrue(check_output_mock.called)
+        self.assertEqual(fetched_version, "vX.Y.Z")
+
+    @patch("get_version.check_output")
+    def test_get_history_since(self, check_output_mock):
+        check_output_mock.return_value = "commit1\ncommit2"
+
+        history = get_version.get_history_since("vX.Y.Z", "repo_path")
+        self.assertEqual(history, ["commit1", "commit2"])
+        args, kwargs = check_output_mock.call_args_list[-1]
+        self.assertEqual(kwargs["cwd"], "repo_path")
+        self.assertIn("vX.Y.Z", shlex.join(args[0]))
+
+    def test_get_most_severe(self):
+        self.assertEqual(
+            TraceabilityEnum.BREAKING,
+            get_version.get_most_severe(
+                TraceabilityEnum.BREAKING, TraceabilityEnum.NEW
+            ),
+        )
+        self.assertEqual(
+            TraceabilityEnum.NEW,
+            get_version.get_most_severe(
+                TraceabilityEnum.BUGFIX, TraceabilityEnum.NEW
+            ),
+        )
+        self.assertEqual(
+            TraceabilityEnum.BUGFIX,
+            get_version.get_most_severe(
+                TraceabilityEnum.BUGFIX, TraceabilityEnum.INFRA
+            ),
+        )
+        self.assertEqual(
+            TraceabilityEnum.INFRA,
+            get_version.get_most_severe(
+                TraceabilityEnum.INFRA, TraceabilityEnum.INFRA
+            ),
+        )
+
+    def test_get_needed_bump_breaking(self):
+        history = ["a (new) #3", "b (bugfix) #2", "c (Breaking) #1"]
+
+        needed_bump = get_version.get_needed_bump(history)
+
+        self.assertEqual(needed_bump, TraceabilityEnum.BREAKING)
+
+    def test_get_needed_bump_new(self):
+        history = ["a (new) #3", "b (bugfix) #2", "c (infra) #1"]
+
+        needed_bump = get_version.get_needed_bump(history)
+
+        self.assertEqual(needed_bump, TraceabilityEnum.NEW)
+
+    def test_get_needed_bump_bugfix(self):
+        history = ["a (bugfix) #3", "b (bugfix) #2", "c (infra) #1"]
+
+        needed_bump = get_version.get_needed_bump(history)
+
+        self.assertEqual(needed_bump, TraceabilityEnum.BUGFIX)
+
+    def test_get_needed_bump_infra(self):
+        history = ["a (infra) #3", "b (infra) #2", "c (infra) #1"]
+
+        needed_bump = get_version.get_needed_bump(history)
+
+        self.assertEqual(needed_bump, TraceabilityEnum.INFRA)
+
+    def test_get_needed_bump_warning(self):
+        history = ["a #2", "b #3"]
+
+        needed_bump = get_version.get_needed_bump(history)
+
+        # warns once per commit + a header tha explains that some commits
+        # were not categorized
+        self.assertEqual(get_version.logger.warning.call_count, 3)
+        self.assertEqual(needed_bump, TraceabilityEnum.INFRA)
+
+    def test_add_dev_suffix(self):
+        postfixed_version = get_version.add_dev_suffix("vX.Y.Z", 24)
+        self.assertEqual(postfixed_version, "vX.Y.Z-dev24")
+
+    def test_describe_bump(self):
+        # describe supports all traceability enums
+        for value in TraceabilityEnum:
+            get_version.describe_bump(value)
+
+
+@patch("logging.getLogger", new=MagicMock())
+class MainTests(unittest.TestCase):
+    @patch("get_version.check_output")
+    @patch("get_version.print")
+    def test_get_version_major(self, print_mock, check_output_mock):
+        check_output_mock.side_effect = [
+            "v1.2.3",
+            "a (new) #1\nb (breaking) #2\nc (infra) #3",
+        ]
+        get_version.main(["--dev-suffix", "--log", "WARNING"])
+        self.assertEqual(print_mock.call_count, 1)
+        # last version is v1.2.3
+        # we had at least 1 breaking change, we should get v2.0.0
+        # we asked the dev suffix and we have 3 commits in the history
+        # so it should have a -dev3 at the end
+        self.assertEqual(print_mock.call_args, call("v2.0.0-dev3"))
+
+    @patch("get_version.check_output")
+    @patch("get_version.print")
+    def test_get_version_minor(self, print_mock, check_output_mock):
+        check_output_mock.side_effect = [
+            "v1.2.3",
+            "a (new) #1\nb (new) #2\nc (infra) #3",
+        ]
+        get_version.main(["--log", "WARNING"])
+        self.assertEqual(print_mock.call_count, 1)
+        # last version is v1.2.3
+        # we had at least 1 new feature, we should get v1.3.0
+        # we didnt ask the dev suffix, so it shouldnt be there
+        self.assertEqual(print_mock.call_args, call("v1.3.0"))
+
+    @patch("get_version.check_output")
+    @patch("get_version.print")
+    def test_get_version_patch(self, print_mock, check_output_mock):
+        check_output_mock.side_effect = [
+            "v1.2.3",
+            "a (bugfix) #1\nb (infra) #2\nc (infra) #3",
+        ]
+        get_version.main(["--log", "WARNING"])
+        self.assertEqual(print_mock.call_count, 1)
+        # last version is v1.2.3
+        # we had at least 1 bugfix, we should get v1.2.4
+        # we didnt ask the dev suffix, so it shouldnt be there
+        self.assertEqual(print_mock.call_args, call("v1.2.4"))
+
+    @patch("get_version.check_output")
+    @patch("get_version.print")
+    def test_get_version_error(self, print_mock, check_output_mock):
+        check_output_mock.side_effect = [
+            "v1.2.3",
+            "a (infra) #1\nb (infra) #2\nc (infra) #3",
+        ]
+        # last version is v1.2.3
+        # this should fail because we didn't have any release worthy commit
+        with self.assertRaises(SystemExit):
+            get_version.main(["--log", "WARNING"])
+
+        check_output_mock.side_effect = [
+            "v1.2.3",
+            "",
+        ]
+        # last version is v1.2.3
+        # this should fail because we are on a tagged commit
+        # (so nothing to release here)
+        with self.assertRaises(SystemExit):
+            get_version.main(["--log", "WARNING"])

--- a/tools/release/test_get_version.py
+++ b/tools/release/test_get_version.py
@@ -99,7 +99,7 @@ class GetVersionTests(unittest.TestCase):
     def test_describe_bump(self):
         # describe supports all traceability enums
         for value in TraceabilityEnum:
-            get_version.describe_bump(value)
+            value.describe()
 
 
 @patch("logging.getLogger", new=MagicMock())

--- a/tools/release/test_get_version.py
+++ b/tools/release/test_get_version.py
@@ -29,30 +29,9 @@ class GetVersionTests(unittest.TestCase):
         self.assertIn("vX.Y.Z", shlex.join(args[0]))
 
     def test_get_most_severe(self):
-        self.assertEqual(
-            TraceabilityEnum.BREAKING,
-            get_version.get_most_severe(
-                TraceabilityEnum.BREAKING, TraceabilityEnum.NEW
-            ),
-        )
-        self.assertEqual(
-            TraceabilityEnum.NEW,
-            get_version.get_most_severe(
-                TraceabilityEnum.BUGFIX, TraceabilityEnum.NEW
-            ),
-        )
-        self.assertEqual(
-            TraceabilityEnum.BUGFIX,
-            get_version.get_most_severe(
-                TraceabilityEnum.BUGFIX, TraceabilityEnum.INFRA
-            ),
-        )
-        self.assertEqual(
-            TraceabilityEnum.INFRA,
-            get_version.get_most_severe(
-                TraceabilityEnum.INFRA, TraceabilityEnum.INFRA
-            ),
-        )
+        self.assertTrue(TraceabilityEnum.BREAKING > TraceabilityEnum.NEW)
+        self.assertTrue(TraceabilityEnum.BUGFIX < TraceabilityEnum.NEW)
+        self.assertTrue(TraceabilityEnum.BUGFIX > TraceabilityEnum.INFRA)
 
     def test_get_needed_bump_breaking(self):
         history = ["a (new) #3", "b (bugfix) #2", "c (Breaking) #1"]


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

We need a tool to automatically calculate the version of Checkbox that we are currently building. Currently we are relying on setuptools_scm builtin mechanism but it is very unclear how to customize to meet our needs. 

This PR introduces a new script that calculates the version reading our traceability markers and outputs it to standard output. This is ment to repalce setuptools_scm version calculator in snaps and debs using the mechanism (that we already use) of defining the `SETUPTOOLS_SCM_PRETEND_VERSION` environment variable. 

Note that this new script is usable as a library so we can use it in the doc builder as well (setuptools_scm deprecated the `get_version` api)

## Resolved issues

N/A

## Documentation

N/A

## Tests

This comes with a test suite.

If you want to use this launch it via:
```
$ ./get_version.py --help
```

If you want to run the tests run:
```
$ python -m pytest -v .
``` 