### PR TITLE
Fix crash on missing plainbox-provider-develop (BugFix)

### DIFF
--- a/checkbox-ng/plainbox/provider_manager.py
+++ b/checkbox-ng/plainbox/provider_manager.py
@@ -552,7 +552,9 @@ class DevelopCommand(ManageCommand):
     def invoked(self, ns):
         pp_env = os.getenv("PROVIDERPATH")
         try:
-            samefile = os.path.samefile(pp_env, ns.directory)
+            samefile = pp_env is not None and os.path.samefile(
+                pp_env, ns.directory
+            )
         except FileNotFoundError:
             samefile = False
         if pp_env and not samefile:

--- a/checkbox-ng/plainbox/provider_manager.py
+++ b/checkbox-ng/plainbox/provider_manager.py
@@ -551,7 +551,11 @@ class DevelopCommand(ManageCommand):
 
     def invoked(self, ns):
         pp_env = os.getenv("PROVIDERPATH")
-        if pp_env and not os.path.samefile(pp_env, ns.directory):
+        try:
+            samefile = os.path.samefile(pp_env, ns.directory)
+        except FileNotFoundError:
+            samefile = False
+        if pp_env and not samefile:
             _logger.warning(
                 "$PROVIDERPATH is defined, ignoring -d/--directory"
                 " and developing in: %s", pp_env

--- a/checkbox-ng/plainbox/provider_manager.py
+++ b/checkbox-ng/plainbox/provider_manager.py
@@ -563,10 +563,6 @@ class DevelopCommand(ManageCommand):
                     "$PROVIDERPATH is defined, ignoring -d/--directory"
                     " and developing in: %s", pp_env
                 )
-            _logger.warning(
-                "$PROVIDERPATH is defined, ignoring -d/--directory"
-                " and developing in: %s", pp_env
-            )
             ns.directory = pp_env
         pathname = os.path.join(
             ns.directory, "{}.provider".format(

--- a/checkbox-ng/plainbox/provider_manager.py
+++ b/checkbox-ng/plainbox/provider_manager.py
@@ -551,13 +551,18 @@ class DevelopCommand(ManageCommand):
 
     def invoked(self, ns):
         pp_env = os.getenv("PROVIDERPATH")
-        try:
-            samefile = pp_env is not None and os.path.samefile(
-                pp_env, ns.directory
-            )
-        except FileNotFoundError:
-            samefile = False
-        if pp_env and not samefile:
+        # If $PROVIDERPATH is defined, use it instead of the one on the
+        # namespace
+        if pp_env:
+            try:
+                samefile = os.path.samefile(pp_env, ns.directory)
+            except FileNotFoundError:
+                samefile = False
+            if not samefile:
+                _logger.warning(
+                    "$PROVIDERPATH is defined, ignoring -d/--directory"
+                    " and developing in: %s", pp_env
+                )
             _logger.warning(
                 "$PROVIDERPATH is defined, ignoring -d/--directory"
                 " and developing in: %s", pp_env

--- a/checkbox-ng/plainbox/test_provider_manager.py
+++ b/checkbox-ng/plainbox/test_provider_manager.py
@@ -274,11 +274,11 @@ class ProviderManagerToolTests(TestCase):
         """
         verify that ``develop`` creates a provider file
         """
-        # no PROVIDERPATH defined
-        mock_getenv.return_value = None
         provider_path = os.path.join(self.tmpdir, "checkbox-providers-develop")
         filename = os.path.join(
             provider_path, "com.example.test.provider")
+        # no PROVIDERPATH defined
+        mock_getenv.return_value = provider_path
         mock_path_entry.return_value = provider_path
         content = (
             "[PlainBox Provider]\n"

--- a/checkbox-ng/plainbox/test_provider_manager.py
+++ b/checkbox-ng/plainbox/test_provider_manager.py
@@ -298,7 +298,7 @@ class ProviderManagerToolTests(TestCase):
 
     @mock.patch('plainbox.impl.providers.v1.get_universal_PROVIDERPATH_entry')
     @mock.patch('os.getenv')
-    def test_develop__force(self,mock_getenv, mock_path_entry):
+    def test_develop__force(self, mock_getenv, mock_path_entry):
         """
         verify that ``develop --force`` overwrites existing .provider
         file


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Currently Checkbox crashes when `/var/tmp/checkbox-providers-develop` is missing if one tries to develop a provider (even if `$PROVIDER_PATH` is defined). This fixes this problem.

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/941

## Documentation

N/A

## Tests

With `main` Checkbox run:
```
# rm -rf /var/tmp/checkbox-providers-develop
# ./manage.py develop
[! boom !]
```

Re-run on this branch, it should work as expected.


