### PR TITLE
Build deb script (infra)

### DIFF
--- a/tools/release/lp_build_monitor_recipe.py
+++ b/tools/release/lp_build_monitor_recipe.py
@@ -1,0 +1,150 @@
+import sys
+import time
+import argparse
+import textwrap
+import itertools
+
+from lazr.restfulclient.errors import BadRequest
+
+
+from utils import get_build_recipe, get_date_utc_now
+
+# delay between updates requested to LP
+LP_POLLING_DELAY = 60
+
+
+def get_new_builds(build_recipe, started_datetime):
+    """
+    Returns all builds of a recipe since started_date (UTC+0)
+    """
+    # note build_recipe.builds is sorted from newer to older
+    # using takewhile here saves quite a lot of time/requests to LP
+    # because we don't get the full history of builds but just those that we
+    # need
+    return list(
+        itertools.takewhile(
+            lambda build: build.date_first_dispatched > started_datetime,
+            build_recipe.builds,
+        )
+    )
+
+
+def wait_every_build_started(build_recipe):
+    pending_builds = build_recipe.getPendingBuildInfo()
+    while pending_builds:
+        print("Waiting some builds that are pending:")
+        print(
+            textwrap.indent(
+                "-".join(build["distroseries"] for build in pending_builds),
+                "  ",
+            )
+        )
+        time.sleep(LP_POLLING_DELAY)
+        pending_builds = build_recipe.getPendingBuildInfo()
+
+
+def start_all_build(build_recipe):
+    for series in build_recipe.distroseries:
+        try:
+            build_recipe.requestBuild(
+                pocket="Release",
+                distroseries=series,
+                archive=build_recipe.daily_build_archive_link,
+            )
+        except BadRequest:
+            print("An identical build of this recipe is already pending")
+
+
+def monitor_retry_builds(build_recipe, start_date):
+    """
+    This function monitors the builds that were started after start_date
+
+    This is how this function reacts to every build status:
+    - Successfully built - ok
+    - Needs building - wait
+    - Currently building - wait
+    - Gathering build output - wait
+    - Uploading build - wait
+    - Failed to build - retry or note failure
+    - Dependency wait - retry or note failure
+    - Chroot problem - retry or note failure
+    - Failed to upload - retry or note failure
+    - Build for superseded Source - retry or note failure
+    - Cancelling build - retry or note failure
+    - Cancelled build - retry or note failure
+
+    If a build can not be retried, once the monitoring of the others
+    is finished, this function will raise SystemExit with the list of
+    failed builds
+    """
+    builds_to_check = get_new_builds(build_recipe, start_date)
+    builds_unrecoverable = []
+    builds_ok = []
+    while builds_to_check:
+        build = builds_to_check.pop()
+        build.lp_refresh()
+        buildstate = build.buildstate
+        if buildstate == "Successfully built":
+            builds_ok.append(build)
+        elif buildstate in [
+            "Needs building",
+            "Currently building",
+            "Uploading build",
+            "Gathering build output",
+        ]:
+            # avoid flooding LP with requests
+            time.sleep(LP_POLLING_DELAY)
+            builds_to_check.insert(0, build)
+            print(f"Build ongoing with status '{buildstate}'")
+            print(f"  weblink: {build.web_link}")
+        elif build.can_be_retried:
+            time.sleep(LP_POLLING_DELAY)
+            print(f"Build failed with status '{buildstate}'")
+            print(f"  retrying: {build.web_link}")
+            build.retry()
+            builds_to_check.insert(0, build)
+        else:
+            builds_unrecoverable.append(build)
+            print(f"Build failed with status '{buildstate}' ")
+            print(f"  unrecoverable: {build.web_link}")
+
+    if builds_unrecoverable:
+        weblinks_of_failed = "\n".join(
+            build.web_link for build in builds_unrecoverable
+        )
+        raise SystemExit(
+            "The following failed and can't be recovered\n"
+            + textwrap.indent(weblinks_of_failed, "  ")
+        )
+
+
+def build_monitor_recipe(project_name: str, recipe_name: str):
+    start_time = get_date_utc_now()  # - datetime.timedelta(hours=3)
+    build_recipe = get_build_recipe(project_name, recipe_name)
+
+    start_all_build(build_recipe)
+
+    wait_every_build_started(build_recipe)
+
+    monitor_retry_builds(build_recipe, start_time)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser("Update a recipe of a specific project")
+    parser.add_argument("project", help="Unique name of the project")
+    parser.add_argument(
+        "--recipe", "-r", help="Recipe name to build with", required=True
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv):
+    args = parse_args(argv)
+    build_monitor_recipe(
+        args.project,
+        args.recipe,
+    )
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tools/release/lp_build_monitor_recipe.py
+++ b/tools/release/lp_build_monitor_recipe.py
@@ -9,7 +9,7 @@ from lazr.restfulclient.errors import BadRequest
 from utils import get_build_recipe, get_date_utc_now
 
 """
-This script builds a recipe (for the platforms requested on LP),
+This script triggers a build on a recipe (for the platforms configured on LP),
 monitoring the build process and automatically retrying any build
 that fails. If Launchpad doesn't allow to retry a build, the script
 will keep on monitoring the others, and then exit with a non-0 return
@@ -126,7 +126,7 @@ def monitor_retry_builds(build_recipe, start_date):
 
 
 def build_monitor_recipe(project_name: str, recipe_name: str):
-    start_time = get_date_utc_now()  # - datetime.timedelta(hours=3)
+    start_time = get_date_utc_now()
     build_recipe = get_build_recipe(project_name, recipe_name)
 
     start_all_build(build_recipe)
@@ -139,9 +139,7 @@ def build_monitor_recipe(project_name: str, recipe_name: str):
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser("Update a recipe of a specific project")
     parser.add_argument("project", help="Unique name of the project")
-    parser.add_argument(
-        "--recipe", "-r", help="Recipe name to build with", required=True
-    )
+    parser.add_argument("recipe", help="Recipe name to build with")
     return parser.parse_args(argv)
 
 

--- a/tools/release/lp_build_monitor_recipe.py
+++ b/tools/release/lp_build_monitor_recipe.py
@@ -6,8 +6,15 @@ import itertools
 
 from lazr.restfulclient.errors import BadRequest
 
-
 from utils import get_build_recipe, get_date_utc_now
+
+"""
+This script builds a recipe (for the platforms requested on LP),
+monitoring the build process and automatically retrying any build
+that fails. If Launchpad doesn't allow to retry a build, the script
+will keep on monitoring the others, and then exit with a non-0 return
+value.
+"""
 
 # delay between updates requested to LP
 LP_POLLING_DELAY = 60

--- a/tools/release/test_lp_build_monitor_recipe.py
+++ b/tools/release/test_lp_build_monitor_recipe.py
@@ -143,7 +143,9 @@ class TestMonitorRetryBuilds(unittest.TestCase):
         get_new_builds_mock.return_value = [build_mock]
 
         with self.assertRaises(SystemExit):
-            lp_build_monitor_recipe.monitor_retry_builds(MagicMock(), MagicMock())
+            lp_build_monitor_recipe.monitor_retry_builds(
+                MagicMock(), MagicMock()
+            )
 
         # we updated till the build reported a success
         self.assertEqual(build_mock.lp_refresh.call_count, 1)
@@ -151,3 +153,110 @@ class TestMonitorRetryBuilds(unittest.TestCase):
         self.assertEqual(build_mock.retry.call_count, 0)
         # we don't update a build that can't be retried at all
         self.assertEqual(len(build_status_evolution), 1)
+
+
+class TestMain(unittest.TestCase):
+    @patch("time.sleep", new=MagicMock())
+    @patch(
+        "lp_build_monitor_recipe.get_date_utc_now",
+        new=MagicMock(return_value=10),
+    )
+    @patch("lp_build_monitor_recipe.print", new=MagicMock())
+    @patch("lp_build_monitor_recipe.get_build_recipe")
+    def test_success(self, get_build_recipe_mock):
+        recipe_mock = get_build_recipe_mock()
+        # we are asking this to build on 3 platforms
+        recipe_mock.distroseries = ["Xenial", "Bionic", "Jammy"]
+        # every build starts and pends for some time
+        pending_build_info = [
+            [
+                {"distroseries": "Xenial"},
+                {"distroseries": "Bionic"},
+                {"distroseries": "Jammy"},
+            ],
+            [
+                {"distroseries": "Xenial"},
+            ],
+            [],
+        ]
+        recipe_mock.getPendingBuildInfo.side_effect = pending_build_info
+        # the builds started and some failed and must be retried
+        build_mock = MagicMock()
+        build_mock.date_first_dispatched = 11  # more than now, 10
+        build_mock.can_be_retried = True
+        # A build is updated via the lp_refresh function, lets do the same
+        # here but inject our test values
+        build_status_evolution = [
+            "Successfully built",
+            "Successfully built",
+            "Successfully built",
+            "Uploading build",
+            "Gathering build output",
+            "Currently building",
+            "Failed to build",
+        ]
+
+        def lp_refresh_side_effect():
+            if build_status_evolution:
+                build_mock.buildstate = build_status_evolution.pop()
+
+        build_mock.lp_refresh.side_effect = lp_refresh_side_effect
+        recipe_mock.builds = [build_mock, build_mock, build_mock]
+
+        lp_build_monitor_recipe.main(["checkbox", "--recipe", "some_recipe"])
+
+        self.assertEqual(recipe_mock.requestBuild.call_count, 3)
+        # after 3 calls all builds were started correctly
+        self.assertEqual(recipe_mock.getPendingBuildInfo.call_count, 3)
+        # only 1 build failed and was retried
+        self.assertEqual(build_mock.retry.call_count, 1)
+
+    @patch("time.sleep", new=MagicMock())
+    @patch(
+        "lp_build_monitor_recipe.get_date_utc_now",
+        new=MagicMock(return_value=10),
+    )
+    @patch("lp_build_monitor_recipe.print", new=MagicMock())
+    @patch("lp_build_monitor_recipe.get_build_recipe")
+    def test_failure(self, get_build_recipe_mock):
+        recipe_mock = get_build_recipe_mock()
+        # we are asking this to build on 3 platforms
+        recipe_mock.distroseries = ["Xenial", "Bionic", "Jammy"]
+        # every build starts and pends for some time
+        pending_build_info = [
+            [],
+        ]
+        recipe_mock.getPendingBuildInfo.side_effect = pending_build_info
+        # the builds started and some failed and must be retried
+        build_mock = MagicMock()
+        build_mock.date_first_dispatched = 11  # more than now, 10
+        build_mock.web_link = ""
+        build_mock.can_be_retried = False
+        # A build is updated via the lp_refresh function, lets do the same
+        # here but inject our test values
+        build_status_evolution = [
+            "Successfully built",
+            "Successfully built",
+            "Uploading build",
+            "Gathering build output",
+            "Currently building",
+            "Failed to build",
+        ]
+
+        def lp_refresh_side_effect():
+            if build_status_evolution:
+                build_mock.buildstate = build_status_evolution.pop()
+
+        build_mock.lp_refresh.side_effect = lp_refresh_side_effect
+        recipe_mock.builds = [build_mock, build_mock, build_mock]
+
+        with self.assertRaises(SystemExit):
+            lp_build_monitor_recipe.main(
+                ["checkbox", "--recipe", "some_recipe"]
+            )
+
+        self.assertEqual(recipe_mock.requestBuild.call_count, 3)
+        self.assertEqual(recipe_mock.getPendingBuildInfo.call_count, 1)
+        # all the build that didnt unrecoverably fail were followed to
+        # completion
+        self.assertFalse(build_status_evolution)

--- a/tools/release/test_lp_build_monitor_recipe.py
+++ b/tools/release/test_lp_build_monitor_recipe.py
@@ -1,0 +1,153 @@
+import unittest
+
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import lp_build_monitor_recipe
+
+
+class TestHelperFunctions(unittest.TestCase):
+    def test_get_new_builds(self):
+        # all builds that were created after started_datetime are returned
+        build_recipe = MagicMock()
+
+        build_selected = MagicMock()
+        build_selected.date_first_dispatched = 10
+
+        build_not_selected = MagicMock()
+        build_not_selected.date_first_dispatched = 0
+
+        build_recipe.builds = [build_selected, build_not_selected]
+        selected = lp_build_monitor_recipe.get_new_builds(build_recipe, 6)
+
+        self.assertEqual(selected, [build_selected])
+
+    @patch("time.sleep", new=MagicMock())
+    @patch("lp_build_monitor_recipe.print")
+    def test_wait_every_build_started(self, print_mock):
+        build_recipe_mock = MagicMock()
+        build_recipe_mock.getPendingBuildInfo.side_effect = [
+            [{"distroseries": "Xenial"}, {"distroseries": "Bionic"}],
+            [{"distroseries": "Xenial"}],
+            [],
+        ]
+
+        lp_build_monitor_recipe.wait_every_build_started(build_recipe_mock)
+
+        # the function waited for getPendingBuildInfo to return an empty list
+        self.assertEqual(build_recipe_mock.getPendingBuildInfo.call_count, 3)
+        # the user was notified of every pending build
+        self.assertTrue(print_mock.call_count >= 3)
+
+
+class TestMonitorRetryBuilds(unittest.TestCase):
+    @patch("time.sleep")
+    @patch("lp_build_monitor_recipe.get_new_builds")
+    def test_monitor_retry_builds_success(
+        self, get_new_builds_mock, time_sleep_mock
+    ):
+        build_mock = MagicMock()
+        build_mock.buildstate = "Successfully built"
+
+        get_new_builds_mock.return_value = [build_mock]
+
+        lp_build_monitor_recipe.monitor_retry_builds(MagicMock(), MagicMock())
+        self.assertFalse(time_sleep_mock.called)
+
+    @patch("time.sleep")
+    @patch("lp_build_monitor_recipe.get_new_builds")
+    def test_monitor_retry_builds_retry_failures(
+        self, get_new_builds_mock, time_sleep_mock
+    ):
+        build_mock = MagicMock()
+        build_mock.can_be_retried = True
+        # A build is updated via the lp_refresh function, lets do the same
+        # here but inject our test values
+        build_status_evolution = [
+            "Successfully built",
+            "Uploading build",
+            "Currently building",
+            "Failed to build",
+            "Dependency wait",
+            "Chroot problem",
+        ]
+
+        def lp_refresh_side_effect():
+            if build_status_evolution:
+                build_mock.buildstate = build_status_evolution.pop()
+
+        build_mock.lp_refresh.side_effect = lp_refresh_side_effect
+
+        get_new_builds_mock.return_value = [build_mock]
+
+        lp_build_monitor_recipe.monitor_retry_builds(MagicMock(), MagicMock())
+
+        # we updated till the build reported a success
+        self.assertEqual(build_mock.lp_refresh.call_count, 6)
+        # we didnt fload LP with requests, waiting once per progress
+        self.assertEqual(time_sleep_mock.call_count, 5)
+        # each time a failure was detected, the build was retried
+        self.assertEqual(build_mock.retry.call_count, 3)
+
+    @patch("time.sleep")
+    @patch("lp_build_monitor_recipe.get_new_builds")
+    def test_monitor_retry_builds_more_wait(
+        self, get_new_builds_mock, time_sleep_mock
+    ):
+        build_mock = MagicMock()
+        # A build is updated via the lp_refresh function, lets do the same
+        # here but inject our test values
+        build_status_evolution = [
+            "Successfully built",
+            "Uploading build",
+            "Gathering build output",
+            "Currently building",
+            "Needs building",
+        ]
+
+        def lp_refresh_side_effect():
+            if build_status_evolution:
+                build_mock.buildstate = build_status_evolution.pop()
+
+        build_mock.lp_refresh.side_effect = lp_refresh_side_effect
+
+        get_new_builds_mock.return_value = [build_mock]
+
+        lp_build_monitor_recipe.monitor_retry_builds(MagicMock(), MagicMock())
+
+        # we updated till the build reported a success
+        self.assertEqual(build_mock.lp_refresh.call_count, 5)
+        # we didnt fload LP with requests, waiting once per progress
+        self.assertEqual(time_sleep_mock.call_count, 4)
+
+    @patch("time.sleep")
+    @patch("lp_build_monitor_recipe.get_new_builds")
+    def test_monitor_retry_builds_unrecoverable_failures(
+        self, get_new_builds_mock, time_sleep_mock
+    ):
+        build_mock = MagicMock()
+        build_mock.can_be_retried = False
+        build_mock.web_link = "https://some.web.build/build"
+        # A build is updated via the lp_refresh function, lets do the same
+        # here but inject our test values
+        build_status_evolution = [
+            "-- invalid value --",
+            "Failed to upload",
+        ]
+
+        def lp_refresh_side_effect():
+            if build_status_evolution:
+                build_mock.buildstate = build_status_evolution.pop()
+
+        build_mock.lp_refresh.side_effect = lp_refresh_side_effect
+
+        get_new_builds_mock.return_value = [build_mock]
+
+        with self.assertRaises(SystemExit):
+            lp_build_monitor_recipe.monitor_retry_builds(MagicMock(), MagicMock())
+
+        # we updated till the build reported a success
+        self.assertEqual(build_mock.lp_refresh.call_count, 1)
+        # each time a failure was detected, the build was retried
+        self.assertEqual(build_mock.retry.call_count, 0)
+        # we don't update a build that can't be retried at all
+        self.assertEqual(len(build_status_evolution), 1)

--- a/tools/release/test_lp_build_monitor_recipe.py
+++ b/tools/release/test_lp_build_monitor_recipe.py
@@ -1,6 +1,6 @@
 import unittest
 
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import lp_build_monitor_recipe
 
@@ -161,7 +161,6 @@ class TestMain(unittest.TestCase):
         "lp_build_monitor_recipe.get_date_utc_now",
         new=MagicMock(return_value=10),
     )
-    @patch("lp_build_monitor_recipe.print", new=MagicMock())
     @patch("lp_build_monitor_recipe.get_build_recipe")
     def test_success(self, get_build_recipe_mock):
         recipe_mock = get_build_recipe_mock()
@@ -203,7 +202,7 @@ class TestMain(unittest.TestCase):
         build_mock.lp_refresh.side_effect = lp_refresh_side_effect
         recipe_mock.builds = [build_mock, build_mock, build_mock]
 
-        lp_build_monitor_recipe.main(["checkbox", "--recipe", "some_recipe"])
+        lp_build_monitor_recipe.main(["checkbox", "some_recipe"])
 
         self.assertEqual(recipe_mock.requestBuild.call_count, 3)
         # after 3 calls all builds were started correctly
@@ -216,7 +215,6 @@ class TestMain(unittest.TestCase):
         "lp_build_monitor_recipe.get_date_utc_now",
         new=MagicMock(return_value=10),
     )
-    @patch("lp_build_monitor_recipe.print", new=MagicMock())
     @patch("lp_build_monitor_recipe.get_build_recipe")
     def test_failure(self, get_build_recipe_mock):
         recipe_mock = get_build_recipe_mock()
@@ -251,9 +249,7 @@ class TestMain(unittest.TestCase):
         recipe_mock.builds = [build_mock, build_mock, build_mock]
 
         with self.assertRaises(SystemExit):
-            lp_build_monitor_recipe.main(
-                ["checkbox", "--recipe", "some_recipe"]
-            )
+            lp_build_monitor_recipe.main(["checkbox", "some_recipe"])
 
         self.assertEqual(recipe_mock.requestBuild.call_count, 3)
         self.assertEqual(recipe_mock.getPendingBuildInfo.call_count, 1)

--- a/tools/release/utils.py
+++ b/tools/release/utils.py
@@ -10,9 +10,6 @@ from launchpadlib.launchpad import Launchpad
 
 
 def get_launchpad_client() -> Launchpad:
-    """return Launchpad(
-        None, None, None, service_root="production", version="devel"
-    )"""
     credentials = os.getenv("LP_CREDENTIALS")
     if not credentials:
         raise SystemExit("LP_CREDENTIALS environment variable missing")

--- a/tools/release/utils.py
+++ b/tools/release/utils.py
@@ -3,6 +3,8 @@ This module contains various shared utils function used in
 multiple release scripts
 """
 import os
