### PR TITLE
Pad every frontend snap with workaround part (infra)

### DIFF
--- a/checkbox-snap/series_classic16/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic16/snap/snapcraft.yaml
@@ -66,4 +66,10 @@ parts:
       # This is a workaround for an upstream bug in the automated snap review tool
       # remove this once this issue is resolved:
       # https://bugs.launchpad.net/review-tools/+bug/2049093
-      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1
+      # Note: this cats /dev/urandom because the squashfs will collapse any
+      #       predictable output to less than the desired size making this
+      #       ineffective
+      echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
+      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround

--- a/checkbox-snap/series_classic16/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic16/snap/snapcraft.yaml
@@ -60,3 +60,10 @@ parts:
     plugin: dump
     source: .
     stage: [config_vars]
+  workaround-automated-review-issue:
+    plugin: nil
+    override-build: |
+      # This is a workaround for an upstream bug in the automated snap review tool
+      # remove this once this issue is resolved:
+      # https://bugs.launchpad.net/review-tools/+bug/2049093
+      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1

--- a/checkbox-snap/series_classic18/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic18/snap/snapcraft.yaml
@@ -69,4 +69,10 @@ parts:
       # This is a workaround for an upstream bug in the automated snap review tool
       # remove this once this issue is resolved:
       # https://bugs.launchpad.net/review-tools/+bug/2049093
-      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1
+      # Note: this cats /dev/urandom because the squashfs will collapse any
+      #       predictable output to less than the desired size making this
+      #       ineffective
+      echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
+      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround

--- a/checkbox-snap/series_classic18/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic18/snap/snapcraft.yaml
@@ -63,3 +63,10 @@ parts:
     plugin: dump
     source: .
     stage: [config_vars]
+  workaround-automated-review-issue:
+    plugin: nil
+    override-build: |
+      # This is a workaround for an upstream bug in the automated snap review tool
+      # remove this once this issue is resolved:
+      # https://bugs.launchpad.net/review-tools/+bug/2049093
+      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1

--- a/checkbox-snap/series_classic20/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic20/snap/snapcraft.yaml
@@ -69,4 +69,10 @@ parts:
       # This is a workaround for an upstream bug in the automated snap review tool
       # remove this once this issue is resolved:
       # https://bugs.launchpad.net/review-tools/+bug/2049093
-      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1
+      # Note: this cats /dev/urandom because the squashfs will collapse any
+      #       predictable output to less than the desired size making this
+      #       ineffective
+      echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
+      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround

--- a/checkbox-snap/series_classic20/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic20/snap/snapcraft.yaml
@@ -63,3 +63,10 @@ parts:
     plugin: dump
     source: .
     stage: [config_vars]
+  workaround-automated-review-issue:
+    plugin: nil
+    override-build: |
+      # This is a workaround for an upstream bug in the automated snap review tool
+      # remove this once this issue is resolved:
+      # https://bugs.launchpad.net/review-tools/+bug/2049093
+      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1

--- a/checkbox-snap/series_classic22/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic22/snap/snapcraft.yaml
@@ -65,3 +65,10 @@ parts:
     source: .
     build-attributes: [no-patchelf]
     stage: [config_vars]
+  workaround-automated-review-issue:
+    plugin: nil
+    override-build: |
+      # This is a workaround for an upstream bug in the automated snap review tool
+      # remove this once this issue is resolved:
+      # https://bugs.launchpad.net/review-tools/+bug/2049093
+      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1

--- a/checkbox-snap/series_classic22/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic22/snap/snapcraft.yaml
@@ -71,4 +71,10 @@ parts:
       # This is a workaround for an upstream bug in the automated snap review tool
       # remove this once this issue is resolved:
       # https://bugs.launchpad.net/review-tools/+bug/2049093
-      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1
+      # Note: this cats /dev/urandom because the squashfs will collapse any
+      #       predictable output to less than the desired size making this
+      #       ineffective
+      echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
+      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround

--- a/checkbox-snap/series_uc16/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc16/snap/snapcraft.yaml
@@ -106,3 +106,10 @@ parts:
     plugin: dump
     source: .
     stage: [config_vars]
+  workaround-automated-review-issue:
+    plugin: nil
+    override-build: |
+      # This is a workaround for an upstream bug in the automated snap review tool
+      # remove this once this issue is resolved:
+      # https://bugs.launchpad.net/review-tools/+bug/2049093
+      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1

