### PR TITLE
[checkbox-ce-oem] add iio sensors test (New)

### DIFF
--- a/contrib/checkbox-provider-ce-oem/bin/iio_sensor_test.py
+++ b/contrib/checkbox-provider-ce-oem/bin/iio_sensor_test.py
@@ -219,4 +219,3 @@ if __name__ == "__main__":
     args = register_arguments()
 
     args.test_func(args)
-

--- a/contrib/checkbox-provider-ce-oem/bin/iio_sensor_test.py
+++ b/contrib/checkbox-provider-ce-oem/bin/iio_sensor_test.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+import logging
+import argparse
+from pathlib import Path
+
+
+IIO_PATH = "/sys/bus/iio/devices/iio:device"
+
+
+def _check_root_node(path):
+
+    iio_node = Path(path)
+    if not iio_node.exists():
+        raise FileNotFoundError("{} file not exists".format(str(iio_node)))
+
+    return iio_node
+
+
+def check_pressure_sensor(index):
+
+    iio_node = _check_root_node(IIO_PATH + index)
+    sub_nodes = [
+        "in_pressure_input",
+        "in_pressure_oversampling_ratio",
+        "in_pressure_sampling_frequency"
+    ]
+    for sub_node in sub_nodes:
+        tmp_node = iio_node.joinpath(sub_node)
+        if tmp_node.exists():
+            value = tmp_node.read_text().strip("\n")
+            print("the value of {} node is {}".format(str(tmp_node), value))
+
+            try:
+                float(value)
+            except ValueError:
+                print("The accelerometer sensor test failed")
+                raise ValueError("The accelerometer value is not valid")
+        else:
+            print("The pressure sensor test failed")
+            raise FileNotFoundError(
+                    "{} file not exists".format(str(tmp_node)))
+
+
+def check_accelerometer_sensor(index):
+
+    iio_node = _check_root_node(IIO_PATH + index)
+    sub_nodes = [
+        "in_accel_sampling_frequency",
+        "in_accel_scale",
+        "in_accel_x_calibbias",
+        "in_accel_x_raw",
+        "in_accel_y_calibbias",
+        "in_accel_y_raw",
+        "in_accel_z_calibbias",
+        "in_accel_z_raw"
+    ]
+    for sub_node in sub_nodes:
+        tmp_node = iio_node.joinpath(sub_node)
+        if tmp_node.exists():
+            value = tmp_node.read_text().strip("\n")
+            print("the value of {} node is {}".format(str(tmp_node), value))
+
+            try:
+                float(value)
+            except ValueError:
+                print("The accelerometer sensor test failed")
+                raise ValueError("The accelerometer value is not valid")
+        else:
+            print("The accelerometer sensor test failed")
+            raise FileNotFoundError(
+                    "{} file not exists".format(str(tmp_node)))
+
+
+def check_humidity_sensor(index):
+
+    iio_node = _check_root_node(IIO_PATH + index)
+    sub_nodes = [
+        "in_humidityrelative_integration_time",
+        "in_humidityrelative_scale",
+        "in_humidityrelative_raw",
+    ]
+    for sub_node in sub_nodes:
+        tmp_node = iio_node.joinpath(sub_node)
+        if tmp_node.exists():
+            value = tmp_node.read_text().strip("\n")
+            print("the value of {} node is {}".format(str(tmp_node), value))
+
+            try:
+                value = float(value)
+            except ValueError:
+                print("The accelerometer sensor test failed")
+                raise ValueError("The accelerometer value is not valid")
+        else:
+            print("The humidity sensor test failed")
+            raise FileNotFoundError(
+                    "{} file not exists".format(str(tmp_node)))
+
+
+def register_arguments():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description='Industrial IO sensor tests')
+    parser.add_argument(
+        "-t", "--type",
+        required=True,
+        choices=["pressure", "accelerometer", "humidityrelative"],
+        type=str
+    )
+    parser.add_argument(
+        "-i", "--index",
+        required=True,
+        type=str,
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == "__main__":
+
+    args = register_arguments()
+
+    test_funcs = {
+        "pressure": check_pressure_sensor,
+        "accelerometer": check_accelerometer_sensor,
+        "humidityrelative": check_humidity_sensor
+    }
+
+    try:
+        print("# Perform {} sensor test - index {}".format(
+            args.type, args.index
+        ))
+        test_funcs[args.type](args.index)
+
+        print("# The {} sensor test passed".format(args.type))
+
+    except Exception as err:
+        logging.error(err)

--- a/contrib/checkbox-provider-ce-oem/bin/iio_sensor_test.py
+++ b/contrib/checkbox-provider-ce-oem/bin/iio_sensor_test.py
@@ -189,7 +189,7 @@ def dump_sensor_resource(args):
         args (Namespace): the arguments includes type and index of sensor
     """
     output = ""
-    resource_text = "index: {}\nsensor_type: {}\n\n"
+    resource_text = "index: {}\ntype: {}\n\n"
     for sensor in args.mapping.split():
         index, sensor_type = sensor.split(":")
         output += resource_text.format(index, sensor_type)

--- a/contrib/checkbox-provider-ce-oem/bin/iio_sensor_test.py
+++ b/contrib/checkbox-provider-ce-oem/bin/iio_sensor_test.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Stanley Huang <stanley.huang@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox. If not, see <http://www.gnu.org/licenses/>.
 import re
 import argparse
 from pathlib import Path

--- a/contrib/checkbox-provider-ce-oem/bin/iio_sensor_test.py
+++ b/contrib/checkbox-provider-ce-oem/bin/iio_sensor_test.py
@@ -101,7 +101,7 @@ def check_pressure_sensor(index):
         tmp_node = iio_node.joinpath(sub_node)
         _check_node(tmp_node)
         value = tmp_node.read_text().strip("\n")
-        print("the value of {} node is {}".format(tmp_node, value))
+        print("The value of {} node is {}".format(tmp_node, value))
         readings.append(value)
 
     if readings and _check_reading(readings):

--- a/contrib/checkbox-provider-ce-oem/bin/iio_sensor_test.py
+++ b/contrib/checkbox-provider-ce-oem/bin/iio_sensor_test.py
@@ -60,7 +60,7 @@ def _check_node(path):
     """
     iio_node = Path(path)
     if not iio_node.exists():
-        raise FileNotFoundError("{} file not exists".format(str(iio_node)))
+        raise FileNotFoundError("{} file not exists".format(iio_node))
 
     return iio_node
 
@@ -101,7 +101,7 @@ def check_pressure_sensor(index):
         tmp_node = iio_node.joinpath(sub_node)
         _check_node(tmp_node)
         value = tmp_node.read_text().strip("\n")
-        print("the value of {} node is {}".format(str(tmp_node), value))
+        print("the value of {} node is {}".format(tmp_node, value))
         readings.append(value)
 
     if readings and _check_reading(readings):
@@ -128,7 +128,7 @@ def check_accelerometer_sensor(index):
         _check_node(tmp_node)
 
         value = tmp_node.read_text().strip("\n")
-        print("the value of {} node is {}".format(str(tmp_node), value))
+        print("the value of {} node is {}".format(tmp_node, value))
         readings.append(value)
 
     if readings and _check_reading(readings):
@@ -154,7 +154,7 @@ def check_humidity_sensor(index):
         tmp_node = iio_node.joinpath(sub_node)
         _check_node(tmp_node)
         value = tmp_node.read_text().strip("\n")
-        print("the value of {} node is {}".format(str(tmp_node), value))
+        print("the value of {} node is {}".format(tmp_node, value))
         readings.append(value)
 
     if readings and _check_reading(readings):

--- a/contrib/checkbox-provider-ce-oem/bin/iio_sensor_test.py
+++ b/contrib/checkbox-provider-ce-oem/bin/iio_sensor_test.py
@@ -1,14 +1,46 @@
 #!/usr/bin/env python3
-import logging
+import re
 import argparse
 from pathlib import Path
 
 
 IIO_PATH = "/sys/bus/iio/devices/iio:device"
 
+pressure_nodes = [
+    "in_pressure_input",
+    "in_pressure_oversampling_ratio",
+    "in_pressure_sampling_frequency"
+]
+accelerometer_nodes = [
+    "in_accel_sampling_frequency",
+    "in_accel_scale",
+    "in_accel_x_calibbias",
+    "in_accel_x_raw",
+    "in_accel_y_calibbias",
+    "in_accel_y_raw",
+    "in_accel_z_calibbias",
+    "in_accel_z_raw"
+]
+humidity_nodes = [
+    "in_humidityrelative_integration_time",
+    "in_humidityrelative_scale",
+    "in_humidityrelative_raw",
+]
 
-def _check_root_node(path):
 
+def _check_node(path):
+    """
+    Initial a Path object for the industrial I/O sensor
+
+    Args:
+        path (str): the full path of the industrial I/O sensor
+
+    Raises:
+        FileNotFoundError: the sysfs of sensor not exists
+
+    Returns:
+        iio_node: the node of the industrial I/O sensor. (Path object)
+    """
     iio_node = Path(path)
     if not iio_node.exists():
         raise FileNotFoundError("{} file not exists".format(str(iio_node)))
@@ -16,87 +48,111 @@ def _check_root_node(path):
     return iio_node
 
 
+def _check_reading(values):
+    """
+    Check the format of sensor reading
+
+    Args:
+        values (list): a list of sensor reading
+
+    Returns:
+        bool: True if all reading match expected format
+    """
+    result = True
+    reading_pattern = r"^[+-]?\d+(\.[0-9]+)?$"
+    for value in values:
+        if re.search(reading_pattern, value) is None:
+            result = False
+
+    return result
+
+
 def check_pressure_sensor(index):
+    """
+    Validate the sysfs of industrial I/O pressure sensor
 
-    iio_node = _check_root_node(IIO_PATH + index)
-    sub_nodes = [
-        "in_pressure_input",
-        "in_pressure_oversampling_ratio",
-        "in_pressure_sampling_frequency"
-    ]
-    for sub_node in sub_nodes:
+    Args:
+        index (str): the index of sensor
+
+    Raises:
+        ValueError: the reading of sensor is not expected format
+    """
+    iio_node = _check_node(IIO_PATH + index)
+    readings = []
+
+    for sub_node in pressure_nodes:
         tmp_node = iio_node.joinpath(sub_node)
-        if tmp_node.exists():
-            value = tmp_node.read_text().strip("\n")
-            print("the value of {} node is {}".format(str(tmp_node), value))
+        _check_node(tmp_node)
+        value = tmp_node.read_text().strip("\n")
+        print("the value of {} node is {}".format(str(tmp_node), value))
+        readings.append(value)
 
-            try:
-                float(value)
-            except ValueError:
-                print("The accelerometer sensor test failed")
-                raise ValueError("The accelerometer value is not valid")
-        else:
-            print("The pressure sensor test failed")
-            raise FileNotFoundError(
-                    "{} file not exists".format(str(tmp_node)))
+    if readings and _check_reading(readings):
+        print("The pressure sensor test passed")
+    else:
+        raise ValueError("ERROR: The pressure value is not valid")
 
 
 def check_accelerometer_sensor(index):
+    """
+    Validate the sysfs of industrial I/O accelerometer sensor
 
-    iio_node = _check_root_node(IIO_PATH + index)
-    sub_nodes = [
-        "in_accel_sampling_frequency",
-        "in_accel_scale",
-        "in_accel_x_calibbias",
-        "in_accel_x_raw",
-        "in_accel_y_calibbias",
-        "in_accel_y_raw",
-        "in_accel_z_calibbias",
-        "in_accel_z_raw"
-    ]
-    for sub_node in sub_nodes:
+    Args:
+        index (str): the index of sensor
+
+    Raises:
+        ValueError: the reading of sensor is not expected format
+    """
+    readings = []
+    iio_node = _check_node(IIO_PATH + index)
+
+    for sub_node in accelerometer_nodes:
         tmp_node = iio_node.joinpath(sub_node)
-        if tmp_node.exists():
-            value = tmp_node.read_text().strip("\n")
-            print("the value of {} node is {}".format(str(tmp_node), value))
+        _check_node(tmp_node)
 
-            try:
-                float(value)
-            except ValueError:
-                print("The accelerometer sensor test failed")
-                raise ValueError("The accelerometer value is not valid")
-        else:
-            print("The accelerometer sensor test failed")
-            raise FileNotFoundError(
-                    "{} file not exists".format(str(tmp_node)))
+        value = tmp_node.read_text().strip("\n")
+        print("the value of {} node is {}".format(str(tmp_node), value))
+        readings.append(value)
+
+    if readings and _check_reading(readings):
+        print("The accelerometer sensor test passed")
+    else:
+        raise ValueError("ERROR: The accelerometer value is not valid")
 
 
 def check_humidity_sensor(index):
+    """
+    Validate the sysfs of industrial I/O humidity sensor
 
-    iio_node = _check_root_node(IIO_PATH + index)
-    sub_nodes = [
-        "in_humidityrelative_integration_time",
-        "in_humidityrelative_scale",
-        "in_humidityrelative_raw",
-    ]
-    for sub_node in sub_nodes:
+    Args:
+        index (str): the index of sensor
+
+    Raises:
+        ValueError: the reading of sensor is not expected format
+    """
+    readings = []
+    iio_node = _check_node(IIO_PATH + index)
+
+    for sub_node in humidity_nodes:
         tmp_node = iio_node.joinpath(sub_node)
-        if tmp_node.exists():
-            value = tmp_node.read_text().strip("\n")
-            print("the value of {} node is {}".format(str(tmp_node), value))
+        _check_node(tmp_node)
+        value = tmp_node.read_text().strip("\n")
+        print("the value of {} node is {}".format(str(tmp_node), value))
+        readings.append(value)
 
-            try:
-                value = float(value)
-            except ValueError:
-                print("The accelerometer sensor test failed")
-                raise ValueError("The accelerometer value is not valid")
-        else:
-            print("The humidity sensor test failed")
-            raise FileNotFoundError(
-                    "{} file not exists".format(str(tmp_node)))
+    if readings and _check_reading(readings):
+        print("The humidity sensor test passed")
+    else:
+        raise ValueError("ERROR: The humidity value is not valid")
 
 
 def validate_iio_sensor(args):
+    """
+    Check sensor and validate the format of reading
+
+    Args:
+        args (Namespace): the arguments includes type and index of sensor
+    """
     test_funcs = {
         "pressure": check_pressure_sensor,
         "accelerometer": check_accelerometer_sensor,
@@ -109,6 +165,12 @@ def validate_iio_sensor(args):
 
 
 def dump_sensor_resource(args):
+    """
+    Print out the sensor index and sensor type
+
+    Args:
+        args (Namespace): the arguments includes type and index of sensor
+    """
     output = ""
     resource_text = "index: {}\nsensor_type: {}\n\n"
     for sensor in args.mapping.split():
@@ -156,7 +218,5 @@ if __name__ == "__main__":
 
     args = register_arguments()
 
-    try:
-        args.test_func(args)
-    except Exception as err:
-        logging.error(err)
+    args.test_func(args)
+

--- a/contrib/checkbox-provider-ce-oem/tests/test_iio_sensor_test.py
+++ b/contrib/checkbox-provider-ce-oem/tests/test_iio_sensor_test.py
@@ -150,11 +150,11 @@ class TestIndustrialIOSensorTest(unittest.TestCase):
             stdout.getvalue(),
             (
                 "index: 0\n"
-                "sensor_type: pressure\n\n"
+                "type: pressure\n\n"
                 "index: 1\n"
-                "sensor_type: accelerometer\n\n"
+                "type: accelerometer\n\n"
                 "index: 2\n"
-                "sensor_type: humidityrelative\n\n\n"
+                "type: humidityrelative\n\n\n"
             )
         )
 

--- a/contrib/checkbox-provider-ce-oem/tests/test_iio_sensor_test.py
+++ b/contrib/checkbox-provider-ce-oem/tests/test_iio_sensor_test.py
@@ -1,0 +1,176 @@
+import unittest
+import sys
+from pathlib import Path
+from io import StringIO
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+import iio_sensor_test
+
+
+class TestIndustrialIOSensorTest(unittest.TestCase):
+
+    @patch("pathlib.Path.exists")
+    def test_check_root_node_exists(self, mock_path):
+        mock_path.return_value = True
+        node = iio_sensor_test._check_node("iio_sensor1")
+
+        self.assertIsInstance(node, Path)
+
+    @patch("pathlib.Path.exists")
+    def test_check_root_node_not_exists(self, mock_path):
+        mock_path.return_value = False
+
+        with self.assertRaises(FileNotFoundError):
+            iio_sensor_test._check_node("iio_sensor1")
+
+    def test_check_reading_is_expected(self):
+        readings = ["20.1", "-255", "+123.3"]
+
+        self.assertTrue(iio_sensor_test._check_reading(readings))
+
+    def test_check_reading_not_expected(self):
+        readings = ["20.1", "-255", "+a"]
+
+        self.assertFalse(iio_sensor_test._check_reading(readings))
+
+    @patch("iio_sensor_test._check_reading")
+    @patch("pathlib.Path.read_text")
+    @patch("iio_sensor_test._check_node")
+    def test_check_pressure_sensor(
+            self, mock_check_node, mock_read, mock_check_reading):
+        mock_check_node.return_value = Path("fake")
+
+        mock_check_node.return_value = Path("fake")
+        mock_read.side_effect = ["20.1", "-255", "+123.3"]
+
+        with redirect_stdout(StringIO()):
+            iio_sensor_test.check_pressure_sensor("iio_sensor1")
+
+        self.assertEqual(mock_check_node.call_count, 4)
+        self.assertEqual(mock_read.call_count, 3)
+        self.assertEqual(mock_check_reading.call_count, 1)
+
+    @patch("pathlib.Path.read_text")
+    @patch("iio_sensor_test._check_node")
+    def test_check_pressure_sensor_unexpected_value(
+                self, mock_check_node, mock_read):
+
+        mock_check_node.return_value = Path("fake")
+        mock_read.side_effect = ["20.1", "-255", "+a"]
+        with redirect_stdout(StringIO()):
+            with self.assertRaises(ValueError):
+                iio_sensor_test.check_pressure_sensor("iio_sensor1")
+
+    @patch("iio_sensor_test._check_reading")
+    @patch("pathlib.Path.read_text")
+    @patch("iio_sensor_test._check_node")
+    def test_check_accelerometer_sensor(
+            self, mock_check_node, mock_read, mock_check_reading):
+
+        mock_check_node.return_value = Path("fake")
+        mock_read.side_effect = [
+            "20.1", "-255", "+123.3", "1",
+            "509", "-0.1235", "+0.2222", "6666"
+        ]
+
+        with redirect_stdout(StringIO()):
+            iio_sensor_test.check_accelerometer_sensor("iio_sensor1")
+
+        self.assertEqual(mock_check_node.call_count, 9)
+        self.assertEqual(mock_read.call_count, 8)
+        self.assertEqual(mock_check_reading.call_count, 1)
+
+    @patch("pathlib.Path.read_text")
+    @patch("iio_sensor_test._check_node")
+    def test_check_accelerometer_sensor_unexpected_value(
+                self, mock_check_node, mock_read):
+
+        mock_check_node.return_value = Path("fake")
+        mock_read.side_effect = [
+            "d20.1", "-255", "+123.3", "1",
+            "5d09", "-0a.1235", "+0.2222", "6666"
+        ]
+        with redirect_stdout(StringIO()):
+            with self.assertRaises(ValueError):
+                iio_sensor_test.check_accelerometer_sensor(
+                                            "iio_sensor1")
+
+    @patch("iio_sensor_test._check_reading")
+    @patch("pathlib.Path.read_text")
+    @patch("iio_sensor_test._check_node")
+    def test_check_humidity_sensor(
+            self, mock_check_node, mock_read, mock_check_reading):
+
+        mock_check_node.return_value = Path("fake")
+        mock_read.side_effect = ["20.1", "-255", "+123.3"]
+
+        with redirect_stdout(StringIO()):
+            iio_sensor_test.check_humidity_sensor("iio_sensor1")
+
+        self.assertEqual(mock_check_node.call_count, 4)
+        self.assertEqual(mock_read.call_count, 3)
+        self.assertEqual(mock_check_reading.call_count, 1)
+
+    @patch("pathlib.Path.read_text")
+    @patch("iio_sensor_test._check_node")
+    def test_check_humidity_sensor_unexpected_value(
+                self, mock_check_node, mock_read):
+
+        mock_check_node.return_value = Path("fake")
+        mock_read.side_effect = ["20.d1", "-255", "+a"]
+        with redirect_stdout(StringIO()):
+            with self.assertRaises(ValueError):
+                iio_sensor_test.check_humidity_sensor("iio_sensor1")
+
+
+class TestArgumentParser(unittest.TestCase):
+
+    def test_pressure_parser(self):
+        sys.argv = [
+            "iio_sensor_test.py", "test", "-t", "pressure",
+            "-i", "3"
+        ]
+        args = iio_sensor_test.register_arguments()
+
+        self.assertEqual(args.test_func,
+                         iio_sensor_test.validate_iio_sensor)
+        self.assertEqual(args.type, "pressure")
+        self.assertEqual(args.index, "3")
+
+    def test_accelerometer_parser(self):
+        sys.argv = [
+            "iio_sensor_test.py", "test", "-t", "accelerometer",
+            "-i", "3"
+        ]
+        args = iio_sensor_test.register_arguments()
+
+        self.assertEqual(args.test_func,
+                         iio_sensor_test.validate_iio_sensor)
+        self.assertEqual(args.type, "accelerometer")
+        self.assertEqual(args.index, "3")
+
+    def test_humidityrelative_parser(self):
+        sys.argv = [
+            "iio_sensor_test.py", "test",
+            "--type", "humidityrelative",
+            "--index", "3"
+        ]
+        args = iio_sensor_test.register_arguments()
+
+        self.assertEqual(args.test_func,
+                         iio_sensor_test.validate_iio_sensor)
+        self.assertEqual(args.type, "humidityrelative")
+        self.assertEqual(args.index, "3")
+
+    def test_iio_sensore_resource_parser(self):
+        sys.argv = [
+            "iio_sensor_test.py",
+            "sensor-resource",
+            "0:pressure 1:accelerometer 2:humidityrelative"
+        ]
+        args = iio_sensor_test.register_arguments()
+
+        self.assertEqual(args.test_func,
+                         iio_sensor_test.dump_sensor_resource)
+        self.assertEqual(args.mapping, sys.argv[2])

--- a/contrib/checkbox-provider-ce-oem/units/iio-sensors/category.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/iio-sensors/category.pxu
@@ -1,0 +1,3 @@
+unit: category
+id: iio-sensors
+_name: Industrial IO sensors Test

--- a/contrib/checkbox-provider-ce-oem/units/iio-sensors/jobs.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/iio-sensors/jobs.pxu
@@ -10,13 +10,7 @@ category_id: iio-sensors
 plugin: resource
 environ: IIO_SENSORS
 command:
-    awk '{
-        split($0, record, " ")
-        for (i in record) {
-            split(record[i], data, ":")
-            printf "INDEX: %s\nSENSOR_TYPE: %s\n\n", data[1], data[2]
-        }
-    }' <<< "$IIO_SENSORS"
+    iio_sensor_test.py sensor-resource "$IIO_SENSORS"
 
 unit: template
 template-resource: ce-oem-iio-sensors/resource
