### PR TITLE
Unique validator for packaging metadata (BugFix)

### DIFF
--- a/checkbox-ng/plainbox/impl/unit/packaging.py
+++ b/checkbox-ng/plainbox/impl/unit/packaging.py
@@ -124,6 +124,7 @@ import sys
 from plainbox.i18n import gettext as _
 from plainbox.impl.symbol import SymbolDef
 from plainbox.impl.unit import concrete_validators
+from plainbox.impl.unit.validators import UniqueValueValidator
 from plainbox.impl.unit.unit import Unit
 
 _logger = logging.getLogger("plainbox.unit.packaging")
@@ -153,6 +154,22 @@ class PackagingMetaDataUnit(Unit):
         """Version of the operating system."""
         return self.get_record_value(self.Meta.fields.os_version_id)
 
+    @property
+    def Depends(self):
+        """Package dependencies"""
+        return self.get_record_value(self.Meta.fields.Depends)
+
+    @property
+    def Recommends(self):
+        """Package recommendations"""
+        return self.get_record_value(self.Meta.fields.Recommends)
+
+    @property
+    def Suggests(self):
+        """Package suggestions"""
+        return self.get_record_value(self.Meta.fields.Suggests)
+
+
     class Meta:
 
         name = 'packaging meta-data'
@@ -163,6 +180,9 @@ class PackagingMetaDataUnit(Unit):
 
             os_id = 'os-id'
             os_version_id = 'os-version-id'
