### PR TITLE
update definitions in base/audio jobs using an AI tool (BugFix)

### DIFF
--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -6,7 +6,8 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
 command: cat /proc/asound/cards
-_description: Test to detect audio devices
+_purpose: Test to detect audio devices
+_summary: Check if audio devices can be detected.
 
 plugin: shell
 category_id: com.canonical.plainbox::audio
@@ -27,7 +28,8 @@ command:
      fi
  done
  exit $fail
-_description: Valid sof firmware signature
+_purpose: Validate SOF firmware signature.
+_summary: Ensure SOF firmware signature is valid.
 
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
@@ -54,15 +56,16 @@ command:
   fi
   exit $EXIT_CODE
 _description:
- PURPOSE:
-     This test will check that internal speakers work correctly
- STEPS:
-     1. Make sure that no external speakers or headphones are connected
-        When testing a desktop, you can skip this test if there is no
-        internal speaker, we will test the external output later
-     2. Commence the test to play a brief tone on your audio device
- VERIFICATION:
-     Did you hear a tone?
+_purpose:
+    This test will check that internal speakers work correctly
+_steps:
+    1. Make sure that no external speakers or headphones are connected
+       When testing a desktop, you can skip this test if there is no
+       internal speaker, we will test the external output later
+    2. Commence the test to play a brief tone on your audio device
+_verification:
+    Did you hear a tone?
+_summary: Ensure the internal speakers are working by playing a tone.
 
 unit: template
 template-resource: graphics_card
@@ -275,11 +278,13 @@ command:
 _purpose:
     HDMI audio via USB Type-C port interface verification
 _steps:
-    1. Plug an external HDMI device with sound on a USB Type-C port using a "USB Typce-C to HDMI" adapter (Use only one HDMI/DisplayPort/Thunderbolt interface at a time for this test)
-    2. Commence the test
+    1. Plug an external HDMI device with sound into a USB Type-C port using a "USB Type-C to HDMI" adapter (Use only one HDMI/DisplayPort/Thunderbolt interface at a time for this test)
+    2. Begin the test
 _verification:
     Did you hear the sound from the HDMI device?
-    
+_summary:
+    Verify HDMI audio playback through the USB Type-C port using a "USB Type-C to HDMI" adapter and confirm sound output.
+
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 flags: also-after-suspend
@@ -305,13 +310,14 @@ command:
   fi
   exit $EXIT_CODE
 _description:
- PURPOSE:
-     This test will check that headphones connector works correctly
- STEPS:
-     1. Connect a pair of headphones to your audio device
-     2. Commence the test to play a sound to your audio device
- VERIFICATION:
-     Did you hear a sound through the headphones and did the sound play without any distortion, clicks or other strange noises from your headphones?
+_purpose:
+    This test will check that the headphones connector works correctly.
+_steps:
+    1. Connect a pair of headphones to your audio device.
+    2. Commence the test to play a sound through your audio device.
+_verification:
+    Did you hear a sound through the headphones, and did the sound play without any distortion, clicks, or other strange noises from your headphones?
+_summary: Verify headphone connectivity and audio playback quality.
 
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
@@ -338,14 +344,15 @@ command:
   fi
   exit $EXIT_CODE
 _description:
- PURPOSE:
-     This test will check that recording sound using the onboard microphone works correctly
- STEPS:
-     1. Disconnect any external microphones that you have plugged in
-     2. Click "Test", then speak into your internal microphone
-     3. After a few seconds, your speech will be played back to you.
- VERIFICATION:
-     Did you hear your speech played back?
+_purpose:
+    This test will check that recording sound using the onboard microphone works correctly
+_steps: 
+    1. Disconnect any external microphones that you have plugged in
+    2. Click "Test", then speak into your internal microphone
+    3. After a few seconds, your speech will be played back to you.
+_verification:
+    Did you hear your speech played back?
+_summary: Test internal microphone recording and playback functionality.
 
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
@@ -371,15 +378,15 @@ command:
     audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
   fi
   exit $EXIT_CODE
-_description:
- PURPOSE:
+_purpose:
      This test will check that recording sound using an external microphone works correctly
- STEPS:
+_steps:
      1. Connect a microphone to your microphone port
      2. Click "Test", then speak into the external microphone
      3. After a few seconds, your speech will be played back to you
