### PR TITLE
Resume Screen for Checkbox Remote expose API (Breaking)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -445,15 +445,15 @@ class RemoteController(ReportsStage, MainLoopStage):
         return False
 
     def _resume_session(self, resume_params):
-        metadata = self.sa._sa.resume_session(resume_params.session_id)
+        metadata = self.sa.resume_session(resume_params.session_id)
         if "testplanless" not in metadata.flags:
             app_blob = json.loads(metadata.app_blob.decode("UTF-8"))
             test_plan_id = app_blob["testplan_id"]
-            self.sa._sa.select_test_plan(test_plan_id)
-            self.sa._sa.bootstrap()
+            self.sa.select_test_plan(test_plan_id)
+            self.sa.bootstrap()
         last_job = metadata.running_job_name
         is_cert_blocker = (
-            self.sa._sa.get_job_state(last_job).effective_certification_status
+            self.sa.get_job_state(last_job).effective_certification_status
             == "blocker"
         )
         # If we resumed maybe not rerun the same, probably broken job
@@ -811,7 +811,7 @@ class RemoteController(ReportsStage, MainLoopStage):
 
     def _run_jobs(self, jobs_repr, total_num=0):
         for job in jobs_repr:
-            job_state = self.sa._sa.get_job_state(job["id"])
+            job_state = self.sa.get_job_state(job["id"])
             self.sa.note_metadata_starting_job(job, job_state)
             SimpleUI.header(
                 _("Running job {} / {}").format(

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -151,7 +151,7 @@ class ControllerTests(TestCase):
             "job1": mock.MagicMock(result=mock.MagicMock(outcome="pass")),
             "job2": mock.MagicMock(result=mock.MagicMock(outcome="pass")),
         }
-        self_mock._sa.manager.default_device_context._state._job_state_map = (
+        self_mock.manager.default_device_context._state._job_state_map = (
             mock_job_state_map
         )
         RemoteController.finish_session(self_mock)
@@ -170,12 +170,12 @@ class ControllerTests(TestCase):
             "job2": mock.MagicMock(result=mock.MagicMock(outcome="fail")),
             "job3": mock.MagicMock(result=mock.MagicMock(outcome="pass")),
         }
-        self_mock._sa.manager.default_device_context._state._job_state_map = (
+        self_mock.manager.default_device_context._state._job_state_map = (
             mock_job_state_map
         )
         RemoteController.finish_session(self_mock)
 
-        self.assertTrue(self_mock._has_anything_failed)
+        self.assertTrue(self_mock._sa._has_anything_failed)
 
     def test_finish_session_with_crash(self):
         """
@@ -189,12 +189,12 @@ class ControllerTests(TestCase):
             "job2": mock.MagicMock(result=mock.MagicMock(outcome="crash")),
             "job3": mock.MagicMock(result=mock.MagicMock(outcome="pass")),
         }
-        self_mock._sa.manager.default_device_context._state._job_state_map = (
+        self_mock.manager.default_device_context._state._job_state_map = (
             mock_job_state_map
         )
         RemoteController.finish_session(self_mock)
 
-        self.assertTrue(self_mock._has_anything_failed)
+        self.assertTrue(self_mock._sa._has_anything_failed)
 
     @mock.patch("checkbox_ng.launcher.controller.SimpleUI")
     @mock.patch("checkbox_ng.launcher.controller.resume_dialog")
@@ -538,8 +538,8 @@ class ControllerTests(TestCase):
             flags=[],
             running_job_name="job1",
         )
-        sa_mock._sa.resume_session.return_value = metadata_mock
-        sa_mock._sa.get_job_state.return_value = mock.MagicMock(
+        sa_mock.resume_session.return_value = metadata_mock
+        sa_mock.get_job_state.return_value = mock.MagicMock(
             effective_certification_status="non-blocker"
         )
 
@@ -548,9 +548,9 @@ class ControllerTests(TestCase):
         RemoteController._resume_session(self_mock, resume_params)
 
         # Assertions
-        sa_mock._sa.resume_session.assert_called_once_with("123")
-        sa_mock._sa.select_test_plan.assert_called_once_with("abc")
-        self.assertTrue(sa_mock._sa.bootstrap.called)
+        sa_mock.resume_session.assert_called_once_with("123")
+        sa_mock.select_test_plan.assert_called_once_with("abc")
+        self.assertTrue(sa_mock.bootstrap.called)
         sa_mock.resume_by_id.assert_called_once_with(
             "123",
             {
@@ -583,8 +583,8 @@ class ControllerTests(TestCase):
             flags=[],
             running_job_name="job1",
         )
-        sa_mock._sa.resume_session.return_value = metadata_mock
-        sa_mock._sa.get_job_state.return_value = mock.MagicMock(
+        sa_mock.resume_session.return_value = metadata_mock
+        sa_mock.get_job_state.return_value = mock.MagicMock(
             effective_certification_status="non-blocker"
         )
 
@@ -593,9 +593,9 @@ class ControllerTests(TestCase):
         RemoteController._resume_session(self_mock, resume_params)
 
         # Assertions
-        sa_mock._sa.resume_session.assert_called_once_with("123")
-        sa_mock._sa.select_test_plan.assert_called_once_with("abc")
-        self.assertTrue(sa_mock._sa.bootstrap.called)
+        sa_mock.resume_session.assert_called_once_with("123")
+        sa_mock.select_test_plan.assert_called_once_with("abc")
+        self.assertTrue(sa_mock.bootstrap.called)
         sa_mock.resume_by_id.assert_called_once_with(
             "123",
             {
@@ -628,8 +628,8 @@ class ControllerTests(TestCase):
             flags=["testplanless"],
             running_job_name="job1",
         )
-        sa_mock._sa.resume_session.return_value = metadata_mock
-        sa_mock._sa.get_job_state.return_value = mock.MagicMock(
+        sa_mock.resume_session.return_value = metadata_mock
+        sa_mock.get_job_state.return_value = mock.MagicMock(
             effective_certification_status="blocker"
         )
 
@@ -638,7 +638,7 @@ class ControllerTests(TestCase):
         RemoteController._resume_session(self_mock, resume_params)
 
         # Assertions
-        sa_mock._sa.resume_session.assert_called_once_with("123")
+        sa_mock.resume_session.assert_called_once_with("123")
         sa_mock.resume_by_id.assert_called_once_with(
             "123",
             {
@@ -671,8 +671,8 @@ class ControllerTests(TestCase):
             flags=[],
             running_job_name="job1",
         )
-        sa_mock._sa.resume_session.return_value = metadata_mock
-        sa_mock._sa.get_job_state.return_value = mock.MagicMock(
+        sa_mock.resume_session.return_value = metadata_mock
+        sa_mock.get_job_state.return_value = mock.MagicMock(
             effective_certification_status="non-blocker"
         )
 
@@ -681,9 +681,9 @@ class ControllerTests(TestCase):
         RemoteController._resume_session(self_mock, resume_params)
 
         # Assertions
-        sa_mock._sa.resume_session.assert_called_once_with("123")
-        sa_mock._sa.select_test_plan.assert_called_once_with("abc")
-        self.assertTrue(sa_mock._sa.bootstrap.called)
+        sa_mock.resume_session.assert_called_once_with("123")
+        sa_mock.select_test_plan.assert_called_once_with("abc")
+        self.assertTrue(sa_mock.bootstrap.called)
         sa_mock.resume_by_id.assert_called_once_with(
             "123",
             {
@@ -716,8 +716,8 @@ class ControllerTests(TestCase):
             flags=["testplanless"],
             running_job_name="job1",
         )
-        sa_mock._sa.resume_session.return_value = metadata_mock
-        sa_mock._sa.get_job_state.return_value = mock.MagicMock(
+        sa_mock.resume_session.return_value = metadata_mock
+        sa_mock.get_job_state.return_value = mock.MagicMock(
             effective_certification_status="blocker"
         )
 
@@ -726,7 +726,7 @@ class ControllerTests(TestCase):
         RemoteController._resume_session(self_mock, resume_params)
 
         # Assertions
-        sa_mock._sa.resume_session.assert_called_once_with("123")
+        sa_mock.resume_session.assert_called_once_with("123")
         sa_mock.resume_by_id.assert_called_once_with(
             "123",
             {
@@ -759,8 +759,8 @@ class ControllerTests(TestCase):
             flags=["testplanless"],
             running_job_name="job1",
         )
-        sa_mock._sa.resume_session.return_value = metadata_mock
-        sa_mock._sa.get_job_state.return_value = mock.MagicMock(
+        sa_mock.resume_session.return_value = metadata_mock
+        sa_mock.get_job_state.return_value = mock.MagicMock(
             effective_certification_status="blocker"
         )
 
@@ -769,7 +769,7 @@ class ControllerTests(TestCase):
         RemoteController._resume_session(self_mock, resume_params)
 
         # Assertions
-        sa_mock._sa.resume_session.assert_called_once_with("123")
+        sa_mock.resume_session.assert_called_once_with("123")
         sa_mock.resume_by_id.assert_called_once_with(
             "123",
             {

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -349,6 +349,9 @@ class RemoteSessionAssistant:
         )  # sorted by name
         return self._available_testplans
 
+    def select_test_plan(self, test_plan_id):
+        return self._sa.select_test_plan(test_plan_id)
+
     @allowed_when(Started)
     def prepare_bootstrapping(self, test_plan_id):
         """Save picked test plan to the app blob."""
@@ -635,6 +638,9 @@ class RemoteSessionAssistant:
     def get_job_result(self, job_id):
         return self._sa.get_job_state(job_id).result
 
+    def get_job_state(self, job_id):
+        return self._sa.get_job_state(job_id)
+
     def get_jobs_repr(self, job_ids, offset=0):
         """
         Translate jobs into a {'field': 'val'} representations.
@@ -688,6 +694,12 @@ class RemoteSessionAssistant:
     def get_resumable_sessions(self):
         return self._sa.get_resumable_sessions()
 
+    def resume_session(self, session_id, runner_kwargs={}):
+        return self._sa.resume_session(session_id, runner_kwargs=runner_kwargs)
+
+    def bootstrap(self):
+        return self._sa.bootstrap()
+
     def resume_by_id(self, session_id=None, overwrite_result_dict={}):
         _logger.info("resume_by_id: %r", session_id)
         self._launcher = load_configs()
@@ -706,7 +718,7 @@ class RemoteSessionAssistant:
             "stdin": self._pipe_to_subproc,
             "extra_env": self.prepare_extra_env,
         }
-        meta = self._sa.resume_session(session_id, runner_kwargs=runner_kwargs)
+        meta = self.resume_session(session_id, runner_kwargs=runner_kwargs)
         app_blob = json.loads(meta.app_blob.decode("UTF-8"))
         launcher_from_controller = Configuration.from_text(
             app_blob["launcher"], "Remote launcher"

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -143,7 +143,7 @@ class BackgroundExecutor(Thread):
 class RemoteSessionAssistant:
     """Remote execution enabling wrapper for the SessionAssistant"""
 
-    REMOTE_API_VERSION = 12
+    REMOTE_API_VERSION = 13
 
     def __init__(self, cmd_callback):
         _logger.debug("__init__()")

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -75,7 +75,7 @@ class RemoteAssistantTests(TestCase):
         extra_cfg = dict()
         extra_cfg["launcher"] = "test_launcher"
         rsa = mock.Mock()
-        rsa._sa.get_test_plans.return_value = [mock.Mock()]
+        rsa.get_test_plans.return_value = [mock.Mock()]
         rsa._state = remote_assistant.Idle
         with mock.patch("plainbox.impl.config.Configuration.from_text") as cm:
             cm.return_value = Configuration()
@@ -93,7 +93,7 @@ class RemoteAssistantTests(TestCase):
         extra_cfg = dict()
         extra_cfg["launcher"] = "test_launcher"
         rsa = mock.Mock()
-        rsa._sa.get_test_plans.return_value = [mock.Mock()]
+        rsa.get_test_plans.return_value = [mock.Mock()]
         rsa._state = remote_assistant.Idle
         with mock.patch("plainbox.impl.config.Configuration.from_text") as cm:
             cm.return_value = Configuration()
@@ -111,7 +111,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa._sa.resume_session.return_value = mock_meta
+        rsa.resume_session.return_value = mock_meta
         remote_assistant.RemoteSessionAssistant.resume_by_id(rsa, "session_id")
         self.assertEqual(rsa._state, "testsselected")
 
@@ -124,7 +124,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa._sa.resume_session.return_value = mock_meta
+        rsa.resume_session.return_value = mock_meta
         remote_assistant.RemoteSessionAssistant.resume_by_id(rsa, "bad_id")
         self.assertEqual(rsa._state, "idle")
 
@@ -137,7 +137,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa._sa.resume_session.return_value = mock_meta
+        rsa.resume_session.return_value = mock_meta
         remote_assistant.RemoteSessionAssistant.resume_by_id(rsa)
         self.assertEqual(rsa._state, "testsselected")
 
@@ -153,7 +153,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa._sa.resume_session.return_value = mock_meta
+        rsa.resume_session.return_value = mock_meta
         os_path_exists_mock = mock.Mock()
 
         with mock.patch("plainbox.impl.session.remote_assistant._") as mock__:
@@ -193,7 +193,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa._sa.resume_session.return_value = mock_meta
+        rsa.resume_session.return_value = mock_meta
         os_path_exists_mock = mock.Mock()
 
         with mock.patch("plainbox.impl.session.remote_assistant._") as mock__:
@@ -233,10 +233,9 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa._sa.resume_session.return_value = mock_meta
+        rsa.resume_session.return_value = mock_meta
         os_path_exists_mock = mock.Mock()
 
-        rsa._sa.get_job = mock.Mock()
         rsa._sa.get_job.return_value.plugin = "shell"
 
         with mock.patch("os.path.exists", os_path_exists_mock):
@@ -268,10 +267,9 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa._sa.resume_session.return_value = mock_meta
+        rsa.resume_session.return_value = mock_meta
         os_path_exists_mock = mock.Mock()
 
-        rsa._sa.get_job = mock.Mock()
         rsa._sa.get_job.return_value.plugin = "shell"
 
         with mock.patch("os.path.exists", os_path_exists_mock):
@@ -301,7 +299,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa._sa.resume_session.return_value = mock_meta
+        rsa.resume_session.return_value = mock_meta
         os_path_exists_mock = mock.Mock()
         with mock.patch("plainbox.impl.session.remote_assistant._") as mock__:
             mock__.side_effect = lambda x: x
@@ -377,7 +375,6 @@ class RemoteAssistantTests(TestCase):
 class RemoteAssistantFinishJobTests(TestCase):
     def setUp(self):
         self.rsa = mock.MagicMock()
-        self.rsa._sa = mock.Mock()
         self.rsa._be = None
 
     @mock.patch("plainbox.impl.session.remote_assistant.JobResultBuilder")


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

[This PR ](https://github.com/canonical/checkbox/pull/839) modified the remote API but didn't bump the REMOTE_API number.  The api bump is warranted because we need every new api entry:
- delete_session : used by the menu to delete old sessions
- get_resumable_sessions: same, used by the menu to list/manage sessions and get the resumable id
- new kwarg  overwrite_result_dict={}: used to overwrite the result of an older session via the menu, wasn't there before

Additionally (this to do only 1 remote api bump) many parts of the code use private apis of the RemoteAssistant. This is a problem as they are not stable. This also fixes this issue
## Resolved issues

Currently checkbox crashes if launched across revisions because the version wasn't bumped

## Documentation

N/A

## Tests

N/A

