### PR TITLE
Correct desktop 2404 suspend cycles plan (BugFix)

### DIFF
--- a/providers/certification-client/units/client-cert-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-24-04.pxu
@@ -172,6 +172,6 @@ nested_part:
     stress-ng-cert-automated
     stress-iperf3-automated
     #stress-cert-full
-    stress-suspend-30-cycles-with-reboots-automated
+    suspend-cycles-stress-test
     stress-warmboot-coldboot-automated
     stress-pm-graph

--- a/providers/certification-client/units/client-cert-odm-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-desktop-24-04.pxu
@@ -172,7 +172,7 @@ nested_part:
     stress-iperf3-automated
     warm-boot-stress-test
     cold-boot-stress-test
-    suspend-stress-test
+    suspend-cycles-stress-test
     stress-ng-cert-automated
     tpm-cert-automated
     info-attachment-cert-full


### PR DESCRIPTION
## Description
Correct the desktop 24.04 suspend cycles plan.
It should use the new suspend cycles test plan.


## Resolved issues



## Documentation



## Tests


