### PR TITLE
Fix pending binary builds (infra)

### DIFF
--- a/tools/release/lp_build_monitor_recipe.py
+++ b/tools/release/lp_build_monitor_recipe.py
@@ -68,6 +68,7 @@ def wait_every_source_build_started(build_recipe: LPSourcePackageRecipe):
                 "  ",
             )
         )
+        # avoid flooding LP with requests
         time.sleep(LP_POLLING_DELAY)
         pending_builds = build_recipe.getPendingBuildInfo()
 
@@ -201,9 +202,9 @@ def monitor_retry_builds(builds_to_check: list[LPBuild]) -> list[LPBuild]:
             "Uploading build",
             "Gathering build output",
         ]:
-            # avoid flooding LP with requests
             print(f"Build ongoing with status '{buildstate}'")
             print(f"  weblink: {build.web_link}")
+            # avoid flooding LP with requests
             time.sleep(LP_POLLING_DELAY)
             builds_to_check.insert(0, build)
         elif buildstate not in [
@@ -217,11 +218,13 @@ def monitor_retry_builds(builds_to_check: list[LPBuild]) -> list[LPBuild]:
         ]:
             print(f"Unknown build status '{buildstate}'")
             print(f"  weblink: {build.web_link}")
+            # avoid flooding LP with requests
             time.sleep(LP_POLLING_DELAY)
             builds_to_check.insert(0, build)
         elif build.can_be_retried:
             print(f"Build failed with status '{buildstate}'")
             print(f"  retrying: {build.web_link}")
+            # avoid flooding LP with requests
             time.sleep(LP_POLLING_DELAY)
             build.retry()
             builds_to_check.insert(0, build)

--- a/tools/release/lp_build_monitor_recipe.py
+++ b/tools/release/lp_build_monitor_recipe.py
@@ -145,10 +145,9 @@ def monitor_retry_binary_builds(
         iteration_start_time = get_date_utc_now()
 
         # this filters the binary builds from start_checking_binary (the
-        # beginning of the previous iteration or the latest pending build).
-        # This is done because if a build was included in the previous
-        # get_all_binary_builds it has been taken to completion
-        # by monitor_retry_builds either failing it
+        # beginning of the previous iteration). This is done because if a build
+        # was included in the previous get_all_binary_builds it has been
+        # taken to completion by monitor_retry_builds either failing it
         # completely or making it pass. What matters is that we don't
         # under-monitor, as re-getting the same build will deterministically
         # yield the same result resulting in the wcs. in a duplicated

--- a/tools/release/test_lp_build_monitor_recipe.py
+++ b/tools/release/test_lp_build_monitor_recipe.py
@@ -1,6 +1,6 @@
 import unittest
 
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import lp_build_monitor_recipe
 
@@ -14,18 +14,25 @@ class TestHelperFunctions(unittest.TestCase):
         build_selected = MagicMock()
         build_selected.date_first_dispatched = 10
 
+        build_selected_pending = MagicMock()
+        # pending builds have a None date_first_dispatched
+        # we select them because they are "newer" of the start date
+        # for sure given that they didn't even start yet
+        build_selected_pending.date_first_dispatched = None
+
         build_not_selected = MagicMock()
         build_not_selected.date_first_dispatched = 0
 
         build_recipe.daily_build_archive.getBuildRecords.return_value = [
             build_selected,
+            build_selected_pending,
             build_not_selected,
         ]
         selected = lp_build_monitor_recipe.get_all_binary_builds(
             build_recipe, 6
         )
 
-        self.assertEqual(selected, [build_selected])
+        self.assertEqual(selected, [build_selected, build_selected_pending])
         build_recipe.daily_build_archive.getBuildRecords.assert_called_with(
             source_name="checkbox-ng"
         )


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

[This run of daily builds](https://github.com/canonical/checkbox/actions/runs/7199217221/job/19610485472) failed because the `date_first_dispatched` attribute of a build is filled only once it is actually started, therefore if a build is pending it will be None. This fixes this issue and adds a sanity check on the build status (currently we can not determine how that field is filled for pending builds AND we want to resist/know spurious values in there so that we can proactively fix the script if they come up). 

## Resolved issues

[This build fail](https://github.com/canonical/checkbox/actions/runs/7199217221/job/19610485472)

## Documentation

This explains why the `None` case is included in the selector in a comment both in the function and in the test

## Tests

The new value is now included in the function test.
