### PR TITLE
Fix version format (infra)

### DIFF
--- a/checkbox-core-snap/prepare.sh
+++ b/checkbox-core-snap/prepare.sh
@@ -52,7 +52,7 @@ if which python3 1>/dev/null && which git 1>/dev/null; then
 	# get_version.py produces a version number from the traceability
 	# markers in the history of the repository in the form
 	# vX.Y.Z-devXX, where XX is the number of commits since the latest tag
-	(cd .. && python3 tools/release/get_version.py -v --dev-suffix) 1>$series/version.txt
+	(cd .. && python3 tools/release/get_version.py -v --dev-suffix --output-format snap) 1>$series/version.txt
 else
 	echo "Error: python3 and git binaries are required."
 	echo "Please install them and try again."

--- a/checkbox-snap/prepare_classic.sh
+++ b/checkbox-snap/prepare_classic.sh
@@ -46,7 +46,7 @@ if which python3 1>/dev/null && which git 1>/dev/null; then
 	# get_version.py produces a version number from the traceability
 	# markers in the history of the repository in the form
 	# vX.Y.Z-devXX, where XX is the number of commits since the latest tag
-	(cd .. && python3 tools/release/get_version.py -v --dev-suffix) 1>$series/version.txt
+	(cd .. && python3 tools/release/get_version.py -v --dev-suffix --output-format snap) 1>$series/version.txt
 else
 	echo "Error: python3 and git binaries are required."
 	echo "Please install them and try again."

--- a/checkbox-snap/prepare_uc.sh
+++ b/checkbox-snap/prepare_uc.sh
@@ -46,7 +46,7 @@ if which python3 1>/dev/null && which git 1>/dev/null; then
 	# get_version.py produces a version number from the traceability
 	# markers in the history of the repository in the form
 	# vX.Y.Z-devXX, where XX is the number of commits since the latest tag
-	(cd .. && python3 tools/release/get_version.py -v --dev-suffix) 1>$series/version.txt
+	(cd .. && python3 tools/release/get_version.py -v --dev-suffix --output-format snap) 1>$series/version.txt
 else
 	echo "Error: python3 and git binaries are required."
 	echo "Please install them and try again."

--- a/tools/release/deb_daily_builds.py
+++ b/tools/release/deb_daily_builds.py
@@ -24,7 +24,7 @@ import subprocess
 
 from functools import partial
 from contextlib import suppress
-from get_version import get_version
+from get_version import get_version, OutputFormats
 
 CONFIG_PPA_DEV_TOOLS = """{{
     'wait_max_age_hours' : 10,
@@ -97,7 +97,9 @@ def main():
     to_check = []
     # Find projects new commits from the last 24 hours
     for name, path in sorted(projects.items(), key=lambda i: i[1]):
-        version = get_version(dev_suffix=True, verbose=True)
+        version = get_version(
+            dev_suffix=True, output_format=OutputFormats.SNAP, verbose=True
+        )
         output = (
             run(
                 "./tools/release/lp-recipe-update-build.py checkbox "

--- a/tools/release/deb_daily_builds.py
+++ b/tools/release/deb_daily_builds.py
@@ -98,7 +98,7 @@ def main():
     # Find projects new commits from the last 24 hours
     for name, path in sorted(projects.items(), key=lambda i: i[1]):
         version = get_version(
-            dev_suffix=True, output_format=OutputFormats.SNAP, verbose=True
+            dev_suffix=True, output_format=OutputFormats.DEB, verbose=True
         )
         output = (
             run(

--- a/tools/release/get_version.py
+++ b/tools/release/get_version.py
@@ -42,6 +42,15 @@ from subprocess import check_output
 logger = logging.getLogger(__name__)
 
 
+class OutputFormats(Enum):
+    DEB = "deb"  # M.m.p~devXX
+    TAG = "tag"  # vM.m.p-devXX
+    SNAP = "snap"  # M.m.p-devXX
+
+    def __str__(self):
+        return self.value
+
+
 class TraceabilityEnum(Enum):
     BREAKING = "breaking"
     NEW = "new"
@@ -64,7 +73,7 @@ class TraceabilityEnum(Enum):
             description = "patch"
         return description
 
-    def __lt__(self, trace_other: 'Self') -> bool:
+    def __lt__(self, trace_other: "Self") -> bool:
         severity = [
             TraceabilityEnum.INFRA,
             TraceabilityEnum.BUGFIX,
@@ -159,14 +168,21 @@ def get_needed_bump(history: list[str]) -> TraceabilityEnum:
     return needed_bump
 
 
-def add_dev_suffix(version: str, history_len: int):
+def add_dev_suffix(
+    version: str, history_len: int, output_format: OutputFormats
+):
     """
     Adds the dev suffix to a version string
     """
-    return f"{version}-dev{history_len}"
+    dev_prefix = "-"
+    if output_format == OutputFormats.DEB:
+        dev_prefix = "~"
+    return f"{version}{dev_prefix}dev{history_len}"
 
 
-def bump_version(version: str, needed_bump: TraceabilityEnum) -> str:
+def bump_version(
+    version: str, needed_bump: TraceabilityEnum, output_format: OutputFormats
+) -> str:
     """
     Increases to the correct version part given the traceability
     """
@@ -186,7 +202,11 @@ def bump_version(version: str, needed_bump: TraceabilityEnum) -> str:
             pass
         case _:
             raise ValueError(f"Unknown traceability marker {needed_bump}")
-    return f"v{major}.{minor}.{patch}"
+
+    prefix = ""
+    if output_format == OutputFormats.TAG:
+        prefix = "v"
+    return f"{prefix}{major}.{minor}.{patch}"
 
 
 def setup_logger(verbose: bool):
@@ -215,13 +235,22 @@ def get_cli_args(argv):
         ),
     )
     parser.add_argument(
+        "--output-format",
+        choices=list(OutputFormats),
+        type=OutputFormats,
+        default=OutputFormats.TAG,
+    )
+    parser.add_argument(
         "repo_path", nargs="?", help="location of the repo (default: cwd)"
     )
     return parser.parse_args(argv)
 
 
 def get_version(
-    dev_suffix: bool, verbose: bool = False, repo_path: str = None
+    dev_suffix: bool,
+    output_format: OutputFormats,
+    verbose: bool = False,
+    repo_path: str = None,
 ) -> str:
     """
     Gets the next version string after calculting the current using tags.
