### PR TITLE
Fix gateway ping (BugFix)

### DIFF
--- a/providers/base/bin/gateway_ping_test.py
+++ b/providers/base/bin/gateway_ping_test.py
@@ -422,7 +422,7 @@ def main(argv) -> int:
             print("Possible cause: {}".format(ping_summary["cause"]))
         return 1
     elif ping_summary["transmitted"] != ping_summary["received"]:
-        print("FAIL: {0}% packet loss.")
+        print(_("FAIL: {0}% packet loss.").format(ping_summary["pct_loss"]))
         return 1
     else:
         print(_("PASS: 0% packet loss").format(host))

--- a/providers/base/bin/gateway_ping_test.py
+++ b/providers/base/bin/gateway_ping_test.py
@@ -38,7 +38,7 @@ import sys
 import time
 
 from contextlib import suppress
-from typing import Dict, List
+from typing import Dict
 
 
 class Route:
@@ -429,7 +429,7 @@ def main(argv) -> int:
         return 0
 
 
-def get_default_gateways() -> dict[str, str]:
+def get_default_gateways() -> Dict[str, str]:
     """
     Use `route` program to find default gateways for all interfaces.
 

--- a/providers/base/bin/gateway_ping_test.py
+++ b/providers/base/bin/gateway_ping_test.py
@@ -192,8 +192,8 @@ class Route:
             )
         return def_gateways
 
-    @classmethod
-    def get_interface_from_ip(cls, ip):
+    @staticmethod
+    def get_interface_from_ip(ip):
         # Note: this uses -o instead of -j for xenial/bionic compatibility
         route_info = subprocess.check_output(
             ["ip", "-o", "route", "get", ip], universal_newlines=True
@@ -207,8 +207,8 @@ class Route:
             "Unable to determine any device used for {}".format(ip)
         )
 
-    @classmethod
-    def get_any_interface(cls):
+    @staticmethod
+    def get_any_interface():
         # Note: this uses -o instead of -j for xenial/bionic compatibility
         route_infos = subprocess.check_output(
             ["ip", "-o", "route", "show", "default", "0.0.0.0/0"],
@@ -220,8 +220,8 @@ class Route:
                 return route_info_fields[4]
         raise ValueError("Unable to determine any valid interface")
 
-    @classmethod
-    def from_ip(cls, ip: str):
+    @staticmethod
+    def from_ip(ip: str):
         """
         Build an instance of Route given an ip, if no ip is provided the best
         interface that can route to 0.0.0.0/0 is selected (as described by

--- a/providers/base/bin/gateway_ping_test.py
+++ b/providers/base/bin/gateway_ping_test.py
@@ -401,7 +401,7 @@ def main(argv) -> int:
     if args.any_cable_interface:
         print(_("Looking for all cable interfaces..."))
         all_ifaces = get_default_gateways().keys()
-        args.interfaces = filter(is_cable_interface, all_ifaces)
+        args.interfaces = list(filter(is_cable_interface, all_ifaces))
 
     # If given host is not pingable, override with something pingable.
     host = get_host_to_ping(interface=args.interfaces[0], target=args.host)

--- a/providers/base/bin/gateway_ping_test.py
+++ b/providers/base/bin/gateway_ping_test.py
@@ -38,6 +38,7 @@ import sys
 import time
 
 from contextlib import suppress
+from typing import Dict
 
 
 class Route:

--- a/providers/base/bin/gateway_ping_test.py
+++ b/providers/base/bin/gateway_ping_test.py
@@ -370,8 +370,6 @@ def ping(
 
 
 def parse_args(argv):
-    default_count = 2
-    default_delay = 4
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "host",
@@ -382,14 +380,14 @@ def parse_args(argv):
     parser.add_argument(
         "-c",
         "--count",
-        default=default_count,
+        default=2,
         type=int,
         help=_("number of packets to send"),
     )
     parser.add_argument(
         "-d",
         "--deadline",
-        default=default_delay,
+        default=4,
         type=int,
         help=_("timeout in seconds"),
     )

--- a/providers/base/bin/gateway_ping_test.py
+++ b/providers/base/bin/gateway_ping_test.py
@@ -307,6 +307,8 @@ def get_host_to_ping(interface: str, target: str = None) -> "str|None":
 def ping(
     host: str,
     interface: "str|None",
+    count: int = 2,
+    deadline: int = 4,
     broadcast=False,
 ):
     """
@@ -318,7 +320,7 @@ def ping(
               "pct_loss"
     @returns: on failure a dict with a "cause" key, with the failure reason
     """
-    command = ["ping", str(host), "-c", "2", "-w", "4"]
+    command = ["ping", str(host), "-c", str(count), "-w", str(deadline)]
     if interface:
         command.append("-I{}".format(interface))
     if broadcast:

--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -256,7 +256,7 @@ def perform_ping_test(interface):
 
     if target:
         count = 5
-        result = ping(target, interface, count, 10, verbose=True)
+        result = ping(target, interface, count, 10)
         if result['received'] == count:
             return True
 

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -119,7 +119,7 @@ def perform_ping_test(interface):
 
     if target:
         count = 5
-        result = ping(target, interface, count, 10, verbose=True)
+        result = ping(target, interface, count, 10)
         if result['received'] == count:
             return True
 

--- a/providers/base/tests/test_gateway_ping_test.py
+++ b/providers/base/tests/test_gateway_ping_test.py
@@ -529,7 +529,12 @@ class TestMainFunction(unittest.TestCase):
     def test_spotty_connection_with_cause(
         self, mock_ping, mock_get_host_to_ping
     ):
-        mock_ping.return_value = {"received": 1, "cause": "Test cause"}
+        mock_ping.return_value = {
+            "received": 1,
+            "transmitted": 2,
+            "pct_loss": 50,
+            "cause": "Test cause",
+        }
         result = main(["1.1.1.1"])
         self.assertEqual(result, 1)
 

--- a/providers/base/tests/test_gateway_ping_test.py
+++ b/providers/base/tests/test_gateway_ping_test.py
@@ -517,6 +517,16 @@ class TestMainFunction(unittest.TestCase):
 
     @patch("gateway_ping_test.get_host_to_ping")
     @patch("gateway_ping_test.ping")
+    def test_no_internet_connection_auto_cause(
+        self, mock_ping, mock_get_host_to_ping
+    ):
+        mock_get_host_to_ping.return_value = None
+        mock_ping.return_value = {"received": 0}
+        result = main(["1.1.1.1"])
+        self.assertEqual(result, 1)
+
+    @patch("gateway_ping_test.get_host_to_ping")
+    @patch("gateway_ping_test.ping")
     def test_no_internet_connection_cause(
         self, mock_ping, mock_get_host_to_ping
     ):

--- a/providers/base/tests/test_gateway_ping_test.py
+++ b/providers/base/tests/test_gateway_ping_test.py
@@ -282,6 +282,14 @@ class TestRoute(unittest.TestCase):
         self.assertEqual(Route.from_ip(None).interface, "enp6s0")
         self.assertTrue(mock_get_interface_from_ip.called)
 
+    @patch("subprocess.check_output", return_value="")
+    def test_get_ip_addr_info(self, mock_check_output):
+        self_mock = MagicMock()
+        self.assertEqual(Route._get_ip_addr_info(self_mock), "")
+        mock_check_output.assert_called_once_with(
+            ["ip", "-o", "addr", "show"], universal_newlines=True
+        )
+
 
 class TestUtilityFunctions(unittest.TestCase):
     @patch("gateway_ping_test.ping")

--- a/providers/base/tests/test_gateway_ping_test.py
+++ b/providers/base/tests/test_gateway_ping_test.py
@@ -526,6 +526,15 @@ class TestMainFunction(unittest.TestCase):
 
     @patch("gateway_ping_test.get_host_to_ping")
     @patch("gateway_ping_test.ping")
+    def test_spotty_connection_with_cause(
+        self, mock_ping, mock_get_host_to_ping
+    ):
+        mock_ping.return_value = {"received": 1, "cause": "Test cause"}
+        result = main(["1.1.1.1"])
+        self.assertEqual(result, 1)
+
+    @patch("gateway_ping_test.get_host_to_ping")
+    @patch("gateway_ping_test.ping")
     def test_some_packet_loss(self, mock_ping, mock_get_host_to_ping):
         mock_ping.return_value = {
             "transmitted": 100,

--- a/providers/base/tests/test_gateway_ping_test.py
+++ b/providers/base/tests/test_gateway_ping_test.py
@@ -538,6 +538,17 @@ class TestMainFunction(unittest.TestCase):
         result = main(["1.1.1.1"])
         self.assertEqual(result, 0)
 
+    @patch("gateway_ping_test.is_reachable", return_value=True)
+    @patch("gateway_ping_test.get_default_gateways")
+    @patch("gateway_ping_test.ping")
+    def test_main_any_cable(self, mock_ping, mock_get_default_gateways, _):
+        mock_get_default_gateways.return_value = {
+            "enp5s0": "192.168.1.1",
+            "wlan0": "192.168.1.2",
+        }
+        main(["--any-cable-interface"])
+        mock_ping.assert_called_once_with("192.168.1.1", "enp5s0")
+
 
 class GetDefaultGatewaysTests(unittest.TestCase):
     @patch("subprocess.check_output")

--- a/providers/base/tests/test_gateway_ping_test.py
+++ b/providers/base/tests/test_gateway_ping_test.py
@@ -511,7 +511,7 @@ class TestMainFunction(unittest.TestCase):
         self, mock_ping, mock_get_host_to_ping
     ):
         mock_get_host_to_ping.return_value = None
-        mock_ping.return_value = None
+        mock_ping.return_value = {"received": 0}
         result = main(["1.1.1.1"])
         self.assertEqual(result, 1)
 

--- a/providers/base/tests/test_gateway_ping_test.py
+++ b/providers/base/tests/test_gateway_ping_test.py
@@ -510,7 +510,7 @@ class TestMainFunction(unittest.TestCase):
     def test_no_internet_connection_no_cause(
         self, mock_ping, mock_get_host_to_ping
     ):
-        mock_get_host_to_ping.return_value = None
+        mock_get_host_to_ping.return_value = "1.1.1.1"
         mock_ping.return_value = {"received": 0}
         result = main(["1.1.1.1"])
         self.assertEqual(result, 1)

--- a/providers/base/units/ethernet/jobs.pxu
+++ b/providers/base/units/ethernet/jobs.pxu
@@ -206,7 +206,7 @@ _summary: Can ping another machine over Ethernet port {interface}
 _description: Check Ethernet works by pinging another machine
 plugin: shell
 command:
-  gateway_ping_test.py -v --interface {interface}
+  gateway_ping_test.py --interface {interface}
 category_id: com.canonical.plainbox::ethernet
 estimated_duration: 4.0
 flags: preserve-locale also-after-suspend
@@ -299,7 +299,7 @@ _steps:
  2. Follow the instructions on the screen.
 plugin: user-interact
 command:
- eth_hotplugging.py {{ interface }} && gateway_ping_test.py -v --interface {{ interface }}
+ eth_hotplugging.py {{ interface }} && gateway_ping_test.py --interface {{ interface }}
 category_id: com.canonical.plainbox::ethernet
 estimated_duration: 60.0
 user: root


### PR DESCRIPTION
## Description

This PR simplifies the argument handling in `gateway_ping_test` test script.

The `count`, `threshold`, and `deadline` options were never used and they made the logic complicated. The verbosity option was also a mixed bag, and [lately was suffering from a bug](https://github.com/canonical/checkbox/issues/993)

~~This is a partial fix for the [#371](https://github.com/canonical/checkbox/issues/371) bug.~~

Namely it moves code around to make allow for getting the interface name.
This PR doesn't change anything, just adds an command-line option and refactors some functions

## Resolved issues

Fixes: 
https://github.com/canonical/checkbox/issues/993
https://warthogs.atlassian.net/browse/CHECKBOX-1258

https://github.com/canonical/checkbox/issues/992


## Tests

Unit tests were added and the previous ones got adjusted.