- VERIFICATION:
+_verification:
      Did you hear your speech played back?
+_summary: Verify external microphone sound recording and playback.
 
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
@@ -402,15 +409,15 @@ command:
     audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
   fi
   exit $EXIT_CODE
-_description:
- PURPOSE:
-     This test will check that a USB audio device works correctly
- STEPS:
-     1. Connect a USB audio device to your system
-     2. Click "Test", then speak into the microphone
-     3. After a few seconds, your speech will be played back to you
- VERIFICATION:
-     Did you hear your speech played back through the USB headphones?
+_purpose:
+ This test will check that a USB audio device works correctly
+_steps:
+ 1. Connect a USB audio device to your system
+ 2. Click "Test", then speak into the microphone
+ 3. After a few seconds, your speech will be played back to you
+_verification:
+ Did you hear your speech played back through the USB headphones?
+_summary: Verify USB audio device functionality through record and playback test.
 
 plugin: shell
 category_id: com.canonical.plainbox::audio
@@ -433,9 +440,8 @@ command:
   else
     audio_test.py
   fi
-_description:
- Play back a sound on the default output and listen for it on the
- default input.
+_purpose: Play back a sound on the default output and listen for it on the default input.
+_summary: Test playback and recording functionality on the default audio input and output.
 
 plugin: shell
 category_id: com.canonical.plainbox::audio
@@ -452,8 +458,8 @@ command:
   else
     pactl_list.sh sinks
   fi
-_description:
-  Test to detect if there's available sinks
+_purpose: Test to detect if there are available sinks
+_summary: Ensure audio sinks are available for detection.
 
 plugin: shell
 category_id: com.canonical.plainbox::audio
@@ -470,18 +476,19 @@ command:
   else
     pactl_list.sh sources
   fi
-_description:
-  Test to detect if there's available sources.
+_purpose: Test to detect if there are available sources.
+_summary: Test to ensure audio sources can be detected.
 
 plugin: shell
 category_id: com.canonical.plainbox::audio
 id: audio/alsa_info_collect
 estimated_duration: 2.0
 command: alsa_info --no-dialog --no-upload --output "${PLAINBOX_SESSION_SHARE}"/alsa_info.log
-_description:
+_purpose:
  Collect audio-related system information. This data can be used to
  simulate this computer's audio subsystem and perform more detailed tests
  under a controlled environment.
+_summary: Collect audio-related system information for simulation and detailed testing.
 
 plugin: attachment
 category_id: com.canonical.plainbox::audio
@@ -489,8 +496,8 @@ id: audio/alsa_info_attachment
 depends: audio/alsa_info_collect
 estimated_duration: 1.0
 command: [ -e "${PLAINBOX_SESSION_SHARE}"/alsa_info.log ] && cat "${PLAINBOX_SESSION_SHARE}"/alsa_info.log
-_description:
- Attaches the audio hardware data collection log to the results.
+_purpose: Attaches the audio hardware data collection log to the results.
+_summary: Attach audio hardware data collection log to the results.
 
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
@@ -498,13 +505,13 @@ id: audio/channels
 flags: also-after-suspend
 estimated_duration:  20.0
 command: speaker-test -c 2 -l 1 -t wav
-_description:
- PURPOSE:
-     Check that the various audio channels are working properly
- STEPS:
-     1. Commence the test
- VERIFICATION:
-     You should clearly hear a voice from the different audio channels
+_purpose:
+    Check that the various audio channels are working properly
+_steps:
+    1. Commence the test
+_verification:
+    You should clearly hear a voice from the different audio channels
+_summary: Verify that all audio channels are functioning correctly by hearing a voice clearly from them.
 
 plugin: shell
 category_id: com.canonical.plainbox::audio
@@ -514,13 +521,14 @@ requires:
  package.name == 'pulseaudio-utils'
  device.category == 'AUDIO'
 command: volume_test.py --minvol 1 --maxvol 100
-_description:
+_purpose:
  This test will verify that the volume levels are at an acceptable level on
- your local system.  The test will validate that the volume is greater than
+ your local system. The test will validate that the volume is greater than
  or equal to minvol and less than or equal to maxvol for all sources (inputs)
