### PR TITLE
Support case insensitive searching in names or ids (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/urwid_ui.py
@@ -766,11 +766,15 @@ class TestPlanBrowser:
                     if filter_str == "":
                         self._update_button_pile(self.controller_list)
                     else:
+                        filter_str = filter_str.lower()
                         self._update_button_pile(
                             [
                                 x
                                 for x in self.controller_list
-                                if filter_str in x.get("name")
+                                if (
+                                    filter_str in x.get("name").lower()
+                                    or filter_str in x.get("id").lower()
+                                )
                             ]
                         )
                 if key in ("esc", "enter"):


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Searching is very cumbersome sometimes in checkbox test plans because you either don't know the test plan name (but only the id) or you don't remember the exact case (also, everybody always types lowercase by default). 

This makes the search case insensitive and adds filtering also on ids

## Resolved issues

Resolves: https://github.com/canonical/checkbox/issues/700

## Documentation

N/A

## Tests

N/A

