### PR TITLE
Fixed unknown method name in checkbox-support test (bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/snap_utils/tests/test_config.py
+++ b/checkbox-support/checkbox_support/snap_utils/tests/test_config.py
@@ -85,17 +85,17 @@ class TestWriteCheckboxConf(unittest.TestCase):
         m = mock_open()
         with patch('builtins.open', m):
             write_checkbox_conf({'foo': 'bar'})
-        m().write.called_once_with('[environ]\n')
-        m().write.called_once_with('FOO = bar\n')
-        m().write.called_once_with('\n')
+        m().write.assert_called_once_with('[environ]\n')
+        m().write.assert_called_once_with('FOO = bar\n')
+        m().write.assert_called_once_with('\n')
         self.assertEqual(m().write.call_count, 3)
 
     def test_writes_empty(self):
         m = mock_open()
         with patch('builtins.open', m):
             write_checkbox_conf({})
-        m().write.called_once_with('[environ]\n')
-        m().write.called_once_with('\n')
+        m().write.assert_called_once_with('[environ]\n')
+        m().write.assert_called_once_with('\n')
         self.assertEqual(m().write.call_count, 2)
 
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

When running via the deb runner, this test fails on python 3.12. This should always fail and the reason why it doesn't is still unclear to me at this point. The function name is wrong and it should be **`assert_`**`called_once_with`

This updates every test with the correct function call.

## Resolved issues

Resolves: https://launchpadlibrarian.net/710488943/buildlog_ubuntu-noble-amd64.checkbox-support_3.3.0~dev96~ubuntu24.04.1_BUILDING.txt.gz

## Documentation

N/A

## Tests

N/A