@@ -32,4 +26,4 @@ requires: manifest.has_iio_sensors == 'True'
 flags: also-after-suspend
 command:
     echo "## Perform the industrial I/O {SENSOR_TYPE}-{INDEX} sensor test"
-    iio_sensor_test.py -t {SENSOR_TYPE} -i {INDEX}
+    iio_sensor_test.py test -t {SENSOR_TYPE} -i {INDEX}

--- a/contrib/checkbox-provider-ce-oem/units/iio-sensors/jobs.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/iio-sensors/jobs.pxu
@@ -1,0 +1,35 @@
+id: ce-oem-iio-sensors/resource
+_summary: Generates a IIO sensors mapping for IIO sensor test
+_description:
+    A IIO sensors mapping. By giving an IIO sensors on machnie to generates test jobs.
+    Usage of parameter:
+        IIO_SENSORS=device:sensor_type device:sensor_type ...
+    e.g. IIO_SENSORS=0:pressure 1:accelerometer 2:humidityrelative
+estimated_duration: 0.02
+category_id: iio-sensors
+plugin: resource
+environ: IIO_SENSORS
+command:
+    awk '{
+        split($0, record, " ")
+        for (i in record) {
+            split(record[i], data, ":")
+            printf "INDEX: %s\nSENSOR_TYPE: %s\n\n", data[1], data[2]
+        }
+    }' <<< "$IIO_SENSORS"
+
+unit: template
+template-resource: ce-oem-iio-sensors/resource
+template-unit: job
+id: ce-oem-iio-sensors/check-{SENSOR_TYPE}-{INDEX}
+_summary: To test industrial IO {SENSOR_TYPE}-{INDEX}
+plugin: shell
+user: root
+category_id: iio-sensors
+estimated_duration: 40s
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_iio_sensors == 'True'
+flags: also-after-suspend
+command:
+    echo "## Perform the industrial I/O {SENSOR_TYPE}-{INDEX} sensor test"
+    iio_sensor_test.py -t {SENSOR_TYPE} -i {INDEX}

