### PR TITLE
New edge -> beta promotion workflow (infra)

### DIFF
--- a/.github/workflows/checkbox-beta-release.yml
+++ b/.github/workflows/checkbox-beta-release.yml
@@ -1,0 +1,86 @@
+name: Beta version of checkbox
+run-name: Promote edge versions of checkbox to beta
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release-notes:
+    runs-on: [self-hosted, linux, large]
+    steps:
+      - name: Checkout checkbox monorepo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup the gh repository and install gh
+        run: |
+          which curl || (sudo apt update && sudo apt install curl -y)
+          sudo curl https://cli.github.com/packages/githubcli-archive-keyring.gpg --output /usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          gpg --import /usr/share/keyrings/githubcli-archive-keyring.gpg
+          gpg --fingerprint "2C6106201985B60E6C7AC87323F3D4EA75716059"
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt update -qq
+          sudo apt install -qq -y gh
+      - name: Generate the github release note
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
+          CHECKBOX_REPO: ${{ github.repository }}
+        run: |
+          gh release create $(git describe --tags --abbrev=0 --match v*) -d --generate-notes
+
+  checkbox_deb_packages:
+    name: Checkbox Debian packages
+    runs-on: [self-hosted, linux, large]
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt update -qq
+          sudo apt install -qq -y python3-launchpadlib
+      - name: Checkout checkbox monorepo
+        uses: actions/checkout@v3
+      - name: Copy deb packages from edge to beta ppa
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
+          CHECKBOX_REPO: ${{ github.repository }}
+        run: |
+          tools/release/lp_copy_packages.py checkbox-dev edge checkbox-dev beta
+
+  checkbox_core_snap:
+    name: Checkbox core snap packages
+    runs-on: [self-hosted, linux, large]
+    env:
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
+    steps:
+      - name: Setup Snapcraft
+        run: |
+          sudo snap install snapcraft --classic
+      - name: Promote checkbox core snaps to the beta channel
+        run: |
+          snapcraft promote checkbox16 --from-channel latest/edge --to-channel latest/beta --yes
+          snapcraft promote checkbox18 --from-channel latest/edge --to-channel latest/beta --yes
+          snapcraft promote checkbox20 --from-channel latest/edge --to-channel latest/beta --yes
+          snapcraft promote checkbox22 --from-channel latest/edge --to-channel latest/beta --yes
+
+  checkbox_snap:
+    name: Checkbox snap packages
+    runs-on: [self-hosted, linux, large]
+    env:
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
+    steps:
+      - name: Setup Snapcraft
+        run: |
+          sudo snap install snapcraft --classic
+      - name: Promote checkbox snaps to the beta channel
+        run: |
+          snapcraft promote checkbox --from-channel uc16/edge --to-channel uc16/beta --yes
+          snapcraft promote checkbox --from-channel uc18/edge --to-channel uc18/beta --yes
+          snapcraft promote checkbox --from-channel uc20/edge --to-channel uc20/beta --yes
+          snapcraft promote checkbox --from-channel uc22/edge --to-channel uc22/beta --yes
+          snapcraft promote checkbox --from-channel 16.04/edge --to-channel 16.04/beta --yes
+          snapcraft promote checkbox --from-channel 18.04/edge --to-channel 18.04/beta --yes
+          snapcraft promote checkbox --from-channel 20.04/edge --to-channel 20.04/beta --yes
+          snapcraft promote checkbox --from-channel 22.04/edge --to-channel 22.04/beta --yes
+          snapcraft promote checkbox --from-channel 22.04/edge --to-channel latest/beta --yes


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This introduces a new workflow that promotes the current edge channel of every source (ppa,store) to the beta channel. This also produces a draft release note.

## Resolved issues

Part of the work needed for: https://warthogs.atlassian.net/browse/CHECKBOX-1056

## Documentation

This is mostly inherited from the stable promotion workflow. The text in the step names should be clear enough to understand what is going on.

## Tests

Given that this is basically a copy of what is already in the stable promotion workflow (minor some obvious tweaks), I will try to run it from this branch.

