### PR TITLE
Refactor watchdog test case (New)

### DIFF
--- a/providers/base/bin/watchdog_config_test.py
+++ b/providers/base/bin/watchdog_config_test.py
@@ -17,10 +17,27 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
+'''
+Watchdog implementation on both classic and core image no longer rely
+on watchdogd service since 20.04, with this change watchdog/systemd-config
+tests only systemd configuration on 20.04 and later series while keeping
+the original test for prior releases
+'''
+
 import subprocess
+import argparse
+import sys
 
 from checkbox_support.snap_utils.system import on_ubuntucore
 from checkbox_support.snap_utils.system import get_series
+
+
+def watchdog_argparse():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-t', '--check_time', action='store_true')
+    parser.add_argument('-s', '--check_service', action='store_true')
+
+    return parser.parse_args()
 
 
 def get_systemd_wdt_usec():
@@ -91,8 +108,8 @@ def main():
             print("systemd watchdog disabled")
             print("watchdog.service active")
 
-    raise SystemExit(not watchdog_config_ready)
+    return not watchdog_config_ready
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/providers/base/tests/test_watchdog_config_test.py
+++ b/providers/base/tests/test_watchdog_config_test.py
@@ -108,12 +108,133 @@ class TestWatchdogConfigTest(unittest.TestCase):
         with self.assertRaises(SystemExit):
             watchdog_service_check()
 
-    @patch('watchdog_config_test.watchdog_argparse')
-    @patch('watchdog_config_test.get_series')
-    @patch('watchdog_config_test.get_systemd_wdt_usec')
-    @patch('watchdog_config_test.on_ubuntucore')
-    @patch('watchdog_config_test.watchdog_service_check')
-    def test_main_check_time(self, mock_watchdog_service_check, mock_on_ubuntucore, mock_get_systemd_wdt_usec, mock_get_series, mock_watchdog_argparse):
+    @patch("watchdog_config_test.watchdog_argparse")
+    @patch("watchdog_config_test.get_series")
+    @patch("watchdog_config_test.get_systemd_wdt_usec")
+    @patch("watchdog_config_test.on_ubuntucore")
+    @patch("watchdog_config_test.watchdog_service_check")
+    def test_main_check_time_and_service(
+        self,
+        mock_watchdog_service_check,
+        mock_on_ubuntucore,
+        mock_get_systemd_wdt_usec,
+        mock_get_series,
+        mock_watchdog_argparse,
+    ):
+        # Mock arguments
+        mock_args = MagicMock()
+        mock_args.check_time = True
+        mock_args.check_service = True
+        mock_watchdog_argparse.return_value = mock_args
+
+        # Mock get_series
+        mock_get_series.return_value = "20.04"
+
+        # Mock on_ubuntucore
+        mock_on_ubuntucore.return_value = False
+
+        # Mock get_systemd_wdt_usec
+        mock_get_systemd_wdt_usec.return_value = "1000000"
+
+        # Mock watchdog_service_check
+        mock_watchdog_service_check.return_value = False
+
+        # Call the function under test
+        with patch("builtins.print") as mock_print:
+            main()
+
+        # Assert that the expected messages are printed
+        mock_print.assert_any_call(
+            "systemd watchdog enabled, reset timeout: 1000000"
+        )
+        mock_print.assert_any_call("watchdog.service is not active")
+
+    @patch("watchdog_config_test.watchdog_argparse")
+    @patch("watchdog_config_test.get_series")
+    @patch("watchdog_config_test.get_systemd_wdt_usec")
+    @patch("watchdog_config_test.on_ubuntucore")
+    @patch("watchdog_config_test.watchdog_service_check")
+    def test_main_check_time_ubuntucore(
+        self,
+        mock_watchdog_service_check,
+        mock_on_ubuntucore,
+        mock_get_systemd_wdt_usec,
+        mock_get_series,
+        mock_watchdog_argparse,
+    ):
+        # Mock arguments
+        mock_args = MagicMock()
+        mock_args.check_time = True
+        mock_args.check_service = False
+        mock_watchdog_argparse.return_value = mock_args
+
+        # Mock get_systemd_wdt_usec
+        mock_get_systemd_wdt_usec.return_value = 1000000
+
+        # Mock get_series
+        mock_get_series.return_value = "18.04"
+
+        # Mock on_ubuntucore
+        mock_on_ubuntucore.return_value = True
+        # Call the function under test
+        with patch("builtins.print") as mock_print:
+            main()
+
+        # Assert that the expected messages are printed
+        mock_print.assert_any_call(
+            "systemd watchdog enabled, reset timeout: 1000000"
+        )
+
+    @patch("watchdog_config_test.watchdog_argparse")
+    @patch("watchdog_config_test.get_series")
+    @patch("watchdog_config_test.get_systemd_wdt_usec")
+    @patch("watchdog_config_test.on_ubuntucore")
+    @patch("watchdog_config_test.watchdog_service_check")
+    def test_main_check_time_not_active(
+        self,
+        mock_watchdog_service_check,
+        mock_on_ubuntucore,
+        mock_get_systemd_wdt_usec,
+        mock_get_series,
+        mock_watchdog_argparse,
+    ):
+        # Mock arguments
+        mock_args = MagicMock()
+        mock_args.check_time = True
+        mock_args.check_service = False
+        mock_watchdog_argparse.return_value = mock_args
+
+        # Mock get_series
+        mock_get_series.return_value = "20.04"
+
+        # Mock on_ubuntucore
+        mock_on_ubuntucore.return_value = False
+
+        # Mock get_systemd_wdt_usec
+        mock_get_systemd_wdt_usec.return_value = "0"
+
+        # Call the function under test
+        with patch("builtins.print") as mock_print:
+            main()
+
+        # Assert that the expected message is printed
+        mock_print.assert_any_call(
+            "systemd watchdog should be enabled but reset timeout: 0"
+        )
+
+    @patch("watchdog_config_test.watchdog_argparse")
+    @patch("watchdog_config_test.get_series")
+    @patch("watchdog_config_test.get_systemd_wdt_usec")
+    @patch("watchdog_config_test.on_ubuntucore")
+    @patch("watchdog_config_test.watchdog_service_check")
+    def test_main_check_time_and_systemd_wdt_configured(
+        self,
+        mock_watchdog_service_check,
+        mock_on_ubuntucore,
+        mock_get_systemd_wdt_usec,
+        mock_get_series,
+        mock_watchdog_argparse,
+    ):
         # Mock arguments
         mock_args = MagicMock()
         mock_args.check_time = True
