### PR TITLE
Edge to beta validation script (infra)

### DIFF
--- a/tools/release/can_promote_edge.py
+++ b/tools/release/can_promote_edge.py
@@ -14,6 +14,11 @@ import subprocess
 
 
 def get_gh_daily_builds_array() -> list[dict]:
+    """
+    Query github for the latest 20 runs of the daily-builds.yml workflow
+    returning a parsed array of dicts containing their headSha (hash the run
+    was triggered on) and conclusion.
+    """
     return json.loads(
         subprocess.check_output(
             [
@@ -35,6 +40,9 @@ def get_gh_daily_builds_array() -> list[dict]:
 
 
 def get_latest_ok_head(builds: list[dict]) -> str:
+    """
+    Returns the headSha of the most recent run of a build that was successful
+    """
     try:
         return next(
             x["headSha"] for x in builds if x["conclusion"] == "success"
@@ -44,13 +52,26 @@ def get_latest_ok_head(builds: list[dict]) -> str:
 
 
 def get_head_beta_validated() -> str:
+    """
+    Returns the full hash of origin/beta_validation's HEAD
+    """
     return subprocess.check_output(
-        ["git", "show", "origin/beta_validation", "--pretty=format:%H", "--no-patch"],
+        [
+            "git",
+            "show",
+            "origin/beta_validation",
+            "--pretty=format:%H",
+            "--no-patch",
+        ],
         text=True,
     )
 
 
-def beta_validation_matches_successful_daily():
+def beta_validation_matches_successful_daily() -> bool:
+    """
+    Returns true if the most recent daily build was run on the same commit
+    that the head of beta_validation points to, else false
+    """
     builds = get_gh_daily_builds_array()
     last_daily_build_commit_hash = get_latest_ok_head(builds)
     last_beta_validated_head = get_head_beta_validated()

--- a/tools/release/can_promote_edge.py
+++ b/tools/release/can_promote_edge.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+"""
+This script is ment to be the validation step to gate the promotion of
+the edge channel in the store/ppa to beta. This only checks if the
+preconditions are met for such an event.
+
+Current pre-conditions:
+- Latest succesful Daily Build matches origin/beta_validation
+"""
+
+import json
+import subprocess
+
+
+def get_gh_daily_builds_array() -> list[dict]:
+    return json.loads(
+        subprocess.check_output(
+            [
+                "gh",
+                "run",
+                "list",
+                "--repo",
+                "canonical/checkbox",
+                "--workflow",
+                ".github/workflows/daily-builds.yml",
+                "--limit",
+                "20",
+                "--json",
+                "headSha,conclusion",
+            ],
+            text=True,
+        )
+    )
+
+
+def get_latest_ok_head(builds: list[dict]) -> str:
+    try:
+        return next(
+            x["headSha"] for x in builds if x["conclusion"] == "success"
+        )
+    except StopIteration:
+        raise SystemExit("Couldn't fetch any successful daily build")
+
+
+def get_head_beta_validated() -> str:
+    return subprocess.check_output(
+        ["git", "show", "origin/main", "--pretty=format:%H", "--no-patch"],
+        text=True,
+    )
+
+
+def beta_validation_matches_successful_daily():
+    builds = get_gh_daily_builds_array()
+    last_daily_build_commit_hash = get_latest_ok_head(builds)
+    last_beta_validated_head = get_head_beta_validated()
+    print("Latest daily build commit hash:", last_daily_build_commit_hash)
+    print("Latest beta validated head: ", last_beta_validated_head)
+    return last_daily_build_commit_hash == last_beta_validated_head
+
+
+def main():
+    if not beta_validation_matches_successful_daily():
+        raise SystemExit(
+            "Latest built version and validated version do not match"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/release/can_promote_edge.py
+++ b/tools/release/can_promote_edge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 This script is ment to be the validation step to gate the promotion of

--- a/tools/release/can_promote_edge.py
+++ b/tools/release/can_promote_edge.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-This script is ment to be the validation step to gate the promotion of
+This script is meant to be the validation step to gate the promotion of
 the edge channel in the store/ppa to beta. This only checks if the
 preconditions are met for such an event.
 

--- a/tools/release/can_promote_edge.py
+++ b/tools/release/can_promote_edge.py
@@ -45,7 +45,7 @@ def get_latest_ok_head(builds: list[dict]) -> str:
 
 def get_head_beta_validated() -> str:
     return subprocess.check_output(
-        ["git", "show", "origin/main", "--pretty=format:%H", "--no-patch"],
+        ["git", "show", "origin/beta_validation", "--pretty=format:%H", "--no-patch"],
         text=True,
     )
 

--- a/tools/release/test_can_promote_edge.py
+++ b/tools/release/test_can_promote_edge.py
@@ -1,0 +1,49 @@
+import unittest
+from unittest.mock import patch
+
+import can_promote_edge
+
+
+class TestCanPromoteEdge(unittest.TestCase):
+    def test_get_latest_ok_head_ok(self):
+        # get_lastest_ok is able to scroll back and find the most
+        # recent passing build
+        builds = [
+            {"headSha": "abc", "conclusion": "failure"},
+            {"headSha": "cde", "conclusion": "failure"},
+            {"headSha": "correct_hash", "conclusion": "success"},
+            {"headSha": "stale_hash", "conclusion": "success"},
+        ]
+        correct_hash = can_promote_edge.get_latest_ok_head(builds)
+        self.assertEqual(correct_hash, "correct_hash")
+
+    def test_get_latest_ok_head_fail(self):
+        # if no build has passed in the last 20 run, fail gracefully
+        builds = [
+            {"headSha": "abc", "conclusion": "failure"},
+            {"headSha": "cde", "conclusion": "failure"},
+        ]
+        with self.assertRaises(SystemExit):
+            _ = can_promote_edge.get_latest_ok_head(builds)
+
+    @patch("subprocess.check_output")
+    def test_beta_validation_matches_successful_daily_ok(
+        self, check_output_mock
+    ):
+        check_output_mock.side_effect = [
+            '[{"headSha" : "correct_hash", "conclusion" : "success"}]',
+            "correct_hash",
+        ]
+
+        can_promote_edge.main()
+
+    @patch("subprocess.check_output")
+    def test_beta_validation_matches_successful_daily_fail(
+        self, check_output_mock
+    ):
+        check_output_mock.side_effect = [
+            '[{"headSha" : "correct_hash", "conclusion" : "success"}]',
+            "stale_hash",
+        ]
+        with self.assertRaises(SystemExit):
+            can_promote_edge.main()


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Before calling the [edge to beta](https://github.com/canonical/checkbox/blob/main/.github/workflows/checkbox-beta-release.yml) workflow, we need to validate that the operation is what we want to do. This introduces a new script with one automatic check that the operation is actually correct.

The check is: the latest daily build has built/pushed to the store the same hash that we have validated via canary. The rationale is: We are promoting from the store/ppa. If a daily build ran succesfully after we have moved the head of beta_validated, we have overwritten the last beta_validated version (as the workflow uploads to the store/LP). We can not promote the current version as it is untested.


## Resolved issues

This is preliminary work for: CHECKBOX-1056

## Documentation

The script has a documentation header

## Tests

The script comes with unit tests, to run them run:
```
$ pytest test_can_promote_edge.py
```


