### PR TITLE
Mock module and explain why it was done (Bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/secure/origin.py
+++ b/checkbox-ng/plainbox/impl/secure/origin.py
@@ -25,6 +25,7 @@
 import functools
 import inspect
 import os
+import sys
 
 from plainbox.abc import ITextSource
 from plainbox.i18n import gettext as _
@@ -185,6 +186,19 @@ class Origin:
         """
         # Create an Origin instance that pinpoints the place that called
         # get_caller_origin().
+
+        # This avoids a sideffect of using inspect.stack(0) when the urwid
+        # module is in said stack. The python3-urwid
+        # package is currently partially broken on Ubuntu Noble. inspect.stack
+        # activates a sideffect of the urwid.__init__ module that imports
+        # urwid.display.web. That can not be done because the web module is
+        # missing the _web.js and _web.css. We don't need this part of urwid but
+        # given the chain described it is improted anyway. The following line
+        # will only make the import go through.
+        # See: https://packages.ubuntu.com/noble/amd64/python3-urwid/filelist
+        # FIXME: remove this line once the files are back
+        sys.modules["urwid.display.web"] = {}
+
         caller_frame, filename, lineno = inspect.stack(0)[2 + back][:3]
         try:
             source = PythonFileTextSource(filename)


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

A few versions ago, urwid splitted the `web.py` file into `web.py`, `_web.js` and `_web.css`. They have also moved the `web` module inside `display`. To be backward compatible they have added a mechanism to redirect calls from the old name `urwid.web_display` to `urwid.display.web`.  For reasons that I don't fully comprehend, `inspect.stack` seems to be triggering this mechanism, leading to the `web` module being imported. This causes an issue on Ubuntu Noble currently that doesn't let us build checkbox-ng. This is because this happens in any test that uses `Origin.get_caller_origin` (many of them) but the Noble package is currently broken [(bug in packaging fixed upstream here)](https://github.com/urwid/urwid/pull/750).

This PR fixes this issue while we wait for the debian package (and subsequently the ubuntu package) to be updated, allowing us to build checkbox-ng on noble again 

## Resolved issues

Fixes daily builds of checkbox-ng

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

Reproducing the issue:
```
$ python -m venv venv
$ . venv/bin/activate
$ pip install urwid
$ rm venv/lib/python*/site-packages/urwid/display/_web.css
$ rm venv/lib/python*/site-packages/urwid/display/_web.js
```

Now you have a package that is the same as the one installable on ubuntu noble. Alternatively, on ubuntu noble, run 
```
$ sudo apt install python3-urwid
```

Verify that the package is broken by running the following:
```
$ python3 -c "import urwid.display.web"
```

Verify that inspect causes the same issue as above by running the following:
```
$ python3.12 -c "import urwid; import inspect; inspect.stack(0)"
```

Now try runnint the following, this is the result of this patch:
```
$ python3.12 -c "import urwid; import inspect; import sys; sys.modules['urwid.display.web']={}; inspect.stack(0)"
```

> Note: Use the latest version of urwid to test this, the mechanism was introduced this bug triggers another bug on an older versions of the library! (RecursionError)