### PR TITLE
[checkbox-ce-oem] Fix wrong arg name (Bugfix)

### DIFF
--- a/contrib/checkbox-provider-ce-oem/bin/socketcan_busoff_test.py
+++ b/contrib/checkbox-provider-ce-oem/bin/socketcan_busoff_test.py
@@ -167,7 +167,7 @@ def main():
     logger = init_logger()
     if args.debug:
         logger.setLevel(logging.DEBUG)
-    can_bus_off_test(args.dev, args.timeout)
+    can_bus_off_test(args.device, args.timeout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Wrong argument name.
from `dev` to `device`

## Resolved issues
N/A

## Documentation
N/A

## Tests
https://certification.canonical.com/hardware/202307-31906/submission/358052/ 


