### PR TITLE
Add 'expand' subcommand to list jobs and templates in a test plan (New)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
+++ b/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
@@ -37,6 +37,7 @@ from checkbox_ng.launcher.subcommands import (
     StartProvider,
     Submit,
     ListBootstrapped,
+    Expand,
     TestPlanExport,
     Show,
 )
@@ -72,6 +73,7 @@ def main():
         "submit": Submit,
         "show": Show,
         "list-bootstrapped": ListBootstrapped,
+        "expand": Expand,
         "merge-reports": MergeReports,
         "merge-submissions": MergeSubmissions,
         "tp-export": TestPlanExport,

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -19,6 +19,7 @@
 Definition of sub-command classes for checkbox-cli
 """
 from argparse import ArgumentTypeError
+from argparse import RawDescriptionHelpFormatter
 from argparse import SUPPRESS
 from collections import defaultdict
 from string import Formatter
@@ -45,12 +46,14 @@ from plainbox.impl.highlevel import Explorer
 from plainbox.impl.result import MemoryJobResult
 from plainbox.impl.runner import slugify
 from plainbox.impl.secure.sudo_broker import sudo_password_provider
+from plainbox.impl.secure.qualifiers import select_jobs
 from plainbox.impl.session.assistant import SA_RESTARTABLE
 from plainbox.impl.session.restart import detect_restart_strategy
 from plainbox.impl.session.storage import WellKnownDirsHelper
 from plainbox.impl.transport import TransportError
 from plainbox.impl.transport import get_all_transports
 from plainbox.impl.transport import SECURE_ID_PATTERN
+from plainbox.impl.unit.testplan import TestPlanUnitSupport
 
 from checkbox_ng.config import load_configs
 from checkbox_ng.launcher.stages import MainLoopStage, ReportsStage
@@ -1265,6 +1268,91 @@ class List:
         elif ctx.args.format:
             print(_("--format applies only to 'all-jobs' group.  Ignoring..."))
         print_objs(ctx.args.GROUP, ctx.sa, ctx.args.attrs)
+
+
+class Expand:
+    def __init__(self):
+        self.override_list = []
+
+    @property
+    def sa(self):
+        return self.ctx.sa
+
+    def register_arguments(self, parser):
+        parser.formatter_class = RawDescriptionHelpFormatter
+        parser.description = (
+            "Expand a given test plan: display all the jobs and templates "
+            "that are defined in this test plan and that would be executed "
+            "if ran. This is useful to visualize the full list of jobs and "
+            "templates for complex test plans that consist of many nested "
+            "parts with different 'include' and 'exclude' sections.\n\n"
+            "NOTE: the elements listed here are not sorted by execution "
+            "order. To see the execution order, please use the "
+            "'list-bootstrapped' command instead."
+        )
+        parser.add_argument("TEST_PLAN", help=_("test-plan id to expand"))
+        parser.add_argument(
+            "-f",
+            "--format",
+            type=str,
+            default="text",
+            help=_("output format: 'text' or 'json' (default: %(default)s)"),
+        )
+
+    def invoked(self, ctx):
+        self.ctx = ctx
+        session_title = "checkbox-expand-{}".format(ctx.args.TEST_PLAN)
+        self.sa.start_new_session(session_title)
+        tps = self.sa.get_test_plans()
+        if ctx.args.TEST_PLAN not in tps:
+            raise SystemExit("Test plan not found")
+        self.sa.select_test_plan(ctx.args.TEST_PLAN)
+        all_jobs_and_templates = [
+            unit
+            for unit in self.sa._context.state.unit_list
+            if unit.unit in ["job", "template"]
+        ]
+        tp = self.sa._context._test_plan_list[0]
+        tp_us = TestPlanUnitSupport(tp)
+        self.override_list = tp_us.override_list
+        jobs_and_templates_list = select_jobs(
+            all_jobs_and_templates,
+            [tp.get_mandatory_qualifier()] + [tp.get_qualifier()],
+        )
+
+        list_obj = []
+        for unit in jobs_and_templates_list:
+            obj = unit._raw_data.copy()
+            obj["unit"] = unit.unit
+            obj["id"] = unit.id  # To get the fully qualified id
+            obj[
+                "certification-status"
+            ] = self.get_effective_certification_status(unit)
+            if unit.template_id:
+                obj["template-id"] = unit.template_id
+            list_obj.append(obj)
+        if ctx.args.format == "json":
+            print(json.dumps(list_obj))
+        else:
+            for obj in list_obj:
+                if obj["unit"] == "template":
+                    print("Template '{}'".format(obj["template-id"]))
+                else:
+                    print("Job '{}'".format(obj["id"]))
+
+    def get_effective_certification_status(self, unit):
+        if unit.unit == "template":
+            unit_id = unit.template_id
+        else:
+            unit_id = unit.id
+        for regex, override_field_list in self.override_list:
+            if re.match(regex, unit_id):
+                for field, value in override_field_list:
+                    if field == "certification_status":
+                        return value
+        if hasattr(unit, "certification_status"):
+            return unit.certification_status
+        return "unspecified"
 
 
 class ListBootstrapped:

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -1320,7 +1320,7 @@ class Expand:
             [tp.get_mandatory_qualifier()] + [tp.get_qualifier()],
         )
 
-        list_obj = []
+        obj_list = []
         for unit in jobs_and_templates_list:
             obj = unit._raw_data.copy()
             obj["unit"] = unit.unit
@@ -1330,11 +1330,12 @@ class Expand:
             ] = self.get_effective_certification_status(unit)
             if unit.template_id:
                 obj["template-id"] = unit.template_id
-            list_obj.append(obj)
+            obj_list.append(obj)
+        obj_list.sort(key=lambda x: x.get("template-id", x["id"]))
         if ctx.args.format == "json":
-            print(json.dumps(list_obj))
+            print(json.dumps(obj_list, sort_keys=True))
         else:
-            for obj in list_obj:
+            for obj in obj_list:
                 if obj["unit"] == "template":
                     print("Template '{}'".format(obj["template-id"]))
                 else:

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -46,7 +46,7 @@ from plainbox.impl.highlevel import Explorer
 from plainbox.impl.result import MemoryJobResult
 from plainbox.impl.runner import slugify
 from plainbox.impl.secure.sudo_broker import sudo_password_provider
-from plainbox.impl.secure.qualifiers import select_jobs
+from plainbox.impl.secure.qualifiers import select_units
 from plainbox.impl.session.assistant import SA_RESTARTABLE
 from plainbox.impl.session.restart import detect_restart_strategy
 from plainbox.impl.session.storage import WellKnownDirsHelper
@@ -1315,7 +1315,7 @@ class Expand:
         tp = self.sa._context._test_plan_list[0]
         tp_us = TestPlanUnitSupport(tp)
         self.override_list = tp_us.override_list
-        jobs_and_templates_list = select_jobs(
+        jobs_and_templates_list = select_units(
             all_jobs_and_templates,
             [tp.get_mandatory_qualifier()] + [tp.get_qualifier()],
         )

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -718,8 +718,8 @@ class TestExpand(TestCase):
 
     @patch("sys.stdout", new_callable=StringIO)
     @patch("checkbox_ng.launcher.subcommands.TestPlanUnitSupport")
-    @patch("checkbox_ng.launcher.subcommands.select_jobs")
-    def test_invoke__text(self, mock_select_jobs, mock_tpus, stdout):
+    @patch("checkbox_ng.launcher.subcommands.select_units")
+    def test_invoke__text(self, mock_select_units, mock_tpus, stdout):
         template1 = TemplateUnit({
             "template-id": "test-template",
             "id": "test-{res}",
@@ -728,15 +728,15 @@ class TestExpand(TestCase):
         job1 = JobDefinition({
             "id": "job1",
         })
-        mock_select_jobs.return_value = [job1, template1]
+        mock_select_units.return_value = [job1, template1]
         self.ctx.args.TEST_PLAN = "test-plan1"
         self.launcher.invoked(self.ctx)
         self.assertIn("Template 'test-template'", stdout.getvalue())
 
     @patch("sys.stdout", new_callable=StringIO)
     @patch("checkbox_ng.launcher.subcommands.TestPlanUnitSupport")
-    @patch("checkbox_ng.launcher.subcommands.select_jobs")
-    def test_invoke__json(self, mock_select_jobs, mock_tpus, stdout):
+    @patch("checkbox_ng.launcher.subcommands.select_units")
+    def test_invoke__json(self, mock_select_units, mock_tpus, stdout):
         template1 = TemplateUnit({
             "template-id": "test-template",
             "id": "test-{res}",
@@ -745,7 +745,7 @@ class TestExpand(TestCase):
         job1 = JobDefinition({
             "id": "job1",
         })
-        mock_select_jobs.return_value = [job1, template1]
+        mock_select_units.return_value = [job1, template1]
         self.ctx.args.TEST_PLAN = "test-plan1"
         self.ctx.args.format = "json"
         self.launcher.invoked(self.ctx)

--- a/checkbox-ng/plainbox/abc.py
+++ b/checkbox-ng/plainbox/abc.py
@@ -287,12 +287,12 @@ class IJobResult(metaclass=ABCMeta):
         """
 
 