@@ -130,18 +251,94 @@ class TestWatchdogConfigTest(unittest.TestCase):
         mock_get_systemd_wdt_usec.return_value = "1000000"
 
         # Call the function under test
-        with patch('builtins.print') as mock_print:
+        with patch("builtins.print") as mock_print:
             main()
-
         # Assert that the expected messages are printed
-        mock_print.assert_any_call("systemd watchdog enabled, reset timeout: 1000000")
+        mock_print.assert_any_call(
+            "systemd watchdog enabled, reset timeout: 1000000"
+        )
 
-    @patch('watchdog_config_test.watchdog_argparse')
-    @patch('watchdog_config_test.get_series')
-    @patch('watchdog_config_test.get_systemd_wdt_usec')
-    @patch('watchdog_config_test.on_ubuntucore')
-    @patch('watchdog_config_test.watchdog_service_check')
-    def test_main_check_service(self, mock_watchdog_service_check, mock_on_ubuntucore, mock_get_systemd_wdt_usec, mock_get_series, mock_watchdog_argparse):
+    @patch("watchdog_config_test.watchdog_argparse")
+    @patch("watchdog_config_test.get_series")
+    @patch("watchdog_config_test.get_systemd_wdt_usec")
+    @patch("watchdog_config_test.on_ubuntucore")
+    @patch("watchdog_config_test.watchdog_service_check")
+    def test_main_check_time_and_watchdog_config_ready(
+        self,
+        mock_watchdog_service_check,
+        mock_on_ubuntucore,
+        mock_get_systemd_wdt_usec,
+        mock_get_series,
+        mock_watchdog_argparse,
+    ):
+        # Mock arguments
+        mock_args = MagicMock()
+        mock_args.check_time = True
+        mock_args.check_service = False
+        mock_watchdog_argparse.return_value = mock_args
+
+        # Mock get_series
+        mock_get_series.return_value = "18.04"
+
+        # Mock on_ubuntucore
+        mock_on_ubuntucore.return_value = False
+
+        # Mock get_systemd_wdt_usec
+        mock_get_systemd_wdt_usec.return_value = "0"
+
+        # Call the function under test
+        with patch("builtins.print") as mock_print:
+            main()
+        # Assert that the expected messages are printed
+        mock_print.assert_any_call("systemd watchdog disabled")
+
+    @patch("watchdog_config_test.watchdog_argparse")
+    @patch("watchdog_config_test.get_series")
+    @patch("watchdog_config_test.get_systemd_wdt_usec")
+    @patch("watchdog_config_test.on_ubuntucore")
+    @patch("watchdog_config_test.watchdog_service_check")
+    def test_main_check_time_is_systemd_wdt_configured(
+        self,
+        mock_watchdog_service_check,
+        mock_on_ubuntucore,
+        mock_get_systemd_wdt_usec,
+        mock_get_series,
+        mock_watchdog_argparse,
+    ):
+        # Mock arguments
+        mock_args = MagicMock()
+        mock_args.check_time = True
+        mock_args.check_service = False
+        mock_watchdog_argparse.return_value = mock_args
+
+        # Mock get_series
+        mock_get_series.return_value = "18.04"
+
+        # Mock on_ubuntucore
+        mock_on_ubuntucore.return_value = False
+
+        # Mock get_systemd_wdt_usec
+        mock_get_systemd_wdt_usec.return_value = "1000000"
+
+        # Call the function under test
+        with patch("builtins.print") as mock_print:
+            main()
+        # Assert that the expected messages are printed
+        mock_print.assert_any_call(
+            "systemd watchdog should not be enabled but reset timeout: 1000000"
+        )
+
+    @patch("watchdog_config_test.watchdog_argparse")
+    @patch("watchdog_config_test.get_series")
+    @patch("watchdog_config_test.on_ubuntucore")
+    @patch("watchdog_config_test.watchdog_service_check")
+    def test_main_check_service_ubuntucore_not_active(
+        self,
+        mock_watchdog_service_check,
+        mock_on_ubuntucore,
+        mock_get_series,
+        mock_watchdog_argparse,
+    ):
         # Mock arguments
         mock_args = MagicMock()
         mock_args.check_time = False
