### PR TITLE
Documentation for job statuses (infra)

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -11,3 +11,4 @@ Reference
    units/index
    snaps
    submission-schema
+   job-status

--- a/docs/reference/job-status.rst
+++ b/docs/reference/job-status.rst
@@ -7,7 +7,7 @@ A Checkbox job always receives a finishing status either automatically or
 manually. The following is a description of what each status means and when/how
 it is received.
 
-Passing Jobs
+Passed Jobs
 ------------
 
 The Passing outcome is the marker for a successful run. It can be assigned in
@@ -41,7 +41,7 @@ Every skipped job is either marked by the following symbol ``"  "`` (white
 space) or the text ``job skipped``. Checkbox internally uses the
 ``IJobResult.OUTCOME_SKIP``.
 
-Failing Jobs
+Failed Jobs
 ------------
 
 The Failing outcome is the marker for a failing job run. It can be assigned in
@@ -58,7 +58,7 @@ Every failing job is either marked by the following symbol ``☒`` or the text
 ``job failed``. Checkbox internally uses the ``IJobResult.OUTCOME_FAIL`` object
 to mark these jobs.
 
-Crashing Jobs
+Crashed Jobs
 -------------
 
 The Crashing outcome is the marker for a crashing job. It can only be assigned

--- a/docs/reference/job-status.rst
+++ b/docs/reference/job-status.rst
@@ -17,12 +17,12 @@ the following situations:
 - Automated job is marked as ``noreturn`` and the session was interrupted and
   brought back
 - Manual job marked as passed by the user
-- Job explicitly marked as passed by the user when a session was manually brought back after interruption
-  the job as pass
+- Job explicitly marked as passed by the user when a session was manually
+  brought back after interruption
 
-Every passed job is marked by either the following symbol ``☑`` (ballot box with check) or the text
-``job passed``. Checkbox internally uses the ``IJobResult.OUTCOME_PASS`` object
-to mark these jobs.
+Every passed job is marked by either the following symbol ``☑`` (ballot box
+with check) or the text ``job passed``. Checkbox internally uses the
+``IJobResult.OUTCOME_PASS`` object to mark these jobs.
 
 Skipped Jobs
 ------------
@@ -48,15 +48,13 @@ The Failing outcome is the marker for a failing job run. It can be assigned in
 the following situations:
 
 - Automated job returned a non-0 return code
-- Automated job is marked as ``noreturn`` and the session was interrupted and
-  brought back
-- Manual job marked as passed by the user
-- Session was interrupted and when manually brought back, explicitly marking
-  the job as pass
+- Manual job marked as failed by the user
+- Job explicitly marked as failed by the user when a session was manually
+  brought back after interruption
 
-Every failed job is marked by either the following symbol ``☒`` (ballot box with X) or the text
-``job failed``. Checkbox internally uses the ``IJobResult.OUTCOME_FAIL`` object
-to mark these jobs.
+Every failed job is marked by either the following symbol ``☒``
+(ballot box with X) or the text ``job failed``. Checkbox internally
+uses the ``IJobResult.OUTCOME_FAIL`` object to mark these jobs.
 
 Crashed Jobs
 -------------
@@ -68,9 +66,9 @@ to automated job in the following situations:
   Memory Guardian)
 - Job interrupted the testing session without a ``noreturn`` flag
 
-Every crashed job is marked by either the warning marker ``⚠`` or the text
-``job crashed``. Checkbox internally uses the ``IJobResult.OUTCOME_CRASH``
-object to mark these jobs.
+Every crashed job is marked by either the warning marker ``⚠`` (warning sign)
+or the text ``job crashed``. Checkbox internally uses the
+``IJobResult.OUTCOME_CRASH`` object to mark these jobs.
 
 Not Started Jobs
 ----------------
@@ -79,6 +77,6 @@ The Not Started outcome is the marker for a job that can not be started. It is
 assigned only in the situation where a job depends on another job that was
 either skipped or not started itself.
 
-Every not-started job is marked either by the following marker ``☐`` (ballot box) or the
-text ``job cannot be started``. Checkbox internally uses the
+Every not-started job is marked either by the following marker ``☐`` (ballot
+box) or the text ``job cannot be started``. Checkbox internally uses the
 ``IJobResult.OUTCOME_NOT_SUPPORTED`` object to mark these jobs.

