### PR TITLE
Use pylxd api to mount disks (infra)

### DIFF
--- a/metabox/metabox/core/lxd_provider.py
+++ b/metabox/metabox/core/lxd_provider.py
@@ -285,40 +285,18 @@ class LxdMachineProvider:
 
     def _mount_source(self, machine, path):
         logger.debug("Mounting dir {}", path)
-        output = subprocess.check_output(
-            [
-                "lxc",
-                "config",
-                "device",
-                "add",
-                machine._container.name,
-                self.LXD_MOUNT_DEVICE,
-                "disk",
-                "source={}".format(path),
-                "path={}".format(self.LXD_SOURCE_MOUNT_POINT),
-            ],
-            stderr=subprocess.PIPE,
-            text=True,
-        ).strip()
-        if output:
-            logger.debug(output)
+        disk_config = {
+            "source": path,
+            "path": self.LXD_SOURCE_MOUNT_POINT,
+            "type": "disk",
+        }
+        machine._container.devices.update({self.LXD_MOUNT_DEVICE: disk_config})
+        machine._container.save()
 
     def _unmount_source(self, machine):
         logger.debug("Unmounting dir...")
-        output = subprocess.check_output(
-            [
-                "lxc",
-                "config",
-                "device",
-                "remove",
-                machine._container.name,
-                self.LXD_MOUNT_DEVICE,
-            ],
-            stderr=subprocess.PIPE,
-            text=True,
-        ).strip()
-        if output:
-            logger.debug(output)
+        del machine._container.devices[self.LXD_MOUNT_DEVICE]
+        machine._container.save()
 
     @contextmanager
     def _mounted_source(self, machine, path):


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This was introduced a while back as it was unclear to me how to actually mount a disk via pylxd. This PR mounts the disk via the pylxd api instead of using the lxc subprocess

## Resolved issues

N/A

## Documentation

N/A

## Tests

Ran metabox, it works as before.

