### PR TITLE
Use action-validator to valdate workflows (infra)

### DIFF
--- a/.github/workflows/tox-tools-release.yaml
+++ b/.github/workflows/tox-tools-release.yaml
@@ -4,11 +4,11 @@ on:
   push:
     branches: [ main ]
     paths:
-      - tools/release/**
+      - tools/release/*
   pull_request:
     branches: [ main ]
     paths:
-      - tools/release/**
+      - tools/release/*
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/validate_workflows.yaml
+++ b/.github/workflows/validate_workflows.yaml
@@ -1,0 +1,22 @@
+name: Workflow validation
+
+on:
+  push:
+    paths:
+      - '.github/workflows/*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout checkbox monorepo
+        uses: actions/checkout@v3
+      - name: Install action-validator with asdf
+        uses: asdf-vm/actions/install@v3
+        with:
+          tool_versions: |
+            action-validator 0.5.1
+      - name: Lint Actions
+        run: |
+          find .github/workflows -type f \( -iname \*.yaml -o -iname \*.yml \) \
+            | xargs -I {} action-validator --verbose {}


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

[This](https://github.com/canonical/checkbox/pull/921/files) has introduced a problem in the `checkbox-beta-release.yml` workflow. We could not tell without because we are missing an automated way to check for trivial regression like these. This adds a new validator that checks yaml file and automatically rejects malformed ones.

## Resolved issues

[Anti-regression for trivial grammar mistakes like here](https://github.com/canonical/checkbox/pull/921/files)

## Documentation

N/A

## Tests

N/A

[This was taken from the official repo here](https://github.com/mpalmer/action-validator/blob/main/.github/workflows/qa.yml#L194C1-L203C56)

