### PR TITLE
Retire hwclock (BugFix)

### DIFF
--- a/providers/base/units/power-management/jobs.pxu
+++ b/providers/base/units/power-management/jobs.pxu
@@ -176,10 +176,22 @@ id: power-management/rtc
 flags: also-after-suspend
 requires:
   rtc.state == 'supported'
-  executable.name == 'hwclock'
   cpuinfo.other != 'emulated by qemu'
 user: root
-command: hwclock -r
+environ: RTC_DEVICE_FILE
+command: 
+  if [[ -n "$RTC_DEVICE_FILE" ]]; then
+    rtc_path="/sys/class/rtc/${RTC_DEVICE_FILE/#\/dev\/}"
+  else
+    rtc_path="/sys/class/rtc/rtc0"
+  fi
+  if [[ -f "${rtc_path}/since_epoch" ]]; then
+    rtc_time=$(cat "${rtc_path}/since_epoch")
+    echo "RTC time: ${rtc_time} seconds since epoch."
+  else
+    echo "RTC time information not available."
+    exit 1
+  fi
 estimated_duration: 0.02
 _summary: Test that RTC functions properly (if present)
 _description:

--- a/providers/base/units/rtc/jobs.pxu
+++ b/providers/base/units/rtc/jobs.pxu
@@ -82,19 +82,18 @@ plugin: shell
 user: root
 category_id: rtc_category
 estimated_duration: 5
+environ:
 command: 
-    rtctime=$(date +"%s" -d "$( hwclock --rtc /dev/{rtc} -u)")
-    rtc_date=$(date -d "@$rtctime")
-    systime=$(date +"%s")
-    systime_date=$(date -d "@$systime")
-    result=$(("$systime" - "$rtctime"))
+    rtc_time=$(cat "/sys/class/rtc/{rtc}/since_epoch")
+    sys_time=$(date +"%s")
+    result=$(("$sys_time" - "$rtc_time"))
     if [[ "$result" -le "5" ]]; then
         echo "{rtc} Clock synchronized with System Clock"
-        echo "$rtc_date"
+        echo "RTC clock= $rtc_time"
     else
         echo "{rtc} Clock not synchronized with System Clock"
-        echo "System clock=" "$systime_date"
-        echo "RTC clock=" "$rtc_date"
+        echo "System clock= $sys_time"
+        echo "RTC clock= $rtc_time"
         exit 1
     fi
 flags: also-after-suspend


### PR DESCRIPTION
## Description
Retire hwclock which is used to get the hw_clock (rtc) time, and change to `cat` the `/sys/class/rtc/${rtc}/since_epoch` directly.

