### PR TITLE
Add template-id field to instantiated jobs (New)

### DIFF
--- a/checkbox-ng/plainbox/impl/unit/job.py
+++ b/checkbox-ng/plainbox/impl/unit/job.py
@@ -374,6 +374,19 @@ class JobDefinition(UnitWithId, IJobDefinition):
             self.get_record_value(
                 'category_id', 'com.canonical.plainbox::uncategorised'))
 
+    @cached_property
+    def template_id(self):
+        """
+        Fully qualified identifier of the template this job is instantiated
+        from.
+
+        .. note::
+            This field should only be present in jobs instantiated from
+            templates. It should not be used when writing jobs manually.
+            Therefore, it is not described in the user-facing documentation.
+        """
+        return self.get_record_value("template-id")
+
     @propertywithsymbols(symbols=_AutoRetryValues)
     def auto_retry(self):
         """

--- a/checkbox-ng/plainbox/impl/unit/template.py
+++ b/checkbox-ng/plainbox/impl/unit/template.py
@@ -416,9 +416,11 @@ class TemplateUnit(UnitWithId):
             key: value for key, value in self._raw_data.items()
             if not key.startswith('template-')
         }
-        # Only keep the template-engine field
+        # Only keep template-engine and template-id fields
         raw_data['template-engine'] = self.template_engine
         data['template-engine'] = raw_data['template-engine']
+        raw_data["template-id"] = self.template_id
+        data["template-id"] = raw_data["template-id"]
         # Override the value of the 'unit' field from 'template-unit' field
         data['unit'] = raw_data['unit'] = self.template_unit
         # XXX: extract raw dictionary from the resource object, there is no

--- a/checkbox-ng/plainbox/impl/unit/test_template.py
+++ b/checkbox-ng/plainbox/impl/unit/test_template.py
@@ -335,6 +335,32 @@ class TemplateUnitTests(TestCase):
         self.assertEqual(job.partial_id, 'check-device-sda1')
         self.assertEqual(job.summary, 'Test some device (/sys/something)')
         self.assertEqual(job.plugin, 'shell')
+        self.assertEqual(job.template_id, "check-device-dev_name")
+
+    def test_instantiate_one_with_template_id(self):
+        """
+        Ensure the full template-id (including namespace) is passed down to the
+        instantiated jobs.
+        """
+        provider = mock.Mock(spec=IProvider1)
+        provider.namespace = "namespace"
+        template = TemplateUnit({
+            "template-resource": "resource",
+            "template-id": "origin-template",
+            "id": "check-device-{dev_name}",
+            "summary": "Test {name} ({sys_path})",
+            "plugin": "shell",
+        }, provider=provider)
+        job = template.instantiate_one(Resource({
+            "dev_name": "sda1",
+            "name": "some device",
+            "sys_path": "/sys/something",
+        }))
+        self.assertIsInstance(job, JobDefinition)
+        self.assertEqual(job.partial_id, "check-device-sda1")
+        self.assertEqual(job.summary, "Test some device (/sys/something)")
+        self.assertEqual(job.plugin, "shell")
+        self.assertEqual(job.template_id, "namespace::origin-template")
 
     def test_instantiate_missing_parameter(self):
         """


### PR DESCRIPTION
## Description

Pass the `template-id` field from the template unit to the instantiated jobs in order to track their origin.



<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->



<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
Fix CHECKBOX-1076

## Documentation

This is a change in the internal mechanism of how Checkbox instantiates jobs. The `template-id` field is not supposed to be used when writing normal jobs (ones that are not generated from a template), so the it is not documented in the user-facing [Job Unit reference page](https://checkbox.readthedocs.io/en/stable/reference/units/job.html).

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

The `list-bootstrapped` command can now expose the origin (`template-id`) of instantiated jobs:

```
$ checkbox-cli list-bootstrapped com.canonical.certification::graphics-integrated-gpu-cert-full -f "{id} (from template {template-id})\n"
(...)
graphics_card (from template <missing template-id>)
lsb (from template <missing template-id>)
graphics/1_auto_switch_card_Alder_Lake-UP3_GT2__Iris_Xe_Graphics_ (from template com.canonical.certification::graphics/index_auto_switch_card_product_slug)
graphics/VESA_drivers_not_in_use (from template <missing template-id>)
graphics/1_driver_version_Alder_Lake-UP3_GT2__Iris_Xe_Graphics_ (from template com.canonical.certification::graphics/index_driver_version_product_slug)
graphics/1_gl_support_Alder_Lake-UP3_GT2__Iris_Xe_Graphics_ (from template com.canonical.certification::graphics/index_gl_support_product_slug)
device (from template <missing template-id>)
graphics/1_minimum_resolution_Alder_Lake-UP3_GT2__Iris_Xe_Graphics_ (from template com.canonical.certification::graphics/index_minimum_resolution_product_slug)
suspend/1_resolution_before_suspend_Alder_Lake-UP3_GT2__Iris_Xe_Graphics__auto (from template com.canonical.certification::suspend/index_resolution_before_suspend_product_slug_auto)
package (from template <missing template-id>)
miscellanea/chvt (from template <missing template-id>)
graphics/1_maximum_resolution_Alder_Lake-UP3_GT2__Iris_Xe_Graphics_ (from template com.canonical.certification::graphics/index_maximum_resolution_product_slug)
executable (from template <missing template-id>)
graphics/1_glxgears_Alder_Lake-UP3_GT2__Iris_Xe_Graphics_ (from template com.canonical.certification::graphics/index_glxgears_product_slug)
(...)

$ checkbox-cli list template | grep "com.canonical.certification::graphics/index_glxgears_product_slug"
(...)
template 'com.canonical.certification::graphics/index_glxgears_product_slug'
```

