### PR TITLE
Disable failfast in snap daily builds (infra)

### DIFF
--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   snap:
     strategy:
+      fail-fast: false
       matrix:
         type: [classic, uc]
         releases: [16, 18, 20, 22]


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

If any of the snap (frontend) daily builds fail, all of the others are cancelled. This is undesirable because these builds are fairly quick and cancelling them only saves a few minutes but it leads to us having less data to make a deliberation on what the cause on ones failure may be/if there is anything else wrong to fix. Additionally, cancelling the workflow doesn't cancel the build itself, that will run to completion on LP either way.

## Resolved issues

N/A

## Documentation

N/A

## Tests

This was done (for more or less the same reason) for the deb/PPA builds.