@@ -158,8 +355,111 @@ class TestWatchdogConfigTest(unittest.TestCase):
         mock_watchdog_service_check.return_value = False
 
         # Call the function under test
-        with patch('builtins.print') as mock_print:
+        with patch("builtins.print") as mock_print:
             main()
 
-        # Assert that the expected messages are printed
+        # Assert that the expected message is printed
         mock_print.assert_any_call("watchdog.service is not active")
+
+    @patch("watchdog_config_test.watchdog_argparse")
+    @patch("watchdog_config_test.get_series")
+    @patch("watchdog_config_test.on_ubuntucore")
+    @patch("watchdog_config_test.watchdog_service_check")
+    def test_main_check_service_ubuntucore_is_wdt_service_configured(
+        self,
+        mock_watchdog_service_check,
+        mock_on_ubuntucore,
+        mock_get_series,
+        mock_watchdog_argparse,
+    ):
+        # Mock arguments
+        mock_args = MagicMock()
+        mock_args.check_time = False
+        mock_args.check_service = True
+        mock_watchdog_argparse.return_value = mock_args
+
+        # Mock get_series
+        mock_get_series.return_value = "20.04"
+
+        # Mock on_ubuntucore
+        mock_on_ubuntucore.return_value = False
+
+        # Mock watchdog_service_check
+        mock_watchdog_service_check.return_value = True
+
+        # Call the function under test
+        with patch("builtins.print") as mock_print:
+            main()
+
+        # Assert that the expected message is printed
+        mock_print.assert_any_call(
+            "found unexpected active watchdog.service unit"
+        )
+
+    @patch("watchdog_config_test.watchdog_argparse")
+    @patch("watchdog_config_test.get_series")
+    @patch("watchdog_config_test.on_ubuntucore")
+    @patch("watchdog_config_test.watchdog_service_check")
+    def test_main_check_service_active(
+        self,
+        mock_watchdog_service_check,
+        mock_on_ubuntucore,
+        mock_get_series,
+        mock_watchdog_argparse,
+    ):
+        # Mock arguments
+        mock_args = MagicMock()
+        mock_args.check_time = False
+        mock_args.check_service = True
+        mock_watchdog_argparse.return_value = mock_args
+
+        # Mock get_series
+        mock_get_series.return_value = "18.04"
+
+        # Mock on_ubuntucore
+        mock_on_ubuntucore.return_value = False
+
+        # Mock watchdog_service_check
+        mock_watchdog_service_check.return_value = True
+
+        # Call the function under test
+        with patch("builtins.print") as mock_print:
+            main()
+
+        # Assert that the expected message is printed
+        mock_print.assert_any_call("watchdog.service is active")
+
+    @patch("watchdog_config_test.watchdog_argparse")
+    @patch("watchdog_config_test.get_series")
+    @patch("watchdog_config_test.on_ubuntucore")
+    @patch("watchdog_config_test.watchdog_service_check")
+    def test_main_check_service_is_wdt_service_configured(
+        self,
+        mock_watchdog_service_check,
+        mock_on_ubuntucore,
+        mock_get_series,
+        mock_watchdog_argparse,
+    ):
+        # Mock arguments
+        mock_args = MagicMock()
+        mock_args.check_time = False
+        mock_args.check_service = True
+        mock_watchdog_argparse.return_value = mock_args
+
+        # Mock get_series
+        mock_get_series.return_value = "18.04"
+
+        # Mock on_ubuntucore
+        mock_on_ubuntucore.return_value = False
+
+        # Mock watchdog_service_check
+        mock_watchdog_service_check.return_value = False
+
+        # Call the function under test
+        with patch("builtins.print") as mock_print:
+            main()
+
+        # Assert that the expected message is printed
+        mock_print.assert_any_call(
+            "watchdog.service unit does not report as active"
+        )

