### PR TITLE
Refactor LED tests (BugFix)

### DIFF
--- a/providers/base/bin/gpio_control_test.py
+++ b/providers/base/bin/gpio_control_test.py
@@ -19,7 +19,7 @@ class GPIOController:
         if gpiochip.isnumeric() is False or gpiopin.isnumeric() is False:
             raise ValueError("Invalid GPIO chip or GPIO pin")
 
-        self._gpio_root_node = Path(self.GPIORootPath)
+        self._gpio_root_node = Path(self.GPIO_ROOT_PATH)
         self._gpiochip_mapping = self.get_gpiochip_mapping()
 
         if gpiochip not in self._gpiochip_mapping.keys():
@@ -125,12 +125,12 @@ class GPIOController:
 
     def _export(self, gpio_number: str):
         logging.debug("export GPIO node %s", gpio_number)
-        with Path(self.GPIOExportPath) as gpio_node:
+        with Path(self.GPIO_EXPORT_PATH) as gpio_node:
             self._write_node(gpio_node, gpio_number, False)
 
     def _unexport(self, gpio_number: str):
         logging.debug("unexport GPIO node %s", gpio_number)
-        with Path(self.GPIOUnexportPath) as gpio_node:
+        with Path(self.GPIO_UNEXPORT_PATH) as gpio_node:
             self._write_node(gpio_node, gpio_number, False)
 
     @property
@@ -206,6 +206,15 @@ def dump_gpiochip(args):
         raise FileNotFoundError("{} file not exists".format(str(gpio_debug)))
 
 
+def leds_resource(args):
+    output = ""
+    resource_text = "name: {}\nchip_number: {}\nport: {}\n\n"
+    for led in args.mapping.split():
+        name, chip_number, port = led.split(":")
+        output += resource_text.format(name, chip_number, port)
+    print(output)
+
+
 def register_arguments():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -255,6 +264,15 @@ def register_arguments():
 
     gpio_dump_parser = sub_parsers.add_parser("dump")
     gpio_dump_parser.set_defaults(test_func=dump_gpiochip)
+
+    gpio_args_parser = sub_parsers.add_parser("led-resource")
+    gpio_args_parser.set_defaults(test_func=leds_resource)
+    gpio_args_parser.add_argument(
+        "mapping",
+        help=("Usage of parameter: GPIO_CONTROLLER_LEDS="
+              "{name1}:{controller1}:{port1} "
+              "{name2}:{controller1}:{port2} ..."),
+    )
 
     args = parser.parse_args()
     return args

--- a/providers/base/bin/gpio_control_test.py
+++ b/providers/base/bin/gpio_control_test.py
@@ -181,11 +181,29 @@ def blinking_test(args):
         led_controller.blinking(args.duration, args.interval)
 
 
+def dump_gpiochip(args):
+    gpio_debug_path = "/sys/kernel/debug/gpio"
+
+    gpio_debug = Path(gpio_debug_path)
+    if gpio_debug.exists():
+        print(gpio_debug.read_text())
+    else:
+        raise FileNotFoundError("{} file not exists".format(str(gpio_debug)))
+
+
 def register_arguments():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description='GPIO Control Tests')
-    sub_parsers = parser.add_subparsers(help="GPIO test type")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Turn on debug level output for extra info during test run.",
+    )
+
+    sub_parsers = parser.add_subparsers(
+        help="GPIO test type", dest="test_func", required=True)
+
     gpio_led_parser = sub_parsers.add_parser("led")
     gpio_led_parser.add_argument(
         "-n", "--name",
@@ -217,12 +235,10 @@ def register_arguments():
         action="store_true",
         default=False
     )
-    parser.add_argument(
-        "--debug",
-        action="store_true",
-        help="Turn on debug level output for extra info during test run.",
-    )
     gpio_led_parser.set_defaults(test_func=blinking_test)
+
+    gpio_dump_parser = sub_parsers.add_parser("dump")
+    gpio_dump_parser.set_defaults(test_func=dump_gpiochip)
 
     args = parser.parse_args()
     return args
@@ -230,6 +246,7 @@ def register_arguments():
 
 def main():
     args = register_arguments()
+    print(args)
     logger = init_logger()
     if args.debug:
         logger.setLevel(logging.DEBUG)

--- a/providers/base/bin/gpio_control_test.py
+++ b/providers/base/bin/gpio_control_test.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from datetime import datetime
 
 
-class GPIOController():
+class GPIOController:
 
     GPIORootPath = "/sys/class/gpio"
     GPIOExportPath = "{}/export".format(GPIORootPath)

--- a/providers/base/bin/gpio_control_test.py
+++ b/providers/base/bin/gpio_control_test.py
@@ -10,9 +10,9 @@ from datetime import datetime
 
 class GPIOController:
 
-    GPIORootPath = "/sys/class/gpio"
-    GPIOExportPath = "{}/export".format(GPIORootPath)
-    GPIOUnexportPath = "{}/unexport".format(GPIORootPath)
+    GPIO_ROOT_PATH = "/sys/class/gpio"
+    GPIO_EXPORT_PATH = "{}/export".format(GPIO_ROOT_PATH)
+    GPIO_UNEXPORT_PATH = "{}/unexport".format(GPIO_ROOT_PATH)
 
     def __init__(self, gpiochip: str, gpiopin: str,
                  direction: int, need_export: bool):

