### PR TITLE
Add trigger and needs constraint to promotion workflow (infra)

### DIFF
--- a/.github/workflows/checkbox-beta-release.yml
+++ b/.github/workflows/checkbox-beta-release.yml
@@ -2,10 +2,34 @@ name: Beta version of checkbox
 run-name: Promote edge versions of checkbox to beta
 
 on:
+  push:
+    branches:
+      - beta
   workflow_dispatch:
 
 jobs:
+  should-run:
+    runs-on: [self-hosted, linux, large]
+      - name: Setup the gh repository and install gh
+        run: |
+          which curl || (sudo apt update && sudo apt install curl -y)
+          sudo curl https://cli.github.com/packages/githubcli-archive-keyring.gpg --output /usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          gpg --import /usr/share/keyrings/githubcli-archive-keyring.gpg
+          gpg --fingerprint "2C6106201985B60E6C7AC87323F3D4EA75716059"
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt update -qq
+          sudo apt install -qq -y gh
+      - name: Checkout checkbox monorepo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Verify Promotion Conditions
+        run: |
+          tools/release/can_promote_edge.py
+
   release-notes:
+    needs: should-run
     runs-on: [self-hosted, linux, large]
     steps:
       - name: Checkout checkbox monorepo
@@ -31,6 +55,7 @@ jobs:
           gh release create $(git describe --tags --abbrev=0 --match v*) -d --generate-notes
 
   checkbox_deb_packages:
+    needs: should-run
     name: Checkbox Debian packages
     runs-on: [self-hosted, linux, large]
     steps:
@@ -49,6 +74,7 @@ jobs:
           tools/release/lp_copy_packages.py checkbox-dev edge checkbox-dev beta
 
   checkbox_core_snap:
+    needs: should-run
     name: Checkbox core snap packages
     runs-on: [self-hosted, linux, large]
     env:
@@ -70,6 +96,7 @@ jobs:
           yes | snapcraft promote checkbox22 --from-channel latest/edge --to-channel latest/beta
 
   checkbox_snap:
+    needs: should-run
     name: Checkbox snap packages
     runs-on: [self-hosted, linux, large]
     env:


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

We have decided that the promotion to the beta channel of the snap is governed by the moving target that is the `beta` branch. Once that branch is moved, the current `edge` version of the snap/deb must be promoted to stable. This introduces the mechanism to the beta promotion workflow along a sanity check to avoid race conditions (namely, the last "green" run of the daily build must have happened on the commit pointed by `beta`, else something went wrong!).

## Resolved issues

Resolves: CHECKBOX-1056

## Documentation

N/A (This is just the workflow work, it works as described before)

## Tests

The mechanism was partially validated offline, it is easier to iterate online on the last details

