### PR TITLE
Autoresume checkbox local (New)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
+++ b/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
@@ -56,6 +56,8 @@ class Context:
     def __init__(self, args, sa):
         self.args = args
         self.sa = sa
+    def reset_sa(self):
+        self.sa = SessionAssistant()
 
 
 def main():

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -377,10 +377,9 @@ class Launcher(MainLoopStage, ReportsStage):
         except IncompatibleJobError as ije:
             # last resumable session is incompatible, produce a helpful log
             _logger.error(
-                "Checkbox tried to resume last session ({}), but the "
-                "content of Checkbox Providers has changed.".format(
-                    last_abandoned_session.id
-                )
+                "Checkbox tried to resume last session (%s), but the "
+                "content of Checkbox Providers has changed.",
+                last_abandoned_session.id,
             )
             _logger.error(str(ije))
             if os.getenv("SNAP"):
@@ -389,7 +388,7 @@ class Launcher(MainLoopStage, ReportsStage):
                 )
             else:
                 _logger.error(
-                    "To resume it, downgrade the relevant provider package first"
+                    "To resume it, roll back the relevant provider package first"
                 )
 
             input("\nPress enter to start Checkbox.")
@@ -497,18 +496,12 @@ class Launcher(MainLoopStage, ReportsStage):
                 return False
 
     def _resume_session_via_resume_params(self, resume_params):
-        if resume_params.action == "pass":
-            outcome = IJobResult.OUTCOME_PASS
-        elif resume_params.action == "fail":
-            outcome = IJobResult.OUTCOME_FAIL
-        elif resume_params.action == "skip":
-            outcome = IJobResult.OUTCOME_SKIP
-        elif resume_params.action == "rerun":
-            outcome = IJobResult.OUTCOME_UNDECIDED
-        else:
-            raise ValueError(
-                "Unknonw resume_param action {}".format(resume_params.action)
-            )
+        outcome = {
+            "pass": IJobResult.OUTCOME_PASS,
+            "fail": IJobResult.OUTCOME_FAIL,
+            "skip": IJobResult.OUTCOME_SKIP,
+            "rerun": IJobResult.OUTCOME_UNDECIDED,
+        }[resume_params.action]
         return self._resume_session(
             resume_params.session_id, outcome, resume_params.comments
         )

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -387,7 +387,9 @@ class Launcher(MainLoopStage, ReportsStage):
             )
             _logger.error(str(ije))
             if os.getenv("SNAP"):
-                _logger.error("To resume it revert the latest Checkbox snap refresh")
+                _logger.error(
+                    "To resume it revert the latest Checkbox snap refresh"
+                )
             else:
                 _logger.error(
                     "To resume it, downgrade the relevant provider package first"

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -260,10 +260,8 @@ class Launcher(MainLoopStage, ReportsStage):
                         something_got_chosen = True
                     except ResumeInstead:
                         self.sa.finalize_session()
-                        something_got_chosen = (
-                            self._manually_resume_session(
-                                self.resume_candidates
-                            )
+                        something_got_chosen = self._manually_resume_session(
+                            self.resume_candidates
                         )
 
             if not self.ctx.sa.get_static_todo_list():
@@ -342,7 +340,6 @@ class Launcher(MainLoopStage, ReportsStage):
             lambda session_id: [join_cmd(respawn_cmd + [session_id])]
         )
 
-
     @contextlib.contextmanager
     def _resumed_session(self, session_id):
         """
@@ -397,7 +394,6 @@ class Launcher(MainLoopStage, ReportsStage):
 
             input("\nPress enter to start Checkbox.")
             return False
-
 
     def _auto_resume_session(self, resume_candidates):
         """
@@ -517,7 +513,6 @@ class Launcher(MainLoopStage, ReportsStage):
             resume_params.session_id, outcome, resume_params.comments
         )
 
-
     def _get_autoresume_outcome_last_job(self, metadata):
         """
         Calculates the result of the latest running job given its flags. This
@@ -531,7 +526,9 @@ class Launcher(MainLoopStage, ReportsStage):
             return IJobResult.OUTCOME_PASS
         return IJobResult.OUTCOME_CRASH
 
-    def _resume_session(self, session_id: str, outcome: 'IJobResult|None', comments=[]):
+    def _resume_session(
+        self, session_id: str, outcome: "IJobResult|None", comments=[]
+    ):
         """
         Resumes the session with the given session_id assigning to the latest
         running job the given outcome. If outcome is not provided it will be
@@ -1318,7 +1315,8 @@ class ListBootstrapped:
             attrs["full_id"] = job_unit.id
             attrs["id"] = job_unit.partial_id
             attrs["certification_status"] = self.ctx.sa.get_job_state(
-                                      job).effective_certification_status
+                job
+            ).effective_certification_status
             jobs.append(attrs)
         if ctx.args.format == "?":
             all_keys = set()

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -382,14 +382,12 @@ class Launcher(MainLoopStage, ReportsStage):
                 last_abandoned_session.id,
             )
             _logger.error(str(ije))