- and sinks (outputs) recognized by PulseAudio.  It will also validate that the
- active source and sink are not muted.  You should not manually adjust the
+ and sinks (outputs) recognized by PulseAudio. It will also validate that the
+ active source and sink are not muted. You should not manually adjust the
  volume or mute before running this test.
+_summary: Verify acceptable volume levels on the system for all sources and sinks recognized by PulseAudio.
 
 plugin: manual
 category_id: com.canonical.plainbox::audio
@@ -529,17 +537,17 @@ flags: also-after-suspend
 estimated_duration: 30.0
 requires:
  dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower','Space-saving','All In One','All-In-One','AIO']
-_description:
- PURPOSE:
+_purpose:
       Check that external line out connection works correctly
- STEPS:
+_steps:
       1. Insert cable to speakers (with built-in amplifiers) on the line out port
       2. Open system sound preferences, 'Output' tab, select 'Line Out' on the connector list. Commence the test
       3. On the system sound preferences, click 'Test Sound' to check left and right channel
- VERIFICATION:
-      1. Do you see internal speakers? The internal speakers should be replaced by external speaker from Line out port, if any
+_verification:
+      1. Do you see internal speakers? The internal speakers should be replaced by external speakers from the Line out port, if any
       2. Do you hear the sound in the internal speakers? The internal speakers should be muted automatically
-      3. Do you hear the sound coming out on the corresponding channel by external speakers from Line out port?
+      3. Do you hear the sound coming out on the corresponding channel by external speakers from the Line out port?
+_summary: Verify external line out connection functionality by inserting a cable to speakers, selecting 'Line Out' in system sound preferences, and testing sound channels.
 
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
@@ -566,14 +574,15 @@ command:
   fi
   exit $EXIT_CODE
 _description:
- PURPOSE:
-     Check that external line in connection works correctly
- STEPS:
-     1. Use a cable to connect the line in port to an external line out source.
-     2. Open system sound preferences, 'Input' tab, select 'Line-in' on the connector list. Commence the test
+_purpose:
+     Check that external line-in connection works correctly
+_steps:
+     1. Use a cable to connect the line-in port to an external line-out source.
+     2. Open system sound preferences, 'Input' tab, select 'Line-in' on the connector list. Commence the test.
      3. After a few seconds, your recording will be played back to you.
- VERIFICATION:
+_verification:
      Did you hear your recording?
+_summary: Verify external line-in connection functionality by recording and playback testing.
 
 plugin: user-interact
 category_id: com.canonical.plainbox::audio
@@ -584,23 +593,23 @@ requires:
  device.category == 'AUDIO'
  package.name in ['pulseaudio-utils', 'pipewire']
 command: 
-  if check_audio_deamon.sh ; then
+  if check_audio_daemon.sh ; then
     pipewire_utils.py monitor -t 30 -m sinks
   else
     pulse_active_port_change.py sinks
   fi
-_description:
- PURPOSE:
-     Check that system detects speakers or headphones being plugged in
- STEPS:
-     1. Prepare a pair of headphones or speakers with a standard 3.5mm jack
-     2. Locate the speaker / headphone jack on the device under test
-     3. Run the test (you have 30 seconds from now on)
-     4. Plug headphones or speakers into the appropriate jack
-     5. Unplug the device for subsequent tests.
- VERIFICATION:
-     Verification is automatic, no action is required.
-     The test times out after 30 seconds (and fails in that case).
+_purpose:
+ Check that system detects speakers or headphones being plugged in
+_steps:
+ 1. Prepare a pair of headphones or speakers with a standard 3.5mm jack
+ 2. Locate the speaker / headphone jack on the device under test
+ 3. Run the test (you have 30 seconds from now on)
+ 4. Plug headphones or speakers into the appropriate jack
+ 5. Unplug the device for subsequent tests.
+_verification:
+ Verification is automatic, no action is required.
+ The test times out after 30 seconds (and fails in that case).
+_summary: Ensure the system automatically detects when speakers or headphones are plugged in.
 
 plugin: user-interact
 category_id: com.canonical.plainbox::audio
@@ -611,24 +620,24 @@ requires:
  device.category == 'AUDIO'
  package.name in ['pulseaudio-utils', 'pipewire']
 command: 