--- a/providers/base/tests/test_watchdog_config_test.py
+++ b/providers/base/tests/test_watchdog_config_test.py
@@ -1,0 +1,165 @@
+import unittest
+import argparse
+from unittest.mock import patch, Mock, MagicMock
+from watchdog_config_test import (
+    watchdog_argparse,
+    get_systemd_wdt_usec,
+    watchdog_service_check,
+    main,
+)
+
+
+class TestWatchdogConfigTest(unittest.TestCase):
+
+    @patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=argparse.Namespace(check_time=True, check_service=False),
+    )
+    def test_check_time_argument(self, mock_parse_args):
+        result = watchdog_argparse()
+        self.assertTrue(result.check_time)
+        self.assertFalse(result.check_service)
+
+    @patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=argparse.Namespace(check_time=False, check_service=True),
+    )
+    def test_check_service_argument(self, mock_parse_args):
+        result = watchdog_argparse()
+        self.assertFalse(result.check_time)
+        self.assertTrue(result.check_service)
+
+    @patch("watchdog_config_test.subprocess.check_output")
+    def test_get_systemd_wdt_usec_success(self, mock_check_output):
+        # Mock subprocess.check_output to return a mock result
+        mock_check_output.return_value = "RuntimeWatchdogUSec=1000000\n"
+
+        # Call the function under test
+        result = get_systemd_wdt_usec()
+
+        # Assert that subprocess.check_output was called
+        # with the correct arguments
+        mock_check_output.assert_called_once_with(
+            ["systemctl", "show", "-p", "RuntimeWatchdogUSec"],
+            universal_newlines=True,
+        )
+
+        # Assert that the correct value was returned
+        self.assertEqual(result, "1000000")
+
+    @patch("watchdog_config_test.subprocess.check_output")
+    def test_get_systemd_wdt_usec_exception(self, mock_check_output):
+        # Mock subprocess.check_output to raise an exception
+        mock_check_output.side_effect = Exception("Something went wrong")
+
+        # Call the function under test
+        with self.assertRaises(SystemExit):
+            get_systemd_wdt_usec()
+
+    @patch("watchdog_config_test.subprocess.check_output")
+    def test_get_systemd_wdt_usec_no_result(self, mock_check_output):
+        # Mock subprocess.check_output to return an empty result
+        mock_check_output.return_value = ""
+
+        # Call the function under test
+        with self.assertRaises(SystemExit):
+            get_systemd_wdt_usec()
+
+    @patch("watchdog_config_test.subprocess.run")
+    def test_watchdog_service_check_active(self, mock_subprocess_run):
+        # Mock subprocess.run to return a process with returncode 0 (active)
+        mock_process = Mock(returncode=0)
+        mock_subprocess_run.return_value = mock_process
+
+        # Call the function under test
+        result = watchdog_service_check()
+
+        # Assert that subprocess.run was called with the correct arguments
+        mock_subprocess_run.assert_called_once_with(
+            ["systemctl", "is-active", "watchdog.service", "--quiet"]
+        )
+
+        # Assert that the correct value was returned
+        self.assertTrue(result)
+
+    @patch("watchdog_config_test.subprocess.run")
+    def test_watchdog_service_check_inactive(self, mock_subprocess_run):
+        # Mock subprocess.run to return a process with returncode 1 (inactive)
+        mock_process = Mock(returncode=1)
+        mock_subprocess_run.return_value = mock_process
+
+        # Call the function under test
+        result = watchdog_service_check()
+
+        # Assert that subprocess.run was called with the correct arguments
+        mock_subprocess_run.assert_called_once_with(
+            ["systemctl", "is-active", "watchdog.service", "--quiet"]
+        )
+
+        # Assert that the correct value was returned
+        self.assertFalse(result)
+
+    @patch("watchdog_config_test.subprocess.run")
+    def test_watchdog_service_check_exception(self, mock_subprocess_run):
+        # Mock subprocess.run to raise an exception
+        mock_subprocess_run.side_effect = Exception("Something went wrong")
+
+        # Call the function under test
+        with self.assertRaises(SystemExit):
+            watchdog_service_check()
+
+    @patch('watchdog_config_test.watchdog_argparse')
+    @patch('watchdog_config_test.get_series')
+    @patch('watchdog_config_test.get_systemd_wdt_usec')
+    @patch('watchdog_config_test.on_ubuntucore')
+    @patch('watchdog_config_test.watchdog_service_check')
+    def test_main_check_time(self, mock_watchdog_service_check, mock_on_ubuntucore, mock_get_systemd_wdt_usec, mock_get_series, mock_watchdog_argparse):
+        # Mock arguments
+        mock_args = MagicMock()
+        mock_args.check_time = True
+        mock_args.check_service = False
+        mock_watchdog_argparse.return_value = mock_args
+
+        # Mock get_series
+        mock_get_series.return_value = "20.04"
+
+        # Mock on_ubuntucore
+        mock_on_ubuntucore.return_value = False
+
+        # Mock get_systemd_wdt_usec
+        mock_get_systemd_wdt_usec.return_value = "1000000"
+
+        # Call the function under test
+        with patch('builtins.print') as mock_print:
+            main()
+
+        # Assert that the expected messages are printed
+        mock_print.assert_any_call("systemd watchdog enabled, reset timeout: 1000000")
+
+    @patch('watchdog_config_test.watchdog_argparse')
+    @patch('watchdog_config_test.get_series')
+    @patch('watchdog_config_test.get_systemd_wdt_usec')
+    @patch('watchdog_config_test.on_ubuntucore')
+    @patch('watchdog_config_test.watchdog_service_check')
+    def test_main_check_service(self, mock_watchdog_service_check, mock_on_ubuntucore, mock_get_systemd_wdt_usec, mock_get_series, mock_watchdog_argparse):
+        # Mock arguments
+        mock_args = MagicMock()
+        mock_args.check_time = False
+        mock_args.check_service = True
+        mock_watchdog_argparse.return_value = mock_args
+
+        # Mock get_series
+        mock_get_series.return_value = "20.04"
+
+        # Mock on_ubuntucore
+        mock_on_ubuntucore.return_value = False
+
+        # Mock watchdog_service_check
+        mock_watchdog_service_check.return_value = False
+
+        # Call the function under test
+        with patch('builtins.print') as mock_print:
+            main()
+
+        # Assert that the expected messages are printed
+        mock_print.assert_any_call("watchdog.service is not active")

