### PR TITLE
New tool to update ppa recipes (infra)

### DIFF
--- a/tools/release/lp_copy_packages.py
+++ b/tools/release/lp_copy_packages.py
@@ -25,13 +25,12 @@ without the need for rebuilding.
 
 Note: This script uses the LP_CREDENTIALS environment variable
 """
-import os
 import sys
 import datetime
 import argparse
 
-from launchpadlib.credentials import Credentials
-from launchpadlib.launchpad import Launchpad
+from utils import get_launchpad_client
+
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
@@ -41,17 +40,6 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("dest_ppa", help="Destination ppa to copy to")
 
     return parser.parse_args(argv)
-
-
-def get_launchpad_client() -> Launchpad:
-    credentials = os.getenv("LP_CREDENTIALS")
-    if not credentials:
-        raise SystemExit("LP_CREDENTIALS environment variable missing")
-
-    credentials = Credentials.from_string(credentials)
-    return Launchpad(
-        credentials, None, None, service_root="production", version="devel"
-    )
 
 
 def get_ppa(lp, ppa_name: str, ppa_owner: str):

--- a/tools/release/lp_update_recipe.py
+++ b/tools/release/lp_update_recipe.py
@@ -36,7 +36,7 @@ import argparse
 from utils import get_build_recipe
 
 
-def get_build_path(recipe_name: str):
+def get_build_path(recipe_name: str) -> str:
     # recipe name is in the form checkbox-{package}-{risk}
     package = recipe_name.split("-")[:-1]  # remove checkbox and risk
     if "provider" in recipe_name:
@@ -49,7 +49,7 @@ def get_updated_build_recipe(
     recipe_name: str,
     version: str,
     revision: str,
-):
+) -> str:
     target_path = get_build_path(recipe_name)
     new_recipe = textwrap.dedent(
         f"""
@@ -96,10 +96,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 def main(argv):
     args = parse_args(argv)
     update_build_recipe(
-        args.project,
-        args.recipe,
-        args.new_version,
-        args.revision
+        args.project, args.recipe, args.new_version, args.revision
     )
 
 

--- a/tools/release/lp_update_recipe.py
+++ b/tools/release/lp_update_recipe.py
@@ -19,14 +19,10 @@
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Kicks off a recipe build for a branch in Launchpad which has an associated
-recipe.
-Meant to be used as part of a checkbox release to the Hardware Certification
-public PPA and the ~checkbox-dev testing PPA.
+This script updates a recipe on a given ppa with the objective of
+updating the revision to build and the version of the package.
 
-NOTE: The Hardware Certification public PPA has no further use over the
-~checkbox-dev testing PPA. It is kept for historical reasons and should be
-removed at some point.
+Note: This script uses the LP_CREDENTIALS environment variable
 """
 
 import sys

--- a/tools/release/lp_update_recipe.py
+++ b/tools/release/lp_update_recipe.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Sylvain Pineau <sylvain.pineau@canonical.com>
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Kicks off a recipe build for a branch in Launchpad which has an associated
+recipe.
+Meant to be used as part of a checkbox release to the Hardware Certification
+public PPA and the ~checkbox-dev testing PPA.
+
+NOTE: The Hardware Certification public PPA has no further use over the
+~checkbox-dev testing PPA. It is kept for historical reasons and should be
+removed at some point.
+"""
+
+import sys
+import textwrap
+import argparse
+
+from utils import get_build_recipe
+
+
+def get_build_path(recipe_name: str):
+    # recipe name is in the form checkbox-{package}-{risk}
+    package = recipe_name.split("-")[:-1]  # remove checkbox and risk
+    if "provider" in recipe_name:
+        component_name = "-".join(package[2:])  # 0-1 are checkbox provider
+        return f"providers/{component_name}"
+    return "-".join(package)
+
+
+def get_updated_build_recipe(
+    recipe_name: str,
+    version: str,
+    revision: str,
+):
+    target_path = get_build_path(recipe_name)
+    new_recipe = textwrap.dedent(
+        f"""
+        # git-build-recipe format 0.4 deb-version {version}
+        lp:~checkbox-dev/checkbox/+git/support empty
+        nest-part packaging lp:~checkbox-dev/checkbox {target_path}/debian debian {revision}
+        nest-part monorepo lp:~checkbox-dev/checkbox {target_path} {target_path} {revision}
+        """
+    ).strip()
+    return new_recipe
+
+
+def update_build_recipe(
+    project_name: str,
+    recipe_name: str,
+    version: str,
+    revision: str,
+):
+    lp_recipe = get_build_recipe(project_name, recipe_name)
+    new_recipe = get_updated_build_recipe(recipe_name, version, revision)
+    lp_recipe.recipe_text = new_recipe
+    lp_recipe.lp_save()
+    print(f"Updated build recipe: {lp_recipe.web_link}")
+    print(new_recipe)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser("Update a recipe of a specific project")
+    parser.add_argument("project", help="Unique name of the project")
+    parser.add_argument(
+        "--recipe", "-r", help="Recipe name to build with", required=True
+    )
+    parser.add_argument(
+        "--new-version",
+        "-n",
+        help="New version to use in the recipe "
+        "(for debian changelog) and bzr tags.",
+        required=True,
+    )
+    parser.add_argument("--revision", help="Revision to build", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv):
+    args = parse_args(argv)
+    update_build_recipe(
+        args.project,
+        args.recipe,
+        args.new_version,
+        args.revision
+    )
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tools/release/test_lp_copy_packages.py
+++ b/tools/release/test_lp_copy_packages.py
@@ -4,29 +4,6 @@ from unittest.mock import patch, MagicMock
 import lp_copy_packages
 
 
