### PR TITLE
Refactor bt_list_adapters.py and add unit tests to it (BugFix)

### DIFF
--- a/providers/base/bin/bt_list_adapters.py
+++ b/providers/base/bin/bt_list_adapters.py
@@ -2,10 +2,11 @@
 #
 # This file is part of Checkbox.
 #
-# Copyright 2018 Canonical Ltd.
+# Copyright 2018-2023 Canonical Ltd.
 #
 # Authors:
 #    Jonathan Cave <jonathan.cave@canonical.com>
+#    Pierre Equoy <pierre.equoy@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
@@ -19,28 +20,63 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
+from pathlib import Path
 
 
-def main():
-    rfkill = '/sys/class/rfkill'
-    found_adatper = False
-    for rfdev in os.listdir(rfkill):
-        typef = os.path.join(rfkill, rfdev, 'type')
-        type = ''
-        with open(typef, 'r') as f:
-            type = f.read().strip()
-        if type != 'bluetooth':
-            continue
-        found_adatper = True
-        namef = os.path.join(rfkill, rfdev, 'name')
-        name = ''
-        with open(namef, 'r') as f:
-            name = f.read().strip()
-        print(rfdev, name)
-    if found_adatper is False:
-        raise SystemExit('No bluetooth adatpers registered with rfkill')
+def get_node_content(path):
+    """Retrieve the content from a sysfs path.
+
+    :param path: path to the sysfs node
+    :type path: str or Path
+    :return: content of the sysfs node
+    :rtype: str
+    """
+    content = None
+    with open(path, "r") as f:
+        content = f.read().strip()
+    return content
+
+
+def is_bluetooth_adapter(path):
+    """Check if a given sysfs node is a bluetooth adapter.
+
+    :param path: Path to the sysfs node
+    :type path: Path
+    :return: `True` if it is a bluetooth adapter, `False` otherwise
+    :rtype: bool
+    """
+    type = get_node_content(path / "type")
+    if type == "bluetooth":
+        return True
+    return False
+
+
+def get_bluetooth_devices(paths_list):
+    """Retrieve information about bluetooth devices from a list of sysfs paths.
+
+    :param paths_list: List of sysfs paths to check
+    :type paths_list: list
+    :raises SystemExit: If no bluetooth adapters are found
+    :return: List of tuples containing the sysfs basename and the device name
+        (e.g.: [("rfkill3", "dell-bluetooth"),])
+    :rtype: list
+    """
+    rf_devices = []
+    for rfdev in paths_list:
+        if is_bluetooth_adapter(rfdev):
+            device_name = get_node_content(rfdev / "name")
+            rf_devices.append((rfdev.name, device_name))
+    if rf_devices:
+        return rf_devices
+    else:
+        raise SystemExit("No bluetooth adapters registered with rfkill")
 
 
 if __name__ == "__main__":
-    main()
+    rfkill_path = Path("/sys/class/rfkill")
+    rf_devices_paths = []
+    if rfkill_path.is_dir():
+        rf_devices_paths = list(rfkill_path.iterdir())
+    rf_devices = get_bluetooth_devices(rf_devices_paths)
+    for rf_device in rf_devices:
+        print(" ".join(rf_device))

--- a/providers/base/tests/test_bt_list_adapters.py
+++ b/providers/base/tests/test_bt_list_adapters.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch, mock_open
 from pathlib import Path
+from io import StringIO
 
 import bt_list_adapters
 
@@ -20,8 +21,8 @@ class BTTests(unittest.TestCase):
         self.assertFalse(bt_list_adapters.is_bluetooth_adapter(Path("test")))
 
     def test_bt_adapter_not_found(self):
-        with self.assertRaises(SystemExit):
-            bt_list_adapters.get_bluetooth_devices([])
+        list_bt_devices = bt_list_adapters.get_bluetooth_devices([])
+        self.assertEqual(list_bt_devices, [])
 
     @patch("bt_list_adapters.is_bluetooth_adapter")
     @patch("bt_list_adapters.get_node_content")
@@ -30,3 +31,35 @@ class BTTests(unittest.TestCase):
         mock_is_bt_adapter.return_value = True
         fake_devices = bt_list_adapters.get_bluetooth_devices([Path("/test")])
         self.assertEqual(fake_devices, [("test", "test")])
+
+    @patch("bt_list_adapters.get_bluetooth_devices")
+    @patch("bt_list_adapters.Path.iterdir")
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_main(self, mock_stdout, mock_path, mock_bt_devices):
+        mock_path.return_value = [
+            "test",
+        ]
+        btdev = bt_list_adapters.BTDevice("test", "test")
+        mock_bt_devices.return_value = [
+            btdev,
+        ]
+        bt_list_adapters.main()
+        self.assertEqual(mock_stdout.getvalue().strip(), "test test")
+
+    @patch("bt_list_adapters.get_bluetooth_devices")
+    @patch("bt_list_adapters.Path.iterdir")
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_main_no_bt_devices(self, mock_stdout, mock_path, mock_bt_devices):
+        mock_path.return_value = []
+        mock_bt_devices.return_value = []
+        with self.assertRaises(SystemExit):
+            bt_list_adapters.main()
+
+    @patch("bt_list_adapters.get_bluetooth_devices")
+    @patch("bt_list_adapters.Path.iterdir")
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_main_no_rfkill_path(self, mock_stdout, mock_path, mock_bt_devices):
+        mock_path.side_effect = FileNotFoundError
+        mock_bt_devices.return_value = []
+        with self.assertRaises(SystemExit):
+            bt_list_adapters.main()

--- a/providers/base/tests/test_bt_list_adapters.py
+++ b/providers/base/tests/test_bt_list_adapters.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import patch, mock_open
+from pathlib import Path
+
+import bt_list_adapters
+
+
+class BTTests(unittest.TestCase):
+    @patch("builtins.open", new_callable=mock_open, read_data=" test ")
+    def test_get_node_content(self, mock_open):
+        content = bt_list_adapters.get_node_content(Path("test"))
+        self.assertEqual(content, "test")
+
+    @patch("builtins.open", new_callable=mock_open, read_data="bluetooth")
+    def test_is_bluetooth_adapter(self, mock_open):
+        self.assertTrue(bt_list_adapters.is_bluetooth_adapter(Path("test")))
+
+    @patch("builtins.open", new_callable=mock_open, read_data="not bluetooth")
+    def test_is_not_bluetooth_adapter(self, mock_open):
+        self.assertFalse(bt_list_adapters.is_bluetooth_adapter(Path("test")))
+
+    def test_bt_adapter_not_found(self):
+        with self.assertRaises(SystemExit):
+            bt_list_adapters.get_bluetooth_devices([])
+
+    @patch("bt_list_adapters.is_bluetooth_adapter")
+    @patch("bt_list_adapters.get_node_content")
+    def test_bt_adapter_found(self, mock_content, mock_is_bt_adapter):
+        mock_content.return_value = "test"
+        mock_is_bt_adapter.return_value = True
+        fake_devices = bt_list_adapters.get_bluetooth_devices([Path("/test")])
+        self.assertEqual(fake_devices, [("test", "test")])


### PR DESCRIPTION
## Description

Gave a presentation about unit testing in Checkbox. As a demo, picked a script with 0% coverage and improved its coverage.

While I initially wrote tests for the script, I realized it was a good candidate for a refactor, so I modified the script and wrote unit tests for my refactor.



<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->


## Tests

- `./manage.py test -u` pass
- I ran the script on my laptop and it prints out exactly the same data as before:

```
$ ./bt_list_adapters.py
rfkill3 dell-bluetooth
```

