### PR TITLE
Allow listing instances from resume state (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -599,6 +599,7 @@ class SessionAssistant:
             ).allowed_calls = self._get_allowed_calls_in_normal_state()
         else:
             UsageExpectation.of(self).allowed_calls = {
+                self.get_resumable_sessions: "to get resume candidates",
                 self.select_test_plan: "to save test plan selection",
                 self.use_alternate_configuration: (
                     "use an alternate configuration system"


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

It in unclear why get_resumable_sessions is called after resume_session currently but given that the cache that get_resumable builds is re-invalidated/built if resume_session doesn't find the session is looking for in it after it is called, then there is no danger on this new edge.

This adds the possibility of listing resumable sessions after the resume_session function was called. 

## Resolved issues

Solves: https://github.com/canonical/checkbox/issues/935#issuecomment-1980005512

(although it is not clear how this was triggered at all, I am unable to recreate this)

## Documentation

N/A

## Tests

N/A

