### PR TITLE
Remote resistant no launcher (Bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -720,9 +720,12 @@ class RemoteSessionAssistant:
         }
         meta = self.resume_session(session_id, runner_kwargs=runner_kwargs)
         app_blob = json.loads(meta.app_blob.decode("UTF-8"))
-        launcher_from_controller = Configuration.from_text(
-            app_blob["launcher"], "Remote launcher"
-        )
+        if "launcher" in app_blob:
+            launcher_from_controller = Configuration.from_text(
+                app_blob["launcher"], "Remote launcher"
+            )
+        else:
+            launcher_from_controller = Configuration()
         self._launcher.update_from_another(
             launcher_from_controller, "Remote launcher"
         )

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -231,7 +231,7 @@ class RemoteAssistantTests(TestCase):
         rsa._state = remote_assistant.Idle
 
         mock_meta = mock.Mock()
-        mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
+        mock_meta.app_blob = b'{"testplan_id": "tp_id"}'
 
         rsa.resume_session.return_value = mock_meta
         os_path_exists_mock = mock.Mock()


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

When trying to resume a session that was started without any launcher Checkbox remote will crash complaining about the missing launcher. This makes the agent use an empty configuration (as it should do) when the launcher is not provided by the controller

## Resolved issues

N/A

## Documentation

N/A

## Tests

Modified a test so that the launcher is not provided but the flow continues as expected