--- a/providers/base/bin/gpio_control_test.py
+++ b/providers/base/bin/gpio_control_test.py
@@ -1,0 +1,244 @@
+import sys
+import time
+import logging
+import argparse
+from pathlib import Path
+from datetime import datetime
+
+
+def init_logger():
+    """
+    Set the logger to log DEBUG and INFO to stdout, and
+    WARNING, ERROR, CRITICAL to stderr.
+    """
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    logger_format = "%(asctime)s %(levelname)-8s %(message)s"
+    date_format = "%Y-%m-%d %H:%M:%S"
+
+    # Log DEBUG and INFO to stdout, others to stderr
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stdout_handler.setLevel(logging.DEBUG)
+    stderr_handler.setLevel(logging.WARNING)
+
+    # Add a filter to the stdout handler to limit log records to
+    # INFO level and below
+    stdout_handler.addFilter(lambda record: record.levelno <= logging.INFO)
+
+    root_logger.addHandler(stderr_handler)
+    root_logger.addHandler(stdout_handler)
+
+    return root_logger
+
+
+class GPIOController():
+
+    GPIORootPath = "/sys/class/gpio"
+    GPIOExportPath = "{}/export".format(GPIORootPath)
+    GPIOUnexportPath = "{}/unexport".format(GPIORootPath)
+
+    def __init__(self, gpio_chip, gpio_pin, direction, need_export):
+        self.gpio_pin = gpio_pin
+        self.gpio_chip_node = Path(self.GPIORootPath).joinpath(
+                                    "gpiochip{}".format(gpio_chip))
+        self.gpio_node = None
+        self.value_node = None
+        self.direction_node = None
+        self.gpiochip_info = {"base": None, "ngpio": None}
+        self._direction = direction
+        self._need_export = need_export
+        self.initial_state = {"value": None, "direction": None}
+
+    def __enter__(self):
+        logging.debug("setup action for GPIO testing")
+        for key in ["base", "ngpio"]:
+            with self.gpio_chip_node.joinpath(key) as gpio_node:
+                if gpio_node.exists():
+                    self.gpiochip_info[key] = gpio_node.read_text().strip("\n")
+                else:
+                    raise FileNotFoundError(
+                        "{} file not exists".format(str(gpio_node)))
+
+        if int(self.gpio_pin) > int(self.gpiochip_info["ngpio"]):
+            raise IndexError(
+                "GPIO pin '{}' greater than ngpio value '{}'".format(
+                    self.gpio_pin, self.gpiochip_info["ngpio"]
+                )
+            )
+
+        self.gpio_pin = (
+            int(self.gpiochip_info["base"]) + int(self.gpio_pin) - 1)
+        self.gpio_node = Path(self.GPIORootPath).joinpath(
+                                    "gpio{}".format(self.gpio_pin))
+
+        # Export GPIO node if needed
+        if self.initial_state["need_export"]:
+            self._export(str(self.gpio_pin))
+            time.sleep(1)
+
+        if not self.gpio_node.exists():
+            raise FileNotFoundError(
+                        "{} file not exists".format(str(self.gpio_node)))
+
+        # Store the initial state for GPIO
+        self.initial_state["value"] = self.value
+        self.initial_state["direction"] = self.direction
+
+        self.direction = self._direction
+
+        return self
+
+    def __exit__(self, type, value, traceback):
+        logging.debug("teardown action for LED testing")
+        self.value = self.initial_state["value"]
+        self.direction = self.initial_state["direction"]
+        if self._need_export:
+            self._unexport(str(self.gpio_pin))
+
+    def _node_exists(self, node):
+        if node.exists() is False:
+            raise FileNotFoundError("{} file not exists".format(str(node)))
+
+    def _read_node(self, node):
+        self._node_exists(node)
+        return node.read_text().strip("\n")
+
+    def _write_node(self, node, value, check=True):
+
+        self._node_exists(node)
+        node.write_text(value)
+        if check and self._read_node(node) != value:
+            raise ValueError(
+                "Unable to change the value of {} file".format(str(node)))
+
+    def _export(self, pin):
+        logging.debug("export %s node", self.gpio_node.name)
+        with Path(self.GPIOExportPath) as gpio_node:
+            gpio_node.write_text(pin)
+
+    def _unexport(self, pin):
+        logging.debug("unexport %s node", self.gpio_node.name)
+        with Path(self.GPIOUnexportPath) as gpio_node:
+            gpio_node.write_text(pin)
+
+    @property
+    def direction(self):
+        with self.gpio_node.joinpath("direction") as gpio_node:
+            return self._read_node(gpio_node)
+
+    @direction.setter
+    def direction(self, value):
+
+        with self.gpio_node.joinpath("direction") as gpio_node:
+            logging.debug("set direction to {} for {}".format(
+                value, gpio_node.name
+            ))
+            self._write_node(gpio_node, value)
+
+    @property
+    def value(self):
+        with self.gpio_node.joinpath("value") as gpio_node:
+            return self._read_node(gpio_node)
+
+    @value.setter
+    def value(self, value):
+        with self.gpio_node.joinpath("value") as gpio_node:
+            logging.debug("set value to {} for {}".format(
+                value, gpio_node.name
+            ))
+            self._write_node(gpio_node, value)
+
+    def on(self):
+        logging.debug("turn on GPIO{} LED".format(self.gpio_pin))
+        self.value = 1
+
+    def off(self):
+        logging.debug("turn off GPIO{} LED".format(self.gpio_pin))
+        self.value = 0
+
+    def blinking(self, duration=10, interval=1):
+        logging.debug("set GPIO{} LED blinking".format(self.gpio_pin))
+        start_time = datetime.now()
+        while (datetime.now() - start_time).total_seconds() <= duration:
+            self.on()
+            time.sleep(interval)
+            self.off()
+            time.sleep(interval)
+
+
+def blinking_test(args):
+
+    with GPIOController(args.gpio_chip, args.gpio_pin,
+                        "out", args.need_export) as led_controller:
+        logging.info(("# Set the {} LED blinking around {} seconds "
+                     "with {} seconds blink interval").format(
+                        args.led_name, args.duration, args.interval))
+        led_controller.blinking(args.duration, args.interval)
+
+
+def register_arguments():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description='GPIO Control Tests')
+    sub_parsers = parser.add_subparsers(help="GPIO test type")
+    gpio_led_parser = sub_parsers.add_parser("led")
+    gpio_led_parser.add_argument(
+        "-n", "--name",
+        required=True,
+        type=str
+    )
+    gpio_led_parser.add_argument(
+        "-d", "--duration",
+        type=int,
+        default=5
+    )
+    gpio_led_parser.add_argument(
+        "-i", "--interval",
+        type=int,
+        default=0.5
+    )
+    gpio_led_parser.add_argument(
+        "--gpio-chip",
+        type=str,
+        required=True
+    )
+    gpio_led_parser.add_argument(
+        "--gpio-pin",
+        type=str,
+        required=True
+    )
+    gpio_led_parser.add_argument(
+        "--need-export",
+        action="store_true",
+        default=False
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Turn on debug level output for extra info during test run.",
+    )
+    gpio_led_parser.set_defaults(test_func=blinking_test)
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = register_arguments()
+    logger = init_logger()
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+
+    try:
+        args.test_func(args)
+    except Exception as err:
+        logging.error(err)
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/base/bin/led_control_test.py
+++ b/providers/base/bin/led_control_test.py
@@ -9,36 +9,6 @@ from pathlib import Path
 from datetime import datetime
 
 
-def init_logger():
-    """
-    Set the logger to log DEBUG and INFO to stdout, and
-    WARNING, ERROR, CRITICAL to stderr.
-    """
-    root_logger = logging.getLogger()
-    root_logger.setLevel(logging.INFO)
-    logger_format = "%(asctime)s %(levelname)-8s %(message)s"
-    date_format = "%Y-%m-%d %H:%M:%S"
-
-    # Log DEBUG and INFO to stdout, others to stderr
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.setFormatter(logging.Formatter(logger_format, date_format))
-
-    stderr_handler = logging.StreamHandler(sys.stderr)
-    stderr_handler.setFormatter(logging.Formatter(logger_format, date_format))
-
-    stdout_handler.setLevel(logging.DEBUG)
-    stderr_handler.setLevel(logging.WARNING)
-
-    # Add a filter to the stdout handler to limit log records to
-    # INFO level and below
-    stdout_handler.addFilter(lambda record: record.levelno <= logging.INFO)
-
-    root_logger.addHandler(stderr_handler)
-    root_logger.addHandler(stdout_handler)
-
-    return root_logger
-
-
 class SysFsLEDController():
 
     SysFsLEDPath = "/sys/class/leds"
@@ -186,11 +156,33 @@ def register_arguments():
     return args
 
 
-def main():
+if __name__ == "__main__":
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    logger_format = "%(asctime)s %(levelname)-8s %(message)s"
+    date_format = "%Y-%m-%d %H:%M:%S"
+
+    # Log DEBUG and INFO to stdout, others to stderr
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stdout_handler.setLevel(logging.DEBUG)
+    stderr_handler.setLevel(logging.WARNING)
+
+    # Add a filter to the stdout handler to limit log records to
+    # INFO level and below
+    stdout_handler.addFilter(lambda record: record.levelno <= logging.INFO)
+
+    root_logger.addHandler(stderr_handler)
+    root_logger.addHandler(stdout_handler)
+
     args = register_arguments()
-    logger = init_logger()
     if args.debug:
