### PR TITLE
Remove reference to bin when importing modules in some unit tests (BugFix)

### DIFF
--- a/providers/base/tests/test_camera_quality.py
+++ b/providers/base/tests/test_camera_quality.py
@@ -21,13 +21,12 @@
 
 import os
 from pathlib import Path
-import time
 import unittest
 from unittest.mock import patch, MagicMock
 
 import cv2
 
-import bin.camera_quality_test as cqt
+import camera_quality_test as cqt
 
 
 default_dir = Path(__file__).parent.joinpath("../data")
@@ -36,8 +35,8 @@ data_dir = Path(os.getenv("PLAINBOX_PROVIDER_DATA", default=default_dir))
 score_path = "checkbox_support.vendor.brisque.brisque.BRISQUE.score"
 
 
-@patch("bin.camera_quality_test.TIMEOUT", new=0.05)
-@patch("bin.camera_quality_test.MIN_INTERVAL", new=0.01)
+@patch("camera_quality_test.TIMEOUT", new=0.05)
+@patch("camera_quality_test.MIN_INTERVAL", new=0.01)
 @patch("builtins.print", new=MagicMock())
 class CameraQualityTests(unittest.TestCase):
     """This class provides test cases for the camera_quality_test module."""
@@ -64,7 +63,7 @@ class CameraQualityTests(unittest.TestCase):
         self.assertEqual(result, 0)
         self.assertTrue(mock_score.called)
 
-    @patch("bin.camera_quality_test.get_score_from_device")
+    @patch("camera_quality_test.get_score_from_device")
     def test_get_score_from_device(self, mock_score):
         """
         The test should pass if a good image is read from a device.
@@ -151,8 +150,8 @@ class CameraQualityTests(unittest.TestCase):
         mock_score.return_value = 10
 
         # Set the timeout and the min interval to 0 to force the iteration
-        with patch("bin.camera_quality_test.TIMEOUT", new=0.0), patch(
-            "bin.camera_quality_test.MIN_INTERVAL", new=0.0
+        with patch("camera_quality_test.TIMEOUT", new=0.0), patch(
+            "camera_quality_test.MIN_INTERVAL", new=0.0
         ):
             self.assertEqual(cqt.get_score_from_device("video0"), 10)
             self.assertEqual(mock_score.call_count, 2)

--- a/providers/base/tests/test_edid_cycle.py
+++ b/providers/base/tests/test_edid_cycle.py
@@ -4,14 +4,14 @@ import textwrap
 from pathlib import Path
 from unittest.mock import patch, call, Mock
 
-from bin import edid_cycle
+import edid_cycle
 
 
 class ZapperEdidCycleTests(unittest.TestCase):
     """This class provides test cases for the edid_cycle module."""
 
     @patch("time.sleep", new=Mock)
-    @patch("bin.edid_cycle.zapper_run", new=Mock)
+    @patch("edid_cycle.zapper_run", new=Mock)
     @patch("builtins.open")
     @patch("os.getenv")
     @patch("subprocess.check_output")
@@ -42,7 +42,7 @@ class ZapperEdidCycleTests(unittest.TestCase):
         self.assertEqual(port, "HDMI-1")
 
     @patch("time.sleep", new=Mock)
-    @patch("bin.edid_cycle.zapper_run", new=Mock)
+    @patch("edid_cycle.zapper_run", new=Mock)
     @patch("builtins.open")
     @patch("os.getenv")
     @patch("subprocess.check_output")
@@ -69,7 +69,7 @@ class ZapperEdidCycleTests(unittest.TestCase):
             edid_cycle.discover_video_output_device("zapper-ip")
 
     @patch("time.sleep", new=Mock)
-    @patch("bin.edid_cycle.zapper_run", new=Mock)
+    @patch("edid_cycle.zapper_run", new=Mock)
     @patch("builtins.open")
     @patch("os.getenv")
     @patch("subprocess.check_output")
@@ -103,7 +103,7 @@ class ZapperEdidCycleTests(unittest.TestCase):
         self.assertEqual(port, "HDMI-1")
 
     @patch("time.sleep", new=Mock)
-    @patch("bin.edid_cycle.zapper_run", new=Mock)
+    @patch("edid_cycle.zapper_run", new=Mock)
     @patch("builtins.open")
     @patch("os.getenv")
     @patch("subprocess.check_output")
@@ -133,7 +133,7 @@ class ZapperEdidCycleTests(unittest.TestCase):
             edid_cycle.discover_video_output_device("zapper-ip")
 
     @patch("time.sleep", new=Mock)
-    @patch("bin.edid_cycle.zapper_run", new=Mock)
+    @patch("edid_cycle.zapper_run", new=Mock)
     @patch("builtins.open")
     @patch("os.getenv")
     @patch("subprocess.check_output")
@@ -171,7 +171,7 @@ class ZapperEdidCycleTests(unittest.TestCase):
         mock_open.assert_called_with("1920x1080.edid", "rb")
 
     @patch("time.sleep", new=Mock)
-    @patch("bin.edid_cycle.zapper_run", new=Mock)
+    @patch("edid_cycle.zapper_run", new=Mock)
     @patch("builtins.open")
     @patch("os.getenv")
     @patch("subprocess.check_output")
@@ -229,7 +229,7 @@ class ZapperEdidCycleTests(unittest.TestCase):
             edid_cycle.test_edid("zapper-ip", Path("1280x800.edid"), "HDMI-1")
 
     @patch("time.sleep", new=Mock)
-    @patch("bin.edid_cycle.zapper_run", new=Mock)
+    @patch("edid_cycle.zapper_run", new=Mock)
     @patch("builtins.open")
     @patch("os.getenv")
     @patch("subprocess.check_output")
@@ -267,7 +267,7 @@ class ZapperEdidCycleTests(unittest.TestCase):
         mock_open.assert_called_with("1920x1080.edid", "rb")
 
     @patch("time.sleep", new=Mock)
-    @patch("bin.edid_cycle.zapper_run", new=Mock)
+    @patch("edid_cycle.zapper_run", new=Mock)
     @patch("builtins.open")
     @patch("os.getenv")
     @patch("subprocess.check_output")
@@ -324,7 +324,7 @@ class ZapperEdidCycleTests(unittest.TestCase):
         with self.assertRaises(AssertionError):
             edid_cycle.test_edid("zapper-ip", Path("1280x800.edid"), "HDMI-1")
 
-    @patch("bin.edid_cycle.discover_video_output_device")
+    @patch("edid_cycle.discover_video_output_device")
     def test_main_no_device(self, mock_discover):
         """Test if main function exits when no device is detected."""
         args = ["zapper-ip"]
@@ -333,8 +333,8 @@ class ZapperEdidCycleTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             edid_cycle.main(args)
 
-    @patch("bin.edid_cycle.test_edid")
-    @patch("bin.edid_cycle.discover_video_output_device")
+    @patch("edid_cycle.test_edid")
+    @patch("edid_cycle.discover_video_output_device")
     def test_main(self, mock_discover, mock_test_edid):
         """
         Test if main function run the EDID test for every available EDID file.