+import datetime
+
 from launchpadlib.credentials import Credentials
 from launchpadlib.launchpad import Launchpad
 
@@ -46,3 +48,6 @@ def get_build_recipe(project_name: str, recipe_name: str):
             f'{project} does not have a "{recipe_name}" recipe '
             f"(possible recipes: {all_recipe_names})"
         )
+
+def get_date_utc_now():
+    return datetime.datetime.now(tz=datetime.UTC)


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Currently we have no way to build packages individually, retrying failing builds individually or monitor them given a recipe (only package name). This is a problem becase even if we do discover that one build fails via ppa-dev-tools (sometimes we don't), the only action that we have is to restart every package and every build. This will 100% fail because if any of the builds in the previous trial went to completion, the PPA will reject whatever we produce in this run. 

This introduces a new script that is able to build a single recipe (for the platforms requested on LP), monitor the build process and automatically retry any build that fails. If Launchpad doesn't allow to retry a build, the script will keep on monitoring the others, and then fail. This allows it to get as many build to completion as possible for each run. 

## Resolved issues

This is part of the ground work needed by: https://warthogs.atlassian.net/browse/CHECKBOX-1058

## Documentation

The script is documented in the top level string and help function of the argument parser:wq

## Tests

This script comes with a new test suite. To run it:
```
cd checkbox/tools/release && pytest .
```

