### PR TITLE
Autoresume crashed/norerun sessions on interactive runs for remote (New)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -393,7 +393,6 @@ class RemoteController(ReportsStage, MainLoopStage):
             self.sa.bootstrap()
 
             if not metadata.running_job_name:
-                self.sa.abandon_session()
                 return False
 
             job_state = self.sa.get_job_state(metadata.running_job_name)

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -354,7 +354,63 @@ class RemoteController(ReportsStage, MainLoopStage):
                 break
         return self._has_anything_failed
 
-    def resume_or_start_new_session(self):
+    def should_start_via_launcher(self):
+        if self.launcher.get_value("test plan", "forced"):
+            tp_unit = self.launcher.get_value("test plan", "unit")
+            if not tp_unit:
+                _logger.error(
+                    _(
+                        "The test plan selection was forced but no unit was provided"
+                    )
+                )
+                raise SystemExit(1)
+            return True
+        return False
+
+    @contextlib.contextmanager
+    def _resumed_session(self, session_id):
+        try:
+            yield self.sa.resume_session(session_id)
+        finally:
+            self.sa.abandon_session()
+
+    def should_start_via_autoresume(self):
+        try:
+            last_abandoned_session = next(self.sa.get_resumable_sessions())
+        except StopIteration:
+            # no session to resume
+            return False
+        # resume session in agent to be able to peek at the latest job run
+        # info
+        with self._resumed_session(last_abandoned_session.id) as metadata:
+            app_blob = json.loads(metadata.app_blob.decode("UTF-8"))
+
+            if not app_blob.get("testplan_id"):
+                self.sa.abandon_session()
+                return False
+
+            self.sa.select_test_plan(app_blob["testplan_id"])
+            self.sa.bootstrap()
+
+            if not metadata.running_job_name:
+                self.sa.abandon_session()
+                return False
+
+            job_state = self.sa.get_job_state(metadata.running_job_name)
+            if job_state.job.plugin != "shell":
+                return False
+        return True
+
+    def automatically_start_via_launcher(self):
+        tp_unit = self.launcher.get_value("test plan", "unit")
+        self.select_tp(tp_unit)
+        self.select_jobs(self.jobs)
+
+    def automatically_resume_last_session(self):
+        last_abandoned_session = next(self.sa.get_resumable_sessions())
+        self.sa.resume_by_id(last_abandoned_session.id)
+
+    def start_session(self):
         _logger.info("controller: Starting new session.")
         configuration = dict()
         configuration["launcher"] = self._launcher_text
@@ -366,17 +422,15 @@ class RemoteController(ReportsStage, MainLoopStage):
                 _logger.warning("Agent is using sideloaded providers")
         except RuntimeError as exc:
             raise SystemExit(exc.args[0]) from exc
-        if self.launcher.get_value("test plan", "forced"):
-            tp_unit = self.launcher.get_value("test plan", "unit")
-            if not tp_unit:
-                _logger.error(
-                    _(
-                        "The test plan selection was forced but no unit was provided"
-                    )
-                )
-                raise SystemExit(1)
-            self.select_tp(tp_unit)
-            self.select_jobs(self.jobs)
+        return tps
+
+    def resume_or_start_new_session(self):
+        tps = self.start_session()
+
+        if self.should_start_via_autoresume():
+            self.automatically_resume_last_session()
+        elif self.should_start_via_launcher():
+            self.automatically_start_via_launcher()
         else:
             self.interactively_choose_tp(tps)
 

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -358,7 +358,7 @@ class RemoteController(ReportsStage, MainLoopStage):
     def should_start_via_launcher(self):
         """
         Determines if the controller should automatically select a test plan
-        given a launcher. Raises if the launcher tries to skip the test plan
+        if given a launcher. Raises if the launcher tries to skip the test plan
         selection without providing the test plan that must be automatically
         selected
         """