--- a/contrib/checkbox-provider-ce-oem/units/iio-sensors/jobs.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/iio-sensors/jobs.pxu
@@ -15,8 +15,8 @@ command:
 unit: template
 template-resource: ce-oem-iio-sensors/resource
 template-unit: job
-id: ce-oem-iio-sensors/check-{SENSOR_TYPE}-{INDEX}
-_summary: To test industrial IO {SENSOR_TYPE}-{INDEX}
+id: ce-oem-iio-sensors/check-{sensor_type}-{index}
+_summary: To test industrial IO {sensor_type}-{index}
 plugin: shell
 user: root
 category_id: iio-sensors
@@ -25,5 +25,5 @@ imports: from com.canonical.plainbox import manifest
 requires: manifest.has_iio_sensors == 'True'
 flags: also-after-suspend
 command:
-    echo "## Perform the industrial I/O {SENSOR_TYPE}-{INDEX} sensor test"
-    iio_sensor_test.py test -t {SENSOR_TYPE} -i {INDEX}
+    echo "## Perform the industrial I/O {sensor_type}-{index} sensor test"
+    iio_sensor_test.py test -t {sensor_type} -i {index}

--- a/contrib/checkbox-provider-ce-oem/units/iio-sensors/jobs.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/iio-sensors/jobs.pxu
@@ -13,10 +13,12 @@ command:
     iio_sensor_test.py sensor-resource "$IIO_SENSORS"
 
 unit: template
