### PR TITLE
Add tests for resume menu (infra)

### DIFF
--- a/metabox/metabox/scenarios/cert_blocker_comment/launcher.py
+++ b/metabox/metabox/scenarios/cert_blocker_comment/launcher.py
@@ -7,7 +7,6 @@
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
 # as published by the Free Software Foundation.
-
 #
 # Checkbox is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/metabox/metabox/scenarios/config/environment.py
+++ b/metabox/metabox/scenarios/config/environment.py
@@ -7,7 +7,6 @@
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
 # as published by the Free Software Foundation.
-
 #
 # Checkbox is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/metabox/metabox/scenarios/config/test_selection.py
+++ b/metabox/metabox/scenarios/config/test_selection.py
@@ -7,7 +7,6 @@
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
 # as published by the Free Software Foundation.
-
 #
 # Checkbox is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -299,4 +298,3 @@ class TestPlanSelectionFilter(Scenario):
         Send("i"),
         AssertNotPrinted("smoke")
     ]
-

--- a/metabox/metabox/scenarios/ui/interact_jobs.py
+++ b/metabox/metabox/scenarios/ui/interact_jobs.py
@@ -7,7 +7,6 @@
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
 # as published by the Free Software Foundation.
-
 #
 # Checkbox is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/metabox/metabox/scenarios/ui/resume_menu.py
+++ b/metabox/metabox/scenarios/ui/resume_menu.py
@@ -7,7 +7,6 @@
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
 # as published by the Free Software Foundation.
-
 #
 # Checkbox is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/metabox/metabox/scenarios/ui/resume_menu.py
