### PR TITLE
Support user defined snaps from config_var to fix issue 923 (BugFix)

### DIFF
--- a/providers/base/tests/test_snap_confinement_test.py
+++ b/providers/base/tests/test_snap_confinement_test.py
@@ -1,0 +1,49 @@
+import logging
+import unittest
+from unittest.mock import patch
+from snap_confinement_test import SnapsConfinementVerifier
+
+
+class TestSnapsConfinementVerifier(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        logging.disable(logging.CRITICAL)
+
+    @classmethod
+    def tearDownClass(cls):
+        logging.disable(logging.NOTSET)
+
+    @patch("snap_confinement_test.logging")
+    def test_extract_attributes_from_snap_success(self, mock_logging):
+        verifier = SnapsConfinementVerifier()
+        mock_snap = {
+            "name": "test_snap", "confinement": "strict", "devmode": False,
+            "revision": "123", "foo": "bar"}
+
+        # Test when all desired attributes are present in the snap
+        desired_attributes = ["name", "confinement", "devmode", "revision"]
+        result = verifier._extract_attributes_from_snap(
+            mock_snap, desired_attributes)
+
+        self.assertEqual(result, mock_snap)
+        mock_logging.assert_not_called()
+
+    @patch("snap_confinement_test.logging")
+    def test_extract_attributes_from_snap_missing_attribute(self, mock_logging):
+        verifier = SnapsConfinementVerifier()
+        mock_snap = {"name": "test_snap", "confinement": "strict"}
+
+        # Test when some desired attributes are missing
+        desired_attributes = ["name", "nonexistent_attr", "confinement"]
+        result = verifier._extract_attributes_from_snap(
+            mock_snap, desired_attributes)
+
+        expected_result = {"name": "test_snap", "confinement": "strict"}
+        self.assertEqual(result, expected_result)
+        mock_logging.assert_called_once_with(
+            "Snap 'nonexistent_attr' not found in the snap data."
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/providers/base/tests/test_snap_confinement_test.py
+++ b/providers/base/tests/test_snap_confinement_test.py
@@ -1,7 +1,7 @@
 import logging
 import unittest
-from unittest.mock import patch
-from snap_confinement_test import SnapsConfinementVerifier
+from unittest.mock import patch, MagicMock
+from snap_confinement_test import SnapsConfinementVerifier, main
 
 
 class TestSnapsConfinementVerifier(unittest.TestCase):
@@ -13,36 +13,218 @@ class TestSnapsConfinementVerifier(unittest.TestCase):
     def tearDownClass(cls):
         logging.disable(logging.NOTSET)
 
-    @patch("snap_confinement_test.logging")
-    def test_extract_attributes_from_snap_success(self, mock_logging):
-        verifier = SnapsConfinementVerifier()
-        mock_snap = {
-            "name": "test_snap", "confinement": "strict", "devmode": False,
-            "revision": "123", "foo": "bar"}
+    def setUp(self):
+        self.verifier = SnapsConfinementVerifier()
 
-        # Test when all desired attributes are present in the snap
-        desired_attributes = ["name", "confinement", "devmode", "revision"]
-        result = verifier._extract_attributes_from_snap(
-            mock_snap, desired_attributes)
+    def test_snap_in_allow_list_from_config_var(self):
+        with patch.dict(
+            'os.environ', {"SNAP_CONFINEMENT_ALLOWLIST": "sp1, sp2"}
+        ):
+            verifier = SnapsConfinementVerifier()
+            result = verifier._is_snap_in_allow_list("sp2")
+            self.assertTrue(result)
 
-        self.assertEqual(result, mock_snap)
-        mock_logging.assert_not_called()
+    def test_snap_in_official_allow_list(self):
+        result = self.verifier._is_snap_in_allow_list("bugit")
+        self.assertTrue(result)
 
-    @patch("snap_confinement_test.logging")
-    def test_extract_attributes_from_snap_missing_attribute(self, mock_logging):
-        verifier = SnapsConfinementVerifier()
-        mock_snap = {"name": "test_snap", "confinement": "strict"}
+    def test_snap_not_in_allow_list(self):
+        result = self.verifier._is_snap_in_allow_list("non_allowed_snap")
+        self.assertFalse(result)
 
-        # Test when some desired attributes are missing
-        desired_attributes = ["name", "nonexistent_attr", "confinement"]
-        result = verifier._extract_attributes_from_snap(
-            mock_snap, desired_attributes)
+    def test_is_snap_confinement_not_strict_catchs_none_strict_snap(self):
+        result = self.verifier._is_snap_confinement_not_strict("classic")
+        self.assertTrue(result)
 
-        expected_result = {"name": "test_snap", "confinement": "strict"}
-        self.assertEqual(result, expected_result)
-        mock_logging.assert_called_once_with(
-            "Snap 'nonexistent_attr' not found in the snap data."
+    def test_is_snap_confinement_not_strict_success(self):
+        result = self.verifier._is_snap_confinement_not_strict("strict")
+        self.assertFalse(result)
+
+    def test_is_snap_devmode_catchs_devmode_snap(self):
+        result = self.verifier._is_snap_devmode(True)
+        self.assertTrue(result)
+
+    def test_is_snap_devmode_success(self):
+        result = self.verifier._is_snap_devmode(False)
+        self.assertFalse(result)
+
+    def test_is_snap_sideloaded_revision_catchs_sideload_snap(self):
+        result = self.verifier._is_snap_sideloaded_revision("x123")
+        self.assertTrue(result)
+
+    def test_is_snap_sideloaded_revision_success(self):
+        result = self.verifier._is_snap_sideloaded_revision("y456")
+        self.assertFalse(result)
+
+    def test_extract_attributes_from_snap_success(self):
+        self.verifier._desired_attributes = ["hello"]
+        mock_snap = {"hello": "world", "foo": "bar"}
+        result = self.verifier._extract_attributes_from_snap(mock_snap)
+        self.assertEqual(result, (False, {"hello": "world"}))
+
+    def test_extract_attributes_from_snap_missing_desired_attribute(self):
+        self.verifier._desired_attributes = ["name", "nonexistent_attr"]
+        mock_snap = {"name": "test_snap"}
+        result = self.verifier._extract_attributes_from_snap(mock_snap)
+        self.assertEqual(result, (True, {"name": "test_snap"}))
+
+    @patch("snap_confinement_test.Snapd.list")
+    def test_verify_snap_no_snaps_from_snapd_list(self, mock_snapd_list):
+        mock_snapd_list.return_value = []
+        self.assertEqual(0, self.verifier.verify_snap())
+
+    @patch("snap_confinement_test.SnapsConfinementVerifier._extract_attributes_from_snap")   # noqa E501
+    @patch("snap_confinement_test.Snapd.list")
+    def test_verify_snap_fail_without_desired_attribute_in_a_snap(
+        self,
+        mock_snapd_list,
+        mock_extract_attributes_from_snap
+    ):
+        mock_snapd_list.return_value = [{"foo": "bar"}]
+        mock_extract_attributes_from_snap.return_value = (True, {})
+        self.assertEqual(1, self.verifier.verify_snap())
+
+    @patch("snap_confinement_test.SnapsConfinementVerifier._is_snap_in_allow_list")   # noqa E501
+    @patch("snap_confinement_test.SnapsConfinementVerifier._extract_attributes_from_snap")   # noqa E501
+    @patch("snap_confinement_test.Snapd.list")
+    def test_verify_snap_pass_if_snap_in_allow_list(
+        self,
+        mock_snapd_list,
+        mock_extract_attributes_from_snap,
+        mock_is_snap_in_allow_list
+    ):
+        snap_info = {"name": "foo"}
+        mock_snapd_list.return_value = [snap_info]
+        mock_extract_attributes_from_snap.return_value = (False, snap_info)
+        mock_is_snap_in_allow_list.return_value = True
+        result = self.verifier.verify_snap()
+        mock_is_snap_in_allow_list.assert_called_once_with(
+            snap_info.get("name"))
+        self.assertEqual(0, result)
+
+    @patch("snap_confinement_test.SnapsConfinementVerifier._is_snap_sideloaded_revision")   # noqa E501
+    @patch("snap_confinement_test.SnapsConfinementVerifier._is_snap_devmode")   # noqa E501
+    @patch("snap_confinement_test.SnapsConfinementVerifier._is_snap_confinement_not_strict")   # noqa E501
+    @patch("snap_confinement_test.SnapsConfinementVerifier._is_snap_in_allow_list")   # noqa E501
+    @patch("snap_confinement_test.SnapsConfinementVerifier._extract_attributes_from_snap")   # noqa E501
+    @patch("snap_confinement_test.Snapd.list")
+    def test_verify_snap_success(
+        self,
+        mock_snapd_list,
+        mock_extract_attributes_from_snap,
+        mock_is_snap_in_allow_list,
+        mock_is_snap_confinement_not_strict,
+        mock_is_snap_devmode,
+        mock_is_snap_sideloaded_revision,
+    ):
+        """
+        Check verify_snap return 0 if a snap mach all the check criteria
+        """
+        snap_info = {
+            "name": "foo-snap",
+            "devmode": False,
+            "confinement": "strict",
+            "revision": "999"
+        }
+        mock_snapd_list.return_value = [snap_info]
+        mock_extract_attributes_from_snap.return_value = (False, snap_info)
+        mock_is_snap_in_allow_list.return_value = False
+        mock_is_snap_confinement_not_strict.return_value = False
+        mock_is_snap_devmode.return_value = False
+        mock_is_snap_sideloaded_revision.return_value = False
+
+        result = self.verifier.verify_snap()
+        mock_extract_attributes_from_snap.assert_called_once_with(
+            target_snap=snap_info
         )
+        mock_is_snap_in_allow_list.assert_called_once_with(
+            snap_info.get("name"))
+        mock_is_snap_confinement_not_strict.assert_called_once_with(
+            snap_info.get("confinement"))
+        mock_is_snap_devmode.assert_called_once_with(
+            snap_info.get("devmode"))
+        mock_is_snap_sideloaded_revision.assert_called_once_with(
+            snap_info.get("revision"))
+        self.assertEqual(0, result)
+
+    @patch("snap_confinement_test.SnapsConfinementVerifier._is_snap_sideloaded_revision")   # noqa E501
+    @patch("snap_confinement_test.SnapsConfinementVerifier._is_snap_devmode")   # noqa E501
+    @patch("snap_confinement_test.SnapsConfinementVerifier._is_snap_confinement_not_strict")   # noqa E501
+    @patch("snap_confinement_test.SnapsConfinementVerifier._is_snap_in_allow_list")   # noqa E501
+    @patch("snap_confinement_test.SnapsConfinementVerifier._extract_attributes_from_snap")   # noqa E501
+    @patch("snap_confinement_test.Snapd.list")
+    def test_verify_snap_fail_to_match_pass_criteria(
+        self,
+        mock_snapd_list,
+        mock_extract_attributes_from_snap,
+        mock_is_snap_in_allow_list,
+        mock_is_snap_confinement_not_strict,
+        mock_is_snap_devmode,
+        mock_is_snap_sideloaded_revision,
+    ):
+        """
+        Check verify_snap return 1 if a snap doesn't reach out the check
+        criteria
+        """
+        snap_info = {
+            "name": "foo-snap",
+            "devmode": True,
+            "confinement": "not-strict",
+            "revision": "999"
+        }
+        mock_snapd_list.return_value = [snap_info]
+        mock_extract_attributes_from_snap.return_value = (False, snap_info)
+        mock_is_snap_in_allow_list.return_value = False
+        mock_is_snap_confinement_not_strict.return_value = True
+        mock_is_snap_devmode.return_value = True
+        mock_is_snap_sideloaded_revision.return_value = False
+        result = self.verifier.verify_snap()
+        mock_extract_attributes_from_snap.assert_called_once_with(
+            target_snap=snap_info
+        )
+        mock_is_snap_in_allow_list.assert_called_once_with(
+            snap_info.get("name"))
+        mock_is_snap_confinement_not_strict.assert_called_once_with(
+            snap_info.get("confinement"))
+        mock_is_snap_devmode.assert_called_once_with(
+            snap_info.get("devmode"))
+        mock_is_snap_sideloaded_revision.assert_called_once_with(
+            snap_info.get("revision"))
+        self.assertEqual(1, result)
+
+
+class TestMainFunction(unittest.TestCase):
+    @patch('snap_confinement_test.test_system_confinement')
+    @patch('snap_confinement_test.SnapsConfinementVerifier.verify_snap')
+    @patch('snap_confinement_test.argparse.ArgumentParser')
+    def test_main_execute_snaps_command(
+        self,
+        mock_arg_parser,
+        mock_verify_snap,
+        mock_test_system_confinement
+    ):
+        mock_args = MagicMock(subcommand='snaps')
+        mock_arg_parser.return_value.parse_args.return_value = mock_args
+        result = main()
+        mock_verify_snap.assert_called_once_with()
+        mock_test_system_confinement.assert_not_called()
+        self.assertEqual(result, mock_verify_snap.return_value)
+
+    @patch('snap_confinement_test.test_system_confinement')
+    @patch('snap_confinement_test.SnapsConfinementVerifier.verify_snap')
+    @patch('snap_confinement_test.argparse.ArgumentParser')
+    def test_main_execute_system_command(
+        self,
+        mock_arg_parser,
+        mock_verify_snap,
+        mock_test_system_confinement
+    ):
+        mock_args = MagicMock(subcommand='system')
+        mock_arg_parser.return_value.parse_args.return_value = mock_args
+        result = main()
+        mock_test_system_confinement.assert_called_once_with()
+        mock_verify_snap.assert_not_called()
+        self.assertEqual(result, mock_test_system_confinement.return_value)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This PR aims to solve issue #923.

During OEM-QA testing, some testing snaps have to be installed, however, those snap might not meet the criteria defined in the `snappy/test-snaps-confinement` job.

Therefore, I raise this PR address this issue by allowing tester defines their testing snaps through `SNAP_CONFINEMENT_ALLOWLIST` envrionment variable. Tester could assign it to be  `SNAP_CONFINEMENT_ALLOWLIST=test-snap1,test-snap2` before testing, then these snaps will be skipped.

Please reference the sideload test results in the `Test` section below.

## Resolved issues
#923 - snappy/test-snaps-confinement test failed with testing snaps be installed

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

The following two snaps are testing snap in Baoshan Project

1. mediatek-genio-g1200-gpu-drivers-core22: [LP#2017882](https://bugs.launchpad.net/baoshan/+bug/2017882) - [g1200] Ubuntu Frame Bringup
2. genio-test-tool: https://snapcraft.io/genio-test-tool

Sideload Results

1. Tester **_didn't_** define the `SNAP_CONFINEMENT_ALLOWLIST=genio-test-tool,mediatek-genio-g1200-gpu-drivers-core22`

    - https://certification.canonical.com/hardware/202307-31864/submission/352448/test/202979/result/38867010/

1. Tester **_did_** define the `SNAP_CONFINEMENT_ALLOWLIST=genio-test-tool,mediatek-genio-g1200-gpu-drivers-core22`

    - https://certification.canonical.com/hardware/202307-31864/submission/352451/test/202979/result/38867150/