@@ -238,10 +267,12 @@ def get_version(
         raise SystemExit("Could not detect any release worthy commit!")
 
     final_version = bumped_version = bump_version(
-        last_stable_release, needed_bump
+        last_stable_release, needed_bump, output_format
     )
     if dev_suffix:
-        final_version = add_dev_suffix(bumped_version, len(history))
+        final_version = add_dev_suffix(
+            bumped_version, len(history), output_format
+        )
 
     bump_reason = needed_bump.describe()
     logger.info(f"Detected necessary bump: {bump_reason}")
@@ -252,7 +283,9 @@ def get_version(
 
 def main(argv):
     args = get_cli_args(argv)
-    version = get_version(args.dev_suffix, args.v, args.repo_path)
+    version = get_version(
+        args.dev_suffix, args.output_format, args.v, args.repo_path
+    )
     print(version)
 
 

--- a/tools/release/get_version.py
+++ b/tools/release/get_version.py
@@ -239,6 +239,8 @@ def get_cli_args(argv):
         choices=list(OutputFormats),
         type=OutputFormats,
         default=OutputFormats.TAG,
+        help="formats the output into a valid version string for the given "
+        "choice. (default: %(default)s)"
     )
     parser.add_argument(
         "repo_path", nargs="?", help="location of the repo (default: cwd)"

--- a/tools/release/lp-recipe-update-build.py
+++ b/tools/release/lp-recipe-update-build.py
@@ -86,9 +86,7 @@ def main():
                 )
             )
 
-        # pre-release versions (for us, not tagged daily versions) on LP are denoted
-        # with ~dev[...] not -dev[...] as setuptools_scm marks them
-        new_version = args.new_version.replace("-dev", "~dev")
+        new_version = args.new_version
 
         text = build_recipe.recipe_text
         # 0.28.0rc1 → 0.28.0~rc1


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The `get_version` script is generating a version with a `v` at the beginning. This is ok if that version is used to generate the tag but not if it is used to give a version to snaps or debs. This patch introduces the `output-format` option that allows the script to generate a valid version string for tagging and snap/deb building. This also allows us to kill two birds with one stone and remove the string replacement that we did in the deb recipe updater to transform the version it was fed into a valid dpkg version.

## Resolved issues

[Yesterday deb daily builds](https://github.com/canonical/checkbox/actions/runs/7038609106) failed because the version string is invalid. 

## Documentation

The addition has an help prompt and helpful comments near the options.

## Tests

This adds two new tests to verify the deb version and snap version. To run the tests:
```bash
pytest -v .
```

