### PR TITLE
Add keys to fast interact with resume menu action (new)

### DIFF
--- a/checkbox-ng/checkbox_ng/resume_menu.py
+++ b/checkbox-ng/checkbox_ng/resume_menu.py
@@ -184,11 +184,11 @@ class ResumeMenu:
         """Create a view for the action selection menu."""
         self._action_buttons = [
             # label that goes on the button and the action string recorded
-            ("Add comment", "comment"),
-            ("Resume and skip the job", "skip"),
-            ("Mark the job as passed and continue", "pass"),
-            ("Mark the job as failed and continue", "fail"),
-            ("Resume and run the job again.", "rerun"),
+            ("Add comment (C)", "comment"),
+            ("Resume and skip the job (S)", "skip"),
+            ("Mark the job as passed and continue (P)", "pass"),
+            ("Mark the job as failed and continue (F)", "fail"),
+            ("Resume and run the job again. (R)", "rerun"),
         ]
         action_listbox_content = self._ACTION_MENU_STATIC_ELEMENTS + [
             urwid.Button(btn[0]) for btn in self._action_buttons
@@ -257,7 +257,7 @@ class ResumeMenu:
             self.chosen_session = None
 
             raise urwid.ExitMainLoop()
-        elif key in ["d", "D"]:
+        elif key.upper() == "D":
             # user chose to delete the session
             self.chosen_session = self._entries[self.focused_index][0]
             self._chosen_action = "delete"
@@ -269,21 +269,32 @@ class ResumeMenu:
             # user cancelled the action, go back to the session selection
             self.chosen_session = None
             self.loop.widget = self._body
-
+            return
         elif key == "enter":
             # user chose an action, let's record it and exit
             # if the action is "comment" we need to show the comment box
-
             action_index = self._action_menu.base_widget.focus_position - len(
                 self._ACTION_MENU_STATIC_ELEMENTS
             )
             action = self._action_buttons[action_index][1]
 
             self._chosen_action = action
-            if action == "comment":
-                self.loop.widget = self._comment_view
-            else:
-                raise urwid.ExitMainLoop()
+        elif key.upper() == "C":
+            self._chosen_action = "comment"
+            self.loop.widget = self._comment_view
+        elif key.upper() == "S":
+            self._chosen_action = "skip"
+        elif key.upper() == "P":
+            self._chosen_action = "pass"
+        elif key.upper() == "F":
+            self._chosen_action = "fail"
+        elif key.upper() == "R":
+            self._chosen_action = "rerun"
+
+        if self._chosen_action == "comment":
+            self.loop.widget = self._comment_view
+        else:
+            raise urwid.ExitMainLoop()
 
     def _handle_input_on_comment_box(self, key):
         """Handle input on the comment box."""


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Navigating the menu with arrows may be slow or harder on high latency. This PR adds shortcut keys to interact with each action

## Resolved issues

N/A

## Documentation

N/A

## Tests

N/A