-            if os.getenv("SNAP"):
-                _logger.error(
-                    "To resume it revert the latest Checkbox snap refresh"
-                )
-            else:
-                _logger.error(
-                    "To resume it, roll back the relevant provider package first"
-                )
+            _logger.error(
+                "To resume it either revert the latest Checkbox snap refresh"
+            )
+            _logger.error(
+                "or roll back the relevant provider debian package first"
+            )
 
             input("\nPress enter to start Checkbox.")
             return False
@@ -413,18 +411,14 @@ class Launcher(MainLoopStage, ReportsStage):
             if requested_sessions:
                 # session_ids are unique, so there should be only 1
                 self._resume_session(
-                    requested_sessions[0].id, IJobResult.OUTCOME_UNDECIDED, []
+                    requested_sessions[0].id, IJobResult.OUTCOME_UNDECIDED
                 )
                 return True
             else:
                 raise RuntimeError("Requested session is not resumable!")
         elif self._should_autoresume_last_run(resume_candidates):
             last_session = resume_candidates[0]
-            self._resume_session(
-                last_session.id,
-                None,
-                [],
-            )
+            self._resume_session(last_session.id, None)
             return True
         return False
 

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -18,6 +18,7 @@
 
 import datetime
 
+from functools import partial
 from unittest import TestCase
 
 from unittest.mock import patch, Mock, MagicMock
@@ -102,7 +103,7 @@ class TestLauncher(TestCase):
         # the user has selected something from the list, we notice
         self.assertTrue(Launcher._manually_resume_session(self_mock, []))
         # and we try to resume the session
-        self.assertTrue(self_mock._resume_session.called)
+        self.assertTrue(self_mock._resume_session_via_resume_params.called)
 
 
     @patch("checkbox_ng.launcher.subcommands.ResumeMenu")
@@ -117,13 +118,14 @@ class TestLauncher(TestCase):
     @patch("checkbox_ng.launcher.subcommands.newline_join", new=MagicMock())
     def test__resume_session_pass(self, memory_job_result_mock):
         self_mock = MagicMock()
+        self_mock._resume_session = partial(Launcher._resume_session, self_mock)
         session_metadata_mock = self_mock.ctx.sa.resume_session.return_value
         session_metadata_mock.flags = ["testplanless"]
 
         resume_params_mock = MagicMock()
         resume_params_mock.action = "pass"
 
-        Launcher._resume_session(self_mock, resume_params_mock)
+        Launcher._resume_session_via_resume_params(self_mock, resume_params_mock)
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
@@ -136,6 +138,7 @@ class TestLauncher(TestCase):
         self, request_comment_mock, memory_job_result_mock
     ):
         self_mock = MagicMock()
+        self_mock._resume_session = partial(Launcher._resume_session, self_mock)
         self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
             "blocker"
         )
@@ -147,7 +150,7 @@ class TestLauncher(TestCase):
         resume_params_mock.action = "fail"
         resume_params_mock.comments = None
 
-        Launcher._resume_session(self_mock, resume_params_mock)
+        Launcher._resume_session_via_resume_params(self_mock, resume_params_mock)
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
@@ -159,6 +162,7 @@ class TestLauncher(TestCase):
     @patch("checkbox_ng.launcher.subcommands.newline_join", new=MagicMock())
     def test__resume_session_fail_non_blocker(self, memory_job_result_mock):
         self_mock = MagicMock()
+        self_mock._resume_session = partial(Launcher._resume_session, self_mock)
         self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
             "non-blocker"
         )
@@ -169,7 +173,7 @@ class TestLauncher(TestCase):
         resume_params_mock = MagicMock()
         resume_params_mock.action = "fail"
 
-        Launcher._resume_session(self_mock, resume_params_mock)
+        Launcher._resume_session_via_resume_params(self_mock, resume_params_mock)
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
@@ -182,6 +186,7 @@ class TestLauncher(TestCase):
         self, request_comment_mock, memory_job_result_mock
     ):
         self_mock = MagicMock()
+        self_mock._resume_session = partial(Launcher._resume_session, self_mock)
         self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
             "blocker"
         )
@@ -193,7 +198,7 @@ class TestLauncher(TestCase):
         resume_params_mock.action = "skip"
         resume_params_mock.comments = None
 
-        Launcher._resume_session(self_mock, resume_params_mock)
+        Launcher._resume_session_via_resume_params(self_mock, resume_params_mock)
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
@@ -205,6 +210,7 @@ class TestLauncher(TestCase):
     @patch("checkbox_ng.launcher.subcommands.newline_join", new=MagicMock())
     def test__resume_session_skip_non_blocker(self, memory_job_result_mock):
         self_mock = MagicMock()