-        logger.setLevel(logging.DEBUG)
+        root_logger.setLevel(logging.DEBUG)
 
     logging.info("# Start LED testing")
     logging.info(("# Set the %s LED blinking around %d seconds"
@@ -200,7 +192,3 @@ def main():
     with SysFsLEDController(args.name, str(args.on_value),
                             str(args.off_value)) as led_controller:
         led_controller.blinking(args.duration, args.interval)
-
-
-if __name__ == "__main__":
-    main()

--- a/providers/base/bin/led_control_test.py
+++ b/providers/base/bin/led_control_test.py
@@ -1,0 +1,194 @@
+import sys
+import re
+import time
+import logging
+import argparse
+from pathlib import Path
+from datetime import datetime
+
+
+def init_logger():
+    """
+    Set the logger to log DEBUG and INFO to stdout, and
+    WARNING, ERROR, CRITICAL to stderr.
+    """
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    logger_format = "%(asctime)s %(levelname)-8s %(message)s"
+    date_format = "%Y-%m-%d %H:%M:%S"
+
+    # Log DEBUG and INFO to stdout, others to stderr
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stdout_handler.setLevel(logging.DEBUG)
+    stderr_handler.setLevel(logging.WARNING)
+
+    # Add a filter to the stdout handler to limit log records to
+    # INFO level and below
+    stdout_handler.addFilter(lambda record: record.levelno <= logging.INFO)
+
+    root_logger.addHandler(stderr_handler)
+    root_logger.addHandler(stdout_handler)
+
+    return root_logger
+
+
+class SysFsLEDController():
+
+    SysFsLEDPath = "/sys/class/leds"
+
+    def __init__(self, name, on_value="0", off_value="0"):
+        self.led_name = name
+        self.led_node = Path(self.SysFsLEDPath).joinpath(name)
+        self.brightness_node = self.led_node / "brightness"
+        self.max_brightness_node = self.led_node / "max_brightness"
+        self.trigger_node = self.led_node / "trigger"
+        self.initial_state = {"trigger": None, "brightness": None}
+        self._on_value = on_value
+        self._off_value = off_value
+
+    def __enter__(self):
+        logging.debug("setup action for LED testing")
+
+        if int(self._on_value) > int(self.max_brightness):
+            raise ValueError("brightness value greater than max brightness")
+        if self._on_value == "0":
+            self._on_value = self.max_brightness
+
+        # Get the initial value of trigger and brightness
+        self._get_initial_state()
+        # Set the trigger type to none
+        self.trigger = "none"
+        self.off()
+
+        return self
+
+    def __exit__(self, type, value, traceback):
+        logging.debug("teardown action for LED testing")
+        initial_state = self.initial_state
+        self.brightness = initial_state["brightness"]
+        self.trigger = initial_state["trigger"]
+
+    def _node_exists(self, node):
+        if node.exists() is False:
+            raise FileNotFoundError("{} file not exists".format(str(node)))
+
+    def _read_node(self, node):
+        self._node_exists(node)
+        return node.read_text().strip("\n")
+
+    def _write_node(self, node, value, check=True):
+
+        self._node_exists(node)
+        node.write_text(value)
+        if check and self._read_node(node) != value:
+            raise ValueError(
+                "Unable to change the value of {} file".format(str(node)))
+
+    @property
+    def brightness(self):
+        return self._read_node(self.brightness_node)
+
+    @brightness.setter
+    def brightness(self, value):
+        logging.debug("set brightness to %s for %s LED", value, self.led_name)
+        self._write_node(self.brightness_node, value)
+
+    @property
+    def max_brightness(self):
+        return self._read_node(self.max_brightness_node)
+
+    @property
+    def trigger(self):
+        return self._read_node(self.trigger_node)
+
+    @trigger.setter
+    def trigger(self, value):
+        logging.debug("set trigger action to {} for {} LED".format(
+            value, self.led_name
+        ))
+        # The read value from trigger node is all supported trigger type
+        # So skip the check
+        self._write_node(self.trigger_node, value, False)
+
+    def _get_initial_state(self):
+        match = re.search(r"\[([\w-]+)\]", self.trigger)
+        if match:
+            self.initial_state["trigger"] = match.groups()[0]
+
+        self.initial_state["brightness"] = self.brightness
+
+    def on(self):
+        logging.debug("turn on {} LED".format(self.led_name))
+        self.brightness = self._on_value
+
+    def off(self):
+        logging.debug("turn off {} LED".format(self.led_name))
+        self.brightness = self._off_value
+
+    def blinking(self, duration=10, interval=1):
+        logging.debug("set {} LED blinking".format(self.led_name))
+        start_time = datetime.now()
+        while (datetime.now() - start_time).total_seconds() <= duration:
+            self.on()
+            time.sleep(interval)
+            self.off()
+            time.sleep(interval)
+
+
+def register_arguments():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description='LED Tests')
+    parser.add_argument(
+        "-n", "--name",
+        required=True,
+        type=str
+    )
+    parser.add_argument(
+        "-d", "--duration",
+        type=int,
+        default=5
+    )
+    parser.add_argument(
+        "-i", "--interval",
+        type=int,
+        default=0.5
+    )
+    parser.add_argument(
+        "--on-value",
+        type=int,
+        default="0"
+    )
+    parser.add_argument(
+        "--off-value",
+        type=int,
+        default="0"
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = register_arguments()
+    logger = init_logger()
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+
+    logging.info("# Start LED testing")
+    logging.info(("# Set the %s LED blinking around %d seconds"
+                  "with %d seconds blink interval"),
+                 args.led_name, args.duration, args.interval)
+
+    with SysFsLEDController(args.led_name, str(args.on_value),
+                            str(args.off_value)) as led_controller:
+        led_controller.blinking(args.duration, args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/base/tests/test_gpio_control_test.py
+++ b/providers/base/tests/test_gpio_control_test.py
@@ -284,7 +284,8 @@ class TestMainFunction(unittest.TestCase):
         mock_path.return_value = True
         mock_read.return_value = "mock-string"
 
-        dump_gpiochip(None)
+        with redirect_stdout(StringIO()) as stdout:
+            dump_gpiochip(None)
         mock_path.assert_called_once_with()
         mock_read.assert_called_once_with()
 

--- a/providers/base/tests/test_gpio_control_test.py
+++ b/providers/base/tests/test_gpio_control_test.py
@@ -3,6 +3,8 @@ import sys
 import argparse
 from unittest.mock import patch, Mock
 from pathlib import PosixPath, Path
+from io import StringIO
+from contextlib import redirect_stdout
 from gpio_control_test import GPIOController
 from gpio_control_test import blinking_test
 from gpio_control_test import dump_gpiochip

--- a/providers/base/tests/test_gpio_control_test.py
+++ b/providers/base/tests/test_gpio_control_test.py
@@ -303,7 +303,8 @@ class TestMainFunction(unittest.TestCase):
     def test_led_resource(self):
         mock_args = Mock(
             return_value=argparse.Namespace(mapping="DL14:5:1 DL14:5:2"))
-        leds_resource(mock_args())
+        with redirect_stdout(StringIO()) as stdout:
+            leds_resource(mock_args())
 
     def test_led_resource_with_unexpected_format(self):
         mock_args = Mock(

--- a/providers/base/tests/test_gpio_control_test.py
+++ b/providers/base/tests/test_gpio_control_test.py
@@ -6,6 +6,7 @@ from pathlib import PosixPath, Path
 from gpio_control_test import GPIOController
 from gpio_control_test import blinking_test
 from gpio_control_test import dump_gpiochip
+from gpio_control_test import leds_resource
 from gpio_control_test import register_arguments
 
 
@@ -298,6 +299,23 @@ class TestMainFunction(unittest.TestCase):
             str(context.exception), "/sys/kernel/debug/gpio file not exists"
         )
 
+    def test_led_resource(self):
+        mock_args = Mock(
+            return_value=argparse.Namespace(mapping="DL14:5:1 DL14:5:2"))
+        leds_resource(mock_args())
+
+    def test_led_resource_with_unexpected_format(self):
+        mock_args = Mock(
+            return_value=argparse.Namespace(mapping="DL14-5:1"))
+
+        with self.assertRaises(ValueError) as context:
+            leds_resource(mock_args())
+
+        self.assertEqual(
+            str(context.exception),
+            "not enough values to unpack (expected 3, got 2)"
+        )
+
 
 class TestArgumentParser(unittest.TestCase):
 
@@ -323,4 +341,11 @@ class TestArgumentParser(unittest.TestCase):
         args = register_arguments()
 
         self.assertEqual(args.test_func, dump_gpiochip)
+        self.assertEqual(args.debug, False)
+
+    def test_led_resource_parser(self):
+        sys.argv = ["gpio_control_test.py", "led-resource", "DL14:5:1"]
+        args = register_arguments()
+
+        self.assertEqual(args.test_func, leds_resource)
         self.assertEqual(args.debug, False)

--- a/providers/base/tests/test_gpio_control_test.py
+++ b/providers/base/tests/test_gpio_control_test.py
@@ -1,0 +1,78 @@
+import unittest
+from unittest.mock import patch
+from pathlib import PosixPath, Path
+from gpio_control_test import GPIOController
+
+
+class TestGPIOController(unittest.TestCase):
+
+    @patch("pathlib.Path.exists")
+    def test_file_not_exists(self, mock_path):
+        mock_path.return_value = False
+        gpio_controller = GPIOController("32", "1", "in", True)
+        with self.assertRaises(FileNotFoundError):
+            gpio_controller._node_exists(Path("test-fake"))
+
+    @patch("pathlib.Path.read_text")
+    @patch("pathlib.Path.exists")
+    def test_read_file(self, mock_path, mock_read):
+        mock_path.return_value = True
+        mock_read.return_value = "test-string"
+        with GPIOController("32", "1", "in", True) as gpio_controller:
+            self.assertEqual(
+                mock_read.return_value,
+                gpio_controller._read_node(Path("test-fake")))
+
+    @patch("pathlib.Path.write_text")
+    @patch("pathlib.Path.read_text")
+    @patch("pathlib.Path.exists")
+    def test_write_failed(self, mock_path, mock_read, mock_write):
+        mock_path.return_value = True
+        mock_read.return_value = "33"
+
+        with self.assertRaises(ValueError):
+            gpio_controller = GPIOController("32", "1", "out", True)
+            gpio_controller._write_node(Path("test-fake"), "22", True)
+
+    @patch("pathlib.Path.write_text")
+    @patch("pathlib.Path.read_text")
+    @patch("pathlib.Path.exists")
+    def test_write_passed(self, mock_path, mock_read, mock_write):
+        mock_path.return_value = True
+        mock_read.return_value = "33"
+
+        with self.assertRaises(ValueError):
+            gpio_controller = GPIOController("32", "1", "out", True)
+            gpio_controller._write_node(Path("test-fake"), "22", True)
+
+    def test_initial_gpio_controller_property(self):
+
+        with GPIOController("32", "3", "out", False) as led_controller:
+            self.assertEqual(led_controller.gpio_pin, "3")
+            self.assertIsInstance(led_controller.gpio_chip_node, PosixPath)
+            self.assertEqual(led_controller.gpio_chip_node.name, "gpiochip32")
+            self.assertDictEqual(
+                led_controller.gpiochip_info, {"base": None, "ngpio": None})
+            self.assertDictEqual(
+                led_controller.initial_state,
+                {"value": None, "direction": None})
+
+    @patch("pathlib.Path.read_text")
+    @patch("pathlib.Path.exists")
+    def test_get_gpio_direction(self, mock_path, mock_path_get):
+        mock_path.return_value = True
+        mock_path_get.return_value = "out"
+
+        with GPIOController("32", "1", "out", True) as gpio_controller:
+            gpio_controller.gpio_node = Path("fake-node")
+            self.assertEqual(gpio_controller.direction, "out")
+
+    @patch("pathlib.Path.read_text")
+    @patch("pathlib.Path.exists")
+    def test_get_gpio_value(self, mock_path, mock_path_get):
+        mock_path.return_value = True
+        mock_path_get.return_value = "1"
+
+        with GPIOController("32", "1", "out", True) as gpio_controller:
+            gpio_controller.gpio_node = Path("fake-node")
+            self.assertEqual(gpio_controller.value, "1")

--- a/providers/base/tests/test_gpio_control_test.py
+++ b/providers/base/tests/test_gpio_control_test.py
@@ -252,7 +252,7 @@ class TestGPIOController(unittest.TestCase):
         mock_mapping.return_value = {"1": "32"}
 
         gpio_controller = GPIOController("1", "1", "out", True)
-        gpio_controller.blinking(1, 0.5)
+        gpio_controller.blinking(0.0001, 0.0001)
         mock_on.assert_called_with()
         mock_off.assert_called_with()
 

--- a/providers/base/tests/test_gpio_control_test.py
+++ b/providers/base/tests/test_gpio_control_test.py
@@ -6,6 +6,7 @@ from gpio_control_test import GPIOController
 
 class TestGPIOController(unittest.TestCase):
 
+    @patch("gpio_control_test.GPIOController.get_gpiochip_mapping")
     @patch("gpio_control_test.GPIOController._unexport")
     @patch("gpio_control_test.GPIOController._export")
     @patch("gpio_control_test.GPIOController._write_node")
@@ -13,11 +14,12 @@ class TestGPIOController(unittest.TestCase):
     @patch("gpio_control_test.GPIOController._node_exists")
     def test_initial_gpio_controller_success(
             self, mock_path, mock_read, mock_write,
-            mock_export, mock_unexport):
+            mock_export, mock_unexport, mock_mapping):
         mock_path.return_value = True
         mock_read.side_effect = ["32", "16", "0", "in"]
+        mock_mapping.return_value = {"1": "32"}
 
-        with GPIOController("32", "1", "in", True) as gpio_controller:
+        with GPIOController("1", "1", "in", True) as gpio_controller:
             mock_path.assert_called()
             mock_read.assert_called()
             mock_write.assert_called()
@@ -40,6 +42,7 @@ class TestGPIOController(unittest.TestCase):
             with GPIOController("12", "1a", "in", True) as _:
                 pass
 
+    @patch("gpio_control_test.GPIOController.get_gpiochip_mapping")
     @patch("gpio_control_test.GPIOController._unexport")
     @patch("gpio_control_test.GPIOController._export")
     @patch("gpio_control_test.GPIOController._write_node")
@@ -47,90 +50,110 @@ class TestGPIOController(unittest.TestCase):
     @patch("gpio_control_test.GPIOController._node_exists")
     def test_initial_gpiopin_exceeds_maximum(
             self, mock_path, mock_read, mock_write,
-            mock_export, mock_unexport):
+            mock_export, mock_unexport, mock_mapping):
         mock_path.return_value = True
         mock_read.side_effect = ["32", "16", "0", "in"]
+        mock_mapping.return_value = {"1": "32"}
 
         with self.assertRaises(IndexError):
-            with GPIOController("32", "18", "in", True) as _:
+            with GPIOController("1", "18", "in", True) as _:
                 mock_path.assert_called()
                 mock_read.assert_called()
 
+    @patch("gpio_control_test.GPIOController.get_gpiochip_mapping")
     @patch("pathlib.Path.exists")
-    def test_file_not_exists(self, mock_path):
+    def test_file_not_exists(self, mock_path, mock_mapping):
         mock_path.return_value = False
-        gpio_controller = GPIOController("32", "1", "in", True)
+        mock_mapping.return_value = {"1": "32"}
+        gpio_controller = GPIOController("1", "1", "in", True)
         with self.assertRaises(FileNotFoundError):
             gpio_controller._node_exists(Path("test-fake"))
 
+    @patch("gpio_control_test.GPIOController.get_gpiochip_mapping")
     @patch("pathlib.Path.read_text")
     @patch("pathlib.Path.exists")
-    def test_read_file(self, mock_path, mock_read):
+    def test_read_file(self, mock_path, mock_read, mock_mapping):
         expected_result = "test-string"
         mock_path.return_value = True
         mock_read.return_value = expected_result
-        gpio_controller = GPIOController("32", "1", "in", True)
+        mock_mapping.return_value = {"1": "32"}
+        gpio_controller = GPIOController("1", "1", "in", True)
         self.assertEqual(
             expected_result,
             gpio_controller._read_node(gpio_controller.gpio_chip_node))
 
+    @patch("gpio_control_test.GPIOController.get_gpiochip_mapping")
     @patch("pathlib.Path.write_text")
     @patch("pathlib.Path.read_text")
     @patch("pathlib.Path.exists")
-    def test_write_failed(self, mock_path, mock_read, mock_write):
+    def test_write_failed(self, mock_path, mock_read,
+                          mock_write, mock_mapping):
         read_value = "33"
         write_value = "22"
 
         mock_path.return_value = True
         mock_read.return_value = read_value
+        mock_mapping.return_value = {"1": "32"}
 
         with self.assertRaises(ValueError):
-            gpio_controller = GPIOController("32", "1", "out", True)
+            gpio_controller = GPIOController("1", "1", "out", True)
             gpio_controller._write_node(Path("test-fake"), write_value, True)
 
+    @patch("gpio_control_test.GPIOController.get_gpiochip_mapping")
     @patch("pathlib.Path.write_text")
     @patch("pathlib.Path.read_text")
     @patch("pathlib.Path.exists")
-    def test_write_passed(self, mock_path, mock_read, mock_write):
+    def test_write_passed(self, mock_path,
+                          mock_read, mock_write, mock_mapping):
         read_value = "33"
         write_value = "33"
-
         mock_path.return_value = True
         mock_read.return_value = read_value
+        mock_mapping.return_value = {"1": "32"}
 
-        gpio_controller = GPIOController("32", "1", "out", True)
+        gpio_controller = GPIOController("1", "1", "out", True)
         gpio_controller._write_node(Path("test-fake"), write_value, True)
 
         mock_path.assert_called()
         mock_read.assert_called_once()
         mock_write.assert_called_once()
 
+    @patch("gpio_control_test.GPIOController.get_gpiochip_mapping")
     @patch("pathlib.Path.read_text")
     @patch("pathlib.Path.exists")
-    def test_get_gpio_direction(self, mock_path, mock_path_get):
+    def test_get_gpio_direction(self, mock_path, mock_path_get, mock_mapping):
         mock_path.return_value = True
         mock_path_get.return_value = "out"
+        mock_mapping.return_value = {"1": "32"}
 
-        gpio_controller = GPIOController("32", "1", "out", True)
+        gpio_controller = GPIOController("1", "1", "out", True)
         gpio_controller.gpio_node = Path("fake-node")
         self.assertEqual(gpio_controller.direction, "out")
 
-    def test_set_gpio_direction_failed(self):
+    @patch("gpio_control_test.GPIOController.get_gpiochip_mapping")
+    def test_set_gpio_direction_failed(self, mock_mapping):
+        mock_mapping.return_value = {"1": "32"}
+
         with self.assertRaises(ValueError):
-            gpio_controller = GPIOController("32", "1", "out", True)
+            gpio_controller = GPIOController("1", "1", "out", True)
             gpio_controller.direction = "wrong_direction"
 
+    @patch("gpio_control_test.GPIOController.get_gpiochip_mapping")
     @patch("pathlib.Path.read_text")
     @patch("pathlib.Path.exists")
-    def test_get_gpio_value(self, mock_path, mock_path_get):
+    def test_get_gpio_value(self, mock_path, mock_path_get, mock_mapping):
         mock_path.return_value = True
         mock_path_get.return_value = "1"
+        mock_mapping.return_value = {"1": "32"}
 
-        gpio_controller = GPIOController("32", "1", "out", True)
+        gpio_controller = GPIOController("1", "1", "out", True)
         gpio_controller.gpio_node = Path("fake-node")
         self.assertEqual(gpio_controller.value, "1")
 
-    def test_set_gpio_value_failed(self):
+    @patch("gpio_control_test.GPIOController.get_gpiochip_mapping")
+    def test_set_gpio_value_failed(self, mock_mapping):
+        mock_mapping.return_value = {"1": "32"}
+
         with self.assertRaises(ValueError):
-            gpio_controller = GPIOController("32", "1", "out", True)
+            gpio_controller = GPIOController("1", "1", "out", True)
             gpio_controller.value = "wrong_value"

--- a/providers/base/tests/test_gpio_control_test.py
+++ b/providers/base/tests/test_gpio_control_test.py
@@ -18,6 +18,7 @@ class TestGPIOController(unittest.TestCase):
     @patch("gpio_control_test.GPIOController._write_node")
     @patch("gpio_control_test.GPIOController._read_node")
     @patch("gpio_control_test.GPIOController._node_exists")
+    @patch("gpio_control_test.time.sleep", new=Mock)
     def test_initial_gpio_controller_success(
             self, mock_path, mock_read, mock_write,
             mock_export, mock_unexport, mock_mapping):

--- a/providers/base/tests/test_gpio_control_test.py
+++ b/providers/base/tests/test_gpio_control_test.py
@@ -6,6 +6,56 @@ from gpio_control_test import GPIOController
 
 class TestGPIOController(unittest.TestCase):
 
+    @patch("gpio_control_test.GPIOController._unexport")
+    @patch("gpio_control_test.GPIOController._export")
+    @patch("gpio_control_test.GPIOController._write_node")
+    @patch("gpio_control_test.GPIOController._read_node")
+    @patch("gpio_control_test.GPIOController._node_exists")
+    def test_initial_gpio_controller_success(
+            self, mock_path, mock_read, mock_write,
+            mock_export, mock_unexport):
+        mock_path.return_value = True
+        mock_read.side_effect = ["32", "16", "0", "in"]
+
+        with GPIOController("32", "1", "in", True) as gpio_controller:
+            mock_path.assert_called()
+            mock_read.assert_called()
+            mock_write.assert_called()
+            self.assertIsInstance(gpio_controller.gpio_chip_node, PosixPath)
+            self.assertEqual(gpio_controller.gpio_chip_node.name, "gpiochip32")
+            self.assertDictEqual(
+                gpio_controller.gpiochip_info,
+                {"base": "32", "ngpio": "16", "offset": "1"})
+            self.assertDictEqual(
+                gpio_controller.initial_state,
+                {"value": "0", "direction": "in", "number": "32"})
+
+    def test_initial_gpio_controller_with_invalid_gpiochip(self):
+        with self.assertRaises(ValueError):
+            with GPIOController("6a", "1", "in", True) as gpio_controller:
+                gpio_controller.gpio_chip_node
+
+    def test_initial_gpio_controller_with_invalid_gpiopin(self):
+        with self.assertRaises(ValueError):
+            with GPIOController("12", "1a", "in", True) as _:
+                pass
+
+    @patch("gpio_control_test.GPIOController._unexport")
+    @patch("gpio_control_test.GPIOController._export")
+    @patch("gpio_control_test.GPIOController._write_node")
+    @patch("gpio_control_test.GPIOController._read_node")
+    @patch("gpio_control_test.GPIOController._node_exists")
+    def test_initial_gpiopin_exceeds_maximum(
+            self, mock_path, mock_read, mock_write,
+            mock_export, mock_unexport):
+        mock_path.return_value = True
+        mock_read.side_effect = ["32", "16", "0", "in"]
+
+        with self.assertRaises(IndexError):
+            with GPIOController("32", "18", "in", True) as _:
+                mock_path.assert_called()
+                mock_read.assert_called()
+
     @patch("pathlib.Path.exists")
     def test_file_not_exists(self, mock_path):
         mock_path.return_value = False
@@ -16,46 +66,44 @@ class TestGPIOController(unittest.TestCase):
     @patch("pathlib.Path.read_text")
     @patch("pathlib.Path.exists")
     def test_read_file(self, mock_path, mock_read):
+        expected_result = "test-string"
         mock_path.return_value = True
-        mock_read.return_value = "test-string"
-        with GPIOController("32", "1", "in", True) as gpio_controller:
-            self.assertEqual(
-                mock_read.return_value,
-                gpio_controller._read_node(Path("test-fake")))
+        mock_read.return_value = expected_result
+        gpio_controller = GPIOController("32", "1", "in", True)
+        self.assertEqual(
+            expected_result,
+            gpio_controller._read_node(gpio_controller.gpio_chip_node))
 
     @patch("pathlib.Path.write_text")
     @patch("pathlib.Path.read_text")
     @patch("pathlib.Path.exists")
     def test_write_failed(self, mock_path, mock_read, mock_write):
+        read_value = "33"
+        write_value = "22"
+
         mock_path.return_value = True
-        mock_read.return_value = "33"
+        mock_read.return_value = read_value
 
         with self.assertRaises(ValueError):
             gpio_controller = GPIOController("32", "1", "out", True)
-            gpio_controller._write_node(Path("test-fake"), "22", True)
+            gpio_controller._write_node(Path("test-fake"), write_value, True)
 
     @patch("pathlib.Path.write_text")
     @patch("pathlib.Path.read_text")
     @patch("pathlib.Path.exists")
     def test_write_passed(self, mock_path, mock_read, mock_write):
+        read_value = "33"
+        write_value = "33"
+
         mock_path.return_value = True
-        mock_read.return_value = "33"
+        mock_read.return_value = read_value
 
-        with self.assertRaises(ValueError):
-            gpio_controller = GPIOController("32", "1", "out", True)
-            gpio_controller._write_node(Path("test-fake"), "22", True)
+        gpio_controller = GPIOController("32", "1", "out", True)
+        gpio_controller._write_node(Path("test-fake"), write_value, True)
 
-    def test_initial_gpio_controller_property(self):
-
-        with GPIOController("32", "3", "out", False) as led_controller:
-            self.assertEqual(led_controller.gpio_pin, "3")
-            self.assertIsInstance(led_controller.gpio_chip_node, PosixPath)
-            self.assertEqual(led_controller.gpio_chip_node.name, "gpiochip32")
-            self.assertDictEqual(
-                led_controller.gpiochip_info, {"base": None, "ngpio": None})
-            self.assertDictEqual(
-                led_controller.initial_state,
-                {"value": None, "direction": None})
+        mock_path.assert_called()
+        mock_read.assert_called_once()
+        mock_write.assert_called_once()
 
     @patch("pathlib.Path.read_text")
     @patch("pathlib.Path.exists")
@@ -63,9 +111,14 @@ class TestGPIOController(unittest.TestCase):
         mock_path.return_value = True
         mock_path_get.return_value = "out"
 
-        with GPIOController("32", "1", "out", True) as gpio_controller:
-            gpio_controller.gpio_node = Path("fake-node")
-            self.assertEqual(gpio_controller.direction, "out")
+        gpio_controller = GPIOController("32", "1", "out", True)
+        gpio_controller.gpio_node = Path("fake-node")
+        self.assertEqual(gpio_controller.direction, "out")
+
+    def test_set_gpio_direction_failed(self):
+        with self.assertRaises(ValueError):
+            gpio_controller = GPIOController("32", "1", "out", True)
+            gpio_controller.direction = "wrong_direction"
 
     @patch("pathlib.Path.read_text")
     @patch("pathlib.Path.exists")
@@ -73,6 +126,11 @@ class TestGPIOController(unittest.TestCase):
         mock_path.return_value = True
         mock_path_get.return_value = "1"
 
-        with GPIOController("32", "1", "out", True) as gpio_controller:
-            gpio_controller.gpio_node = Path("fake-node")
-            self.assertEqual(gpio_controller.value, "1")
+        gpio_controller = GPIOController("32", "1", "out", True)
+        gpio_controller.gpio_node = Path("fake-node")
+        self.assertEqual(gpio_controller.value, "1")
+
+    def test_set_gpio_value_failed(self):
+        with self.assertRaises(ValueError):
+            gpio_controller = GPIOController("32", "1", "out", True)
+            gpio_controller.value = "wrong_value"

--- a/providers/base/tests/test_led_control_test.py
+++ b/providers/base/tests/test_led_control_test.py
@@ -1,7 +1,9 @@
+import sys
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 from pathlib import PosixPath, Path
 from led_control_test import SysFsLEDController
+from led_control_test import register_arguments
 
 
 class TestSysFsLEDController(unittest.TestCase):
@@ -9,6 +11,27 @@ class TestSysFsLEDController(unittest.TestCase):
     def setUp(self):
 
         self.led_controller = SysFsLEDController("test-fake")
+
+    @patch("led_control_test.SysFsLEDController._read_node")
+    @patch("led_control_test.SysFsLEDController._node_exists")
+    def test_setup_failed(self, mock_path, mock_read):
+        mock_path.return_value = False
+        mock_read.return_value = "30"
+        self.led_controller._on_value = "50"
+
+        with self.assertRaises(ValueError):
+            self.led_controller.setup()
+
+    @patch("led_control_test.SysFsLEDController._write_node")
+    @patch("led_control_test.SysFsLEDController._read_node")
+    @patch("led_control_test.SysFsLEDController._node_exists")
+    def test_setup_passed(self, mock_path, mock_read, mock_write):
+        mock_path.return_value = True
+        mock_read.return_value = "30"
+
+        self.led_controller.setup()
+        self.assertEqual(self.led_controller._on_value,
+                         mock_read.return_value)
 
     @patch("pathlib.Path.exists")
     def test_file_not_exists(self, mock_path):
@@ -42,9 +65,10 @@ class TestSysFsLEDController(unittest.TestCase):
         mock_path.return_value = True
         mock_read.return_value = "22"
 
-        self.led_controller._write_node(Path("test-fake"), "22", True)
-        mock_read.assert_called_once()
-        mock_write.assert_called_once()
+        self.led_controller._write_node(
+            self.led_controller.led_node, "22", True)
+        mock_read.assert_called_once_with(self.led_controller.led_node)
+        mock_write.assert_called_once_with("22")
 
     @patch("led_control_test.SysFsLEDController._write_node")
     @patch("led_control_test.SysFsLEDController.off")
@@ -56,10 +80,12 @@ class TestSysFsLEDController(unittest.TestCase):
 
         led_name = "status"
         with SysFsLEDController(led_name, "3", "0") as led_controller:
-            mock_read.assert_called_once()
-            mock_get_initial.assert_called_once()
-            mock_off.assert_called_once()
-            mock_write.assert_called_once()
+            mock_read.assert_called_once_with(
+                led_controller.max_brightness_node)
+            mock_get_initial.assert_called_once_with()
+            mock_off.assert_called_once_with()
+            mock_write.assert_called_once_with(
+                led_controller.trigger_node, "none", False)
             self.assertEqual(led_controller.led_name, led_name)
             self.assertIsInstance(led_controller.led_node, PosixPath)
             self.assertIsInstance(led_controller.brightness_node, PosixPath)
@@ -75,12 +101,14 @@ class TestSysFsLEDController(unittest.TestCase):
     def test_get_brightness(self, mock_read):
         mock_read.return_value = "33"
         self.assertEqual(self.led_controller.brightness, "33")
-        mock_read.assert_called_once()
+        mock_read.assert_called_once_with(
+            self.led_controller.brightness_node)
 
     @patch("led_control_test.SysFsLEDController._write_node")
     def test_set_brightness(self, mock_write):
         self.led_controller.brightness = "33"
-        mock_write.assert_called_once()
+        mock_write.assert_called_once_with(
+            self.led_controller.brightness_node, "33")
 
     @patch("led_control_test.SysFsLEDController._read_node")
     def test_get_trigger(self, mock_read):
@@ -98,3 +126,29 @@ class TestSysFsLEDController(unittest.TestCase):
         expected_data = {"trigger": "usb-host", "brightness": "255"}
         self.led_controller._get_initial_state()
         self.assertEqual(expected_data, self.led_controller.initial_state)
+
+    @patch("led_control_test.SysFsLEDController.off")
+    @patch("led_control_test.SysFsLEDController.on")
+    def test_blinking_test(self, mock_on, mock_off):
+
+        self.led_controller.blinking(1, 0.5)
+        mock_on.assert_called_with()
+        mock_off.assert_called_with()
+
+
+class TestArgumentParser(unittest.TestCase):
+
+    def test_parser(self):
+        sys.argv = [
+            "led_control_test.py", "--debug", "-n", "fake-led",
+            "--on-value", "33", "--off-value", "1", "-d", "30", "-i", "2"
+
+        ]
+        args = register_arguments()
+
+        self.assertEqual(args.debug, True)
+        self.assertEqual(args.name, "fake-led")
+        self.assertEqual(args.duration, 30)
+        self.assertEqual(args.interval, 2)
+        self.assertEqual(args.on_value, 33)
+        self.assertEqual(args.off_value, 1)

--- a/providers/base/tests/test_led_control_test.py
+++ b/providers/base/tests/test_led_control_test.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 from pathlib import PosixPath, Path
 from led_control_test import SysFsLEDController
 
@@ -36,53 +36,62 @@ class TestSysFsLEDController(unittest.TestCase):
             self.led_controller._write_node(Path("test-fake"), "22", True)
 
     @patch("pathlib.Path.write_text")
-    @patch("pathlib.Path.read_text")
+    @patch("led_control_test.SysFsLEDController._read_node")
     @patch("pathlib.Path.exists")
     def test_write_passed(self, mock_path, mock_read, mock_write):
         mock_path.return_value = True
-        mock_read.return_value = "33"
+        mock_read.return_value = "22"
 
-        with self.assertRaises(ValueError):
-            self.led_controller._write_node(Path("test-fake"), "22", True)
+        self.led_controller._write_node(Path("test-fake"), "22", True)
+        mock_read.assert_called_once()
+        mock_write.assert_called_once()
 
-    def test_initial_sysfs_controller_property(self):
+    @patch("led_control_test.SysFsLEDController._write_node")
+    @patch("led_control_test.SysFsLEDController.off")
+    @patch("led_control_test.SysFsLEDController._get_initial_state")
+    @patch("led_control_test.SysFsLEDController._read_node")
+    def test_initial_sysfs_controller_property(
+            self, mock_read, mock_get_initial, mock_off, mock_write):
+        mock_read.return_value = 255
 
         led_name = "status"
-        led_controller = SysFsLEDController(led_name, "3", "0")
-        self.assertEqual(led_controller.led_name, led_name)
-        self.assertIsInstance(led_controller.led_node, PosixPath)
-        self.assertIsInstance(led_controller.brightness_node, PosixPath)
-        self.assertIsInstance(led_controller.trigger_node, PosixPath)
-        self.assertEqual(led_controller.led_node.name, led_name)
-        self.assertEqual(led_controller.brightness_node.name, "brightness")
-        self.assertEqual(led_controller.trigger_node.name, "trigger")
-        self.assertDictEqual(led_controller.initial_state,
-                             {"trigger": None, "brightness": None})
+        with SysFsLEDController(led_name, "3", "0") as led_controller:
+            mock_read.assert_called_once()
+            mock_get_initial.assert_called_once()
+            mock_off.assert_called_once()
+            mock_write.assert_called_once()
+            self.assertEqual(led_controller.led_name, led_name)
+            self.assertIsInstance(led_controller.led_node, PosixPath)
+            self.assertIsInstance(led_controller.brightness_node, PosixPath)
+            self.assertIsInstance(led_controller.trigger_node, PosixPath)
+            self.assertEqual(led_controller.led_node.name, led_name)
+            self.assertEqual(led_controller.brightness_node.name, "brightness")
+            self.assertEqual(led_controller.trigger_node.name, "trigger")
+            self.assertDictEqual(
+                led_controller.initial_state,
+                {"trigger": None, "brightness": None})
 
-    @patch("pathlib.Path.read_text")
-    @patch("pathlib.Path.exists")
-    def test_get_brightness(
-            self, mock_path, mock_path_get):
-        mock_path.return_value = True
-        mock_path_get.return_value = "33"
-
+    @patch("led_control_test.SysFsLEDController._read_node")
+    def test_get_brightness(self, mock_read):
+        mock_read.return_value = "33"
         self.assertEqual(self.led_controller.brightness, "33")
+        mock_read.assert_called_once()
 
-    @patch("pathlib.Path.read_text")
-    @patch("pathlib.Path.exists")
-    def test_get_trigger(self, mock_path, mock_path_get):
+    @patch("led_control_test.SysFsLEDController._write_node")
+    def test_set_brightness(self, mock_write):
+        self.led_controller.brightness = "33"
+        mock_write.assert_called_once()
+
+    @patch("led_control_test.SysFsLEDController._read_node")
+    def test_get_trigger(self, mock_read):
         expected_data = "[none] usb-gadget rfkill-any kbd-scrolllock"
-        mock_path.return_value = True
-        mock_path_get.return_value = expected_data
+        mock_read.return_value = expected_data
 
         self.assertEqual(self.led_controller.trigger, expected_data)
 
-    @patch("pathlib.Path.read_text")
-    @patch("pathlib.Path.exists")
-    def test_get_initial_state(self, mock_path, mock_path_get):
-
-        mock_path.return_value = True
-        mock_path_get.side_effect = [
+    @patch("led_control_test.SysFsLEDController._read_node")
+    def test_get_initial_state(self, mock_read):
+        mock_read.side_effect = [
             "none usb-gadget [usb-host] rfkill-any rfkill-none kbd-scrolllock",
             "255"
         ]

--- a/providers/base/tests/test_led_control_test.py
+++ b/providers/base/tests/test_led_control_test.py
@@ -1,0 +1,91 @@
+import unittest
+from unittest.mock import patch, Mock
+from pathlib import PosixPath, Path
+from led_control_test import SysFsLEDController
+
+
+class TestSysFsLEDController(unittest.TestCase):
+
+    def setUp(self):
+
+        self.led_controller = SysFsLEDController("test-fake")
+
+    @patch("pathlib.Path.exists")
+    def test_file_not_exists(self, mock_path):
+        mock_path.return_value = False
+        with self.assertRaises(FileNotFoundError):
+            self.led_controller._node_exists(Path("test-fake"))
+
+    @patch("pathlib.Path.read_text")
+    @patch("pathlib.Path.exists")
+    def test_read_file(self, mock_path, mock_read):
+        mock_path.return_value = True
+        mock_read.return_value = "test-string"
+        self.assertEqual(
+            mock_read.return_value,
+            self.led_controller._read_node(Path("test-fake")))
+
+    @patch("pathlib.Path.write_text")
+    @patch("pathlib.Path.read_text")
+    @patch("pathlib.Path.exists")
+    def test_write_failed(self, mock_path, mock_read, mock_write):
+        mock_path.return_value = True
+        mock_read.return_value = "33"
+
+        with self.assertRaises(ValueError):
+            self.led_controller._write_node(Path("test-fake"), "22", True)
+
+    @patch("pathlib.Path.write_text")
+    @patch("pathlib.Path.read_text")
+    @patch("pathlib.Path.exists")
+    def test_write_passed(self, mock_path, mock_read, mock_write):
+        mock_path.return_value = True
+        mock_read.return_value = "33"
+
+        with self.assertRaises(ValueError):
+            self.led_controller._write_node(Path("test-fake"), "22", True)
+
+    def test_initial_sysfs_controller_property(self):
+
+        led_name = "status"
+        led_controller = SysFsLEDController(led_name, "3", "0")
+        self.assertEqual(led_controller.led_name, led_name)
+        self.assertIsInstance(led_controller.led_node, PosixPath)
+        self.assertIsInstance(led_controller.brightness_node, PosixPath)
+        self.assertIsInstance(led_controller.trigger_node, PosixPath)
+        self.assertEqual(led_controller.led_node.name, led_name)
+        self.assertEqual(led_controller.brightness_node.name, "brightness")
+        self.assertEqual(led_controller.trigger_node.name, "trigger")
+        self.assertDictEqual(led_controller.initial_state,
+                             {"trigger": None, "brightness": None})
+
+    @patch("pathlib.Path.read_text")
+    @patch("pathlib.Path.exists")
+    def test_get_brightness(
+            self, mock_path, mock_path_get):
+        mock_path.return_value = True
+        mock_path_get.return_value = "33"
+
+        self.assertEqual(self.led_controller.brightness, "33")
+
+    @patch("pathlib.Path.read_text")
+    @patch("pathlib.Path.exists")
+    def test_get_trigger(self, mock_path, mock_path_get):
+        expected_data = "[none] usb-gadget rfkill-any kbd-scrolllock"
+        mock_path.return_value = True
+        mock_path_get.return_value = expected_data
+
+        self.assertEqual(self.led_controller.trigger, expected_data)
+
+    @patch("pathlib.Path.read_text")
+    @patch("pathlib.Path.exists")
+    def test_get_initial_state(self, mock_path, mock_path_get):
+
+        mock_path.return_value = True
+        mock_path_get.side_effect = [
+            "none usb-gadget [usb-host] rfkill-any rfkill-none kbd-scrolllock",
+            "255"
+        ]
+        expected_data = {"trigger": "usb-host", "brightness": "255"}
+        self.led_controller._get_initial_state()
+        self.assertEqual(expected_data, self.led_controller.initial_state)

--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -347,4 +347,52 @@ estimated_duration: 10
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_led_indicator == 'True'
 command:
-    led_test.sh -t sysfs -n {path}
+    led_tests.py sysfs_led -n {path}
+
+id: led-indicator/gpio-controller-leds
+plugin: resource
+_summary: Gather a list of LED indicators for the device that controls via GPIO chip.
+_description:
+    A LED GPIO devices mapping resource that relies on the user specifying in config variable.
+    Usage of parameter: GPIP_CONTROLLER_LEDS={name1}:{controller1}:{port1} {name2}:{controller1}:{port2} ...
+    e.g. GPIP_CONTROLLER_LEDS=dl14:504:1 dl15:504:2 dl16:504:3
+estimated_duration: 3
+environ: GPIP_CONTROLLER_LEDS
+command:
+    awk '{
+        split($0, record, " ")
+        for (i in record) {
+            split(record[i], data, ":")
+            printf "name: %s\nchip_number: %s\nport: %s\n\n", data[1], data[2], data[3]
+        }
+    }' <<< "$GPIP_CONTROLLER_LEDS"
+
+unit: template
+template-resource: led-indicator/gpio-controller-leds
+template-unit: job
+category_id: led
+id: led-indicator/gpio-controller-leds-{name}
+estimated_duration: 10
+plugin: user-interact-verify
+user: root
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_led_indicator == 'True'
+flags: also-after-suspend
+_summary: Check control of {name} LED indecator.
+_description:
+    Check that {name} LED turns on and off.
+_steps:
+    1. Press Enter and observe LED behavior on DUT.
+_verification:
+    Does the "{name}" LED blink?
+command:
+    if $(snap connections | grep $SNAP_NAME:gpio); then
+        # the gpio slots has been connected to checkbox
+        #   skip the GPIO export steps
+        led_tests.py gpio_led -n {path} --gpio-chip {chip_number} --gpio-pin {port}
+    else
+        # the gpio slots has not been connected to checkbox
+        # perform the GPIO export steps during testing
+        led_tests.py gpio_led -n {path} --gpio-chip {chip_number} --gpio-pin {port} --need-export
+    fi
+

--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -347,7 +347,7 @@ estimated_duration: 10
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_led_indicator == 'True'
 command:
-    led_tests.py sysfs_led -n {path}
+    led_control_test.py -n {path} -d 10
 
 id: led-indicator/gpio-controller-leds
 plugin: resource
@@ -387,12 +387,9 @@ _verification:
     Does the "{name}" LED blink?
 command:
     if $(snap connections | grep $SNAP_NAME:gpio); then
-        # the gpio slots has been connected to checkbox
-        #   skip the GPIO export steps
-        led_tests.py gpio_led -n {path} --gpio-chip {chip_number} --gpio-pin {port}
+        # the gpio slots has been connected to checkbox, skip the GPIO export steps
+        gpio_control_test.py led -n {name} --gpio-chip {chip_number} --gpio-pin {port}
     else
-        # the gpio slots has not been connected to checkbox
-        # perform the GPIO export steps during testing
-        led_tests.py gpio_led -n {path} --gpio-chip {chip_number} --gpio-pin {port} --need-export
+        # the gpio slots has not been connected to checkbox, perform the GPIO export steps during testing
+        gpio_control_test.py led -n {name} --gpio-chip {chip_number} --gpio-pin {port} --need-export
     fi
-

--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -354,8 +354,9 @@ plugin: resource
 _summary: Gather a list of LED indicators for the device that controls via GPIO chip.
 _description:
     A LED GPIO devices mapping resource that relies on the user specifying in config variable.
+    Refer to the /sys/kernel/debug/gpio for the gpiochip number
     Usage of parameter: GPIP_CONTROLLER_LEDS={name1}:{controller1}:{port1} {name2}:{controller1}:{port2} ...
-    e.g. GPIP_CONTROLLER_LEDS=dl14:504:1 dl15:504:2 dl16:504:3
+    e.g. GPIP_CONTROLLER_LEDS=dl14:3:1 dl15:3:2 dl16:3:3
 estimated_duration: 3
 environ: GPIP_CONTROLLER_LEDS
 command:

--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -355,18 +355,12 @@ _summary: Gather a list of LED indicators for the device that controls via GPIO 
 _description:
     A LED GPIO devices mapping resource that relies on the user specifying in config variable.
     Refer to the /sys/kernel/debug/gpio for the gpiochip number
-    Usage of parameter: GPIP_CONTROLLER_LEDS={name1}:{controller1}:{port1} {name2}:{controller1}:{port2} ...
-    e.g. GPIP_CONTROLLER_LEDS=dl14:3:1 dl15:3:2 dl16:3:3
+    Usage of parameter: GPIO_CONTROLLER_LEDS={name1}:{controller1}:{port1} {name2}:{controller1}:{port2} ...
+    e.g. GPIO_CONTROLLER_LEDS=dl14:3:1 dl15:3:2 dl16:3:3
 estimated_duration: 3
-environ: GPIP_CONTROLLER_LEDS
+environ: GPIO_CONTROLLER_LEDS
 command:
-    awk '{
-        split($0, record, " ")
-        for (i in record) {
-            split(record[i], data, ":")
-            printf "name: %s\nchip_number: %s\nport: %s\n\n", data[1], data[2], data[3]
-        }
-    }' <<< "$GPIP_CONTROLLER_LEDS"
+    gpio_control_test.py led-resource "$GPIO_CONTROLLER_LEDS"
 
 unit: template
 template-resource: led-indicator/gpio-controller-leds