--- a/providers/base/tests/test_zapper_keyboard.py
+++ b/providers/base/tests/test_zapper_keyboard.py
@@ -5,13 +5,13 @@ import threading
 import unittest
 from unittest.mock import patch, Mock
 
-from bin import zapper_keyboard_test
+import zapper_keyboard_test
 
 
 class ZapperKeyboardTests(unittest.TestCase):
     """This class provides test cases for the zapper_keyboard_test module."""
 
-    @patch("bin.zapper_keyboard_test.zapper_run")
+    @patch("zapper_keyboard_test.zapper_run")
     def test_assert_key_combo(self, mock_run):
         """
         Check if the function properly clear the events list and
@@ -32,7 +32,7 @@ class ZapperKeyboardTests(unittest.TestCase):
             {},
         )
 
-    @patch("bin.zapper_keyboard_test.zapper_run")
+    @patch("zapper_keyboard_test.zapper_run")
     def test_assert_type_string(self, mock_run):
         """
         Check if the function properly clear the events list and
@@ -65,9 +65,9 @@ class ZapperKeyboardTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             zapper_keyboard_test.main([1, 2])
 
-    @patch("bin.zapper_keyboard_test.assert_type_string")
-    @patch("bin.zapper_keyboard_test.assert_key_combo")
-    @patch("bin.zapper_keyboard_test.KeyboardListener")
+    @patch("zapper_keyboard_test.assert_type_string")
+    @patch("zapper_keyboard_test.assert_key_combo")
+    @patch("zapper_keyboard_test.KeyboardListener")
     @patch("os.access")
     def test_main(self, mock_access, mock_key, mock_combo, mock_type):
         """Check main exits with failure if any of the test fails."""


### PR DESCRIPTION
When running `./manage.py test -u` from the provider, unittest is made aware of the content of the bin/ directory so Python code from this directory can be imported directly.



## Description

When preparing a presentation about unit testing in Checkbox, I found that some unit tests import scripts from bin, which is not required when running unit tests the usual way (`./manage.py test -u`).

## Resolved issues

Running unit tests locally using the `./manage.py test -u` command.

## Tests

- Tests are passing when running the `./manage.py test -u` command from the base provider directory in a venv.
- Single test files can be executed, for example `PYTHONPATH=~/checkbox/providers/base/bin python -m unittest test_camera_quality.py` from the `providers/base/tests/` directory.

