### PR TITLE
Doc: add reference doc for submission json schema (Infra)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "[markdown]": {
-    "editor.formatOnSave": false
-  }
-}

--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -13,3 +13,4 @@ lxd-sphinx-extensions
 sphinx-copybutton
 myst-parser
 setuptools-scm
+sphinx-jsonschema

--- a/docs/.sphinx/spellingcheck.yaml
+++ b/docs/.sphinx/spellingcheck.yaml
@@ -8,7 +8,7 @@ matrix:
     - .sphinx/wordslist.txt
     output: .sphinx/.wordlist.dic
   sources:
-  - _build/**/*.html
+  - _build/**/*.html|!_build/reference/submission-schema/*
   pipeline:
   - pyspelling.filters.html:
       comments: false

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,8 @@ extensions = [
     'terminal-output',
     'sphinx_copybutton',
     'sphinxext.opengraph',
-    'myst_parser'
+    'myst_parser',
+    'sphinx-jsonschema'
     ]
 
 myst_enable_extensions = [

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -10,3 +10,4 @@ Reference
    launcher
    units/index
    snaps
+   submission-schema

--- a/docs/reference/submission-schema.rst
+++ b/docs/reference/submission-schema.rst
@@ -3,15 +3,14 @@
 Submission Schema
 ==================
 
-Checkbox :ref:`Submission files <submission-files>` provide a summary of the test results and in-depth information that help analyzing the tests. 
+Checkbox :ref:`submissions <submission-files>` contain reports of the tests and in-depth information that helps analyzing the test results. These files are sent to the :term:`Certification Website` for sharing test results.
 
-This document describes the schema the ``submission.json`` files that's sent to the `Certification website <https://certification.canonical.com>`_ as part of the submission. To get the latest schema definition file in Json, go to the Checkbox `GitHub repository <https://github.com/canonical/checkbox/blob/main/submission-schema/schema.json>`_.
+This document describes the schema of the ``submission.json`` files as part of the submission. To get the latest JSON schema file, go to the Checkbox `GitHub repository <https://github.com/canonical/checkbox/blob/main/submission-schema/schema.json>`_.
 
 .. important:: 
 
     The schema described in this document is work-in-progress and being reviewed. If you need assistance in validating the schema, please contact the Checkbox team.
-    
+        
 .. jsonschema:: ../../submission-schema/schema.json
     :lift_definitions:
     :auto_reference:
-    

--- a/docs/reference/submission-schema.rst
+++ b/docs/reference/submission-schema.rst
@@ -1,0 +1,17 @@
+.. _submission_schema:
+
+Submission Schema
+==================
+
+Checkbox :ref:`Submission files <submission-files>` provide a summary of the test results and in-depth information that help analyzing the tests. 
+
+This document describes the schema the ``submission.json`` files that's sent to the `Certification website <https://certification.canonical.com>`_ as part of the submission. To get the latest schema definition file in Json, go to the Checkbox `GitHub repository <https://github.com/canonical/checkbox/blob/main/submission-schema/schema.json>`_.
+
+.. important:: 
+
+    The schema described in this document is work-in-progress and being reviewed. If you need assistance in validating the schema, please contact the Checkbox team.
+    
+.. jsonschema:: ../../submission-schema/schema.json
+    :lift_definitions:
+    :auto_reference:
+    

--- a/docs/tutorial/using-checkbox/test-report.rst
+++ b/docs/tutorial/using-checkbox/test-report.rst
@@ -133,8 +133,10 @@ in the search bar, you can view all test results related to audio testing.
     The xz compressed tarball is a comprehensive archive that includes the 
     aforementioned reports and all associated attachments, such as I/O logs 
     and binary files. You can extract the tarball with ``tar -xf 
-    sumbission.tar.xz -C /path/to/destination``.
+    submission.tar.xz -C /path/to/destination``.
 
     Certification Website only accepts submissions tarballs, from which it 
     extracts the ``submission.json`` file to create a new test report in the 
     database. 
+
+For a detailed description of the ``submission.json`` file, see the :doc:`../../reference/submission-schema` reference.


### PR DESCRIPTION
## Description

- added reference doc for the `submission.json` schema using `sphinx-jsonschema` extension
- excluded the schema HTML from spelling check (property names will cause check failures)
- cross-reference with the Test Report tutorial

## Resolved issues

Resolves [CHECKBOX-1043](https://warthogs.atlassian.net/browse/CHECKBOX-1043)

## Documentation

Preview on Readthedocs: https://canonical-checkbox.readthedocs-hosted.com/en/doc-preview/reference/submission-schema.html

## Tests

In the `docs/` folder, run:
```
make install
make run
```
Documentation is served at http://127.0.0.1:8000/reference/submission-schema/
