### PR TITLE
virtualization/verify_lxd_vm requires lxd versions only available as snaps (BugFix)

### DIFF
--- a/providers/base/units/virtualization/jobs.pxu
+++ b/providers/base/units/virtualization/jobs.pxu
@@ -5,7 +5,7 @@ environ: LXD_TEMPLATE KVM_IMAGE
 estimated_duration: 60.0
 requires:
  executable.name == 'lxc'
- package.name == 'lxd' or snap.name == 'lxd'
+ snap.name == 'lxd'
 command: virtualization.py --debug lxdvm
 _description:
  Verifies that an LXD Virtual Machine can be created and launched


### PR DESCRIPTION
This is the rebased and signed version of the #686 PR.