### PR TITLE
Added udisks2 requirement (BugFix)

### DIFF
--- a/providers/base/units/usb/usb.pxu
+++ b/providers/base/units/usb/usb.pxu
@@ -54,7 +54,7 @@ id: usb/insert
 flags: also-after-suspend fail-on-resource
 template-engine: jinja2
 requires:
- package.name == 'udisks2'
+ package.name == 'udisks2' or snap.name == 'udisks2'
 _summary: USB 2.0 storage device insertion detected
 _purpose:
  Check system can detect USB 2.0 storage when inserted.


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

Following the second suggestion of #1029, I have add a requirement for the systems that are running the `usb/insert`, so the `udisks2` package has to be installed for the test to be executed.  

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/CHECKBOX-1279

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

There are no changes on the documentation.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

1. Prepare a DUT with image which does not have udisks2.
2. Install checkbox
```
 sudo snap install checkbox22 --beta
 sudo snap install checkbox --classic --beta
```
3. Run the test
```
 checkbox.checkbox-cli run com.canonical.certification::usb/insert
```

The test should fail with an error message:
```
==============[ Running job 2 / 2. Estimated time left: 0:02:00 ]===============
-----------------[ USB 2.0 storage device insertion detected ]------------------
ID: com.canonical.certification::usb/insert
Category: com.canonical.plainbox::usb
Job cannot be started because:
 - resource expression "package.name == 'udisks2'" evaluates to false
Outcome: job failed
package.name == 'udisks2'
False
```