--- a/providers/base/units/watchdog/jobs.pxu
+++ b/providers/base/units/watchdog/jobs.pxu
@@ -41,18 +41,16 @@ requires:
     image_source_and_type.type == 'classic'
 environ: WATCHDOG_TYPE
 command:
-    if [[ ! -n "$WATCHDOG_TYPE" ]]; then
+    if [[ -z "$WATCHDOG_TYPE" ]]; then
         >&2 echo "WATCHDOG_TYPE is not available"
         exit 1
     fi
     echo "Trying to probe '$WATCHDOG_TYPE' module"
-    modprobe $WATCHDOG_TYPE
-    if [[ "$?" -ne 0 ]]; then
+    if ! modprobe "$WATCHDOG_TYPE"; then
         >&2 echo "Unable to probe the '$WATCHDOG_TYPE' module"
         exit 1
     fi
-    lsmod | grep -q -i $WATCHDOG_TYPE
-    if [[ "$?" -ne 0 ]]; then
+    if ! lsmod | grep -q -i "$WATCHDOG_TYPE"; then
         >&2 echo "Unable to find the '$WATCHDOG_TYPE' module after probing it"
         exit 1
     fi
@@ -113,7 +111,7 @@ command:
     search_pattern="#RuntimeWatchdogSec=[0-9]*s*"
     for i in {0..1}
     do
