### PR TITLE
Add template-summary and template-description fields to the Template Unit (New)

### DIFF
--- a/checkbox-ng/plainbox/impl/unit/test_template.py
+++ b/checkbox-ng/plainbox/impl/unit/test_template.py
@@ -234,12 +234,24 @@ class TemplateUnitTests(TestCase):
         }).template_description, "description")
 
     def test_tr_template_summary(self):
+        template = TemplateUnit({
+            "_template-summary": "summary",
+        })
+        self.assertEqual(template.tr_template_summary(), "summary")
+
+    def test_translated_template_summary(self):
         """Ensure template_summary is populated with the translated field."""
         self.assertEqual(TemplateUnit({
             "_template-summary": "summary",
         }).template_summary, "summary")
 
     def test_tr_template_description(self):
+        template = TemplateUnit({
+            "_template-description": "description",
+        })
+        self.assertEqual(template.tr_template_description(), "description")
+
+    def test_translated_template_description(self):
         """
         Ensure template_description is populated with the translated field.
         """

--- a/checkbox-ng/plainbox/impl/unit/test_template.py
+++ b/checkbox-ng/plainbox/impl/unit/test_template.py
@@ -223,6 +223,30 @@ class TemplateUnitTests(TestCase):
             "id": "job_id_{{ param }}",
         }).template_id, "template_id")
 
+    def test_template_summary(self):
+        self.assertEqual(TemplateUnit({
+            "template-summary": "summary",
+        }).template_summary, "summary")
+
+    def test_template_description(self):
+        self.assertEqual(TemplateUnit({
+            "template-description": "description",
+        }).template_description, "description")
+
+    def test_tr_template_summary(self):
+        """Ensure template_summary is populated with the translated field."""
+        self.assertEqual(TemplateUnit({
+            "_template-summary": "summary",
+        }).template_summary, "summary")
+
+    def test_tr_template_description(self):
+        """
+        Ensure template_description is populated with the translated field.
+        """
+        self.assertEqual(TemplateUnit({
+            "_template-description": "description",
+        }).template_description, "description")
+
     def test_template_resource__empty(self):
         self.assertEqual(TemplateUnit({}).template_resource, None)
 
@@ -495,6 +519,50 @@ class TemplateUnitFieldValidationTests(UnitFieldValidationTests):
         self.assertIssueFound(
             issue_list, self.unit_cls.Meta.fields.template_unit,
             Problem.unexpected_i18n, Severity.warning)
+
+    def test_template_summary__translatable(self):
+        issue_list = self.unit_cls({
+            'template-summary': 'template_summary'
+        }, provider=self.provider).check()
+        self.assertIssueFound(issue_list,
+                              self.unit_cls.Meta.fields.template_summary,
+                              Problem.expected_i18n,
+                              Severity.warning)
+
+    def test_template_summary__present(self):
+        issue_list = self.unit_cls({
+        }, provider=self.provider).check()
+        self.assertIssueFound(issue_list,
+                              self.unit_cls.Meta.fields.template_summary,
+                              Problem.missing,
+                              Severity.advice)
+
+    def test_template_summary__one_line(self):
+        issue_list = self.unit_cls({
+            'template-summary': 'line1\nline2'
+        }, provider=self.provider).check()
+        self.assertIssueFound(issue_list,
+                              self.unit_cls.Meta.fields.template_summary,
+                              Problem.wrong,
+                              Severity.warning)
+
+    def test_template_summary__short_line(self):
+        issue_list = self.unit_cls({
+            'template-summary': 'x' * 81
+        }, provider=self.provider).check()
+        self.assertIssueFound(issue_list,
+                              self.unit_cls.Meta.fields.template_summary,
+                              Problem.wrong,
+                              Severity.warning)
+
+    def test_template_description__translatable(self):
+        issue_list = self.unit_cls({
+            'template-description': 'template_description'
+        }, provider=self.provider).check()
+        self.assertIssueFound(issue_list,
+                              self.unit_cls.Meta.fields.template_description,
+                              Problem.expected_i18n,
+                              Severity.warning)
 
     def test_template_resource__untranslatable(self):
         issue_list = self.unit_cls({

--- a/docs/reference/units/template.rst
+++ b/docs/reference/units/template.rst
@@ -41,6 +41,24 @@ Template-Specific Fields
     ``stress/reboot_{iterations}_times``, the computed ``template-id`` field
     will be ``stress/reboot_iterations_times``.
 
+.. _Template template-summary field:
+
+``template-summary``
+    A human readable name for the template. This value is available for
+    translation into other languages. It must be one line long, ideally it
+    should be short (50-70 characters max).
+
+    This field is optional (Checkbox will only advise you to provide one when
+    running provider validation).
+
+.. _Template template-description field:
+
+``template-description``
+    A long form description of what the template does or the kind of jobs it
+    instantiates. This value is available for translation into other languages.
+
+    This field is optional.
+
 .. _Template template-unit field:
 
 ``template-unit``


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Add two fields to Template Units:

- `template-summary`
- `template-description`

These fields mimick the summary and description fields of the Job Unit to provide a quick explanation and a longer form one about what a template unit does.
    
Both of these fields are translatable, and validation is added for the `template-summary` field to make sure if a value is provided, it is one line only and less than 80 characters.


## Resolved issues

https://warthogs.atlassian.net/browse/CHECKBOX-1239

## Documentation

Template Unit reference page is updated to mention both fields.

## Tests

- Unit tests have been added (you can run them with `pytest checkbox-ng/plainbox/impl/unit/test_template.py`)
- Validators are present, so if you create a template with a `template-summary` field of more than 80 characters, or if the value for this field has more than one line, you will see warnings when running validation for the provider.

For instance, if I add the following `template-summary` to an existing `xxx` template unit in the base provider:

```
template-summary:
 This is a veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long summary!
 and it's more than one line anyway...
```

and then run `./manage.py validate` for the base provider, I will see three warnings:

```
warning: units/.../jobs.pxu:69: template 'xxx', field 'template-summary', field should be marked as translatable
warning: units/.../jobs.pxu:69: template 'xxx', field 'template-summary', please use only one line
warning: units/.../jobs.pxu:69: template 'xxx', field 'template-summary', please stay under 80 characters
```