### PR TITLE
Fix and refactor gateway_ping_test (Bugfix)

### DIFF
--- a/providers/base/bin/gateway_ping_test.py
+++ b/providers/base/bin/gateway_ping_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # This file is part of Checkbox.
 #
-# Copyright 2007-2023 Canonical Ltd.
+# Copyright 2007-2024 Canonical Ltd.
 # Written by:
 #   Brendan Donegan <brendan.donegan@canonical.com>
 #   Daniel Manrique <daniel.manrique@canonical.com>
@@ -237,11 +237,11 @@ def is_reachable(ip, interface, verbose=False):
     """
     Ping an ip to see if it is reachable
     """
-    result = ping(ip, interface, 3, 10, verbose)
+    result = ping(ip, interface, 3, 10, verbose=verbose)
     return result["transmitted"] >= result["received"] > 0
 
 
-def get_default_gateway_reachable_on(interface: str, verbose=False) -> str:
+def get_default_gateway_reachable_on(interface: str) -> str:
     """
     Returns the default gateway of an interface if it is reachable
     """

--- a/providers/base/bin/gateway_ping_test.py
+++ b/providers/base/bin/gateway_ping_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # This file is part of Checkbox.
 #
-# Copyright 2007-2014 Canonical Ltd.
+# Copyright 2007-2023 Canonical Ltd.
 # Written by:
 #   Brendan Donegan <brendan.donegan@canonical.com>
 #   Daniel Manrique <daniel.manrique@canonical.com>
@@ -11,6 +11,7 @@
 #   Marc Tardif <marc.tardif@canonical.com>
 #   Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
 #   Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
+#   Massimiliano Girardi <massimiliano.giarardi@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
@@ -36,7 +37,6 @@ import struct
 import subprocess
 import sys
 import time
-import json
 
 from contextlib import suppress
 

--- a/providers/base/bin/gateway_ping_test.py
+++ b/providers/base/bin/gateway_ping_test.py
@@ -36,6 +36,9 @@ import struct
 import subprocess
 import sys
 import time
+import json
+
+from contextlib import suppress
 
 
 class Route:
@@ -43,11 +46,36 @@ class Route:
     Gets routing information from the system.
     """
 
+    def __init__(self, interface):
+        self.interface = interface
+
     def _num_to_dotted_quad(self, number):
         """
         Convert long int to dotted quad string
         """
         return socket.inet_ntoa(struct.pack("<L", number))
+
+    def _get_default_gateway_from_ip(self):
+        try:
+            routes = subprocess.check_output(
+                [
+                    "ip",
+                    "-o",
+                    "route",
+                    "show",
+                    "default",
+                    "0.0.0.0/0",
+                    "dev",
+                    self.interface,
+                ],
+                universal_newlines=True,
+            )
+        except subprocess.CalledProcessError:
+            return None
+        for route in routes.splitlines():
+            if route.startswith("default via"):
+                return route.split()[2]
+        return None
 
     def _get_default_gateway_from_proc(self):
         """
@@ -60,21 +88,18 @@ class Route:
         except Exception:
             logging.error(_("Failed to read def gateway from /proc"))
             return None