-  if check_audio_deamon.sh ; then
+  if check_audio_daemon.sh ; then
     pipewire_utils.py monitor -t 30 -m sources
   else
     pulse_active_port_change.py sources
   fi
-_description:
- PURPOSE:
+_purpose:
      Check that system detects a microphone being plugged in
- STEPS:
+_steps:
      1. Prepare a microphone with a standard 3.5mm jack
      2. Locate the microphone jack on the device under test.
         Keep in mind that it may be shared with the headphone jack.
      3. Run the test (you have 30 seconds from now on)
      4. Plug the microphone into the appropriate jack
      5. Unplug the device for subsequent tests.
- VERIFICATION:
+_verification:
      Verification is automatic, no action is required.
      The test times out after 30 seconds (and fails in that case).
+_summary: Ensure that the system can detect when a microphone is plugged in.
 
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
@@ -653,16 +662,16 @@ command:
     audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
   fi
   exit $EXIT_CODE
-_description:
- PURPOSE:
+_purpose:
      Check that balance control works correctly on internal speakers
- STEPS:
+_steps:
      1. Check that moving the balance slider from left to right works smoothly
      2. Commence the test to play an audio tone for 10 seconds.
      3. Move the balance slider from left to right and back.
      4. Check that actual speaker audio balance follows your setting.
- VERIFICATION:
-     Does the slider move smoothly, as well as being followed by the setting by the actual audio output?
+_verification:
+     Does the slider move smoothly, as well as being followed by the actual audio output?
+_summary: Test the balance control on internal speakers by playing an audio tone and adjusting the balance slider.
 
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
@@ -689,15 +698,16 @@ command:
   fi
   exit $EXIT_CODE
 _description:
- PURPOSE:
-     Check that balance control works correctly on external headphone
- STEPS:
-     1. Check that moving the balance slider from left to right works smoothly
+_purpose:
+     Check that balance control works correctly on external headphones
+_steps:
+     1. Check that moving the balance slider from left to right works smoothly.
      2. Commence the test to play an audio tone for 10 seconds.
      3. Move the balance slider from left to right and back.
-     4. Check that actual headphone audio balance follows your setting.
- VERIFICATION:
-     Does the slider move smoothly, as well as being followed by the setting by the actual audio output?
+     4. Check that actual headphone audio balance follows your settings.
+_verification:
+     Does the slider move smoothly, as well as being followed by the settings by the actual audio output?
+_summary: Test for checking balance control functioning on external headphones.
 
 plugin: shell
 category_id: com.canonical.plainbox::audio
@@ -708,7 +718,8 @@ requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
 command: cat /proc/asound/cards
-_description: Test to detect audio devices after suspending 30 times.
+_purpose: Test to detect audio devices after suspending 30 times.
+_summary: Test the detection of audio devices post 30 suspend cycles.
 
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
@@ -734,15 +745,16 @@ command:
   fi
   exit $EXIT_CODE
 _description:
- PURPOSE:
+_purpose:
      This test will check that internal speakers work correctly after suspending 30 times.
- STEPS:
+_steps:
      1. Make sure that no external speakers or headphones are connected
         When testing a desktop, you can skip this test if there is no
         internal speaker, we will test the external output later
      2. Commence the test to play a brief tone on your audio device
- VERIFICATION:
+_verification:
      Did you hear a tone?
+_summary: Verify internal speakers' functionality after 30 suspension cycles.
 
 plugin: shell
 category_id: com.canonical.plainbox::audio
@@ -764,9 +776,8 @@ command: audio_test.py
   else
     audio_test.py
   fi
-_description:
- Play back a sound on the default output and listen for it on the
- default input, after suspending 30 times.
+_purpose: Play back a sound on the default output and listen for it on the default input, after suspending 30 times.
+_summary: Test audio playback and recording post-system suspension.
 
 plugin: shell
 category_id: com.canonical.plainbox::audio
@@ -780,8 +791,8 @@ command:
   else
     pactl_list.sh sinks
   fi
-_description:
-  Test to detect if there's available sources and sinks after suspending 30 times.
+_purpose: Test to detect if there's available sources and sinks after suspending 30 times.
+_summary: Test detection of audio sources and sinks after 30 suspend cycles.
 
 plugin: shell
 category_id: com.canonical.plainbox::audio
