### PR TITLE
Remove the dependency on Sylvain's ppa to get libraspberrypi0 (BugFix)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -404,15 +404,7 @@ parts:
       - picamera
     build-environment:
       - READTHEDOCS: 'True'
-  rpi-ppa:
-    plugin: nil
-    override-pull: |
-      sudo add-apt-repository ppa:sylvain-pineau/ppa-rpi
-      sudo apt-get update
-    build-packages:
-      - software-properties-common
   rpi-support-binaries:
-    after: [rpi-ppa]
     plugin: nil
     stage-packages:
       - on armhf:

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -404,15 +404,7 @@ parts:
       - picamera
     build-environment:
       - READTHEDOCS: 'True'
-  rpi-ppa:
-    plugin: nil
-    override-pull: |
-      sudo add-apt-repository ppa:sylvain-pineau/ppa-rpi
-      sudo apt-get update
-    build-packages:
-      - software-properties-common
   rpi-support-binaries:
-    after: [rpi-ppa]
     plugin: nil
     stage-packages:
       - on armhf:

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -437,15 +437,7 @@ parts:
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-certification-server --root="$SNAPCRAFT_PART_INSTALL"
     after: [checkbox-provider-certification-client]
 ################################################################################
-  rpi-ppa:
-    plugin: nil
-    override-pull: |
-      sudo add-apt-repository ppa:sylvain-pineau/ppa-rpi
-      sudo apt-get update
-    build-packages:
-      - software-properties-common
   rpi-support-binaries:
-    after: [rpi-ppa]
     plugin: nil
     stage-packages:
       - on armhf:


### PR DESCRIPTION
## Description

The same packages are availbale from the checkbox stable ppa as of now:
https://launchpad.net/~checkbox-dev/+archive/ubuntu/stable

## Resolved issues

external dep on a ppa

## Documentation

N/A

## Tests

Tested using a remote build of checkbox20