-class IJobQualifier(metaclass=ABCMeta):
+class IUnitQualifier(metaclass=ABCMeta):
     """
-    An opaque qualifier for a job definition.
+    An opaque qualifier for a unit (job or template).
 
-    This is an abstraction for matching jobs definitions to names, patterns and
-    other means of selecting jobs.
+    This is an abstraction for matching jobs and templates to names, patterns
+    and other means of selecting jobs and templates.
 
     There are two ways to use a qualifier object. The naive, direct, old API
     can simply check if a qualifier designates a particular job (if it selects
@@ -305,15 +305,15 @@ class IJobQualifier(metaclass=ABCMeta):
     expressiveness can be preserved.
 
     :attr VOTE_EXCLUDE:
-        (0) vote indicating that a job should *not* be included for
+        (0) vote indicating that a unit should *not* be included for
         selection. It overwrites any other votes.
 
     :attr VOTE_INCLUDE:
-        (1) vote indicating that a job should be included for selection. It is
+        (1) vote indicating that a unit should be included for selection. It is
         overridden by VOTE_EXCLUDE.
 
     :attr VOTE_IGNORE:
-        (2) vote indicating that a job should neither be included nor excluded
+        (2) vote indicating that a unit should neither be included nor excluded
         for selection. This is a neutral value overridden by all other votes.
     """
 
@@ -326,13 +326,13 @@ class IJobQualifier(metaclass=ABCMeta):
     VOTE_IGNORE = 2
 
     @abstractmethod
-    def get_vote(self, job):
+    def get_vote(self, unit):
         """
         Get one of the :attr:`VOTE_IGNORE`, :attr:`VOTE_INCLUDE`,
         :attr:`VOTE_EXCLUDE` votes that this qualifier associated with the
-        specified job.
+        specified unit.
 
-        :param job:
+        :param unit:
             A IJobDefinition instance that is to be visited
         :returns:
             one of the ``VOTE_xxx`` constants
@@ -346,7 +346,7 @@ class IJobQualifier(metaclass=ABCMeta):
         Return a list of primitives that constitute this qualifier.
 
         :returns:
-            A list of IJobQualifier objects that each is the smallest,
+            A list of IUnitQualifier objects that each is the smallest,
             indivisible entity.
 
         When each vote cast by those qualifiers is applied sequentially to

--- a/checkbox-ng/plainbox/impl/applogic.py
+++ b/checkbox-ng/plainbox/impl/applogic.py
@@ -32,12 +32,12 @@ from plainbox.abc import IJobResult
 from plainbox.i18n import gettext as _
 from plainbox.impl.result import MemoryJobResult
 from plainbox.impl.secure import config
-from plainbox.impl.secure.qualifiers import select_jobs
+from plainbox.impl.secure.qualifiers import select_units
 from plainbox.impl.session import SessionManager
 from plainbox.impl.session.jobs import InhibitionCause
 
 
-# Deprecated, use plainbox.impl.secure.qualifiers.select_jobs() instead
+# Deprecated, use plainbox.impl.secure.qualifiers.select_units() instead
 def get_matching_job_list(job_list, qualifier):
     """
     Get a list of jobs that are designated by the specified qualifier.
