### PR TITLE
Add VA API test cases from checkbox-providers (New)

### DIFF
--- a/providers/base/units/va-api/category.pxu
+++ b/providers/base/units/va-api/category.pxu
@@ -1,0 +1,3 @@
+unit: category
+id: va-api
+_name: Hardware video acceleration

--- a/providers/base/units/va-api/jobs.pxu
+++ b/providers/base/units/va-api/jobs.pxu
@@ -1,0 +1,12 @@
+id: va-api/va-initialize
+_summary: Detect if the VA API could be loaded
+category_id: va-api
+imports: from com.canonical.plainbox import manifest
+requires:
+    package.name == 'vainfo'
+    cpuinfo.platform == 'x86_64'
+    manifest.has_va_api == 'True'
+plugin: shell
+flags: simple
+command:
+    vainfo && exit 0 || exit 1

--- a/providers/base/units/va-api/manifest.pxu
+++ b/providers/base/units/va-api/manifest.pxu
@@ -1,0 +1,4 @@
+unit: manifest entry
+id: has_va_api
+_name: Has support for hardware video acceleration (VA API)
+value-type: bool

--- a/providers/base/units/va-api/test-plan.pxu
+++ b/providers/base/units/va-api/test-plan.pxu
@@ -1,0 +1,20 @@
+id: va-api-full
+_name: Hardware video acceleration tests
+unit: test plan
+include:
+nested_part:
+    va-api-manual
+    va-api-automated
+
+id: va-api-manual
+_name: Hardware video acceleration tests (manual)
+unit: test plan
+include:
+bootstrap_include:
+
+id: va-api-automated
+_name: Hardware video acceleration tests (automated)
+unit: test plan
+include:
+    va-api/va-initialize
+bootstrap_include:


### PR DESCRIPTION
## Description
I move the VA API related test cases from [checkbox-iiotg-provider](https://git.launchpad.net/~checkbox-dev/checkbox-iiotg/+git/checkbox-provider-intliotg/tree/units/va-api) to the base provider in checkbox monorepo.

## Resolved issues
N/A

## Documentation
N/A

## Tests
I run testplan `va-api-full` you can say `Hardware video acceleration tests` on EHL ([202306-31656](https://certification.canonical.com/hardware/202306-31656/)) which support VA API.

submission: https://certification.canonical.com/hardware/202306-31656/submission/350370/

