### PR TITLE
Be verbose when breaking pipes when interacting with bluetoothctl (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/interactive_cmd.py
+++ b/checkbox-support/checkbox_support/interactive_cmd.py
@@ -86,7 +86,7 @@ class InteractiveCommand:
             self._logger.warning("Broken pipe when sending to the process!")
             if self._pending:
                 self._logger.warning(
-                    "the output before the pipe broke: %s", self.read_all())
+                    "The output before the pipe broke: %s", self.read_all())
             self._close_fds([self._proc.stdin])
             raise
         time.sleep(sleep)

--- a/checkbox-support/checkbox_support/interactive_cmd.py
+++ b/checkbox-support/checkbox_support/interactive_cmd.py
@@ -84,6 +84,9 @@ class InteractiveCommand:
             self._proc.stdin.flush()
         except BrokenPipeError:
             self._logger.warning("Broken pipe when sending to the process!")
+            if self._pending:
+                self._logger.warning(
+                    "the output before the pipe broke: %s", self.read_all())
             self._close_fds([self._proc.stdin])
             raise
         time.sleep(sleep)

--- a/checkbox-support/checkbox_support/tests/test_interactive_cmd.py
+++ b/checkbox-support/checkbox_support/tests/test_interactive_cmd.py
@@ -23,12 +23,14 @@ class InteractiveCommandTests(unittest.TestCase):
 
     def test_write_line_nominal(self):
         mock_self = MagicMock()
+        mock_self._proc.stdin.encoding = 'utf-8'
         InteractiveCommand.writeline(mock_self, 'Hello, world!')
         mock_self._proc.stdin.write.assert_called_with(b'Hello, world!\n')
 
     def test_write_line_broken_pipe(self):
         mock_self = MagicMock()
         mock_self._proc.stdin.write.side_effect = BrokenPipeError
+        mock_self._proc.stdin.encoding = 'utf-8'
         mock_self.read_all.return_value = 'my pipe is gonna break'
         with self.assertRaises(BrokenPipeError):
             InteractiveCommand.writeline(mock_self, 'Hello, world!')

--- a/checkbox-support/checkbox_support/tests/test_interactive_cmd.py
+++ b/checkbox-support/checkbox_support/tests/test_interactive_cmd.py
@@ -29,15 +29,27 @@ class InteractiveCommandTests(unittest.TestCase):
         mock_self._proc.stdin.write.assert_called_with(b'Hello, world!\n')
 
     @patch('sys.stdin')
-    def test_write_line_broken_pipe(self, mock_stdin):
+    def test_write_line_broken_pipe_with_pending(self, mock_stdin):
         mock_self = MagicMock()
         mock_self._proc.stdin.write.side_effect = BrokenPipeError
         mock_stdin.encoding = 'utf-8'
         mock_self.read_all.return_value = 'my pipe is gonna break'
         with self.assertRaises(BrokenPipeError):
             InteractiveCommand.writeline(mock_self, 'Hello, world!')
-        
         mock_self._logger.warning.assert_called_with(
             "The output before the pipe broke: %s",
             "my pipe is gonna break")
+        mock_self._proc.stdin.write.assert_called_with(b'Hello, world!\n')
+
+    @patch('sys.stdin')
+    def test_write_line_broken_pipe_without_pending(self, mock_stdin):
+        mock_self = MagicMock()
+        mock_self._proc.stdin.write.side_effect = BrokenPipeError
+        mock_self._pending = 0
+        mock_stdin.encoding = 'utf-8'
+        mock_self.read_all.return_value = ''
+        with self.assertRaises(BrokenPipeError):
+            InteractiveCommand.writeline(mock_self, 'Hello, world!')
+        mock_self._logger.warning.assert_called_with(
+            "Broken pipe when sending to the process!")
         mock_self._proc.stdin.write.assert_called_with(b'Hello, world!\n')    

--- a/checkbox-support/checkbox_support/tests/test_interactive_cmd.py
+++ b/checkbox-support/checkbox_support/tests/test_interactive_cmd.py
@@ -15,22 +15,24 @@
 
 import unittest
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from checkbox_support.interactive_cmd import InteractiveCommand
 
 class InteractiveCommandTests(unittest.TestCase):
 
-    def test_write_line_nominal(self):
+    @patch('sys.stdin')
+    def test_write_line_nominal(self, mock_stdin):
         mock_self = MagicMock()
-        mock_self._proc.stdin.encoding = 'utf-8'
+        mock_stdin.encoding = 'utf-8'
         InteractiveCommand.writeline(mock_self, 'Hello, world!')
         mock_self._proc.stdin.write.assert_called_with(b'Hello, world!\n')
 
-    def test_write_line_broken_pipe(self):
+    @patch('sys.stdin')
+    def test_write_line_broken_pipe(self, mock_stdin):
         mock_self = MagicMock()
         mock_self._proc.stdin.write.side_effect = BrokenPipeError
-        mock_self._proc.stdin.encoding = 'utf-8'
+        mock_stdin.encoding = 'utf-8'
         mock_self.read_all.return_value = 'my pipe is gonna break'
         with self.assertRaises(BrokenPipeError):
             InteractiveCommand.writeline(mock_self, 'Hello, world!')

--- a/checkbox-support/checkbox_support/tests/test_interactive_cmd.py
+++ b/checkbox-support/checkbox_support/tests/test_interactive_cmd.py
@@ -1,0 +1,39 @@
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from unittest.mock import MagicMock
+
+from checkbox_support.interactive_cmd import InteractiveCommand
+
+class InteractiveCommandTests(unittest.TestCase):
+
+    def test_write_line_nominal(self):
+        mock_self = MagicMock()
+        InteractiveCommand.writeline(mock_self, 'Hello, world!')
+        mock_self._proc.stdin.write.assert_called_with(b'Hello, world!\n')
+
+    def test_write_line_broken_pipe(self):
+        mock_self = MagicMock()
+        mock_self._proc.stdin.write.side_effect = BrokenPipeError
+        mock_self.read_all.return_value = 'my pipe is gonna break'
+        with self.assertRaises(BrokenPipeError):
+            InteractiveCommand.writeline(mock_self, 'Hello, world!')
+        
+        mock_self._logger.warning.assert_called_with(
+            "The output before the pipe broke: %s",
+            "my pipe is gonna break")
+        mock_self._proc.stdin.write.assert_called_with(b'Hello, world!\n')    


### PR DESCRIPTION
## Description

We've had a few examples of BT beacon test failures that finished with just an information about broken pipe, with no context. This made it hard to reason about the real cause of failure.

This patch dumps the stdout of the called process (`bluetoothctl`) when the pipe breaks.

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/986
Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1249

## Tests

Tested by emulating the called process crashing and by executing bluetoothctl without root privileges. In all cases the warning with more context was attached.