-        result=`grep $DEFAULT_WATCHDOG /etc/systemd/system.conf`
+        result=$(grep $DEFAULT_WATCHDOG /etc/systemd/system.conf)
         if [[ -n "$result" && $i -eq 0 ]]; then
             echo "Modifying the watchdog timeout"
             sed -i "s/$search_pattern/RuntimeWatchdogSec=35/g" /etc/systemd/system.conf
@@ -132,7 +130,7 @@ command:
             break
         fi
     done
-    exit $RET
+    exit "$RET"
 
 
 id: watchdog/revert-timeout
@@ -152,7 +150,7 @@ command:
     SET_WATCHDOG="RuntimeWatchdogSec=35"
     for i in {0..1}
     do
-        result=`grep $SET_WATCHDOG /etc/systemd/system.conf`
+        result=$(grep $SET_WATCHDOG /etc/systemd/system.conf)
         if [[ "$result" == "$SET_WATCHDOG" && $i -eq 0 ]]; then
             echo "Modifying the watchdog timeout"
             sed -i "s/$SET_WATCHDOG/#RuntimeWatchdogSec=0/g" /etc/systemd/system.conf
@@ -167,13 +165,13 @@ command:
                 fi
             fi
         else
-            timeout_value=`grep RuntimeWatchdogSec /etc/systemd/system.conf | awk -F '=' {'print $2'}`
+            timeout_value=$(grep RuntimeWatchdogSec /etc/systemd/system.conf | awk -F '=' '{print $2}')
             echo "The watchdog timeout is $timeout_value now, not the value we set in previouse job"
             echo "No need to revert watchdog timeout"
             break
         fi
     done
-    exit $RET
+    exit "$RET"
 
 
 id: watchdog/trigger-system-reset-auto

--- a/providers/base/units/watchdog/jobs.pxu
+++ b/providers/base/units/watchdog/jobs.pxu
@@ -1,43 +1,208 @@
+id: watchdog/check-timeout
+category_id: com.canonical.plainbox::power-management
+_summary: Check the timeout of Hardware Watchdog
+_description:
+    Check the value of RuntimeWatchdogUSec shouldn't be 0 in OEM image.
+    It means the systemd watchdog is disabled if the value is 0.
+flags: simple
+imports: from com.canonical.plainbox import manifest
+requires:
+    manifest.has_hardware_watchdog == 'True'
+    image_source_and_type.source == 'oem'
+command: watchdog_config_test.py --check_time
+
+
+id: watchdog/check-service
+category_id: com.canonical.plainbox::power-management
+_summary: Check the watchdog.service is enabled or not
+_description:
+    Check the watchdog.service is enabled or not.
+    Watchdog implementation on both classic and core image no longer rely
+    on watchdogd service since 20.04.
+flags: simple
+imports: from com.canonical.plainbox import manifest
+requires:
+    manifest.has_hardware_watchdog == 'True'
+command: watchdog_config_test.py --check_service
+
+
+id: watchdog/probe-module
+category_id: com.canonical.plainbox::power-management
+_summary: Probe the suitable module for watchdog
+_description:
+    Probe the suitable module of watchdog based on the environment variable 'WATCHDOG_TYPE' in config file.
+    This job only be execute on the Stock Classic image because the module isn't probed automatically.
+user: root
+flags: simple
+imports: from com.canonical.plainbox import manifest
+requires:
+    manifest.has_hardware_watchdog == 'True'
+    image_source_and_type.source == 'stock'
+    image_source_and_type.type == 'classic'
+environ: WATCHDOG_TYPE
+command:
+    if [[ ! -n "$WATCHDOG_TYPE" ]]; then
+        >&2 echo "WATCHDOG_TYPE is not available"
+        exit 1
+    fi
+    echo "Trying to probe '$WATCHDOG_TYPE' module"
+    modprobe $WATCHDOG_TYPE
+    if [[ "$?" -ne 0 ]]; then
+        >&2 echo "Unable to probe the '$WATCHDOG_TYPE' module"
+        exit 1
+    fi
+    lsmod | grep -q -i $WATCHDOG_TYPE
+    if [[ "$?" -ne 0 ]]; then
+        >&2 echo "Unable to find the '$WATCHDOG_TYPE' module after probing it"
+        exit 1
+    fi
+
+
 id: watchdog/detect
 category_id: com.canonical.plainbox::power-management
 _summary: Detect presence of a Hardware Watchdog
