### PR TITLE
Move lsb_release install up to stage and build of checkbox-support (bugfix)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -155,6 +155,7 @@ parts:
       - python3-yaml
       - pyotherside
       - libbluetooth3
+      - lsb-release
     build-environment:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$PYTHONPATH
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $SNAPCRAFT_STAGE/version.txt)"
@@ -177,6 +178,7 @@ parts:
       - libbluetooth-dev
       - python3-dev
       - python3-pip
+      - lsb-release
     override-build: |
       # we need a new version of pip and setuptools + dependencies
       # these have an hardcoded version because we need a combination that is
@@ -204,7 +206,6 @@ parts:
       - python3-xlsxwriter
       - python3-setuptools
       - python3-dev
-      - lsb-release
     python-packages:
       - tqdm
     after: [checkbox-support]


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The previous patch was incomplete (but I didnt notice because of snapcraft caching). We need lsb_release both in build and in stage. Also, we need it for checkbox-support as well. This moves the install in the first part that needs it.

## Resolved issues

Failing daily builds

## Documentation

N/A

## Tests

Built via LXD (as LP remote-builds are still broken)