+        self_mock._resume_session = partial(Launcher._resume_session, self_mock)
         self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
             "non-blocker"
         )
@@ -215,7 +221,7 @@ class TestLauncher(TestCase):
         resume_params_mock = MagicMock()
         resume_params_mock.action = "skip"
 
-        Launcher._resume_session(self_mock, resume_params_mock)
+        Launcher._resume_session_via_resume_params(self_mock, resume_params_mock)
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
@@ -225,6 +231,7 @@ class TestLauncher(TestCase):
     @patch("checkbox_ng.launcher.subcommands.newline_join", new=MagicMock())
     def test__resume_session_rerun(self, memory_job_result_mock):
         self_mock = MagicMock()
+        self_mock._resume_session = partial(Launcher._resume_session, self_mock)
         self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
             "non-blocker"
         )
@@ -235,7 +242,7 @@ class TestLauncher(TestCase):
         resume_params_mock = MagicMock()
         resume_params_mock.action = "rerun"
 
-        Launcher._resume_session(self_mock, resume_params_mock)
+        Launcher._resume_session_via_resume_params(self_mock, resume_params_mock)
 
         # we don't use job result of rerun jobs
         self.assertFalse(self_mock.ctx.sa.use_job_result.called)
@@ -265,7 +272,7 @@ class TestLauncherReturnCodes(TestCase):
         self.launcher = Launcher()
         self.launcher._maybe_rerun_jobs = Mock(return_value=False)
         self.launcher._auto_resume_session = Mock(return_value=False)
-        self.launcher._resume_session = Mock(return_value=False)
+        self.launcher._resume_session_via_resume_params = Mock(return_value=False)
         self.launcher._start_new_session = Mock()
         self.launcher._pick_jobs_to_run = Mock()
         self.launcher._export_results = Mock()

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -92,9 +92,7 @@ class TestLauncher(TestCase):
 
         # delete something, the check should see that the entries list is
         # empty and return false as there is nothing to maybe resume
-        self.assertFalse(
-            Launcher._manually_resume_session(self_mock, [])
-        )
+        self.assertFalse(Launcher._manually_resume_session(self_mock, []))
 
     @patch("checkbox_ng.launcher.subcommands.ResumeMenu")
     def test__manually_resume_session(self, resume_menu_mock):
@@ -106,7 +104,6 @@ class TestLauncher(TestCase):
         # and we try to resume the session
         self.assertTrue(self_mock._resume_session_via_resume_params.called)
 
-
     @patch("checkbox_ng.launcher.subcommands.ResumeMenu")
     def test__manually_resume_session_empty_id(self, resume_menu_mock):
         self_mock = MagicMock()
@@ -114,19 +111,22 @@ class TestLauncher(TestCase):
 
         self.assertFalse(Launcher._manually_resume_session(self_mock, []))
 
-
     @patch("checkbox_ng.launcher.subcommands.MemoryJobResult")
     @patch("checkbox_ng.launcher.subcommands.newline_join", new=MagicMock())
     def test__resume_session_pass(self, memory_job_result_mock):
         self_mock = MagicMock()
-        self_mock._resume_session = partial(Launcher._resume_session, self_mock)
+        self_mock._resume_session = partial(
+            Launcher._resume_session, self_mock
+        )
         session_metadata_mock = self_mock.ctx.sa.resume_session.return_value
         session_metadata_mock.flags = ["testplanless"]
 
         resume_params_mock = MagicMock()
         resume_params_mock.action = "pass"
 
-        Launcher._resume_session_via_resume_params(self_mock, resume_params_mock)
+        Launcher._resume_session_via_resume_params(
+            self_mock, resume_params_mock
+        )
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
@@ -139,7 +139,9 @@ class TestLauncher(TestCase):
         self, request_comment_mock, memory_job_result_mock
     ):
         self_mock = MagicMock()
-        self_mock._resume_session = partial(Launcher._resume_session, self_mock)
+        self_mock._resume_session = partial(
+            Launcher._resume_session, self_mock
+        )
         self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
             "blocker"
         )
@@ -151,7 +153,9 @@ class TestLauncher(TestCase):
         resume_params_mock.action = "fail"
         resume_params_mock.comments = None
 
-        Launcher._resume_session_via_resume_params(self_mock, resume_params_mock)
+        Launcher._resume_session_via_resume_params(
+            self_mock, resume_params_mock
+        )
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
@@ -163,7 +167,9 @@ class TestLauncher(TestCase):
     @patch("checkbox_ng.launcher.subcommands.newline_join", new=MagicMock())
     def test__resume_session_fail_non_blocker(self, memory_job_result_mock):
         self_mock = MagicMock()
-        self_mock._resume_session = partial(Launcher._resume_session, self_mock)
+        self_mock._resume_session = partial(
+            Launcher._resume_session, self_mock
+        )
         self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
             "non-blocker"
         )
