### PR TITLE
Fix daily build by removing unsupported syntax (infra)

### DIFF
--- a/tools/release/get_version.py
+++ b/tools/release/get_version.py
@@ -36,7 +36,6 @@ import argparse
 import textwrap
 
 from enum import Enum
-from typing import Self
 from collections import namedtuple
 from subprocess import check_output
 
@@ -65,7 +64,7 @@ class TraceabilityEnum(Enum):
             description = "patch"
         return description
 
-    def __lt__(self, trace_other: Self) -> bool:
+    def __lt__(self, trace_other: 'Self') -> bool:
         severity = [
             TraceabilityEnum.INFRA,
             TraceabilityEnum.BUGFIX,


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

[This PR](https://github.com/canonical/checkbox/pull/852) has introduced an unsupported import for python3.10 (that is the standard version of python on jammy. This PR fixes this problem by removing the import for `Self` and making the annotation a string.

## Resolved issues

[Failing daily build due to the import](https://github.com/canonical/checkbox/actions/runs/7036640718)

## Documentation

N/A

## Tests

I have re-run the tests and they still all pass. I have ran the tests on ubuntu jammy and (now) they also pass there. 

