### PR TITLE
Ensure that jobs that have an after suspend counterpart are run before suspend (New)

### DIFF
--- a/checkbox-ng/plainbox/configuration.py
+++ b/checkbox-ng/plainbox/configuration.py
@@ -1,0 +1,30 @@
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Pierre Equoy <pierre.equoy@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+:mod:`plainbox.impl.configuration` -- Configuration variables
+=============================================================
+"""
+
+
+class Suspend:
+    AUTO_JOB_ID = "com.canonical.certification::suspend/suspend_advanced_auto"
+    MANUAL_JOB_ID = "com.canonical.certification::suspend/suspend_advanced"
+    AUTO_FLAG = "also-after-suspend"
+    MANUAL_FLAG = "also-after-suspend-manual"

--- a/checkbox-ng/plainbox/impl/ctrl.py
+++ b/checkbox-ng/plainbox/impl/ctrl.py
@@ -7,7 +7,6 @@
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
 # as published by the Free Software Foundation.
-
 #
 # Checkbox is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -53,7 +52,6 @@ from subprocess import check_output, CalledProcessError, STDOUT
 
 from plainbox.abc import IJobResult
 from plainbox.abc import ISessionStateController
-from plainbox.configuration import Suspend
 from plainbox.i18n import gettext as _
 from plainbox.impl import get_plainbox_dir
 from plainbox.impl.depmgr import DependencyDuplicateError
@@ -72,6 +70,7 @@ from plainbox.impl.unit.job import JobDefinition
 from plainbox.impl.unit.template import TemplateUnit
 from plainbox.impl.unit.unit import MissingParam
 from plainbox.impl.validation import Severity
+from plainbox.suspend_consts import Suspend
 from plainbox.vendor import morris
 from plainbox.vendor import extcmd
 

--- a/checkbox-ng/plainbox/impl/ctrl.py
+++ b/checkbox-ng/plainbox/impl/ctrl.py
@@ -166,7 +166,9 @@ class CheckBoxSessionStateController(ISessionStateController):
         :returns:
             A set of job ids that need to be run before the suspend job
         """
-        p_suspend_job_id = partial(self._is_job_impacting_suspend, suspend_job_id)
+        p_suspend_job_id = partial(
+            self._is_job_impacting_suspend, suspend_job_id
+        )
         suspend_deps_jobs = filter(p_suspend_job_id, job_list)
         suspend_deps = set(job.id for job in suspend_deps_jobs)
         return suspend_deps
@@ -334,7 +336,10 @@ class CheckBoxSessionStateController(ISessionStateController):
         )
         suspend_inhibitors_jobs = filter(p_suspend_job_id, run_list)
         for job in suspend_inhibitors_jobs:
-            if session_state.job_state_map[job.id].result.outcome == IJobResult.OUTCOME_NONE:
+            if (
+                session_state.job_state_map[job.id].result.outcome
+                == IJobResult.OUTCOME_NONE
+            ):
                 inhibitor = JobReadinessInhibitor(
                     cause=InhibitionCause.PENDING_DEP,
                     related_job=job,

--- a/checkbox-ng/plainbox/impl/depmgr.py
+++ b/checkbox-ng/plainbox/impl/depmgr.py
@@ -340,12 +340,12 @@ class DependencySolver:
         if visit_list is None:
             visit_list = self._job_list
         for job in visit_list:
-            self._visit(job)
+            self._visit(job=job, visit_list=visit_list)
         logger.debug(_("Done solving"))
         # Return the solution
         return self._solution
 
-    def _visit(self, job, trail=None):
+    def _visit(self, job, visit_list, trail=None):
         """
         Internal method of DependencySolver.
 
@@ -367,7 +367,9 @@ class DependencySolver:
             # If the trail was not specified start a trail for this node
             if trail is None:
                 trail = [job]
-            for dep_type, job_id in job.controller.get_dependency_set(job):
+            for dep_type, job_id in job.controller.get_dependency_set(
+                job, visit_list
+            ):
                 # Dependency is just an id, we need to resolve it
                 # to a job instance. This can fail (missing dependencies)
                 # so let's guard against that.
@@ -383,7 +385,7 @@ class DependencySolver:
                     logger.debug(_("Visiting dependency: %r"), next_job)
                     # Update the trail as we visit that node
                     trail.append(next_job)
-                    self._visit(next_job, trail)
+                    self._visit(next_job, visit_list, trail)
                     trail.pop()
             # We've visited (recursively) all dependencies of this node,
             # let's color it black and append it to the solution list.

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -41,6 +41,7 @@ from plainbox.impl.session.system_information import(
 from plainbox.impl.unit.job import JobDefinition
 from plainbox.impl.unit.unit_with_id import UnitWithId
 from plainbox.impl.unit.testplan import TestPlanUnitSupport
+from plainbox.suspend_consts import Suspend
 from plainbox.vendor import morris
 
 
@@ -1091,24 +1092,21 @@ class SessionState:
                         field_offset_map=new_job.field_offset_map),
                     recompute,
                     via)
-        if 'also-after-suspend' in new_job.get_flag_set():
+        if Suspend.AUTO_FLAG in new_job.get_flag_set():
             data = {
                 key: value for key, value in new_job._data.items()
                 if not key.endswith('siblings')
             }
-            data['flags'] = data['flags'].replace('also-after-suspend', '')
-            data['flags'] = data['flags'].replace(
-                'also-after-suspend-manual', '')
+            data['flags'] = data['flags'].replace(Suspend.AUTO_FLAG, '')
+            data['flags'] = data['flags'].replace(Suspend.MANUAL_FLAG, '')
             data['id'] = "after-suspend-{}".format(new_job.partial_id)
             data['_summary'] = "{} after suspend (S3)".format(
                 new_job.summary)
-            provider_id = "com.canonical.certification"
-            suspend_test_id = "suspend/suspend_advanced_auto"
             if new_job.depends:
                 data['depends'] += " {}".format(new_job.id)
             else:
                 data['depends'] = "{}".format(new_job.id)
-            data['depends'] += " {}::{}".format(provider_id, suspend_test_id)
+            data['depends'] += " {}".format(Suspend.AUTO_JOB_ID)
             self._add_job_unit(
                 JobDefinition(
                     data,
@@ -1119,24 +1117,21 @@ class SessionState:
                     field_offset_map=new_job.field_offset_map),
                 recompute,
                 via)
-        if 'also-after-suspend-manual' in new_job.get_flag_set():
+        if Suspend.MANUAL_FLAG in new_job.get_flag_set():
             data = {
                 key: value for key, value in new_job._data.items()
                 if not key.endswith('siblings')
             }
-            data['flags'] = data['flags'].replace('also-after-suspend', '')
-            data['flags'] = data['flags'].replace(
-                'also-after-suspend-manual', '')
+            data['flags'] = data['flags'].replace(Suspend.AUTO_FLAG, '')
+            data['flags'] = data['flags'].replace(Suspend.MANUAL_FLAG, '')
             data['id'] = "after-suspend-manual-{}".format(new_job.partial_id)
             data['_summary'] = "{} after suspend (S3)".format(
                 new_job.summary)
-            provider_id = "com.canonical.certification"
-            suspend_test_id = "suspend/suspend_advanced"
             if new_job.depends:
                 data['depends'] += " {}".format(new_job.id)
             else:
                 data['depends'] = "{}".format(new_job.id)
-            data['depends'] += " {}::{}".format(provider_id, suspend_test_id)
+            data['depends'] += " {}".format(Suspend.MANUAL_JOB_ID)
             self._add_job_unit(
                 JobDefinition(
                     data,

--- a/checkbox-ng/plainbox/impl/session/test_state.py
+++ b/checkbox-ng/plainbox/impl/session/test_state.py
@@ -43,8 +43,8 @@ from plainbox.impl.session.state import SessionMetaData
 from plainbox.impl.testing_utils import make_job
 from plainbox.impl.unit.job import JobDefinition
 from plainbox.impl.unit.category import CategoryUnit
-
 from plainbox.impl.unit.unit_with_id import UnitWithId
+from plainbox.suspend_consts import Suspend
 from plainbox.vendor import mock
 from plainbox.vendor.morris import SignalTestCase
 
@@ -309,7 +309,7 @@ class SessionStateAPITests(TestCase):
 
     def test_also_after_suspend_flag(self):
         # Define a job
-        job = make_job("A", summary="foo", flags="also-after-suspend")
+        job = make_job("A", summary="foo", flags=Suspend.AUTO_FLAG)
         # Define an empty session
         session = SessionState([])
         # Add the job to the session
@@ -319,12 +319,13 @@ class SessionStateAPITests(TestCase):
         self.assertIn(job, session.job_list)
         self.assertEqual(session.job_list[1].id, "after-suspend-A")
         self.assertEqual(session.job_list[1].summary, "foo after suspend (S3)")
+        expected_depends = "A {}".format(Suspend.AUTO_JOB_ID)
         self.assertEqual(
             session.job_list[1].depends,
-            ("A com.canonical.certification::suspend/suspend_advanced_auto"),
+            (expected_depends),
         )
         sibling = session.job_list[1]
-        self.assertNotIn("also-after-suspend", sibling.get_flag_set())
+        self.assertNotIn(Suspend.AUTO_FLAG, sibling.get_flag_set())
         # Both jobs got added to job state map
         self.assertIs(session.job_state_map[job.id].job, job)
         self.assertIs(session.job_state_map[sibling.id].job, sibling)
@@ -346,7 +347,7 @@ class SessionStateAPITests(TestCase):
 
     def test_also_after_suspend_manual_flag(self):
         # Define a job
-        job = make_job("A", summary="foo", flags="also-after-suspend-manual")
+        job = make_job("A", summary="foo", flags=Suspend.MANUAL_FLAG)
         # Define an empty session
         session = SessionState([])
         # Add the job to the session
@@ -356,12 +357,13 @@ class SessionStateAPITests(TestCase):
         self.assertIn(job, session.job_list)
         self.assertEqual(session.job_list[1].id, "after-suspend-manual-A")
         self.assertEqual(session.job_list[1].summary, "foo after suspend (S3)")
+        expected_depends = "A {}".format(Suspend.MANUAL_JOB_ID)
         self.assertEqual(
             session.job_list[1].depends,
-            "A com.canonical.certification::suspend/suspend_advanced",
+            expected_depends,
         )
         sibling = session.job_list[1]
-        self.assertNotIn("also-after-suspend-manual", sibling.get_flag_set())
+        self.assertNotIn(Suspend.MANUAL_FLAG, sibling.get_flag_set())
         # Both jobs got added to job state map
         self.assertIs(session.job_state_map[job.id].job, job)
         self.assertIs(session.job_state_map[sibling.id].job, sibling)

--- a/checkbox-ng/plainbox/impl/test_ctrl.py
+++ b/checkbox-ng/plainbox/impl/test_ctrl.py
@@ -7,7 +7,6 @@
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
 # as published by the Free Software Foundation.
-
 #
 # Checkbox is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -33,7 +32,7 @@ import shutil
 from plainbox.abc import IJobResult
 from plainbox.abc import IProvider1
 from plainbox.abc import IProviderBackend1
-from plainbox.configuration import Suspend
+from plainbox.suspend_consts import Suspend
 from plainbox.impl.ctrl import CheckBoxSessionStateController
 from plainbox.impl.ctrl import SymLinkNest
 from plainbox.impl.ctrl import gen_rfc822_records_from_io_log

--- a/checkbox-ng/plainbox/impl/test_ctrl.py
+++ b/checkbox-ng/plainbox/impl/test_ctrl.py
@@ -26,12 +26,14 @@ Test definitions for plainbox.impl.ctrl module
 
 from subprocess import CalledProcessError
 from unittest import TestCase
+import json
 import os
 import shutil
 
 from plainbox.abc import IJobResult
 from plainbox.abc import IProvider1
 from plainbox.abc import IProviderBackend1
+from plainbox.configuration import Suspend
 from plainbox.impl.ctrl import CheckBoxSessionStateController
 from plainbox.impl.ctrl import SymLinkNest
 from plainbox.impl.ctrl import gen_rfc822_records_from_io_log
@@ -102,6 +104,66 @@ class CheckBoxSessionStateControllerTests(TestCase):
         self.assertEqual(
             self.ctrl.get_dependency_set(job_f),
             {('direct', 'j6'), ('resource', 'j6')})
+        # Job with an "also-after-suspend" flag, meaning this job should be
+        # set to run before the suspend job
+        job_g = JobDefinition({
+            "id": "j7",
+            "flags": Suspend.AUTO_FLAG
+        })
+        suspend_job = JobDefinition({
+            "id": Suspend.AUTO_JOB_ID
+        })
+        self.assertEqual(
+            self.ctrl.get_dependency_set(suspend_job, [job_g]),
+            {("ordering", "j7")}
+        )
+
+    def test_get_before_suspend_dependency_set__not_suspend_job_id(self):
+        self.assertEqual(
+            self.ctrl._get_before_suspend_dependency_set("not-suspend", []),
+            set()
+        )
+
+    def test_get_before_suspend_dependency_set__manual_suspend(self):
+        job1 = JobDefinition({
+            "id": "job1",
+            "flags": Suspend.MANUAL_FLAG
+        })
+        job2 = JobDefinition({
+            "id": "job2",
+        })
+        suspend_job = JobDefinition({
+            "id": Suspend.MANUAL_JOB_ID
+        })
+        self.assertEqual(
+            self.ctrl._get_before_suspend_dependency_set(
+                suspend_job.id,
+                [job1, job2]
+            ),
+            {"job1"}
+        )
+
+    def test_get_before_suspend_dependency_set__sibling(self):
+        job1 = JobDefinition({
+            "id": "job1",
+            "siblings": json.dumps([{
+                "id": "sibling-j1",
+                "depends": Suspend.AUTO_JOB_ID,
+            }])
+        })
+        job2 = JobDefinition({
+            "id": "job2",
+        })
+        suspend_job = JobDefinition({
+            "id": Suspend.AUTO_JOB_ID
+        })
+        self.assertEqual(
+            self.ctrl._get_before_suspend_dependency_set(
+                suspend_job.id,
+                [job1, job2]
+            ),
+            {"job1"}
+        )
 
     def test_get_inhibitor_list_PENDING_RESOURCE(self):
         # verify that jobs that require a resource that hasn't been
@@ -227,6 +289,30 @@ class CheckBoxSessionStateControllerTests(TestCase):
             [JobReadinessInhibitor(
                 InhibitionCause.FAILED_DEP, j2, None)])
 
+    def test_get_inhibitor_list_NOT_FAILED_DEP(self):
+        # verify that jobs that depend on another job that ran but
+        # didn't result in OUTCOME_FAIL produce the NOT_FAILED_DEP
+        # inhibitor.
+        j1 = JobDefinition({
+            'id': 'j1',
+            'salvages': 'j2',
+        })
+        j2 = JobDefinition({
+            'id': 'j2'
+        })
+        session_state = mock.MagicMock(spec=SessionState)
+        session_state.job_state_map = {
+            'j1': mock.Mock(spec_set=JobState),
+            'j2': mock.Mock(spec_set=JobState),
+        }
+        jsm_j2 = session_state.job_state_map['j2']
+        jsm_j2.job = j2
+        jsm_j2.result.outcome = IJobResult.OUTCOME_NONE
+        self.assertEqual(
+            self.ctrl.get_inhibitor_list(session_state, j1),
+            [JobReadinessInhibitor(
+                InhibitionCause.NOT_FAILED_DEP, j2, None)])
+
     def test_get_inhibitor_list_good_dep(self):
         # verify that jobs that depend on another job that ran and has outcome
         # equal to OUTCOME_PASS don't have any inhibitors
@@ -255,6 +341,170 @@ class CheckBoxSessionStateControllerTests(TestCase):
         jsm_j3.result.outcome = IJobResult.OUTCOME_PASS
         self.assertEqual(
             self.ctrl.get_inhibitor_list(session_state, j1), [])
+
+    def test_get_inhibitor_list__suspend_job(self):
+        j1 = JobDefinition({
+            "id": "j1",
+            "flags": Suspend.AUTO_FLAG,
+        })
+        j2 = JobDefinition({
+            "id": "j2",
+        })
+        suspend_job = JobDefinition({
+            "id": Suspend.AUTO_JOB_ID
+        })
+        session_state = mock.MagicMock(spec=SessionState)
+        session_state.job_state_map = {
+            "j1": mock.Mock(spec_set=JobState),
+            "j2": mock.Mock(spec_set=JobState),
+            Suspend.AUTO_JOB_ID: mock.Mock(spec_set=JobState),
+        }
+        jsm_j1 = session_state.job_state_map["j1"]
+        jsm_j1.job = j1
+        jsm_j1.result.outcome = IJobResult.OUTCOME_NONE
+        jsm_j2 = session_state.job_state_map["j2"]
+        jsm_j2.job = j2
+        jsm_j2.result.outcome = IJobResult.OUTCOME_NONE
+        jsm_suspend = session_state.job_state_map[Suspend.AUTO_JOB_ID]
+        jsm_suspend.job = suspend_job
+        jsm_suspend.result.outcome = IJobResult.OUTCOME_NONE
+        self.assertEqual(
+            self.ctrl.get_inhibitor_list(session_state, suspend_job),
+            [JobReadinessInhibitor(InhibitionCause.PENDING_DEP, j1, None)])
+
+    def test_get_suspend_inhibitor_list__not_suspend_job_id(self):
+        j1 = JobDefinition({
+            "id": "not-a-suspend-job"
+        })
+        session_state = mock.MagicMock(spec=SessionState)
+        self.assertEqual(
+            self.ctrl._get_suspend_inhibitor_list(session_state, j1), [])
+
+    def test_get_suspend_inhibitor_list__auto_suspend(self):
+        j1 = JobDefinition({
+            "id": "j1",
+            "flags": Suspend.AUTO_FLAG,
+        })
+        j2 = JobDefinition({
+            "id": "j2",
+        })
+        suspend_job = JobDefinition({
+            "id": Suspend.AUTO_JOB_ID
+        })
+        session_state = mock.MagicMock(spec=SessionState)
+        session_state.job_state_map = {
+            "j1": mock.Mock(spec_set=JobState),
+            "j2": mock.Mock(spec_set=JobState),
+            Suspend.AUTO_JOB_ID: mock.Mock(spec_set=JobState),
+        }
+        jsm_j1 = session_state.job_state_map["j1"]
+        jsm_j1.job = j1
+        jsm_j1.result.outcome = IJobResult.OUTCOME_NONE
+        jsm_j2 = session_state.job_state_map["j2"]
+        jsm_j2.job = j2
+        jsm_j2.result.outcome = IJobResult.OUTCOME_NONE
+        jsm_suspend = session_state.job_state_map[Suspend.AUTO_JOB_ID]
+        jsm_suspend.job = suspend_job
+        jsm_suspend.result.outcome = IJobResult.OUTCOME_NONE
+        self.assertEqual(
+            self.ctrl._get_suspend_inhibitor_list(session_state, suspend_job),
+            [JobReadinessInhibitor(InhibitionCause.PENDING_DEP, j1, None)])
+
+    def test_get_suspend_inhibitor_list__manual_suspend(self):
+        j1 = JobDefinition({
+            "id": "j1",
+            "flags": Suspend.MANUAL_FLAG,
+        })
+        j2 = JobDefinition({
+            "id": "j2",
+        })
+        suspend_job = JobDefinition({
+            "id": Suspend.MANUAL_JOB_ID
+        })
+        session_state = mock.MagicMock(spec=SessionState)
+        session_state.job_state_map = {
+            "j1": mock.Mock(spec_set=JobState),
+            "j2": mock.Mock(spec_set=JobState),
+            Suspend.MANUAL_JOB_ID: mock.Mock(spec_set=JobState),
+        }
+        jsm_j1 = session_state.job_state_map["j1"]
+        jsm_j1.job = j1
+        jsm_j1.result.outcome = IJobResult.OUTCOME_NONE
+        jsm_j2 = session_state.job_state_map["j2"]
+        jsm_j2.job = j2
+        jsm_j2.result.outcome = IJobResult.OUTCOME_NONE
+        jsm_suspend = session_state.job_state_map[Suspend.MANUAL_JOB_ID]
+        jsm_suspend.job = suspend_job
+        jsm_suspend.result.outcome = IJobResult.OUTCOME_NONE
+        self.assertEqual(
+            self.ctrl._get_suspend_inhibitor_list(session_state, suspend_job),
+            [JobReadinessInhibitor(InhibitionCause.PENDING_DEP, j1, None)])
+
+    def test_get_suspend_inhibitor_list__auto_sibling(self):
+        j1 = JobDefinition({
+            "id": "j1",
+            "siblings": json.dumps([{
+                "id": "sibling-j1",
+                "depends": Suspend.AUTO_JOB_ID,
+            }])
+        })
+        j2 = JobDefinition({
+            "id": "j2",
+        })
+        suspend_job = JobDefinition({
+            "id": Suspend.AUTO_JOB_ID
+        })
+        session_state = mock.MagicMock(spec=SessionState)
+        session_state.job_state_map = {
+            "j1": mock.Mock(spec_set=JobState),
+            "j2": mock.Mock(spec_set=JobState),
+            Suspend.AUTO_JOB_ID: mock.Mock(spec_set=JobState),
+        }
+        jsm_j1 = session_state.job_state_map["j1"]
+        jsm_j1.job = j1
+        jsm_j1.result.outcome = IJobResult.OUTCOME_NONE
+        jsm_j2 = session_state.job_state_map["j2"]
+        jsm_j2.job = j2
+        jsm_j2.result.outcome = IJobResult.OUTCOME_NONE
+        jsm_suspend = session_state.job_state_map[Suspend.AUTO_JOB_ID]
+        jsm_suspend.job = suspend_job
+        jsm_suspend.result.outcome = IJobResult.OUTCOME_NONE
+        self.assertEqual(
+            self.ctrl._get_suspend_inhibitor_list(session_state, suspend_job),
+            [JobReadinessInhibitor(InhibitionCause.PENDING_DEP, j1, None)])
+
+    def test_get_suspend_inhibitor_list__manual_sibling(self):
+        j1 = JobDefinition({
+            "id": "j1",
+            "siblings": json.dumps([{
+                "id": "sibling-j1",
+                "depends": Suspend.MANUAL_JOB_ID,
+            }])
+        })
+        j2 = JobDefinition({
+            "id": "j2",
+        })
+        suspend_job = JobDefinition({
+            "id": Suspend.MANUAL_JOB_ID
+        })
+        session_state = mock.MagicMock(spec=SessionState)
+        session_state.job_state_map = {
+            "j1": mock.Mock(spec_set=JobState),
+            "j2": mock.Mock(spec_set=JobState),
+            Suspend.MANUAL_JOB_ID: mock.Mock(spec_set=JobState),
+        }
+        jsm_j1 = session_state.job_state_map["j1"]
+        jsm_j1.job = j1
+        jsm_j1.result.outcome = IJobResult.OUTCOME_NONE
+        jsm_j2 = session_state.job_state_map["j2"]
+        jsm_j2.job = j2
+        jsm_j2.result.outcome = IJobResult.OUTCOME_NONE
+        jsm_suspend = session_state.job_state_map[Suspend.MANUAL_JOB_ID]
+        jsm_suspend.job = suspend_job
+        jsm_suspend.result.outcome = IJobResult.OUTCOME_NONE
+        self.assertEqual(
+            self.ctrl._get_suspend_inhibitor_list(session_state, suspend_job),
+            [JobReadinessInhibitor(InhibitionCause.PENDING_DEP, j1, None)])
 
     def test_observe_result__normal(self):
         job = mock.Mock(spec=JobDefinition)

--- a/checkbox-ng/plainbox/impl/test_ctrl.py
+++ b/checkbox-ng/plainbox/impl/test_ctrl.py
@@ -314,12 +314,15 @@ class CheckBoxSessionStateControllerTests(TestCase):
         jsm_j1 = session_state.job_state_map["j1"]
         jsm_j1.job = j1
         jsm_j1.result.outcome = IJobResult.OUTCOME_NONE
+        jsm_j1.readiness_inhibitor_list = []
         jsm_j2 = session_state.job_state_map["j2"]
         jsm_j2.job = j2
         jsm_j2.result.outcome = IJobResult.OUTCOME_NONE
+        jsm_j2.readiness_inhibitor_list = []
         jsm_suspend = session_state.job_state_map[Suspend.AUTO_JOB_ID]
         jsm_suspend.job = suspend_job
         jsm_suspend.result.outcome = IJobResult.OUTCOME_NONE
+        jsm_suspend.readiness_inhibitor_list = []
         self.assertEqual(
             self.ctrl.get_inhibitor_list(session_state, suspend_job),
             [JobReadinessInhibitor(InhibitionCause.PENDING_DEP, j1, None)])

--- a/checkbox-ng/plainbox/suspend_consts.py
+++ b/checkbox-ng/plainbox/suspend_consts.py
@@ -7,7 +7,6 @@
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
 # as published by the Free Software Foundation.
-
 #
 # Checkbox is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -18,8 +17,8 @@
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-:mod:`plainbox.impl.configuration` -- Configuration variables
-=============================================================
+:mod:`plainbox.impl.suspend_consts` -- Suspend-related constants
+================================================================
 """
 
 

--- a/docs/reference/units/job.rst
+++ b/docs/reference/units/job.rst
@@ -315,11 +315,17 @@ Following fields may be used by the job unit:
 
     .. _also-after-suspend flag:
 
-    ``also-after-suspend``: See :ref:`Job siblings field` below.
+    ``also-after-suspend``:
+        Ensure the test will be run before **and** after suspend by creating
+        a :ref:`sibling<Job siblings field>` that will depend on the automated
+        suspend job. The current job is guaranteed to run before suspend.
 
     .. _also-after-suspend-manual flag:
 
-    ``also-after-suspend-manual``: See :ref:`Job siblings field` below.
+    ``also-after-suspend-manual``:
+        Ensure the test will be run before **and** after suspend by creating
+        a :ref:`sibling<Job siblings field>` that will depend on the manual
+        suspend job. The current job is guaranteed to run before suspend.
 
     Additional flags may be present in job definition; they are ignored.
 
@@ -399,16 +405,20 @@ Following fields may be used by the job unit:
           com.canonical.certification::suspend/suspend_advanced
           foo
 
-.. warning::
-    The curly braces used in this field have to be escaped when used in a
-    template job (python format, Jinja2 templates do not have this issue).
-    The syntax for templates is::
+    .. note::
+        If the sibling definition depends on one of the suspend jobs, Checkbox
+        will make sure the original job runs **before** the suspend job.
 
-            _siblings: [
-                {{ "id": "bar-after-suspend_{interface}",
-                  "_summary": "bar after suspend",
-                  "depends": "suspend/advanced"}}
-                ]
+    .. warning::
+        The curly braces used in this field have to be escaped when used in a
+        template job (python format, Jinja2 templates do not have this issue).
+        The syntax for templates is::
+
+                _siblings: [
+                    {{ "id": "bar-after-suspend_{interface}",
+                      "_summary": "bar after suspend",
+                      "depends": "suspend/advanced"}}
+                    ]
 
 .. _Job imports field:
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Some jobs should be run before *and* after suspend. To take this into
account, [the `siblings` field](https://checkbox.readthedocs.io/en/stable/reference/units/job.html#job-siblings-field) was developed, along with the
[`also-after-suspend` and `also-after-suspend-manual` flags](https://checkbox.readthedocs.io/en/stable/reference/units/job.html#also-after-suspend-flag).

These would let Checkbox spawn a similar job with an added dependency on
the suspend job (either the manual or the automated version of it).

The problem is that the original job did not have any dependency to
force it to be run *before* the suspend job.

This was not an issue for test plans organized manually, using regular
expressions, because you could have an include section that looks like:

    storage_.*
    com.canonical.certification::suspend/suspend_advanced_auto
    after-suspend-storage.*

However, now that template ids can be added in [test plans](https://checkbox.readthedocs.io/en/latest/reference/units/test-plan.html), this is a
problem.

This patch will make sure the jobs that need to run before suspend are
added as dependencies of their related suspend job, so that regardless
of the order in the test plan, they will be run in the proper order.

## Resolved issues

https://warthogs.atlassian.net/browse/CHECKBOX-1265

## Documentation

The Job Unit reference page has been updated to explain what happens when the `also-after-suspend` flag is used, or when a `sibling` is defined that depends on a suspend job.

## Tests

Given the following units:

```
id: demoresource
plugin: resource
command:
    echo 'name: sda'
    echo 'path: /dev/sda'
    echo
    echo 'name: sdb'
    echo 'path: /dev/sdb'

unit: template
template-resource: demoresource
template-id: demo-template
id: demo-test-storage-{name}
plugin: shell
command: echo "This is the path: {path}"
flags: also-after-suspend

unit: test plan
id: demo-test-plan
bootstrap_include:
  demoresource
include:
  demo-template     # template id generated from job id
```

Before applying the patch:

```
$ checkbox-cli list-bootstrapped com.canonical.certification::demo-test-plan

com.canonical.certification::demo-test-storage-sda
com.canonical.certification::sleep
com.canonical.certification::rtc
com.canonical.certification::suspend/suspend_advanced_auto
com.canonical.certification::after-suspend-demo-test-storage-sda
com.canonical.certification::demo-test-storage-sdb
com.canonical.certification::after-suspend-demo-test-storage-sdb
```

The `demo-test-storage-sdb` job should be run **before** `suspend/suspend_advanced_auto`, but is run after.

After applying the patch:

```
$ checkbox-cli list-bootstrapped com.canonical.certification::demo-test-plan

com.canonical.certification::demo-test-storage-sda
com.canonical.certification::rtc
com.canonical.certification::sleep
com.canonical.certification::demo-test-storage-sdb
com.canonical.certification::suspend/suspend_advanced_auto
com.canonical.certification::after-suspend-demo-test-storage-sda
com.canonical.certification::after-suspend-demo-test-storage-sdb
```

I also ran the test plan to make sure it executed properly and in the right order.