@@ -792,13 +803,14 @@ requires:
  package.name == 'pulseaudio-utils'
  device.category == 'AUDIO'
 command: volume_test.py --minvol 1 --maxvol 100
-_description:
+_purpose:
  This test will verify that the volume levels are at an acceptable level on
- your local system.  The test will validate that the volume is greater than
+ your local system. The test will validate that the volume is greater than
  or equal to minvol and less than or equal to maxvol for all sources (inputs)
- and sinks (outputs) recognized by PulseAudio.  It will also validate that the
- active source and sink are not muted.  You should not manually adjust the
+ and sinks (outputs) recognized by PulseAudio. It will also validate that the
+ active source and sink are not muted. You should not manually adjust the
  volume or mute before running this test.
+_summary: Verify that volume levels are within acceptable limits after suspending for 30 cycles.
 
 plugin: shell
 category_id: com.canonical.plainbox::audio
@@ -808,10 +820,11 @@ depends: power-management/suspend_30_cycles
 requires:
  device.category == 'AUDIO'
  package.name == 'alsa-base'
-_description: Record mixer settings after suspending 30 times.
+_purpose: Record mixer settings after suspending 30 times.
 command:
   audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/audio_settings_after_suspend_30_cycles
   diff "$PLAINBOX_SESSION_SHARE"/audio_settings_before_suspend "$PLAINBOX_SESSION_SHARE"/audio_settings_after_suspend_30_cycles
+_summary: Record and compare audio mixer settings before and after suspending the device 30 times.
 
 id: audio/detect-playback-devices
 _summary: Check that at least one audio playback device exists
@@ -843,14 +856,14 @@ command:
   if [ "$COUNT" -eq 0 ]; then
     exit 1
   fi
-esimated_duration: 0.5
+estimated_duration: 0.5
 
 id: audio/alsa-playback
 _summary: Playback works
 _purpose:
  Check if sound is played through ALSA on the default output
 _steps:
- 1. Make sure speakers or headphones are connect to the device
+ 1. Make sure speakers or headphones are connected to the device
  2. Commence the test
 _verification:
  Did you hear the sound?
@@ -881,13 +894,13 @@ requires: manifest.has_audio_loopback_connector == 'True'
 id: audio/pa-record-internal-mic
 _summary: Record a wav file and check it using pulseaudio - internal mic
 _purpose:
- Check if audio input work fine through pulseaudio on internal mic
+ Check if audio input works fine through pulseaudio on the internal mic
 _steps:
- 1. Make sure no external mic is connected to the device
- 2. Make sure there's at least one output device connected to the device
+ 1. Make sure no external mic is connected to the device.
+ 2. Make sure there's at least one output device connected to the device.
  3. Workaround to run pulseaudio correctly:
     sudo mkdir -p /run/user/0/snap.pulseaudio/pulse
- 4. Find out corrent source, sink id:
+ 4. Find out correct source, sink id:
     sudo pulseaudio.pactl list
  5. Set input/output profile:
     sudo pulseaudio.pactl set-card-profile 0 output:analog-stereo+input:analog-stereo
@@ -898,9 +911,9 @@ _steps:
     sudo pulseaudio.pactl set-source-volume <Source id #, e.g. 0> 80%
  7. Record for 5 seconds to a wav file:
     sudo timeout 5 pulseaudio.parec -v /var/snap/pulseaudio/common/test.wav
- 8. Play the recorded file
+ 8. Play the recorded file:
     sudo pulseaudio.paplay -v /var/snap/pulseaudio/common/test.wav
- 9. Remove the recorded file
+ 9. Remove the recorded file:
     sudo rm /var/snap/pulseaudio/common/test.wav
 _verification:
  Did you hear the recorded sound correctly?
@@ -913,13 +926,13 @@ estimated_duration: 1m
 id: audio/pa-record-external-mic
 _summary: Record a wav file and check it using pulseaudio - external mic
 _purpose:
- Check if audio input work fine through pulseaudio on external mic
+ Check if audio input works fine through pulseaudio on an external mic
 _steps:
  1. Make sure an external mic is connected to the device
  2. Make sure there's at least one output device connected to the device
  3. Workaround to run pulseaudio correctly:
     sudo mkdir -p /run/user/0/snap.pulseaudio/pulse
