### PR TITLE
Remove snappy-revert sub-tp from sru (BugFix)

### DIFF
--- a/providers/sru/units/sru.pxu
+++ b/providers/sru/units/sru.pxu
@@ -135,7 +135,6 @@ nested_part:
     # Now we ask to switch to the integrated graphics card.
     after-suspend-graphics-integrated-gpu-cert-automated
     # after-suspend-monitor-integrated-gpu-cert-automated # not defined
-    com.canonical.certification::snap-refresh-revert
 bootstrap_include:
     device
     graphics_card


### PR DESCRIPTION
## Description

This patch removes the snappy-revert sub test plan from the SRU test plan. At the current state of things it's main suspect for causing instability of other tests (due to lack of reboots).

The followup story is [CHECKBOX-1292](https://warthogs.atlassian.net/browse/CHECKBOX-1292)