### PR TITLE
Add "list-testplan" subcommand (New)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
+++ b/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
@@ -37,6 +37,7 @@ from checkbox_ng.launcher.subcommands import (
     StartProvider,
     Submit,
     ListBootstrapped,
+    ListTestplan,
     TestPlanExport,
     Show,
 )
@@ -72,6 +73,7 @@ def main():
         "submit": Submit,
         "show": Show,
         "list-bootstrapped": ListBootstrapped,
+        "list-testplan": ListTestplan,
         "merge-reports": MergeReports,
         "merge-submissions": MergeSubmissions,
         "tp-export": TestPlanExport,

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -685,7 +685,6 @@ class TestLListBootstrapped(TestCase):
 
 
 class TestListTestplan(TestCase):
-    maxDiff = None
     def setUp(self):
         self.launcher = ListTestplan()
         self.ctx = Mock()
@@ -740,6 +739,11 @@ class TestListTestplan(TestCase):
                 ),
             ),
         )
+
+    def test_register_arguments(self):
+        parser_mock = Mock()
+        self.launcher.register_arguments(parser_mock)
+        self.assertTrue(parser_mock.add_argument.called)
 
     def test_invoke_test_plan_not_found(self):
         self.ctx.args.TEST_PLAN = "test-plan3"

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -693,6 +693,7 @@ class TestListTestplan(TestCase):
         test_template = TemplateUnit({
             "template-id": "test-template",
             "id": "test-{res}",
+            "template-summary": "Test Template Summary",
         })
         self.ctx.sa = Mock(
             start_new_session=Mock(),
@@ -747,22 +748,11 @@ class TestListTestplan(TestCase):
             self.launcher.invoked(self.ctx)
 
     @patch("sys.stdout", new_callable=StringIO)
-    def test_invoke_print_output_standard_format(self, stdout):
+    def test_invoke_print_output(self, stdout):
         self.ctx.args.TEST_PLAN = "test-plan1"
 
-        expected_out = (
-            '[{"template-id": "test-template", '
-            '"id": "test-{res}", '
-            '"certification_status": "blocker"}, '
-            '{"id": "namespace2::test-job2", '
-            '"summary": "fake-job2", '
-            '"plugin": "shell", '
-            '"command": "ls", '
-            '"certification_status": "blocker", '
-            '"unit": "job"}]\n'
-        )
         self.launcher.invoked(self.ctx)
-        self.assertEqual(stdout.getvalue(), expected_out)
+        self.assertIn("Test Template Summary", stdout.getvalue())
 
 
 class TestUtilsFunctions(TestCase):

--- a/checkbox-ng/plainbox/impl/secure/qualifiers.py
+++ b/checkbox-ng/plainbox/impl/secure/qualifiers.py
@@ -516,13 +516,12 @@ def select_jobs(job_list, qualifier_list):
             excluded_set.add(job)
 
     for qualifier in flat_qualifier_list:
+        # optimize the super-common case where a qualifier refers to
+        # a specific job
         if (isinstance(qualifier, FieldQualifier) and
                 qualifier.field == 'id' and
                 isinstance(qualifier.matcher, OperatorMatcher) and
                 qualifier.matcher.op == operator.eq):
-            # optimize the super-common case where a qualifier refers to
-            # a specific job by using the id_to_index_map to instantly
-            # perform the requested operation on a single job
             for job in job_list:
                 if job.id == qualifier.matcher.value:
                     _handle_vote(qualifier, job)


### PR DESCRIPTION

## Description

The new subcommand works similarly to "list-bootstrapped" since it also
bootstraps a given test plan.

However, it filters out the instantiated jobs and replaces them with
their original template.

In the end, a list of jobs and templates used in this test plan are
returned as JSON-formatted data.

This is to be used by external tools, for instance to create a document
listing information (summary, description...) about executed jobs and
templates.


## Resolved issues

CHECKBOX-1263

## Documentation

TBD

## Tests

Given the following units:

```
id: pieq-job-fail
plugin: shell
command: false
flags: also-after-suspend

id: demoresource
plugin: resource
command:
    echo 'name: sda'
    echo 'path: /dev/sda'
    echo
    echo 'name: sdb'
    echo 'path: /dev/sdb'

unit: template
template-resource: demoresource
template-id: demo-template
template-summary: Display the path of all the disks on the system
template-description:
  Walking sysfs devices, display information about disk while retaining
  other information that could be useful, but we will not get into too much
  details here because this is not the point.
id: demo-test-storage-{name}
plugin: shell
command: echo "This is the path: {path}"
flags: also-after-suspend

unit: test plan
id: pieq-job-test-plan
name: pieq job test plan
bootstrap_include:
  demoresource
include:
  pieq-job-fail certification_status=blocker
  after-suspend-pieq-job-fail
  demo-template
```

The command `$ checkbox-cli list-testplan  com.canonical.certification::pieq-job-test-plan | jq` will return:

```json
[
  {
    "id": "pieq-job-fail",
    "plugin": "shell",
    "command": "false",
    "flags": "also-after-suspend",
    "unit": "job",
    "certification_status": "blocker"
  },
  {
    "id": "pieq-job-sibling",
    "plugin": "shell",
    "command": "echo \"This is a job\"",
    "siblings": "[\n {\n \"id\": \"after-suspend-pieq-job-sibling\",\n \"depends\": \"com.canonical.certification::suspend/suspend_advanced_auto pieq-job-sibling\"\n }\n ]",
    "unit": "job",
    "certification_status": "unspecified"
  },
  {
    "unit": "template",
    "template-resource": "demoresource",
    "template-id": "demo-template",
    "template-summary": "Display the path of all the disks on the system",
    "template-description": " Walking sysfs devices, display information about disk while retaining\n other information that could be useful, but we will not get into too much\n details here because this is not the point.",
    "id": "demo-test-storage-{name}",
    "plugin": "shell",
    "command": "echo \"This is the path: {path}\"",
    "flags": "also-after-suspend",
    "certification_status": "unspecified"
  },
  {
    "id": "rtc",
    "estimated_duration": "0.02",
    "plugin": "resource",
    "category_id": "information_gathering",
    "command": " if [ -e /proc/driver/rtc ]\n then\n     echo \"state: supported\"\n else\n     echo \"state: unsupported\"\n fi",
    "_summary": "Creates resource info for RTC",
    "unit": "job",
    "certification_status": "unspecified"
  },
  {
    "id": "sleep",
    "estimated_duration": "0.03",
    "plugin": "resource",
    "category_id": "information_gathering",
    "command": " tr ' ' '\\n' < /sys/power/state | while IFS= read -r state; do echo \"$state: supported\"; done\n if [ -e /sys/power/mem_sleep ]; then\n     awk -F\"[][]\" '{ print \"mem_sleep: \" $2 }' < /sys/power/mem_sleep\n else\n     echo \"mem_sleep: unsupported\"\n fi",
    "_summary": "Create resource info for supported sleep states",
    "unit": "job",
    "certification_status": "unspecified"
  },
  {
    "plugin": "shell",
    "category_id": "com.canonical.plainbox::suspend",
    "id": "suspend/suspend_advanced_auto",
    "requires": "   sleep.mem == 'supported'\n   rtc.state == 'supported'",
    "_summary": "Automated test of suspend function",
    "_description": "This is the automated version of suspend/suspend_advanced.",
    "user": "root",
    "environ": "PLAINBOX_SESSION_SHARE RTC_DEVICE_FILE",
    "command": "if [[ -v SNAP ]]; then\n    export LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH:$SNAP/usr/lib/fwts\"\nfi\n# fwts s3 is not available on all architectures (i.e ARM)\nif fwts --show-tests-categories | grep -q 's3 '; then\n    echo \"Calling fwts\"\n    set -o pipefail; checkbox-support-fwts_test -f none -l \"$PLAINBOX_SESSION_SHARE\"/suspend_single.log -s s3 --s3-sleep-delay=30 --s3-device-check --s3-device-check-delay=45 | tee \"$PLAINBOX_SESSION_SHARE\"/suspend_single_times.log\nelse\n   if [ -z \"$RTC_DEVICE_FILE\" ]; then\n     echo \"Calling rtcwake\"\n     rtcwake -m no -s 30 && systemctl suspend || exit 1\n   else\n     echo \"Calling rtcwake with -d $RTC_DEVICE_FILE\"\n     rtcwake -d \"$RTC_DEVICE_FILE\" -m no -s 30 && systemctl suspend || exit 1\n   fi\nfi",
    "estimated_duration": "90.000",
    "unit": "job",
    "certification_status": "unspecified"
  },
  {
    "id": "after-suspend-pieq-job-fail",
    "plugin": "shell",
    "command": "false",
    "flags": "",
    "_summary": "pieq-job-fail after suspend (S3)",
    "depends": "com.canonical.certification::pieq-job-fail com.canonical.certification::suspend/suspend_advanced_auto",
    "unit": "job",
    "certification_status": "unspecified"
  },
  {
    "id": "after-suspend-pieq-job-sibling",
    "plugin": "shell",
    "command": "echo \"This is a job\"",
    "depends": "com.canonical.certification::suspend/suspend_advanced_auto pieq-job-sibling",
    "unit": "job",
    "certification_status": "unspecified"
  }
]
```