### PR TITLE
fix the wrong file name pactl.sh to pactl_list.sh (Bugfix)

### DIFF
--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -778,7 +778,7 @@ command:
   if check_audio_deamon.sh ; then
     pipewire_utils.py detect -t audio -c sinks
   else
-    pactl.sh sinks
+    pactl_list.sh sinks
   fi
 _description:
   Test to detect if there's available sources and sinks after suspending 30 times.


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
The pactl.sh should be a typo which introduced by the commit 228b716bba2ec511f09ee36bf87aa969d348df8b :
```
@@ -654,9 +773,13 @@ category_id: com.canonical.plainbox::audio
 id: audio/detect_sinks_sources_after_suspend_30_cycles
 estimated_duration: 1.0
 requires:
-  package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
 command:
-  pactl_list.sh
+  if check_audio_deamon.sh ; then
+    pipewire_utils.py detect -t audio -c sinks
+  else
+    pactl.sh sinks
+  fi
```

There is not such a file named pactl.sh.

When run the tests:
checkbox-cli  run com.canonical.certification::audio/detect_sinks_sources_after_suspend_30_cycles:

```
==============[ Running job 2 / 2. Estimated time left: 0:00:01 ]===============
-------------[ audio/detect_sinks_sources_after_suspend_30_cycles ]-------------
ID: com.canonical.certification::audio/detect_sinks_sources_after_suspend_30_cycles
Category: com.canonical.plainbox::audio
... 8< -------------------------------------------------------------------------
Daemon is pulseaudio, use pulseaudio function
bash: line 4: pactl.sh: command not found
------------------------------------------------------------------------- >8 ---
Outcome: job failed
```

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
A typo introduced by https://github.com/canonical/checkbox/pull/826

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
NA
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests
After side load the fix, the test results look like this:

```
==============[ Running job 2 / 2. Estimated time left: 0:00:01 ]===============
-------------[ audio/detect_sinks_sources_after_suspend_30_cycles ]-------------
ID: com.canonical.certification::audio/detect_sinks_sources_after_suspend_30_cycles
Category: com.canonical.plainbox::audio
... 8< -------------------------------------------------------------------------
Daemon is pulseaudio, use pulseaudio function
1	alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_5__sink	module-alsa-card.c	s16le 2ch 48000Hz	SUSPENDED
2	alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_4__sink	module-alsa-card.c	s16le 2ch 48000Hz	SUSPENDED
3	alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp_3__sink	module-alsa-card.c	s16le 2ch 48000Hz	SUSPENDED
4	alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink	module-alsa-card.c	s16le 2ch 48000Hz	SUSPENDED
------------------------------------------------------------------------- >8 ---
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-01-18T08.46.21
==================================[ Results ]===================================
 ☑ : Collect information about installed software packages
 ☑ : audio/detect_sinks_sources_after_suspend_30_cycles
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

