### PR TITLE
fix detecting insertion/removal of tb3 drive (BugFix)

### DIFF
--- a/providers/base/units/thunderbolt/jobs.pxu
+++ b/providers/base/units/thunderbolt/jobs.pxu
@@ -7,11 +7,7 @@ requires: manifest.has_thunderbolt == 'True'
 estimated_duration: 20.0
 template-engine: jinja2
 command:
-    {%- if __on_ubuntucore__ %}
-        checkbox-support-run_watcher insertion thunderbolt
-    {%- else %}
-        removable_storage_watcher.py insert --timeout 40 scsi
-    {% endif -%}
+ checkbox-support-run_watcher insertion thunderbolt
 _siblings: [
     { "id": "after-suspend-thunderbolt/insert",
       "_summary": "thunderbolt/insert after suspend",
@@ -65,11 +61,7 @@ depends: thunderbolt/insert
 estimated_duration: 10.0
 template-engine: jinja2
 command:
-    {%- if __on_ubuntucore__ %}
-        checkbox-support-run_watcher insertion thunderbolt
-    {%- else %}
-        removable_storage_watcher.py remove scsi
-    {% endif -%}
+ checkbox-support-run_watcher insertion thunderbolt
 _summary: Storage removal detection on Thunderbolt
 _siblings: [
     { "id": "after-suspend-thunderbolt/remove",
@@ -120,11 +112,7 @@ requires: manifest.has_thunderbolt3 == 'True'
 estimated_duration: 20.0
 template-engine: jinja2
 command:
-    {%- if __on_ubuntucore__ %}
-        checkbox-support-run_watcher insertion thunderbolt
-    {%- else %}
-        removable_storage_watcher.py insert --timeout 40 scsi
-    {% endif -%}
+ checkbox-support-run_watcher insertion thunderbolt
 _summary: Storage insert detection on Thunderbolt 3 port
 _description:
  PURPOSE:
@@ -184,11 +172,7 @@ depends: thunderbolt3/insert
 estimated_duration: 10.0
 template-engine: jinja2
 command:
-    {%- if __on_ubuntucore__ %}
-        checkbox-support-run_watcher removal thunderbolt
-    {%- else %}
-        removable_storage_watcher.py remove scsi
-    {% endif -%}
+ checkbox-support-run_watcher removal thunderbolt
 _summary: Storage removal detection on Thunderbolt 3 port
 _description:
  PURPOSE:


### PR DESCRIPTION
## Description

Fix Thunderbolt "insert" and "remove" tests on Classic.

On classic images the "scsi detection" that was employed by the job definition did not work.
Historically we've had two version of insertion/removal detection code: one for Classic and one for Core. The patch that introduced the tests was using this approach, but in fact it was it was not needed, as the version provided by the implementation in checkbox-support (that was used exclusively for UC) works on both.

The patch I'm proposing here makes Checkbox use the working one, regardless of whether we're running on UC or Classic, thus fixing the problem

## Resolved issues
Fixes: #97, CHECKBOX-1123


## Documentation
No changes.

## Tests

Tested on classic image with the tb3 drive.