### PR TITLE
Change Tox GitHub workflows naming (Infra)

### DIFF
--- a/.github/workflows/tox-checkbox-ng.yaml
+++ b/.github/workflows/tox-checkbox-ng.yaml
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  tox_test_checkbox_ng:
+    name: Test checkbox-ng with tox
     defaults:
       run:
         working-directory: checkbox-ng

--- a/.github/workflows/tox-checkbox-support.yaml
+++ b/.github/workflows/tox-checkbox-support.yaml
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  tox_test_checkbox_support:
+    name: Test checkbox-support with tox
     defaults:
       run:
         working-directory: checkbox-support

--- a/.github/workflows/tox-provider-base.yaml
+++ b/.github/workflows/tox-provider-base.yaml
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  tox_test_provider_base:
+    name: Test provider-base with tox
     defaults:
       run:
         working-directory: providers/base

--- a/.github/workflows/tox-provider-certification-client.yaml
+++ b/.github/workflows/tox-provider-certification-client.yaml
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  tox_test_provider_certification_client:
+    name: Test provider-certification-client with tox
     defaults:
       run:
         working-directory: providers/certification-client

--- a/.github/workflows/tox-provider-certification-server.yaml
+++ b/.github/workflows/tox-provider-certification-server.yaml
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  tox_test_provider_certification_server:
+    name: Test provider-certification-server with tox
     defaults:
       run:
         working-directory: providers/certification-server

--- a/.github/workflows/tox-provider-docker.yaml
+++ b/.github/workflows/tox-provider-docker.yaml
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  tox_test_provider_docker:
+    name: Test provider-docker with tox
     defaults:
       run:
         working-directory: providers/docker

--- a/.github/workflows/tox-provider-gpgpu.yaml
+++ b/.github/workflows/tox-provider-gpgpu.yaml
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  tox_test_provider_gpgpu:
+    name: Test provider-gpgpu with tox
     defaults:
       run:
         working-directory: providers/gpgpu

--- a/.github/workflows/tox-provider-iiotg.yaml
+++ b/.github/workflows/tox-provider-iiotg.yaml
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  tox_test_provider_iiotg:
+    name: Test Intel IOTG provider with tox
     defaults:
       run:
         working-directory: providers/iiotg

--- a/.github/workflows/tox-provider-resource.yaml
+++ b/.github/workflows/tox-provider-resource.yaml
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  tox_test_provider_resource:
+    name: Test provider-resource with tox
     defaults:
       run:
         working-directory: providers/resource

--- a/.github/workflows/tox-provider-sru.yaml
+++ b/.github/workflows/tox-provider-sru.yaml
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  tox_test_provider_sru:
+    name: Test provider-sru with tox
     defaults:
       run:
         working-directory: providers/sru

--- a/.github/workflows/tox-provider-tpm2.yaml
+++ b/.github/workflows/tox-provider-tpm2.yaml
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  tox_test_provider_tpm2:
+    name: Test provider-tpm2 with tox
     defaults:
       run:
         working-directory: providers/tpm2

--- a/.github/workflows/tox-tools-release.yaml
+++ b/.github/workflows/tox-tools-release.yaml
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  tox_test_release_tools:
+  name: Test release tools with tox
     defaults:
       run:
         working-directory: tools/release

--- a/.github/workflows/validate_workflows.yaml
+++ b/.github/workflows/validate_workflows.yaml
@@ -6,7 +6,8 @@ on:
       - '.github/workflows/*'
 
 jobs:
-  build:
+  workflow_validation:
+  name: Workflow validation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout checkbox monorepo


### PR DESCRIPTION
Most of our tox-related workflows are named "build", without any name given. Because of this, they cannot be searched easily in GitHub settings, and only "build" appears in the automated checks when submitting a PR.

This commit fixes this issue.

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->


<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

This is required as part of the work for https://warthogs.atlassian.net/browse/RTW-251

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->



