### PR TITLE
Improve suspend/suspend_advanced* tests #857 (BugFix)

### DIFF
--- a/providers/base/units/suspend/suspend.pxu
+++ b/providers/base/units/suspend/suspend.pxu
@@ -177,13 +177,12 @@ command:
          echo "Calling fwts"
          set -o pipefail; checkbox-support-fwts_test -f none -l "$PLAINBOX_SESSION_SHARE"/suspend_single.log -s s3 --s3-sleep-delay=30 --s3-device-check --s3-device-check-delay=45 | tee "$PLAINBOX_SESSION_SHARE"/suspend_single_times.log
      else
-         echo "Calling rtcwake"
          if [ -z "$RTC_DEVICE_FILE" ]; then
-             rtcwake -m on -s 30 &
-             systemctl suspend
+             echo "Calling rtcwake"
+             rtcwake -m no -s 30 && systemctl suspend || exit 1
          else
-             rtcwake -d "$RTC_DEVICE_FILE" -m on -s 30 &
-             systemctl suspend
+             echo "Calling rtcwake with -d $RTC_DEVICE_FILE"
+             rtcwake -d "$RTC_DEVICE_FILE" -m no -s 30 && systemctl suspend || exit 1
          fi
      fi
  else
@@ -262,14 +261,13 @@ command:
      echo "Calling fwts"
      set -o pipefail; checkbox-support-fwts_test -f none -l "$PLAINBOX_SESSION_SHARE"/suspend_single.log -s s3 --s3-sleep-delay=30 --s3-device-check --s3-device-check-delay=45 | tee "$PLAINBOX_SESSION_SHARE"/suspend_single_times.log
  else
-     echo "Calling rtcwake"
-     if [ -z "$RTC_DEVICE_FILE" ]; then
-         rtcwake -m on -s 30 &
-         systemctl suspend
-     else
-         rtcwake -d "$RTC_DEVICE_FILE" -m on -s 30 &
-         systemctl suspend
-     fi
+    if [ -z "$RTC_DEVICE_FILE" ]; then
+      echo "Calling rtcwake"
+      rtcwake -m no -s 30 && systemctl suspend || exit 1
+    else
+      echo "Calling rtcwake with -d $RTC_DEVICE_FILE"
+      rtcwake -d "$RTC_DEVICE_FILE" -m no -s 30 && systemctl suspend || exit 1
+    fi
  fi
 estimated_duration: 90.000
 


### PR DESCRIPTION


<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
rtwake can sometimes fail to set the alarm. While running the command in background before suspending the system, in such a case the whole test plan will hang.

This patch change the mode to allow the command to return immediately, while still setting the alarm, which allow to serialize its result.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues
https://github.com/canonical/checkbox/issues/857
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests
Tested on Riverside jobs using a side loaded provider... Issue is still under observation, but this change isn't preventing the correct execution of the suspend test (at least on this device).
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