@@ -174,7 +180,9 @@ class TestLauncher(TestCase):
         resume_params_mock = MagicMock()
         resume_params_mock.action = "fail"
 
-        Launcher._resume_session_via_resume_params(self_mock, resume_params_mock)
+        Launcher._resume_session_via_resume_params(
+            self_mock, resume_params_mock
+        )
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
@@ -194,7 +202,9 @@ class TestLauncher(TestCase):
         session_metadata_mock = self_mock.ctx.sa.resume_session.return_value
         session_metadata_mock.flags = ["testplanless"]
 
-        Launcher._resume_session(self_mock, "session_id", IJobResult.OUTCOME_CRASH, None)
+        Launcher._resume_session(
+            self_mock, "session_id", IJobResult.OUTCOME_CRASH, None
+        )
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
@@ -213,7 +223,9 @@ class TestLauncher(TestCase):
         session_metadata_mock = self_mock.ctx.sa.resume_session.return_value
         session_metadata_mock.flags = ["testplanless"]
 
-        Launcher._resume_session(self_mock, "session_id", IJobResult.OUTCOME_CRASH, None)
+        Launcher._resume_session(
+            self_mock, "session_id", IJobResult.OUTCOME_CRASH, None
+        )
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
@@ -226,7 +238,9 @@ class TestLauncher(TestCase):
         self, request_comment_mock, memory_job_result_mock
     ):
         self_mock = MagicMock()
-        self_mock._resume_session = partial(Launcher._resume_session, self_mock)
+        self_mock._resume_session = partial(
+            Launcher._resume_session, self_mock
+        )
         self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
             "blocker"
         )
@@ -238,7 +252,9 @@ class TestLauncher(TestCase):
         resume_params_mock.action = "skip"
         resume_params_mock.comments = None
 
-        Launcher._resume_session_via_resume_params(self_mock, resume_params_mock)
+        Launcher._resume_session_via_resume_params(
+            self_mock, resume_params_mock
+        )
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
@@ -250,7 +266,9 @@ class TestLauncher(TestCase):
     @patch("checkbox_ng.launcher.subcommands.newline_join", new=MagicMock())
     def test__resume_session_skip_non_blocker(self, memory_job_result_mock):
         self_mock = MagicMock()
-        self_mock._resume_session = partial(Launcher._resume_session, self_mock)
+        self_mock._resume_session = partial(
+            Launcher._resume_session, self_mock
+        )
         self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
             "non-blocker"
         )
@@ -261,7 +279,9 @@ class TestLauncher(TestCase):
         resume_params_mock = MagicMock()
         resume_params_mock.action = "skip"
 
-        Launcher._resume_session_via_resume_params(self_mock, resume_params_mock)
+        Launcher._resume_session_via_resume_params(
+            self_mock, resume_params_mock
+        )
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
@@ -271,7 +291,9 @@ class TestLauncher(TestCase):
     @patch("checkbox_ng.launcher.subcommands.newline_join", new=MagicMock())
     def test__resume_session_rerun(self, memory_job_result_mock):
         self_mock = MagicMock()
-        self_mock._resume_session = partial(Launcher._resume_session, self_mock)
+        self_mock._resume_session = partial(
+            Launcher._resume_session, self_mock
+        )
         self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
             "non-blocker"
         )
@@ -282,19 +304,25 @@ class TestLauncher(TestCase):
         resume_params_mock = MagicMock()
         resume_params_mock.action = "rerun"
 
-        Launcher._resume_session_via_resume_params(self_mock, resume_params_mock)
+        Launcher._resume_session_via_resume_params(
+            self_mock, resume_params_mock
+        )
 
         # we don't use job result of rerun jobs
         self.assertFalse(self_mock.ctx.sa.use_job_result.called)
 
     @patch("checkbox_ng.launcher.subcommands.MemoryJobResult")
     @patch("checkbox_ng.launcher.subcommands.newline_join", new=MagicMock())
-    def test__resume_session_autocalculate_outcome(self, memory_job_result_mock):
+    def test__resume_session_autocalculate_outcome(
+        self, memory_job_result_mock
+    ):
         self_mock = MagicMock()
         self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
             "non-blocker"
         )
-        self_mock._get_autoresume_outcome_last_job.return_value = IJobResult.OUTCOME_CRASH
+        self_mock._get_autoresume_outcome_last_job.return_value = (
+            IJobResult.OUTCOME_CRASH
+        )
 
         session_metadata_mock = self_mock.ctx.sa.resume_session.return_value
         session_metadata_mock.flags = []
@@ -313,7 +341,9 @@ class TestLauncher(TestCase):
         metadata_mock = MagicMock()
         metadata_mock.running_job_name = "running_metadata_job_name"
 