-        else:
-            h = re.compile(r"\n(?P<interface>\w+)\s+00000000\s+"
-                           r"(?P<def_gateway>[\w]+)\s+")
-            w = h.search(route)
-            if w:
-                if w.group("def_gateway"):
-                    return self._num_to_dotted_quad(
-                        int(w.group("def_gateway"), 16))
-                else:
-                    logging.error(
-                        _("Could not find def gateway info in /proc"))
-                    return None
-            else:
-                logging.error(_("Could not find def gateway info in /proc"))
-                return None
+
+        proc_table_re = re.compile(
+            r"\n(?P<interface>\w+)\s+00000000\s+" r"(?P<def_gateway>[\w]+)\s+"
+        )
+        proc_table_lines = proc_table_re.finditer(route)
+        for proc_table_line in proc_table_lines:
+            def_gateway = proc_table_line.group("def_gateway")
+            interface = proc_table_line.group("interface")
+            if interface == self.interface and def_gateway:
+                return self._num_to_dotted_quad(int(def_gateway, 16))
+        logging.error(_("Could not find def gateway info in /proc"))
+        return None
 
     def _get_default_gateway_from_bin_route(self):
         """
@@ -83,114 +108,221 @@ class Route:
         and is only used if could not get that from /proc
         """
         logging.debug(
-            _("Reading default gateway information from route binary"))
-        routebin = subprocess.getstatusoutput(
-            "export LANGUAGE=C; " "/usr/bin/env route -n")
-        if routebin[0] == 0:
-            h = re.compile(r"\n0.0.0.0\s+(?P<def_gateway>[\w.]+)\s+")
-            w = h.search(routebin[1])
-            if w:
-                def_gateway = w.group("def_gateway")
-                if def_gateway:
-                    return def_gateway
+            _("Reading default gateway information from route binary")
+        )
+        try:
+            routebin = subprocess.check_output(
+                ["/usr/bin/env", "route", "-n"],
+                env={"LANGUAGE": "C"},
+                universal_newlines=True,
+            )
+        except subprocess.CalledProcessError:
+            return None
+        route_line_re = re.compile(
+            r"^0\.0\.0\.0\s+(?P<def_gateway>[\w.]+)(?P<tail>.+)"
+        )
+        route_lines = route_line_re.finditer(routebin)
+        for route_line in route_lines:
+            def_gateway = route_line.group("def_gateway")
+            interface = route_line.rsplit(" ", 1)
+            if interface == self.interface and def_gateway:
+                return def_gateway
         logging.error(_("Could not find default gateway by running route"))
         return None
 
-    def get_hostname(self):
-        return socket.gethostname()
+    def _get_ip_addr_info(self) -> dict:
+        return subprocess.check_output(
+            ["ip", "-o", "addr", "show"], universal_newlines=True
+        )
 
-    def get_default_gateway(self):
-        t1 = self._get_default_gateway_from_proc()
-        if not t1:
-            t1 = self._get_default_gateway_from_bin_route()
-        return t1
+    def get_broadcast(self):
+        # Get list of all IPs from all my interfaces,
+        ip_addr_infos = self._get_ip_addr_info()
+        for addr_info_line in ip_addr_infos.splitlines():
+            # id: if_name inet addr/mask brd broadcast
+            addr_info_fields = addr_info_line.split()
+            if (
+                addr_info_fields[1] == self.interface
+                and addr_info_fields[4] == "brd"
+            ):
+                return addr_info_fields[5]
+        raise ValueError(
+            "Unable to determine broadcast for iface {}".format(self.interface)
+        )
 
-
-def get_host_to_ping(interface=None, verbose=False, default=None):
-    # Get list of all IPs from all my interfaces,
-    interface_list = subprocess.check_output(["ip", "-o", 'addr', 'show'])
-    reg = re.compile(r'\d: (?P<iface>\w+) +inet (?P<address>[\d\.]+)/'
-                     r'(?P<netmask>[\d]+) brd (?P<broadcast>[\d\.]+)')
-    # Will magically exclude lo because it lacks brd field
-    interfaces = reg.findall(interface_list.decode())
-    # ping -b the network on each one (one ping only)
-    # exclude the ones not specified in iface
-    for iface in interfaces:
-        if not interface or iface[0] == interface:
-            # Use check_output even if I'll discard the output
-            # looks cleaner than using .call and redirecting stdout to null
-            try:
-                subprocess.check_output(["ping", "-q", "-c", "1", "-b",
-                                         iface[3]], stderr=subprocess.STDOUT)
-            except subprocess.CalledProcessError:
-                pass
-    # If default host given, ping it as well,
-    # to try to get it into the arp table.
-    # Needed in case it's not responding to broadcasts.
-    if default:
+    def _get_default_gateway_from_networkctl(self):
         try:
-            subprocess.check_output(["ping", "-q", "-c", "1", default],
-                                    stderr=subprocess.STDOUT)
+            network_info = subprocess.check_output(
+                [
+                    "networkctl",
+                    "status",
+                    "--no-pager",
+                    "--no-legend",
+                    self.interface,
+                ],
+                universal_newlines=True,
+            )
         except subprocess.CalledProcessError:
-            pass
-    # Try to get the gateway address for the interface from networkctl
-    cmd = 'networkctl status --no-pager --no-legend {}'.format(interface)
-    try:
-        output = subprocess.check_output(cmd, shell=True)
-        for line in output.decode(sys.stdout.encoding).splitlines():
-            vals = line.strip().split(' ')
-            if len(vals) >= 2:
-                if vals[0] == 'Gateway:':
-                    subprocess.check_output(["ping", "-q", "-c", "1", vals[1]],
-                                            stderr=subprocess.STDOUT)
-                    break
-    except subprocess.CalledProcessError:
-        pass
-    ARP_POPULATE_TRIES = 10
-    num_tries = 0
-    while num_tries < ARP_POPULATE_TRIES:
+            return None
+        for line in network_info.splitlines():
+            line = line.strip()
+            if line.startswith("Gateway:"):
+                return line.split()[-1]
+        return None
+
+    def get_default_gateways(self) -> set:
+        """
+        Use multiple sources to get the default gateway to be robust to
+        possible platform bugs
+        """
+        def_gateways = {
+            self._get_default_gateway_from_ip(),
+            self._get_default_gateway_from_proc(),
+            self._get_default_gateway_from_bin_route(),
+            self._get_default_gateway_from_networkctl(),
+        }
+        def_gateways -= {None}
+        if len(def_gateways) > 1:
+            logging.warning(
+                "Found more than one default gateway for interface {}".format(
+                    self.interface
+                )
+            )
+        return def_gateways
+
+    @classmethod
+    def get_interface_from_ip(cls, ip):
+        # Note: this uses -o instead of -j for xenial/bionic compatibility
+        route_info = subprocess.check_output(
+            ["ip", "route", "get", ip], universal_newlines=True
+        )
+        for line in route_info.splitlines():
+            # ip dev device_name src ...
+            fields = line.split()
+            if len(fields) > 3:
+                return fields[2]
+        raise ValueError(
+            "Unable to determine any device used for {}".format(ip)
+        )
+
+    @classmethod
+    def get_any_interface(cls):
+        route_infos = subprocess.check_output(
+            ["ip", "-o", "route", "show", "default", "0.0.0.0/0"],
+            universal_newlines=True,
+        )
+        for route_info in route_infos.splitlines():
+            route_info_fields = route_info.split()
+            if len(route_info_fields) > 5:
+                return route_info_fields[4]
+        raise ValueError("Unable to determine any valid interface")
+
+    @classmethod
+    def from_ip(cls, ip: str):
+        """
+        Build an instance of Route given an ip, if no ip is provided the best
+        interface that can route to 0.0.0.0/0 is selected (as described by
+        metric)
+        """
+        if ip:
+            interface = Route.get_interface_from_ip(ip)
+            return Route(interface)
+        return Route(Route.get_any_interface())
+
+
+def is_reachable(ip, interface, verbose=False):
+    """
+    Ping an ip once to see if it is reachable
+    """
+    result = ping(ip, interface, 1, 10, verbose)
+    return result["transmitted"] == result["received"] == 1
+
+
+def get_default_gateway_reachable_on(interface, verbose=False):
+    if not interface:
+        raise ValueError("Unable to ping on interface None")
+    route = Route(interface=interface)
+    desired_targets = route.get_default_gateways()
+    for desired_target in desired_targets:
+        if is_reachable(desired_target, interface):
+            return desired_target
+    raise ValueError(
+        "Unable to reach any estimated gateway of interface {}".format(
+            interface
+        ),
+    )
+
+
+def get_any_host_reachable_on(interface, verbose=False):
+    if not interface:
+        raise ValueError("Unable to ping on interface None")
+    route = Route(interface=interface)
+    broadcast = route.get_broadcast()
+    arp_parser_re = re.compile(
+        r"\? \((?P<ip>[\d.]+)\) at (?P<mac>[a-f0-9\:]+) "
+        r"\[ether\] on (?P<iface>[\w\d]+)"
+    )
+    # retry a few times to get something in the arp table
+    for i in range(10):
+        ping(broadcast, interface, 1, 1, broadcast=True, verbose=verbose)
         # Get output from arp -a -n to get known IPs
