### PR TITLE
Add fwupdmgr attachment job (New)

### DIFF
--- a/providers/base/bin/get_firmware_info_fwupd.py
+++ b/providers/base/bin/get_firmware_info_fwupd.py
@@ -18,44 +18,91 @@
 # along with Checkbox. If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import sys
 import json
 import shlex
+import logging
 import subprocess
 from checkbox_support.snap_utils.snapd import Snapd
 
 
-def get_firmware_info_fwupd():
+def get_fwupdmgr_services_versions():
+    """Show fwupd client and daemon versions
 
-    fwupd_snap = Snapd().list("fwupd")
-    if fwupd_snap:
+    Returns:
+        list: fwupd client and daemon versions
+    """
+    fwupd_vers = subprocess.run(
+        shlex.split("fwupdmgr --version --json"),
+        capture_output=True)
+    fwupd_vers = json.loads(fwupd_vers.stdout).get("Versions", [])
+
+    return fwupd_vers
+
+
+def get_fwupd_runtime_version():
+    """Get fwupd runtime version
+
+    Returns:
+        tuple: fwupd runtime version
+    """
+    runtime_ver = ()
+
+    for ver in get_fwupdmgr_services_versions():
+        if (ver.get("Type") == "runtime" and
+                ver.get("AppstreamId") == "org.freedesktop.fwupd"):
+            runtime_ver = tuple(map(int, ver.get("Version").split(".")))
+
+    return runtime_ver
+
+
+def get_firmware_info_fwupd():
+    """
+    Dump firmware information for all devices detected by fwupd
+    """
+    if Snapd().list("fwupd"):
         # Dump firmware info by fwupd snap
         subprocess.run(shlex.split("fwupd.fwupdmgr get-devices --json"))
     else:
         # Dump firmware info by fwupd debian package
-        fwupd_vers = subprocess.run(
-            shlex.split("fwupdmgr --version --json"),
-            capture_output=True)
-        fwupd_vers = json.loads(fwupd_vers.stdout)
-
-        runtime_ver = ()
-        for ver in fwupd_vers.get("Versions", []):
-            if (ver.get("Type") == "runtime" and
-                    ver.get("AppstreamId") == "org.freedesktop.fwupd"):
-                runtime_ver = tuple(map(int, ver.get("Version").split(".")))
+        runtime_ver = get_fwupd_runtime_version()
         # Apply workaround to unset the SNAP for the fwupd issue
         # See details from following PR
         # https://github.com/canonical/checkbox/pull/1089
 
         # SNAP environ is avaialble, so it's running on checkbox snap
         # Unset the environ variable if debian fwupd lower than 1.9.14
-        if os.environ["SNAP"] and runtime_ver < (1, 9, 14):
+        if os.environ.get("SNAP") and runtime_ver < (1, 9, 14):
             del os.environ["SNAP"]
 
         subprocess.run(shlex.split("fwupdmgr get-devices --json"))
 
 
 if __name__ == "__main__":
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    logger_format = "%(asctime)s %(levelname)-8s %(message)s"
+    date_format = "%Y-%m-%d %H:%M:%S"
+
+    # Log DEBUG and INFO to stdout, others to stderr
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stdout_handler.setLevel(logging.DEBUG)
+    stderr_handler.setLevel(logging.WARNING)
+
+    # Add a filter to the stdout handler to limit log records to
+    # INFO level and below
+    stdout_handler.addFilter(lambda record: record.levelno <= logging.INFO)
+
+    root_logger.addHandler(stderr_handler)
+    root_logger.addHandler(stdout_handler)
+
     try:
         get_firmware_info_fwupd()
     except Exception as err:
-        print(err)
+        logging.error(err)