+template-engine: jinja2
 template-resource: ce-oem-iio-sensors/resource
 template-unit: job
-id: ce-oem-iio-sensors/check-{sensor_type}-{index}
-_summary: To test industrial IO {sensor_type}-{index}
+template-id: ce-oem-iio-sensors/check_sensor_type_index
+id: ce-oem-iio-sensors/check-{{ type }}-{{ index }}
+_summary: To test industrial IO {{ type }}-{{ index }}
 plugin: shell
 user: root
 category_id: iio-sensors
@@ -25,5 +27,5 @@ imports: from com.canonical.plainbox import manifest
 requires: manifest.has_iio_sensors == 'True'
 flags: also-after-suspend
 command:
-    echo "## Perform the industrial I/O {sensor_type}-{index} sensor test"
-    iio_sensor_test.py test -t {sensor_type} -i {index}
+    echo "## Perform the industrial I/O {{ type }}-{{ index }} sensor test"
+    iio_sensor_test.py test -t {{ type }} -i {{ index }}

--- a/contrib/checkbox-provider-ce-oem/units/iio-sensors/manifest.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/iio-sensors/manifest.pxu
@@ -1,0 +1,4 @@
+unit: manifest entry
+id: has_iio_sensors
+_name: Does platform support industrial IO sensor?
+value-type: bool

