### PR TITLE
Fix flag name for cpu/topology (Bugfix)

### DIFF
--- a/providers/base/units/cpu/jobs.pxu
+++ b/providers/base/units/cpu/jobs.pxu
@@ -151,7 +151,7 @@ _description:
 plugin: shell
 category_id: com.canonical.plainbox::cpu
 id: cpu/topology
-flags: also-after-suspend-
+flags: also-after-suspend
 estimated_duration: 1.0
 requires: int(cpuinfo.count) > 1 and (cpuinfo.platform == 'i386' or cpuinfo.platform == 'x86_64')
 command: cpu_topology.py


### PR DESCRIPTION
## Description
Fix the flag name for the job `cpu/topology`

### Before
```
$ checkbox.checkbox-cli list-bootstrapped com.canonical.certification::after-suspend-cpu-cert-automated

com.canonical.certification::rtc
com.canonical.certification::sleep
com.canonical.certification::suspend/suspend_advanced_auto
com.canonical.certification::cpuinfo
com.canonical.certification::executable
com.canonical.certification::after-suspend-cpu/cstates
com.canonical.certification::after-suspend-cpu/cstates_results.log
com.canonical.certification::after-suspend-cpu/scaling_test
com.canonical.certification::after-suspend-cpu/scaling_test-log-attach
com.canonical.certification::after-suspend-cpu/maxfreq_test
com.canonical.certification::after-suspend-cpu/maxfreq_test-log-attach
com.canonical.certification::cpu_offlining
com.canonical.certification::cpu/offlining_test
com.canonical.certification::after-suspend-cpu/offlining_test
com.canonical.certification::cpu/clocktest
com.canonical.certification::after-suspend-cpu/clocktest
```

### After
```
$ checkbox.checkbox-cli list-bootstrapped com.canonical.certification::after-suspend-cpu-cert-automated

com.canonical.certification::rtc
com.canonical.certification::sleep
com.canonical.certification::suspend/suspend_advanced_auto
com.canonical.certification::executable
com.canonical.certification::cpuinfo
com.canonical.certification::after-suspend-cpu/cstates
com.canonical.certification::after-suspend-cpu/cstates_results.log
com.canonical.certification::after-suspend-cpu/scaling_test
com.canonical.certification::after-suspend-cpu/scaling_test-log-attach
com.canonical.certification::after-suspend-cpu/maxfreq_test
com.canonical.certification::after-suspend-cpu/maxfreq_test-log-attach
com.canonical.certification::cpu_offlining
com.canonical.certification::cpu/offlining_test
com.canonical.certification::after-suspend-cpu/offlining_test
com.canonical.certification::cpu/topology <----------------------- Now the job appears
com.canonical.certification::after-suspend-cpu/topology <--------- Now the job appears
com.canonical.certification::cpu/clocktest
com.canonical.certification::after-suspend-cpu/clocktest
```


## Resolved issues
Wrong flag causes the job can not be run.

## Documentation
N/A

## Tests
N/A