@@ -371,7 +371,7 @@ class RemoteController(ReportsStage, MainLoopStage):
     @contextlib.contextmanager
     def _resumed_session(self, session_id):
         """
-        Used to temporarely resume a session to inspect it, abandoning it
+        Used to temporarily resume a session to inspect it, abandoning it
         before exiting the context
         """
         try:

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -362,18 +362,11 @@ class RemoteController(ReportsStage, MainLoopStage):
         selection without providing the test plan that must be automatically
         selected
         """
-        if self.launcher.get_value("test plan", "forced"):
-            tp_unit = self.launcher.get_value("test plan", "unit")
-            if not tp_unit:
-                _logger.error(
-                    _(
-                        "The test plan selection was forced but no unit"
-                        " was provided"
-                    )
-                )
-                raise SystemExit(1)
-            return True
-        return False
+        tp_forced = self.launcher.get_value("test plan", "forced")
+        chosen_tp = self.launcher.get_value("test plan", "unit")
+        if tp_forced and not chosen_tp:
+            raise SystemExit("The test plan selection was forced but no unit was provided") # split me into lines
+        return tp_forced
 
     @contextlib.contextmanager
     def _resumed_session(self, session_id):

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -243,15 +243,17 @@ class ControllerTests(TestCase):
         self.assertTrue(self_mock.abandon.called)
         self.assertTrue(self_mock.resume_or_start_new_session.called)
 
-    def test_resume_or_start_new_session_interactive(self):
+    @mock.patch("checkbox_ng.launcher.controller._logger")
+    def test_resume_or_start_new_session_interactive(self, _logger_mock):
         self_mock = mock.MagicMock()
         self_mock.sa.sideloaded_providers = True  # trigger the warning
         # the session is not interactive
-        self_mock.launcher.get_value.return_value = False
 
-        RemoteController.resume_or_start_new_session(self_mock)
+        test_plans = RemoteController.start_session(self_mock)
 
-        self.assertTrue(self_mock.interactively_choose_tp.called)
+        self.assertTrue(_logger_mock.warning.called)
+        self.assertTrue(self_mock.sa.start_session.called)
+        self.assertEqual(self_mock.sa.start_session.return_value, test_plans)
 
     @mock.patch("checkbox_ng.launcher.controller.SimpleUI")
     def test__run_jobs_description_command_none(self, simple_ui_mock):
@@ -806,6 +808,7 @@ class ControllerTests(TestCase):
 
         self.assertTrue(self_mock._new_session_flow.called)
         self.assertTrue(self_mock._resume_session_menu.called)
+
 
 class IsHostnameALoopbackTests(TestCase):
     @mock.patch("socket.gethostbyname")

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -854,6 +854,18 @@ class ControllerTests(TestCase):
         self.assertTrue(self_mock._new_session_flow.called)
         self.assertTrue(self_mock._resume_session_menu.called)
 
+    def test__resumed_session(self):
+        self_mock = mock.MagicMock()
+
+        with RemoteController._resumed_session(
+            self_mock, "session_id"
+        ) as metadata:
+            self.assertEqual(
+                self_mock.sa.resume_session.return_value, metadata
+            )
+        self.assertTrue(self_mock.sa.resume_session.called)
+        self.assertTrue(self_mock.sa.abandon_session.called)
+
 
 class IsHostnameALoopbackTests(TestCase):
     @mock.patch("socket.gethostbyname")

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -962,6 +962,22 @@ class ControllerTests(TestCase):
             RemoteController.should_start_via_autoresume(self_mock)
         )
 
+    def test_automatically_start_via_launcher(self):
+        self_mock = mock.MagicMock()
+
+        RemoteController.automatically_start_via_launcher(self_mock)
+
+        self.assertTrue(self_mock.select_tp.called)
+        self.assertTrue(self_mock.select_jobs.called)
+
+    def test_automatically_resume_last_session(self):
+        self_mock = mock.MagicMock()
+
+        RemoteController.automatically_resume_last_session(self_mock)
+
+        self.assertTrue(self_mock.sa.get_resumable_sessions.called)
+        self.assertTrue(self_mock.sa.resume_by_id.called)
+
 
 class IsHostnameALoopbackTests(TestCase):
     @mock.patch("socket.gethostbyname")

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -780,6 +780,51 @@ class ControllerTests(TestCase):
             },
         )
 
+    def test_should_start_via_launcher_true(self):
+        self_mock = mock.MagicMock()
+
+        def get_value_mock(top_level, attribute):
+            if top_level == "test plan":
+                if attribute == "forced":
+                    return True
+                elif attribute == "unit":
+                    return "tp_unit_id"
+            return mock.MagicMock()
+
+        self_mock.launcher.get_value = get_value_mock
+
+        self.assertTrue(RemoteController.should_start_via_launcher(self_mock))
+
+    def test_should_start_via_launcher_false(self):
+        self_mock = mock.MagicMock()
+
+        def get_value_mock(top_level, attribute):
+            if top_level == "test plan":
+                if attribute == "forced":
+                    return False
+                elif attribute == "unit":
+                    return "tp_unit_id"
+            return mock.MagicMock()
+
+        self_mock.launcher.get_value = get_value_mock
+
+        self.assertFalse(RemoteController.should_start_via_launcher(self_mock))
+
+    def test_should_start_via_launcher_exit(self):
+        self_mock = mock.MagicMock()
+
+        def get_value_mock(top_level, attribute):
+            if top_level == "test plan":
+                if attribute == "forced":
+                    return True
+                elif attribute == "unit":
+                    return None
+            return mock.MagicMock()
+
+        self_mock.launcher.get_value = get_value_mock
+        with self.assertRaises(SystemExit):
+            RemoteController.should_start_via_launcher(self_mock)
+
     def test_interactively_choose_tp(self):
         self_mock = mock.MagicMock()
 

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -978,6 +978,41 @@ class ControllerTests(TestCase):
         self.assertTrue(self_mock.sa.get_resumable_sessions.called)
         self.assertTrue(self_mock.sa.resume_by_id.called)
 
+    def test_start_session_success(self):
+        self_mock = mock.MagicMock()
+        self_mock._launcher_text = "launcher_example"
+        self_mock._normal_user = True
+        expected_configuration = {
+            "launcher": "launcher_example",
+            "normal_user": True
+        }
+
+        self_mock.sa.start_session.return_value = "session_started"
+
+        tps = RemoteController.start_session(self_mock)
+
+        self_mock.sa.start_session.assert_called_once_with(expected_configuration)
+        self.assertEqual(tps, "session_started")
+
+    def test_start_session_with_sideloaded_providers(self):
+        self_mock = mock.MagicMock()
+        self_mock._launcher_text = "launcher_example"
+        self_mock._normal_user = True
+        self_mock.sa.sideloaded_providers = True
+
+        self_mock.sa.start_session.return_value = "session_started"
+
+        RemoteController.start_session(self_mock)
+
+    def test_start_session_runtime_error(self):
+        self_mock = mock.MagicMock()
+        self_mock._launcher_text = "launcher_example"
+        self_mock._normal_user = True
+        self_mock.sa.start_session.side_effect = RuntimeError("Failed to start session")
+
+        with self.assertRaises(SystemExit) as _:
+            RemoteController.start_session(self_mock)
+
 
 class IsHostnameALoopbackTests(TestCase):
     @mock.patch("socket.gethostbyname")

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -848,7 +848,7 @@ class ControllerTests(TestCase):
         self_mock = mock.MagicMock()
 
         # by default always try to start a new session and not resuming
-        RemoteController.interactively_choose_tp(self_mock, [])
+        RemoteController.interactively_choose_tp(self_mock)
 
         self.assertTrue(self_mock._new_session_flow.called)
         self.assertFalse(self_mock._resume_session_menu.called)
@@ -858,7 +858,7 @@ class ControllerTests(TestCase):
         self_mock._new_session_flow.side_effect = ResumeInstead
         self_mock._resume_session_menu.return_value = True
 
-        RemoteController.interactively_choose_tp(self_mock, [])
+        RemoteController.interactively_choose_tp(self_mock)
 
         self.assertTrue(self_mock._new_session_flow.called)
         self.assertTrue(self_mock._resume_session_menu.called)
@@ -868,7 +868,7 @@ class ControllerTests(TestCase):
         self_mock._new_session_flow.side_effect = [ResumeInstead, True]
         self_mock._resume_session_menu.return_value = True
 
-        RemoteController.interactively_choose_tp(self_mock, [])
+        RemoteController.interactively_choose_tp(self_mock)
 
         self.assertTrue(self_mock._new_session_flow.called)
         self.assertTrue(self_mock._resume_session_menu.called)

--- a/metabox/metabox/metabox-provider/units/resume.pxu
+++ b/metabox/metabox/metabox-provider/units/resume.pxu
@@ -1,20 +1,22 @@
-id: agent-crasher
-_summary: Crash the agent
+id: checkbox-crasher
+_summary: Crash Checkbox
 flags: simple
 user: root
 command:
- kill `ps aux|grep run-agent|grep -v 'grep'  | awk '{print $2}'`
+ PID=`ps -o ppid= $$`
+ kill $PID
 
 id: reboot-emulator
 _summary: Emulate the reboot
 flags: simple noreturn
 user: root
 command:
- kill `ps aux|grep run-agent|grep -v 'grep'  | awk '{print $2}'`
+ PID=`ps -o ppid= $$`
+ kill $PID
 
 unit: test plan
-id: agent-resume-crash-then-reboot
-_name: Agent resume after crash then reboot
+id: checkbox-crash-then-reboot
+_name: Checkbox crash then reboot
 include:
- agent-crasher
+ checkbox-crasher
  reboot-emulator

--- a/metabox/metabox/scenarios/restart/agent_respawn.py
+++ b/metabox/metabox/scenarios/restart/agent_respawn.py
@@ -36,7 +36,7 @@ class ResumeAfterCrashAuto(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::agent-resume-crash-then-reboot
+        unit = 2021.com.canonical.certification::checkbox-crash-then-reboot
         forced = yes
         [test selection]
         forced = yes
@@ -46,24 +46,29 @@ class ResumeAfterCrashAuto(Scenario):
     )
     steps = [
         AssertRetCode(1),
-        AssertPrinted("job crashed  : Crash the agent"),
-        AssertPrinted("job passed   : Emulate the reboot"),
+        AssertPrinted("job crashed"),
+        AssertPrinted("Crash Checkbox"),
+        AssertPrinted("job passed"),
+        AssertPrinted("Emulate the reboot"),
     ]
 
 
 @tag("resume", "manual")
 class ResumeAfterCrashManual(Scenario):
+    modes = ["remote"]
     launcher = "# no launcher"
     steps = [
         Expect("Select test plan"),
         SelectTestPlan(
-            "2021.com.canonical.certification::agent-resume-crash-then-reboot"
+            "2021.com.canonical.certification::checkbox-crash-then-reboot"
         ),
         Send(keys.KEY_ENTER),
         Expect("Press (T) to start"),
         Send("T"),
         Expect("Select jobs to re-run"),
         Send("F"),
-        Expect("job crashed  : Crash the agent"),
-        Expect("job passed   : Emulate the reboot"),
+        Expect("job crashed"),
+        Expect("Crash Checkbox"),
+        Expect("job passed"),
+        Expect("Emulate the reboot"),
     ]

--- a/metabox/metabox/scenarios/restart/agent_respawn.py
+++ b/metabox/metabox/scenarios/restart/agent_respawn.py
@@ -15,13 +15,20 @@
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 import textwrap
 
-from metabox.core.actions import AssertPrinted, AssertRetCode
+from metabox.core import keys
+from metabox.core.actions import (
+    AssertPrinted,
+    AssertRetCode,
+    SelectTestPlan,
+    Send,
+    Expect,
+)
 from metabox.core.scenario import Scenario
 from metabox.core.utils import tag
 
 
-@tag("resume")
-class ResumeAfterCrash(Scenario):
+@tag("resume", "automatic")
+class ResumeAfterCrashAuto(Scenario):
     modes = ["remote"]
     launcher = textwrap.dedent(
         """