--- a/checkbox-snap/series_uc16/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc16/snap/snapcraft.yaml
@@ -112,4 +112,10 @@ parts:
       # This is a workaround for an upstream bug in the automated snap review tool
       # remove this once this issue is resolved:
       # https://bugs.launchpad.net/review-tools/+bug/2049093
-      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1
+      # Note: this cats /dev/urandom because the squashfs will collapse any
+      #       predictable output to less than the desired size making this
+      #       ineffective
+      echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
+      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround

--- a/checkbox-snap/series_uc18/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc18/snap/snapcraft.yaml
@@ -110,3 +110,10 @@ parts:
     plugin: dump
     source: .
     stage: [config_vars]
+  workaround-automated-review-issue:
+    plugin: nil
+    override-build: |
+      # This is a workaround for an upstream bug in the automated snap review tool
+      # remove this once this issue is resolved:
+      # https://bugs.launchpad.net/review-tools/+bug/2049093
+      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1

--- a/checkbox-snap/series_uc18/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc18/snap/snapcraft.yaml
@@ -116,4 +116,10 @@ parts:
       # This is a workaround for an upstream bug in the automated snap review tool
       # remove this once this issue is resolved:
       # https://bugs.launchpad.net/review-tools/+bug/2049093
-      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1
+      # Note: this cats /dev/urandom because the squashfs will collapse any
+      #       predictable output to less than the desired size making this
+      #       ineffective
+      echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
+      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround

--- a/checkbox-snap/series_uc20/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc20/snap/snapcraft.yaml
@@ -110,3 +110,10 @@ parts:
     plugin: dump
     source: .
     stage: [config_vars]
+  workaround-automated-review-issue:
+    plugin: nil
+    override-build: |
+      # This is a workaround for an upstream bug in the automated snap review tool
+      # remove this once this issue is resolved:
+      # https://bugs.launchpad.net/review-tools/+bug/2049093
+      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1

--- a/checkbox-snap/series_uc20/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc20/snap/snapcraft.yaml
@@ -116,4 +116,10 @@ parts:
       # This is a workaround for an upstream bug in the automated snap review tool
       # remove this once this issue is resolved:
       # https://bugs.launchpad.net/review-tools/+bug/2049093
-      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1
+      # Note: this cats /dev/urandom because the squashfs will collapse any
+      #       predictable output to less than the desired size making this
+      #       ineffective
+      echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
+      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround

--- a/checkbox-snap/series_uc22/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc22/snap/snapcraft.yaml
@@ -118,4 +118,10 @@ parts:
       # This is a workaround for an upstream bug in the automated snap review tool
       # remove this once this issue is resolved:
       # https://bugs.launchpad.net/review-tools/+bug/2049093
-      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1
+      # Note: this cats /dev/urandom because the squashfs will collapse any
+      #       predictable output to less than the desired size making this
+      #       ineffective
+      echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
+      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround

--- a/checkbox-snap/series_uc22/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc22/snap/snapcraft.yaml
@@ -112,3 +112,10 @@ parts:
     source: .
     build-attributes: [no-patchelf]
     stage: [config_vars]
+  workaround-automated-review-issue:
+    plugin: nil
+    override-build: |
+      # This is a workaround for an upstream bug in the automated snap review tool
+      # remove this once this issue is resolved:
+      # https://bugs.launchpad.net/review-tools/+bug/2049093
+      dd if=/dev/urandom of=$SNAPCRAFT_PART_INSTALL/size_workaround bs=16k count=1


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

snapd has added a minimal 16kb size of snap files in the following commit (https://github.com/snapcore/snapd/commit/5bae3c14accb039b9fec5d2522dc5c71b90244a3)
but  the automated review tool unaware that. This causes very small snaps to be automatically rejected by the review tool because they are automatically padded by snapcraft but not by the cross-verification process that the review tool does. 

To work around this I propose introducing a new part that links back to the upstream bug, making the build pass for now.  

## Resolved issues

Failing daily builds

## Documentation

This patch comes with a comment explaining why the part is there and when it should be removed.

## Tests

I have built the snap offline and it is passing the validator (also, in the last few days due to another bug, the only snaps that were passing the validator were the snaps who included some other build log, making them slightly bigger!)

