### PR TITLE
Avoid breaking the cat pipe by reading from head (infra)

### DIFF
--- a/checkbox-snap/series_classic16/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic16/snap/snapcraft.yaml
@@ -72,4 +72,4 @@ parts:
       echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
-      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      head -c 16384 /dev/urandom >> $SNAPCRAFT_PART_INSTALL/size_workaround

--- a/checkbox-snap/series_classic18/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic18/snap/snapcraft.yaml
@@ -75,4 +75,4 @@ parts:
       echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
-      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      head -c 16384 /dev/urandom >> $SNAPCRAFT_PART_INSTALL/size_workaround

--- a/checkbox-snap/series_classic20/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic20/snap/snapcraft.yaml
@@ -75,4 +75,4 @@ parts:
       echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
-      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      head -c 16384 /dev/urandom >> $SNAPCRAFT_PART_INSTALL/size_workaround

--- a/checkbox-snap/series_classic22/snap/snapcraft.yaml
+++ b/checkbox-snap/series_classic22/snap/snapcraft.yaml
@@ -77,4 +77,4 @@ parts:
       echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
-      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      head -c 16384 /dev/urandom >> $SNAPCRAFT_PART_INSTALL/size_workaround

--- a/checkbox-snap/series_uc16/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc16/snap/snapcraft.yaml
@@ -118,4 +118,4 @@ parts:
       echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
-      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      head -c 16384 /dev/urandom >> $SNAPCRAFT_PART_INSTALL/size_workaround

--- a/checkbox-snap/series_uc18/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc18/snap/snapcraft.yaml
@@ -122,4 +122,4 @@ parts:
       echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
-      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      head -c 16384 /dev/urandom >> $SNAPCRAFT_PART_INSTALL/size_workaround

--- a/checkbox-snap/series_uc20/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc20/snap/snapcraft.yaml
@@ -122,4 +122,4 @@ parts:
       echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
-      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      head -c 16384 /dev/urandom >> $SNAPCRAFT_PART_INSTALL/size_workaround

--- a/checkbox-snap/series_uc22/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc22/snap/snapcraft.yaml
@@ -124,4 +124,4 @@ parts:
       echo "This file is a workaround for a bug in the automated snap review tool" > $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "this only contains random bytes to pad the snap to 16kb" >> $SNAPCRAFT_PART_INSTALL/size_workaround
       echo "see: https://bugs.launchpad.net/review-tools/+bug/2049093" >>  $SNAPCRAFT_PART_INSTALL/size_workaround
-      cat /dev/urandom | head -c 16384 >> $SNAPCRAFT_PART_INSTALL/size_workaround
+      head -c 16384 /dev/urandom >> $SNAPCRAFT_PART_INSTALL/size_workaround


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Currenty the frontend snaps are failing to build. In the logs snapcraft is reporting a non-0 return value on the new workaround part. This error is `141` (broken pipe). This happens because we are `cat`-ing from `/dev/urandom` (an infinite source) and closing the pipe via head, effectively breaking it. This doesn't make some series fail because it may be (not confirmed, but a very likely theory) that snapcraft started to set the `set -o pipefail` only recently-ish.

This PR fixes this problem by making head read the file directly instead of reading it via cat

## Resolved issues

Broken daily builds here: https://github.com/canonical/checkbox/actions/runs/7505763759

## Documentation

N/A 

This doesn't change the effect of the command, it should only make it go through without "breaking" the pipe and making snapcraft mad 

## Tests

The following fails (exits with return code 141) with the same error:
```
!/bin/bash

set -o pipefail
set -e

cat /dev/urandom | head -c 1000 > /dev/null
```

while this doesn't:
```
!/bin/bash

set -o pipefail
set -e

head -c 1000 /dev/urandom > /dev/null
```