--- a/contrib/checkbox-provider-ce-oem/units/iio-sensors/test-plan.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/iio-sensors/test-plan.pxu
@@ -6,35 +6,18 @@ include:
 nested_part:
     ce-oem-iio-sensors-manual
     ce-oem-iio-sensors-automated
-    after-suspend-ce-oem-iio-sensors-manual
-    after-suspend-ce-oem-iio-sensors-automated
 
 id: ce-oem-iio-sensors-manual
 unit: test plan
 _name: Industrial I/O sensor manual tests
-_description: Manual tests for Industrial I/O sensors
+_description: Manual tests for Industrial I/O sensors in before suspend and post suspend stage
 include:
 
 id: ce-oem-iio-sensors-automated
 unit: test plan
 _name: Industrial I/O sensor auto tests
-_description: Automated tests for Industrial I/O sensors
+_description: Automated tests for Industrial I/O sensors in before suspend and post suspend stage
 bootstrap_include:
     ce-oem-iio-sensors/resource
 include:
-    ce-oem-iio-sensors/check-.*-.*
-
-id: after-suspend-ce-oem-iio-sensors-manual
-unit: test plan
-_name: Post suspend Industrial I/O sensor manual tests
-_description: Manual tests for Industrial I/O sensors
-include:
-
-id: after-suspend-ce-oem-iio-sensors-automated
-unit: test plan
-_name: Post suspend Industrial I/O sensor auto tests
-_description: Automated tests for Industrial I/O sensors
-bootstrap_include:
-    ce-oem-iio-sensors/resource
-include:
-    after-suspend-ce-oem-iio-sensors/check-.*-.*
+    ce-oem-iio-sensors/check_sensor_type_index