-        outcome = Launcher._get_autoresume_outcome_last_job(self_mock, metadata_mock)
+        outcome = Launcher._get_autoresume_outcome_last_job(
+            self_mock, metadata_mock
+        )
 
         self.assertEqual(outcome, IJobResult.OUTCOME_PASS)
 
@@ -324,7 +354,9 @@ class TestLauncher(TestCase):
         metadata_mock = MagicMock()
         metadata_mock.running_job_name = "running_metadata_job_name"
 
-        outcome = Launcher._get_autoresume_outcome_last_job(self_mock, metadata_mock)
+        outcome = Launcher._get_autoresume_outcome_last_job(
+            self_mock, metadata_mock
+        )
 
         self.assertEqual(outcome, IJobResult.OUTCOME_CRASH)
 
@@ -345,18 +377,19 @@ class TestLauncher(TestCase):
     @patch("checkbox_ng.launcher.subcommands.input")
     @patch("checkbox_ng.launcher.subcommands._logger")
     def test__should_autoresume_last_run_incompatible_session_snaps(
-        self,
-        _logger_mock,
-        input_mock,
-        os_getenv_mock
+        self, _logger_mock, input_mock, os_getenv_mock
     ):
         self_mock = MagicMock()
-        self_mock._resumed_session = partial(Launcher._resumed_session, self_mock)
+        self_mock._resumed_session = partial(
+            Launcher._resumed_session, self_mock
+        )
         session_mock = MagicMock(id="session_id")
 
         self_mock.sa.resume_session.side_effect = IncompatibleJobError
 
-        self.assertFalse(Launcher._should_autoresume_last_run(self_mock, [session_mock]))
+        self.assertFalse(
+            Launcher._should_autoresume_last_run(self_mock, [session_mock])
+        )
         # very important here that we print errors and stop because else the
         # user is left wondering why the session didn't autoresume
         self.assertTrue(_logger_mock.error.called)
@@ -369,18 +402,19 @@ class TestLauncher(TestCase):
     @patch("checkbox_ng.launcher.subcommands.input")
     @patch("checkbox_ng.launcher.subcommands._logger")
     def test__should_autoresume_last_run_incompatible_session_debs(
-        self,
-        _logger_mock,
-        input_mock,
-        os_getenv_mock
+        self, _logger_mock, input_mock, os_getenv_mock
     ):
         self_mock = MagicMock()
-        self_mock._resumed_session = partial(Launcher._resumed_session, self_mock)
+        self_mock._resumed_session = partial(
+            Launcher._resumed_session, self_mock
+        )
         session_mock = MagicMock(id="session_id")
 
         self_mock.sa.resume_session.side_effect = IncompatibleJobError
 
-        self.assertFalse(Launcher._should_autoresume_last_run(self_mock, [session_mock]))
+        self.assertFalse(
+            Launcher._should_autoresume_last_run(self_mock, [session_mock])
+        )
         # very important here that we print errors and stop because else the
         # user is left wondering why the session didn't autoresume
         self.assertTrue(_logger_mock.error.called)
@@ -391,52 +425,67 @@ class TestLauncher(TestCase):
 
     def test__should_autoresume_last_run_no_testplan(self):
         self_mock = MagicMock()
-        self_mock._resumed_session = partial(Launcher._resumed_session, self_mock)
+        self_mock._resumed_session = partial(
+            Launcher._resumed_session, self_mock
+        )
         session_mock = MagicMock(id="session_id")
-        metadata_mock = MagicMock(app_blob=b'{}')
+        metadata_mock = MagicMock(app_blob=b"{}")
         self_mock.sa.resume_session.return_value = metadata_mock
 
-        self.assertFalse(Launcher._should_autoresume_last_run(self_mock, [session_mock]))
+        self.assertFalse(
+            Launcher._should_autoresume_last_run(self_mock, [session_mock])
+        )
 
     def test__should_autoresume_last_run_no_running_job_name(self):
         self_mock = MagicMock()
-        self_mock._resumed_session = partial(Launcher._resumed_session, self_mock)
+        self_mock._resumed_session = partial(
+            Launcher._resumed_session, self_mock
+        )
         session_mock = MagicMock(id="session_id")
         metadata_mock = MagicMock(
-            app_blob=b'{"testplan_id" : "testplan_id"}',
-            running_job_name=None
+            app_blob=b'{"testplan_id" : "testplan_id"}', running_job_name=None
         )
         self_mock.sa.resume_session.return_value = metadata_mock
 
-        self.assertFalse(Launcher._should_autoresume_last_run(self_mock, [session_mock]))
+        self.assertFalse(
+            Launcher._should_autoresume_last_run(self_mock, [session_mock])
+        )
 
     def test__should_autoresume_last_run_manual_job(self):
         self_mock = MagicMock()
