### PR TITLE
Take inline overrides into account in mandatory_include and bootstrap_include sections of a test plan (BugFix)

### DIFF
--- a/checkbox-ng/plainbox/impl/unit/test_testplan.py
+++ b/checkbox-ng/plainbox/impl/unit/test_testplan.py
@@ -513,25 +513,35 @@ class TestNestedTestPlan(TestCase):
 class TestTestPlanUnitSupport(TestCase):
 
     def setUp(self):
-        self.provider1 = mock.Mock(name='provider1', spec_set=IProvider1)
-        self.provider1.namespace = 'ns1'
         self.tp1 = TestPlanUnit({
             "id": "tp1",
             "unit": "test plan",
             "name": "An example test plan 1",
+            "bootstrap_include": "bootstrap_job certification_status=blocker",
             "mandatory_include": "mandatory_job certification_status=blocker",
             "include": "job1 certification_status=non-blocker",
-        }, provider=self.provider1)
-        self.provider1.unit_list = []
-        self.tp1.provider_list = [self.provider1,]
-        self.provider1.unit_list.append(self.tp1)
+        })
+        self.tp2 = TestPlanUnit({
+            "id": "tp1",
+            "unit": "test plan",
+            "name": "An example test plan 2",
+            "include": "job1        certification_status=blocker",
+        })
 
     def test_inline_override(self):
-        support = TestPlanUnitSupport(self.tp1)
+        support_tp1 = TestPlanUnitSupport(self.tp1)
+        support_tp2 = TestPlanUnitSupport(self.tp2)
         self.assertEqual(
-            support.override_list,
+            support_tp1.override_list,
             [
-                ("^ns1::job1$", [("certification_status", "non-blocker")]),
-                ("^ns1::mandatory_job$", [("certification_status", "blocker")])
-            ]
+                ("^bootstrap_job$", [("certification_status", "blocker")]),
+                ("^job1$", [("certification_status", "non-blocker")]),
+                ("^mandatory_job$", [("certification_status", "blocker")]),
+            ],
+        )
+        self.assertEqual(
+            support_tp2.override_list,
+            [
+                ("^job1$", [("certification_status", "blocker")]),
+            ],
         )

--- a/checkbox-ng/plainbox/impl/unit/testplan.py
+++ b/checkbox-ng/plainbox/impl/unit/testplan.py
@@ -843,6 +843,8 @@ PatternMatcher('^job-[x-z]$'), inclusive=False)])
                     override_list.append((pattern, field_value_list))
 
             V().visit(IncludeStmtList.parse(testplan.include))
+            if testplan.mandatory_include:
+                V().visit(IncludeStmtList.parse(testplan.mandatory_include))
         for tp_unit in testplan.get_nested_part():
             override_list.extend(self._get_inline_overrides(tp_unit))
         return override_list

--- a/checkbox-ng/plainbox/impl/unit/testplan.py
+++ b/checkbox-ng/plainbox/impl/unit/testplan.py
@@ -826,25 +826,27 @@ PatternMatcher('^job-[x-z]$'), inclusive=False)])
         collected into a list of tuples ``(field, value)`` and this list is
         subsequently packed into a tuple ``(pattern, field_value_list)``.
         """
+        class V(Visitor):
+
+            def visit_IncludeStmt_node(self, node: IncludeStmt):
+                if not node.overrides:
+                    return
+                pattern = r"^{}$".format(
+                    testplan.qualify_id(node.pattern.text))
+                field_value_list = [
+                    (override_exp.field.text.replace('-', '_'),
+                     override_exp.value.text)
+                    for override_exp in node.overrides]
+                override_list.append((pattern, field_value_list))
         override_list = []
-        if testplan.include is not None:
-
-            class V(Visitor):
-
-                def visit_IncludeStmt_node(self, node: IncludeStmt):
-                    if not node.overrides:
-                        return
-                    pattern = r"^{}$".format(
-                        testplan.qualify_id(node.pattern.text))
-                    field_value_list = [
-                        (override_exp.field.text.replace('-', '_'),
-                         override_exp.value.text)
-                        for override_exp in node.overrides]
-                    override_list.append((pattern, field_value_list))
-
-            V().visit(IncludeStmtList.parse(testplan.include))
-            if testplan.mandatory_include:
-                V().visit(IncludeStmtList.parse(testplan.mandatory_include))
+        include_sections = (
+            testplan.bootstrap_include,
+            testplan.mandatory_include,
+            testplan.include,
+        )
+        for section in include_sections:
+            if section:
+                V().visit(IncludeStmtList.parse(section))
         for tp_unit in testplan.get_nested_part():
             override_list.extend(self._get_inline_overrides(tp_unit))
         return override_list


### PR DESCRIPTION
## Description

Although inline overrides were taking into account in the `include` section of a test plan, it was not the case for the `mandatory_include` and `bootstrap_include` sections.

So a test plan like this:

```
unit: test plan
id: test-plan
name: My test plan
bootstrap_include:
    bootstrap-cert-blocker-job  certification_status=blocker
mandatory_include:
    mandatory-cert-blocker-job  certification_status=blocker
include:
    regular-cert-blocker-job    certification_status=blocker
```

would only make "regular-cert-blocker-job" a cert-blocker, not "mandatory-cert-blocker-job".

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->



<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Tests

Tested by running a test plan similar as the one described above and making sure the HTML report includes the job in `mandatory_include` and `bootstrap_include` sections as a cert-blocker.

