### PR TITLE
Fix config loading after resume (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -522,7 +522,12 @@ class Launcher(MainLoopStage, ReportsStage):
             return IJobResult.OUTCOME_PASS
         return IJobResult.OUTCOME_CRASH
 
-    def abc(self, app_blob):
+    def load_configs_from_app_blob(self, app_blob):
+        """
+        Load the configs taking into consideration the app_blob. This recovers
+        the original launcher that was provided to the session and loads the
+        configs from disk
+        """
         if "launcher" in app_blob:
             resumed_launcher = Configuration.from_text(
                 app_blob["launcher"], "Resume launcher"
@@ -530,7 +535,6 @@ class Launcher(MainLoopStage, ReportsStage):
         else:
             resumed_launcher = Configuration()
         config = load_configs(cfg=resumed_launcher)
-        breakpoint()
         self.ctx.sa.use_alternate_configuration(config)
 
     def _resume_session(
@@ -545,7 +549,7 @@ class Launcher(MainLoopStage, ReportsStage):
         if "testplanless" not in metadata.flags:
             app_blob = json.loads(metadata.app_blob.decode("UTF-8"))
             test_plan_id = app_blob["testplan_id"]
-            self.abc(app_blob)
+            self.load_configs_from_app_blob(app_blob)
             self.ctx.sa.select_test_plan(test_plan_id)
             self.ctx.sa.bootstrap()
             if outcome is None:

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -54,6 +54,7 @@ from plainbox.impl.transport import TransportError
 from plainbox.impl.transport import get_all_transports
 from plainbox.impl.transport import SECURE_ID_PATTERN
 from plainbox.impl.unit.testplan import TestPlanUnitSupport
+from plainbox.impl.config import Configuration
 
 from checkbox_ng.config import load_configs
 from checkbox_ng.launcher.stages import MainLoopStage, ReportsStage
@@ -521,6 +522,17 @@ class Launcher(MainLoopStage, ReportsStage):
             return IJobResult.OUTCOME_PASS
         return IJobResult.OUTCOME_CRASH
 
+    def abc(self, app_blob):
+        if "launcher" in app_blob:
+            resumed_launcher = Configuration.from_text(
+                app_blob["launcher"], "Resume launcher"
+            )
+        else:
+            resumed_launcher = Configuration()
+        config = load_configs(cfg=resumed_launcher)
+        breakpoint()
+        self.ctx.sa.use_alternate_configuration(config)
+
     def _resume_session(
         self, session_id: str, outcome: "IJobResult|None", comments=[]
     ):
@@ -533,6 +545,7 @@ class Launcher(MainLoopStage, ReportsStage):
         if "testplanless" not in metadata.flags:
             app_blob = json.loads(metadata.app_blob.decode("UTF-8"))
             test_plan_id = app_blob["testplan_id"]
+            self.abc(app_blob)
             self.ctx.sa.select_test_plan(test_plan_id)
             self.ctx.sa.bootstrap()
             if outcome is None:
@@ -629,9 +642,16 @@ class Launcher(MainLoopStage, ReportsStage):
         description = self.ctx.args.message or self.configuration.get_value(
             "launcher", "session_desc"
         )
+        app_blob = {"testplan_id": tp_id, "description": description}
+        if self.ctx.args.launcher:
+            try:
+                with open(self.ctx.args.launcher, "r") as f:
+                    app_blob["launcher"] = f.read()
+            except FileNotFoundError:
+                pass
         self.ctx.sa.update_app_blob(
             json.dumps(
-                {"testplan_id": tp_id, "description": description}
+                app_blob
             ).encode("UTF-8")
         )
         bs_jobs = self.ctx.sa.get_bootstrap_todo_list()

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -42,7 +42,10 @@ from checkbox_ng.launcher.subcommands import (
 
 
 class TestLauncher(TestCase):
-    @mock_open(read_data=textwrap.dedent(
+    @patch(
+        "checkbox_ng.launcher.subcommands.open",
+        new_callable=mock_open,
+        read_data=textwrap.dedent(
             """
             [launcher]
             app_id = "appid"
@@ -50,9 +53,9 @@ class TestLauncher(TestCase):
             session_title = "session_title"
             session_desc = "description"
             """
-        ))
-
-    def test_start_new_session_ok(self):
+        ),
+    )
+    def test_start_new_session_ok(self, _):
         self_mock = MagicMock()
         self_mock.is_interactive = True
         self_mock._interactively_pick_test_plan.return_value = "test plan id"

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -79,6 +79,32 @@ class TestLauncher(TestCase):
 
         Launcher._start_new_session(self_mock)
 
+    @patch("checkbox_ng.launcher.subcommands.open")
+    def test_start_new_session_ok_no_launcher(self, mock_open):
+        self_mock = MagicMock()
+        self_mock.is_interactive = True
+        self_mock._interactively_pick_test_plan.return_value = "test plan id"
+        self_mock.ctx.args.launcher = "launcher_path.conf"
+        self_mock.ctx.args.message = None
+        mock_open.side_effect = FileNotFoundError
+
+        def configuration_get_value(tl_key, sl_key):
+            configuration = {
+                "launcher": {
+                    "app_id": "appid",
+                    "app_version": 0,
+                    "session_title": "session_title",
+                    "session_desc": "description",
+                },
+                "agent": {"normal_user": "ubuntu"},
+                "test plan": {"forced": False, "unit": "some unit"},
+            }
+            return configuration[tl_key][sl_key]
+
+        self_mock.configuration.get_value = configuration_get_value
+
+        Launcher._start_new_session(self_mock)
+
     @patch("checkbox_ng.launcher.subcommands.detect_restart_strategy")
     @patch("os.getenv")
     @patch("sys.argv")

--- a/metabox/metabox/metabox-provider/units/basic-jobs.pxu
+++ b/metabox/metabox/metabox-provider/units/basic-jobs.pxu
@@ -30,9 +30,13 @@ flags: simple
 command: echo variables: $Case $CASE $case
 environ: Case CASE case
 
-id: sleep_100ms
+id: sleep_1000s
 flags: simple
-command: sleep .1
+_summary:
+  This job is ment to be killed, so it prints some text and sleeps for a while
+command:
+  echo starting to sleep
+  sleep 1000
 
 id: stub/manual
 _summary: A simple manual job

--- a/metabox/metabox/metabox-provider/units/basic-jobs.pxu
+++ b/metabox/metabox/metabox-provider/units/basic-jobs.pxu
@@ -30,6 +30,10 @@ flags: simple
 command: echo variables: $Case $CASE $case
 environ: Case CASE case
 
+id: sleep_100ms
+flags: simple
+command: sleep .1
+
 id: stub/manual
 _summary: A simple manual job
 _description:

--- a/metabox/metabox/metabox-provider/units/basic-tps.pxu
+++ b/metabox/metabox/metabox-provider/units/basic-tps.pxu
@@ -47,6 +47,16 @@ include:
  config-environ-case
 
 unit: test plan
+id: config-slow-automated
+_name: Checkbox Slow Configuration Test
+include:
+ config-environ-source
+ sleep_100ms
+ config-environ-vars
+ config-environ-case
+
+
+unit: test plan
 id: pass-and-fail
 _name: Pass and Fail
 include:

--- a/metabox/metabox/metabox-provider/units/basic-tps.pxu
+++ b/metabox/metabox/metabox-provider/units/basic-tps.pxu
@@ -51,7 +51,7 @@ id: config-slow-automated
 _name: Checkbox Slow Configuration Test
 include:
  config-environ-source
- sleep_100ms
+ sleep_1000s
  config-environ-vars
  config-environ-case
 

--- a/metabox/metabox/scenarios/config/resume.py
+++ b/metabox/metabox/scenarios/config/resume.py
@@ -54,10 +54,9 @@ class ConfigLoadedAlsoAfterResume(Scenario):
     steps = [
         Start(),
         Expect("source: source"),
-        Signal(keys.SIGINT),
+        Expect("starting to sleep"),
+        Signal(keys.SIGKILL),
         Start(),
         # autoresume
-        Expect("Case"),
-        Expect("CASE"),
-        Expect("case"),
+        Expect("Case CASE case"),
     ]

--- a/metabox/metabox/scenarios/config/resume.py
+++ b/metabox/metabox/scenarios/config/resume.py
@@ -1,0 +1,63 @@
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Pierre Equoy <pierre.equoy@canonical.com>
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+import textwrap
+
+from metabox.core import keys
+from metabox.core.scenario import Scenario
+from metabox.core.actions import Expect, Start, Signal
+
+
+class ConfigLoadedAlsoAfterResume(Scenario):
+    """
+    Check that environment variables are case sensitive
+    """
+
+    modes = ["local"]
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::config-slow-automated
+        forced = yes
+        [test selection]
+        forced = yes
+        [ui]
+        type = silent
+        [environment]
+        var1=a
+        var2=b
+        var3=c
+        case=case
+        Case=Case
+        CASE=CASE
+        source=source
+        """
+    )
+    steps = [
+        Start(),
+        Expect("source: source"),
+        Signal(keys.SIGINT),
+        Start(),
+        # autoresume
+        Expect("Case"),
+        Expect("CASE"),
+        Expect("case"),
+    ]

--- a/metabox/metabox/scenarios/config/resume.py
+++ b/metabox/metabox/scenarios/config/resume.py
@@ -25,7 +25,7 @@ from metabox.core.actions import Expect, Start, Signal
 
 class ConfigLoadedAlsoAfterResume(Scenario):
     """
-    Check that environment variables are case sensitive
+    Check that configs are loaded also after resume
     """
 
     modes = ["local"]


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

When resuming a session, checkbox local doesn't currently load any config. This is an issue for any job that relies of a config (for example, the environment), so it must be fixed.

This introduces basically the same mechanism that remote uses (storing the launcher in the app blob, loading it and reading the configs on the machine after resume, using the alternative config).

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/1115
Fixes: CHECKBOX-1340

## Documentation

New function is documented

## Tests

unit tests and metabox tests added
