### PR TITLE
Don't diff results of the network test (BugFix)

### DIFF
--- a/providers/base/units/suspend/suspend.pxu
+++ b/providers/base/units/suspend/suspend.pxu
@@ -401,7 +401,7 @@ id: suspend/network_after_suspend
 estimated_duration: 20.0
 depends: suspend/suspend_advanced_auto suspend/network_before_suspend
 _description: Test the network after resuming.
-command: network_wait.sh; gateway_ping_test.py | diff "$PLAINBOX_SESSION_SHARE"/network_before_suspend.txt -
+command: network_wait.sh; gateway_ping_test.py
 user: root
 
 plugin: shell
@@ -410,7 +410,7 @@ id: suspend/network_after_suspend_auto
 estimated_duration: 20.0
 depends: suspend/suspend_advanced_auto suspend/network_before_suspend
 _description: Test the network after resuming.
-command: network_wait.sh; gateway_ping_test.py | diff "$PLAINBOX_SESSION_SHARE"/network_before_suspend.txt -
+command: network_wait.sh; gateway_ping_test.py
 user: root
 
 plugin: shell


### PR DESCRIPTION
## Description

This patch removes the reliance on diff for the after-suspend network test.

Previously it compared the output of the before and after suspend jobs diffing them. The job now is more reliable and produces precise information about the pings rendering the diffing useless.
This patch removes that.

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/CHECKBOX-1304
Fixes: https://github.com/canonical/checkbox/issues/1056

## Tests

Tested with a stripped down test plan that included the jobs.