--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -387,7 +387,7 @@ _steps:
 _verification:
     Does the "{name}" LED blink?
 command:
-    if $(snap connections | grep $SNAP_NAME:gpio); then
+    if (snap connections | grep "$SNAP_NAME:gpio"); then
         # the gpio slots has been connected to checkbox, skip the GPIO export steps
         gpio_control_test.py led -n {name} --gpio-chip {chip_number} --gpio-pin {port}
     else

--- a/providers/base/units/led/test-plan.pxu
+++ b/providers/base/units/led/test-plan.pxu
@@ -119,21 +119,29 @@ bootstrap_include:
 id: led-indicator-manual
 unit: test plan
 _name: Manual LED indicator tests for IoT
-_description: Manual LED indicator tests for IoT devices
+_description:
+    Manual LED indicator tests for IoT devices
+    Notes: the led-indicator/gpio-leds will be deprecated in next release
 include:
     led-indicator/gpio-leds-.*
+    led-indicator/gpio-controller-leds-.*
     led-indicator/sysfs-leds-.*
 bootstrap_include:
     led-indicator/gpio-leds
+    led-indicator/gpio-controller-leds
     led-indicator/sysfs-leds
 
 id: after-suspend-led-indicator-manual
 unit: test plan
 _name: Manual LED indicator tests for IoT (after_suspend)