@@ -45,7 +45,7 @@ def get_matching_job_list(job_list, qualifier):
     This is intended to be used with :class:`CompositeQualifier`
     but works with any :class:`IJobQualifier` subclass.
     """
-    return select_jobs(job_list, [qualifier])
+    return select_units(job_list, [qualifier])
 
 
 def run_job_if_possible(session, runner, config, job, update=True, ui=None):

--- a/checkbox-ng/plainbox/impl/applogic.py
+++ b/checkbox-ng/plainbox/impl/applogic.py
@@ -43,7 +43,7 @@ def get_matching_job_list(job_list, qualifier):
     Get a list of jobs that are designated by the specified qualifier.
 
     This is intended to be used with :class:`CompositeQualifier`
-    but works with any :class:`IJobQualifier` subclass.
+    but works with any :class:`IUnitQualifier` subclass.
     """
     return select_units(job_list, [qualifier])
 

--- a/checkbox-ng/plainbox/impl/secure/qualifiers.py
+++ b/checkbox-ng/plainbox/impl/secure/qualifiers.py
@@ -34,7 +34,7 @@ import os
 import re
 import sre_constants
 
-from plainbox.abc import IJobQualifier
+from plainbox.abc import IUnitQualifier
 from plainbox.i18n import gettext as _
 from plainbox.impl import pod
 from plainbox.impl.secure.origin import FileTextSource
@@ -45,7 +45,7 @@ from plainbox.impl.secure.origin import UnknownTextSource
 _logger = logging.getLogger("plainbox.secure.qualifiers")
 
 
-class SimpleQualifier(IJobQualifier):
+class SimpleQualifier(IUnitQualifier):
     """
     Abstract base class that implements common features of simple (non
     composite) qualifiers. This allows two concrete subclasses below to
@@ -111,7 +111,7 @@ class SimpleQualifier(IJobQualifier):
         Return a list of primitives that constitute this qualifier.
 
         :returns:
-            A list of IJobQualifier objects that each is the smallest,
+            A list of IUnitQualifier objects that each is the smallest,
             indivisible entity. Here it just returns a list of one element,
             itself.
 
@@ -381,7 +381,7 @@ class CompositeQualifier(pod.POD):
         return False
 
     def designates(self, job):
-        return self.get_vote(job) == IJobQualifier.VOTE_INCLUDE
+        return self.get_vote(job) == IUnitQualifier.VOTE_INCLUDE
 
     def get_vote(self, job):
         """
@@ -403,7 +403,7 @@ class CompositeQualifier(pod.POD):
                 qualifier.get_vote(job)
                 for qualifier in self.qualifier_list])
         else:
-            return IJobQualifier.VOTE_IGNORE
+            return IUnitQualifier.VOTE_IGNORE
 
     def get_primitive_qualifiers(self):
         return get_flat_primitive_qualifier_list(self.qualifier_list)
@@ -413,12 +413,12 @@ class CompositeQualifier(pod.POD):
         raise NonPrimitiveQualifierOrigin
 
 
-IJobQualifier.register(CompositeQualifier)
+IUnitQualifier.register(CompositeQualifier)
 
 
 class NonPrimitiveQualifierOrigin(Exception):
     """
-    Exception raised when IJobQualifier.origin is meaningless as it is being
+    Exception raised when IUnitQualifier.origin is meaningless as it is being
     requested on a non-primitive qualifier such as the CompositeQualifier
     """
 

--- a/checkbox-ng/plainbox/impl/secure/test_qualifiers.py
+++ b/checkbox-ng/plainbox/impl/secure/test_qualifiers.py
@@ -494,16 +494,16 @@ class FunctionTests(TestCase):
     def setUp(self):
         self.origin = mock.Mock(name='origin', spec_set=Origin)
 
-    def test_select_jobs__empty_qualifier_list(self):
+    def test_select_units__empty_qualifier_list(self):
         """
-        verify that select_jobs() returns an empty list if no qualifiers are
+        verify that select_units() returns an empty list if no qualifiers are
         passed
         """
-        self.assertEqual(select_jobs([], []), [])
+        self.assertEqual(select_units([], []), [])
 
-    def test_select_jobs__inclusion(self):
+    def test_select_units__inclusion(self):
         """
-        verify that select_jobs() honors qualifier ordering
+        verify that select_units() honors qualifier ordering
         """
         job_a = JobDefinition({'id': 'a'})
         job_b = JobDefinition({'id': 'b'})
@@ -514,12 +514,12 @@ class FunctionTests(TestCase):
             # Regardless of how the list of job is ordered the result
             # should be the same, depending on the qualifier list
             self.assertEqual(
-                select_jobs(job_list, [qual_a, qual_c]),
+                select_units(job_list, [qual_a, qual_c]),
                 [job_a, job_c])
 
-    def test_select_jobs__exclusion(self):
+    def test_select_units__exclusion(self):
         """
-        verify that select_jobs() honors qualifier ordering
+        verify that select_units() honors qualifier ordering
         """
         job_a = JobDefinition({'id': 'a'})
         job_b = JobDefinition({'id': 'b'})