+            Depends = 'Depends'
+            Recommends = 'Recommends'
+            Suggests = 'Suggests'
 
         field_validators = {
             fields.os_id: [
@@ -172,20 +192,26 @@ class PackagingMetaDataUnit(Unit):
             fields.os_version_id: [
                 concrete_validators.untranslatable,
             ],
+            fields.Depends: [
+                UniqueValueValidator(),
+            ],
+            fields.Recommends: [
+                UniqueValueValidator(),
+            ],
+            fields.Suggests: [
+                UniqueValueValidator(),
+            ],
         }
 
     def __str__(self):
         parts = [_("Operating System: {}").format(self.os_id)]
         if self.os_id == 'debian' or self.os_id == 'ubuntu':
-            Depends = self.get_record_value('Depends')
-            Recommends = self.get_record_value('Recommends')
-            Suggests = self.get_record_value('Suggests')
-            if Depends:
-                parts.append(_("Depends: {}").format(Depends))
-            if Recommends:
-                parts.append(_("Recommends: {}").format(Recommends))
-            if Suggests:
-                parts.append(_("Suggests: {}").format(Suggests))
+            if self.Depends:
+                parts.append(_("Depends: {}").format(self.Depends))
+            if self.Recommends:
+                parts.append(_("Recommends: {}").format(self.Recommends))
+            if self.Suggests:
+                parts.append(_("Suggests: {}").format(self.Suggests))
         else:
             parts.append("...")
         return ', '.join(parts)

--- a/checkbox-ng/plainbox/impl/unit/test_packaging.py
+++ b/checkbox-ng/plainbox/impl/unit/test_packaging.py
@@ -24,6 +24,11 @@ import textwrap
 from plainbox.impl.unit.packaging import DebianPackagingDriver
 from plainbox.impl.unit.packaging import PackagingDriverBase
 from plainbox.impl.unit.packaging import PackagingMetaDataUnit
+from plainbox.impl.unit.test_unit import UnitFieldValidationTests
+from plainbox.impl.unit.validators import UnitValidationContext
+from plainbox.impl.validation import Problem
+from plainbox.impl.validation import Severity
+
 from plainbox.impl.secure.rfc822 import load_rfc822_records
 
 
@@ -300,3 +305,59 @@ class DebianPackagingDriverTests(TestCase):
         # Using wrong version format
         with self.assertRaises(SystemExit) as context:
             compare_versions("== ***", "1.0.0")
+
+
+class PackagingUnitFieldValidationTests(UnitFieldValidationTests):
+    def test_validation_unique_package(self):
+        unit_1 = PackagingMetaDataUnit(
+            {
+                "os-id": "ubuntu",
+                "os-version-id": ">=20.04",
+                "Depends": "dep_package1",
+                "Recommends": "rec_package1",
+                "Suggests": "sug_package1",
+            },
+            provider=self.provider,
+        )
+        unit_2 = PackagingMetaDataUnit(
+            {
+                "os-id": "ubuntu",
+                "os-version-id": ">=20.04",
+                "Depends": "dep_package1",
+                "Recommends": "rec_package1",
+                "Suggests": "sug_package1",
+            },
+            provider=self.provider,
+        )
+
+        self.provider.unit_list = [unit_1, unit_2]
+        self.provider.problem_list = []
+        context = UnitValidationContext([self.provider])
+        issue_list = unit_1.check(context=context)
+
+        message_start = "field 'Depends', clashes with 1 other unit"
+        depends_issue = self.assertIssueFound(
+            issue_list,
+            PackagingMetaDataUnit.Meta.fields.Depends,
+            Problem.not_unique,
+            Severity.error,
+        )
+        self.assertTrue(depends_issue.message.startswith(message_start))
+
+        message_start = "field 'Recommends', clashes with 1 other unit"
+        recommends_issue = self.assertIssueFound(
+            issue_list,
+            PackagingMetaDataUnit.Meta.fields.Recommends,
+            Problem.not_unique,
+            Severity.error,
+        )
+        self.assertTrue(recommends_issue.message.startswith(message_start))
+
+        message_start = "field 'Suggests', clashes with 1 other unit"
+        suggests_issue = self.assertIssueFound(
+            issue_list,
+            PackagingMetaDataUnit.Meta.fields.Suggests,
+            Problem.not_unique,
+            Severity.error,
+        )
+        self.assertTrue(suggests_issue.message.startswith(message_start))

--- a/checkbox-ng/plainbox/impl/unit/test_packaging.py
+++ b/checkbox-ng/plainbox/impl/unit/test_packaging.py
@@ -306,6 +306,24 @@ class DebianPackagingDriverTests(TestCase):
         with self.assertRaises(SystemExit) as context:
             compare_versions("== ***", "1.0.0")
 
+    def test_unit_to_string(self):
+        unit = PackagingMetaDataUnit(
+            {
+                "os-id": "ubuntu",
+                "os-version-id": "22.04",
+                "Depends": "dep_package",
+                "Recommends": "rec_package",
+                "Suggests": "sug_package",
+            }
+        )
+
+        unit_string = str(unit)
+
+        self.assertIn("ubuntu", unit_string)
+        self.assertIn("Depends: dep_package", unit_string)
+        self.assertIn("Recommends: rec_package", unit_string)
+        self.assertIn("Suggests: sug_package", unit_string)
+
 
 class PackagingUnitFieldValidationTests(UnitFieldValidationTests):
     def test_validation_unique_package(self):

--- a/checkbox-ng/plainbox/impl/unit/validators.py
+++ b/checkbox-ng/plainbox/impl/unit/validators.py
@@ -582,7 +582,7 @@ class UniqueValueValidator(FieldValidatorBase):
         value = getattr(unit, field2prop(field))
         units_with_this_value = value_map[value]
         n = len(units_with_this_value)
-        if n > 1:
+        if n > 1 and value is not None:
             # come up with unit_list where this unit is always at the front
             unit_list = list(units_with_this_value)
             unit_list = sorted(

--- a/docs/reference/units/packaging-meta-data.rst
+++ b/docs/reference/units/packaging-meta-data.rst
@@ -52,6 +52,9 @@ for **Debian** are:
     The syntax is the same as in normal Debian control files (including package
     version dependencies). This field can be split into multiple lines, for
     readability, as newlines are discarded.
+    In order to avoid unwanted dependency repetitions, this field is declared as
+    an unique value for validation.
+
 
 .. _Packaging Meta Data Suggests field:
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This PR is a follow up of #909. We were missing a check during the validation phase to make sure that there are not repeated packages in the packaging metadata files.

For that purpose, we have used the `UniqueValueValidator` for the `Depends`, `Recommends` and `Suggests` fields of the packaging metadata units, so they can't be repeated.

This change is not probable to make any break in previous versions, but it is possible if some package metadata units were using the same package twice.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

Closes [CHECKBOX-1062](https://warthogs.atlassian.net/browse/CHECKBOX-1062)

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->
Updated packaging-meta-data.rst

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

To run the new packaging tests:
```
cd ~/checkbox/checkbox-ng
python3 -m pytest -k PackagingUnitFieldValidationTests
```



[CHECKBOX-1062]: https://warthogs.atlassian.net/browse/CHECKBOX-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