--- a/providers/base/bin/get_firmware_info_fwupd.py
+++ b/providers/base/bin/get_firmware_info_fwupd.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Stanley Huang <stanley.huang@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox. If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import json
+import shlex
+import subprocess
+from checkbox_support.snap_utils.snapd import Snapd
+
+
+def get_firmware_info_fwupd():
+
+    fwupd_snap = Snapd().list("fwupd")
+    if fwupd_snap:
+        # Dump firmware info by fwupd snap
+        subprocess.run(shlex.split("fwupd.fwupdmgr get-devices --json"))
+    else:
+        # Dump firmware info by fwupd debian package
+        fwupd_vers = subprocess.run(
+            shlex.split("fwupdmgr --version --json"),
+            capture_output=True)
+        fwupd_vers = json.loads(fwupd_vers.stdout)
+
+        runtime_ver = ()
+        for ver in fwupd_vers.get("Versions", []):
+            if (ver.get("Type") == "runtime" and
+                    ver.get("AppstreamId") == "org.freedesktop.fwupd"):
+                runtime_ver = tuple(map(int, ver.get("Version").split(".")))
+        # Apply workaround to unset the SNAP for the fwupd issue
+        # See details from following PR
+        # https://github.com/canonical/checkbox/pull/1089
+
+        # SNAP environ is avaialble, so it's running on checkbox snap
+        # Unset the environ variable if debian fwupd lower than 1.9.14
+        if os.environ["SNAP"] and runtime_ver < (1, 9, 14):
+            del os.environ["SNAP"]
+
+        subprocess.run(shlex.split("fwupdmgr get-devices --json"))
+
+
+if __name__ == "__main__":
+    try:
+        get_firmware_info_fwupd()
+    except Exception as err:
+        print(err)

--- a/providers/base/tests/test_get_firmware_info_fwupd.py
+++ b/providers/base/tests/test_get_firmware_info_fwupd.py
@@ -1,65 +1,178 @@
 import os
+import json
 import unittest
+import subprocess
 from unittest.mock import patch
-from get_firmware_info_fwupd import get_firmware_info_fwupd
+import get_firmware_info_fwupd
 
 
 class TestGetFirmwareInfo(unittest.TestCase):
+
+    @patch("json.loads")
+    @patch("subprocess.run")
+    def test_get_deb_fwupd_version_success(self, mock_subporcess, mock_json):
+
+        dict_resp = {
+            "Versions": [
+                {
+                    "Type": "runtime",
+                    "AppstreamId": "org.freedesktop.fwupd",
+                    "Version": "1.9.14"
+                },
+                {
+                    "Type": "compile",
+                    "AppstreamId": "org.freedesktop.fwupd",
+                    "Version": "1.7.9"
+                }
+            ]
+        }
+        json_resp = json.dumps(dict_resp)
+        mock_subporcess.return_value = subprocess.CompletedProcess(
+                returncode=0,
+                stdout=json_resp,
+                args=["fwupdmgr", "--version", "--json"]
+            )
+        mock_json.return_value = dict_resp
+
+        fwupd_vers = get_firmware_info_fwupd.get_fwupdmgr_services_versions()
+        mock_subporcess.assert_called_with(
+            ['fwupdmgr', '--version', '--json'],
+            capture_output=True)
+        mock_json.assert_called_with(json_resp)
+        self.assertListEqual(dict_resp["Versions"], fwupd_vers)
+
+    @patch("json.loads")
+    @patch("subprocess.run")
+    def test_get_deb_fwupd_version_key_not_match(
+                    self, mock_subporcess, mock_json):
+
+        dict_resp = {
+            "Services": [
+                {
+                    "Type": "runtime",
+                    "AppstreamId": "org.freedesktop.fwupd",
+                    "Version": "1.9.14"
+                },
+                {
+                    "Type": "compile",
+                    "AppstreamId": "org.freedesktop.fwupd",
+                    "Version": "1.7.9"
+                }
+            ]
+        }
+        json_resp = json.dumps(dict_resp)
+        mock_subporcess.return_value = subprocess.CompletedProcess(
+                returncode=0,
+                stdout=json_resp,
+                args=["fwupdmgr", "--version", "--json"]
+            )
+        mock_json.return_value = dict_resp
+
+        fwupd_vers = get_firmware_info_fwupd.get_fwupdmgr_services_versions()
+        mock_subporcess.assert_called_with(
+            ['fwupdmgr', '--version', '--json'], capture_output=True)
+        mock_json.assert_called_with(json_resp)
+        self.assertListEqual([], fwupd_vers)
+
+    @patch("get_firmware_info_fwupd.get_fwupdmgr_services_versions")
+    def test_get_deb_fwupd_runtime_version_success(self, mock_fwupd_vers):
+
+        expected_fwupd_ver = (1, 7, 9)
+        fwupd_vers_resp = [
+            {
+                "Type": "runtime",
+                "AppstreamId": "org.freedesktop.fwupd",
+                "Version": "1.7.9"
+            },
+            {
+                "Type": "compile",
+                "AppstreamId": "org.freedesktop.fwupd",
+                "Version": "1.7.9"
+            }
+        ]
+
+        mock_fwupd_vers.return_value = fwupd_vers_resp
+        runtime_ver = get_firmware_info_fwupd.get_fwupd_runtime_version()
+        self.assertEqual(expected_fwupd_ver, runtime_ver)
+
+    @patch("get_firmware_info_fwupd.get_fwupdmgr_services_versions")
+    def test_get_deb_fwupd_runtime_version_failed(self, mock_fwupd_vers):
+
+        fwupd_vers_resp = [
+            {
+                "Type": "compile",
+                "AppstreamId": "org.freedesktop.fwupd",
+                "Version": "1.7.9"
+            }
+        ]
+
+        mock_fwupd_vers.return_value = fwupd_vers_resp
+        runtime_ver = get_firmware_info_fwupd.get_fwupd_runtime_version()
+        self.assertEqual((), runtime_ver)
 
     @patch("subprocess.run")
     @patch("checkbox_support.snap_utils.snapd.Snapd.list")
     def test_get_firmware_data_by_fwupd_snap(
             self, mock_snapd, mock_subporcess):
 
