### PR TITLE
Set inxi permissions (+x) in checkbox-ng debian packaging (BugFix)

### DIFF
--- a/checkbox-ng/debian/rules
+++ b/checkbox-ng/debian/rules
@@ -36,6 +36,12 @@ override_dh_clean:
 	dh_clean
 	rm -rf plainbox/impl/providers/categories/build
 
+# Override dh_fixperms to ensure inxi is set as an executable (required for bionic builds)
+override_dh_fixperms:
+	dh_fixperms
+	chmod 755 debian/python3-checkbox-ng/usr/lib/python3/dist-packages/plainbox/vendor/inxi
+
+
 # Drop the empty python-3.4 directory
 # Taken from https://wiki.debian.org/Python/LibraryStyleGuide
 override_dh_python3:


### PR DESCRIPTION
## Description

Fix the checkbox-ng debian packaging to always install `inxi` as an executable.

## Resolved issues

Fixes #955 

## Documentation

N/A

## Tests
Tested the binary build in LXC (18.04) using `dpkg-buildpackage -b -d -uc -us`
Inxi is now packaged with the following permissions:
`-rwxr-xr-x root/root   1263081 2023-06-14 06:35 ./usr/lib/python3/dist-packages/plainbox/vendor/inxi
`