--- a/contrib/checkbox-provider-ce-oem/units/iio-sensors/test-plan.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/iio-sensors/test-plan.pxu
@@ -1,0 +1,40 @@
+id: ce-oem-iio-sensors-full
+unit: test plan
+_name: Industrial I/O sensor tests
+_description: Full tests for Industrial I/O sensors
+include:
+nested_part:
+    ce-oem-iio-sensors-manual
+    ce-oem-iio-sensors-automated
+    after-suspend-ce-oem-iio-sensors-manual
+    after-suspend-ce-oem-iio-sensors-automated
+
+id: ce-oem-iio-sensors-manual
+unit: test plan
+_name: Industrial I/O sensor manual tests
+_description: Manual tests for Industrial I/O sensors
+include:
+
+id: ce-oem-iio-sensors-automated
+unit: test plan
+_name: Industrial I/O sensor auto tests
+_description: Automated tests for Industrial I/O sensors
+bootstrap_include:
+    ce-oem-iio-sensors/resource
+include:
+    ce-oem-iio-sensors/check-.*-.*
+
+id: after-suspend-ce-oem-iio-sensors-manual
+unit: test plan
+_name: Post suspend Industrial I/O sensor manual tests
+_description: Manual tests for Industrial I/O sensors
+include:
+
+id: after-suspend-ce-oem-iio-sensors-automated
+unit: test plan
+_name: Post suspend Industrial I/O sensor auto tests
+_description: Automated tests for Industrial I/O sensors
+bootstrap_include:
+    ce-oem-iio-sensors/resource
+include:
+    after-suspend-ce-oem-iio-sensors/check-.*-.*

