### PR TITLE
Add 'environ' for the job 'graphics/{index}_glmark2-es2_{product_slug}' and change from automated to manual (Bugfix)

### DIFF
--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -497,7 +497,7 @@ _description: Check NVLINK are supported and NVLINK are connected properly on sy
 
 unit: template
 template-resource: graphics_card
-plugin: shell
+plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_glmark2-es2_{product_slug}
 requires:
@@ -509,3 +509,7 @@ command:
     glmark2-es2 --data-path "$CHECKBOX_RUNTIME"/usr/share/glmark2/
 estimated_duration: 60.5
 _summary: Run OpenGL ES 2.0 X11 benchmark on the {product} video card
+_steps:
+    1. Commence the test to start rendering
+_verification:
+    Did all the videos and images rendered correctly?

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -501,8 +501,11 @@ plugin: shell
 category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_glmark2-es2_{product_slug}
 requires:
- executable.name == 'glmark2-es2'
- 'classic' in environment.SNAP_NAME
-command: glmark2-es2 --data-path "$CHECKBOX_RUNTIME"/usr/share/glmark2/
+    executable.name == 'glmark2-es2'
+    'classic' in environment.SNAP_NAME
+environ:
+    CHECKBOX_RUNTIME
+command:
+    glmark2-es2 --data-path "$CHECKBOX_RUNTIME"/usr/share/glmark2/
 estimated_duration: 60.5
 _summary: Run OpenGL ES 2.0 X11 benchmark on the {product} video card


### PR DESCRIPTION
## Description
Fixed the [issue](https://github.com/canonical/checkbox/issues/1076) that black output when in remote run and I also change a little bit of the job layout.
And change this job from automated to manual, because
1. As you can see in the submission, this job passed even the output is wrong
2. If there is any broken image while running, the automated job is not able to catch this.

## Resolved issues
1. Fix #1076 
2. Broken image in automated test cases can not be catched

## Documentation
N/A

## Tests
 - Before: https://certification.canonical.com/hardware/202205-30258/submission/360208/test/156567/result/39811896/
 - After: https://certification.canonical.com/hardware/202205-30258/submission/360631/test/156567/result/39862396/

