### PR TITLE
Strip color code in unity_support_test results (BugFix)

### DIFF
--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -265,7 +265,7 @@ category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_gl_support_{product_slug}
 flags: also-after-suspend
 command:
-  "$CHECKBOX_RUNTIME"/usr/lib/nux/unity_support_test -p 2>&1
+  "$CHECKBOX_RUNTIME"/usr/lib/nux/unity_support_test -p 2>&1 | sed -e "s/\x1b\[[0-9;]*m//g"
 estimated_duration: 0.131
 _description: Check that {vendor} {product} hardware is able to run a desktop session (OpenGL)
 _summary: Test OpenGL support for {vendor} {product}


### PR DESCRIPTION
BugFix: fixed checkbox issue 629, strip the color code from the response of unity_support_test.

## Description
The changes we made simply strip the color code from the response of unity_support_test

## Resolved issues
https://github.com/canonical/checkbox/issues/629


## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