+_description:
+    Detect the watchdog is under the /sys/class/watchdog/ path and no other type of watchdog
 flags: simple
 imports: from com.canonical.plainbox import manifest
-requires: manifest.has_hardware_watchdog == 'True'
-command: udev_resource.py -f WATCHDOG
+requires:
+    manifest.has_hardware_watchdog == 'True'
+environ: WATCHDOG_TYPE WATCHDOG_IDENTITY
+command:
+    source=$(checkbox-support-image_checker -s| awk -F ": " '{print $2}')
+    if [[ $source == "oem" ]]; then
+        udev_resource.py -f WATCHDOG
+    elif [[ $source == "stock" ]]; then
+        if [ -z "$WATCHDOG_TYPE" ] || [ -z "$WATCHDOG_IDENTITY" ]; then
+            >&2 echo "Please define the WATCHDOG_TYPE and WATCHDOG_IDENTITY in advance"
+            exit 1
+        fi
+        WATCHDOGDS=$(find /sys/class/watchdog/watchdog*[0-9])
+        EXIT=$?
+        for w in $WATCHDOGDS; do
+            identity=$(cat "$w"/identity)
+            echo "Identity of $w: $identity"
+            if [[ "$identity" != "$WATCHDOG_IDENTITY" ]]; then
+                >&2 echo "Find an unmatched watchdog"
+                EXIT=1
+            fi
+        done
+        exit $EXIT
+    else
+        >&2 echo "Unrecognized image source: $source"
+        exit 1
+    fi
 
-id: watchdog/systemd-config
-_summary: Check if the hardware watchdog is properly configured
-template-engine: jinja2
-command: watchdog_config_test.py
+
+id: watchdog/set-timeout
 category_id: com.canonical.plainbox::power-management
+_summary: Configure the timeout for Hardware Watchdog
+_description:
+    Configure the value of RuntimeWatchdogSec
 flags: simple
 imports: from com.canonical.plainbox import manifest
-requires: manifest.has_hardware_watchdog == 'True'
+requires:
+    manifest.has_hardware_watchdog == 'True'
+    image_source_and_type.source == 'stock'
+depends:
+    watchdog/check-service
+    watchdog/detect
+user: root
+command:
+    DEFAULT_WATCHDOG="^#RuntimeWatchdogSec"
+    search_pattern="#RuntimeWatchdogSec=[0-9]*s*"
+    for i in {0..1}
+    do
+        result=`grep $DEFAULT_WATCHDOG /etc/systemd/system.conf`
+        if [[ -n "$result" && $i -eq 0 ]]; then
+            echo "Modifying the watchdog timeout"
+            sed -i "s/$search_pattern/RuntimeWatchdogSec=35/g" /etc/systemd/system.conf
+        elif [[ $i -eq 1 ]]; then
+            if [[ -n "$result" ]]; then
+                >&2 echo "Failed to set watchdog timeout"; RET=1
+            else
+                echo "Watchdog timeout has been configured, reloading configuration"
+                systemctl daemon-reexec; RET=$?
+                if [[ $RET -ne 0 ]]; then
+                    >&2 echo "Failed to reloading configuration"
+                fi
+            fi
+        else
+            echo "Watchdog timeout is already set"
+            break
+        fi
+    done
+    exit $RET
+
+
+id: watchdog/revert-timeout
+category_id: com.canonical.plainbox::power-management
+_summary: Restore the timeout for Hardware Watchdog
+_description:
+    Restore the value of RuntimeWatchdogSec
+flags: simple
+imports: from com.canonical.plainbox import manifest
+requires:
+    manifest.has_hardware_watchdog == 'True'
+    image_source_and_type.source == 'stock'
+depends:
+    watchdog/set-timeout
+user: root
+command:
+    SET_WATCHDOG="RuntimeWatchdogSec=35"
+    for i in {0..1}
+    do
+        result=`grep $SET_WATCHDOG /etc/systemd/system.conf`
+        if [[ "$result" == "$SET_WATCHDOG" && $i -eq 0 ]]; then
+            echo "Modifying the watchdog timeout"
+            sed -i "s/$SET_WATCHDOG/#RuntimeWatchdogSec=0/g" /etc/systemd/system.conf
+        elif [[ $i -eq 1 ]]; then
+            if [[ "$result" == "$SET_WATCHDOG" ]]; then
+                >&2 echo "Failed to revert watchdog timeout"; RET=1
+            else
+                echo "Watchdog timeout has been configured, reloading configuration"
+                systemctl daemon-reexec; RET=$?
+                if [[ $RET -ne 0 ]]; then
+                    >&2 echo "Failed to reloading configuration"
+                fi
+            fi
+        else
+            timeout_value=`grep RuntimeWatchdogSec /etc/systemd/system.conf | awk -F '=' {'print $2'}`
+            echo "The watchdog timeout is $timeout_value now, not the value we set in previouse job"
+            echo "No need to revert watchdog timeout"
+            break
+        fi
+    done
+    exit $RET
+
 
 id: watchdog/trigger-system-reset-auto
