### PR TITLE
Replacing value of `name` to `direction` in logic to make this validation more robust (BugFix)

### DIFF
--- a/providers/base/bin/pipewire_utils.py
+++ b/providers/base/bin/pipewire_utils.py
@@ -248,7 +248,7 @@ class PipewireTest:
                     for route in client["info"]["params"]["Route"]:
                         name = route["name"]
                         available = route["available"]
-                        if (device in name
+                        if (device.lower() in name.lower()
                                 and "output" in route["direction"].lower()
                                 and available in ["unknown", "yes"]):
                             self.logger.info(

--- a/providers/base/bin/pipewire_utils.py
+++ b/providers/base/bin/pipewire_utils.py
@@ -249,7 +249,7 @@ class PipewireTest:
                         name = route["name"]
                         available = route["available"]
                         if (device in name
-                                and "output" in name
+                                and "output" in route["direction"].lower()
                                 and available in ["unknown", "yes"]):
                             self.logger.info(
                                     "[ Audio sink ]".center(80, '='))
@@ -258,7 +258,7 @@ class PipewireTest:
                                     .format(route["description"],
                                             available))
                             return True
-            raise ValueError('No abailable output device for {}'
+            raise ValueError('No available output device for {}'
                              .format(device))
         except (IndexError, ValueError) as e:
             logging.error(repr(e))

--- a/providers/base/tests/test_pipewire_utils.py
+++ b/providers/base/tests/test_pipewire_utils.py
@@ -23,7 +23,7 @@ import sys
 from unittest.mock import MagicMock
 sys.modules["gi"] = MagicMock()
 sys.modules["gi.repository"] = MagicMock()
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 from pipewire_utils import *
 
 
@@ -372,7 +372,8 @@ class GstPipeLineTests(unittest.TestCase):
                      "Route": [{
                          "name": "hdmi_demo_output",
                          "available": "yes",
-                         "description": "hdmi demo output"
+                         "description": "hdmi demo output",
+                         "direction": "Output"
                      }]
                  }
                }
@@ -385,6 +386,7 @@ class GstPipeLineTests(unittest.TestCase):
         mock_checkout.return_value = self.device
         self.assertEqual(PipewireTestError.NO_SPECIFIC_DEVICE,
                          pt.gst_pipeline("pipe", 10, "qoo"))
+
     @patch("time.sleep")
     @patch("subprocess.check_output")
     def test_gst_pipeline(self, mock_checkout, _):
@@ -587,6 +589,7 @@ class ShowDefaultDeviceTests(unittest.TestCase):
                                        "@DEFAULT_AUDIO_SINK@"],
                                       universal_newlines=True)
 
+
 class ArgsParsingTests(unittest.TestCase):
     def test_success(self):
         pt = PipewireTest()
@@ -675,7 +678,7 @@ class FunctionSelectTests(unittest.TestCase):
         self.assertEqual(rv, 55)
 
     @patch("pipewire_utils.PipewireTest.show_default_device", return_value=44)
-    def test_through(self, mock_monitor):
+    def test_show_default_device(self, mock_monitor):
         pt = PipewireTest()
         args = ["show", "-t", "AUDIO"]
         rv = pt.function_select(pt._args_parsing(args))


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->
While testing the Noble on pilot devices, we found that the naming in the pw-dump is different between different devices, therefore replacing the value of `name` to `direction` in logic could be more robust in the future.

```json
{
            "index": 5,
            "direction": "Output",
            "name": "hdmi-output-0",
            "description": "HDMI / DisplayPort",
            "priority": 5900,
            "available": "yes",
            "info": [
              7,
              "port.type",
              "hdmi",
              "port.availability-group",
              "Legacy 4",
              "device.icon_name",
              "video-display",
              "card.profile.port",
              "5",
              "device.product.name",
              "HP 24fw",
              "route.hw-mute",
              "false",
              "route.hw-volume",
              "false"
            ],
            "profiles": [ 4, 3, 13, 11, 14, 12 ],
            "device": 8,
            "props": {
              "mute": false,
              "channelVolumes": [ 0.940169, 0.940169 ],
              "volumeBase": 1.000000,
              "volumeStep": 0.000015,
              "channelMap": [ "FL", "FR" ],
              "softVolumes": [ 0.940169, 0.940169 ],
              "latencyOffsetNsec": 0,
              "iec958Codecs": [ ]
            },
            "devices": [ 8, 9, 10 ],
            "profile": 3,
            "save": true
          }
```

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
Fix the wrong logic assuming the direction included in the name

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Test by this command:
if one hdmi device is connected to DUT

```shell
python3 pipewire_utils.py gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
```

the output is
```shell
=================================[ Audio sink ]=================================
Device: [HDMI / DisplayPort] availavle: [yes]
Attempting to initialize Gstreamer pipeline: audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink
Pipeline initialized, now starting playback.
```