-        self_mock._resumed_session = partial(Launcher._resumed_session, self_mock)
+        self_mock._resumed_session = partial(
+            Launcher._resumed_session, self_mock
+        )
         session_mock = MagicMock(id="session_id")
         metadata_mock = MagicMock(
             app_blob=b'{"testplan_id" : "testplan_id"}',
-            running_job_name="running_job_name"
+            running_job_name="running_job_name",
         )
         self_mock.sa.resume_session.return_value = metadata_mock
         job_state_mock = self_mock.sa.get_job_state()
         job_state_mock.job.plugin = "user-interact"
 
-        self.assertFalse(Launcher._should_autoresume_last_run(self_mock, [session_mock]))
+        self.assertFalse(
+            Launcher._should_autoresume_last_run(self_mock, [session_mock])
+        )
 
     def test__should_autoresume_last_run_yes(self):
         self_mock = MagicMock()
-        self_mock._resumed_session = partial(Launcher._resumed_session, self_mock)
+        self_mock._resumed_session = partial(
+            Launcher._resumed_session, self_mock
+        )
         session_mock = MagicMock(id="session_id")
         metadata_mock = MagicMock(
             app_blob=b'{"testplan_id" : "testplan_id"}',
-            running_job_name="running_job_name"
+            running_job_name="running_job_name",
         )
         self_mock.sa.resume_session.return_value = metadata_mock
         job_state_mock = self_mock.sa.get_job_state()
         job_state_mock.job.plugin = "shell"
 
-        self.assertTrue(Launcher._should_autoresume_last_run(self_mock, [session_mock]))
+        self.assertTrue(
+            Launcher._should_autoresume_last_run(self_mock, [session_mock])
+        )
 
     def test__auto_resume_session_from_ctx(self):
         self_mock = MagicMock()
@@ -455,7 +504,9 @@ class TestLauncher(TestCase):
 
         with self.assertRaises(RuntimeError):
             self.assertTrue(
-                Launcher._auto_resume_session(self_mock, [resume_candidate_mock])
+                Launcher._auto_resume_session(
+                    self_mock, [resume_candidate_mock]
+                )
             )
 
     def test__auto_resume_session_autoresume(self):
@@ -505,7 +556,9 @@ class TestLauncherReturnCodes(TestCase):
         self.launcher = Launcher()
         self.launcher._maybe_rerun_jobs = Mock(return_value=False)
         self.launcher._auto_resume_session = Mock(return_value=False)
-        self.launcher._resume_session_via_resume_params = Mock(return_value=False)
+        self.launcher._resume_session_via_resume_params = Mock(
+            return_value=False
+        )
         self.launcher._start_new_session = Mock()
         self.launcher._pick_jobs_to_run = Mock()
         self.launcher._export_results = Mock()
@@ -541,6 +594,7 @@ class TestLauncherReturnCodes(TestCase):
         self.ctx.sa.get_summary = Mock(return_value=mock_results)
         self.assertEqual(self.launcher.invoked(self.ctx), 1)
 
+
 class TestLListBootstrapped(TestCase):
     def setUp(self):
         self.launcher = ListBootstrapped()
@@ -548,12 +602,10 @@ class TestLListBootstrapped(TestCase):
         self.ctx.args = Mock(TEST_PLAN="", format="")
         self.ctx.sa = Mock(
             start_new_session=Mock(),
-            get_test_plans=Mock(
-                return_value=["test-plan1", "test-plan2"]),
+            get_test_plans=Mock(return_value=["test-plan1", "test-plan2"]),
             select_test_plan=Mock(),
             bootstrap=Mock(),
-            get_static_todo_list=Mock(
-                return_value=["test-job1", "test-job2"]),
+            get_static_todo_list=Mock(return_value=["test-job1", "test-job2"]),
             get_job=Mock(
                 side_effect=[
                     Mock(
@@ -562,10 +614,10 @@ class TestLListBootstrapped(TestCase):
                             "summary": "fake-job1",
                             "plugin": "manual",
                             "description": "fake-description1",
-                            "certification_status": "unspecified"
+                            "certification_status": "unspecified",
                         },
                         id="namespace1::test-job1",
-                        partial_id="test-job1"
+                        partial_id="test-job1",
                     ),
                     Mock(
                         _raw_data={
@@ -573,15 +625,16 @@ class TestLListBootstrapped(TestCase):
                             "summary": "fake-job2",
                             "plugin": "shell",
                             "command": "ls",
-                            "certification_status": "unspecified"
+                            "certification_status": "unspecified",
                         },
                         id="namespace2::test-job2",
-                        partial_id="test-job2"
+                        partial_id="test-job2",
                     ),
                 ]
             ),
             get_job_state=Mock(
-                return_value=Mock(effective_certification_status="blocker")),
+                return_value=Mock(effective_certification_status="blocker")
+            ),
             get_resumable_sessions=Mock(return_value=[]),
             get_dynamic_todo_list=Mock(return_value=[]),
         )
