### PR TITLE
Increase step timeout to 10h for snaps and 13h for debs build (infra)

### DIFF
--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -11,6 +11,7 @@ jobs:
         releases: [16, 18, 20, 22]
         arch: [amd64, arm64, armhf]
     runs-on: [self-hosted, linux, small]
+    timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     env:
       SERIES: series${{ matrix.releases }}
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         releases: [16, 18, 20, 22]
         arch: [amd64, arm64, armhf]
-    runs-on: [self-hosted, linux, large]
+    runs-on: [self-hosted, linux, small]
     env:
       SERIES: series${{ matrix.releases }}
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
@@ -38,6 +38,7 @@ jobs:
           echo "Building at: https://git.launchpad.net/~ce-certification-qa/+snap/$SNAPCRAFT_BUILDER_ID"
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
         name: Build the snap
+        timeout-minutes: 600 # 10hours
         with:
           action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
           attempt_delay: 600000 # 10min
@@ -62,6 +63,7 @@ jobs:
           path: checkbox-core-snap/series${{ matrix.releases }}/*.snap
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
         name: Upload the snap to the store
+        timeout-minutes: 600 # 10hours
         with:
           attempt_delay: 600000 # 10min
           attempt_limit: 10

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -12,6 +12,7 @@ jobs:
         type: [classic, uc]
         releases: [16, 18, 20, 22]
     runs-on: [self-hosted, linux, small]
+    timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     env:
       SERIES: series_${{ matrix.type }}${{ matrix.releases }}
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         type: [classic, uc]
         releases: [16, 18, 20, 22]
-    runs-on: [self-hosted, linux, large]
+    runs-on: [self-hosted, linux, small]
     env:
       SERIES: series_${{ matrix.type }}${{ matrix.releases }}
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
@@ -40,6 +40,7 @@ jobs:
           echo "Building at: https://git.launchpad.net/~ce-certification-qa/+snap/$SNAPCRAFT_BUILDER_ID"
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
         name: Building the snaps
+        timeout-minutes: 600 # 10hours
         with:
           action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
           attempt_delay: 600000 # 10min
@@ -64,6 +65,7 @@ jobs:
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
         name: Upload the snaps to the store
+        timeout-minutes: 600 # 10hours
         with:
           attempt_delay: 600000 # 10min
           attempt_limit: 10

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -26,18 +26,15 @@ jobs:
     if: ${{ needs.check_for_commits.outputs.new_commit_count > 0 || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/checkbox-core-snap-daily-builds.yml
     secrets: inherit
-    timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
 
   checkbox-snap-daily:
     needs: check_for_commits
     if: ${{ needs.check_for_commits.outputs.new_commit_count > 0 || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/checkbox-snap-daily-builds.yml
     secrets: inherit
-    timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
 
   checkbox-deb-daily:
     needs: check_for_commits
     if: ${{ needs.check_for_commits.outputs.new_commit_count > 0 || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/deb-daily-builds.yml
     secrets: inherit
-    timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check_for_commits:
-    runs-on: [self-hosted, linux, large]
+    runs-on: [self-hosted, linux, small]
     name: Check for commits
     outputs:
       new_commit_count: ${{ steps.commit_check.outputs.new_commit_count }}
@@ -26,15 +26,18 @@ jobs:
     if: ${{ needs.check_for_commits.outputs.new_commit_count > 0 || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/checkbox-core-snap-daily-builds.yml
     secrets: inherit
+    timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
 
   checkbox-snap-daily:
     needs: check_for_commits
     if: ${{ needs.check_for_commits.outputs.new_commit_count > 0 || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/checkbox-snap-daily-builds.yml
     secrets: inherit
+    timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
 
   checkbox-deb-daily:
     needs: check_for_commits
     if: ${{ needs.check_for_commits.outputs.new_commit_count > 0 || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/deb-daily-builds.yml
     secrets: inherit
+    timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -8,6 +8,7 @@ jobs:
   ppa_update:
     name: Sync PPA history with monorepo
     runs-on: [self-hosted, linux, small]
+    timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   ppa_update:
     name: Sync PPA history with monorepo
-    runs-on: [self-hosted, linux, large]
+    runs-on: [self-hosted, linux, small]
     steps:
       - name: Install dependencies
         run: |
@@ -65,6 +65,7 @@ jobs:
             tools/release/lp_update_recipe.py checkbox --recipe ${{ matrix.recipe }} --new-version $(tools/release/get_version.py --dev-suffix --output-format deb) --revision $GITHUB_SHA
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
         name: Build and wait result
+        timeout-minutes: 780 # 13hours
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
           PYTHONUNBUFFERED: 1


### PR DESCRIPTION

## Description

This increases the maxium timeout of a job step from 6h to 10+10h for snaps and 13h for debs. This is hopefully enough.

Minor: this moves all of these jobs to small workers, we don't want/need to hog large ones for such inactive tasks

## Resolved issues

Failing daily builds due to timeouts (ty armhf)

## Documentation

N/A (comments to translate minutes into hours)

## Tests

N/A