@@ -41,4 +48,22 @@ class ResumeAfterCrash(Scenario):
         AssertRetCode(1),
         AssertPrinted("job crashed  : Crash the agent"),
         AssertPrinted("job passed   : Emulate the reboot"),
+    ]
+
+
+@tag("resume", "manual")
+class ResumeAfterCrashManual(Scenario):
+    launcher = "# no launcher"
+    steps = [
+        Expect("Select test plan"),
+        SelectTestPlan(
+            "2021.com.canonical.certification::agent-resume-crash-then-reboot"
+        ),
+        Send(keys.KEY_ENTER),
+        Expect("Press (T) to start"),
+        Send("T"),
+        Expect("Select jobs to re-run"),
+        Send("F"),
+        Expect("job crashed  : Crash the agent"),
+        Expect("job passed   : Emulate the reboot"),
     ]


### PR DESCRIPTION
## Description

Checkbox remote used to automatically resume the latest session when it crashed or the machine turned off. This was obtained via an obscure code-path that has since been simplified but the behaviour was useful to QA testing. 

The idea was that a session would be automatically resumed if it was non-interactive, else the user would have to manually trigger the resume. QA's need for autoresume is not adressed by the new resume menu as test session that contain multiple reboots, for example, would be way easier to carry out if checkbox just automatically resumed them.

This introduces a new autoresume behaviour for interactive runs. If the latest resumable session was running a shell job when it was closed unexpectedly, it will be resumed automatically. The status of the latest job follows the usual logic (in order of priority):
1. read from disk when possible
2. pass if the job was noreturn
3. crash for everything else

> Note: the test is remote only as local doesn't seem to autoresume interactive sessions yet. If we want it to do so we can follow this up in the future

> Note2: A possible follow up to this is to give the user some time to interrupt the resume process via the Ctrl+C menu similarly to what is done for automated runs

> Note3: This introduces a small hack in controller.py:490. The reason is that this needs a followup that fixes `get_resumable_sessions` to only return resumable sessions and not incompatible ones

## Resolved issues

Resolves: https://github.com/canonical/checkbox/issues/935

## Documentation

N/A

## Tests

This adds a new metabox scenario where both noreturn and crash are tested in manual interactive runs.