-depends: watchdog/systemd-config
-_summary: Test that the watchdog module can trigger a system reset
-command:
-  sync
-  sleep 5
-  echo 1 > /proc/sys/kernel/sysrq
-  echo 0 > /proc/sys/kernel/panic
-  echo c > /proc/sysrq-trigger
-flags: preserve-locale noreturn autorestart
-user: root
 plugin: shell
 category_id: com.canonical.plainbox::power-management
+_summary: Test that the watchdog module can trigger a system reset
+user: root
+flags: noreturn autorestart
 estimated_duration: 60
+depends:
+    watchdog/check-service
+    watchdog/detect
+command:
+    sync
+    sleep 5
+    echo 1 > /proc/sys/kernel/sysrq
+    echo 0 > /proc/sys/kernel/panic
+    echo c > /proc/sysrq-trigger
+
 
 id: watchdog/post-trigger-system-reset-auto
-after: watchdog/trigger-system-reset-auto
+plugin: shell
 category_id: com.canonical.plainbox::power-management
 _summary: Post watchdog reset service check
 _description: Check there are no failed services after the watchdog triggered
-unit: job
-plugin: shell
-command: failed_service_check.sh
 estimated_duration: 1.0
 imports: from com.canonical.plainbox import manifest
-requires: manifest.has_hardware_watchdog == 'True'
+requires:
+    manifest.has_hardware_watchdog == 'True'
+depends:
+    watchdog/trigger-system-reset-auto
+command: failed_service_check.sh

--- a/providers/base/units/watchdog/test-plan.pxu
+++ b/providers/base/units/watchdog/test-plan.pxu
@@ -1,7 +1,7 @@
 id: watchdog-full
 unit: test plan
 _name: Watchdog tests
-_description: Watchdog tests for Ubuntu Core devices
+_description: Watchdog tests
 include:
 nested_part:
     watchdog-manual
@@ -10,15 +10,21 @@ nested_part:
 id: watchdog-manual
 unit: test plan
 _name: Manual watchdog tests
-_description: Manual watchdog tests for Ubuntu Core devices
+_description: Manual watchdog tests
 include:
 
 id: watchdog-automated
 unit: test plan
 _name: Automated watchdog tests
-_description: Automated watchdog tests for Ubuntu Core devices
+_description: Automated watchdog tests
 include:
+    watchdog/check-timeout
+    watchdog/check-service
+    watchdog/probe-module
     watchdog/detect
-    watchdog/systemd-config
+    watchdog/set-timeout
     watchdog/trigger-system-reset-auto
     watchdog/post-trigger-system-reset-auto
+    watchdog/revert-timeout
+bootstrap_include:
+    image_source_and_type


### PR DESCRIPTION
## Description
After refactoring watchdog test cases, there are several benefits and flexibility.
1. Fit all classic and core, oem or stock image.
2. Automatically set watchdog timeout

The only prerequisite is to set up the environment variable before starting the test.
- WATCHDOG_TYPE=wdat_wdt
- WATCHDOG_IDENTITY=wdat_wdt

## Resolved issues
N/A

## Documentation
N/A

## Tests
 - When did not set environment variables first: https://certification.canonical.com/hardware/202311-32337/submission/362459/
 - After setting environment variables: https://certification.canonical.com/hardware/202311-32337/submission/362460/