### PR TITLE
Disable fail fast in deb daily build (infra)

### DIFF
--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: [self-hosted, linux, large]
     needs: ppa_update
     strategy:
+      fail-fast: false
       matrix:
         recipe:
         - checkbox-ng-edge


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Given that every workflow monitors and tries to get as many builds as possible landed in the PPA, killing them all if one fails is not a great idea. Doing so disrupts the monitor->retry loop and removes the information from the daily build log about which ppa(s) failed specifically (namely if checkbox-ng and checkbox-support fail while all the others pass, the daily builds workflow will list 1 failures and all the others cancelled or a few pass, a few cancelled and 1 fail).

## Resolved issues

We can not determine from[ yesterday's build](https://github.com/canonical/checkbox/actions/runs/7199217221/job/19610485472) which PPAs are currently ok and which need some additional attention.

## Documentation

N/A

## Tests

N/A

