### PR TITLE
Switching power mode for Lenovo's platforms (New)

### DIFF
--- a/providers/base/bin/switch_power_mode.py
+++ b/providers/base/bin/switch_power_mode.py
@@ -9,6 +9,7 @@
 import os
 from pathlib import Path
 import sys
+import subprocess
 
 
 def main():
@@ -20,7 +21,12 @@ def main():
     return_value = 0
 
     # Get the current power mode in quiet mode.
-    old_profile = os.popen("powerprofilesctl get").read().strip().split()[0]
+    result = subprocess.check_output(["powerprofilesctl", "get"], shell=True, text=True)
+    if result.returncode != 0:
+        print("Failed to get the current power mode.")
+        return 1
+    else:
+        old_profile = result.strip().split()[0]
 
     # Read the power mode from /sys/firmware/acpi/platform_profile_choices
     with open(choices_path, "rt", encoding="utf-8") as stream:

--- a/providers/base/bin/switch_power_mode.py
+++ b/providers/base/bin/switch_power_mode.py
@@ -1,9 +1,23 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
-# All rights reserved.
 #
-# Written by:
-#   Bin Li <bin.li@canonical.com>
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+#    Authors: Bin Li <bin.li@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=consider-using-f-string
 
 """ Switching the power mode to check if the power mode can be switched. """
 from pathlib import Path

--- a/providers/base/bin/switch_power_mode.py
+++ b/providers/base/bin/switch_power_mode.py
@@ -52,7 +52,9 @@ def set_power_profile(profile):
     try:
         subprocess.check_call(["powerprofilesctl", "set", profile])
     except subprocess.CalledProcessError as e:
-        raise SystemExit(f"Failed to set power mode to {profile}.") from e
+        raise SystemExit(
+            "Failed to set power mode to {}.".format(profile)
+        ) from e
 
 
 def main():
@@ -75,7 +77,9 @@ def main():
             if get_sysfs_content(profile_path) == choice:
                 print("Switch to {} successfully.".format(choice))
             else:
-                raise SystemExit("Failed to switch power mode to {}".format(choice))
+                raise SystemExit(
+                    "ERROR: Failed to switch power mode to {}".format(choice)
+                )
 
 
 if __name__ == "__main__":

--- a/providers/base/bin/switch_power_mode.py
+++ b/providers/base/bin/switch_power_mode.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# All rights reserved.
+#
+# Written by:
+#   Bin Li <bin.li@canonical.com>
+
+"""Modules providing a function running os or sys commands."""
+import os
+import sys
+
+
+def main():
+    """Switching the power mode to check if the power mode can be switched."""
+    sysfs_root = "/sys/firmware/acpi/"
+    if not os.path.isdir(sysfs_root):
+        return
+    choices_filename = os.path.join(sysfs_root, "platform_profile_choices")
+    if (not os.path.isfile(choices_filename) or
+            not os.access(choices_filename, os.R_OK)):
+        return
+    profile_filename = os.path.join(sysfs_root, "platform_profile")
+    if (not os.path.isfile(profile_filename) or
+            not os.access(profile_filename, os.R_OK)):
+        return
+
+    return_value = 0
+
+    # Get the current power mode in quiet mode.
+    old_profile = os.popen("powerprofilesctl get").read().strip().split()[0]
+
+    # Read the power mode from /sys/firmware/acpi/platform_profile_choices
+    with open(choices_filename, "rt", encoding="utf-8") as stream:
+        choices = stream.read().strip().split()
+        if len(choices) < 1:
+            print("No power mode to switch.")
+            return
+    print(f'Power mode choices: {choices}')
+    # Switch the power mode with powerprofilesctl
+    for choice in choices:
+        # Convert the power mode, e.g. low-power = power-saver,
+        # balanced and performance keep the same.
+        if choice == "low-power":
+            value = "power-saver"
+        else:
+            value = choice
+
+        os.system(f"powerprofilesctl set {value}")
+
+        os.system("sleep 2")
+
+        with open(profile_filename, "rt", encoding="utf-8") as stream:
+            current_profile = stream.read().strip().split()
+        if current_profile[0] == choice:
+            print(f"Switch to {value} successfully.")
+        else:
+            print(f"Failed to switch to {value}.")
+            return_value = 1
+
+    # Switch back to the original power mode
+    os.system(f"powerprofilesctl set {old_profile}")
+
+    sys.exit(return_value)
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/base/bin/switch_power_mode.py
+++ b/providers/base/bin/switch_power_mode.py
@@ -20,13 +20,12 @@ def main():
 
     return_value = 0
 
