### PR TITLE
Support job flags being None (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -509,7 +509,7 @@ class Launcher(MainLoopStage, ReportsStage):
         else, if the job made Checkbox crash, it will be marked as crash
         """
         job_state = self.sa.get_job_state(metadata.running_job_name)
-        if "noreturn" in (job_state.job.flags or ""):
+        if "noreturn" in (job_state.job.flags or set()):
             return IJobResult.OUTCOME_PASS
         return IJobResult.OUTCOME_CRASH
 

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -509,7 +509,7 @@ class Launcher(MainLoopStage, ReportsStage):
         else, if the job made Checkbox crash, it will be marked as crash
         """
         job_state = self.sa.get_job_state(metadata.running_job_name)
-        if "noreturn" in job_state.job.flags:
+        if "noreturn" in (job_state.job.flags or ""):
             return IJobResult.OUTCOME_PASS
         return IJobResult.OUTCOME_CRASH
 

--- a/metabox/metabox/metabox-provider/units/resume.pxu
+++ b/metabox/metabox/metabox-provider/units/resume.pxu
@@ -1,12 +1,14 @@
 id: checkbox-crasher
+unit: job
 _summary: Crash Checkbox
-flags: simple
+plugin: shell
 user: root
 command:
  PID=`pgrep -f checkbox-cli`
  kill $PID
 
 id: reboot-emulator
+unit: job
 _summary: Emulate the reboot
 flags: simple noreturn
 user: root


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

job_status.job.flags can be `None` if the job doesn't list any flag in its definition. This makes the resume code crash as it assumes that flags is iterable.

This fixes the issue by correctly treating no flags as no "noreturn" flags, therefore marking the job as crashed.

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/935#issuecomment-1980000477

## Documentation

N/A

## Tests

Modified the metabox scenario so that the crasher doesn't have any flag

