### PR TITLE
Add TemplateUnit.__repr__ and modify its __str__ method (Bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/unit/template.py
+++ b/checkbox-ng/plainbox/impl/unit/template.py
@@ -187,7 +187,11 @@ class TemplateUnit(UnitWithId):
 
     def __str__(self):
         """String representation of Template unit objects."""
-        return "{} <~ {}".format(self.id, self.resource_id)
+        return "{} <~ {}".format(self.template_id, self.resource_id)
+
+    def __repr__(self):
+        return "<TemplateUnit template_id:{!r}>".format(
+            self.template_id)
 
     @property
     def unit(self):

--- a/checkbox-ng/plainbox/impl/unit/test_template.py
+++ b/checkbox-ng/plainbox/impl/unit/test_template.py
@@ -42,6 +42,25 @@ from plainbox.vendor import mock
 
 class TemplateUnitTests(TestCase):
 
+    def test_str(self):
+        template = TemplateUnit({
+            "template-resource": "resource",
+            "template-id": "check-devices",
+            "id": "check-device-{dev_name}",
+        })
+        self.assertEqual(str(template), "check-devices <~ resource")
+
+    def test_repr(self):
+        template = TemplateUnit({
+            "template-resource": "resource",
+            "template-id": "check-devices",
+            "id": "check-device-{dev_name}",
+        })
+        self.assertEqual(
+            repr(template),
+            "<TemplateUnit template_id:'check-devices'>"
+        )
+
     def test_id(self):
         template = TemplateUnit({
             "template-resource": "resource",


### PR DESCRIPTION
Quick fix to tpdate TemplateUnit.__str__ to use the new `template_id` field for more accuracy.

Add proper representation, similar to `JobDefinition` objects.

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->