-        mock_snapd.return_value = True
-        get_firmware_info_fwupd()
+        mock_snapd.return_value = {
+            "id": "HpOj37PuyuaMUZY0NQhtwnp7oS5P8u5R",
+            "title": "fwupd",
+            "summary": "Firmware updates for Linux"
+        }
+        get_firmware_info_fwupd.get_firmware_info_fwupd()
         mock_snapd.assert_called_with("fwupd")
         mock_subporcess.assert_called_with(
             ['fwupd.fwupdmgr', 'get-devices', '--json'])
 
     @patch.dict(os.environ, {"SNAP": "checkbox-snap"})
-    @patch("json.loads")
     @patch("subprocess.run")
+    @patch("get_firmware_info_fwupd.get_fwupd_runtime_version")
     @patch("checkbox_support.snap_utils.snapd.Snapd.list")
     def test_get_firmware_data_by_fwupd1914_deb_on_checkbox_snap(
-            self, mock_snapd, mock_subporcess, mock_json):
+            self, mock_snapd, mock_fwupd_ver, mock_subporcess):
 
-        mock_snapd.return_value = False
-        mock_json.return_value = {
-            "Versions": [
-                {
-                    "Type": "runtime",
-                    "AppstreamId": "org.freedesktop.fwupd",
-                    "Version": "1.9.14"
-                }
-            ]
-        }
-        get_firmware_info_fwupd()
+        mock_snapd.return_value = None
+        mock_fwupd_ver.return_value = (1, 9, 14)
+
+        get_firmware_info_fwupd.get_firmware_info_fwupd()
         mock_snapd.assert_called_with("fwupd")
-        mock_subporcess.assert_called_with(
-            ['fwupdmgr', 'get-devices', '--json'])
         self.assertEqual(
             os.environ.get("SNAP"), "checkbox-snap")
+        mock_subporcess.assert_called_with(
+            ['fwupdmgr', 'get-devices', '--json'])
 
     @patch.dict(os.environ, {"SNAP": "checkbox-snap"})
-    @patch("json.loads")
     @patch("subprocess.run")
+    @patch("get_firmware_info_fwupd.get_fwupd_runtime_version")
     @patch("checkbox_support.snap_utils.snapd.Snapd.list")
