### PR TITLE
Explicitly use verbose kwarg (bugfix)

### DIFF
--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -256,7 +256,7 @@ def perform_ping_test(interface):
 
     if target:
         count = 5
-        result = ping(target, interface, count, 10, True)
+        result = ping(target, interface, count, 10, verbose=True)
         if result['received'] == count:
             return True
 

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -119,7 +119,7 @@ def perform_ping_test(interface):
 
     if target:
         count = 5
-        result = ping(target, interface, count, 10, True)
+        result = ping(target, interface, count, 10, verbose=True)
         if result['received'] == count:
             return True
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Update the two bins that were importing the old gateway test as they were using the wrong argument order after refactoring

## Resolved issues

This is now broken as the ping can not fail

## Documentation

N/A

## Tests

N/A

