### PR TITLE
Replace setuptools_scm version with new get_version script (Infra)

### DIFF
--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -27,4 +27,4 @@ jobs:
           attempt_delay: 600000 # 10min
           attempt_limit: 3
           command: |
-            tools/daily-builds/deb_daily_builds.py
+            tools/release/deb_daily_builds.py

--- a/checkbox-core-snap/prepare.sh
+++ b/checkbox-core-snap/prepare.sh
@@ -48,17 +48,15 @@ rsync -r --links ../checkbox-ng $series/
 echo "Copying over checkbox-support to $series"
 rsync -r --links ../checkbox-support $series
 echo "Dumping version in version file for $series..."
-if python3 -c 'import setuptools_scm' &> /dev/null; then
-	# setuptools_scm fetches the version calculating it from the latest tag.
-	# We use the default setuptools_scm schema refert to:
-	# https://pypi.org/project/setuptools-scm/ for more infos. Generally:
-	# no distance and clean: {tag}
-	# distance and clean: {next_version}.dev{distance}+{scm letter}{revision hash}
-	# no distance and not clean: {tag}+dYYYYMMDD
-	# distance and not clean: {next_version}.dev{distance}+{scm letter}{revision hash}.dYYYYMMDD
-	(cd .. && python3 -m setuptools_scm | grep -oP "\S+$") 2>/dev/null 1>$series/version.txt
+if which python3 1>/dev/null && which git 1>/dev/null; then
+	# get_version.py produces a version number from the traceability
+  # markers in the history of the repository in the form
+  # vX.Y.Z-devXX, where XX is the number of commits since the latest tag
+	(cd .. && python3 tools/release/get_version.py -v --dev-suffix) 1>$series/version.txt
 else
-	echo "Error: Python package 'setuptools-scm' not available."
-	echo "Please install it and try again."
+	echo "Error: python3 and git binaries are required."
+	echo "Please install them and try again."
+  echo "If they are not installed run: "
+  echo "  apt install python3 git"
 	exit 1
 fi

--- a/checkbox-core-snap/prepare.sh
+++ b/checkbox-core-snap/prepare.sh
@@ -50,13 +50,13 @@ rsync -r --links ../checkbox-support $series
 echo "Dumping version in version file for $series..."
 if which python3 1>/dev/null && which git 1>/dev/null; then
 	# get_version.py produces a version number from the traceability
-  # markers in the history of the repository in the form
-  # vX.Y.Z-devXX, where XX is the number of commits since the latest tag
+	# markers in the history of the repository in the form
+	# vX.Y.Z-devXX, where XX is the number of commits since the latest tag
 	(cd .. && python3 tools/release/get_version.py -v --dev-suffix) 1>$series/version.txt
 else
 	echo "Error: python3 and git binaries are required."
 	echo "Please install them and try again."
-  echo "If they are not installed run: "
-  echo "  apt install python3 git"
+	echo "If they are not installed run: "
+	echo "  apt install python3 git"
 	exit 1
 fi

--- a/checkbox-snap/prepare_classic.sh
+++ b/checkbox-snap/prepare_classic.sh
@@ -42,17 +42,15 @@ fi
 echo "Copying over common_series_classic/* to $series"
 rsync -r --links common_series_classic/ $series/
 echo "Dumping version in version file for $series..."
-if python3 -c 'import setuptools_scm' &> /dev/null; then
-	# setuptools_scm fetches the version calculating it from the latest tag.
-	# We use the default setuptools_scm schema refert to:
-	# https://pypi.org/project/setuptools-scm/ for more infos. Generally:
-	# no distance and clean: {tag}
-	# distance and clean: {next_version}.dev{distance}+{scm letter}{revision hash}
-	# no distance and not clean: {tag}+dYYYYMMDD
-	# distance and not clean: {next_version}.dev{distance}+{scm letter}{revision hash}.dYYYYMMDD
-	(cd .. && python3 -m setuptools_scm | grep -oP "\S+$") 2>/dev/null 1>$series/version.txt
+if which python3 1>/dev/null && which git 1>/dev/null; then
+	# get_version.py produces a version number from the traceability
+  # markers in the history of the repository in the form
+  # vX.Y.Z-devXX, where XX is the number of commits since the latest tag
+	(cd .. && python3 tools/release/get_version.py -v --dev-suffix) 1>$series/version.txt
 else
-	echo "Error: Python package 'setuptools-scm' not available."
-	echo "Please install it and try again."
+	echo "Error: python3 and git binaries are required."
+	echo "Please install them and try again."
+  echo "If they are not installed run: "
+  echo "  apt install python3 git"
 	exit 1
 fi

--- a/checkbox-snap/prepare_classic.sh
+++ b/checkbox-snap/prepare_classic.sh
@@ -44,13 +44,13 @@ rsync -r --links common_series_classic/ $series/
 echo "Dumping version in version file for $series..."
 if which python3 1>/dev/null && which git 1>/dev/null; then
 	# get_version.py produces a version number from the traceability
-  # markers in the history of the repository in the form
-  # vX.Y.Z-devXX, where XX is the number of commits since the latest tag
+	# markers in the history of the repository in the form
+	# vX.Y.Z-devXX, where XX is the number of commits since the latest tag
 	(cd .. && python3 tools/release/get_version.py -v --dev-suffix) 1>$series/version.txt
 else
 	echo "Error: python3 and git binaries are required."
 	echo "Please install them and try again."
-  echo "If they are not installed run: "
-  echo "  apt install python3 git"
+	echo "If they are not installed run: "
+	echo "  apt install python3 git"
 	exit 1
 fi