-    def test_get_firmware_data_by_fwupd_deb_on_checkbox_snap(
-            self, mock_snapd, mock_subporcess, mock_json):
+    def test_get_firmware_data_by_fwupd_deb179_on_checkbox_snap(
+            self, mock_snapd, mock_fwupd_ver, mock_subporcess):
 
         mock_snapd.return_value = False
-        mock_json.return_value = {
-            "Versions": [
-                {
-                    "Type": "runtime",
-                    "AppstreamId": "org.freedesktop.fwupd",
-                    "Version": "1.7.9"
-                }
-            ]
-        }
-        get_firmware_info_fwupd()
+        mock_fwupd_ver.return_value = (1, 7, 9)
+
+        # SNAP env is available before get_firmware_info_fwupd been called
+        self.assertEqual(os.environ.get("SNAP"), "checkbox-snap")
+        get_firmware_info_fwupd.get_firmware_info_fwupd()
+        mock_snapd.assert_called_with("fwupd")
+        # SNAP env is empty after get_firmware_info_fwupd been called
+        self.assertIsNone(os.environ.get("SNAP"))
+        mock_subporcess.assert_called_with(
+            ['fwupdmgr', 'get-devices', '--json'])
+
+    @patch("subprocess.run")
+    @patch("get_firmware_info_fwupd.get_fwupd_runtime_version")
+    @patch("checkbox_support.snap_utils.snapd.Snapd.list")
+    def test_get_firmware_data_by_fwupd_deb_on_checkbox_deb(
+            self, mock_snapd, mock_fwupd_ver, mock_subporcess):
+
+        mock_snapd.return_value = False
+        mock_fwupd_ver.return_value = (1, 7, 9)
+
+        # SNAP env is empty
+        self.assertIsNone(os.environ.get("SNAP"))
+        get_firmware_info_fwupd.get_firmware_info_fwupd()
         mock_snapd.assert_called_with("fwupd")
         mock_subporcess.assert_called_with(
             ['fwupdmgr', 'get-devices', '--json'])
-        self.assertIsNone(os.environ.get("SNAP"))

--- a/providers/base/tests/test_get_firmware_info_fwupd.py
+++ b/providers/base/tests/test_get_firmware_info_fwupd.py
@@ -1,0 +1,65 @@
+import os
+import unittest
+from unittest.mock import patch
+from get_firmware_info_fwupd import get_firmware_info_fwupd
+
+
+class TestGetFirmwareInfo(unittest.TestCase):
+
+    @patch("subprocess.run")
+    @patch("checkbox_support.snap_utils.snapd.Snapd.list")
+    def test_get_firmware_data_by_fwupd_snap(
+            self, mock_snapd, mock_subporcess):
+
+        mock_snapd.return_value = True
+        get_firmware_info_fwupd()
+        mock_snapd.assert_called_with("fwupd")
+        mock_subporcess.assert_called_with(
+            ['fwupd.fwupdmgr', 'get-devices', '--json'])
+
+    @patch.dict(os.environ, {"SNAP": "checkbox-snap"})
+    @patch("json.loads")
+    @patch("subprocess.run")
+    @patch("checkbox_support.snap_utils.snapd.Snapd.list")
+    def test_get_firmware_data_by_fwupd1914_deb_on_checkbox_snap(
+            self, mock_snapd, mock_subporcess, mock_json):
+
+        mock_snapd.return_value = False
+        mock_json.return_value = {
+            "Versions": [
+                {
+                    "Type": "runtime",
+                    "AppstreamId": "org.freedesktop.fwupd",
+                    "Version": "1.9.14"
+                }
+            ]
+        }
+        get_firmware_info_fwupd()
+        mock_snapd.assert_called_with("fwupd")
+        mock_subporcess.assert_called_with(
+            ['fwupdmgr', 'get-devices', '--json'])
+        self.assertEqual(
+            os.environ.get("SNAP"), "checkbox-snap")
+
+    @patch.dict(os.environ, {"SNAP": "checkbox-snap"})
+    @patch("json.loads")
+    @patch("subprocess.run")
+    @patch("checkbox_support.snap_utils.snapd.Snapd.list")
+    def test_get_firmware_data_by_fwupd_deb_on_checkbox_snap(
+            self, mock_snapd, mock_subporcess, mock_json):
+
+        mock_snapd.return_value = False
+        mock_json.return_value = {
+            "Versions": [
+                {
+                    "Type": "runtime",
+                    "AppstreamId": "org.freedesktop.fwupd",
+                    "Version": "1.7.9"
+                }
+            ]
+        }
+        get_firmware_info_fwupd()
+        mock_snapd.assert_called_with("fwupd")
+        mock_subporcess.assert_called_with(
+            ['fwupdmgr', 'get-devices', '--json'])
+        self.assertIsNone(os.environ.get("SNAP"))

