### PR TITLE
Cover boot partition genio (New)

### DIFF
--- a/contrib/genio/tests/test_boot_partition.py
+++ b/contrib/genio/tests/test_boot_partition.py
@@ -1,0 +1,200 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import boot_partition as bp
+
+
+class TestBootPartition(unittest.TestCase):
+
+    def setUp(self):
+        self.pbd = bp.TestPartedBootDevice()
+
+    @patch("boot_partition.subprocess.run")
+    def test_runcmd(self, mock_run):
+        mock_run.return_value = MagicMock(
+            stdout="output", stderr="error", returncode=0
+        )
+        result = bp.runcmd("echo Hello")
+
+        mock_run.assert_called_once()
+        self.assertEqual(result.stdout, "output")
+        self.assertEqual(result.stderr, "error")
+        self.assertEqual(result.returncode, 0)
+
+    @patch("pathlib.Path.is_block_device")
+    def test_check_is_block_device(self, mock_is_block_device):
+        self.pbd.path = "/dev/sdc"
+
+        mock_is_block_device.return_value = True
+        self.pbd.check_is_block_device()
+
+        mock_is_block_device.return_value = False
+        with self.assertRaises(SystemExit):
+            self.pbd.check_is_block_device()
+
+    @patch("boot_partition.TestPartedBootDevice.check_sector_size")
+    @patch("boot_partition.TestPartedBootDevice.check_partitions")
+    def test_check_disk(self, mock_cp, mock_css):
+        self.pbd.check_disk()
+        self.pbd.check_sector_size.assert_called_once()
+        self.pbd.check_partitions.assert_called_once()
+
+    @patch("boot_partition.runcmd")
+    def test_get_disk_information(self, mock_runcmd):
+        json_data = (
+            '{"disk": {"logical-sector-size": 4096, "physical-sector-size": '
+            '4096, "partitions": [ {"number": 1, "name": "bootloaders"} ] } }'
+        )
+
+        mock_runcmd.return_value.stdout = json_data
+
+        self.pbd.path = "/dev/sdc"
+        self.pbd.get_disk_information()
+        self.assertEqual(
+            self.pbd.expected_result,
+            self.pbd.expected_result_UFS,
+            "Failed to get expected result for UFS",
+        )
+
+        self.pbd.path = "/dev/mmcblk0"
+        self.pbd.get_disk_information()
+        self.assertEqual(
+            self.pbd.expected_result,
+            self.pbd.expected_result_EMMC,
+            "Failed to get expected result for EMMC",
+        )
+
+        self.pbd.path = "/dev/unknown"
+        with self.assertRaises(SystemExit):
+            self.pbd.get_disk_information()
+
+    def test_check_sector_size(self):
+        self.pbd.expected_result = {
+            "logical-sector-size": 4096,
+            "physical-sector-size": 4096,
+        }
+
+        # Correct sector size
+        self.pbd.actual_result = {
+            "logical-sector-size": 4096,
+            "physical-sector-size": 4096,
+        }
+        self.pbd.check_sector_size()
+
+        # Different logical-sector-size
+        self.pbd.actual_result = {
+            "logical-sector-size": 8192,
+            "physical-sector-size": 4096,
+        }
+        with self.assertRaises(SystemExit):
+            self.pbd.check_sector_size()
+
+        # Different logical-sector-size not found
+        self.pbd.actual_result = {"physical-sector-size": 4096}
+        with self.assertRaises(SystemExit):
+            self.pbd.check_sector_size()
+
+        # Different physical-sector-size
+        self.pbd.actual_result = {
+            "logical-sector-size": 4096,
+            "physical-sector-size": 8192,
+        }
+        with self.assertRaises(SystemExit):
+            self.pbd.check_sector_size()
+
+        # Different physical-sector-size not found
+        self.pbd.actual_result = {"logical-sector-size": 4096}
+        with self.assertRaises(SystemExit):
+            self.pbd.check_sector_size()
+
+    def test_check_partitions(self):
+        self.pbd.expected_result = {
+            "partitions": [{"number": 1, "name": "bootloaders"}]
+        }
+
+        # Correct partitions
+        self.pbd.actual_result = {
+            "partitions": [{"number": 1, "name": "bootloaders"}]
+        }
+        self.pbd.check_partitions()
+
+        # Different lenght of partitions
+        self.pbd.actual_result = {
+            "partitions": [
+                {"number": 1, "name": "bootloaders"},
+                {"number": 9, "name": "writable"},
+            ]
+        }
+        with self.assertRaises(SystemExit):
+            self.pbd.check_partitions()
+
+        # Different partition number
+        self.pbd.actual_result = {
+            "partitions": [{"number": 2, "name": "bootloaders"}]
+        }
+        with self.assertRaises(SystemExit):
+            self.pbd.check_partitions()
+
+        # Different partition name
+        self.pbd.actual_result = {
+            "partitions": [{"number": 1, "name": "bad_name"}]
+        }
+        with self.assertRaises(SystemExit):
+            self.pbd.check_partitions()
+
+        # Different partitions not found
+        self.pbd.actual_result = {}
+        with self.assertRaises(SystemExit):
+            self.pbd.check_partitions()
+
+    @patch("boot_partition.runcmd")
+    def test_check_device(self, mock_runcmd):
+        mock_runcmd.return_value.stdout = "sdc"
+        self.pbd.check_device(True)
+
+        mock_runcmd.return_value.stdout = "mmcblk0"
+        self.pbd.check_device(True)
+
+        mock_runcmd.return_value.stdout = "unknown"
+        self.pbd.check_device(False)
+
+        mock_runcmd.return_value.stdout = "unknown"
+        with self.assertRaises(SystemExit):
+            self.pbd.check_device(True)
+
+    @patch("boot_partition.TestPartedBootDevice.check_device")
+    @patch("boot_partition.TestPartedBootDevice.check_is_block_device")
+    @patch("boot_partition.TestPartedBootDevice.get_disk_information")
+    @patch("boot_partition.TestPartedBootDevice.check_disk")
+    def test_main_with_path(
+        self, mock_check_disk, mock_get_disk, mock_is_block, mock_check_dev
+    ):
+        args = ["script_name", "--path", "/dev/sda"]
+        with patch("sys.argv", args):
+            self.pbd.main()
+        mock_check_dev.assert_not_called()
+        mock_is_block.assert_called_once()
+        mock_get_disk.assert_called_once()
+        mock_check_disk.assert_called_once()
+
+    @patch("boot_partition.TestPartedBootDevice.check_device")
+    @patch("boot_partition.TestPartedBootDevice.check_is_block_device")
+    def test_main_check_device(self, mock_is_block, mock_check_dev):
+        # Test with --check_device_name flag
+        args = ["script_name", "--check_device_name"]
+        with patch("sys.argv", args):
+            self.pbd.main()
+        mock_check_dev.assert_called_once()
+        mock_is_block.assert_not_called()
+
+    @patch("boot_partition.TestPartedBootDevice.check_device")
+    def test_main_check_device_with_exit(self, mock_is_block):
+        # Test with --check_device_name flag
+        mock_is_block.return_value = None
+        args = ["script_name", "--check_device_name", "--exit_when_check_fail"]
+        with patch("sys.argv", args):
+            self.pbd.main()
+
+        mock_is_block.side_effect = SystemExit
+        with self.assertRaises(SystemExit):
+            with patch("sys.argv", args):
+                self.pbd.main()


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

