### PR TITLE
Add fwupdmgr attachment job (New)

### DIFF
--- a/providers/base/units/firmware/jobs.pxu
+++ b/providers/base/units/firmware/jobs.pxu
@@ -105,3 +105,13 @@ plugin: attachment
 depends: firmware/fwts_dump
 command:
   [ -f "$PLAINBOX_SESSION_SHARE/acpidump.log" ] && gzip -c "$PLAINBOX_SESSION_SHARE/acpidump.log"
+
+id: firmware/fwupdmgr_get_devices
+plugin: attachment
+category_id: com.canonical.plainbox::firmware
+_summary: Collect the device firmware update information
+requires:
+    executable.name == "fwupdmgr"
+    environment.SNAP == ""  # only execute on debian checkbox
+command:
+    fwupdmgr get-devices --json

--- a/providers/base/units/firmware/test-plan.pxu
+++ b/providers/base/units/firmware/test-plan.pxu
@@ -36,3 +36,28 @@ include:
     firmware/fwts_desktop_diagnosis
     firmware/fwts_desktop_diagnosis_results.log.gz
 
+
+id: firmware-fwupdmgr-full
+unit: test plan
+_name: fwupdmgr test
+_description: Firmware update manager tests
+include:
+nested_part:
+    firmware-fwupdmgr-automated
+    firmware-fwupdmgr-manual
+
+id: firmware-fwupdmgr-automated
+unit: test plan
+_name: Auto fwupdmgr tests
+_description: Automated firmware update manager tests
+bootstrap_include:
+    executable
+    environment
+include:
+    firmware/fwupdmgr_get_devices
+
+id: firmware-fwupdmgr-manual
+unit: test plan
+_name: Manual fwupdmgr tests
+_description: Manual firmware update manager tests
+include:

--- a/providers/certification-client/units/client-cert-desktop-18-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-18-04.pxu
@@ -99,6 +99,7 @@ nested_part:
     disk-cert-automated
     misc-client-cert-automated
     fingerprint-automated
+    firmware-fwupdmgr-automated
     keys-cert-automated
     led-cert-automated
     mediacard-cert-automated

--- a/providers/certification-client/units/client-cert-desktop-20-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-20-04.pxu
@@ -102,6 +102,7 @@ nested_part:
     disk-cert-automated
     misc-client-cert-automated
     fingerprint-automated
+    firmware-fwupdmgr-automated
     keys-cert-automated
     led-cert-automated
     mediacard-cert-automated

--- a/providers/certification-client/units/client-cert-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-22-04.pxu
@@ -106,6 +106,7 @@ nested_part:
     disk-cert-automated
     misc-client-cert-automated
     fingerprint-automated
+    firmware-fwupdmgr-automated
     keys-cert-automated
     led-cert-automated
     mediacard-cert-automated

--- a/providers/certification-client/units/client-cert-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-24-04.pxu
@@ -106,6 +106,7 @@ nested_part:
     disk-cert-automated
     misc-client-cert-automated
     fingerprint-automated
+    firmware-fwupdmgr-automated
     keys-cert-automated
     led-cert-automated
     mediacard-cert-automated


### PR DESCRIPTION
## Description
This attachment job is requested from the OEM SWE team. They'd like to parse the `fwupdmgr` device information from the submission.
This PR added a `firmware/fwupdmgr_get_devices` attachment job and the related test plan to be nested in the client-cert-desktop test plan.

The `firmware/fwupdmgr_get_devices` only does the following command:
```
fwupdmgr get-devices --json
```

#### Requires
```
requires:
    executable.name == "fwupdmgr"
    environment.SNAP == ""  # only execute on Debian checkbox
```
The tests will only be executed when `fwupdmgr` executable is available.
Also, we found a limitation:

Our purpose is to run the `fwupdmgr` command from the default deb package to get the needed information. However, while Checkbox is running in the snap environment, the `fwupdmgr` will try to find the snap services `snap.fwupd.fwupd.service`, which leads to the following daemon and client mismatch error,
```
root@u-Inspiron-15-5508:/home/u# fwupdmgr get-devices
Mismatched daemon and client, use fwupd.fwupdmgr instead
```
This environment check is written in https://github.com/fwupd/fwupd/blob/main/src/fu-util-common.c#L42

``` C
#define SYSTEMD_FWUPD_UNIT	"fwupd.service"
#define SYSTEMD_SNAP_FWUPD_UNIT "snap.fwupd.fwupd.service"

fu_util_get_systemd_unit(void)
{
	if (g_getenv("SNAP") != NULL)
		return SYSTEMD_SNAP_FWUPD_UNIT;
	return SYSTEMD_FWUPD_UNIT;
}
```
Using the Debian version checkbox will not encounter this problem. Currently, I don’t have any good idea to solve this problem. So I intend to add a job for Debian Checkbox for now. And the `environment.SNAP == ""` is to ensure the job will only be executed with Debian Checkbox.

## Resolved issues
Request from SWE team
https://warthogs.atlassian.net/browse/OEMQA-3797

## Tests
Sideload result on an Ubuntu Desktop 22.04 laptop with Debian Checkbox
https://pastebin.canonical.com/p/4Jf5gXDKYV/
Sideload result on an Ubuntu Desktop 22.04 laptop with Snap Checkbox -> job skipped
https://pastebin.canonical.com/p/8wnCchBnWv/
