### PR TITLE
Fixed SyntaxWarning correctly marking regex strings (bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/parsers/pactl.py
+++ b/checkbox-support/checkbox_support/parsers/pactl.py
@@ -170,7 +170,7 @@ class Profile(Node):
             lambda t: t[0].rstrip(':')
         ).setResultsName("profile-name")
         + p.delimitedList(
-            p.Literal("(HDMI)") | p.Literal("(IEC958)") | p.Regex('[^ (\n]+'),
+            p.Literal("(HDMI)") | p.Literal("(IEC958)") | p.Regex(r'[^ (\n]+'),
             ' ', combine=True
         ).setResultsName('profile-label')
         + p.Suppress('(')
@@ -229,7 +229,7 @@ class Port(Node):
         # anything other than a space and '(', delimited by a single
         # whitespace.
         + p.delimitedList(
-            p.Regex('[^ (\n]+'), ' ', combine=True
+            p.Regex(r'[^ (\n]+'), ' ', combine=True
         ).setResultsName('port-label')
         + p.Suppress('(')
         + p.Optional(
@@ -314,10 +314,10 @@ class PortWithProfile(Node):
         + p.Combine(
             p.OneOrMore(
                 ~p.FollowedBy(
-                    p.Regex('\(.+?\)')
+                    p.Regex(r'\(.+?\)')
                     + p.LineEnd()
                 )
-                + p.Regex('[^ \n]+')
+                + p.Regex(r'[^ \n]+')
                 + p.White().suppress()
             ),
             ' '
@@ -384,13 +384,13 @@ class PortWithProfile(Node):
 # Non-collection attributes
 # =========================
 
-AttributeName = p.Regex("[a-zA-Z][^:\n]+").setResultsName("attribute-name")
+AttributeName = p.Regex(r"[a-zA-Z][^:\n]+").setResultsName("attribute-name")
 
 
 ActivePortAttributeValue = (
     p.Combine(
         p.Or([p.Literal('[Out] '), p.Literal('[In] ')]).suppress()
-        + p.Regex("[^\n]*")
+        + p.Regex(r"[^\n]*")
         + p.LineEnd().suppress(),
         adjacent=False
     ).setResultsName("attribute-value")
@@ -402,27 +402,27 @@ VolumeAttributeValue = (
         p.Or([
             p.Or([
                 p.Literal("(invalid)"),
-                p.Regex("([0-9]+: +[0-9]+% ?)+")
+                p.Regex(r"([0-9]+: +[0-9]+% ?)+")
             ]),
             p.Or([
                 p.Literal("(invalid)"),
-                p.Regex("([0-9]+: +[0-9]+% ?)+")
+                p.Regex(r"([0-9]+: +[0-9]+% ?)+")
             ])
             + p.LineEnd()
             + p.Optional(p.White('\t').suppress())
             + p.Or([
                 p.Literal("(invalid)"),
-                p.Regex("([0-9]+: -?([0-9]+\.[0-9]+|inf) dB ?)+"),
+                p.Regex(r"([0-9]+: -?([0-9]+\.[0-9]+|inf) dB ?)+"),
             ]),
             p.Or([
                 p.Literal("(invalid)"),
-                p.Regex("([\w\-]+: [0-9]+ / +[0-9]+%(?: /"
+                p.Regex(r"([\w\-]+: [0-9]+ / +[0-9]+%(?: /"
                         " +-?([0-9]+\.[0-9]+|inf) dB)?,? *)+")
             ])
         ])
         + p.LineEnd()
         + p.Optional(p.White('\t').suppress())
-        + p.Regex("balance -?[0-9]+\.[0-9]+")
+        + p.Regex(r"balance -?[0-9]+\.[0-9]+")
         + p.LineEnd(),
         adjacent=False
     ).setResultsName("attribute-value")
@@ -431,10 +431,10 @@ VolumeAttributeValue = (
 
 BaseVolumeAttributeValue = (
     p.Combine(
-        p.Regex("[0-9]+%")
+        p.Regex(r"[0-9]+%")
         + p.LineEnd()
         + p.Optional(p.White('\t').suppress())
-        + p.Regex("-?[0-9]+\.[0-9]+ dB")
+        + p.Regex(r"-?[0-9]+\.[0-9]+ dB")
         + p.LineEnd(),
         adjacent=False
     ).setResultsName("attribute-value")
@@ -442,7 +442,7 @@ BaseVolumeAttributeValue = (
 
 
 SimpleAttributeValue = (
-    p.Regex("[^\n]*").setResultsName("attribute-value")
+    p.Regex(r"[^\n]*").setResultsName("attribute-value")
     + p.LineEnd().suppress())
 
 # simple values
@@ -565,7 +565,7 @@ class Record(Node):
     __syntax__ = (
         p.LineStart()
         + p.NotAny(p.White(' \t'))
-        + p.Regex("[A-Z][a-zA-Z ]+ #[0-9]+").setResultsName("record-name")
+        + p.Regex(r"[A-Z][a-zA-Z ]+ #[0-9]+").setResultsName("record-name")
         + p.LineEnd().suppress()
         + p.OneOrMore(
             p.Or([


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Regexes in the pactl parser module are incorrectly put in normal strings.

This marks every string as a raw string, removing the SyntaxWarning that can be seen in the builder and pytest runs.

## Resolved issues

N/A

## Documentation

N/A

## Tests

N/A