--- a/docs/reference/job-status.rst
+++ b/docs/reference/job-status.rst
@@ -1,0 +1,83 @@
+.. _job_status:
+
+Checkbox Job Status
+===================
+
+A Checkbox job always receives a finishing status either automatically or
+manually. The following is a description of what each status means and when/how
+it is received.
+
+Passing Jobs
+------------
+
+The Passing outcome is the marker for a succesful run. It can be assigned in
+the following situations:
+
+- Automated job returned a 0 return code
+- Automated job is marked as ``noreturn`` and the session was interrupted and
+  brought back
+- Manual job marked as passed by the user
+- Session was interrupted and when manually brought back, explicitly marking
+  the job as pass
+
+Every passing job is either marked by the following symbol ``☑`` or the text
+``job passed``. Checkbox internally uses the ``IJobResult.OUTCOME_PASS`` object
+to mark these jobs.
+
+Skipped Jobs
+------------
+
+The Skipped outcome is the marker for a job that was intentionally not started
+either by the user or Checkbox itself. This can be due to the following
+reasons:
+
+- Job with a ``require`` constraint that can not be satisfied
+- Job with a dependency on a job that is skipped itself
+- Job explicitly skipped by the user via the ``launcher``
+- Job explicitly skipped by the user via the Ctrl+C menu
+- Job explicitly skipped by the user via the resume screen
+
+Every skipped job is either marked by the following symbol ``"  "`` (white
+space) or the text ``job skipped``. Checkbox internally uses the
+``IJobResult.OUTCOME_SKIP``.
+
+Failing Jobs
+------------
+
+The Failing outcome is the marker for a failing job run. It can be assigned in
+the following situations:
+
+- Automated job returned a non-0 return code
+- Automated job is marked as ``noreturn`` and the session was interrupted and
+  brought back
+- Manual job marked as passed by the user
+- Session was interrupted and when manually brought back, explicitly marking
+  the job as pass
+
+Every failing job is either marked by the following symbol ``☒`` or the text
+``job failed``. Checkbox internally uses the ``IJobResult.OUTCOME_FAIL`` object
+to mark these jobs.
+
+Crashing Jobs
+-------------
+
+The Crashing outcome is the marker for a crashing job. It can only be assigned
+to automated job in the following situations:
+
+- Job crashed or was forcibly terminated by an external actor (like the OOMK)
+- Job interrupted the testing session without a ``noreturn`` flag
+
+Every crashing job is either merked by the following marker ``⚠`` or the text
+``job crashed``. Checkbox internally uses the ``IJobResult.OUTCOME_CRASH``
+object to mark these jobs.
+
+Not Started Jobs
+----------------
+
+The Not Started outcome is the marker for a job that can not be started. It is
+assigned only in the situation where a job depends on another job that was
+either skipped or not started itself.
+
+Every not started job is either marked by the following marker ``☐`` or the
+text ``job cannot be started``. Checkbox internally uses the
+``IJobResult.OUTCOME_NOT_SUPPORTED`` object to mark these jobs.

--- a/docs/reference/job-status.rst
+++ b/docs/reference/job-status.rst
@@ -10,7 +10,7 @@ it is received.
 Passing Jobs
 ------------
 
-The Passing outcome is the marker for a succesful run. It can be assigned in
+The Passing outcome is the marker for a successful run. It can be assigned in
 the following situations:
 
 - Automated job returned a 0 return code
@@ -64,10 +64,11 @@ Crashing Jobs
 The Crashing outcome is the marker for a crashing job. It can only be assigned
 to automated job in the following situations:
 
-- Job crashed or was forcibly terminated by an external actor (like the OOMK)
+- Job crashed or was forcibly terminated by an external actor (like the Out of
+  Memory Guardian)
 - Job interrupted the testing session without a ``noreturn`` flag
 
-Every crashing job is either merked by the following marker ``⚠`` or the text
+Every crashing job is either marked by the following marker ``⚠`` or the text
 ``job crashed``. Checkbox internally uses the ``IJobResult.OUTCOME_CRASH``
 object to mark these jobs.
 

--- a/docs/reference/job-status.rst
+++ b/docs/reference/job-status.rst
@@ -3,7 +3,7 @@
 Checkbox Job Status
 ===================
 
-A Checkbox job always receives a finishing status either automatically or
+A Checkbox job always receives a final status either automatically or
 manually. The following is a description of what each status means and when/how
 it is received.
 
@@ -17,10 +17,10 @@ the following situations:
 - Automated job is marked as ``noreturn`` and the session was interrupted and
   brought back
 - Manual job marked as passed by the user
-- Session was interrupted and when manually brought back, explicitly marking
+- Job explicitly marked as passed by the user when a session was manually brought back after interruption
   the job as pass
 
-Every passing job is either marked by the following symbol ``☑`` or the text
+Every passed job is marked by either the following symbol ``☑`` (ballot box with check) or the text
 ``job passed``. Checkbox internally uses the ``IJobResult.OUTCOME_PASS`` object
 to mark these jobs.
 
@@ -39,7 +39,7 @@ reasons:
 
 Every skipped job is either marked by the following symbol ``"  "`` (white
 space) or the text ``job skipped``. Checkbox internally uses the
-``IJobResult.OUTCOME_SKIP``.
+``IJobResult.OUTCOME_SKIP`` to mark these jobs.
 
 Failed Jobs
 ------------
@@ -54,7 +54,7 @@ the following situations:
 - Session was interrupted and when manually brought back, explicitly marking
   the job as pass
 
-Every failing job is either marked by the following symbol ``☒`` or the text
+Every failed job is marked by either the following symbol ``☒`` (ballot box with X) or the text
 ``job failed``. Checkbox internally uses the ``IJobResult.OUTCOME_FAIL`` object
 to mark these jobs.
 
@@ -68,7 +68,7 @@ to automated job in the following situations:
   Memory Guardian)
 - Job interrupted the testing session without a ``noreturn`` flag
 
-Every crashing job is either marked by the following marker ``⚠`` or the text
+Every crashed job is marked by either the warning marker ``⚠`` or the text
 ``job crashed``. Checkbox internally uses the ``IJobResult.OUTCOME_CRASH``
 object to mark these jobs.
 
@@ -79,6 +79,6 @@ The Not Started outcome is the marker for a job that can not be started. It is
 assigned only in the situation where a job depends on another job that was
 either skipped or not started itself.
 
-Every not started job is either marked by the following marker ``☐`` or the
+Every not-started job is marked either by the following marker ``☐`` (ballot box) or the
 text ``job cannot be started``. Checkbox internally uses the
 ``IJobResult.OUTCOME_NOT_SUPPORTED`` object to mark these jobs.


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

We don't have a comprehensive reference to job outcomes and what they mean. This introduces (as a followup to the resume PR) a reference page that documents everything that an user may want to know about them.

## Resolved issues

Resolves: [CHECKBOX-492](https://warthogs.atlassian.net/browse/CHECKBOX-492)

## Documentation

This is the documentation

## Tests
N/A


[CHECKBOX-492]: https://warthogs.atlassian.net/browse/CHECKBOX-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