### PR TITLE
Cut down time it takes to run base provider unit tests by 95% (Infra)

### DIFF
--- a/providers/base/tests/test_pipewire_test.py
+++ b/providers/base/tests/test_pipewire_test.py
@@ -101,8 +101,9 @@ class VolumeControllerTests(unittest.TestCase):
                                           '1'],
                                          universal_newlines=True)
 
+    @patch("time.sleep")
     @patch("subprocess.check_output")
-    def test_wpctl_output_fail(self, mock_checkout):
+    def test_wpctl_output_fail(self, mock_checkout, _):
         vc = VolumeController(type='input', logger=MagicMock())
         mock_checkout.side_effect = subprocess.CalledProcessError(2, "echo")
         with self.assertRaises(SystemExit) as cm:

--- a/providers/base/tests/test_pipewire_utils.py
+++ b/providers/base/tests/test_pipewire_utils.py
@@ -385,9 +385,9 @@ class GstPipeLineTests(unittest.TestCase):
         mock_checkout.return_value = self.device
         self.assertEqual(PipewireTestError.NO_SPECIFIC_DEVICE,
                          pt.gst_pipeline("pipe", 10, "qoo"))
-
+    @patch("time.sleep")
     @patch("subprocess.check_output")
-    def test_gst_pipeline(self, mock_checkout):
+    def test_gst_pipeline(self, mock_checkout, _):
         pt = PipewireTest()
 
         mock_checkout.return_value = self.device
@@ -485,8 +485,9 @@ class MonitorActivePortTests(unittest.TestCase):
                       }
                      }]"""
 
+    @patch("time.sleep")
     @patch("subprocess.check_output")
-    def test_couldnt_detect_change(self, mock_checkout):
+    def test_couldnt_detect_change(self, mock_checkout, _):
         pt = PipewireTest()
 
         mock_checkout.return_value = self.before_device


### PR DESCRIPTION
## Description

There were multiple tests that were calling the real time.sleep().
The patch proposed here mocks them out.

This got the wall-time of running the tests from 19s to 0.85s.
