### PR TITLE
Update the rotation test cases to against the bug (bugfix)

### DIFF
--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -253,7 +253,8 @@ _description:
      This test will test display rotation on the {vendor} {product} graphics card
  STEPS:
      1. Click "Test" to test display rotation. The display will be rotated every 4 seconds.
-     2. Check if all rotations (normal right inverted left) took place without permanent screen corruption
+     2. Try moving the mouse or try opening multiple terminals via ‘Ctrl+Alt+T’ every time the screen automatically turns.
+     3. Check if all rotations (normal right inverted left) took place without permanent screen corruption.
  VERIFICATION:
      Did the display rotation take place without permanent screen corruption?
 

--- a/providers/base/units/suspend/suspend-graphics.pxu
+++ b/providers/base/units/suspend/suspend-graphics.pxu
@@ -304,6 +304,7 @@ _description:
      This test will test display rotation on the {{ vendor }} {{ product }} graphics card after suspend
  STEPS:
      1. Click "Test" to test display rotation. The display will be rotated every 4 seconds.
-     2. Check if all rotations (normal right inverted left) took place without permanent screen corruption
+     2. Try moving the mouse or try opening multiple terminals via ‘Ctrl+Alt+T’ every time the screen automatically turns
+     3. Check if all rotations (normal right inverted left) took place without permanent screen corruption
  VERIFICATION:
      Did the display rotation take place without permanent screen corruption after suspend?


### PR DESCRIPTION
Update the rotation test cases to against the bug [#2045249](https://bugs.launchpad.net/sutton/+bug/2045249)



## Description

Improve this test case by adding test steps

## Resolved issues

Update the rotation test cases to against the bug [#2045249](https://bugs.launchpad.net/sutton/+bug/2045249)

## Documentation

## Tests

In the three AMD configurations of Sutton Laptop, we found that 
the system will have a blurred screen when moving the mouse or 
opening the terminal after Rotation.

 Please refer to the video [https://bugs.launchpad.net/sutton/+bug/2045249/+attachment/5725161/+files/screen%20flipped.mp4](url)

We plan to add a manual operation of moving the mouse focus 
to the test cases of Rotation, so that we can imitate the operation 
process of this bug to verify whether the screen display is normal 
after Rotation. Thanks.