-class TestLpCopyPackages(unittest.TestCase):
-    @patch("lp_copy_packages.Credentials")
-    @patch("lp_copy_packages.Launchpad")
-    @patch("os.getenv")
-    def test_get_launchpad_client_ok(
-        self, getenv_mock, launchpad_mock, credentials_mock
-    ):
-        getenv_mock.return_value = "some credential"
-
-        lp_client = lp_copy_packages.get_launchpad_client()
-
-        # credentials are built from the env
-        self.assertTrue(credentials_mock.from_string.called)
-        self.assertEqual(lp_client, launchpad_mock())
-
-    @patch("os.getenv")
-    def test_get_launchpad_client_no_cred(self, getenv_mock):
-        getenv_mock.return_value = None
-
-        with self.assertRaises(SystemExit):
-            lp_copy_packages.get_launchpad_client()
-
-
 class TestMain(unittest.TestCase):
     @patch("lp_copy_packages.get_launchpad_client")
     def test_main(self, get_launchpad_client_mock):

--- a/tools/release/test_lp_update_recipe.py
+++ b/tools/release/test_lp_update_recipe.py
@@ -1,0 +1,53 @@
+import unittest
+
+from unittest.mock import MagicMock, patch
+
+import lp_update_recipe
+
+
+class TestUpdateBuildRecipe(unittest.TestCase):
+    def test_get_build_path_provider(self):
+        provider_recipe_name = "checkbox-provider-name-risk"
+        self.assertEqual(
+            lp_update_recipe.get_build_path(provider_recipe_name),
+            "providers/name",
+        )
+
+    def test_get_build_path_checkbox_ng(self):
+        checkbox_ng_recipe_name = "checkbox-ng-risk"
+        self.assertEqual(
+            lp_update_recipe.get_build_path(checkbox_ng_recipe_name),
+            "checkbox-ng",
+        )
+
+    def test_get_updated_build_recipe(self):
+        new_recipe = lp_update_recipe.get_updated_build_recipe(
+            "checkbox-provider-base-edge", "X.Y.Z~dev13", "aaabbb"
+        )
+        # part path is correctly calculated
+        self.assertIn("providers/base", new_recipe)
+        # version is included in the recipe
+        self.assertIn("X.Y.Z~dev13", new_recipe)
+        # revision is also included in the recipe
+        self.assertIn("aaabbb", new_recipe)
+
+    @patch("lp_update_recipe.get_build_recipe")
+    @patch("lp_update_recipe.print")
+    def test_main(self, print_mock, get_build_path_mock):
+        lp_recipe = get_build_path_mock()
+
+        lp_update_recipe.main(
+            [
+                "checkbox",
+                "--recipe",
+                "checkbox-support-edge",
+                "--new-version",
+                "X.Y.Z~dev2",
+                "--revision",
+                "abcd",
+            ]
+        )
+        self.assertIn("X.Y.Z~dev2", lp_recipe.recipe_text)
+        self.assertIn("checkbox-support", lp_recipe.recipe_text)
+        self.assertIn("abcd", lp_recipe.recipe_text)
+        self.assertTrue(lp_recipe.lp_save.called)