- 4. Find out corrent source, sink id:
+ 4. Find out correct source and sink id:
     sudo pulseaudio.pactl list
  5. Set input/output profile:
     sudo pulseaudio.pactl set-card-profile 0 output:analog-stereo+input:analog-stereo
@@ -945,12 +958,12 @@ estimated_duration: 1m
 id: audio/pa-playback-headphone
 _summary: Play sample wav file using pulseaudio - headphone
 _purpose:
- Check if sound is played through pulseaudio to headphone
+ Check if sound is played through pulseaudio to headphones
 _steps:
- 1. Make sure a headphone is connected to the device
+ 1. Make sure headphones are connected to the device.
  2. Workaround to run pulseaudio correctly:
     sudo mkdir -p /run/user/0/snap.pulseaudio/pulse
- 3. Find out corrent source, sink id:
+ 3. Find out current source, sink id:
     sudo pulseaudio.pactl list
  4. Set input/output profile:
     sudo pulseaudio.pactl set-card-profile 0 output:analog-stereo+input:analog-stereo
@@ -958,9 +971,9 @@ _steps:
     sudo pulseaudio.pactl set-sink-mute <Sink id #, e.g. 0> 0
     sudo pulseaudio.pactl set-sink-volume <Sink id #, e.g. 0> 80%
  6. Put a test wav file in system as /var/snap/pulseaudio/common/test.wav
- 7. Play the test wav file
+ 7. Play the test wav file:
     sudo pulseaudio.paplay -v /var/snap/pulseaudio/common/test.wav
- 8. Remove the test file
+ 8. Remove the test file:
     sudo rm /var/snap/pulseaudio/common/test.wav
 _verification:
  Did you hear the sound correctly?
@@ -975,20 +988,20 @@ _summary: Play sample wav file using pulseaudio - lineout
 _purpose:
  Check if sound is played through pulseaudio to lineout
 _steps:
- 1. Make sure a output device is connected to the lineout port on device
+ 1. Make sure an output device is connected to the lineout port on the device.
  2. Workaround to run pulseaudio correctly:
     sudo mkdir -p /run/user/0/snap.pulseaudio/pulse
- 3. Find out corrent source, sink id:
+ 3. Find out current source, sink id:
     sudo pulseaudio.pactl list
  4. Set input/output profile:
     sudo pulseaudio.pactl set-card-profile 0 output:analog-stereo+input:analog-stereo
  5. Unmute and set volume of output:
-    sudo pulseaudio.pactl set-sink-mute <Sink id #, e.g. 0> 0
+    sudo pulseaudio.pactl set-sink-mute <Sink id #, e.g. 0> false
     sudo pulseaudio.pactl set-sink-volume <Sink id #, e.g. 0> 80%
- 6. Put a test wav file in system as /var/snap/pulseaudio/common/test.wav
- 7. Play the test wav file
+ 6. Place a test wav file in the system as /var/snap/pulseaudio/common/test.wav
+ 7. Play the test wav file:
     sudo pulseaudio.paplay -v /var/snap/pulseaudio/common/test.wav
- 8. Remove the test file
+ 8. Remove the test file:
     sudo rm /var/snap/pulseaudio/common/test.wav
 _verification:
  Did you hear the sound correctly?
@@ -1003,16 +1016,16 @@ _summary: Play sample wav file using pulseaudio - hdmi
 _purpose:
  Check if sound is played through pulseaudio to HDMI output device
 _steps:
- 1. Make sure a HDMI output device is connected to the device
+ 1. Make sure an HDMI output device is connected to the device.
  2. Workaround to run pulseaudio correctly:
     sudo mkdir -p /run/user/0/snap.pulseaudio/pulse
- 3. Find out corrent source, sink id:
+ 3. Find out current source, sink id:
     sudo pulseaudio.pactl list
  4. Set input/output profile:
     sudo pulseaudio.pactl set-card-profile 0 output:hdmi-stereo+input:analog-stereo
  5. Unmute and set volume of output:
-    sudo pulseaudio.pactl set-sink-mute <Sink id #, e.g. 0> 0
-    sudo pulseaudio.pactl set-sink-volume <Sink id #, e.g. 0> 80%
+    sudo pulseaudio.pactl set-sink-mute <Sink id #, e.g., 0> 0
+    sudo pulseaudio.pactl set-sink-volume <Sink id #, e.g., 0> 80%
  6. Put a test wav file in system as /var/snap/pulseaudio/common/test.wav
  7. Play the test wav file
     sudo pulseaudio.paplay -v /var/snap/pulseaudio/common/test.wav

--- a/providers/base/units/audio/manifest.pxu
+++ b/providers/base/units/audio/manifest.pxu
@@ -13,9 +13,12 @@ unit: manifest entry
 id: has_audio_capture
 _name: Audio capture
 value-type: bool
+_summary: Determine if audio capture is available.
 
 unit: manifest entry
 id: has_audio_loopback_connector
 _prompt: Does this device have the following?:
 _name: Audio Loopback Connector
 value-type: bool
+_summary: Check if the device has an Audio Loopback Connector.
+

--- a/providers/base/units/audio/test-plan.pxu
+++ b/providers/base/units/audio/test-plan.pxu
@@ -8,6 +8,7 @@ include:
 nested_part:
  com.canonical.certification::audio-cert-manual
  com.canonical.certification::audio-cert-automated
+_summary: Execute audio tests and see Monitor / Graphic test plans for hybrid-graphic monitor audio tests.
 
 id: audio-cert-manual
 unit: test plan


### PR DESCRIPTION
This is a set of changes that my new AI tool did on the pxu files located in the `providers/base/audio/` directory.

The system prompt I used was:
```
The task is to help improve test job definition records.
Each record is composed of fields. The name of the field starts in column 0,
and ends with a colon. Everything after the colon is the value. The value can span multiple lines. The continuation has to be indented,
otherwise the line would be treated as the next field.

First task is to reformat a given record by extracting
specific information from the '_description' field and placing it into new fields. 
Skip this task if there are not all three fields - "PURPOSE", "STEPS", or "VERIFICATION" - written in the "_description" field.
After extracting information for 'PURPOSE', 'STEPS', and 'VERIFICATION' headers, place the extracted text into new
fields named '_purpose', '_steps', and '_verification' respectively. The rest of the record should remain unchanged. Finally, rewrite the record with the new fields, maintaining the original syntax.
If the `_description` field looks like it only describes the purpose of the test, change it to `_purpose`.
Very important: preserve all the other fields!
Preserve the indentation of those three fields.
Do not add anything new to the record.

The second task is to find and fix typos and other language problems in fields that start with an underscore character `_`.

The third task is to add a `_summary` field, if it's missing. Use other fields to generate its contents.

Output the corrected record using the same syntax.
If nothing was changed, just output "===NO CHANGE===".

Example 2:

Input:

id: audio_test
_summary:
 Test the aydio subsystem
_description:
 PURPOSE:
  foo
 STEPS: 
  1. First step
  2. Second step
 VERIFICATION:
  bar

Output:

id: audio_test
_summary:
 Test the audio subsystem
_description:
_purpose
 foo
_steps: 
 1. First step
 2. Second step
_verification
 bar

Example 2:

Input:

id: bluetooth_test
_summary:
 Test bluetooth headphones
_purpose:
 Verify that we can connect bluetooth headphones to the host
_steps:
 1. Open bluetooth settings menu
 2. Turn on scan
 3. Follow the wizard
_verification:
 Can you hear the test sound in your headphones?

Output:

===NO CHANGE===

Example 3:

Input:

plugin: shell
category_id: com.canonical.plainbox::audio
id: audio/list_devices
estimated_duration: 1.0
requires:
 device.category == 'AUDIO'
 package.name == 'alsa-base'
command: cat /proc/asound/cards
_description: Test to detect audio devices

Output:

plugin: shell
category_id: com.canonical.plainbox::audio
id: audio/list_devices
estimated_duration: 1.0
requires:
 device.category == 'AUDIO'
 package.name == 'alsa-base'
command: cat /proc/asound/cards
_purpose: Test to detect audio devices
_summary: Check if audio devices can be detected.

The record to be improved starts at the next line:
```