-    # Get the current power mode in quiet mode.
-    result = subprocess.check_output(["powerprofilesctl", "get"], shell=True, text=True)
-    if result.returncode != 0:
-        print("Failed to get the current power mode.")
-        return 1
-    else:
+    try:
+        result = subprocess.check_output(["powerprofilesctl", "get"], text=True)
         old_profile = result.strip().split()[0]
+    except subprocess.CalledProcessError as err:
+        print("Failed to get the current power mode: {}".format(err))
+        return 1
 
     # Read the power mode from /sys/firmware/acpi/platform_profile_choices
     with open(choices_path, "rt", encoding="utf-8") as stream:

--- a/providers/base/tests/test_switch_power_mode.py
+++ b/providers/base/tests/test_switch_power_mode.py
@@ -148,10 +148,14 @@ Switch to performance successfully.
         mock_get_sysfs_content.side_effect = [
             "balanced",
             "low-power balanced performance",
+            "low-power",
+            "low-power",
         ]
         mock_set_power_profile.side_effect = [
-            SystemExit("Failed to switch power mode to low-power."),
-            None,
+            "lower-power",
+            "balanced",
+            "performance",
+            None
         ]
 
         # Call the function and check if SystemExit is raised
@@ -160,11 +164,12 @@ Switch to performance successfully.
 
         # Assertions
         self.assertEqual(
-            cm.exception.code, "Failed to switch power mode to low-power."
+            cm.exception.code, "ERROR: Failed to switch power mode to balanced"
         )
-        expected_output = (
-            "Power mode choices: ['low-power', 'balanced', 'performance']\n"
-        )
+        expected_output = """\
+Power mode choices: ['low-power', 'balanced', 'performance']
+Switch to low-power successfully.
+"""
         self.assertEqual(mock_stdout.getvalue(), expected_output)
 
 