--- a/contrib/checkbox-provider-ce-oem/units/iio-sensors/test-plan.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/iio-sensors/test-plan.pxu
@@ -17,7 +17,26 @@ id: ce-oem-iio-sensors-automated
 unit: test plan
 _name: Industrial I/O sensor auto tests
 _description: Automated tests for Industrial I/O sensors in before suspend and post suspend stage
+              # Not nested this test plan for now due to it leads the mismatch job order
 bootstrap_include:
     ce-oem-iio-sensors/resource
 include:
     ce-oem-iio-sensors/check_sensor_type_index
+
+id: before-suspend-ce-oem-iio-sensors-automated
+unit: test plan
+_name: Industrial I/O sensor auto tests
+_description: Automated tests for Industrial I/O sensors in before suspend stage
+bootstrap_include:
+    ce-oem-iio-sensors/resource
+include:
+    ce-oem-iio-sensors/check-.*
+
+id: after-suspend-ce-oem-iio-sensors-automated
+unit: test plan
+_name: Industrial I/O sensor auto tests
+_description: Automated tests for Industrial I/O sensors in post suspend stage
+bootstrap_include:
+    ce-oem-iio-sensors/resource
+include:
+    after-suspend-ce-oem-iio-sensors/check-.*

--- a/contrib/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
@@ -44,6 +44,7 @@ nested_part:
     ce-oem-touchscreen-evdev
     ce-oem-socketcan-manual
     com.canonical.certification::led-indicator-manual