@@ -534,12 +534,12 @@ class FunctionTests(TestCase):
             # Regardless of how the list of job is ordered the result
             # should be the same, depending on the qualifier list
             self.assertEqual(
-                select_jobs(job_list, [qual_all, qual_not_c]),
+                select_units(job_list, [qual_all, qual_not_c]),
                 [job_a, job_b])
 
-    def test_select_jobs__id_field_qualifier(self):
+    def test_select_units__id_field_qualifier(self):
         """
-        verify that select_jobs() only returns the job that matches a given
+        verify that select_units() only returns the job that matches a given
         FieldQualifier
         """
         job_a = JobDefinition({'id': 'a'})
@@ -549,11 +549,11 @@ class FunctionTests(TestCase):
         qual = FieldQualifier("id", matcher, self.origin, True)
         job_list = [job_a, job_b, job_c]
         expected_list = [job_a]
-        self.assertEqual(select_jobs(job_list, [qual]), expected_list)
+        self.assertEqual(select_units(job_list, [qual]), expected_list)
 
-    def test_select_jobs__id_field_qualifier_twice(self):
+    def test_select_units__id_field_qualifier_twice(self):
         """
-        verify that select_jobs() only returns the job that matches a given
+        verify that select_units() only returns the job that matches a given
         FieldQualifier once, even if it has been added twice
         """
         job_a = JobDefinition({'id': 'a'})
@@ -561,11 +561,11 @@ class FunctionTests(TestCase):
         qual = FieldQualifier("id", matcher, self.origin, True)
         job_list = [job_a, job_a]
         expected_list = [job_a]
-        self.assertEqual(select_jobs(job_list, [qual, qual]), expected_list)
+        self.assertEqual(select_units(job_list, [qual, qual]), expected_list)
 
-    def test_select_jobs__template_id_field_qualifier(self):
+    def test_select_units__template_id_field_qualifier(self):
         """
-        verify that select_jobs() only returns the jobs that have been
+        verify that select_units() only returns the jobs that have been
         instantiated using a given template
         """
         job_a = JobDefinition({
@@ -583,9 +583,9 @@ class FunctionTests(TestCase):
         qual = FieldQualifier("id", matcher, self.origin, True)
         job_list = [job_a, templated_job_b, templated_job_c]
         expected_list = [templated_job_b, templated_job_c]
-        self.assertEqual(select_jobs(job_list, [qual]), expected_list)
+        self.assertEqual(select_units(job_list, [qual]), expected_list)
 
-    def test_select_jobs__excluded_templated_job(self):
+    def test_select_units__excluded_templated_job(self):
         """
         verify that if a template id is included in the test plan, jobs that
         have been instantiated from it can still be excluded from the list of
@@ -606,4 +606,4 @@ class FunctionTests(TestCase):
         job_list = [templated_job_a, templated_job_b]
         qualifiers = [qual_incl, qual_excl]
         expected_list = [templated_job_a]
-        self.assertEqual(select_jobs(job_list, qualifiers), expected_list)
+        self.assertEqual(select_units(job_list, qualifiers), expected_list)

--- a/checkbox-ng/plainbox/impl/secure/test_qualifiers.py
+++ b/checkbox-ng/plainbox/impl/secure/test_qualifiers.py
@@ -30,7 +30,7 @@ from itertools import permutations
 from unittest import TestCase
 import operator
 
-from plainbox.abc import IJobQualifier
+from plainbox.abc import IUnitQualifier
 from plainbox.impl.job import JobDefinition
 from plainbox.impl.secure.origin import FileTextSource
 from plainbox.impl.secure.origin import Origin
@@ -43,23 +43,23 @@ from plainbox.impl.secure.qualifiers import NonPrimitiveQualifierOrigin
 from plainbox.impl.secure.qualifiers import OperatorMatcher
 from plainbox.impl.secure.qualifiers import PatternMatcher
 from plainbox.impl.secure.qualifiers import RegExpJobQualifier
-from plainbox.impl.secure.qualifiers import select_jobs
+from plainbox.impl.secure.qualifiers import select_units
 from plainbox.impl.secure.qualifiers import SimpleQualifier
 from plainbox.impl.testing_utils import make_job
 from plainbox.vendor import mock
 
 
-class IJobQualifierTests(TestCase):
+class IUnitQualifierTests(TestCase):
     """
-    Test cases for IJobQualifier interface
+    Test cases for IUnitQualifier interface
     """
 
-    def test_IJobQualifier_is_abstract(self):
+    def test_IUnitQualifier_is_abstract(self):
         """
-        Verify that IJobQualifier is an interface and cannot be
+        Verify that IUnitQualifier is an interface and cannot be
         instantiated
         """
-        self.assertRaises(TypeError, IJobQualifier)
+        self.assertRaises(TypeError, IUnitQualifier)
 
 
 class DummySimpleQualifier(SimpleQualifier):
@@ -108,11 +108,11 @@ class SimpleQualifierTests(TestCase):
         the same job returns VOTE_INCLUDE.
         """
         with mock.patch.object(self.obj, 'get_vote') as mock_get_vote:
-            mock_get_vote.return_value = IJobQualifier.VOTE_INCLUDE
+            mock_get_vote.return_value = IUnitQualifier.VOTE_INCLUDE
             self.assertTrue(self.obj.designates(self.job))
-            mock_get_vote.return_value = IJobQualifier.VOTE_EXCLUDE
+            mock_get_vote.return_value = IUnitQualifier.VOTE_EXCLUDE
             self.assertFalse(self.obj.designates(self.job))
-            mock_get_vote.return_value = IJobQualifier.VOTE_IGNORE
+            mock_get_vote.return_value = IUnitQualifier.VOTE_IGNORE
             self.assertFalse(self.obj.designates(self.job))
 
     def test_get_vote__inclusive_matching(self):
@@ -124,7 +124,7 @@ class SimpleQualifierTests(TestCase):
         with mock.patch.object(obj, 'get_simple_match') as mock_gsm:
             mock_gsm.return_value = True
             self.assertEqual(obj.get_vote(self.job),
-                             IJobQualifier.VOTE_INCLUDE)
+                             IUnitQualifier.VOTE_INCLUDE)
 
     def test_get_vote__not_inclusive_matching(self):
         """
@@ -135,7 +135,7 @@ class SimpleQualifierTests(TestCase):
         with mock.patch.object(obj, 'get_simple_match') as mock_gsm:
             mock_gsm.return_value = True
             self.assertEqual(obj.get_vote(self.job),
-                             IJobQualifier.VOTE_EXCLUDE)
+                             IUnitQualifier.VOTE_EXCLUDE)
 
     def test_get_vote__inclusive_nonmatching(self):
         """
@@ -145,7 +145,7 @@ class SimpleQualifierTests(TestCase):
         obj = DummySimpleQualifier(self.origin, inclusive=True)
         with mock.patch.object(obj, 'get_simple_match') as mock_gsm:
             mock_gsm.return_value = False
-            self.assertEqual(obj.get_vote(self.job), IJobQualifier.VOTE_IGNORE)
+            self.assertEqual(obj.get_vote(self.job), IUnitQualifier.VOTE_IGNORE)
 
     def test_get_vote__not_inclusive_nonmatching(self):
         """
@@ -155,7 +155,7 @@ class SimpleQualifierTests(TestCase):
         obj = DummySimpleQualifier(self.origin, inclusive=False)
         with mock.patch.object(obj, 'get_simple_match') as mock_gsm:
             mock_gsm.return_value = False
-            self.assertEqual(obj.get_vote(self.job), IJobQualifier.VOTE_IGNORE)
+            self.assertEqual(obj.get_vote(self.job), IUnitQualifier.VOTE_IGNORE)
 
     def test_get_primitive_qualifiers(self):
         """
@@ -301,19 +301,19 @@ class RegExpJobQualifierTests(TestCase):
         self.assertEqual(
             RegExpJobQualifier("foo", self.origin).get_vote(
                 JobDefinition({'id': 'foo'})),
-            IJobQualifier.VOTE_INCLUDE)
+            IUnitQualifier.VOTE_INCLUDE)
         self.assertEqual(
             RegExpJobQualifier("foo", self.origin, inclusive=False).get_vote(
                 JobDefinition({'id': 'foo'})),
-            IJobQualifier.VOTE_EXCLUDE)
+            IUnitQualifier.VOTE_EXCLUDE)
         self.assertEqual(
             RegExpJobQualifier("foo", self.origin).get_vote(
                 JobDefinition({'id': 'bar'})),
-            IJobQualifier.VOTE_IGNORE)
+            IUnitQualifier.VOTE_IGNORE)
         self.assertEqual(
             RegExpJobQualifier("foo", self.origin, inclusive=False).get_vote(
                 JobDefinition({'id': 'bar'})),
-            IJobQualifier.VOTE_IGNORE)
+            IUnitQualifier.VOTE_IGNORE)
 
 
 class JobIdQualifierTests(TestCase):