@@ -609,10 +662,7 @@ class TestLListBootstrapped(TestCase):
         self.ctx.args.TEST_PLAN = "test-plan1"
         self.ctx.args.format = "{full_id}\n"
 
-        expected_out = (
-            "namespace1::test-job1\n"
-            "namespace2::test-job2\n"
-        )
+        expected_out = "namespace1::test-job1\n" "namespace2::test-job2\n"
         self.launcher.invoked(self.ctx)
         self.assertEqual(stdout.getvalue(), expected_out)
 
@@ -636,6 +686,7 @@ class TestLListBootstrapped(TestCase):
         )
         self.launcher.invoked(self.ctx)
         self.assertEqual(stdout.getvalue(), expected_out)
+
 
 class TestUtilsFunctions(TestCase):
     @patch("checkbox_ng.launcher.subcommands.Colorizer", new=MagicMock())

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -394,9 +394,6 @@ class TestLauncher(TestCase):
         # user is left wondering why the session didn't autoresume
         self.assertTrue(_logger_mock.error.called)
         self.assertTrue(input_mock.called)
-        # also lets make sure that the message is clear on a possible fix for
-        # snaps or debs specifically
-        self.assertTrue(os_getenv_mock.called)
 
     @patch("os.getenv", return_value=None)
     @patch("checkbox_ng.launcher.subcommands.input")
@@ -419,9 +416,6 @@ class TestLauncher(TestCase):
         # user is left wondering why the session didn't autoresume
         self.assertTrue(_logger_mock.error.called)
         self.assertTrue(input_mock.called)
-        # also lets make sure that the message is clear on a possible fix for
-        # snaps or debs specifically
-        self.assertTrue(os_getenv_mock.called)
 
     def test__should_autoresume_last_run_no_testplan(self):
         self_mock = MagicMock()

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -438,6 +438,48 @@ class TestLauncher(TestCase):
 
         self.assertTrue(Launcher._should_autoresume_last_run(self_mock, [session_mock]))
 
+    def test__auto_resume_session_from_ctx(self):
+        self_mock = MagicMock()
+        resume_candidate_mock = MagicMock(id="session_to_resume")
+        self_mock.ctx.args.session_id = "session_to_resume"
+
+        self.assertTrue(
+            Launcher._auto_resume_session(self_mock, [resume_candidate_mock])
+        )
+        self.assertTrue(self_mock._resume_session.called)
+
+    def test__auto_resume_session_from_ctx_unknown_session(self):
+        self_mock = MagicMock()
+        resume_candidate_mock = MagicMock(id="some_other_session")
+        self_mock.ctx.args.session_id = "session_to_resume"
+
+        with self.assertRaises(RuntimeError):
+            self.assertTrue(
+                Launcher._auto_resume_session(self_mock, [resume_candidate_mock])
+            )
+
+    def test__auto_resume_session_autoresume(self):
+        self_mock = MagicMock()
+        resume_candidate_mock = MagicMock(id="session_to_resume")
+        self_mock.ctx.args.session_id = None
+        self_mock._should_autoresume_last_run.return_value = True
+
+        self.assertTrue(
+            Launcher._auto_resume_session(self_mock, [resume_candidate_mock])
+        )
+        self.assertTrue(self_mock._resume_session.called)
+
+    def test__auto_resume_session_no_autoresume(self):
+        self_mock = MagicMock()
+        resume_candidate_mock = MagicMock(id="session_to_resume")
+        self_mock.ctx.args.session_id = None
+        self_mock._should_autoresume_last_run.return_value = False
+
+        self.assertFalse(
+            Launcher._auto_resume_session(self_mock, [resume_candidate_mock])
+        )
+        self.assertFalse(self_mock._resume_session.called)
+
     @patch("checkbox_ng.launcher.subcommands.load_configs")
     @patch("checkbox_ng.launcher.subcommands.Colorizer", new=MagicMock())
     def test_invoked_resume(self, load_config_mock):

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -64,6 +64,7 @@ from plainbox.impl.session.manager import SessionManager
 from plainbox.impl.session.restart import IRestartStrategy
 from plainbox.impl.session.restart import detect_restart_strategy
 from plainbox.impl.session.restart import RemoteDebRestartStrategy
+from plainbox.impl.session.resume import IncompatibleJobError
 from plainbox.impl.session.storage import WellKnownDirsHelper
 from plainbox.impl.transport import OAuthTransport
 from plainbox.impl.transport import TransportError
@@ -526,7 +527,7 @@ class SessionAssistant:
             ),
         }
 
-    @raises(KeyError, UnexpectedMethodCall)
+    @raises(KeyError, UnexpectedMethodCall, IncompatibleJobError)
     def resume_session(
         self, session_id: str, runner_cls=UnifiedRunner, runner_kwargs=dict()
     ) -> "SessionMetaData":
