### PR TITLE
Update release readme version calculation (infra)

### DIFF
--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -60,44 +60,41 @@ packages to the stable PPA and promote all snaps to stable.
 
 Then, it's time to build the new beta version.
 
-## Tag the release
+## How packages versions are generated?
 
-First you need to understand what tag to push. Checkbox uses
-[semantic versioning], in order to calculate what version number you should
-push, you need to see what you are actually releasing.
+Both Debian packages and checkbox snaps rely on [get\_version.py] to calculate
+package versions from git metadata.
 
-Run the following commands to get a list of changes since the last stable
-release:
-
-```bash
-$ git fetch --tags
-$ git describe --tags --match "*[0123456789]" origin/main &&
-    git log $(
-        git describe --tags --match "*[0123456789]" --abbrev=0 origin/main
-    )..origin/main
+```python
+>>> from get_version import get_version, OutputFormat
+>>> get_version(dev_suffix=True, output_format=OutputFormat.SNAP)
+'2.9.0-dev38
 ```
 
-If the list includes:
-- Only bugfixes: you can use the version tag that was calculated by the
-`edge-verification` job (increment patch).
-- New, backward compatible features: you have to increment the minor version
-- Non-backward compatible changes: you have to increment the major version
+This script can generate the version for any packaging we support and can also
+be called from the CLI. The idea is that each commit since the last tag is
+categorized using the postfix included in the commit message and the version is
+calculated as follows:
+- **Infra:** are changes to our CI/CD infrastructure, they are ignored
+- **Bugfix:** are bugfixes, the patch number is incremented
+- **New:** are new backward compatible features, the minor version is incremented
+- **Breaking:** are new breaking changes, the major version number is incremented
 
-All commit messages in the main history should have a postfix indicating what
-kind of change they are:
-- **Infra:** are changes to our testing infrastructure, you can safely ignore
-them
-- **Bugfix:** are bugfixes, increment patch version
-- **New:** are new backward compatible features, increment minor version
-- **Breaking:** are new breaking changes, increment major version
+> **_NOTE:_** If any commit is in a different format the script will complain
+about it by logging it to the stderr. Don't ignore these messages, double check
+what was changed in the problematic commits and re-calculate the version
+accordingly
 
-If you were to be at at the tag `v2.9.1-edge-validation-success` and you
-had to release a new version with at least one backward compatible new feature,
-run the following commands:
+## Tag the release
 
-- Clone the repository
-  ```
+First you need to understand what tag to push. You can use the previously
+described scipt to do so:
+
+- Clone the repository and get the version
+  ```bash
   $ git clone git@github.com:canonical/checkbox.git
+  $ cd checkbox/tools/release
+  $ ./get_version.py --output-format tag
   ```
 - Tag the release
   ```
@@ -107,26 +104,6 @@ run the following commands:
   ```
   $ git push --tags
   ```
-
-## How packages versions are generated?
-
-Both Debian packages and checkbox snaps rely on [setuptools_scm] to extract
-package versions from git metadata.
-
-```
->>> from setuptools_scm import get_version
->>> get_version()
-'2.9.dev38+g896ae8978
-```
-
-In general, when the HEAD of a branch is tagged, the version is going to be
-the tag. If a branch's HEAD is not tagged, the version is going to be the latest
-tag with the patch number incremented by 1, a postfix that encodes the distance
-from the tag itself (in the form of `dev{N}` where `N` is the number of
-commits since the latest tag) and the hash of the current HEAD.
-
-> **_NOTE_**: If you have some uncommitted changes your version might also have
-a date postfix in the form of `.YYYYMMDD`, this should never happen in a release!
 
 ## Monitor the build and publish workflows
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your chage is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

We have updated how the version is calculated in Checkbox. This updates also the release documentation to refect the new route to get the next version.

## Resolved issues

Documentation out of sync with the process

## Documentation

This PR is the documentation

## Tests

N/A