@@ -352,19 +352,19 @@ class JobIdQualifierTests(TestCase):
         self.assertEqual(
             JobIdQualifier("foo", self.origin).get_vote(
                 JobDefinition({'id': 'foo'})),
-            IJobQualifier.VOTE_INCLUDE)
+            IUnitQualifier.VOTE_INCLUDE)
         self.assertEqual(
             JobIdQualifier("foo", self.origin, inclusive=False).get_vote(
                 JobDefinition({'id': 'foo'})),
-            IJobQualifier.VOTE_EXCLUDE)
+            IUnitQualifier.VOTE_EXCLUDE)
         self.assertEqual(
             JobIdQualifier("foo", self.origin).get_vote(
                 JobDefinition({'id': 'bar'})),
-            IJobQualifier.VOTE_IGNORE)
+            IUnitQualifier.VOTE_IGNORE)
         self.assertEqual(
             JobIdQualifier("foo", self.origin, inclusive=False).get_vote(
                 JobDefinition({'id': 'bar'})),
-            IJobQualifier.VOTE_IGNORE)
+            IUnitQualifier.VOTE_IGNORE)
 
     def test_smoke(self):
         """
@@ -402,33 +402,33 @@ class CompositeQualifierTests(TestCase):
         # Default is IGNORE
         self.assertEqual(
             CompositeQualifier([]).get_vote(make_job("foo")),
-            IJobQualifier.VOTE_IGNORE)
+            IUnitQualifier.VOTE_IGNORE)
         # Any match is INCLUDE
         self.assertEqual(
             CompositeQualifier([
                 RegExpJobQualifier("foo", self.origin),
             ]).get_vote(make_job("foo")),
-            IJobQualifier.VOTE_INCLUDE)
+            IUnitQualifier.VOTE_INCLUDE)
         # Any negative match is EXCLUDE
         self.assertEqual(
             CompositeQualifier([
                 RegExpJobQualifier("foo", self.origin, inclusive=False),
             ]).get_vote(make_job("foo")),
-            IJobQualifier.VOTE_EXCLUDE)
+            IUnitQualifier.VOTE_EXCLUDE)
         # Negative matches take precedence over positive matches
         self.assertEqual(
             CompositeQualifier([
                 RegExpJobQualifier("foo", self.origin),
                 RegExpJobQualifier("foo", self.origin, inclusive=False),
             ]).get_vote(make_job("foo")),
-            IJobQualifier.VOTE_EXCLUDE)
+            IUnitQualifier.VOTE_EXCLUDE)
         # Unrelated patterns are not affecting the result
         self.assertEqual(
             CompositeQualifier([
                 RegExpJobQualifier("foo", self.origin),
                 RegExpJobQualifier("bar", self.origin),
             ]).get_vote(make_job("foo")),
-            IJobQualifier.VOTE_INCLUDE)
+            IUnitQualifier.VOTE_INCLUDE)
 
     def test_inclusive(self):
         """

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -51,7 +51,7 @@ from plainbox.impl.result import JobResultBuilder
 from plainbox.impl.result import MemoryJobResult
 from plainbox.impl.runner import JobRunnerUIDelegate
 from plainbox.impl.secure.origin import Origin
