### PR TITLE
Fix gnome_randr_cycle not working under Wayland (LP:#2036172)(BugFix)

### DIFF
--- a/providers/base/bin/gnome_randr_cycle.py
+++ b/providers/base/bin/gnome_randr_cycle.py
@@ -64,8 +64,8 @@ for line in output:
         modeline = line.split()
         try:
             mode, resolution, rate = modeline[:3]
-            #ignore preferred for rate
-            rate = rate.replace('+', '')
+            # ignore preferred for rate
+            rate = rate.replace("+", "")
             width, height = [int(x) for x in resolution.split('x')]
             aspect = Fraction(width, height)
             if width < 675 or width / aspect < 530:
@@ -73,7 +73,7 @@ for line in output:
             if "*" in rate:
                 current_modes.append((monitor, resolution, mode, rate))
             if resolution in monitors[monitor]:
-                rate=rate.replace('*', '')
+                rate = rate.replace("*", "")
                 existing_rate = monitors[monitor][resolution][3]
                 if float(rate) < float(existing_rate):
                     continue
@@ -81,7 +81,7 @@ for line in output:
         except IndexError:
             continue
         except ValueError as e:
-            print(f"Invalid refresh rate format: {e}")
+            print("Invalid refresh rate format: {}".format(e))
             continue
 
 for monitor in monitors.keys():


### PR DESCRIPTION
## Description

- Change the position of current_modes to earlier.
- Compare rate and existing_rate with float instead of string.

## Resolved issues
Currently runs 'gnome_randr_cycle.py' it will just directly finish without toggling any resolution, because some code glitch, after my change, it will work as expected. 

## Tests
I run code as below on my 22.04 laptop :
``` 
$ python3 /usr/lib/checkbox-provider-base/bin/gnome_randr_cycle.py --screenshot-dir=~/tmp
Set mode 1368x768@119.83 for output eDP-1
Set mode 1600x1200@89.91 for output eDP-1
Set mode 1920x1080@89.93 for output eDP-1
Set mode 1920x1200@120.00 for output eDP-1
Set mode 1920x1200@60.00 for output eDP-1
```
It will 
- Pick up a highest refresh rate in each resolution 
- Find the top resolution per aspect
- Change resolutions and get screenshots, 
- Finally change back to original resolution, everything works as expected.