--- a/checkbox-snap/prepare_uc.sh
+++ b/checkbox-snap/prepare_uc.sh
@@ -44,13 +44,13 @@ rsync -r --links common_series_uc/ $series/
 echo "Dumping version in version file for $series..."
 if which python3 1>/dev/null && which git 1>/dev/null; then
 	# get_version.py produces a version number from the traceability
-  # markers in the history of the repository in the form
-  # vX.Y.Z-devXX, where XX is the number of commits since the latest tag
+	# markers in the history of the repository in the form
+	# vX.Y.Z-devXX, where XX is the number of commits since the latest tag
 	(cd .. && python3 tools/release/get_version.py -v --dev-suffix) 1>$series/version.txt
 else
 	echo "Error: python3 and git binaries are required."
 	echo "Please install them and try again."
-  echo "If they are not installed run: "
-  echo "  apt install python3 git"
+	echo "If they are not installed run: "
+	echo "  apt install python3 git"
 	exit 1
 fi

--- a/checkbox-snap/prepare_uc.sh
+++ b/checkbox-snap/prepare_uc.sh
@@ -42,17 +42,15 @@ fi
 echo "Copying over common_series_uc/* to $series"
 rsync -r --links common_series_uc/ $series/
 echo "Dumping version in version file for $series..."
-if python3 -c 'import setuptools_scm' &> /dev/null; then
-	# setuptools_scm fetches the version calculating it from the latest tag.
-	# We use the default setuptools_scm schema refert to:
-	# https://pypi.org/project/setuptools-scm/ for more infos. Generally:
-	# no distance and clean: {tag}
-	# distance and clean: {next_version}.dev{distance}+{scm letter}{revision hash}
-	# no distance and not clean: {tag}+dYYYYMMDD
-	# distance and not clean: {next_version}.dev{distance}+{scm letter}{revision hash}.dYYYYMMDD
-	(cd .. && python3 -m setuptools_scm | grep -oP "\S+$") 2>/dev/null 1>$series/version.txt
+if which python3 1>/dev/null && which git 1>/dev/null; then
+	# get_version.py produces a version number from the traceability
+  # markers in the history of the repository in the form
+  # vX.Y.Z-devXX, where XX is the number of commits since the latest tag
+	(cd .. && python3 tools/release/get_version.py -v --dev-suffix) 1>$series/version.txt
 else
-	echo "Error: Python package 'setuptools-scm' not available."
-	echo "Please install it and try again."
+	echo "Error: python3 and git binaries are required."
+	echo "Please install them and try again."
+  echo "If they are not installed run: "
+  echo "  apt install python3 git"
 	exit 1
 fi

--- a/checkbox-support/debian/rules
+++ b/checkbox-support/debian/rules
@@ -4,7 +4,7 @@ export SRCTOP=checkbox-support
 
 # DEBVER is the latest version as declared by the changelog
 #   it is in this form pkg_version~ubuntu(ubuntu_version)
-# pkg_version = setuptools_scm where .dev -> ~dev (to make this a valid dpkg version)
+# pkg_version = get_version() where -dev -> ~dev (to make this a valid dpkg version)
 # This is not a valid python version, remove the ~ubuntu(ubuntu_version)
 # replace ~dev -> .dev as PEP440 mandates
 DEBVER := $(shell dpkg-parsechangelog -SVersion)

--- a/tools/release/deb_daily_builds.py
+++ b/tools/release/deb_daily_builds.py
@@ -24,7 +24,7 @@ import subprocess
 
 from functools import partial
 from contextlib import suppress
-from setuptools_scm import get_version
+from get_version import get_version
 
 CONFIG_PPA_DEV_TOOLS = """{{
     'wait_max_age_hours' : 10,
@@ -97,10 +97,11 @@ def main():
     to_check = []
     # Find projects new commits from the last 24 hours
     for name, path in sorted(projects.items(), key=lambda i: i[1]):
+        version = get_version(dev_suffix=True, verbose=True)
         output = (
             run(
                 "./tools/release/lp-recipe-update-build.py checkbox "
-                "--recipe {} -n {}".format(name + "-edge", get_version()),
+                "--recipe {} -n {}".format(name + "-edge", version),
                 shell=True,
                 check=True,
             )

--- a/tools/release/lp-recipe-update-build.py
+++ b/tools/release/lp-recipe-update-build.py
@@ -23,7 +23,7 @@ recipe.
 Meant to be used as part of a checkbox release to the Hardware Certification
 public PPA and the ~checkbox-dev testing PPA.
 
-NOTE: The Hardware Certification public PPA has no further use over the 
+NOTE: The Hardware Certification public PPA has no further use over the
 ~checkbox-dev testing PPA. It is kept for historical reasons and should be
 removed at some point.
 """
@@ -87,8 +87,8 @@ def main():
             )
 
         # pre-release versions (for us, not tagged daily versions) on LP are denoted
-        # with ~dev[...] not .dev[...] as setuptools_scm marks them
-        new_version = args.new_version.replace(".dev", "~dev")
+        # with ~dev[...] not -dev[...] as setuptools_scm marks them
+        new_version = args.new_version.replace("-dev", "~dev")
 
         text = build_recipe.recipe_text
         # 0.28.0rc1 → 0.28.0~rc1


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

We have decided to use an alternative way to calculate the version. We have landed the script to do so in 7b2e8d095dcb1419671cd2d6f5a13c83b4819f30. This PR replaces all occurrences of setuptools_scm with this new script with the appropriate calling parameters. 

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/CHECKBOX-1052

## Documentation

This changes the version of produced artifacts to the one generated by the new script documented [here (link)](https://github.com/canonical/checkbox/blob/2349a73ac8c8aa81b12fa5b92c0247edb3324c7d/tools/release/get_version.py#L20)

The way the artifacts are built isn't changed by this so that will not be documented further.

## Tests

N/A