@@ -539,6 +540,8 @@ class SessionAssistant:
             Resumed session metadata.
         :raises KeyError:
             If the session with a given session_id cannot be found.
+        :raises IncompatibleJobError:
+            If the session is incompatible due to a job changing
         :raises UnexpectedMethodCall:
             If the call is made at an unexpected time. Do not catch this error.
             It is a bug in your program. The error message will indicate what
@@ -558,7 +561,7 @@ class SessionAssistant:
                 if resume_candidate.id == session_id:
                     break
             else:
-                raise ValueError("Unknown session {}".format(session_id))
+                raise KeyError("Unknown session {}".format(session_id))
 
         self._manager = SessionManager.load_session(
             all_units, self._resume_candidates[session_id][0]

--- a/checkbox-ng/plainbox/impl/session/test_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_assistant.py
@@ -158,3 +158,38 @@ class SessionAssistantTests(morris.SignalTestCase):
         )
 
         self.assertTrue(self_mock._manager.checkpoint.called)
+
+    @mock.patch("plainbox.impl.session.assistant.UsageExpectation")
+    def test_resume_session_autoload_session_not_found(
+        self, ue_mock, get_providers_mock
+    ):
+        self_mock = mock.MagicMock()
+        self_mock._resume_candidates = {}
+        self_mock.get_resumable_sessions.return_value = []
+
+        with self.assertRaises(KeyError):
+            SessionAssistant.resume_session(self_mock, "session_id")
+
+    @mock.patch("plainbox.impl.session.assistant.SessionManager")
+    @mock.patch("plainbox.impl.session.assistant.JobRunnerUIDelegate")
+    @mock.patch("plainbox.impl.session.assistant._SilentUI")
+    @mock.patch("plainbox.impl.session.assistant.detect_restart_strategy")
+    @mock.patch("plainbox.impl.session.assistant.UsageExpectation")
+    def test_resume_session_autoload_session_found(
+        self,
+        ue_mock,
+        session_manager_mock,
+        jrd_mock,
+        _sui_mock,
+        detect_restart_strategy_mock,
+        get_providers_mock,
+    ):
+        self_mock = mock.MagicMock()
+        session_mock = mock.MagicMock(id="session_id")
+
+        def get_resumable_sessions():
+            self_mock._resume_candidates = {"session_id": session_mock}
+
+        self_mock.get_resumable_sessions.return_value = [session_mock]
+
+        _ = SessionAssistant.resume_session(self_mock, "session_id")

--- a/metabox/metabox/metabox-provider/units/resume.pxu
+++ b/metabox/metabox/metabox-provider/units/resume.pxu
@@ -3,7 +3,7 @@ _summary: Crash Checkbox
 flags: simple
 user: root
 command:
- PID=`ps -o ppid= $$`
+ PID=`pgrep -f checkbox-cli`
  kill $PID
 
 id: reboot-emulator
@@ -11,7 +11,7 @@ _summary: Emulate the reboot
 flags: simple noreturn
 user: root
 command:
- PID=`ps -o ppid= $$`
+ PID=`pgrep -f checkbox-cli`
  kill $PID
 
 unit: test plan

--- a/metabox/metabox/scenarios/restart/agent_respawn.py
+++ b/metabox/metabox/scenarios/restart/agent_respawn.py
@@ -22,13 +22,14 @@ from metabox.core.actions import (
     SelectTestPlan,
     Send,
     Expect,
+    Start
 )
 from metabox.core.scenario import Scenario
 from metabox.core.utils import tag
 
 
 @tag("resume", "automatic")
-class ResumeAfterCrashAuto(Scenario):
+class AutoResumeAfterCrashAuto(Scenario):
     modes = ["remote"]
     launcher = textwrap.dedent(
         """
@@ -71,4 +72,33 @@ class ResumeAfterCrashManual(Scenario):
         Expect("Crash Checkbox"),
         Expect("job passed"),
         Expect("Emulate the reboot"),
+    ]
+
+
+@tag("resume", "automatic")
+class AutoResumeAfterCrashAutoLocal(Scenario):
+    modes = ["local"]
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::checkbox-crash-then-reboot
+        forced = yes
+        [test selection]
+        forced = yes
+        [ui]
+        type = silent
+        """
+    )
+    steps = [
+        Start(),
+        Start(),
+        Start(),
+        AssertRetCode(1),
+        AssertPrinted("job crashed"),
+        AssertPrinted("Crash Checkbox"),
+        AssertPrinted("job passed"),
+        AssertPrinted("Emulate the reboot"),
     ]


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Checkbox local used to resume the latest available session. We have since removed this behaviour as it was hacky and unmaintainable (restart strategy). This reintroduces the feature as requested using resumable_sessions as remote does. 

## Resolved issues

N/A

## Documentation

N./A

## Tests

This introduces a new metabox test to check the new behaviour.

