### PR TITLE
Fix snap boot kernel path (Bugfix)

### DIFF
--- a/providers/base/bin/boot_mode_test_snappy.py
+++ b/providers/base/bin/boot_mode_test_snappy.py
@@ -92,6 +92,8 @@ def main():
 
         kernel_rev = os.path.basename(
             os.path.realpath('/snap/{}/current'.format(kernel)))
+        # update boot kernel path according to
+        # https://snapcraft.io/docs/the-system-backup-interface
         boot_kernel = (
             "/var/lib/snapd/hostfs/boot/uboot/{}_{}.snap/kernel.img".format(
                 kernel, kernel_rev

--- a/providers/base/bin/boot_mode_test_snappy.py
+++ b/providers/base/bin/boot_mode_test_snappy.py
@@ -92,8 +92,11 @@ def main():
 
         kernel_rev = os.path.basename(
             os.path.realpath('/snap/{}/current'.format(kernel)))
-        boot_kernel = '/boot/uboot/{}_{}.snap/kernel.img'.format(
-            kernel, kernel_rev)
+        boot_kernel = (
+            "/var/lib/snapd/hostfs/boot/uboot/{}_{}.snap/kernel.img".format(
+                kernel, kernel_rev
+            )
+        )
         boot_objects = fitdumpimage(boot_kernel)
 
         for obj, attrs in boot_objects.items():


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
As describe in [this snap doc](https://snapcraft.io/docs/the-system-backup-interface
), to access to host’s snap-related files, it's now have to access via `/var/lib/snapd/hostfs`. This `system-backup` interface gives privileged read-only access to system data. The change can be traced back to [snapd 2.36](https://forum.snapcraft.io/t/snapd-2-36-snap-confine-logic-walkthrough/7843).


## Resolved issues

Resolve failed test case `miscellanea/secure_boot_mode_kdrp-kdrp-k4500-gadget` in [denver SUV test](http://10.102.156.15:8080/job/cert-denver-kdrp-hmi-10-core20-latest-beta/10/testReport/junit/com.canonical/certification__miscellanea_secure_boot_mode_kdrp-kdrp-k4500-gadget/com_canonical_certification__miscellanea_secure_boot_mode_kdrp_kdrp_k4500_gadget/
).
```
dumpimage: Can't open "/boot/uboot/avnet-avt-iiotg20-kernel_70.snap/kernel.img": No such file or directory
```

## Documentation
The test case impacted is `miscellanea/secure_boot_mode_{gadget}`. [Confirmed with QA](https://chat.canonical.com/canonical/pl/twirw1rxg3dcurrqraii414dda) that the most of the IoT projects use their own project checkboxs, which already include this boot kernel path change in `boot_mode_test_snappy.py`. The only exception is denver project, that its provider uses `boot_mode_test_snappy.py` in general checkbox provider. Other than that, `miscellanea/secure_boot_mode_{gadget}` is not included in any test plan in checkbox itself,


## Tests
Test on `denver-keurig-001` with side-loaded checkbox. 
```
root@ubuntu:/var/tmp# cd /var/tmp/checkbox-providers/bin/
root@ubuntu:/var/tmp/checkbox-providers/bin# chmod +x boot_mode_test_snappy.py 
root@ubuntu:/var/tmp/checkbox-providers/bin# ./boot_mode_test_snappy.py kdrp-kdrp-k4500-gadget avnet-avt-iiotg20-kernel
Bootloader is u-boot

Parsing FIT image information...

Checking object kernel@1
Found "Sign value"
Found expected signing algorithms

Checking object ramdisk@1
Found "Sign value"
Found expected signing algorithms

Checking object config@1
Found "Sign value"
Found expected signing algorithms

Kernel images in current snap and u-boot match

Secure Boot appears to be enabled on this system
```

