### PR TITLE
Support different kernel repo (BugFix)

### DIFF
--- a/providers/base/bin/check_prerelease.py
+++ b/providers/base/bin/check_prerelease.py
@@ -60,12 +60,13 @@ def get_apt_cache_information(command: str):
         aptinfo = check_output(shlex.split(command), universal_newlines=True)
         # "apt-cache showpkg" returns an empty string with exit code 0 if
         # called on a non-existent package.
-        if aptinfo == '':
-            raise CalledProcessError(returncode=None, cmd=None)
+        if not aptinfo:
+            raise CalledProcessError(returncode=1, cmd=command)
         return aptinfo
-    except CalledProcessError:
+    except CalledProcessError as e:
         # "apt-cache show" returns an error status if called on a
         # non-existent package.
+        logging.error(e)
         logging.error(
             "* Kernel does not match any installed package!")
         raise SystemExit(1)

--- a/providers/base/bin/check_prerelease.py
+++ b/providers/base/bin/check_prerelease.py
@@ -37,6 +37,25 @@ from subprocess import CalledProcessError, check_output
 
 
 def get_apt_cache_information(command: str):
+    """ Execute the given apt-cache command and return the information.
+
+    This function runs the specified apt-cache command using the `check_output`
+    function, which returns the information about the Linux kernel package
+    queried by the command.
+
+    :param command: A string representing the apt-cache command to be executed.
+
+    :return:
+        A string containing the information retrieved from the apt-cache
+        command.
+
+    :raises CalledProcessError:
+        If the apt-cache command returns an empty string with exit code 0,
+        indicating a non-existent package.
+    :raises SystemExit:
+        If the apt-cache command returns an error status, indicating that
+        the kernel does not match any installed package.
+    """
     try:
         aptinfo = check_output(shlex.split(command), universal_newlines=True)
         # "apt-cache showpkg" returns an empty string with exit code 0 if
@@ -113,7 +132,10 @@ def verify_not_lowlatency_kernel(kernel_release: str):
     """
     # Exclude low-latency kernels, which are identified via the kernel name
     # string itself....
-    return False if "lowlatency" in kernel_release else True
+    if "lowlatency" in kernel_release:
+        logging.error("* Kernel is a low-latency kernel!")
+        return False
+    return True
 
 
 def check_kernel_status():

--- a/providers/base/bin/check_prerelease.py
+++ b/providers/base/bin/check_prerelease.py
@@ -27,12 +27,93 @@ system booted from the network (test passes) or from a local disk
 Usage:
    check-prerelease.py
 """
-
+import logging
+import os
 import platform
 import shlex
 import sys
 
 from subprocess import CalledProcessError, check_output
+
+
+def get_apt_cache_information(command: str):
+    try:
+        aptinfo = check_output(shlex.split(command), universal_newlines=True)
+        # "apt-cache showpkg" returns an empty string with exit code 0 if
+        # called on a non-existent package.
+        if aptinfo == '':
+            raise CalledProcessError(returncode=None, cmd=None)
+        return aptinfo
+    except CalledProcessError:
+        # "apt-cache show" returns an error status if called on a
+        # non-existent package.
+        logging.error(
+            "* Kernel does not match any installed package!")
+        raise SystemExit(1)
+
+
+def verify_apt_cache_showpkg(kernel_release: str):
+    """Check kernel to see if it's supported for certification
+        by "apt-cache showpkg linux-image-<kernel_release>"
+
+    :returns:
+        True if OK, False if not
+    """
+    command = "apt-cache showpkg linux-image-{}".format(kernel_release)
+    aptinfo = get_apt_cache_information(command)
+    # Exclude kernels that come from obvious PPAs....
+    retval = True
+    if "ppa.launchpad.net" in aptinfo:
+        logging.error("* Kernel appears to have come from a PPA!")
+        retval = False
+
+    # Exclude kernels that don't come from the specific Ubuntu repository
+    target_repo = os.environ.get("KERNEL_REPO", "main")
+    if "{}_binary".format(target_repo) not in aptinfo:
+        logging.error(
+            "* Kernel does not come from the {} Ubuntu repository!".format(
+                target_repo))
+        retval = False
+    return retval
+
+
+def verify_apt_cache_show(kernel_release: str):
+    """Check kernel to see if it's supported for certification
+        by "apt-cache show linux-image-<kernel_release>"
+
+    :returns:
+        True if OK, False if not
+    """
+    command = "apt-cache show linux-image-{}".format(kernel_release)
+    aptinfo = get_apt_cache_information(command)
+    retval = True
+
+    # Exclude 'edge' kernels, which are identified via the 'Source:' line
+    # in the apt-cache show output....
+    for source in ["Source: linux-signed-hwe-edge", "Source: linux-hwe-edge"]:
+        if source in aptinfo:
+            logging.error("* Kernel is an 'edge' kernel!, found '{}'")
+            retval = False
+
+    # Exclude kernels that aren't from the "linux" (or variant, like
+    # "linux-hwe" or "linux-signed") source....
+    if "Source: linux" not in aptinfo:
+        logging.error("* Kernel is not a Canonical kernel!")
+        retval = False
+
+    return retval
+
+
+def verify_not_lowlatency_kernel(kernel_release: str):
+    """Check kernel to see if it's supported for certification
+        by verifying the "lowlatency" term not in kernel string
+
+    :returns:
+        True if OK, False if not
+    """
+    # Exclude low-latency kernels, which are identified via the kernel name
+    # string itself....
+    return False if "lowlatency" in kernel_release else True
 
 
 def check_kernel_status():