After the inclusion of genio tests on the contrib area of checkbox, we have to add unit-tests to ensure the coverage requirements are satisfied. We have included unit-tests for the boot_partition.py script.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/CHECKBOX-1297 (partly with #1063 )

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

There are no changes to the documentation

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

To run the unittests:
```
cd ~/checkbox/contrib/genio
pytest
```

## Coverage Report

| Module                          | statements | missing | excluded | branches | partial | coverage |
|---------------------------------|-----------:|--------:|---------:|---------:|--------:|---------:|
| bin/boot_partition.py           |         91 |       1 |        0 |       28 |       1 |      98% |
| bin/pmic_regulator.py           |         49 |       1 |        0 |       16 |       1 |      97% |
| bin/spidev_test.py              |         37 |       1 |        0 |       12 |       1 |      96% |
| bin/dvfs_gpu_check_governors.py |         25 |       1 |        0 |       12 |       1 |      95% |
| bin/linux_ccf.py                |         45 |       1 |        0 |       18 |       2 |      95% |
| bin/serialcheck.py              |         34 |       1 |        0 |        8 |       1 |      95% |
| bin/brightness_test.py          |         92 |      92 |        0 |       30 |       0 |       0% |
| bin/cpu_idle.py                 |        142 |     142 |        0 |       50 |       0 |       0% |
| bin/gpio_loopback_test.py       |         92 |      92 |        0 |       24 |       0 |       0% |
| Total                           |        607 |     332 |        0 |      198 |       7 |      45% |