### PR TITLE
Only stage version.txt like in frontend (infra)

### DIFF
--- a/checkbox-snap/series_classic16/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic16/snap/snapcraft.yaml
@@ -49,6 +49,8 @@ parts:
       export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
+    stage:
+      - version.txt
   launchers:
     plugin: dump
     source: launchers/

--- a/checkbox-snap/series_classic18/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic18/snap/snapcraft.yaml
@@ -52,6 +52,8 @@ parts:
       export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
+    stage:
+      - version.txt
   launchers:
     plugin: dump
     source: launchers/

--- a/checkbox-snap/series_classic20/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic20/snap/snapcraft.yaml
@@ -52,6 +52,8 @@ parts:
       export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
+    stage:
+      - version.txt
   launchers:
     plugin: dump
     source: launchers/

--- a/checkbox-snap/series_classic22/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic22/snap/snapcraft.yaml
@@ -52,6 +52,8 @@ parts:
       export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
+    stage:
+      - version.txt
   launchers:
     plugin: dump
     source: launchers/

--- a/checkbox-snap/series_uc16/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc16/snap/snapcraft.yaml
@@ -95,6 +95,8 @@ parts:
       export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
+    stage:
+      - version.txt
   launchers:
     plugin: dump
     source: launchers/

--- a/checkbox-snap/series_uc18/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc18/snap/snapcraft.yaml
@@ -99,6 +99,8 @@ parts:
       export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
+    stage:
+      - version.txt
   launchers:
     plugin: dump
     source: launchers/

--- a/checkbox-snap/series_uc20/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc20/snap/snapcraft.yaml
@@ -99,6 +99,8 @@ parts:
       export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
+    stage:
+      - version.txt
   launchers:
     plugin: dump
     source: launchers/

--- a/checkbox-snap/series_uc22/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc22/snap/snapcraft.yaml
@@ -99,6 +99,8 @@ parts:
       export version=`cat $SNAPCRAFT_PART_SRC/version.txt`
       [ $version ] || exit 1
       snapcraftctl set-version $version
+    stage:
+      - version.txt
   launchers:
     plugin: dump
     source: launchers/


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The version calculator of frontend snaps is currently including in the snap anything in the root of the build directory. 

This is leading to strange consequences, namely right now we are including the build log of a failing when retrying it, but if one or more builds in a build set "pass", they will be staged in the next retry if any failed. This is unnecessary and an unintended consequence that we did fix a while back in the runtime snap.

This fixes the issue by adding the same "stage" constraint to the frontend snap that we have in the backend.

## Resolved issues

Additional content in the snap

## Documentation

N/A

## Tests

N/A

This is the same issue/fix we did for the checkbox core snap

