### PR TITLE
Disk resource gated jobs (bugfix)

### DIFF
--- a/providers/base/bin/disk_resource.py
+++ b/providers/base/bin/disk_resource.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+#
+# This file is part of Checkbox.
+#
+# Copyright (C) 2010-2013 by Cloud Computing Center for Mobile Applications
+# Industrial Technology Research Institute
+# Copyright 2016 Canonical Ltd.
+#
+# Authors:
+#   Nelson Chu <Nelson.Chu@itri.org.tw>
+#   Jeff Lane <jeff@ubuntu.com>
+#   Sylvain Pineau <sylvain.pineau@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+"""
+disk_resource creates a resource per disk from the output of lsblk.
+- name: column KNAME, internal kernel name
+- path: column PATH, path to the device node
+- model: column MODEL, model identifier
+- size: column SIZE, size of the disk in bytes
+- rotational: column ROTA, True for rotational drives like hard disks
+"""
+
+import re
+import sys
+from subprocess import check_output, CalledProcessError
+
+from checkbox_support.parsers.udevadm import find_pkname_is_root_mountpoint
+
+
+def main():
+    """
+    disk_info.
+
+    Uses lsblk to gather information about disks seen by the OS.
+    Outputs kernel name, model and size data
+    """
+    pattern = re.compile(
+        'KNAME="(?P<KNAME>.*)" '
+        'PATH="(?P<PATH>.*)" '
+        'TYPE="(?P<TYPE>.*)" '
+        'SIZE="(?P<SIZE>.*)" '
+        'MODEL="(?P<MODEL>.*)" '
+        'ROTA="(?P<ROTA>.*)" '
+        'MOUNTPOINT="(?P<MOUNTPOINT>.*)"'
+    )
+    try:
+        lsblk = check_output(
+            [
+                "lsblk",
+                "--bytes",
+                "-i",
+                "-n",
+                "-P",
+                "-o",
+                "KNAME,PATH,TYPE,SIZE,MODEL,ROTA,MOUNTPOINT",
+            ],
+            universal_newlines=True,
+        )
+    except CalledProcessError as e:
+        sys.exit(e)
+
+    disks = 0
+    for line in lsblk.splitlines():
+        m = pattern.match(line)
+        if not m or m.group("TYPE") not in ("disk", "crypt"):
+            continue
+        # Only consider MMC block devices if one of their mounted partitions is
+        # root (/)
+        if m.group("KNAME").startswith(
+            "mmcblk"
+        ) and not find_pkname_is_root_mountpoint(m.group("KNAME"), lsblk):
+            continue
+        # Don't consider any block dev mounted as snapd save partition
+        if "snapd/save" in m.group("MOUNTPOINT"):
+            continue
+        disks += 1
+        model = m.group("MODEL") or "Unknown"
+        rotational = m.group("ROTA") == "1"
+        print("name: {}".format(m.group("KNAME")))
+        print("path: {}".format(m.group("PATH")))
+        print("model: {}".format(model))
+        print("size: {}".format(m.group("SIZE")))
+        print("rotational: {}".format(rotational))
+        print()
+
+    if not disks:
+        raise SystemExit("No disk information discovered.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/providers/base/bin/disk_resource.py
+++ b/providers/base/bin/disk_resource.py
@@ -4,12 +4,13 @@
 #
 # Copyright (C) 2010-2013 by Cloud Computing Center for Mobile Applications
 # Industrial Technology Research Institute
-# Copyright 2016 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #
 # Authors:
 #   Nelson Chu <Nelson.Chu@itri.org.tw>
 #   Jeff Lane <jeff@ubuntu.com>
 #   Sylvain Pineau <sylvain.pineau@canonical.com>
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/base/bin/disk_resource.py
+++ b/providers/base/bin/disk_resource.py
@@ -86,12 +86,11 @@ def get_relevant_block_devices(block_devices: list) -> list:
 
 def print_as_resource(block_device):
     model = block_device.get("model", "Unknown")
-    rotational = block_device["rota"] == "1"
     print("name:", block_device["kname"])
     print("path:", block_device["path"])
     print("model:", model)
     print("size:", block_device["size"])
-    print("rotational:", rotational)
+    print("rotational:", block_device["rota"])
     print()
 
 

--- a/providers/base/tests/test_disk_resource.py
+++ b/providers/base/tests/test_disk_resource.py
@@ -1,0 +1,120 @@
+import unittest
+import textwrap
+from subprocess import CalledProcessError
+from unittest.mock import patch, MagicMock
+
+import disk_resource
+
+
+class TestDiskResource(unittest.TestCase):
+    def test_print_as_resource(self):
+        with patch("builtins.print") as mocked_print:
+            block_device = {
+                "kname": "sda",
+                "path": "/dev/sda",
+                "model": "FastSSD",
+                "size": "512110190592",
+                "rota": False,
+            }
+            disk_resource.print_as_resource(block_device)
+            mocked_print.assert_any_call("name:", "sda")
+            mocked_print.assert_any_call("path:", "/dev/sda")
+            mocked_print.assert_any_call("model:", "FastSSD")
+            mocked_print.assert_any_call("size:", "512110190592")
+            mocked_print.assert_any_call("rotational:", False)
+
+    def test_get_relevant_block_devices_is_mmc(self):
+        block_devices = [
+            {"type": "disk", "kname": "mmcblk0", "mountpoint": "/boot"}
+        ]
+        result = list(disk_resource.get_relevant_block_devices(block_devices))
+        self.assertEqual(len(result), 0)
+
+    def test_get_relevant_block_devices_loopback(self):
+        block_devices = [
+            {"type": "loop", "kname": "loop0", "mountpoint": None}
+        ]
+        result = list(disk_resource.get_relevant_block_devices(block_devices))
+        self.assertEqual(len(result), 0)
+
+    def test_get_relevant_block_devices_snapd(self):
+        block_devices = [
+            {
+                "type": "disk",
+                "kname": "sda",
+                "mountpoint": "var/lib/snapd/save",
+            }
+        ]
+        result = list(disk_resource.get_relevant_block_devices(block_devices))
+        self.assertEqual(len(result), 0)
+
+    def test_get_relevant_block_devices_ok(self):
+        block_devices = [{"type": "disk", "kname": "sda", "mountpoint": "/"}]
+        result = list(disk_resource.get_relevant_block_devices(block_devices))
+        self.assertEqual(len(result), 1)
+
+    @patch("disk_resource.check_output")
+    def test_get_blockdevices_info_ok(self, mock_check_output):
+        mock_check_output.return_value = textwrap.dedent(
+            """
+            {
+                "blockdevices": [
+                    {
+                        "kname": "sda",
+                        "path": "/dev/sda",
+                        "type": "disk",
+                        "size": "256G",
+                        "model": "FastSSD",
+                        "rota": false
+                    }
+                ]
+            }
+            """
+        )
+        result = disk_resource.get_blockdevices_info()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["model"], "FastSSD")
+
+    @patch("disk_resource.check_output")
+    def test_get_blockdevices_info_fail(self, mock_check_output):
+        mock_check_output.side_effect = CalledProcessError(1, "Command failed")
+        with self.assertRaises(SystemExit):
+            disk_resource.get_blockdevices_info()
+
+
+class TestMain(unittest.TestCase):
+    @patch("disk_resource.check_output")
+    @patch("disk_resource.print_as_resource")
+    def test_main(self, mock_print_as_resource, mock_check_output):
+        mock_check_output.return_value = textwrap.dedent(
+            """
+            {
+                "blockdevices": [
+                    {
+                        "kname": "sda",
+                        "path": "/dev/sda",
+                        "type": "disk",
+                        "size": "256G",
+                        "model": "FastSSD",
+                        "rota": "0",
+                        "mountpoint" : "/"
+                    },
+                    {
+                        "kname": "loop1",
+                        "path": "/dev/loop1",
+                        "type": "loop",
+                        "size": 58363904,
+                        "model": null,
+                        "rota": false,
+                        "mountpoint": "/var/lib/snapd/snap/core16/2812"
+                    }
+
+                ]
+            }
+            """
+        )
+
+        disk_resource.main()
+
+        self.assertEqual(mock_print_as_resource.call_count, 1)

--- a/providers/base/units/disk/jobs.pxu
+++ b/providers/base/units/disk/jobs.pxu
@@ -152,7 +152,6 @@ requires:
     disk_resource.rotational == 'True'
 depends:
   input/accelerometer
-  disk_resource
 user: root
 command: hdd_parking.py
 _description:

--- a/providers/base/units/disk/jobs.pxu
+++ b/providers/base/units/disk/jobs.pxu
@@ -11,6 +11,15 @@ _description:
 command: disk_info.py
 estimated_duration: 0.25
 
+plugin: resource
+id: disk_resource
+requires:
+  executable.name == 'lsblk'
+_summary: Produces a resource per block device in the lsblk output
+_purpose:
+  Creates a resource to easily query the block devices available on the DUT.
+command: disk_resource.py
+
 unit: template
 template-resource: device
 template-filter: device.category == 'DISK' and device.name != ''
@@ -140,7 +149,10 @@ estimated_duration: 60.0
 requires:
     device.category == 'DISK'
     executable.name == 'hdapsd'
-depends: input/accelerometer
+    disk_resource.rotational == 'True'
+depends:
+  input/accelerometer
+  disk_resource
 user: root
 command: hdd_parking.py
 _description:


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The test `disk/hdd-parking` is currently being ran on every device that has a disk. This leads to other tests failing  because the script enables a service that instantly goes in the degraded state, making other tests (that check that there is no service enabled and degraded) fail. This also pollutes submissions as the test can never pass on devices that do not have an hard disk.

This introduces a new resource job that lists various useful information about block devices, including if the block device is "rotational". This information is integrated in the requires constraint of the hdd test.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1136

## Documentation

N/A

## Tests

The new resource job is unit tested.
