### PR TITLE
Fix lp copy packages arbitrary lookback (infra)

### DIFF
--- a/tools/release/test_lp_copy_packages.py
+++ b/tools/release/test_lp_copy_packages.py
@@ -17,7 +17,10 @@ class TestMain(unittest.TestCase):
         source_no_copy_outdated_distro = MagicMock(date_superseded=None)
 
         ppas = checkbox_dev_user.getPPAByName()
-        ppas.getPublishedSources.return_value = [source_to_copy] * 5 + [source_no_copy_superseeded, source_no_copy_outdated_distro]
+        ppas.getPublishedSources.return_value = [source_to_copy] * 5 + [
+            source_no_copy_superseeded,
+            source_no_copy_outdated_distro,
+        ]
 
         lp_copy_packages.main(
             ["checkbox-dev", "beta", "checkbox-dev", "stable"]

--- a/tools/release/test_lp_copy_packages.py
+++ b/tools/release/test_lp_copy_packages.py
@@ -12,9 +12,12 @@ class TestMain(unittest.TestCase):
         checkbox_dev_user = MagicMock()
         lp_client.people = {"checkbox-dev": checkbox_dev_user}
 
-        source = MagicMock()
+        source_to_copy = MagicMock(date_superseded=None)
+        source_no_copy_superseeded = MagicMock(date_superseded="some date")
+        source_no_copy_outdated_distro = MagicMock(date_superseded=None)
+
         ppas = checkbox_dev_user.getPPAByName()
-        ppas.getPublishedSources.return_value = [source] * 5
+        ppas.getPublishedSources.return_value = [source_to_copy] * 5 + [source_no_copy_superseeded, source_no_copy_outdated_distro]
 
         lp_copy_packages.main(
             ["checkbox-dev", "beta", "checkbox-dev", "stable"]


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The `lp_copy_packages.py` script failed to update our stable PPA because it assumed that any package that had to be copied over was less than 4 weeks old. 

This is false for two reasons:
1. A package has to be copied over regardless of how old it is if it is still the most recent version we have (namely, it took us way more than 1month to release stable this time around)
2. A package doesn't have to be copied over if it is `Superseeded` (namely, we have a more current version in the PPA of that same package)

> Note: there is a bit more insight on the filter I have left in the comment, but this is the top level view.
> Note1: the old comment stating that LP will choke on the request if no date is provided is only true if the iterator that the request returns is fully unwrapped. For this reason this PR only unwraps the relevant part.
## Resolved issues

Last stable release failed to update stable channel, see log: https://github.com/canonical/checkbox/actions/runs/7987143879/job/21809020771


(No copying over message -> no package copied over)

## Documentation

This PR adds documentation for what the function does and also adds a note about the more "counterintuitive" side of it (the fact that non-superseeded packages may still be non-copy-wrothy)

## Tests

This updates the test with the new two cases at hand

