### PR TITLE
Fix feild name  for scaling_test and maxfreq_test log attach from after to depeneds (Bugfix)

### DIFF
--- a/providers/base/units/cpu/jobs.pxu
+++ b/providers/base/units/cpu/jobs.pxu
@@ -56,7 +56,7 @@ plugin: attachment
 category_id: com.canonical.plainbox::cpu
 id: after-suspend-cpu/scaling_test-log-attach
 estimated_duration: 1.0
-after: after-suspend-cpu/scaling_test
+depends: after-suspend-cpu/scaling_test
 command: [[ -e "${PLAINBOX_SESSION_SHARE}"/scaling_test_after_suspend.log ]] && cat "${PLAINBOX_SESSION_SHARE}"/scaling_test_after_suspend.log
 _summary:
  Attach CPU scaling capabilities log
@@ -116,7 +116,7 @@ plugin: attachment
 category_id: com.canonical.plainbox::cpu
 id: after-suspend-cpu/maxfreq_test-log-attach
 estimated_duration: 1.0
-after: after-suspend-cpu/maxfreq_test
+depends: after-suspend-cpu/maxfreq_test
 command: [ -e "$PLAINBOX_SESSION_SHARE"/maxfreq_test.log ] && cat "$PLAINBOX_SESSION_SHARE"/maxfreq_test.log
 _summary:
  Attach CPU max frequency log


### PR DESCRIPTION
## Description
This is a simple PR to fix the mistakes from previous commit.
Fix field from `after` to `depends`.

## Resolved issues
#996 

## Documentation
N/A

## Tests
N/A

