### PR TITLE
Retire pm_test.py from warm/cold boot nested parts in desktop auto test plan (New)

### DIFF
--- a/providers/certification-client/units/client-cert-desktop-18-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-18-04.pxu
@@ -133,7 +133,7 @@ nested_part:
     # The following tests should run BEFORE the automated tests. The reboot and
     # power off tests will also give us a clean system to start the stress run
     # with.
-    power-management-reboot-poweroff-cert-automated
+    power-automated
     tpm2.0_3.0.4
 bootstrap_include:
     device

--- a/providers/certification-client/units/client-cert-desktop-20-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-20-04.pxu
@@ -136,7 +136,7 @@ nested_part:
     # The following tests should run BEFORE the automated tests. The reboot and
     # power off tests will also give us a clean system to start the stress run
     # with.
-    power-management-reboot-poweroff-cert-automated
+    power-automated
     tpm-cert-focal-automated
 bootstrap_include:
     device

--- a/providers/certification-client/units/client-cert-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-22-04.pxu
@@ -152,7 +152,7 @@ nested_part:
     # The following tests should run BEFORE the automated tests. The reboot and
     # power off tests will also give us a clean system to start the stress run
     # with.
-    power-management-reboot-poweroff-cert-automated
+    power-automated
     tpm-cert-automated
 bootstrap_include:
     device

--- a/providers/certification-client/units/client-cert-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-24-04.pxu
@@ -152,7 +152,7 @@ nested_part:
     # The following tests should run BEFORE the automated tests. The reboot and
     # power off tests will also give us a clean system to start the stress run
     # with.
-    power-management-reboot-poweroff-cert-automated
+    power-automated
     tpm-cert-automated
 bootstrap_include:
     device

--- a/providers/sru/units/sru.pxu
+++ b/providers/sru/units/sru.pxu
@@ -95,7 +95,7 @@ nested_part:
     # The following tests should run BEFORE the automated tests. The reboot and
     # power off tests will also give us a clean system to start the stress run
     # with.
-    power-management-reboot-poweroff-cert-automated
+    power-automated
     tpm-cert-automated
     stress-pm-graph
     stress-ng-cert-automated


### PR DESCRIPTION
## Description
Retire pm_test.py from cold/warm boot of desktop auto test plan.
Make the desktop auto test plan use the same test plan as IoT.






## Documentation

### PC
- Test Plan: [client-cert-desktop-22-04-automated](https://github.com/canonical/checkbox/blob/main/providers/certification-client/units/client-cert-desktop-22-04.pxu#L85-L159) 
	- Nested: [power-management-reboot-poweroff-cert-automated](https://github.com/canonical/checkbox/blob/main/providers/base/units/power-management/test-plan.pxu#L51-L59)
		- Include Jobs: 
			- [power-management/poweroff](https://github.com/canonical/checkbox/blob/main/providers/base/units/power-management/jobs.pxu#L52-L63) 
				- `pm_test.py --silent --checkbox-respawn-cmd "$PLAINBOX_SESSION_SHARE"/__respawn_checkbox poweroff --log-level=debug --log-dir="$PLAINBOX_SESSION_SHARE"`
			- [power-management/poweroff-log-attach](https://github.com/canonical/checkbox/blob/main/providers/base/units/power-management/jobs.pxu#L65-L73) 
			- [power-management/reboot](https://github.com/canonical/checkbox/blob/main/providers/base/units/power-management/jobs.pxu#L75-L85)
				- `pm_test.py --silent --checkbox-respawn-cmd "$PLAINBOX_SESSION_SHARE"/__respawn_checkbox reboot --log-level=debug --log-dir="$PLAINBOX_SESSION_SHARE"`
			- [power-management/reboot-log-attach](https://github.com/canonical/checkbox/blob/main/providers/base/units/power-management/jobs.pxu#L87-L95)

### IoT

- Test Plan: [client-cert-iot-server-22-04-automated](https://github.com/canonical/checkbox/blob/main/providers/certification-client/units/client-cert-iot-server-22-04.pxu#L26-L35)
	- Nested: [client-cert-iot-ubuntucore-22-automated](https://github.com/canonical/checkbox/blob/main/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu#L82-L150)

- Test Plan: [client-cert-iot-ubuntucore-22-automated](https://github.com/canonical/checkbox/blob/main/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu#L82-L150)
	- Nested: [power-automated](https://github.com/canonical/checkbox/blob/main/providers/base/units/power-management/test-plan.pxu#L96-L104)
		- Include Jobs:
			- [power-management/warm-reboot](https://github.com/canonical/checkbox/blob/main/providers/base/units/power-management/jobs.pxu#L323-L333)
				- `dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1 "org.freedesktop.login1.Manager.Reboot" boolean:true`
			- [power-management/post-warm-reboot](https://github.com/canonical/checkbox/blob/main/providers/base/units/power-management/jobs.pxu#L335-L343)
				- `failed_service_check.sh`
			- [power-management/cold-reboot](https://github.com/canonical/checkbox/blob/main/providers/base/units/power-management/jobs.pxu#L345-L360)
				- `rtcwake --mode no -s 120`
				- `sleep 5`
				- `rtcwake -m show`
				- `sleep 5`
				- `dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1 "org.freedesktop.login1.Manager.PowerOff" boolean:true`
			- [power-management/post-cold-reboot](https://github.com/canonical/checkbox/blob/main/providers/base/units/power-management/jobs.pxu#L362-L370)
				- `failed_service_check.sh`

## Tests
side load the base and certification-client provider on [202309-32086](https://certification.canonical.com/hardware/202309-32086)
[Modify_warm_cold_local](https://certification.canonical.com/hardware/202309-32086/submission/349789/)
[Modify_warm_cold_remote](https://certification.canonical.com/hardware/202309-32086/submission/349785/)

