### PR TITLE
Workaroud yes not allowed for edge promotions (infra)

### DIFF
--- a/.github/workflows/checkbox-beta-release.yml
+++ b/.github/workflows/checkbox-beta-release.yml
@@ -61,6 +61,9 @@ jobs:
         env:
           SNAPCRAFT_HAS_TTY: "true" # this is necessary because snapcraft will not allow --yes for promotions of the edge channel
         run: |
+          # Note: using `yes |` instead of `--yes` because snapcraft will
+          #       refuse to non-interactively promote a snap from the edge
+          #       channel if it is done without any branch qualifiers
           yes | snapcraft promote checkbox16 --from-channel latest/edge --to-channel latest/beta
           yes | snapcraft promote checkbox18 --from-channel latest/edge --to-channel latest/beta
           yes | snapcraft promote checkbox20 --from-channel latest/edge --to-channel latest/beta
@@ -77,8 +80,11 @@ jobs:
           sudo snap install snapcraft --classic
       - name: Promote checkbox snaps to the beta channel
         env:
-          SNAPCRAFT_HAS_TTY: "true"
+          SNAPCRAFT_HAS_TTY: "true" # this is necessary because snapcraft will not allow --yes for promotions of the edge channel
         run: |
+          # Note: using `yes |` instead of `--yes` because snapcraft will
+          #       refuse to non-interactively promote a snap from the edge
+          #       channel if it is done without any branch qualifiers
           yes | snapcraft promote checkbox --from-channel uc16/edge --to-channel uc16/beta
           yes | snapcraft promote checkbox --from-channel uc18/edge --to-channel uc18/beta
           yes | snapcraft promote checkbox --from-channel uc20/edge --to-channel uc20/beta

--- a/.github/workflows/checkbox-beta-release.yml
+++ b/.github/workflows/checkbox-beta-release.yml
@@ -58,11 +58,13 @@ jobs:
         run: |
           sudo snap install snapcraft --classic
       - name: Promote checkbox core snaps to the beta channel
+        env:
+          SNAPCRAFT_HAS_TTY: "true" # this is necessary because snapcraft will not allow --yes for promotions of the edge channel
         run: |
-          snapcraft promote checkbox16 --from-channel latest/edge --to-channel latest/beta --yes
-          snapcraft promote checkbox18 --from-channel latest/edge --to-channel latest/beta --yes
-          snapcraft promote checkbox20 --from-channel latest/edge --to-channel latest/beta --yes
-          snapcraft promote checkbox22 --from-channel latest/edge --to-channel latest/beta --yes
+          yes | snapcraft promote checkbox16 --from-channel latest/edge --to-channel latest/beta
+          yes | snapcraft promote checkbox18 --from-channel latest/edge --to-channel latest/beta
+          yes | snapcraft promote checkbox20 --from-channel latest/edge --to-channel latest/beta
+          yes | snapcraft promote checkbox22 --from-channel latest/edge --to-channel latest/beta
 
   checkbox_snap:
     name: Checkbox snap packages
@@ -74,13 +76,15 @@ jobs:
         run: |
           sudo snap install snapcraft --classic
       - name: Promote checkbox snaps to the beta channel
+        env:
+          SNAPCRAFT_HAS_TTY: "true"
         run: |
-          snapcraft promote checkbox --from-channel uc16/edge --to-channel uc16/beta --yes
-          snapcraft promote checkbox --from-channel uc18/edge --to-channel uc18/beta --yes
-          snapcraft promote checkbox --from-channel uc20/edge --to-channel uc20/beta --yes
-          snapcraft promote checkbox --from-channel uc22/edge --to-channel uc22/beta --yes
-          snapcraft promote checkbox --from-channel 16.04/edge --to-channel 16.04/beta --yes
-          snapcraft promote checkbox --from-channel 18.04/edge --to-channel 18.04/beta --yes
-          snapcraft promote checkbox --from-channel 20.04/edge --to-channel 20.04/beta --yes
-          snapcraft promote checkbox --from-channel 22.04/edge --to-channel 22.04/beta --yes
-          snapcraft promote checkbox --from-channel 22.04/edge --to-channel latest/beta --yes
+          yes | snapcraft promote checkbox --from-channel uc16/edge --to-channel uc16/beta
+          yes | snapcraft promote checkbox --from-channel uc18/edge --to-channel uc18/beta
+          yes | snapcraft promote checkbox --from-channel uc20/edge --to-channel uc20/beta
+          yes | snapcraft promote checkbox --from-channel uc22/edge --to-channel uc22/beta
+          yes | snapcraft promote checkbox --from-channel 16.04/edge --to-channel 16.04/beta
+          yes | snapcraft promote checkbox --from-channel 18.04/edge --to-channel 18.04/beta
+          yes | snapcraft promote checkbox --from-channel 20.04/edge --to-channel 20.04/beta
+          yes | snapcraft promote checkbox --from-channel 22.04/edge --to-channel 22.04/beta
+          yes | snapcraft promote checkbox --from-channel 22.04/edge --to-channel latest/beta


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Snapcraft doesn't natively allow to non-interactively promote a snap from an un-branched edge channel as it can be seen [here(link)](https://github.com/snapcore/snapcraft/blob/662af4c00fb43b97b87eef16f4edbba4ff12a1cf/snapcraft_legacy/cli/store.py#L164). We need this feature as we do use an unbranched edge channel and we want to automatically promote to beta the builds. This PR removes the `--yes` switch replacing with `yes |`.

> Note: This would not work as snapcraft will try to understand if it is in an interactive session or not. To make snapcraft just use the input provided in stdin, the `SNAPCRAFT_HAS_TTY` envvar is also added. 

## Resolved issues

Failing build: https://github.com/canonical/checkbox/actions/runs/7112360707/job/19362163613

## Documentation

A comment documents why we need the environment variable and the `yes |` workaround

## Tests

I will launch the workflow from this branch before merging