--- a/providers/base/units/firmware/jobs.pxu
+++ b/providers/base/units/firmware/jobs.pxu
@@ -112,7 +112,6 @@ category_id: com.canonical.plainbox::firmware
 _summary: Collect the device firmware update information
 _purpose: Attach information about the devices, as reported by the fwupdmgr
 requires:
-    executable.name == "fwupdmgr"
+    executable.name in ("fwupdmgr", "fwupd.fwupdmgr")
 command:
-    unset SNAP
-    fwupdmgr get-devices --json
+    get_firmware_info_fwupd.py

--- a/providers/base/units/firmware/jobs.pxu
+++ b/providers/base/units/firmware/jobs.pxu
@@ -105,3 +105,13 @@ plugin: attachment
 depends: firmware/fwts_dump
 command:
   [ -f "$PLAINBOX_SESSION_SHARE/acpidump.log" ] && gzip -c "$PLAINBOX_SESSION_SHARE/acpidump.log"
+
+id: firmware/fwupdmgr_get_devices
+plugin: attachment
+category_id: com.canonical.plainbox::firmware
+_summary: Collect the device firmware update information
+requires:
+    executable.name == "fwupdmgr"
+    environment.SNAP == ""  # only execute on debian checkbox
+command:
+    fwupdmgr get-devices --json

--- a/providers/base/units/firmware/jobs.pxu
+++ b/providers/base/units/firmware/jobs.pxu
@@ -110,6 +110,7 @@ id: firmware/fwupdmgr_get_devices
 plugin: attachment
 category_id: com.canonical.plainbox::firmware
 _summary: Collect the device firmware update information
+_purpose: Attach information about the devices, as reported by the fwupdmgr
 requires:
     executable.name == "fwupdmgr"
 command:

--- a/providers/base/units/firmware/jobs.pxu
+++ b/providers/base/units/firmware/jobs.pxu
@@ -112,6 +112,8 @@ category_id: com.canonical.plainbox::firmware
 _summary: Collect the device firmware update information
 requires:
     executable.name == "fwupdmgr"
-    environment.SNAP == ""  # only execute on debian checkbox
 command:
+    snap_var="$SNAP"
+    unset SNAP
     fwupdmgr get-devices --json
+    export SNAP="$snap_var"

--- a/providers/base/units/firmware/jobs.pxu
+++ b/providers/base/units/firmware/jobs.pxu
@@ -114,7 +114,5 @@ _purpose: Attach information about the devices, as reported by the fwupdmgr
 requires:
     executable.name == "fwupdmgr"
 command:
-    snap_var="$SNAP"
     unset SNAP
     fwupdmgr get-devices --json
-    export SNAP="$snap_var"

--- a/providers/base/units/firmware/test-plan.pxu
+++ b/providers/base/units/firmware/test-plan.pxu
@@ -36,3 +36,28 @@ include:
     firmware/fwts_desktop_diagnosis
     firmware/fwts_desktop_diagnosis_results.log.gz
 
+
+id: firmware-fwupdmgr-full
+unit: test plan
+_name: fwupdmgr test
+_description: Firmware update manager tests
+include:
+nested_part:
+    firmware-fwupdmgr-automated
+    firmware-fwupdmgr-manual
+
+id: firmware-fwupdmgr-automated
+unit: test plan
+_name: Auto fwupdmgr tests
+_description: Automated firmware update manager tests
+bootstrap_include:
+    executable
+    environment
+include:
+    firmware/fwupdmgr_get_devices
+
+id: firmware-fwupdmgr-manual
+unit: test plan
+_name: Manual fwupdmgr tests
+_description: Manual firmware update manager tests
+include:

--- a/providers/certification-client/units/client-cert-desktop-18-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-18-04.pxu
@@ -99,6 +99,7 @@ nested_part:
     disk-cert-automated
     misc-client-cert-automated
     fingerprint-automated
+    firmware-fwupdmgr-automated
     keys-cert-automated
     led-cert-automated
     mediacard-cert-automated

--- a/providers/certification-client/units/client-cert-desktop-20-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-20-04.pxu
@@ -102,6 +102,7 @@ nested_part:
     disk-cert-automated
     misc-client-cert-automated
     fingerprint-automated
+    firmware-fwupdmgr-automated
     keys-cert-automated
     led-cert-automated
     mediacard-cert-automated

--- a/providers/certification-client/units/client-cert-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-22-04.pxu
@@ -106,6 +106,7 @@ nested_part:
     disk-cert-automated
     misc-client-cert-automated
     fingerprint-automated
+    firmware-fwupdmgr-automated
     keys-cert-automated
     led-cert-automated
     mediacard-cert-automated

--- a/providers/certification-client/units/client-cert-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-24-04.pxu
@@ -106,6 +106,7 @@ nested_part:
     disk-cert-automated
     misc-client-cert-automated
     fingerprint-automated
+    firmware-fwupdmgr-automated
     keys-cert-automated
     led-cert-automated
     mediacard-cert-automated


### PR DESCRIPTION
## Description
This is a follow up PR for the [PR965](https://github.com/canonical/checkbox/pull/965), I have applied the workaround (provided by Pierre). And I have verified the tests on EGW 3200.
https://certification.canonical.com/hardware/202312-33237/submission/360846/

This attachment job is requested from the OEM SWE team. They'd like to parse the `fwupdmgr` device information from the submission.
This PR added a `firmware/fwupdmgr_get_devices` attachment job and the related test plan to be nested in the client-cert-desktop test plan.

The `firmware/fwupdmgr_get_devices` only does the following command:
```
fwupdmgr get-devices --json
```

#### Requires
```
requires:
    executable.name == "fwupdmgr"
    environment.SNAP == ""  # only execute on Debian checkbox
```
The tests will only be executed when `fwupdmgr` executable is available.
Also, we found a limitation:

Our purpose is to run the `fwupdmgr` command from the default deb package to get the needed information. However, while Checkbox is running in the snap environment, the `fwupdmgr` will try to find the snap services `snap.fwupd.fwupd.service`, which leads to the following daemon and client mismatch error,
```
root@u-Inspiron-15-5508:/home/u# fwupdmgr get-devices
Mismatched daemon and client, use fwupd.fwupdmgr instead
```
This environment check is written in https://github.com/fwupd/fwupd/blob/main/src/fu-util-common.c#L42

``` C
#define SYSTEMD_FWUPD_UNIT	"fwupd.service"
#define SYSTEMD_SNAP_FWUPD_UNIT "snap.fwupd.fwupd.service"

fu_util_get_systemd_unit(void)
{
	if (g_getenv("SNAP") != NULL)
		return SYSTEMD_SNAP_FWUPD_UNIT;
	return SYSTEMD_FWUPD_UNIT;
}
```
Using the Debian version checkbox will not encounter this problem. Currently, I don’t have any good idea to solve this problem. So I intend to add a job for Debian Checkbox for now. And the `environment.SNAP == ""` is to ensure the job will only be executed with Debian Checkbox.

## Resolved issues
Request from SWE team
https://warthogs.atlassian.net/browse/OEMQA-3797

## Tests
Sideload result on an Ubuntu Desktop 22.04 laptop with Debian Checkbox
https://pastebin.canonical.com/p/4Jf5gXDKYV/
Sideload result on an Ubuntu Desktop 22.04 laptop with Snap Checkbox -> job skipped
https://pastebin.canonical.com/p/8wnCchBnWv/