[hwclock is not found in a fresh installed ubuntu 23.10](https://bugs.launchpad.net/ubuntu-seeds/+bug/2037412)


## Resolved issues
#1098


## Documentation



## Tests

Test under deb version

### Slide load to run `power-management/rtc` job
```
===========================[ Running Selected Jobs ]============================                                                                                                                                                        
==============[ Running job 1 / 3. Estimated time left: 0:00:00 ]===============                                                                                                                                                        
---------------------[ Collect information about the CPU ]----------------------                                                                                                                                                        
ID: com.canonical.certification::cpuinfo                                                                                                                                                                                                
Category: com.canonical.certification::information_gathering                                                                                                                              
... 8< -------------------------------------------------------------------------                                                                                                          
bogomips: 4838                                                                                                                                                                            
cache: 8388608                                                                                                                                                                                                 
count: 8                                                                                                                                                                                                       
model: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz                                                                                                                                                          
model_number: 6                                                                                                                                                                                                
model_revision: 1                                                                                                                                                                                              
model_version: 140                                                                                                                                                                        
other: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc c
puid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault e
pb cat_l2 invpcid_single cdp_l2 ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb intel_
pt avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves split_lock_detect dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp hwp_pkg_req vnmi avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_
vnni avx512_bitalg avx512_vpopcntdq rdpid movdiri movdir64b fsrm avx512_vp2intersect md_clear ibt flush_l1d arch_capabilities
platform: x86_64                                                                                                                                                                          
speed: 4200                                                                                                         
type: GenuineIntel                                                                                     
governors: performance powersave                                                                                    
cpu_lpi_file: low_power_idle_cpu_residency_us                                                                       
sys_lpi_file: low_power_idle_system_residency_us                                                                    
scaling: supported                                        
------------------------------------------------------------------------- >8 ---                                    
Outcome: job passed                                       
==============[ Running job 2 / 3. Estimated time left: 0:00:00 ]===============                                    
-----------------------[ Creates resource info for RTC ]------------------------                                    
ID: com.canonical.certification::rtc                      
Category: com.canonical.certification::information_gathering                                                        
... 8< -------------------------------------------------------------------------                                    
state: supported                                          
------------------------------------------------------------------------- >8 ---                                    
Outcome: job passed                                       
==============[ Running job 3 / 3. Estimated time left: 0:00:00 ]===============                                    
---------------[ Test that RTC functions properly (if present) ]----------------                                    
ID: com.canonical.certification::power-management/rtc                                                               
Category: com.canonical.plainbox::power-management                                                                  
... 8< -------------------------------------------------------------------------                                    
RTC time: 1712042132 seconds since epoch.                 
------------------------------------------------------------------------- >8 ---                                    
Outcome: job passed                                       
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-04-02T07.15.28                            
==================================[ Results ]===================================                                    
 ☑ : Collect information about the CPU                    
 ☑ : Creates resource info for RTC                        
 ☑ : Test that RTC functions properly (if present)                             
```

### Slide load adn run `rtc-automated` test plan
`checkbox-cli run com.canonical.certification::rtc-automated`:
```
=========================[ Running Selected Test Plan ]=========================                                    
==============[ Running job 1 / 3. Estimated time left: 0:00:46 ]===============
--------------------[ Check the number of RTC as expected. ]--------------------                                    
ID: com.canonical.certification::rtc/rtc_number                                                                     
Category: com.canonical.certification::rtc_category                                                                 
... 8< -------------------------------------------------------------------------                                    
TOTAL_RTC_NUM not defined, defaulting to 1                                                                          
TOTAL_RTC_NUM: 1                                                                                                                                                                                                                        
Number of RTC devices found in sysfs: 1                                                                             
RTC number matched                                                                                                                                                                                                                      
------------------------------------------------------------------------- >8 ---
Outcome: job passed                                                                                                                                                                                                                     
==============[ Running job 2 / 3. Estimated time left: 0:00:45 ]===============        
---------------------[ Check that RTC alarm of rtc0 works ]---------------------
ID: com.canonical.certification::rtc/rtc_alarm_rtc0
Category: com.canonical.certification::rtc_category
... 8< -------------------------------------------------------------------------
rtcwake: assuming RTC uses UTC ...                                                                                  
Using UTC time.                                                                                                                                                                                                                         
        delta   = 0                                                                                                 
        tzone   = 0                                                                                                                                                                                                                     
        tzname  = UTC                                                                                               
        systime = 1712042953, (UTC) Tue Apr  2 07:29:13 2024                                        
        rtctime = 1712042953, (UTC) Tue Apr  2 07:29:13 2024                                   
alarm 0, sys_time 1712042953, rtc_time 1712042953, seconds 30                                     
rtcwake: wakeup using rtc0 at Tue Apr  2 07:29:44 2024                                                                                                                                                                                  
suspend mode: on; reading rtc                                                                                       
... rtc0: 1a0                                                                                                       
------------------------------------------------------------------------- >8 ---    
Outcome: job passed                                                                                                 
==============[ Running job 3 / 3. Estimated time left: 0:00:05 ]===============         
----------[ Check that rtc0 clock is synchronized with system clock ]-----------                
ID: com.canonical.certification::rtc/rtc_clock_rtc0                                                                 
Category: com.canonical.certification::rtc_category                                                                 
... 8< -------------------------------------------------------------------------               
rtc0 Clock synchronized with System Clock                                                                           
RTC clock= 1712042984                                                                                               
------------------------------------------------------------------------- >8 ---                                                                                                                                                        
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-04-02T07.29.09
==================================[ Results ]===================================
 ☑ : Check the number of RTC as expected.
 ☑ : Check that RTC alarm of rtc0 works
 ☑ : Check that rtc0 clock is synchronized with system clock
```