### PR TITLE
Modify detection for usb-dwc3 to make it really detecting (Bugfix)

### DIFF
--- a/providers/iiotg/units/usb-dwc3/jobs.pxu
+++ b/providers/iiotg/units/usb-dwc3/jobs.pxu
@@ -3,10 +3,15 @@ _summary: Detect if the USB DWC3 drivers are loaded
 category_id: usb-dwc3
 imports: from com.canonical.plainbox import manifest
 requires:
-  device.driver == 'dwc3-pci'
   manifest.has_usb_dwc3_controller == 'True'
-flags: simple fail-on-resource
+plugin: shell
+flags: simple
 command:
+  if ! lspci -v | grep dwc3-pci; then
+    echo "Cannot find the 'dwc3-pci' driver be used!"
+    echo "Please make sure this feature is supported on this platform and check the value of xDCI in BIOS setting."
+    exit 1
+  fi
   echo "dwc3-pci driver loaded"
 
 id: usb-dwc3/module-detect
@@ -14,11 +19,15 @@ _summary: Detect if the USB DWC3 module is loaded
 category_id: usb-dwc3
 imports: from com.canonical.plainbox import manifest
 requires:
-  module.name == 'dwc3_pci'
   manifest.has_usb_dwc3_controller == 'True'
-flags: simple fail-on-resource
+plugin: shell
+flags: simple
 command:
-  echo "dwc3_pci module loaded"
+  if ! lsmod | grep dwc3_pci; then
+    echo "Cannot find the 'dwc3_pci' module be loaded!"
+    echo "Please make sure this feature is supported on this platform and check the value of xDCI in BIOS setting."
+    exit 1
+  fi
 
 id: usb-dwc3/mass-storage
 _summary: Check DUT can be detected as mass storage device
@@ -63,4 +72,3 @@ command:
   fi
 user: root
 estimated_duration: 1s
-


### PR DESCRIPTION
## Description
I migrate the usb-dwc3 test cases from [checkbox-provider-iiotg](https://git.launchpad.net/~checkbox-dev/checkbox-iiotg/+git/checkbox-provider-intliotg/tree/units/usb-dwc3). And we modify the tes jobs, because if we select the manifest for dwc3 to supported, then the `driver` and `module` should be detected. Hence if those are not detected, it should be a fail.


## Resolved issues

N/A

## Documentation

N/A

## Tests

I run the tesplan `usb-dwc3-full` or you can say `DesignWare Core SuperSpeed USB 3.0 Controller (DWC3) tests` on Aaeon EHL ([202306-31656](https://certification.canonical.com/hardware/202306-31656/)).
submission: https://certification.canonical.com/hardware/202306-31656/submission/349779/test-results/

