### PR TITLE
Clearer autoresume text (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -768,8 +768,18 @@ class RemoteSessionAssistant:
             if the_job.plugin == "shell":
                 if "noreturn" in the_job.get_flag_set():
                     result_dict["outcome"] = IJobResult.OUTCOME_PASS
+                    result_dict["comments"] = (
+                        "Job crashed the machine or the checkbox agent, "
+                        "automatically marking it as passed after resuming "
+                        "the session because it has the noreturn flag"
+                    )
                 else:
                     result_dict["outcome"] = IJobResult.OUTCOME_CRASH
+                    result_dict["comments"] = (
+                        "Job crashed the machine or the checkbox agent, "
+                        "automatically marking it as crashed after resuming "
+                        "the session"
+                    )
 
         result_dict.update(overwrite_result_dict)
         result = MemoryJobResult(result_dict)

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -769,14 +769,14 @@ class RemoteSessionAssistant:
                 if "noreturn" in the_job.get_flag_set():
                     result_dict["outcome"] = IJobResult.OUTCOME_PASS
                     result_dict["comments"] = (
-                        "Job crashed the machine or the checkbox agent, "
+                        "Job crashed the machine or the Checkbox agent, "
                         "automatically marking it as passed after resuming "
                         "the session because it has the noreturn flag"
                     )
                 else:
                     result_dict["outcome"] = IJobResult.OUTCOME_CRASH
                     result_dict["comments"] = (
-                        "Job crashed the machine or the checkbox agent, "
+                        "Job crashed the machine or the Checkbox agent, "
                         "automatically marking it as crashed after resuming "
                         "the session"
                     )

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -769,16 +769,15 @@ class RemoteSessionAssistant:
                 if "noreturn" in the_job.get_flag_set():
                     result_dict["outcome"] = IJobResult.OUTCOME_PASS
                     result_dict["comments"] = (
-                        "Job crashed the machine or the Checkbox agent, "
-                        "automatically marking it as passed after resuming "
-                        "the session because it has the noreturn flag"
+                        "Job rebooted the machine or the Checkbox agent. "
+                        "Resuming the session and marking it as passed "
+                        "because the job has the `noreturn` flag"
                     )
                 else:
                     result_dict["outcome"] = IJobResult.OUTCOME_CRASH
                     result_dict["comments"] = (
-                        "Job crashed the machine or the Checkbox agent, "
-                        "automatically marking it as crashed after resuming "
-                        "the session"
+                        "Job rebooted the machine or the Checkbox agent. "
+                        "Resuming the session and marking it as crashed."
                     )
 
         result_dict.update(overwrite_result_dict)

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -250,9 +250,9 @@ class RemoteAssistantTests(TestCase):
             {
                 "outcome": IJobResult.OUTCOME_PASS,
                 "comments": (
-                    "Job crashed the machine or the Checkbox agent, "
-                    "automatically marking it as passed after resuming "
-                    "the session because it has the noreturn flag"
+                    "Job rebooted the machine or the Checkbox agent. "
+                    "Resuming the session and marking it as passed "
+                    "because the job has the `noreturn` flag"
                 ),
             }
         )
@@ -286,9 +286,8 @@ class RemoteAssistantTests(TestCase):
             {
                 "outcome": IJobResult.OUTCOME_CRASH,
                 "comments": (
-                    "Job crashed the machine or the Checkbox agent, "
-                    "automatically marking it as crashed after resuming "
-                    "the session"
+                    "Job rebooted the machine or the Checkbox agent. "
+                    "Resuming the session and marking it as crashed."
                 ),
             }
         )

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -249,7 +249,11 @@ class RemoteAssistantTests(TestCase):
         mjr = MemoryJobResult(
             {
                 "outcome": IJobResult.OUTCOME_PASS,
-                "comments": "Automatically passed after resuming execution",
+                "comments": (
+                    "Job crashed the machine or the Checkbox agent, "
+                    "automatically marking it as passed after resuming "
+                    "the session because it has the noreturn flag"
+                ),
             }
         )
 
@@ -281,7 +285,11 @@ class RemoteAssistantTests(TestCase):
         mjr = MemoryJobResult(
             {
                 "outcome": IJobResult.OUTCOME_CRASH,
-                "comments": "Automatically passed after resuming execution",
+                "comments": (
+                    "Job crashed the machine or the Checkbox agent, "
+                    "automatically marking it as crashed after resuming "
+                    "the session"
+                ),
             }
         )
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Currently the autoresume comment is not clear:
- For marking as passed, it doesn't state why it is doing so
- For marking as crashed, the text is inaccurate as it is using the same as passing

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/1064

## Documentation

This counts as documentation, it clarifies the behaviour with new text

## Tests

Also updated the text in the tests 

