### PR TITLE
[checkbox-ce-oem] Fix serial tests (Bugfix)

### DIFF
--- a/contrib/checkbox-provider-ce-oem/units/serial/jobs.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/serial/jobs.pxu
@@ -25,8 +25,8 @@ template-id: ce-oem-serial/serial-console-tests
 id: ce-oem-serial/serial-console-{{ type }}-{{ node }}-{{ baudrate }}
 imports: from com.canonical.plainbox import manifest
 requires: 
-    manifest.has_serial_console_loopback == True
-template-summary: To check if the serial ports can work as a console
+    manifest.has_serial_console_loopback == 'True'
+_template-summary: To check if the serial ports can work as a console
 _summary: To check if the serial port {{ type }} ({{ node }}) can work as a console
 _purpose: 
     To check the serial port {{ type }} ({{ node }}) can work as a console.
@@ -68,9 +68,9 @@ template-id: ce-oem-serial/serial-transmit-data-tests
 id: ce-oem-serial/serial-transmit-data-{{ type }}-{{ node }}-{{ baudrate }}
 imports: from com.canonical.plainbox import manifest
 requires: 
-    manifest.has_serial_ehco_server == True
-template-summary:
-    Transmit data via {{ type }} ({{ node }}) with baudate {{ baudrate }}
+    manifest.has_serial_ehco_server == 'True'
+_template-summary:
+    Transmit data via serial ports
 _purpose: 
     To check the serial port {{ type }} ({{ node }}) can transmit
     data with baudate {{ baudrate }}

--- a/contrib/checkbox-provider-ce-oem/units/serial/manifest.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/serial/manifest.pxu
@@ -1,6 +1,6 @@
 unit: manifest entry
 id: has_serial_ehco_server
-_name: Has the serial ports connetec to the serial echo server?
+_name: Has the serial ports connect to the serial echo server?
 value-type: bool
 
 unit: manifest entry


### PR DESCRIPTION
## Description
1. Fix the field `requires`: True -> 'True'
2. Fix undecodable byte from `os.urand`: Use ASCII letters, numbers, punctuation instead
3. Correct `_template-summary` by not using jinja variable
4. Increase the testing byte from 128 to 1024
5. Also increase the timeout value from 1 to 3

## Resolved issues
N/A

## Documentation
N/A

## Tests
submission: https://certification.canonical.com/hardware/202401-33430/submission/361465/

@rickwu666666 I also observed that your machine can not receive message with /dev/ttyMAX1 with baudrate 115200