-_description: Manual LED indicator tests for IoT devices (after_suspend)
+_description:
+    Manual LED indicator tests for IoT devices (after_suspend)
+    Notes: the led-indicator/gpio-leds will be deprecated in next release
 include:
     after-suspend-led-indicator/gpio-leds-.*
+    after-suspend-led-indicator/gpio-controller-leds-.*
     after-suspend-led-indicator/sysfs-leds-.*
 bootstrap_include:
     led-indicator/gpio-leds
+    led-indicator/gpio-controller-leds
     led-indicator/sysfs-leds


### PR DESCRIPTION
Fixed the bugs of led-indicator/sysfs-leds tests (Bugfix)

## Description
This PR trying to solved following issues.
- the led-indicator/sysfs-leds failed for a sysfs LED with heartbeat configuration
- create a new led-indicator/gpio-controller-leds tests for GPIO LEDs with new GPIP_CONTROLLER_LEDS configuration variable, so we could simply defined the gpio chip number and gpio pin in the configuration.
- implemented two python scripts for both LED tests and having unit tests for them.

we also want to retired the shell scripts for led-indicator/sysfs-leds, and deprecated the led-indicator/gpio-leds tests. Once this PR is landed to beta channel, Stanley will send another PR for it.

## Resolved issues

Resolves OEMQA-3588

## Documentation
N/A

## Tests
[C3 submission with following config variable](https://certification.canonical.com/hardware/202309-32095/submission/349863/test-results/pass/)
```
[environment]
GPIP_CONTROLLER_LEDS=dl14:5:1 dl15:5:2 dl16:5:3
SYS_LEDS=SocPower:status

```