### PR TITLE
New timeout helper module (New)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/timeout.py
+++ b/checkbox-support/checkbox_support/helpers/timeout.py
@@ -1,0 +1,39 @@
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Massimimliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+"""
+checkbox_support.helpers.timeout
+=============================================
+
+Utility class that provides functionalities connected to placing timeouts on
+functions
+"""
+import multiprocessing
+
+
+def timeout_run(f, timeout_s, *args, **kwargs):
+    """
+    Runs a function with the given args and kwargs. If the function doesn't
+    terminate within timeout_s seconds, this raises TimeoutError.
+    """
+    with multiprocessing.Pool(processes=1) as pool:
+        res = pool.apply_async(f, args, kwargs)
+        pool.close()
+        try:
+            return res.get(timeout_s)
+        except multiprocessing.context.TimeoutError as e:
+            raise TimeoutError from e

--- a/checkbox-support/checkbox_support/tests/test_timeout.py
+++ b/checkbox-support/checkbox_support/tests/test_timeout.py
@@ -1,0 +1,79 @@
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Massimimliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import time
+
+from unittest import TestCase
+
+from checkbox_support.helpers.timeout import timeout_run
+
+
+class ClassSupport:
+    def __init__(self, work_time):
+        self.work_time = work_time
+
+    def heavy_function(self):
+        time.sleep(self.work_time)
+        return "ClassSupport return value"
+
+
+def heavy_function(time_s):
+    time.sleep(time_s)
+    return "ClassSupport return value"
+
+
+def some_exception_raiser():
+    raise ValueError("value error!")
+
+
+def kwargs_args_support(first, second, third=3):
+    return (first, second, third)
+
+
+class TestTimeoutExec(TestCase):
+    def test_class_field_timeouts(self):
+        some = ClassSupport(1)
+        with self.assertRaises(TimeoutError):
+            timeout_run(some.heavy_function, 0.1)
+
+    def test_class_field_ok_return(self):
+        some = ClassSupport(0)
+        self.assertEqual(
+            timeout_run(some.heavy_function, 10), "ClassSupport return value"
+        )
+
+    def test_function_timeouts(self):
+        with self.assertRaises(TimeoutError):
+            timeout_run(heavy_function, 0.1, 10)
+
+    def test_function_ok_return(self):
+        self.assertEqual(
+            timeout_run(heavy_function, 10, 0), "ClassSupport return value"
+        )
+
+    def test_function_exception_propagation(self):
+        with self.assertRaises(ValueError):
+            timeout_run(some_exception_raiser, 0.1)
+
+    def test_function_args_kwargs_support(self):
+        self.assertEqual(
+            timeout_run(
+                kwargs_args_support, 1, "first", "second", third="third"
+            ),
+            ("first", "second", "third"),
+        )


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This is a recurring need in many providers. We need a way to run a function for up to X seconds or bail out. Instead of re-implementing this functionality multiple times, lets create a helper function. 

## Resolved issues

This is partially needed for this: https://warthogs.atlassian.net/browse/CHECKBOX-1250

## Documentation

This has a new docstring that explain what it does

## Tests

This adds unittests for every situation

