### PR TITLE
Set default argv (bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/eddystone_scanner.py
+++ b/checkbox-support/checkbox_support/scripts/eddystone_scanner.py
@@ -71,7 +71,9 @@ def beacon_scan(hci_device):
 
 
 @timeout(60 * 10)  # 10 minutes timeout
-def main(argv=sys.argv[1:]):
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
     init_bluetooth()
 
     parser = argparse.ArgumentParser(

--- a/checkbox-support/checkbox_support/scripts/eddystone_scanner.py
+++ b/checkbox-support/checkbox_support/scripts/eddystone_scanner.py
@@ -71,7 +71,7 @@ def beacon_scan(hci_device):
 
 
 @timeout(60 * 10)  # 10 minutes timeout
-def main(argv):
+def main(argv=sys.argv[1:]):
     init_bluetooth()
 
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

When a console script is installed by python, it is automatically given a wrapper main that looks something like this:
```python
#!/home/h25/prj/canonical/venv/bin/python
# -*- coding: utf-8 -*-
import re
import sys
from checkbox_support.scripts.eddystone_scanner import main
if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
    sys.exit(main())
```

This is a problem when main expects argv as a parameter (or expects to be called by the statement under `if __name__ == "__main__"` for that matter. 

This fixes our eddystone-beacon scriptlet by setting the default value of argv to what main sets it to.

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/1114

## Documentation

N/A

## Tests

Tested locally I was able to reproduce the issue without the patch and see the fix after the patch

