### PR TITLE
Replace `create` with `up --no-start` in docker tests (bugfix)

### DIFF
--- a/providers/docker/units/docker.pxu
+++ b/providers/docker/units/docker.pxu
@@ -285,7 +285,7 @@ command:
  EOF
  )
  echo "$yml" | {compose_command} -f - pull
- echo "$yml" | {compose_command} -f - create
+ echo "$yml" | {compose_command} -f - up --no-start
  echo "$yml" | {compose_command} -f - start
  ID=$(echo "$yml" | {compose_command} -f - ps -q test)
  [ `docker inspect -f {status} $ID` != running ] && exit 1
@@ -446,11 +446,11 @@ command:
   set -ex
   compose_file={root_dir}/docker-compose-california-0.6.1.yml
   wget https://raw.githubusercontent.com/edgexfoundry/developer-scripts/04c933f2c03bb9b212e1035505fed0a386f4d43e/compose-files/docker-compose-california-0.6.1.yml -O $compose_file
-  for svc in volume config-seed mongo logging notifications metadata data command scheduler export-client export-distro rulesengine device-virtual; do 
+  for svc in volume config-seed mongo logging notifications metadata data command scheduler export-client export-distro rulesengine device-virtual; do
     {compose_command} --file $compose_file up -d $svc
     sleep 60
   done
-  for svc in volume mongo logging notifications metadata data command scheduler export-client export-distro device-virtual; do 
+  for svc in volume mongo logging notifications metadata data command scheduler export-client export-distro device-virtual; do
     status=$(docker inspect -f '{status}' $({compose_command} --file $compose_file ps -q $svc))
     if [ "$status" != "running" ]; then
         echo "service $svc is supposed to be running, but currently has status: $status"


### PR DESCRIPTION
## Description

`docker-compose create` is now fully deprecated. This replaces the call to an equivalent `up` call.

> Note: Here --no-start was used because removing --no-start and the subsequent start seems to hang the test 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

Fixes: CHECKBOX-1254

## Documentation

N/A

## Tests

Tested locally via `checkbox-cli` and independent script (resolved the template and dumped it into a file)

```
#!/bin/bash
export -n PYTHONHOME PYTHONUSERBASE PYTHONPATH
set -e
#read content from stdin
yml=$(cat <<EOF
version: '2'
services:
  test:
    image: ubuntu
    command: bash
    tty: true
EOF
)
echo "$yml" | docker-compose -f - pull
echo "$yml" | docker-compose -f - up --no-start
echo "$yml" | docker-compose -f - start
ID=$(echo "$yml" | docker-compose -f - ps -q test)
echo $ID
[ `docker inspect -f {{.State.Status}} $ID` != running ] && exit 1
echo "$yml" | docker-compose -f - stop
[ `docker inspect -f {{.State.Status}} $ID` != exited ] && exit 1
echo "$yml" | docker-compose -f - up -d --scale test=3
docker ps | grep 'test' | grep -c 'Up'
ret=$(docker ps -a | grep 'test' | grep -c 'Up')
[ $ret != 3 ] && exit 1
echo "$yml" | docker-compose -f - up -d --scale test=1
ret=$(docker ps -a | grep 'test' | grep -c 'Up')
[ $ret != 1 ] && exit 1
echo "$yml" | docker-compose -f - down
docker ps -a | grep 'test' || exit 0
echo "The container is still available"
exit 1
```