+++ b/metabox/metabox/scenarios/ui/resume_menu.py
@@ -1,0 +1,301 @@
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox. If not, see <http://www.gnu.org/licenses/>.
+import textwrap
+
+import metabox.core.keys as keys
+from metabox.core.actions import Expect, Send, Start, SelectTestPlan
+from metabox.core.scenario import Scenario
+from metabox.core.utils import tag
+
+
+@tag("manual", "interact", "resume")
+class ResumeMenuMultipleDelete(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test selection]
+        forced = yes
+        """
+    )
+
+    steps = [
+        # Generate 2 resume candidates
+        Start(),
+        Expect("Select test plan"),
+        SelectTestPlan(
+            "2021.com.canonical.certification::cert-blocker-manual-resume"
+        ),
+        Send(keys.KEY_ENTER),
+        Expect("Pick an action"),
+        Send("p" + keys.KEY_ENTER),
+        Expect("Pick an action"),
+        Send("q" + keys.KEY_ENTER),
+        Expect("Session saved"),
+        Start(),
+        Expect("Select test plan"),
+        SelectTestPlan(
+            "2021.com.canonical.certification::cert-blocker-manual-resume"
+        ),
+        Send(keys.KEY_ENTER),
+        Expect("Pick an action"),
+        Send("p" + keys.KEY_ENTER),
+        Expect("Pick an action"),
+        Send("q" + keys.KEY_ENTER),
+        Expect("Session saved"),
+        Start(),
+        Expect("Resume session"),
+        # Enter the resume menu
+        Send("r"),
+        Expect("Incomplete sessions"),
+        # Delete first
+        Send("d"),
+        # More session available, remain in the resume menun
+        Expect("Incomplete sessions"),
+        # Delete second
+        Send("d"),
+        # No more sessions available, go back to test plan selection
+        Expect("Select test plan"),
+        # Now we still have to be able to run test plans
+        SelectTestPlan("2021.com.canonical.certification::whoami_as_user_tp "),
+        Send(keys.KEY_ENTER),
+        Expect("Results"),
+    ]
+
+
+@tag("manual", "interact", "resume")
+class ResumeMenuMarkSkip(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test selection]
+        forced = yes
+        """
+    )
+
+    steps = [
+        # Generate 1 resume candidates
+        Start(),
+        Expect("Select test plan"),
+        SelectTestPlan(
+            "2021.com.canonical.certification::cert-blocker-manual-resume"
+        ),
+        Send(keys.KEY_ENTER),
+        Expect("Pick an action"),
+        Send("p" + keys.KEY_ENTER),
+        Expect("Pick an action"),
+        Send("q" + keys.KEY_ENTER),
+        Expect("Session saved"),
+        Start(),
+        Expect("Resume session"),
+        # Enter the resume menu
+        Send("r"),
+        Expect("Incomplete sessions"),
+        Send(keys.KEY_ENTER),
+        Expect("last job?"),
+        # select Skip
+        Send(keys.KEY_DOWN * 1),
+        Send(keys.KEY_ENTER),
+        # Job is a cert blocker, it must ask for a comment
+        Expect("Please enter your comments"),
+        Send("Comment" + keys.KEY_ENTER),
+        Expect("Skipped Jobs"),
+        Expect("Finish"),
+        Send("f"),
+        Expect("Result"),
+    ]
+
+
+@tag("manual", "interact", "resume")
+class ResumeMenuMarkFail(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test selection]
+        forced = yes
+        """
+    )
+
+    steps = [
+        # Generate 1 resume candidates
+        Start(),
+        Expect("Select test plan"),
+        SelectTestPlan(
+            "2021.com.canonical.certification::cert-blocker-manual-resume"
+        ),
+        Send(keys.KEY_ENTER),
+        Expect("Pick an action"),
+        Send("p" + keys.KEY_ENTER),
+        Expect("Pick an action"),
+        Send("q" + keys.KEY_ENTER),
+        Expect("Session saved"),
+        Start(),
+        Expect("Resume session"),
+        # Enter the resume menu
+        Send("r"),
+        Expect("Incomplete sessions"),
+        Send(keys.KEY_ENTER),
+        Expect("last job?"),
+        # select Skip
+        Send(keys.KEY_DOWN),
+        Send(keys.KEY_DOWN),
+        Send(keys.KEY_DOWN),
+        Send(keys.KEY_ENTER),
+        # Job is a cert blocker, it must ask for a comment
+        Expect("Please enter your comments"),
+        Send("Comment" + keys.KEY_ENTER),
+        # Now we still have to be able to run test plans
+        Expect("Failed Jobs"),
+        Expect("Finish"),
+        Send("f"),
+        Expect("Result"),
+    ]
+
+@tag("manual", "interact", "resume")
+class ResumeMenuMarkPreCommentFail(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test selection]
+        forced = yes
+        """
+    )
+
+    steps = [
+        # Generate 1 resume candidates
+        Start(),
+        Expect("Select test plan"),
+        SelectTestPlan(
+            "2021.com.canonical.certification::cert-blocker-manual-resume"
+        ),
+        Send(keys.KEY_ENTER),
+        Expect("Pick an action"),
+        Send("p" + keys.KEY_ENTER),
+        Expect("Pick an action"),
+        Send("q" + keys.KEY_ENTER),
+        Expect("Session saved"),
+        Start(),
+        Expect("Resume session"),
+        # Enter the resume menu
+        Send("r"),
+        Expect("Incomplete sessions"),
+        Send(keys.KEY_ENTER),
+        Expect("last job?"),
+        # select Comment
+        Send(keys.KEY_ENTER),
+        Expect("Enter comment"),
+        Send("Job failed due to reason" + keys.KEY_ENTER),
+        # select Skip
+        Send("f"),
+        # Job is a cert blocker, but it should not ask for a comment as it was
+        # provided from the resume menu
+        Expect("Failed Jobs"),
+        Expect("Finish"),
+        Send("f"),
+        Expect("Result"),
+    ]
+
+@tag("manual", "interact", "resume")
+class ResumeMenuMarkPassed(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test selection]
+        forced = yes
+        """
+    )
+
+    steps = [
+        # Generate 1 resume candidates
+        Start(),
+        Expect("Select test plan"),
+        SelectTestPlan(
+            "2021.com.canonical.certification::cert-blocker-manual-resume"
+        ),
+        Send(keys.KEY_ENTER),
+        Expect("Pick an action"),
+        Send("p" + keys.KEY_ENTER),
+        Expect("Pick an action"),
+        Send("q" + keys.KEY_ENTER),
+        Expect("Session saved"),
+        Start(),
+        Expect("Resume session"),
+        # Enter the resume menu
+        Send("r"),
+        Expect("Incomplete sessions"),
+        Send(keys.KEY_ENTER),
+        Expect("last job?"),
+        # Select Mark as Pass
+        Send("p"),
+        Expect("Result"),
+    ]
+
+@tag("manual", "interact", "resume")
+class ResumeMenuResumeLastJob(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test selection]
+        forced = yes
+        """
+    )
+
+    steps = [
+        # Generate 1 resume candidates
+        Start(),
+        Expect("Select test plan"),
+        SelectTestPlan(
+            "2021.com.canonical.certification::cert-blocker-manual-resume"
+        ),
+        Send(keys.KEY_ENTER),
+        Expect("Pick an action"),
+        Send("p" + keys.KEY_ENTER),
+        Expect("Pick an action"),
+        Send("q" + keys.KEY_ENTER),
+        Expect("Session saved"),
+        Start(),
+        Expect("Resume session"),
+        # Enter the resume menu
+        Send("r"),
+        Expect("Incomplete sessions"),
+        Send(keys.KEY_ENTER),
+        Expect("last job?"),
+        # select Resume and run the job again
+        Send("R"),
+        Expect("press ENTER to continue"),
+        Send(keys.KEY_ENTER),
+        Expect("Result"),
+    ]

