### PR TITLE
Cover loopback genio test

### DIFF
--- a/contrib/genio/bin/gpio_loopback_test.py
+++ b/contrib/genio/bin/gpio_loopback_test.py
@@ -81,8 +81,8 @@ class GPIOSysFsController():
         print("Input Pin Number: {} + Base Number = {}".format(
             gpio_input_pin, input_pin_number))
         print("\n# Start GPIO loopback test")
-        raise SystemExit(
-            not self.loopback_test(output_pin_number, input_pin_number))
+        if not self.loopback_test(output_pin_number, input_pin_number):
+            raise SystemExit("Failed: GPIO loopback test failed")
 
     def check_gpio_node(self, port):
         """Check the GPIO port is exists
@@ -172,7 +172,7 @@ class GPIOSysFsController():
         self.configure_gpio(in_port, "in")
 
         for state in self.TEST_STATES:
-            print("Try to send and receivce {}".format(state))
+            print("Try to send and receive {}".format(state))
             value = self.read_gpio(in_port)
             print("The initial input GPIO {}'s value is {}".format(
                 in_port, value))

--- a/contrib/genio/tests/test_gpio_loopback.py
+++ b/contrib/genio/tests/test_gpio_loopback.py
@@ -1,0 +1,199 @@
+import textwrap
+import unittest
+from unittest.mock import patch, mock_open, MagicMock
+from gpio_loopback_test import GPIOSysFsController, main
+
+
+class TestGpioLoopback(unittest.TestCase):
+
+    def setUp(self):
+        self.gpio_controller = GPIOSysFsController()
+
+    def test_get_gpio_base_number(self):
+        data = textwrap.dedent(
+            """
+            gpiochip0: GPIOs 0-31, ID1, ID2:
+                gpio-0 (                    |sysfs               ) in  hi
+                gpio-1 (                    |sysfs               ) out hi
+            gpiochip1: GPIOs 32-63, ID3, ID4:
+                gpio-32 (                   |sysfs               ) in  hi
+                gpio-33 (                   |sysfs               ) out hi
+        """
+        )
+        with patch("builtins.open", mock_open(read_data=data)):
+            self.assertEqual(
+                self.gpio_controller.get_gpio_base_number(),
+                {
+                    "gpiochip0": "0",
+                    "gpiochip1": "32",
+                },
+            )
+
+    @patch("gpio_loopback_test.GPIOSysFsController.get_gpio_base_number")
+    @patch("gpio_loopback_test.GPIOSysFsController.loopback_test")
+    @patch("builtins.print")
+    def test_run_test(self, mock_print, mock_loopback, mock_get_base_number):
+        mock_get_base_number.return_value = {
+            "gpiochip0": "0",
+            "gpiochip1": "32",
+        }
+        mock_loopback.return_value = True
+
+        output_gpio_chip_number = "0"
+        input_gpio_chip_number = "1"
+        physical_output_port = "J1"
+        physical_input_port = "J2"
+        gpio_output_pin = "1"
+        gpio_input_pin = "2"
+
+        self.gpio_controller.run_test(
+            output_gpio_chip_number,
+            input_gpio_chip_number,
+            physical_output_port,
+            physical_input_port,
+            gpio_output_pin,
+            gpio_input_pin,
+        )
+
+        print_calls = [
+            "\nOutput Base Number: 0",
+            "Input Base Number: 32",
+            "Physical output port: J1, GPIO number: 1",
+            "Physical input port: J2, GPIO number 2",
+            "Output Pin Number: 1 + Base Number = 1",
+            "Input Pin Number: 2 + Base Number = 34",
+            "\n# Start GPIO loopback test",
+        ]
+
+        actual_calls = [call.args[0] for call in mock_print.call_args_list]
+
+        self.assertEqual(actual_calls, print_calls)
+
+        # SystemExit is raised if the loopback test fails
+        mock_loopback.return_value = False
+        with self.assertRaises(SystemExit):
+            self.gpio_controller.run_test(
+                output_gpio_chip_number,
+                input_gpio_chip_number,
+                physical_output_port,
+                physical_input_port,
+                gpio_output_pin,
+                gpio_input_pin,
+            )
+
+    @patch("os.path.exists")
+    def test_check_gpio_node(self, mock_exists):
+        mock_exists.return_value = True
+        self.assertTrue(self.gpio_controller.check_gpio_node("test"))
+
+    def test_set_gpio(self):
+        with patch("builtins.open", mock_open()) as mock_file:
+            self.gpio_controller.set_gpio("test", "1")
+            mock_file.assert_called_once_with(
+                "/sys/class/gpio/gpio{}/value".format("test"), "wt"
+            )
+            mock_file().write.assert_called_once_with("1\n")
+
+    def test_read_gpio(self):
+        with patch("builtins.open", mock_open(read_data="1")) as mock_file:
+            self.assertEqual(self.gpio_controller.read_gpio("test"), "1")
+            mock_file.assert_called_once_with(
+                "/sys/class/gpio/gpio{}/value".format("test"), "r"
+            )
+
+    def test_set_direction(self):
+        with patch("builtins.open", mock_open()) as mock_file:
+            self.gpio_controller.set_direction("test", "out")
+            mock_file.assert_called_once_with(
+                "/sys/class/gpio/gpio{}/direction".format("test"), "w"
+            )
+            mock_file().write.assert_called_once_with("out\n")
+
+    @patch("gpio_loopback_test.GPIOSysFsController.check_gpio_node")
+    @patch("gpio_loopback_test.GPIOSysFsController.set_direction")
+    @patch("builtins.open")
+    def test_configure_gpio(
+        self, mock_open, mock_set_direction, mock_check_gpio_node
+    ):
+        mock_check_gpio_node.return_value = True
+        self.gpio_controller.configure_gpio("port", "dir")
+        mock_open.assert_not_called()
+        mock_set_direction.assert_called_once_with("port", "dir")
+
+        # If the GPIO node does not exist, it should be created
+        mock_check_gpio_node.side_effect = [False, True]
+        self.gpio_controller.configure_gpio("port", "dir")
+        mock_open.assert_called_once_with("/sys/class/gpio/export", "w")
+        with mock_open() as mock_file:
+            mock_file.write.assert_called_once_with("port\n")
+        mock_set_direction.assert_called_with("port", "dir")
+
+    @patch("gpio_loopback_test.GPIOSysFsController.check_gpio_node")
+    @patch("gpio_loopback_test.GPIOSysFsController.set_direction")
+    @patch("builtins.open")
+    def test_configure_fail(
+        self, mock_open, mock_set_direction, mock_check_gpio_node
+    ):
+        # The test should fail if the GPIO can't be exported
+        mock_check_gpio_node.side_effect = [False, False]
+        with self.assertRaises(SystemExit):
+            self.gpio_controller.configure_gpio("port", "dir")
+        mock_set_direction.assert_not_called()
+
+        # The test should fail if the direction can't be set
+        mock_check_gpio_node.side_effect = [True, True]
+        mock_set_direction.side_effect = IOError
+        with self.assertRaises(IOError):
+            self.gpio_controller.configure_gpio("port", "dir")
+
+    @patch("gpio_loopback_test.GPIOSysFsController.configure_gpio")
+    @patch("gpio_loopback_test.GPIOSysFsController.read_gpio")
+    @patch("gpio_loopback_test.GPIOSysFsController.set_gpio")
+    @patch("time.sleep", MagicMock())
+    def test_loopback_test(
+        self, mock_set_gpio, mock_read_gpio, mock_configure_gpio
+    ):
+        mock_read_gpio.side_effect = ["1", "0", "0", "1"]
+        self.assertTrue(self.gpio_controller.loopback_test("1", "34"))
+        # configure_gpio should be called twice, once for each port
+        self.assertEqual(mock_configure_gpio.call_count, 2)
+        # set_gpio should be called twice, once for each state
+        self.assertEqual(mock_set_gpio.call_count, 2)
+
+    @patch("gpio_loopback_test.GPIOSysFsController.configure_gpio")
+    @patch("gpio_loopback_test.GPIOSysFsController.read_gpio")
+    @patch("gpio_loopback_test.GPIOSysFsController.set_gpio")
+    @patch("time.sleep", MagicMock())
+    def test_loopback_test_fail(
+        self, mock_set_gpio, mock_read_gpio, mock_configure_gpio
+    ):
+        mock_read_gpio.side_effect = ["1", "0", "0", "0"]
+        self.assertFalse(self.gpio_controller.loopback_test("1", "34"))
+        # configure_gpio should be called twice, once for each port
+        self.assertEqual(mock_configure_gpio.call_count, 2)
+        # set_gpio should be called twice, once for each state
+        self.assertEqual(mock_set_gpio.call_count, 2)
+
+    @patch("gpio_loopback_test.GPIOSysFsController.run_test")
+    def test_main(self, mock_run_test):
+        mock_run_test.return_value = None
+        args = (
+            ["script_name"]
+            + ["-oc", "0"]
+            + ["-ic", "1"]
+            + ["-po", "J1"]
+            + ["-pi", "J2"]
+            + ["-go", "1"]
+            + ["-gi", "2"]
+        )
+        with patch("sys.argv", args):
+            self.assertEqual(main(), None)
+            mock_run_test.assert_called_once_with(
+                "0", "1", "J1", "J2", "1", "2"
+            )
+
+        # Test fails if run_test raises a SystemExit
+        mock_run_test.side_effect = SystemExit
+        with patch("sys.argv", args):
+            with self.assertRaises(SystemExit):
+                main()


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

After the inclusion of genio tests on the contrib area of checkbox, we have to add unit-tests to ensure the coverage requirements are satisfied. We have included unit-tests for the brightness_test.py script.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/CHECKBOX-1297 (partly with #1063 )

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

There are no changes to the documentation

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

To run the unittests:
```
cd ~/checkbox/contrib/genio
pytest
```

## Coverage Report

| Module                          | statements | missing | excluded | branches | partial | coverage |
|---------------------------------|-----------:|--------:|---------:|---------:|--------:|---------:|
| bin/cpu_idle.py                 |        142 |       1 |        0 |       50 |       1 |      99% |
| bin/boot_partition.py           |         91 |       1 |        0 |       28 |       1 |      98% |
| bin/brightness_test.py          |         95 |       1 |        0 |       32 |       1 |      98% |
| bin/pmic_regulator.py           |         49 |       1 |        0 |       16 |       1 |      97% |
| bin/spidev_test.py              |         37 |       1 |        0 |       12 |       1 |      96% |
| bin/dvfs_gpu_check_governors.py |         25 |       1 |        0 |       12 |       1 |      95% |
| bin/linux_ccf.py                |         45 |       1 |        0 |       18 |       2 |      95% |
| bin/serialcheck.py              |         34 |       1 |        0 |        8 |       1 |      95% |
| bin/gpio_loopback_test.py       |         92 |      92 |        0 |       24 |       0 |       0% |
| Total                           |        610 |     100 |        0 |      200 |       9 |      84% |