### PR TITLE
Update contruct to v2.10.57 (bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/vendor/construct/debug.py
+++ b/checkbox-support/checkbox_support/vendor/construct/debug.py
@@ -22,9 +22,9 @@ class Probe(Construct):
         --------------------------------------------------
         Probe, path is (parsing), into is None
         Stream peek: (hexlified) b'010203'...
-        Container: 
+        Container:
             count = 5
-            items = ListContainer: 
+            items = ListContainer:
                 97
                 98
                 99
@@ -95,11 +95,11 @@ class Probe(Construct):
 class Debugger(Subconstruct):
     r"""
     PDB-based debugger. When an exception occurs in the subcon, a debugger will appear and allow you to debug the error (and even fix it on-the-fly).
-    
+
     :param subcon: Construct instance, subcon to debug
-    
+
     Example::
-    
+
         >>> Debugger(Byte[3]).build([])
 
         --------------------------------------------------

--- a/checkbox-support/checkbox_support/vendor/construct/lib/binary.py
+++ b/checkbox-support/checkbox_support/vendor/construct/lib/binary.py
@@ -90,7 +90,7 @@ def bytes2integer(data, signed=False):
 
 BYTES2BITS_CACHE = {i:integer2bits(i,8) for i in range(256)}
 def bytes2bits(data):
-    r""" 
+    r"""
     Converts between bit and byte representations in b-strings.
 
     Example:
@@ -103,7 +103,7 @@ def bytes2bits(data):
 
 BITS2BYTES_CACHE = {bytes2bits(int2byte(i)):int2byte(i) for i in range(256)}
 def bits2bytes(data):
-    r""" 
+    r"""
     Converts between bit and byte representations in b-strings.
 
     Example:

--- a/checkbox-support/checkbox_support/vendor/construct/version.py
+++ b/checkbox-support/checkbox_support/vendor/construct/version.py
@@ -1,3 +1,3 @@
-version = (2,10,53)
-version_string = "2.10.53"
-release_date = "2020.01.19"
+version = (2,10,57)
+version_string = "2.10.57"
+release_date = "2021.01.26"


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The vendorized version of contruct uses the now removed (as of python3.12) `imp` module. This PR updates the vendorized module to a more up-to-date version of construct with the following changes:
- All imports made relative to vendor 
- Fixed the creation of a module to be compatible with python3.5
- Patched (keeping the old version) py3compact.py to keep the `supportshalffloats` among other functions (used in python3.5 that doesn't support the struct `e` formatter)

## Resolved issues

Partially solves: https://launchpadlibrarian.net/710488943/buildlog_ubuntu-noble-amd64.checkbox-support_3.3.0~dev96~ubuntu24.04.1_BUILDING.txt.gz

## Documentation

This PR documentation and the commit messages should be enough to document what was done

## Tests

N/A