-        known_ips = subprocess.check_output(["arp", "-a", "-n"])
-        reg = re.compile(r'\? \((?P<ip>[\d.]+)\) at (?P<mac>[a-f0-9\:]+) '
-                         r'\[ether\] on (?P<iface>[\w\d]+)')
-        # Filter (if needed) IPs not on the specified interface
-        pingable_ips = [pingable[0] for pingable in reg.findall(
-                        known_ips.decode()) if not interface or
-                        pingable[2] == interface]
-        # If the default given ip is among the remaining ones,
-        # ping that.
-        if default and default in pingable_ips:
-            if verbose:
-                print(_(
-                    "Desired ip address {0} is reachable, using it"
-                ).format(default))
-            return default
-        # If not, choose another IP.
-        address_to_ping = pingable_ips[0] if len(pingable_ips) else None
-        if verbose:
-            print(_(
-                "Desired ip address {0} is not reachable from {1},"
-                " using {2} instead"
-            ).format(default, interface, address_to_ping))
-        if address_to_ping:
-            return address_to_ping
-        time.sleep(2)
-        num_tries += 1
-    # Wait time expired
+        arp_table = subprocess.check_output(
+            ["arp", "-a", "-n"], universal_newlines=True
+        )
+        hosts_in_arp_table = [
+            arp_entry.group("ip")  # ip
+            for arp_entry in arp_parser_re.finditer(arp_table)
+            if arp_entry.group("iface") == interface
+        ]
+        # we don't know how an ip got in the arp table, lets try to reach them
+        # and return the first that we can acutally reach
+        for host in hosts_in_arp_table:
+            if is_reachable(host, interface):
+                return host
+        # we were unable to get any reachable host in the arp table, this may
+        # be due to a slow network, lets retry in a few seconds
+        time.sleep(5)
+    raise ValueError(
+        "Unable to reach any host on interface {}".format(interface)
+    )
+
+
+def get_host_to_ping(interface: str, target: str = None, verbose=False):
+    # Try to use the provided target if it is reachable
+    if target and is_reachable(target, interface):
+        return target
+    # From here onward, lets try to estimate a reachable target
+    if not interface:
+        route = Route.from_ip(target)
+        interface = route.interface
+
+    # Try first with any default gateway that we can gather on the interface
+    with suppress(ValueError):
+        return get_default_gateway_reachable_on(interface)
+
+    # Try with any host we can find reachable on the interface
+    with suppress(ValueError):
+        return get_any_host_reachable_on(interface)
+
+    # Unable to estimate any host to reach
     return None
 
 
-def ping(host, interface, count, deadline, verbose=False):
-    command = ["ping", str(host),  "-c", str(count), "-w", str(deadline)]
+def ping(host, interface, count, deadline, broadcast=False, verbose=False):
+    command = ["ping", str(host), "-c", str(count), "-w", str(deadline)]
     if interface:
         command.append("-I{}".format(interface))
+    if broadcast:
+        command.append("-b")
     reg = re.compile(
         r"(\d+) packets transmitted, (\d+) received,"
-        r".*([0-9]*\.?[0-9]*.)% packet loss")
-    ping_summary = {'transmitted': 0, 'received': 0, 'pct_loss': 0}
+        r".*([0-9]*\.?[0-9]*.)% packet loss"
+    )
+    ping_summary = {"transmitted": 0, "received": 0, "pct_loss": 0}
     try:
         output = subprocess.check_output(
-            command, universal_newlines=True, stderr=subprocess.PIPE)
+            command, universal_newlines=True, stderr=subprocess.PIPE
+        )
     except OSError as exc:
         if exc.errno == errno.ENOENT:
             # No ping command present;
@@ -200,12 +332,16 @@ def ping(host, interface, count, deadline, verbose=False):
             raise
     except subprocess.CalledProcessError as excp:
         # Ping returned fail exit code
+        # broadcast will always do so
+        if broadcast:
+            return
         print(_("ERROR: ping result: {0}").format(excp))
         if excp.stderr:
             print(excp.stderr)
