### PR TITLE
Implement ExpectNot operator for metabox

### DIFF
--- a/metabox/metabox/core/actions.py
+++ b/metabox/metabox/core/actions.py
@@ -49,6 +49,10 @@ class Expect(ActionBase):
     handler = 'expect'
 
 
+class ExpectNot(ActionBase):
+    handler = 'expect_not'
+
+
 class Send(ActionBase):
     handler = 'send'
 

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -218,6 +218,11 @@ class Scenario:
         outcome = self._pts.expect(data, timeout)
         self._checks.append(outcome)
 
+    def expect_not(self, data, timeout=60):
+        assert self._pts is not None
+        outcome = self._pts.expect_not(data, timeout)
+        self._checks.append(outcome)
+
     def send(self, data):
         assert self._pts is not None
         self._pts.send(data.encode("utf-8"), binary=True)


### PR DESCRIPTION
Minor: small refactor of expect

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Currently we have no way to assert that something wasn't printed by a metabox scenario if it is interactive. This adds this new functionality by making expect fail when the socket is closed and the input string wasnt found (before it used to always timeout and only return on True)

## Resolved issues

Needed for another PR, I need a way to AssertNotPrinted but for interactive runs

## Documentation

N/A

## Tests

N/A