--- a/tools/release/test_utils.py
+++ b/tools/release/test_utils.py
@@ -1,0 +1,28 @@
+import unittest
+
+from unittest.mock import patch
+
+import utils
+
+
+class TestUtils(unittest.TestCase):
+    @patch("utils.Credentials")
+    @patch("utils.Launchpad")
+    @patch("os.getenv")
+    def test_get_launchpad_client_ok(
+        self, getenv_mock, launchpad_mock, credentials_mock
+    ):
+        getenv_mock.return_value = "some credential"
+
+        lp_client = utils.get_launchpad_client()
+
+        # credentials are built from the env
+        self.assertTrue(credentials_mock.from_string.called)
+        self.assertEqual(lp_client, launchpad_mock())
+
+    @patch("os.getenv")
+    def test_get_launchpad_client_no_cred(self, getenv_mock):
+        getenv_mock.return_value = None
+
+        with self.assertRaises(SystemExit):
+            utils.get_launchpad_client()

--- a/tools/release/utils.py
+++ b/tools/release/utils.py
@@ -1,0 +1,44 @@
+"""
+This module contains various shared utils function used in
+multiple release scripts
+"""
+import os
+from launchpadlib.credentials import Credentials
+from launchpadlib.launchpad import Launchpad
+
+def get_launchpad_client() -> Launchpad:
+    """return Launchpad(
+        None, None, None, service_root="production", version="devel"
+    )"""
+    credentials = os.getenv("LP_CREDENTIALS")
+    if not credentials:
+        raise SystemExit("LP_CREDENTIALS environment variable missing")
+
+    credentials = Credentials.from_string(credentials)
+    return Launchpad(
+        credentials, None, None, service_root="production", version="devel"
+    )
+
+
+def get_build_recipe(project_name: str, recipe_name: str):
+    lp = get_launchpad_client()
+    try:
+        project = lp.projects[project_name]
+    except KeyError:
+        raise SystemExit(f"{project_name} was not found in Launchpad.")
+
+    if project.recipes.total_size == 0:
+        raise SystemExit(f"{project_name} does not have any recipes.")
+
+    build_recipe = (
+        recipe for recipe in project.recipes if recipe.name == recipe_name
+    )
+    try:
+        return next(build_recipe)
+    except StopIteration:
+        # There is no recipe with that name
+        all_recipe_names = ", ".join(recipe.name for recipe in project.recipes)
+        raise SystemExit(
+            f'{project} does not have a "{recipe_name}" recipe '
+            f"(possible recipes: {all_recipe_names})"
+        )

--- a/tools/release/utils.py
+++ b/tools/release/utils.py
@@ -6,6 +6,7 @@ import os
 from launchpadlib.credentials import Credentials
 from launchpadlib.launchpad import Launchpad
 
+
 def get_launchpad_client() -> Launchpad:
     """return Launchpad(
         None, None, None, service_root="production", version="devel"
@@ -33,6 +34,9 @@ def get_build_recipe(project_name: str, recipe_name: str):
     build_recipe = (
         recipe for recipe in project.recipes if recipe.name == recipe_name
     )
+    # Note: this is intentionally an iterator because every call that we make
+    #       to .name will make a GET request to LP, so we avoid the full
+    #       unwrapping of the iterator given that we only ever going to use 1
     try:
         return next(build_recipe)
     except StopIteration:


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

As a part of the effort of splitting the build process of debs into more single responsibility steps, this PR creates a new tool that splits the updating of the recipe from the script `lp-recipe-update-build.py`, making it more testable and moving the recipe to the repository (where previously it was only updated but the ground truth was in the PPA).

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/CHECKBOX-1027

## Documentation

This adds a new section at the top of the script that documents what its purpose is. The help prompt was reworded options were added and documented.

## Tests

This adds a new unit test file that covers all the additions. The utils file is tested in [this PR](https://github.com/canonical/checkbox/pull/854) that introduced the functions. Depending what PR lands first I will rebase and move the tests.

