### PR TITLE
Updated the summary of DI/O tests and ce oem test plan (BugFix)

### DIFF
--- a/contrib/checkbox-provider-ce-oem/units/digital-io/jobs.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/digital-io/jobs.pxu
@@ -21,6 +21,7 @@ command:
 unit: template
 template-resource: ce-oem-digital-io/loopback_mapping_gpio
 template-unit: job
+template-summary: Loopback tests for the DO{DO}-DI{DI} pin control by GPIO
 id: ce-oem-digital-io/loopback_gpio_DO{DO}-DI{DI}
 _summary: To test loopback between DO{DO} and DI{DI}
 plugin: shell
@@ -60,6 +61,7 @@ command:
 unit: template
 template-resource: ce-oem-digital-io/loopback_mapping_serial
 template-unit: job
+template-summary: Loopback tests for the DO{DO}-DI{DI} pin control by serial console
 id: ce-oem-digital-io/loopback_serial_DO{DO}-DI{DI}
 _summary: To test loopback between DO{DO} and DI{DI}
 _description:

--- a/contrib/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
+++ b/contrib/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
@@ -44,6 +44,7 @@ nested_part:
     ce-oem-socketcan-manual
     com.canonical.certification::led-indicator-manual
     ce-oem-iio-sensors-manual
+    ce-oem-digital-io-manual
 
 id: ce-oem-automated
 unit: test plan
@@ -76,6 +77,7 @@ nested_part:
     ce-oem-ethernet-tcp-automated
     com.canonical.certification::eeprom-automated
     before-suspend-ce-oem-iio-sensors-automated
+    ce-oem-digital-io-automated
     com.canonical.certification::rtc-automated
 
 id: after-suspend-ce-oem-manual
@@ -105,6 +107,7 @@ nested_part:
     after-suspend-ce-oem-socketcan-manual
     com.canonical.certification::after-suspend-led-indicator-manual
     after-suspend-ce-oem-iio-sensors-manual
+    after-suspend-ce-oem-digital-io-manual
 
 id: after-suspend-ce-oem-automated
 unit: test plan
@@ -136,6 +139,7 @@ nested_part:
     com.canonical.certification::after-suspend-eeprom-automated
     com.canonical.certification::after-suspend-rtc-automated
     after-suspend-ce-oem-iio-sensors-automated
+    after-suspend-ce-oem-digital-io-automated
 
 id: ce-oem-stress
 unit: test plan


### PR DESCRIPTION
Updated the summary of DI/O tests and ce oem test plan (BugFix)

## Description
Added the template-summary field for the Digital I/O tests and added the digital I/O test plan as nested part of ce-oem test plan.

## Resolved issues
N/A

## Documentation
N/A

## Tests
```
stanley@stanley-ThinkPad-T490:~/Desktop/Git_Repos/checkbox-2023/contrib/checkbox-provider-ce-oem$ python3.9 manage.py validate | grep digital
WARNING plainbox.secure.providers.v1: Skipped file: /home/stanley/Desktop/Git_Repos/checkbox-2023/contrib/checkbox-provider-ce-oem/bin/__pycache__/iio_sensor_test.cpython-311.pyc
WARNING plainbox.secure.providers.v1: Skipped file: /home/stanley/Desktop/Git_Repos/checkbox-2023/contrib/checkbox-provider-ce-oem/bin/__pycache__/iio_sensor_test.cpython-39.pyc
WARNING plainbox.secure.providers.v1: Skipped file: /usr/share/checkbox-provider-base/units/camera/README.rst
WARNING plainbox.secure.providers.v1: Skipped file: /usr/share/checkbox-provider-base/units/snapd/README.md
WARNING plainbox.secure.providers.v1: Skipped file: /usr/share/checkbox-provider-base/units/stress/suspend_cycles_reboot.md
WARNING plainbox.secure.providers.v1: Skipped file: /usr/share/checkbox-provider-base/units/camera/README.rst
WARNING plainbox.secure.providers.v1: Skipped file: /usr/share/checkbox-provider-base/units/snapd/README.md
WARNING plainbox.secure.providers.v1: Skipped file: /usr/share/checkbox-provider-base/units/stress/suspend_cycles_reboot.md
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-audio-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-audio-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-button-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-button-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-button-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-button-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-buzzer-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-buzzer-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-buzzer-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-buzzer-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-cpu-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-cpu-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-cpu-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-cpu-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-accelerator-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-accelerator-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-accelerator-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-accelerator-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-crypto-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-crypto-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-crypto-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-crypto-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-dtb-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-dtb-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-dtb-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-dtb-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-digital-io-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-digital-io-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-digital-io-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-digital-io-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-eeprom-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-eeprom-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-eeprom-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-eeprom-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-ethernet-tcp-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-ethernet-tcp-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-iio-sensors-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-iio-sensors-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-installation-info-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-installation-info-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-led-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-led-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-led-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-led-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-gps-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-gps-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-gps-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-gps-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-mir-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-mir-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-mir-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-mir-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-mtd-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-mtd-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-mtd-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-mtd-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-optee-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-optee-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-otg-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-otg-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-ptp-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-ptp-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-ptp-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-ptp-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-rpmsg-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-rpmsg-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-rtc-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-rtc-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-rtc-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-rtc-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-serial-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-socketcan-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-socketcan-stress-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-socketcan-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-socketcan-stress-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-iot-server-22-04-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-iot-server-22-04-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-iot-server-20-04-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-iot-server-20-04-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::docker-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::docker-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-stress
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-stress
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-iot-ubuntucore-22-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-iot-ubuntucore-22-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-iot-ubuntucore-20-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-iot-ubuntucore-20-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-stress
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-stress
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-installation-info-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-cpu-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-button-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-thermal-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-gps-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-mtd-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-buzzer-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-audio-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-otg-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-rtc-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-eeprom-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-led-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-caam-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-crypto-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-touchscreen-evdev
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-socketcan-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-iio-sensors-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-digital-io-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-installation-info-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-dtb-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-cpu-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-button-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-ptp-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-thermal-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-gps-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-mtd-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-buzzer-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-audio-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-otg-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-rtc-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::before-suspend-ce-oem-serial-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-eeprom-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-led-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-accelerator-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-crypto-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-optee-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-socketcan-stress-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-ethernet-tcp-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::before-suspend-ce-oem-iio-sensors-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-digital-io-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-cpu-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-button-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-thermal-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-gps-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-mtd-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-buzzer-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-audio-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-otg-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-rtc-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-eeprom-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-led-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-caam-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-crypto-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-touchscreen-evdev
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-socketcan-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-iio-sensors-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-digital-io-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-cpu-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-button-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-ptp-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-thermal-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-gps-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-mtd-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-buzzer-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-audio-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-otg-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-rtc-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-serial-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-eeprom-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-led-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-accelerator-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-crypto-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-optee-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-socketcan-stress-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-ethernet-tcp-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-iio-sensors-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-digital-io-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-cold-boot-stress-test-by-pdu
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-ethernet-tcp-stress
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::test-strict-confinement-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::test-strict-confinement-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::dbus-warm-boot
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::dbus-cold-boot
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-thermal-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-thermal-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-thermal-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-thermal-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-vpu-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-vpu-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-vpu-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-vpu-automated
warning: units/digital-io/jobs.pxu:24: template 'ce-oem-digital-io/loopback_gpio_DODO-DIDI', field 'template-summary', field should be marked as translatable
warning: units/digital-io/jobs.pxu:64: template 'ce-oem-digital-io/loopback_serial_DODO-DIDI', field 'template-summary', field should be marked as translatable
```