-from plainbox.impl.secure.qualifiers import select_jobs
+from plainbox.impl.secure.qualifiers import select_units
 from plainbox.impl.secure.qualifiers import FieldQualifier
 from plainbox.impl.secure.qualifiers import JobIdQualifier
 from plainbox.impl.secure.qualifiers import PatternMatcher
@@ -802,7 +802,7 @@ class SessionAssistant:
         # NOTE: there is next-to-none UI here as bootstrap jobs are limited to
         # just resource jobs (including their dependencies) so there should be
         # very little UI required.
-        desired_job_list = select_jobs(
+        desired_job_list = select_units(
             self._context.state.job_list,
             [
                 plan.get_bootstrap_qualifier()
@@ -823,7 +823,7 @@ class SessionAssistant:
             self.use_job_result(job.id, rb.get_result())
         # Perform initial selection -- we want to run everything that is
         # described by the test plan that was selected earlier.
-        desired_job_list = select_jobs(
+        desired_job_list = select_units(
             self._context.state.job_list,
             [plan.get_qualifier() for plan in self._manager.test_plans]
             + self._exclude_qualifiers,
@@ -866,7 +866,7 @@ class SessionAssistant:
                     Origin("hand-pick"),
                 )
             )
-        jobs = select_jobs(self._context.state.job_list, qualifiers)
+        jobs = select_units(self._context.state.job_list, qualifiers)
         self._context.state.update_desired_job_list(jobs)
         self._metadata.flags = {
             SessionMetaData.FLAG_INCOMPLETE,
@@ -891,7 +891,7 @@ class SessionAssistant:
         E.g. to inform the user about the progress
         """
         UsageExpectation.of(self).enforce()
-        desired_job_list = select_jobs(
+        desired_job_list = select_units(
             self._context.state.job_list,
             [
                 plan.get_bootstrap_qualifier()
@@ -926,7 +926,7 @@ class SessionAssistant:
         UsageExpectation.of(self).enforce()
         # Perform initial selection -- we want to run everything that is
         # described by the test plan that was selected earlier.
-        desired_job_list = select_jobs(
+        desired_job_list = select_units(
             self._context.state.job_list,
             [plan.get_qualifier() for plan in self._manager.test_plans]
             + self._exclude_qualifiers
@@ -1029,7 +1029,7 @@ class SessionAssistant:
         reigning job selection.
         """
         UsageExpectation.of(self).enforce()
-        desired_job_list = select_jobs(
+        desired_job_list = select_units(
             self._context.state.job_list,
             [plan.get_qualifier() for plan in self._manager.test_plans],
         )
@@ -1171,7 +1171,7 @@ class SessionAssistant:
         test_plan = self._manager.test_plans[0]
         return [
             job.id
-            for job in select_jobs(
+            for job in select_units(
                 self._context.state.job_list,
                 [test_plan.get_mandatory_qualifier()],
             )

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -32,7 +32,7 @@ from plainbox.impl import deprecated
 from plainbox.impl.depmgr import DependencyDuplicateError
 from plainbox.impl.depmgr import DependencyError
 from plainbox.impl.depmgr import DependencySolver
-from plainbox.impl.secure.qualifiers import select_jobs
+from plainbox.impl.secure.qualifiers import select_units
 from plainbox.impl.session.jobs import JobState
 from plainbox.impl.session.jobs import UndesiredJobReadinessInhibitor
 from plainbox.impl.session.system_information import(
@@ -568,7 +568,7 @@ class SessionDeviceContext:
         qualifier_list = []
         for test_plan in self._test_plan_list:
             qualifier_list.append(test_plan.get_mandatory_qualifier())
-        mandatory_job_list = select_jobs(
+        mandatory_job_list = select_units(
             self.state.job_list, qualifier_list)
         self.state.update_mandatory_job_list(mandatory_job_list)
         self.state.update_desired_job_list(self.state.desired_job_list)

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -762,7 +762,7 @@ class SessionState:
         :param qualifier:
             A qualifier that selects jobs to be removed
         :ptype qualifier:
-            IJobQualifier
+            IUnitQualifier
 
         :raises ValueError:
             If any of the jobs selected by the qualifier is on the desired job

--- a/checkbox-ng/plainbox/impl/session/test_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_assistant.py
@@ -199,6 +199,9 @@ class SessionAssistantTests(morris.SignalTestCase):
     def test_bootstrap(self, mock_tpu, mock_su, mock_get_providers):
         self_mock = mock.MagicMock()
         SessionAssistant.bootstrap(self_mock)
+        # Bootstrapping involves updating the list of desired jobs twice:
+        # - one time to get the resource jobs
+        # - one time to generate jobs out of the resource jobs
         self.assertEqual(
             self_mock._context.state.update_desired_job_list.call_count,
             2

--- a/checkbox-ng/plainbox/impl/session/test_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_assistant.py
@@ -193,3 +193,13 @@ class SessionAssistantTests(morris.SignalTestCase):
         self_mock.get_resumable_sessions.return_value = [session_mock]
 
         _ = SessionAssistant.resume_session(self_mock, "session_id")
+
+    @mock.patch("plainbox.impl.session.state.select_units")
+    @mock.patch("plainbox.impl.unit.testplan.TestPlanUnit")
+    def test_bootstrap(self, mock_tpu, mock_su, mock_get_providers):
+        self_mock = mock.MagicMock()
+        SessionAssistant.bootstrap(self_mock)
+        self.assertEqual(
+            self_mock._context.state.update_desired_job_list.call_count,
+            2
+        )

--- a/checkbox-ng/plainbox/impl/session/test_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_assistant.py
@@ -203,3 +203,27 @@ class SessionAssistantTests(morris.SignalTestCase):
             self_mock._context.state.update_desired_job_list.call_count,
             2
         )
+
+    @mock.patch("plainbox.impl.session.state.select_units")
+    def test_hand_pick_jobs(self, mock_su, mock_get_providers):
+        self_mock = mock.MagicMock()
+        SessionAssistant.hand_pick_jobs(self_mock, [])
+        self.assertEqual(
+            self_mock._context.state.update_desired_job_list.call_count,
+            1
+        )
+
+    @mock.patch("plainbox.impl.session.state.select_units")
+    @mock.patch("plainbox.impl.unit.testplan.TestPlanUnit")
+    def test_get_bootstrap_todo_list(
+        self,
+        mock_tpu,
+        mock_su,
+        mock_get_providers
+    ):
+        self_mock = mock.MagicMock()
+        SessionAssistant.get_bootstrap_todo_list(self_mock)
+        self.assertEqual(
+            self_mock._context.state.update_desired_job_list.call_count,
+            1
+        )

--- a/checkbox-ng/plainbox/impl/session/test_resume.py
+++ b/checkbox-ng/plainbox/impl/session/test_resume.py
@@ -31,7 +31,7 @@ import copy
 import gzip
 import json
 
-from plainbox.abc import IJobQualifier
+from plainbox.abc import IUnitQualifier
 from plainbox.abc import IJobResult
 from plainbox.impl.job import JobDefinition
 from plainbox.impl.resource import Resource
@@ -86,13 +86,13 @@ class ResumeDiscardQualifierTests(TestCase):
         # removal)
         self.assertEqual(
             self.obj.get_vote(JobDefinition({'id': 'foo'})),
-            IJobQualifier.VOTE_IGNORE)
+            IUnitQualifier.VOTE_IGNORE)
         self.assertEqual(
             self.obj.get_vote(JobDefinition({'id': 'bar'})),
-            IJobQualifier.VOTE_IGNORE)
+            IUnitQualifier.VOTE_IGNORE)
         self.assertEqual(
             self.obj.get_vote(JobDefinition({'id': 'froz'})),
-            IJobQualifier.VOTE_IGNORE)
+            IUnitQualifier.VOTE_IGNORE)
         # Jobs that are in the retain set are NOT designated
         self.assertEqual(
             self.obj.designates(JobDefinition({'id': 'bar'})), False)
@@ -103,10 +103,10 @@ class ResumeDiscardQualifierTests(TestCase):
         # retain set, ids are matched exactly, not by pattern.
         self.assertEqual(
             self.obj.get_vote(JobDefinition({'id': 'foobar'})),
-            IJobQualifier.VOTE_INCLUDE)
+            IUnitQualifier.VOTE_INCLUDE)
         self.assertEqual(
             self.obj.get_vote(JobDefinition({'id': 'fo'})),
-            IJobQualifier.VOTE_INCLUDE)
+            IUnitQualifier.VOTE_INCLUDE)
 
 
 class SessionResumeExceptionTests(TestCase):

--- a/checkbox-ng/plainbox/impl/session/test_state.py
+++ b/checkbox-ng/plainbox/impl/session/test_state.py
@@ -1251,3 +1251,11 @@ class SessionDeviceContextTests(SignalTestCase):
         }
         SessionDeviceContext._bulk_override_update(self_mock)
         self.assertTrue(self_mock._override_update.called)
+
+    @patch("plainbox.impl.session.state.select_units")
+    @patch("plainbox.impl.unit.testplan.TestPlanUnit.get_mandatory_qualifier")
+    def test_update_mandatory_job_list(self, mock_gmq, mock_su):
+        self_mock = MagicMock()
+        SessionDeviceContext._update_mandatory_job_list(self_mock)
+        self.assertTrue(self_mock.state.update_mandatory_job_list.called)
+        self.assertTrue(self_mock.state.update_desired_job_list.called)


### PR DESCRIPTION

## Description

The new subcommand "expands" a given test plan by going through all its sections and returning the pure (non-instantiated) jobs and templates being used.

It is different from the "list-boostrapped" subcommand since it does not perform any bootstrap.

By default, it outputs the jobs/templates id as text, but it can be called with the `--format json` option to output JSON data with all the known information for said jobs and templates.

This is to be used by external tools, for instance to create a document listing information (summary, description...) about executed jobs and templates.



<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->


<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
Fix CHECKBOX-1263

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

Given the following units:

<details>

<summary>Test plans:</summary>

```
unit: test plan
id: demo-test-plan
name: demo-test-plan
bootstrap_include:
  demo_resource
  demo_resource_none
mandatory_include:
  demo-mandatory certification_status=non-blocker
nested_part:
  demo-nested1
include:
  demo-test-storages certification_status=blocker
  demo-test-storage.*
  demo-none-name
  .*demo-test-regex.*
  .*demo-none-regex.*
exclude:
  demo-job2
  demo-job-sibling4

unit: test plan
id: demo-nested1
name: demo-nested1
include:
  demo-job1 certification_status=blocker
  demo-job2
  demo-job-sibling1
  demo-job-sibling2
  demo-job-sibling3
  demo-job-sibling4
```

</details>

<details>

<summary>Resource jobs:</summary>


```
id: demo_resource
plugin: resource
command:
    echo 'name: sda'
    echo 'path: /dev/sda'
    echo
    echo 'name: sdb'
    echo 'path: /dev/sdb'

id: demo_resource_none
plugin: resource
command:
    echo ''
```

</details>

<details>

<summary>Template jobs:</summary>


```
unit: template
template-resource: demo_resource
template-id: demo-test-storages
template-summary: Demo the test storages
template-description:
  Very long description that explains what demoing the
  test storages means in the context of this change.
id: demo-test-storage-{name}
plugin: shell
command: echo "This is the path: {path}"
flags: also-after-suspend

# Used by a regex in the demo-test-plan
unit: template
template-resource: demo_resource
id: demo-test-regex-{name}
plugin: shell
command: echo "This is the path: {path}"
flags: also-after-suspend

unit: template
template-resource: demo_resource_none
id: demo-none-{name}
plugin: shell
command: echo "Resource always empty, should never show up: {path}"
flags: also-after-suspend

# Used by a regex in the demo-test-plan
unit: template
template-resource: demo_resource_none
id: demo-none-regex-{name}
plugin: shell
command: echo "Resource always empty, should never show up: {path}"
flags: also-after-suspend
```

</details>

<details>

<summary>Regular jobs:</summary>

```
id: demo-mandatory
plugin: shell
command: echo "This is mandatory job"
certification-status: blocker

id: demo-job1
plugin: shell
command: echo "This is job1"
flags: also-after-suspend

id: demo-job2
plugin: shell
command: echo "This is job2"
flags: also-after-suspend

id: demo-job-sibling1
plugin: shell
command: echo "This is a job"
siblings: [
  {"id": "demo-job-sibling2"},
  {"id": "demo-job-sibling3"},
  {"id": "demo-job-sibling4"}
  ]
```

</details>

We can run the `expand` subcommand like so:

```
checkbox-cli expand com.canonical.certification::demo-test-plan

Job 'com.canonical.certification::demo-mandatory'
Template 'com.canonical.certification::demo-test-storages'
Template 'com.canonical.certification::demo-none-name'
Template 'com.canonical.certification::demo-test-regex-name'
Template 'com.canonical.certification::demo-none-regex-name'
Job 'com.canonical.certification::demo-job1'
Job 'com.canonical.certification::demo-job-sibling1'
Job 'com.canonical.certification::demo-job-sibling2'
Job 'com.canonical.certification::demo-job-sibling3'
```

Observations:

- The list includes jobs in the `mandatory_include` section (here, `demo-mandatory`)
- All the jobs from the `nested_part` are included (`demo-job1`, `demo-job-sibling1`, `demo-job-sibling[1-3]`)...
- ... except the ones that are also listed in the `exclude` section (`  demo-job2`, `demo-job-sibling4`)
- Templates that would not match any job are included (`demo-none-name` uses a resource job that does not return anything)
- Any job or template that matches any of the regular expressions are included (`demo-test-regex-name`, `demo-none-regex-name`)

Finally, the command can also output JSON data by adding `--format json`. Here is the output of `checkbox-cli expand --format json com.canonical.certification::demo-test-plan | jq`:

<details>

<summary>JSON output</summary>

```json
[
  {
    "id": "com.canonical.certification::demo-mandatory",
    "plugin": "shell",
    "command": "echo \"This is mandatory job\"",
    "certification-status": "non-blocker",
    "unit": "job"
  },
  {
    "unit": "template",
    "template-resource": "demo_resource",
    "template-id": "com.canonical.certification::demo-test-storages",
    "template-summary": "Demo the test storages",
    "template-description": " Very long description that explains what demoing the\n test storages means in the context of this change.",
    "id": "com.canonical.certification::demo-test-storage-{name}",
    "plugin": "shell",
    "command": "echo \"This is the path: {path}\"",
    "flags": "also-after-suspend",
    "certification-status": "blocker"
  },
  {
    "unit": "template",
    "template-resource": "demo_resource_none",
    "id": "com.canonical.certification::demo-none-{name}",
    "plugin": "shell",
    "command": "echo \"Resource always empty, should never show up: {path}\"",
    "flags": "also-after-suspend",
    "certification-status": "unspecified",
    "template-id": "com.canonical.certification::demo-none-name"
  },
  {
    "unit": "template",
    "template-resource": "demo_resource",
    "id": "com.canonical.certification::demo-test-regex-{name}",
    "plugin": "shell",
    "command": "echo \"This is the path: {path}\"",
    "flags": "also-after-suspend",
    "certification-status": "unspecified",
    "template-id": "com.canonical.certification::demo-test-regex-name"
  },
  {
    "unit": "template",
    "template-resource": "demo_resource_none",
    "id": "com.canonical.certification::demo-none-regex-{name}",
    "plugin": "shell",
    "command": "echo \"Resource always empty, should never show up: {path}\"",
    "flags": "also-after-suspend",
    "certification-status": "unspecified",
    "template-id": "com.canonical.certification::demo-none-regex-name"
  },
  {
    "id": "com.canonical.certification::demo-job1",
    "plugin": "shell",
    "command": "echo \"This is job1\"",
    "flags": "also-after-suspend",
    "unit": "job",
    "certification-status": "blocker"
  },
  {
    "id": "com.canonical.certification::demo-job-sibling1",
    "plugin": "shell",
    "command": "echo \"This is a job\"",
    "siblings": "[\n {\"id\": \"demo-job-sibling2\"},\n {\"id\": \"demo-job-sibling3\"},\n {\"id\": \"demo-job-sibling4\"}\n ]",
    "unit": "job",
    "certification-status": "unspecified"
  },
  {
    "id": "com.canonical.certification::demo-job-sibling2",
    "plugin": "shell",
    "command": "echo \"This is a job\"",
    "unit": "job",
    "certification-status": "unspecified"
  },
  {
    "id": "com.canonical.certification::demo-job-sibling3",
    "plugin": "shell",
    "command": "echo \"This is a job\"",
    "unit": "job",
    "certification-status": "unspecified"
  }
]
```

</details>