### PR TITLE
Add requires for bluetooth/keyboard and bluetooth/keyboard-manual (Bugfix)

### DIFF
--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -357,6 +357,8 @@ requires: device.category == 'BLUETOOTH'
 estimated_duration: 2.0
 
 id: bluetooth/keyboard
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_bt_adapter == 'True'
 _summary: Bluetooth keyboard works
 _purpose:
  Check if bluetooth keyboard works
@@ -370,6 +372,8 @@ category_id: com.canonical.plainbox::bluetooth
 estimated_duration: 1m
 
 id: bluetooth/keyboard-manual
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_bt_adapter == 'True'
 _summary: Bluetooth keyboard manual test
 _purpose:
  Check bluetooth input device works


### PR DESCRIPTION
## Description
The jobs are lack of requires which causes the job will still run even DUTs do not support bluetooth. Hence I add it back in the jobs.

## Resolved issues
Fix #966 

## Documentation
N/A

## Tests
n/A

