### PR TITLE
Cover brightness genio test (New)

### DIFF
--- a/contrib/genio/tests/test_brightness.py
+++ b/contrib/genio/tests/test_brightness.py
@@ -1,0 +1,198 @@
+import unittest
+import os
+from unittest.mock import patch, mock_open, MagicMock
+from brightness_test import Brightness, main
+
+
+class TestBrightness(unittest.TestCase):
+
+    @patch("brightness_test.Brightness._get_interfaces_from_path")
+    def setUp(self, mock_get_interfaces):
+        mock_get_interfaces.return_value = [
+            "/sys/class/backlight/interface1",
+            "/sys/class/backlight/interface2",
+        ]
+        self.bt = Brightness()
+
+    @patch("brightness_test.Brightness._get_interfaces_from_path")
+    def test_init(self, mock_get_interfaces):
+        mock_get_interfaces.return_value = [
+            "/sys/class/backlight/interface1",
+            "/sys/class/backlight/interface2",
+        ]
+        self.bt = Brightness("test_path")
+        self.assertEqual(self.bt.sysfs_path, "test_path")
+        self.assertEqual(
+            self.bt.interfaces,
+            [
+                "/sys/class/backlight/interface1",
+                "/sys/class/backlight/interface2",
+            ],
+        )
+
+    def test_read_value(self):
+        data = "100\n"
+        with patch("builtins.open", mock_open(read_data=data)):
+            self.assertEqual(self.bt.read_value("test_path"), 100)
+
+        # The test raises a value error if the data is None
+        file = None
+        with self.assertRaises(ValueError):
+            self.bt.read_value(file)
+
+        # The test can handle a file object
+        mock_file = MagicMock()
+        mock_file.write = ""
+        mock_file.readlines.return_value = ["100\n"]
+        self.assertEqual(self.bt.read_value(mock_file), 100)
+
+    @patch("builtins.open")
+    def test_write_value(self, mock_open):
+        mock_file = MagicMock()
+        mock_open.return_value = mock_file
+
+        self.bt.write_value(100, "test_path")
+        mock_open.assert_called_once_with("test_path", "w")
+        mock_file.write.assert_called_once_with("100")
+
+        # The file is opened in append mode if the test argument is True
+        self.bt.write_value(100, "test_path", True)
+        mock_open.assert_called_with("test_path", "a")
+
+        # The test can handle a file object
+        self.bt.write_value(100, mock_file)
+        mock_file.write.assert_called_with("100")
+
+    @patch("brightness_test.Brightness.read_value")
+    def test_get_max_brightness(self, mock_read_value):
+        mock_read_value.return_value = 100
+        self.assertEqual(self.bt.get_max_brightness("test_path"), 100)
+
+    @patch("brightness_test.Brightness.read_value")
+    def test_get_actual_brightness(self, mock_read_value):
+        mock_read_value.return_value = 100
+        self.assertEqual(self.bt.get_actual_brightness("test_path"), 100)
+
+    @patch("brightness_test.Brightness.read_value")
+    def test_get_last_set_brightness(self, mock_read_value):
+        mock_read_value.return_value = 100
+        self.assertEqual(self.bt.get_last_set_brightness("test_path"), 100)
+
+    @patch("os.path.isdir")
+    @patch("brightness_test.glob")
+    def test_get_interfaces_from_path(self, mock_glob, mock_isdir):
+        mock_isdir.return_value = True
+        mock_glob.return_value = ["/sys/class/backlight/interface1"]
+        self.assertEqual(
+            self.bt._get_interfaces_from_path(),
+            ["/sys/class/backlight/interface1"],
+        )
+
+        # Returns an empty list if the path is not a directory
+        mock_isdir.return_value = False
+        self.assertEqual(self.bt._get_interfaces_from_path(), [])
+
+        # Returns an empty list if there are no directories in the path
+        mock_isdir.side_effect = [True, False]
+        self.assertEqual(self.bt._get_interfaces_from_path(), [])
+
+    @patch("brightness_test.Brightness.get_actual_brightness")
+    @patch("brightness_test.Brightness.get_last_set_brightness")
+    def test_was_brightness_applied(self, mock_get_last_set, mock_get_actual):
+        mock_get_actual.return_value = 100
+        mock_get_last_set.return_value = 100
+        self.assertEqual(self.bt.was_brightness_applied("test_path"), 0)
+
+        mock_get_actual.return_value = 100
+        mock_get_last_set.return_value = 105
+        self.assertEqual(self.bt.was_brightness_applied("test_path"), 1)
+
+    @patch("brightness_test.Brightness.get_actual_brightness")
+    @patch("brightness_test.Brightness.get_max_brightness")
+    @patch("brightness_test.Brightness.write_value")
+    @patch("brightness_test.Brightness.was_brightness_applied")
+    @patch("time.sleep", MagicMock())
+    def test_brightness(
+        self,
+        mock_was_brightness_applied,
+        mock_write_value,
+        mock_get_max_brightness,
+        mock_get_actual_brightness,
+    ):
+
+        target_interface = "/sys/class/backlight/interface1"
+
+        mock_get_actual_brightness.return_value = 100
+        mock_get_max_brightness.return_value = 200
+        mock_was_brightness_applied.return_value = 0
+        self.bt.brightness_test(target_interface)
+
+        mock_get_actual_brightness.assert_called_once_with(target_interface)
+        mock_get_max_brightness.assert_called_once_with(target_interface)
+        mock_write_value.assert_called_with(
+            100, os.path.join(target_interface, "brightness")
+        )
+        self.assertEqual(mock_was_brightness_applied.call_count, 5)
+
+        # Test the case where the brightness was not applied
+        mock_was_brightness_applied.return_value = 1
+        with self.assertRaises(SystemExit):
+            self.bt.brightness_test(target_interface)
+
+    def test_brightness_no_interfaces(self):
+        self.bt.interfaces = []
+        target_interface = "/sys/class/backlight/interface1"
+        with self.assertRaises(SystemExit) as cm:
+            self.bt.brightness_test(target_interface)
+        self.assertIn("ERROR", str(cm.exception))
+
+    def test_brightness_no_target_interface(self):
+        self.bt.interfaces = [
+            "/sys/class/backlight/interface1",
+            "/sys/class/backlight/interface2",
+        ]
+        target_interface = "/sys/class/backlight/interface3"
+        with self.assertRaises(SystemExit) as cm:
+            self.bt.brightness_test(target_interface)
+        self.assertIn("ERROR", str(cm.exception))
+
+    @patch("os.geteuid")
+    @patch("brightness_test.Brightness.brightness_test")
+    def test_main(self, mock_brightness, mock_getuid):
+        mock_getuid.return_value = 0
+        argv = ["script_name", "-p", "G1200-evk", "-d", "dsi"]
+        with patch("sys.argv", argv):
+            main()
+        self.assertEqual(mock_brightness.call_count, 1)
+
+    @patch("os.geteuid")
+    @patch("brightness_test.Brightness.brightness_test", MagicMock())
+    def test_main_bad_args(self, mock_getuid):
+        mock_getuid.return_value = 0
+        argv = ["script_name", "-p", "bad_platform", "-d", "dsi"]
+        with patch("sys.argv", argv):
+            with self.assertRaises(SystemExit):
+                main()
+
+        argv = ["script_name", "-p", "G1200-evk", "-d", "bad_display"]
+        with patch("sys.argv", argv):
+            with self.assertRaises(SystemExit):
+                main()
+
+    @patch("os.geteuid")
+    @patch("brightness_test.Brightness.brightness_test", MagicMock())
+    def test_main_no_root(self, mock_getuid):
+        mock_getuid.return_value = 1
+        argv = ["script_name", "-p", "G1200-evk", "-d", "dsi"]
+        with patch("sys.argv", argv):
+            with self.assertRaises(SystemExit):
+                main()
+
+    @patch("os.geteuid")
+    @patch("brightness_test.Brightness.brightness_test", MagicMock())
+    def test_main_wrong_interfaces(self, mock_getuid):
+        mock_getuid.return_value = 0
+        argv = ["script_name", "-p", "G350", "-d", "lvds"]
+        with patch("sys.argv", argv):
+            with self.assertRaises(SystemExit):
+                main()