+    ce-oem-iio-sensors-manual
 
 id: ce-oem-automated
 unit: test plan
@@ -76,6 +77,7 @@ nested_part:
     ce-oem-ethernet-tcp-automated
     com.canonical.certification::eeprom-automated
     com.canonical.certification::rtc-automated
+    ce-oem-iio-sensors-automated
 
 id: after-suspend-ce-oem-manual
 unit: test plan
@@ -104,6 +106,7 @@ nested_part:
     after-suspend-ce-oem-touchscreen-evdev
     after-suspend-ce-oem-socketcan-manual
     com.canonical.certification::after-suspend-led-indicator-manual
+    after-suspend-ce-oem-iio-sensors-manual
 
 id: after-suspend-ce-oem-automated
 unit: test plan
@@ -134,6 +137,7 @@ nested_part:
     after-suspend-ce-oem-ethernet-tcp-automated
     com.canonical.certification::after-suspend-eeprom-automated
     com.canonical.certification::after-suspend-rtc-automated
+    after-suspend-ce-oem-iio-sensors-automated
 
 id: ce-oem-stress
 unit: test plan

--- a/contrib/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
@@ -76,8 +76,8 @@ nested_part:
     ce-oem-socketcan-stress-automated
     ce-oem-ethernet-tcp-automated
     com.canonical.certification::eeprom-automated
-    com.canonical.certification::rtc-automated
     ce-oem-iio-sensors-automated
+    com.canonical.certification::rtc-automated
 
 id: after-suspend-ce-oem-manual
 unit: test plan

--- a/contrib/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
@@ -76,7 +76,7 @@ nested_part:
     ce-oem-socketcan-stress-automated
     ce-oem-ethernet-tcp-automated
     com.canonical.certification::eeprom-automated
-    ce-oem-iio-sensors-automated
+    before-suspend-ce-oem-iio-sensors-automated
     com.canonical.certification::rtc-automated
 
 id: after-suspend-ce-oem-manual


### PR DESCRIPTION
## Description
Implement new test cases for industrial I/O sensor

## Resolved issues
N/A

## Documentation
Refer to the kernel document about the Industrial I/O sensor
https://www.kernel.org/doc/html/v5.4/driver-api/iio/core.html#industrial-i-o-devices

## Tests
Tested on Murcia project, please refer the test results from C3 website.
https://certification.canonical.com/hardware/202312-33237/submission/359230/

List-bootstrapped logs
```
stanley@stanley-ThinkPad-T490:~$ checkbox-cli list-bootstrapped com.canonical.contrib::ce-oem-iio-sensors-full
Using sideloaded provider: checkbox-provider-ce-oem, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-ce-oem
Skipped file: /usr/share/checkbox-provider-base/units/camera/README.rst
Skipped file: /usr/share/checkbox-provider-base/units/snapd/README.md
Skipped file: /usr/share/checkbox-provider-base/units/stress/suspend_cycles_reboot.md
Using sideloaded provider: checkbox-provider-ce-oem, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-ce-oem
com.canonical.plainbox::manifest
com.canonical.contrib::ce-oem-iio-sensors/check-pressure-0
com.canonical.certification::rtc
com.canonical.certification::sleep
com.canonical.certification::suspend/suspend_advanced_auto
com.canonical.contrib::after-suspend-ce-oem-iio-sensors/check-pressure-0
com.canonical.contrib::ce-oem-iio-sensors/check-accelerometer-1
com.canonical.contrib::after-suspend-ce-oem-iio-sensors/check-accelerometer-1
com.canonical.contrib::ce-oem-iio-sensors/check-humidityrelative-2
com.canonical.contrib::after-suspend-ce-oem-iio-sensors/check-humidityrelative-2
```