--- a/providers/base/tests/test_switch_power_mode.py
+++ b/providers/base/tests/test_switch_power_mode.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Bin Li <bin.li@canonical.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=import-error
+
+""" A unittest module for the switch_power_mode module. """
+import unittest
+import subprocess
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import io
+
+from switch_power_mode import get_sysfs_content, set_power_profile, main
+
+
+class TestSwitchPowerMode(unittest.TestCase):
+    """ Tests for the switch_power_mode module. """
+    @patch("builtins.open")  # Mock the open function
+    def test_get_sysfs_content_success(self, mock_open):
+        """
+        Tests successful reading of sysfs file content.
+        """
+        mock_file = MagicMock(spec=io.TextIOWrapper)
+        mock_file.read.return_value = "low-power balanced performance"
+        mock_open.return_value.__enter__.return_value = mock_file
+
+        content = get_sysfs_content(Path("/fake/path/power_profile_choices"))
+
+        self.assertEqual(content, "low-power balanced performance")
+        mock_open.assert_called_once_with(
+            Path("/fake/path/power_profile_choices"), "rt", encoding="utf-8"
+        )
+
+    @patch("switch_power_mode.open")  # Mock the open function
+    def test_get_sysfs_content_failure(self, mock_open):
+        """
+        Tests handling of an empty sysfs file.
+        """
+        mock_file = MagicMock(spec=io.TextIOWrapper)
+        mock_file.read.return_value = ""
+        mock_open.return_value.__enter__.return_value = mock_file
+
+        with self.assertRaises(SystemExit) as cm:
+            get_sysfs_content(Path("/fake/path/power_profile"))
+
+        self.assertEqual(
+            str(cm.exception),
+            "Failed to read sysfs file: /fake/path/power_profile"
+        )
+        mock_open.assert_called_once_with(
+            Path("/fake/path/power_profile"), "rt", encoding="utf-8"
+        )
+
+    @patch("subprocess.check_call")  # Mock the subprocess.check_call function
+    def test_set_power_profile_success(self, mock_check_call):
+        """
+        Tests successful setting of the power profile.
+        """
+        set_power_profile("balanced")
+
+        mock_check_call.assert_called_once_with(
+            ["powerprofilesctl", "set", "balanced"]
+        )
+
+    @patch("subprocess.check_call")  # Mock the subprocess.check_call function
+    def test_set_power_profile_low_power(self, mock_check_call):
+        """
+        Tests conversion of "low-power" to "power-saver" before setting.
+        """
+        set_power_profile("low-power")
+
+        mock_check_call.assert_called_once_with(
+            ["powerprofilesctl", "set", "power-saver"]
+        )
+
+    @patch("subprocess.check_call")  # Mock the subprocess.check_call function
+    def test_set_power_profile_failure(self, mock_check_call):
+        """
+        Tests handling of a failed power profile setting.
+        """
+        mock_check_call.side_effect = subprocess.CalledProcessError(
+            1, "powerprofilesctl"
+        )
+
+        with self.assertRaises(SystemExit) as cm:
+            set_power_profile("performance")
+
+        self.assertEqual(
+            str(cm.exception),
+            "Failed to set power mode to performance."
+        )
+        mock_check_call.assert_called_once_with(
+            ["powerprofilesctl", "set", "performance"]
+        )
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_main_success(self, mock_stdout):
+        """
+        Tests successful execution of the main function.
+        """
+        with patch(
+            "switch_power_mode.get_sysfs_content"
+        ) as mock_get_sysfs_content, patch(
+            "switch_power_mode.set_power_profile"
+        ) as mock_set_power_profile:
+            mock_get_sysfs_content.side_effect = [
+                "balanced",
+                "low-power balanced performance",
+                "low-power",
+                "balanced",
+                "performance",
+            ]
+            mock_set_power_profile.side_effect = [None, None, None, None]
+
+            # Call the main function
+            main()
+
+            expected_output = """\
+Power mode choices: ['low-power', 'balanced', 'performance']
+Switch to low-power successfully.
+Switch to balanced successfully.
+Switch to performance successfully.
+"""
+            self.assertEqual(mock_stdout.getvalue(), expected_output)
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    @patch("switch_power_mode.get_sysfs_content")
+    @patch("switch_power_mode.set_power_profile")
+    def test_main_failure(self, mock_set_power_profile,
+                          mock_get_sysfs_content, mock_stdout):
+        """
+        Tests failed execution of the main function.
+        """
+        mock_get_sysfs_content.side_effect = [
+            "balanced",
+            "low-power balanced performance",
+        ]
+        mock_set_power_profile.side_effect = [
+            SystemExit("Failed to switch power mode to low-power."),
+            None,
+        ]
+
+        # Call the function and check if SystemExit is raised
+        with self.assertRaises(SystemExit) as cm:
+            main()
+
+        # Assertions
+        self.assertEqual(
+            cm.exception.code, "Failed to switch power mode to low-power."
+        )
+        expected_output = (
+            "Power mode choices: ['low-power', 'balanced', 'performance']\n"
+        )
+        self.assertEqual(mock_stdout.getvalue(), expected_output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/providers/base/units/power-management/jobs.pxu
+++ b/providers/base/units/power-management/jobs.pxu
@@ -114,6 +114,7 @@ estimated_duration: 10.0
 requires:
   module.name == 'platform_profile'
   package.name == 'power-profiles-daemon'
+  platform_profile.supported == 'True'
 command: switch_power_mode.py
 _description:
   This test will check if the power mode could be switched.

--- a/providers/base/units/power-management/jobs.pxu
+++ b/providers/base/units/power-management/jobs.pxu
@@ -107,6 +107,17 @@ _description:
  VERIFICATION:
     Does closing your laptop lid cause your system to suspend?
 
+plugin: shell
+category_id: com.canonical.plainbox::power-management
+id: power-management/switch_power_mode
+estimated_duration: 10.0
+requires:
+  module.name == 'platform_profile'
+  package.name == 'power-profiles-daemon'
+command: switch_power_mode.py
+_description:
+  This test will check if the power mode could be switched.
+
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::power-management
 id: power-management/lid_close

--- a/providers/resource/bin/platform_profile_resource.py
+++ b/providers/resource/bin/platform_profile_resource.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+#
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+#    Authors: Bin Li <bin.li@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+def check_platform_profiles():
+    """check platform_profiles and print supported or unsupported."""
+    supported = False
+
+    sysfs_root = Path("/sys/firmware/acpi/")
+    choices_path = sysfs_root / "platform_profile_choices"
+    profile_path = sysfs_root / "platform_profile"
+
+    supported = (sysfs_root.exists() and choices_path.exists() and profile_path.exists())
+
+    print("supported: {}".format(supported))
+
+def main():
+    """main function."""
+    check_platform_profiles()
+
+if __name__ == "__main__":
+    main()

--- a/providers/resource/bin/platform_profile_resource.py
+++ b/providers/resource/bin/platform_profile_resource.py
@@ -19,6 +19,7 @@
 
 from pathlib import Path
 
+
 def check_platform_profiles():
     """check platform_profiles and print supported or unsupported."""
     supported = False
@@ -27,13 +28,17 @@ def check_platform_profiles():
     choices_path = sysfs_root / "platform_profile_choices"
     profile_path = sysfs_root / "platform_profile"
 
-    supported = (sysfs_root.exists() and choices_path.exists() and profile_path.exists())
+    supported = (
+        sysfs_root.exists() and choices_path.exists() and profile_path.exists()
+    )
 
     print("supported: {}".format(supported))
+
 
 def main():
     """main function."""
     check_platform_profiles()
+
 
 if __name__ == "__main__":
     main()

--- a/providers/resource/bin/platform_profile_resource.py
+++ b/providers/resource/bin/platform_profile_resource.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Checkbox.
 #
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #    Authors: Bin Li <bin.li@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
+# pylint: disable=consider-using-f-string
+
+""" Provides a resource to check if platform profiles are supported."""
 from pathlib import Path
 
 

--- a/providers/resource/jobs/resource.pxu
+++ b/providers/resource/jobs/resource.pxu
@@ -527,3 +527,10 @@ _description:
     Source: 'stock' or 'oem'
     Type: 'classic' or 'core'
 command: checkbox-support-image_checker -t -s
+
+id: platform_profile
+estimated_duration: 1.0
+plugin: resource
+_summary: Discover if the system supports power modes via acpi
+_description: Discover resource info from /sys/firmware/apci
+command: platform_profile_resource.py

--- a/providers/resource/tests/test_platform_profile_resource.py
+++ b/providers/resource/tests/test_platform_profile_resource.py
@@ -1,0 +1,51 @@
+import unittest
+import platform_profile_resource
+from unittest.mock import patch
+
+class TestPlatformProfilesSupport(unittest.TestCase):
+    # Test the check_platform_profiles function
+    @patch("builtins.print")
+    def test_supported(self, mock_print):
+        with patch('pathlib.Path.exists') as mock_exists:
+            # All paths exist
+            mock_exists.side_effect = [True, True, True]
+            platform_profile_resource.check_platform_profiles()
+            # Check the output
+            mock_print.assert_called_once_with('supported: True')
+
+    @patch("builtins.print")
+    def test_unsupported(self, mock_print):
+        with patch('pathlib.Path.exists') as mock_exists:
+            # First scenario: None of the paths exist
+            mock_exists.side_effect = [False, False, False]
+            platform_profile_resource.check_platform_profiles()
+            # Check the output
+            mock_print.assert_called_once_with('supported: False')
+            
+            # Second scenario: Only sysfs_root exists
+            mock_exists.side_effect = [True, False, False]
+            platform_profile_resource.check_platform_profiles()
+            # Check the output
+            mock_print.assert_called_with('supported: False')
+            self.assertEqual(mock_print.call_count, 2)
+            
+            # Third scenario: sysfs_root and choices_path exist, but profile_path does not exist
+            mock_exists.side_effect = [True, True, False]
+            platform_profile_resource.check_platform_profiles()
+            # Check the output
+            mock_print.assert_called_with('supported: False')
+            self.assertEqual(mock_print.call_count, 3)
+
+            # Fourth scenario: sysfs_root and profile_path exist, but choices_path does not exist
+            mock_exists.side_effect = [True, False, True]
+            platform_profile_resource.check_platform_profiles()
+            # Check the output
+            mock_print.assert_called_with('supported: False')
+            self.assertEqual(mock_print.call_count, 4)
+
+    @patch("platform_profile_resource.check_platform_profiles")
+    def test_main(self, mock_check_platform_profiles):
+        # Call the function
+        platform_profile_resource.main()
+        # Check the output
+        mock_check_platform_profiles.assert_called()

--- a/providers/resource/tests/test_platform_profile_resource.py
+++ b/providers/resource/tests/test_platform_profile_resource.py
@@ -72,4 +72,4 @@ class TestPlatformProfilesSupport(unittest.TestCase):
     def test_main(self, mock_check_platform_profiles):
         """ Test the main function """
         platform_profile_resource.main()
-        mock_check_platform_profiles.assert_called()
+        mock_check_platform_profiles.assert_has_calls([])

--- a/providers/resource/tests/test_platform_profile_resource.py
+++ b/providers/resource/tests/test_platform_profile_resource.py
@@ -1,12 +1,33 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Bin Li <bin.li@canonical.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=import-error
+
+""" A unittest module for the platform_profile_resource module. """
 import unittest
 from unittest.mock import patch
 import platform_profile_resource
 
 
 class TestPlatformProfilesSupport(unittest.TestCase):
-    # Test the check_platform_profiles function
+    """ Test the platform profile support """
     @patch("builtins.print")
     def test_supported(self, mock_print):
+        """ Test the function when all paths exist"""
         with patch("pathlib.Path.exists") as mock_exists:
             # All paths exist
             mock_exists.side_effect = [True, True, True]
@@ -16,6 +37,7 @@ class TestPlatformProfilesSupport(unittest.TestCase):
 
     @patch("builtins.print")
     def test_unsupported(self, mock_print):
+        """ Test the function when some paths do not exist"""
         with patch("pathlib.Path.exists") as mock_exists:
             # First scenario: None of the paths exist
             mock_exists.side_effect = [False, False, False]
@@ -48,7 +70,6 @@ class TestPlatformProfilesSupport(unittest.TestCase):
 
     @patch("platform_profile_resource.check_platform_profiles")
     def test_main(self, mock_check_platform_profiles):
-        # Call the function
+        """ Test the main function """
         platform_profile_resource.main()
-        # Check the output
         mock_check_platform_profiles.assert_called()

--- a/providers/resource/tests/test_platform_profile_resource.py
+++ b/providers/resource/tests/test_platform_profile_resource.py
@@ -1,46 +1,49 @@
 import unittest
-import platform_profile_resource
 from unittest.mock import patch
+import platform_profile_resource
+
 
 class TestPlatformProfilesSupport(unittest.TestCase):
     # Test the check_platform_profiles function
     @patch("builtins.print")
     def test_supported(self, mock_print):
-        with patch('pathlib.Path.exists') as mock_exists:
+        with patch("pathlib.Path.exists") as mock_exists:
             # All paths exist
             mock_exists.side_effect = [True, True, True]
             platform_profile_resource.check_platform_profiles()
             # Check the output
-            mock_print.assert_called_once_with('supported: True')
+            mock_print.assert_called_once_with("supported: True")
 
     @patch("builtins.print")
     def test_unsupported(self, mock_print):
-        with patch('pathlib.Path.exists') as mock_exists:
+        with patch("pathlib.Path.exists") as mock_exists:
             # First scenario: None of the paths exist
             mock_exists.side_effect = [False, False, False]
             platform_profile_resource.check_platform_profiles()
             # Check the output
-            mock_print.assert_called_once_with('supported: False')
-            
+            mock_print.assert_called_once_with("supported: False")
+
             # Second scenario: Only sysfs_root exists
             mock_exists.side_effect = [True, False, False]
             platform_profile_resource.check_platform_profiles()
             # Check the output
-            mock_print.assert_called_with('supported: False')
+            mock_print.assert_called_with("supported: False")
             self.assertEqual(mock_print.call_count, 2)
-            
-            # Third scenario: sysfs_root and choices_path exist, but profile_path does not exist
+
+            # Third scenario: sysfs_root and choices_path exist,
+            # but profile_path does not exist
             mock_exists.side_effect = [True, True, False]
             platform_profile_resource.check_platform_profiles()
             # Check the output
-            mock_print.assert_called_with('supported: False')
+            mock_print.assert_called_with("supported: False")
             self.assertEqual(mock_print.call_count, 3)
 
-            # Fourth scenario: sysfs_root and profile_path exist, but choices_path does not exist
+            # Fourth scenario: sysfs_root and profile_path exist,
+            # but choices_path does not exist
             mock_exists.side_effect = [True, False, True]
             platform_profile_resource.check_platform_profiles()
             # Check the output
-            mock_print.assert_called_with('supported: False')
+            mock_print.assert_called_with("supported: False")
             self.assertEqual(mock_print.call_count, 4)
 
     @patch("platform_profile_resource.check_platform_profiles")


### PR DESCRIPTION
## Description

With Platform Profile (low-power, balanced, performance) support being added to the kernel and GNOME we'd like this to be tested to confirm it is working during HW enablement/certification.
It is expected functionality on these platforms and we need to highlight any issues with it not working to the FW team so it can be fixed before preload signoff.

## Resolved issues

https://github.com/canonical/checkbox/issues/816

Original bug: https://bugs.launchpad.net/sutton/+bug/2036435

## Documentation

This testcase could help verify power mode can be changed and stay in the chosen setting.

## Tests
$ checkbox-cli run com.canonical.certification::power-management/switch_power_mode
```
---------------------[ power-management/switch_power_mode ]---------------------
ID: com.canonical.certification::power-management/switch_power_mode
Category: com.canonical.plainbox::power-management
... 8< -------------------------------------------------------------------------
Power mode choices: ['low-power', 'balanced', 'performance']
Switch to low-power successfully.
Switch to balanced successfully.
Switch to performance successfully.
------------------------------------------------------------------------- >8 ---
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-03-22T16.31.38
==================================[ Results ]===================================
 ☑ : Collect information about kernel modules
 ☑ : Discover if the system supports power modes via acpi
 ☑ : Collect information about installed software packages
 ☑ : power-management/switch_power_mode
```