--- a/contrib/genio/tests/test_brightness.py
+++ b/contrib/genio/tests/test_brightness.py
@@ -6,24 +6,15 @@ from brightness_test import Brightness, main
 
 class TestBrightness(unittest.TestCase):
 
-    @patch("brightness_test.Brightness._get_interfaces_from_path")
-    def setUp(self, mock_get_interfaces):
-        mock_get_interfaces.return_value = [
+    def test_init(self):
+        mock_brightness = MagicMock()
+        mock_brightness._get_interfaces_from_path.return_value = [
             "/sys/class/backlight/interface1",
             "/sys/class/backlight/interface2",
         ]
-        self.bt = Brightness()
-
-    @patch("brightness_test.Brightness._get_interfaces_from_path")
-    def test_init(self, mock_get_interfaces):
-        mock_get_interfaces.return_value = [
-            "/sys/class/backlight/interface1",
-            "/sys/class/backlight/interface2",
-        ]
-        self.bt = Brightness("test_path")
-        self.assertEqual(self.bt.sysfs_path, "test_path")
+        Brightness.__init__(mock_brightness)
         self.assertEqual(
-            self.bt.interfaces,
+            mock_brightness.interfaces,
             [
                 "/sys/class/backlight/interface1",
                 "/sys/class/backlight/interface2",
@@ -31,133 +22,164 @@ class TestBrightness(unittest.TestCase):
         )
 
     def test_read_value(self):
+        mock_brightness = MagicMock()
         data = "100\n"
         with patch("builtins.open", mock_open(read_data=data)):
-            self.assertEqual(self.bt.read_value("test_path"), 100)
+            self.assertEqual(
+                Brightness.read_value(mock_brightness, "test_path"), 100
+            )
 
         # The test raises a value error if the data is None
         file = None
         with self.assertRaises(ValueError):
-            self.bt.read_value(file)
+            Brightness.read_value(mock_brightness, file)
 
         # The test can handle a file object
         mock_file = MagicMock()
         mock_file.write = ""
         mock_file.readlines.return_value = ["100\n"]
-        self.assertEqual(self.bt.read_value(mock_file), 100)
+        self.assertEqual(
+            Brightness.read_value(mock_brightness, mock_file), 100
+        )
 
     @patch("builtins.open")
     def test_write_value(self, mock_open):
+        mock_brightness = MagicMock()
         mock_file = MagicMock()
         mock_open.return_value = mock_file
 
-        self.bt.write_value(100, "test_path")
+        Brightness.write_value(mock_brightness, 100, "test_path")
         mock_open.assert_called_once_with("test_path", "w")
         mock_file.write.assert_called_once_with("100")
 
         # The file is opened in append mode if the test argument is True
-        self.bt.write_value(100, "test_path", True)
+        Brightness.write_value(mock_brightness, 100, "test_path", True)
         mock_open.assert_called_with("test_path", "a")
 
         # The test can handle a file object
-        self.bt.write_value(100, mock_file)
+        Brightness.write_value(mock_brightness, 100, mock_file)
         mock_file.write.assert_called_with("100")
 
-    @patch("brightness_test.Brightness.read_value")
-    def test_get_max_brightness(self, mock_read_value):
-        mock_read_value.return_value = 100
-        self.assertEqual(self.bt.get_max_brightness("test_path"), 100)
+    def test_get_max_brightness(self):
+        mock_brightness = MagicMock()
+        mock_brightness.read_value.return_value = 100
+        self.assertEqual(
+            Brightness.get_max_brightness(mock_brightness, "test_path"), 100
+        )
 
-    @patch("brightness_test.Brightness.read_value")
-    def test_get_actual_brightness(self, mock_read_value):
-        mock_read_value.return_value = 100
-        self.assertEqual(self.bt.get_actual_brightness("test_path"), 100)
+    def test_get_actual_brightness(self):
+        mock_brightness = MagicMock()
+        mock_brightness.read_value.return_value = 100
+        self.assertEqual(
+            Brightness.get_actual_brightness(mock_brightness, "test_path"), 100
+        )
 
-    @patch("brightness_test.Brightness.read_value")
-    def test_get_last_set_brightness(self, mock_read_value):
-        mock_read_value.return_value = 100
-        self.assertEqual(self.bt.get_last_set_brightness("test_path"), 100)
+    def test_get_last_set_brightness(self):
+        mock_brightness = MagicMock()
+        mock_brightness.read_value.return_value = 100
+        self.assertEqual(
+            Brightness.get_last_set_brightness(mock_brightness, "test_path"),
+            100,
+        )
 
     @patch("os.path.isdir")
     @patch("brightness_test.glob")
     def test_get_interfaces_from_path(self, mock_glob, mock_isdir):
+        mock_brightness = MagicMock()
         mock_isdir.return_value = True
         mock_glob.return_value = ["/sys/class/backlight/interface1"]
         self.assertEqual(
-            self.bt._get_interfaces_from_path(),
+            Brightness._get_interfaces_from_path(
+                mock_brightness,
+            ),
             ["/sys/class/backlight/interface1"],
         )
 
         # Returns an empty list if the path is not a directory
         mock_isdir.return_value = False
-        self.assertEqual(self.bt._get_interfaces_from_path(), [])
+        self.assertEqual(
+            Brightness._get_interfaces_from_path(
+                mock_brightness,
+            ),
+            [],
+        )
 
         # Returns an empty list if there are no directories in the path
         mock_isdir.side_effect = [True, False]
-        self.assertEqual(self.bt._get_interfaces_from_path(), [])
+        self.assertEqual(
+            Brightness._get_interfaces_from_path(
+                mock_brightness,
+            ),
+            [],
+        )
 
-    @patch("brightness_test.Brightness.get_actual_brightness")
-    @patch("brightness_test.Brightness.get_last_set_brightness")
-    def test_was_brightness_applied(self, mock_get_last_set, mock_get_actual):
-        mock_get_actual.return_value = 100
-        mock_get_last_set.return_value = 100
-        self.assertEqual(self.bt.was_brightness_applied("test_path"), 0)
+    def test_was_brightness_applied(self):
+        mock_brightness = MagicMock()
+        mock_brightness = MagicMock()
+        mock_brightness.get_actual_brightness.return_value = 100
+        mock_brightness.get_last_set_brightness.return_value = 100
+        self.assertEqual(
+            Brightness.was_brightness_applied(mock_brightness, "test_path"), 0
+        )
 
-        mock_get_actual.return_value = 100
-        mock_get_last_set.return_value = 105
-        self.assertEqual(self.bt.was_brightness_applied("test_path"), 1)
+        mock_brightness.get_actual_brightness.return_value = 100
+        mock_brightness.get_last_set_brightness.return_value = 105
+        self.assertEqual(
+            Brightness.was_brightness_applied(mock_brightness, "test_path"), 1
+        )
 
-    @patch("brightness_test.Brightness.get_actual_brightness")
-    @patch("brightness_test.Brightness.get_max_brightness")
-    @patch("brightness_test.Brightness.write_value")
-    @patch("brightness_test.Brightness.was_brightness_applied")
     @patch("time.sleep", MagicMock())
-    def test_brightness(
-        self,
-        mock_was_brightness_applied,
-        mock_write_value,
-        mock_get_max_brightness,
-        mock_get_actual_brightness,
-    ):
+    def test_brightness(self):
+        mock_brightness = MagicMock()
+        mock_brightness = MagicMock()
+        mock_brightness.interfaces = [
+            "/sys/class/backlight/interface1",
+            "/sys/class/backlight/interface2",
+        ]
+        mock_brightness.get_actual_brightness.return_value = 100
+        mock_brightness.get_max_brightness.return_value = 200
+        mock_brightness.was_brightness_applied.return_value = 0
 
         target_interface = "/sys/class/backlight/interface1"
+        Brightness.brightness_test(mock_brightness, target_interface)
 
-        mock_get_actual_brightness.return_value = 100
-        mock_get_max_brightness.return_value = 200
-        mock_was_brightness_applied.return_value = 0
-        self.bt.brightness_test(target_interface)
-
-        mock_get_actual_brightness.assert_called_once_with(target_interface)
-        mock_get_max_brightness.assert_called_once_with(target_interface)
-        mock_write_value.assert_called_with(
+        mock_brightness.get_actual_brightness.assert_called_once_with(
+            target_interface
+        )
+        mock_brightness.get_max_brightness.assert_called_once_with(
+            target_interface
+        )
+        mock_brightness.write_value.assert_called_with(
             100, os.path.join(target_interface, "brightness")
         )
-        self.assertEqual(mock_was_brightness_applied.call_count, 5)
+        self.assertEqual(mock_brightness.was_brightness_applied.call_count, 5)
 
         # Test the case where the brightness was not applied
-        mock_was_brightness_applied.return_value = 1
+        mock_brightness.was_brightness_applied.return_value = 1
         with self.assertRaises(SystemExit):
-            self.bt.brightness_test(target_interface)
+            Brightness.brightness_test(mock_brightness, target_interface)
 
     def test_brightness_no_interfaces(self):
-        self.bt.interfaces = []
+        mock_brightness = MagicMock()
+        mock_brightness.interfaces = []
         target_interface = "/sys/class/backlight/interface1"
         with self.assertRaises(SystemExit) as cm:
-            self.bt.brightness_test(target_interface)
+            Brightness.brightness_test(mock_brightness, target_interface)
         self.assertIn("ERROR", str(cm.exception))
 
     def test_brightness_no_target_interface(self):
-        self.bt.interfaces = [
+        mock_brightness = MagicMock()
+        mock_brightness.interfaces = [
             "/sys/class/backlight/interface1",
             "/sys/class/backlight/interface2",
         ]
         target_interface = "/sys/class/backlight/interface3"
         with self.assertRaises(SystemExit) as cm:
-            self.bt.brightness_test(target_interface)
+            Brightness.brightness_test(mock_brightness, target_interface)
         self.assertIn("ERROR", str(cm.exception))
 
     @patch("os.geteuid")
-    @patch("brightness_test.Brightness.brightness_test")
+    @patch("brightness_test.Brightness")
     def test_main(self, mock_brightness, mock_getuid):
         mock_getuid.return_value = 0
         argv = ["script_name", "-p", "G1200-evk", "-d", "dsi"]
@@ -166,7 +188,7 @@ class TestBrightness(unittest.TestCase):
         self.assertEqual(mock_brightness.call_count, 1)
 
     @patch("os.geteuid")
-    @patch("brightness_test.Brightness.brightness_test", MagicMock())
+    @patch("brightness_test.Brightness", MagicMock())
     def test_main_bad_args(self, mock_getuid):
         mock_getuid.return_value = 0
         argv = ["script_name", "-p", "bad_platform", "-d", "dsi"]
@@ -180,7 +202,7 @@ class TestBrightness(unittest.TestCase):
                 main()
 
     @patch("os.geteuid")
-    @patch("brightness_test.Brightness.brightness_test", MagicMock())
+    @patch("brightness_test.Brightness", MagicMock())
     def test_main_no_root(self, mock_getuid):
         mock_getuid.return_value = 1
         argv = ["script_name", "-p", "G1200-evk", "-d", "dsi"]
@@ -189,7 +211,7 @@ class TestBrightness(unittest.TestCase):
                 main()
 
     @patch("os.geteuid")
-    @patch("brightness_test.Brightness.brightness_test", MagicMock())
+    @patch("brightness_test.Brightness", MagicMock())
     def test_main_wrong_interfaces(self, mock_getuid):
         mock_getuid.return_value = 0
         argv = ["script_name", "-p", "G350", "-d", "lvds"]

--- a/contrib/genio/tests/test_brightness.py
+++ b/contrib/genio/tests/test_brightness.py
@@ -115,7 +115,6 @@ class TestBrightness(unittest.TestCase):
 
     def test_was_brightness_applied(self):
         mock_brightness = MagicMock()
-        mock_brightness = MagicMock()
         mock_brightness.get_actual_brightness.return_value = 100
         mock_brightness.get_last_set_brightness.return_value = 100
         self.assertEqual(
@@ -130,7 +129,6 @@ class TestBrightness(unittest.TestCase):
 
     @patch("time.sleep", MagicMock())
     def test_brightness(self):
-        mock_brightness = MagicMock()
         mock_brightness = MagicMock()
         mock_brightness.interfaces = [
             "/sys/class/backlight/interface1",


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

After the inclusion of genio tests on the contrib area of checkbox, we have to add unit-tests to ensure the coverage requirements are satisfied. We have included unit-tests for the brightness_test.py script.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/CHECKBOX-1297 (follow-up)

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

There are no changes to the documentation

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

To run the unittests:
```
cd ~/checkbox/contrib/genio
pytest
```

## Coverage Report

| Module                          | statements | missing | excluded | branches | partial | coverage |
|---------------------------------|-----------:|--------:|---------:|---------:|--------:|---------:|
| bin/cpu_idle.py                 |        142 |       1 |        0 |       50 |       1 |      99% |
| bin/boot_partition.py           |         91 |       1 |        0 |       28 |       1 |      98% |
| bin/brightness_test.py          |         95 |       1 |        0 |       32 |       1 |      98% |
| bin/pmic_regulator.py           |         49 |       1 |        0 |       16 |       1 |      97% |
| bin/spidev_test.py              |         37 |       1 |        0 |       12 |       1 |      96% |
| bin/dvfs_gpu_check_governors.py |         25 |       1 |        0 |       12 |       1 |      95% |
| bin/linux_ccf.py                |         45 |       1 |        0 |       18 |       2 |      95% |
| bin/serialcheck.py              |         34 |       1 |        0 |        8 |       1 |      95% |
| bin/gpio_loopback_test.py       |         92 |      92 |        0 |       24 |       0 |       0% |
| Total                           |        610 |     100 |        0 |      200 |       9 |      84% |