@@ -42,57 +123,17 @@ def check_kernel_status():
         True if OK, False if not
     """
     kernel_release = platform.release()
+    logging.info("* Kernel release is {}".format(kernel_release))
 
-    retval = True
-    command = "apt-cache showpkg linux-image-{}".format(kernel_release)
-    aptinfo = check_output(shlex.split(command), universal_newlines=True)
+    is_valid_kernel = True
+    is_valid_kernel &= verify_apt_cache_showpkg(kernel_release)
+    is_valid_kernel &= verify_apt_cache_show(kernel_release)
+    is_valid_kernel &= verify_not_lowlatency_kernel(kernel_release)
 
-    # Exclude kernels that come from obvious PPAs....
-    if "ppa.launchpad.net" in aptinfo:
-        print("* Kernel appears to have come from a PPA!")
-        retval = False
+    if not is_valid_kernel:
+        logging.error("* Kernel is ineligible for certification!")
 
-    # Exclude kernels that don't come from the main repo
-    if "main_binary" not in aptinfo:
-        print("* Kernel does not come from the main Ubuntu repository!")
-        retval = False
-
-    try:
-        command = "apt-cache show linux-image-{}".format(kernel_release)
-        aptinfo = check_output(shlex.split(command), universal_newlines=True)
-    except CalledProcessError:
-        # "apt-cache show" returns an error status if called on a
-        # non-existent package.
-        print("* Kernel does not match any installed package!")
-        aptinfo = ""
-        retval = False
-
-    # Exclude 'edge' kernels, which are identified via the 'Source:' line
-    # in the apt-cache show output....
-    if "Source: linux-signed-hwe-edge" in aptinfo:
-        print("* Kernel is an 'edge' kernel!")
-        retval = False
-    if "Source: linux-hwe-edge" in aptinfo:
-        print("* Kernel is an 'edge' kernel!")
-        retval = False
-
-    # Exclude kernels that aren't from the "linux" (or variant, like
-    # "linux-hwe" or "linux-signed") source....
-    if "Source: linux" not in aptinfo:
-        print("* Kernel is not a Canonical kernel!")
-        retval = False
-
-    # Exclude low-latency kernels, which are identified via the kernel name
-    # string itself....
-    if "lowlatency" in kernel_release:
-        print("* Kernel is a low-latency kernel!")
-        retval = False
-
-    if (not retval):
-        print("* Kernel release is {}".format(kernel_release))
-        print("* Kernel is ineligible for certification!")
-
-    return retval
+    return is_valid_kernel
 
 
 def check_os_status():

--- a/providers/base/tests/test_check_prerelease.py
+++ b/providers/base/tests/test_check_prerelease.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Patrick Chang <patrick.chang@canonical.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import unittest
+from unittest.mock import patch
+from subprocess import CalledProcessError
+from check_prerelease import (
+    check_kernel_status,
+    verify_apt_cache_show,
+    verify_apt_cache_showpkg,
+    get_apt_cache_information,
+    verify_not_lowlatency_kernel
+)
+
+
+class TestGetAptCacheInformation(unittest.TestCase):
+    @patch("check_prerelease.check_output")
+    def test_get_apt_cache_information_success(self, mock_check_output):
+        command = "some_apt_cache_command"
+        expected_output = "some_information"
+        mock_check_output.return_value = expected_output
+        result = get_apt_cache_information(command)
+        self.assertEqual(result, expected_output)
+
+    @patch("check_prerelease.check_output")
+    def test_get_apt_cache_information_empty_output(self, mock_check_output):
+        """Test when getting the empty output from apt-cache showpkg <kernel>
+            command
+        """
+        command = "some_apt_cache_command"
+        mock_check_output.return_value = ''
+
+        with self.assertRaises(SystemExit) as context:
+            get_apt_cache_information(command)
+
+        self.assertEqual(context.exception.code, 1)
+
+    @patch("check_prerelease.check_output")
+    def test_get_apt_cache_information_nonexistent_package(
+        self,
+        mock_check_output
+    ):
+        command = "some_apt_cache_command"
+        mock_check_output.side_effect = CalledProcessError(
+            returncode=0, cmd=command)
+
+        with self.assertRaises(SystemExit) as context:
+            get_apt_cache_information(command)
+
+        self.assertEqual(context.exception.code, 1)
+
+
+class TestVerifyNotLowlatencyKernel(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        logging.disable(logging.CRITICAL)
+
+    @classmethod
+    def tearDownClass(cls):
+        logging.disable(logging.NOTSET)
+
+    def test_normal_kernel(self):
+        """ Test when the kernel release does not contain "lowlatency" """
+        kernel_release = "4.15.0-76-generic"
+        result = verify_not_lowlatency_kernel(kernel_release)
+        self.assertTrue(result)
+
+    def test_lowlatency_kernel(self):
+        """ Test when the kernel release contains "lowlatency" """
+        kernel_release = "4.15.0-76-lowlatency"
+        result = verify_not_lowlatency_kernel(kernel_release)
+        self.assertFalse(result)
+
+
+class TestVerifyAptCacheShowpkg(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        logging.disable(logging.CRITICAL)
+
+    @classmethod
+    def tearDownClass(cls):
+        logging.disable(logging.NOTSET)
+
+    @patch("check_prerelease.get_apt_cache_information")
+    @patch("check_prerelease.os")
+    def test_verify_apt_cache_showpkg_valid_kernel_from_main_repository(
+        self,
+        mock_os,
+        mock_get_apt_cache_information
+    ):
+        test_kernel = "1.2.3-generic"
+        mock_os.environ.get.return_value = "main"
+        mock_get_apt_cache_information.return_value = "ubuntu.com_ubuntu_dists_jammy-updates_main_binary-amd64_Packages"    # noqa E501
+        result = verify_apt_cache_showpkg(test_kernel)
+
+        self.assertTrue(result)
+        mock_get_apt_cache_information.assert_called_with(
+            "apt-cache showpkg linux-image-{}".format(test_kernel))
+
+    @patch("check_prerelease.get_apt_cache_information")
+    @patch("check_prerelease.os")
+    def test_verify_apt_cache_showpkg_valid_kernel_from_universe_repository(
+        self,
+        mock_os,
+        mock_get_apt_cache_information
+    ):
+        test_kernel = "1.2.3-generic"
+        mock_os.environ.get.return_value = "universe"
+        mock_get_apt_cache_information.return_value = "ubuntu.com_ubuntu_dists_jammy-updates_universe_binary-amd64_Packages"    # noqa E501
+        result = verify_apt_cache_showpkg(test_kernel)
+
+        self.assertTrue(result)
+        mock_get_apt_cache_information.assert_called_with(
+            "apt-cache showpkg linux-image-{}".format(test_kernel))
+
+    @patch("check_prerelease.get_apt_cache_information")
+    @patch("check_prerelease.os")
+    def test_verify_apt_cache_showpkg_invalid_kernel_from_a_ppa(
+        self,
+        mock_os,
+        mock_get_apt_cache_information
+    ):
+        test_kernel = "1.2.3-generic"
+        mock_os.environ.get.return_value = "main"
+        mock_get_apt_cache_information.return_value = "ubuntu.com_ubuntu_dists_jammy-updates_main_binary-amd64_Packages\nppa.launchpad.net\n"    # noqa E501
+        result = verify_apt_cache_showpkg(test_kernel)
+
+        self.assertFalse(result)
+        mock_get_apt_cache_information.assert_called_with(
+            "apt-cache showpkg linux-image-{}".format(test_kernel))
+
+    @patch("check_prerelease.get_apt_cache_information")
+    @patch("check_prerelease.os")
+    def test_verify_apt_cache_showpkg_invalid_kernel_from_invalid_repository(
+        self,
+        mock_os,
+        mock_get_apt_cache_information
+    ):
+        test_kernel = "1.2.3-generic"
+        mock_os.environ.get.return_value = "main"
+        mock_get_apt_cache_information.return_value = "ubuntu.com_ubuntu_dists_jammy-updates_OTHER_binary-amd64_Packages"    # noqa E501
+        result = verify_apt_cache_showpkg(test_kernel)
+
+        self.assertFalse(result)
+        mock_get_apt_cache_information.assert_called_with(
+            "apt-cache showpkg linux-image-{}".format(test_kernel))
+
+
+class TestVerifyAptCacheShow(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        logging.disable(logging.CRITICAL)
+
+    @classmethod
+    def tearDownClass(cls):
+        logging.disable(logging.NOTSET)
+
+    @patch("check_prerelease.get_apt_cache_information")
+    def test_verify_apt_cache_show_success(
+        self,
+        mock_get_apt_cache_information
+    ):
+        mock_get_apt_cache_information.return_value = "Source: linux"
+        result = verify_apt_cache_show("kernel_test")
+        self.assertTrue(result)
+
+    @patch("check_prerelease.get_apt_cache_information")
+    def test_verify_apt_cache_show_non_canonical_kernel(
+        self,
+        mock_get_apt_cache_information
+    ):
+        mock_get_apt_cache_information.return_value = "Source: other_source"
+        result = verify_apt_cache_show("kernel_test")
+        self.assertFalse(result)
+
+    @patch("check_prerelease.get_apt_cache_information")
+    def test_verify_apt_cache_show_edge_kernel(
+        self,
+        mock_get_apt_cache_information
+    ):
+        mock_get_apt_cache_information.return_value = "Source: linux-signed-hwe-edge"    # noqa E501
+        result = verify_apt_cache_show("kernel_test")
+        self.assertFalse(result)
+        mock_get_apt_cache_information.return_value = "Source: linux-hwe-edge"
+        result = verify_apt_cache_show("kernel_test")
+        self.assertFalse(result)
+
+
+class TestCheckKernelStatus(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        logging.disable(logging.CRITICAL)
+
+    @classmethod
+    def tearDownClass(cls):
+        logging.disable(logging.NOTSET)
+
+    @patch("check_prerelease.platform")
+    @patch("check_prerelease.verify_not_lowlatency_kernel")
+    @patch("check_prerelease.verify_apt_cache_showpkg")
+    @patch("check_prerelease.verify_apt_cache_show")
+    def test_check_kernel_status_valid_kernel(
+        self,
+        mock_verify_show,
+        mock_verify_showpkg,
+        mock_verify_not_lowlatency_kernel,
+        mock_platform
+    ):
+        test_kernel = "99.98.0-generic"
+        mock_platform.release.return_value = test_kernel
+        mock_verify_showpkg.return_value = True
+        mock_verify_show.return_value = True
+        mock_verify_not_lowlatency_kernel.return_value = True
+
+        result = check_kernel_status()
+
+        self.assertTrue(result)
+        mock_verify_showpkg.assert_called_with(test_kernel)
+        mock_verify_show.assert_called_with(test_kernel)
+        mock_verify_not_lowlatency_kernel.assert_called_with(test_kernel)
+
+    @patch("check_prerelease.platform")
+    @patch("check_prerelease.verify_not_lowlatency_kernel")
+    @patch("check_prerelease.verify_apt_cache_showpkg")
+    @patch("check_prerelease.verify_apt_cache_show")
+    def test_check_kernel_status_invalid_kernel(
+        self,
+        mock_verify_show,
+        mock_verify_showpkg,
+        mock_verify_not_lowlatency_kernel,
+        mock_platform
+    ):
+        test_kernel = "123-generic"
+        mock_platform.release.return_value = test_kernel
+        mock_verify_showpkg.return_value = True
+        mock_verify_show.return_value = False
+        mock_verify_not_lowlatency_kernel.return_value = True
+
+        result = check_kernel_status()
+
+        self.assertFalse(result)
+        mock_verify_showpkg.assert_called_with(test_kernel)
+        mock_verify_show.assert_called_with(test_kernel)
+        mock_verify_not_lowlatency_kernel.assert_called_with(test_kernel)


### PR DESCRIPTION
## Description

Propose an environment variable called **KERNEL_REPO** to address issue. The default Kernel repo is still from**Main**, but provide a flexibility way for alternative.

## Resolved issues
Solve issue: #977 

## Documentation

Ref Jira Card: https://warthogs.atlassian.net/browse/OEMQA-3922

## Tests

- G1200-evk P1V2 (CID: 202307-31859)
  - Pass Result with defining the KERNEL_REPO=”universe” in config_vars
    - https://certification.canonical.com/hardware/202307-31859/submission/354476/test-results/pass/
  - Failed Result since without defining the KERNEL_REPO=”universe” in config_vars
    - https://certification.canonical.com/hardware/202307-31859/submission/354475/test-results/fail/
- BMX13-PV-SKU14 (CID: 202312-33305)
  - Pass Result is expected for OEM-PC (main Ubuntu repository)
    - https://certification.canonical.com/hardware/202312-33305/submission/354484/test-results/pass/

