### PR TITLE
Add a test case for core.efi file check needed by grub and shim upgrade(New)

### DIFF
--- a/providers/base/bin/grub_file_check.sh
+++ b/providers/base/bin/grub_file_check.sh
@@ -2,7 +2,7 @@
 
 declare -A DICT_ARCH
 
-DICT_ARCH=( [x86_64]='x86_64' [aarch64]='arm64' [armhf]='armS' )
+DICT_ARCH=( [x86_64]='x86_64' [aarch64]='arm64' [armhf]='arm' )
 FILE_CORE="/boot/grub/${DICT_ARCH[$(uname -m)]}-efi/core.efi"
 
 if [ -e "${FILE_CORE}" ]; then

--- a/providers/base/bin/grub_file_check.sh
+++ b/providers/base/bin/grub_file_check.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+declare -A DICT_ARCH
+
+DICT_ARCH=( [x86_64]='x86_64' [aarch64]='arm64' [armhf]='armS' )
+FILE_CORE="/boot/grub/${DICT_ARCH[$(uname -m)]}-efi/core.efi"
+
+if [ -e "${FILE_CORE}" ]; then
+    echo "The file ${FILE_CORE} exists, shim and grub can be upgraded."
+    exit 0
+else
+    echo "Due to the absence of the file ${FILE_CORE}, upgrading shim and grub becomes impossible."
+    exit 1
+fi

--- a/providers/base/units/miscellanea/jobs.pxu
+++ b/providers/base/units/miscellanea/jobs.pxu
@@ -540,3 +540,15 @@ command:
     cat "$PLAINBOX_SESSION_SHARE/ubuntu_drivers_list_oem_check"
   fi
   true
+
+id: miscellanea/grub_file_check
+category_id: com.canonical.plainbox::miscellanea
+_summary: Check if the file core.efi exists to make sure shim and grub can be upgraded
+plugin: shell
+estimated_duration: 0.2
+requires:
+  "Ubuntu Core" not in lsb.description
+  cpuinfo.platform in ("x86_64", "aarch64", "armhf")
+  bootloader.name == "grub"
+command: grub_file_check.sh
+

--- a/providers/base/units/miscellanea/test-plan.pxu
+++ b/providers/base/units/miscellanea/test-plan.pxu
@@ -34,6 +34,7 @@ include:
     miscellanea/debsums                            certification-status=blocker
     miscellanea/check_prerelease                   certification-status=blocker
     miscellanea/ubuntu-desktop-recommends          certification-status=blocker
+    miscellanea/grub_file_check
 bootstrap_include:
     fwts
 

--- a/providers/base/units/miscellanea/test-plan.pxu
+++ b/providers/base/units/miscellanea/test-plan.pxu
@@ -34,7 +34,7 @@ include:
     miscellanea/debsums                            certification-status=blocker
     miscellanea/check_prerelease                   certification-status=blocker
     miscellanea/ubuntu-desktop-recommends          certification-status=blocker
-    miscellanea/grub_file_check
+    miscellanea/grub_file_check                    certification-status=blocker
 bootstrap_include:
     fwts
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->
Add a test case for core.efi file check needed by grub and shim upgrade(New)

## Description
To ensure the grub and shim can be upgraded correctly, the file core.efi under /boot/grub should exist.  The test case was added to check the core.efi exist or not.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
Please refer to the Jira card: [[Test Case][Development] Check if grub and shim can be updated correctly](https://warthogs.atlassian.net/browse/OEMQA-2967)
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests
eugene@Drift2-P-2:~$  ccl run com.canonical.certification::miscellanea/grub_file_check
Using sideloaded provider: checkbox-provider-base, version 3.3.0.dev19 from /var/tmp/checkbox-providers/base
===========================[ Running Selected Jobs ]============================
==============[ Running job 1 / 4. Estimated time left: 0:00:03 ]===============
---------------------[ Collect information about the CPU ]----------------------
ID: com.canonical.certification::cpuinfo
Category: com.canonical.plainbox::uncategorised
... 8< -------------------------------------------------------------------------
bogomips: 4600
cache: 8388608
count: 8
model: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
model_number: 6
model_revision: 12
model_version: 142
other: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust sgx bmi1 avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities
platform: x86_64
speed: 4900
type: GenuineIntel
governors: performance powersave
cpu_lpi_file: low_power_idle_cpu_residency_us
sys_lpi_file: low_power_idle_system_residency_us
scaling: supported
------------------------------------------------------------------------- >8 ---
Outcome: job passed
==============[ Running job 2 / 4. Estimated time left: 0:00:03 ]===============
----------[ Collect information about installed system (lsb-release) ]----------
ID: com.canonical.certification::lsb
Category: com.canonical.plainbox::uncategorised
... 8< -------------------------------------------------------------------------
distributor_id: Ubuntu
description: Ubuntu 22.04.3 LTS
release: 22.04
codename: jammy
------------------------------------------------------------------------- >8 ---
Outcome: job passed
==============[ Running job 3 / 4. Estimated time left: 0:00:01 ]===============
---------------[ Detect which bootloader is used on the device ]----------------
ID: com.canonical.certification::bootloader
Category: com.canonical.plainbox::uncategorised
... 8< -------------------------------------------------------------------------
name: grub
booted_kernel_path: /boot/vmlinuz-6.2.0-37-generic
booted_kernel_partition_type: fs

------------------------------------------------------------------------- >8 ---
Outcome: job passed
==============[ Running job 4 / 4. Estimated time left: 0:00:00 ]===============
--[ Check if the file core.efi exist to make sure shim and grub upgradedable ]--
ID: com.canonical.certification::miscellanea/grub_file_check
Category: com.canonical.plainbox::miscellanea
... 8< -------------------------------------------------------------------------
The file /boot/grub/x86_64-efi/core.efi exist, shim and grub can be upgraded.
------------------------------------------------------------------------- >8 ---
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2023-12-13T10.35.43
==================================[ Results ]===================================
 ☑ : Collect information about the CPU
 ☑ : Collect information about installed system (lsb-release)
 ☑ : Detect which bootloader is used on the device
 ☑ : Check if the file core.efi exist to make sure shim and grub upgradedable

For ARM64:

Tested on 2 ARM Baoshan devices
Desktop 22.04: Pass
Submission: https://certification.canonical.com/hardware/202309-32022/submission/348119/test-results/pass/
UC22: Skip
Submission: https://certification.canonical.com/hardware/202307-31864/submission/348114/test-results/skipped/

For Core and Uboot that should be skipped:

Tested on 2 ARM devices, both will be skipped.
* Ubuntu Core 22 (ARM u-boot), skipped by 
'"Ubuntu Core" not in lsb.description' evaluates to false
https://pastebin.canonical.com/p/QpgRrRHTzf/
* Ubuntu Classic 22.04 (ARM u-boot)
'bootloader.name == "grub"' evaluates to false
https://pastebin.canonical.com/p/Y5GJq84qMW/

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