-            if 'SO_BINDTODEVICE' in excp.stderr:
-                ping_summary['cause'] = (
-                    "Could not bind to the {} interface.".format(interface))
+            if "SO_BINDTODEVICE" in excp.stderr:
+                ping_summary[
+                    "cause"
+                ] = "Could not bind to the {} interface.".format(interface)
     else:
         if verbose:
             print(output)
@@ -213,21 +349,21 @@ def ping(host, interface, count, deadline, verbose=False):
         if received:
             ping_summary = received[0]
             ping_summary = {
-                'transmitted': int(ping_summary[0]),
-                'received': int(ping_summary[1]),
-                'pct_loss': int(ping_summary[2])}
+                "transmitted": int(ping_summary[0]),
+                "received": int(ping_summary[1]),
+                "pct_loss": int(ping_summary[2]),
+            }
     return ping_summary
 
 
 def parse_args(argv):
     default_count = 2
     default_delay = 4
-    route = Route()
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "host",
         nargs="?",
-        default=route.get_default_gateway(),
+        default=None,
         help=_("host to ping"),
     )
     parser.add_argument(
@@ -305,7 +441,7 @@ def main(argv) -> int:
 
     # If given host is not pingable, override with something pingable.
     host = get_host_to_ping(
-        interface=args.interface, verbose=args.verbose, default=args.host
+        interface=args.interface, verbose=args.verbose, target=args.host
     )
     if args.verbose:
         print(_("Checking connectivity to {0}").format(host))

--- a/providers/base/bin/gateway_ping_test.py
+++ b/providers/base/bin/gateway_ping_test.py
@@ -345,9 +345,9 @@ def ping(host, interface, count, deadline, broadcast=False, verbose=False):
     try:
         received = next(re.finditer(reg, output))
         ping_summary = {
-            "transmitted": int(received[1]),
-            "received": int(received[2]),
-            "pct_loss": int(received[3]),
+            "transmitted": int(received.group(1)),
+            "received": int(received.group(2)),
+            "pct_loss": int(received.group(3)),
         }
     except StopIteration:
         ping_summary[

--- a/providers/base/bin/gateway_ping_test.py
+++ b/providers/base/bin/gateway_ping_test.py
@@ -121,7 +121,7 @@ class Route:
             return None
         route_line_re = re.compile(
             r"^0\.0\.0\.0\s+(?P<def_gateway>[\w.]+)(?P<tail>.+)",
-            flags=re.MULTILINE
+            flags=re.MULTILINE,
         )
         route_lines = route_line_re.finditer(routebin)
         for route_line in route_lines:
@@ -143,11 +143,12 @@ class Route:
         for addr_info_line in ip_addr_infos.splitlines():
             # id: if_name inet addr/mask brd broadcast
             addr_info_fields = addr_info_line.split()
-            if (
-                addr_info_fields[1] == self.interface
-                and addr_info_fields[4] == "brd"
-            ):
-                return addr_info_fields[5]
+            with suppress(IndexError):
+                if (
+                    addr_info_fields[1] == self.interface
+                    and addr_info_fields[4] == "brd"
+                ):
+                    return addr_info_fields[5]
         raise ValueError(
             "Unable to determine broadcast for iface {}".format(self.interface)
         )

--- a/providers/base/tests/test_gateway_ping_test.py
+++ b/providers/base/tests/test_gateway_ping_test.py
@@ -1,6 +1,213 @@
 import unittest
-from unittest.mock import patch
-from gateway_ping_test import main, parse_args
+import textwrap
+import subprocess
+from unittest.mock import patch, MagicMock, mock_open
+from gateway_ping_test import main, parse_args, ping, Route, is_reachable
+
+
+class TestRoute(unittest.TestCase):
+    @patch("subprocess.check_output")
+    def test__get_default_gateway_from_ip_nominal(self, mock_check_output):
+        ok_output = (
+            "default via 192.168.1.1 proto dhcp src 192.168.1.119 metric 100"
+        )
+        mock_check_output.return_value = ok_output
+        expected_gateway = "192.168.1.1"
+        self_mock = MagicMock()
+        self_mock.interface = "eth0"
+        self.assertEqual(
+            Route._get_default_gateway_from_ip(self_mock), expected_gateway
+        )
+
+    @patch("subprocess.check_output")
+    def test__get_default_gateway_from_ip_noroute(self, mock_check_output):
+        mock_check_output.return_value = ""
+        self_mock = MagicMock()
+        self_mock.interface = "eth0"
+        self.assertIsNone(Route._get_default_gateway_from_ip(self_mock))
+
+    @patch("subprocess.check_output")
+    def test__get_default_gateway_from_ip_invalid_route(
+        self, mock_check_output
+    ):
+        invalid_output = "invalid routing information"
+        mock_check_output.return_value = invalid_output
+        self_mock = MagicMock()
+        self_mock.interface = "eth0"
+        self.assertIsNone(Route._get_default_gateway_from_ip(self_mock))
+
+    def test__get_default_gateway_from_proc_nominal(self):
+        self_mock = MagicMock()
+
+        def _num_to_dotted_quad(x):
+            return Route._num_to_dotted_quad(None, x)
+
+        self_mock._num_to_dotted_quad = _num_to_dotted_quad
+        self_mock.interface = "eth0"
+        expected_gateway = "192.168.1.1"
+        output_sample = textwrap.dedent(
+            """
+            Iface Destination Gateway Flags RefCnt Use Metric Mask MTU Window IRTT
+            eth0 00000000 0101A8C0 0003 0 0 0 00000000 0 0 0
+            """
+        )
+        with patch(
+            "builtins.open", new_callable=mock_open, read_data=output_sample
+        ):
+            self.assertEqual(
+                Route._get_default_gateway_from_proc(self_mock),
+                expected_gateway,
+            )
+
+    def test__get_default_gateway_from_proc_file_error(self):
+        self_mock = MagicMock()
+
+        def _num_to_dotted_quad(x):
+            return Route._num_to_dotted_quad(None, x)
+
+        self_mock._num_to_dotted_quad = _num_to_dotted_quad
+        self_mock.interface = "eth0"
+        with patch(
+            "builtins.open", side_effect=FileNotFoundError("File not found")
+        ):
+            self.assertIsNone(
+                Route._get_default_gateway_from_proc(self_mock),
+            )
+
+    @patch("subprocess.check_output")
+    def test__get_default_gateway_from_bin_route_nominal(
+        self, mock_check_output
+    ):
+        mock_check_output.return_value = textwrap.dedent(
+            """
+            Kernel IP routing table
+            Destination Gateway       Genmask  Flags Metric Ref Use Iface
+            0.0.0.0     192.168.1.1   0.0.0.0  UG    100    0   0   enp5s0
+            0.0.0.0     192.168.1.100 0.0.0.0  UG    600    0   0   wlan0
+            """
+        )
+        self_mock = MagicMock()
+        self_mock.interface = "wlan0"
+        gateway = Route._get_default_gateway_from_bin_route(self_mock)
+        self.assertEqual(gateway, "192.168.1.100")
+
+    @patch("subprocess.check_output")
+    def test__get_default_gateway_from_bin_route_if_not_found(
+        self, mock_check_output
+    ):
+        mock_check_output.return_value = textwrap.dedent(
+            """
+            Kernel IP routing table
+            Destination Gateway       Genmask  Flags Metric Ref Use Iface
+            0.0.0.0     192.168.1.1   0.0.0.0  UG    100    0   0   enp5s0
+            0.0.0.0     192.168.1.100 0.0.0.0  UG    600    0   0   wlan0
+            """
+        )
+        self_mock = MagicMock()
+        self_mock.interface = "enp1s0"
+        gateway = Route._get_default_gateway_from_bin_route(self_mock)
+        self.assertIsNone(gateway)
+
+    @patch("subprocess.check_output")
+    def test__get_default_gateway_from_bin_route_exception(
+        self, mock_check_output
+    ):
+        mock_check_output.side_effect = subprocess.CalledProcessError(1, "")
+        self_mock = MagicMock()
+        self_mock.interface = "enp1s0"
+        gateway = Route._get_default_gateway_from_bin_route(self_mock)
+        self.assertIsNone(gateway)
+
+    def test_get_default_gateways(self):
+        self_mock = MagicMock()
+        self_mock._get_default_gateway_from_ip.return_value = "192.168.1.1"
+        self_mock._get_default_gateway_from_proc.return_value = "192.168.1.1"
+        self_mock._get_default_gateway_from_bin_route.return_value = None
+        self_mock._get_default_gateway_from_networkctl.return_value = None
+
+        self.assertEqual(
+            Route.get_default_gateways(self_mock), {"192.168.1.1"}
+        )
+
+    @patch("logging.warning")
+    def test_get_default_gateways_warns(self, mock_warn):
+        self_mock = MagicMock()
+        self_mock._get_default_gateway_from_ip.return_value = None
+        self_mock._get_default_gateway_from_proc.return_value = None
+        self_mock._get_default_gateway_from_bin_route.return_value = (
+            "192.168.1.1"
+        )
+        self_mock._get_default_gateway_from_networkctl.return_value = (
+            "192.168.1.2"
+        )
+
+        self.assertEqual(
+            Route.get_default_gateways(self_mock),
+            {"192.168.1.1", "192.168.1.2"},
+        )
+        self.assertTrue(mock_warn.called)
+
+
+class TestUtilityFunctions(unittest.TestCase):
+    @patch("gateway_ping_test.ping")
+    def test_is_reachable(self, mock_ping):
+        mock_ping.return_value = {
+            "transmitted" : 3,
+            "received" : 2
+        }
+        self.assertTrue(is_reachable("10.0.0.1", "eth0"))
+
+    @patch("gateway_ping_test.ping")
+    def test_is_reachable_false(self, mock_ping):
+        mock_ping.return_value = {
+            "transmitted" : 0,
+            "received" : 0
+        }
+        self.assertFalse(is_reachable("10.0.0.1", "eth0"))
+
+
+
+class TestPingFunction(unittest.TestCase):
+    @patch("subprocess.check_output")
+    def test_ping_ok(self, mock_check_output):
+        # Simulate successful ping output
+        mock_check_output.return_value = (
+            "4 packets transmitted, 4 received, 0% packet loss"
+        )
+        # Call ping function
+        result = ping("8.8.8.8", "eth0", 4, 5, verbose=True)
+        # Verify the result
+        self.assertEqual(result["transmitted"], 4)
+        self.assertEqual(result["received"], 4)
+        self.assertEqual(result["pct_loss"], 0)
+
+    @patch("subprocess.check_output")
+    def test_ping_failure(self, mock_check_output):
+        # Simulate a failure scenario with subprocess.CalledProcessError
+        mock_check_output.side_effect = MagicMock(
+            side_effect=subprocess.CalledProcessError(
+                1, "ping", "ping: unknown host"
+            )
+        )
+        # Call ping function
+        result = ping("invalid.host", None, 4, 5)
+        # Since the function does not return a detailed error for general
+        # failures, we just check for non-success
+        self.assertNotEqual(
+            result["received"], 4
+        )  # Assuming failure means not all packets are received
+
+    @patch("subprocess.check_output")
+    def test_ping_failure_broadcast(self, mock_check_output):
+        # Simulate broadcast ping which always fails
+        mock_check_output.side_effect = MagicMock(
+            side_effect=subprocess.CalledProcessError(
+                1, "ping", stderr="SO_BINDTODEVICE: Operation not permitted"
+            )
+        )
+        # Call ping function with broadcast=True
+        result = ping("255.255.255.255", None, 4, 5, broadcast=True)
+        self.assertIsNone(result)
 
 
 class TestMainFunction(unittest.TestCase):


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The `gateway_ping_test.py` test regularly fails in many SRU runs. This can be due to the fact that the `get_host_to_ping` function tries to do way more than it should (resorting to regularly scraping the arp table and pinging broadcast  even when the default gateway is reachable). This refactors and hopefully makes more robust the gateway ping test

## Resolved issues

Possibly fixes: https://github.com/canonical/checkbox/issues/493 and https://github.com/canonical/checkbox/issues/371 (TBD)

## Documentation

N/A

## Tests

This also adds tests for every unit and utils functions

