### PR TITLE
migrate `keys/microphone-mute` from pulseaudio to pipewire (BugFix)

### DIFF
--- a/providers/base/units/keys/jobs.pxu
+++ b/providers/base/units/keys/jobs.pxu
@@ -225,16 +225,22 @@ requires:
  manifest.has_special_keys == 'True'
  device.category == 'AUDIO'
  package.name == 'alsa-base'
- package.name == 'pulseaudio-utils'
+ package.name in ['pulseaudio-utils', 'pipewire']
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
 flags: also-after-suspend
 command:
- audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- audio_settings.py set --device=pci --volume=50
- alsa_record_playback.sh
- EXIT_CODE=$?
- audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
- exit $EXIT_CODE
+  if check_audio_daemon.sh ; then
+    pipewire_utils.py show -t audio
+    alsa_record_playback.sh
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --device=pci --volume=50
+    alsa_record_playback.sh
+    EXIT_CODE=$?
+    audio_settings.py restore --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
+  exit $EXIT_CODE
 _description:
  PURPOSE:
      This test will test the mute key for your microphone


### PR DESCRIPTION
This test case is missed to migrate in the #826

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->
This PR is going to make `keys/microphone-mute` could be executed on both environment.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
`keys/microphone-mute` could be only executed on `pulseaudio` environment only.

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
The command is same with `audio/alsa_record_playback_internal`