--- a/metabox/metabox/scenarios/ui/resume_menu.py
+++ b/metabox/metabox/scenarios/ui/resume_menu.py
@@ -23,7 +23,7 @@ from metabox.core.scenario import Scenario
 from metabox.core.utils import tag
 
 
-@tag("manual", "interact", "resume")
+@tag("manual", "resume")
 class ResumeMenuMultipleDelete(Scenario):
     modes = ["remote"]
     launcher = textwrap.dedent(
@@ -80,7 +80,7 @@ class ResumeMenuMultipleDelete(Scenario):
     ]
 
 
-@tag("manual", "interact", "resume")
+@tag("manual", "resume")
 class ResumeMenuMarkSkip(Scenario):
     modes = ["remote"]
     launcher = textwrap.dedent(
@@ -126,7 +126,7 @@ class ResumeMenuMarkSkip(Scenario):
     ]
 
 
-@tag("manual", "interact", "resume")
+@tag("manual", "resume")
 class ResumeMenuMarkFail(Scenario):
     modes = ["remote"]
     launcher = textwrap.dedent(
@@ -174,7 +174,7 @@ class ResumeMenuMarkFail(Scenario):
         Expect("Result"),
     ]
 
-@tag("manual", "interact", "resume")
+@tag("manual", "resume")
 class ResumeMenuMarkPreCommentFail(Scenario):
     modes = ["remote"]
     launcher = textwrap.dedent(
@@ -221,7 +221,7 @@ class ResumeMenuMarkPreCommentFail(Scenario):
         Expect("Result"),
     ]
 
-@tag("manual", "interact", "resume")
+@tag("manual", "resume")
 class ResumeMenuMarkPassed(Scenario):
     modes = ["remote"]
     launcher = textwrap.dedent(
@@ -259,7 +259,7 @@ class ResumeMenuMarkPassed(Scenario):
         Expect("Result"),
     ]
 
-@tag("manual", "interact", "resume")
+@tag("manual", "resume")
 class ResumeMenuResumeLastJob(Scenario):
     modes = ["remote"]
     launcher = textwrap.dedent(

--- a/metabox/metabox/scenarios/ui/testplan.py
+++ b/metabox/metabox/scenarios/ui/testplan.py
@@ -8,7 +8,6 @@
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
 # as published by the Free Software Foundation.
-
 #
 # Checkbox is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

These are all the metabox scenarios for the new resume menu on remote. They were not added to the original resume_remote PR by mistake but given the chance I added a couple more. This should test every scenario the menu must support.

> Note: these are remote only tests because it seems that local is not resuming user-interact jobs correctly (possibly missing the lastest_run_job_name metadata like remote was)  

Driveby fix: this also removes all random newlines in licenses because it seems that every time I init a new metabox scenario I wrongly copy one that has it

## Resolved issues

Missing tests for resume remote

## Documentation

N/A

## Tests

This PR

