### PR TITLE
Pin urllib to <2.0 for Metabox (BugFix)

### DIFF
--- a/metabox/README.md
+++ b/metabox/README.md
@@ -34,8 +34,8 @@ Create a Python virtual environment and install Metabox in it:
 
 ```shell
 $ cd metabox/
-$ python3 -m venv metabox
-$ source metabox/bin/activate
+$ python3 -m venv venv
+$ source venv/bin/activate
 (metabox) $ pip install -e .
 ```
 

--- a/metabox/setup.py
+++ b/metabox/setup.py
@@ -21,17 +21,23 @@
 from setuptools import find_packages, setup
 
 setup(
-    name='metabox',
-    version='0.3',
+    name="metabox",
+    version="0.3",
     packages=find_packages(),
-    install_requires=['loguru', 'pylxd', 'pyyaml', 'importlib-resources'],
+    install_requires=[
+        "importlib-resources",
+        "loguru",
+        "pylxd",
+        "pyyaml",
+        "urllib3 >= 1.26.0, < 2.0.0",
+    ],
     entry_points={
-        'console_scripts': [
-            'metabox = metabox.main:main',
+        "console_scripts": [
+            "metabox = metabox.main:main",
         ]
     },
     include_package_data=True,
     package_data={
-        '': ['metabox/metabox-provider/*'],
-    }
+        "": ["metabox/metabox-provider/*"],
+    },
 )


### PR DESCRIPTION
## Description

This PR pins urllib to a version lower than 2.0. This is to circumvent a known problem of pylxd. [More context here.](https://github.com/canonical/pylxd/issues/308)

## Resolved issues

Fixes: [#868]
Fixes: [CHECKBOX-1068](https://warthogs.atlassian.net/jira/software/c/projects/CHECKBOX/boards/590?selectedIssue=CHECKBOX-1068)

## Documentation
Updated docs to use non-dangerous virtualenv target.

## Tests
Tested by running Metabox on a fresh host (VM).

[CHECKBOX-1068]: https://warthogs.atlassian.net/browse/CHECKBOX-1068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