### PR TITLE
[checkbox-ce-oem] Fix jobs and testplans to pass validate (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/digital-io/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/digital-io/jobs.pxu
@@ -21,7 +21,7 @@ command:
 unit: template
 template-resource: ce-oem-digital-io/loopback_mapping_gpio
 template-unit: job
-template-summary: Loopback tests for the DO{DO}-DI{DI} pin control by GPIO
+_template-summary: Loopback tests for the DO{DO}-DI{DI} pin control by GPIO
 id: ce-oem-digital-io/loopback_gpio_DO{DO}-DI{DI}
 _summary: To test loopback between DO{DO} and DI{DI}
 plugin: shell
@@ -61,7 +61,7 @@ command:
 unit: template
 template-resource: ce-oem-digital-io/loopback_mapping_serial
 template-unit: job
-template-summary: Loopback tests for the DO{DO}-DI{DI} pin control by serial console
+_template-summary: Loopback tests for the DO{DO}-DI{DI} pin control by serial console
 id: ce-oem-digital-io/loopback_serial_DO{DO}-DI{DI}
 _summary: To test loopback between DO{DO} and DI{DI}
 _description:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/serial/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/serial/test-plan.pxu
@@ -33,7 +33,7 @@ bootstrap_include:
     ce-oem-serial/serial-console-list
 include:
     ce-oem-serial/serial-transmit-data-.*
-    ce-oem-serial/serial-console-.*
+    ce-oem-serial/serial-console-(?!list\b).*$
 
 id: after-suspend-ce-oem-serial-automated
 unit: test plan


### PR DESCRIPTION
## Description
Simple fix to pass validate

```
(venv) (base) vincent@vincent-XPS-9320:~/Desktop/git/checkbox/contrib/checkbox-ce-oem/checkbox-provider-ce-oem$ python3 manage.py validate
$PROVIDERPATH is defined, so following provider sources are ignored ['/usr/local/share/plainbox-providers-1', '/usr/share/plainbox-providers-1', '/home/vincent/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
WARNING plainbox.providers.v1: $PROVIDERPATH is defined, so following provider sources are ignored ['/usr/local/share/plainbox-providers-1', '/usr/share/plainbox-providers-1', '/home/vincent/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
WARNING plainbox.secure.providers.v1: Skipped file: /home/vincent/Desktop/git/checkbox/providers/base/units/stress/suspend_cycles_reboot.md
WARNING plainbox.providers.__init__: Using sideloaded provider: checkbox-provider-ce-oem, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-ce-oem
WARNING plainbox.secure.providers.v1: Skipped file: /home/vincent/Desktop/git/checkbox/providers/base/units/stress/suspend_cycles_reboot.md
advice: units/button/jobs.pxu:19-33: template 'ce-oem-button/detect-by-gpio-press-name', field 'template-summary', required field missing
advice: units/button/jobs.pxu:51-65: template 'ce-oem-button/detect-by-interrupts-press-name', field 'template-summary', required field missing
advice: units/buzzer/jobs.pxu:36-50: template 'ce-oem-gpio-buzzer/sound-test-name', field 'template-summary', required field missing
advice: units/buzzer/jobs.pxu:70-84: template 'ce-oem-pwm-buzzer/sound-test-name', field 'template-summary', required field missing
advice: units/cpu/jobs.pxu:20-35: template 'ce-oem-cpu/cpufreq-governor-performance-policypolicy', field 'template-summary', required field missing
advice: units/cpu/jobs.pxu:37-52: template 'ce-oem-cpu/cpufreq-governor-powersave-policypolicy', field 'template-summary', required field missing
advice: units/cpu/jobs.pxu:54-70: template 'ce-oem-cpu/cpufreq-governor-userspace-policypolicy', field 'template-summary', required field missing
advice: units/cpu/jobs.pxu:72-89: template 'ce-oem-cpu/cpufreq-governor-schedutil-policypolicy', field 'template-summary', required field missing
advice: units/cpu/jobs.pxu:91-108: template 'ce-oem-cpu/cpufreq-governor-ondemand-policypolicy', field 'template-summary', required field missing
advice: units/cpu/jobs.pxu:110-127: template 'ce-oem-cpu/cpufreq-governor-conservative-policypolicy', field 'template-summary', required field missing
advice: units/ethernet/jobs.pxu:1-22: template 'ce-oem-ethernet/tcp-echo-stress-interface', field 'template-summary', required field missing
advice: units/iio-sensors/jobs.pxu:15-31: template 'ce-oem-iio-sensors/check_sensor_type_index', field 'template-summary', required field missing
advice: units/mtd/jobs.pxu:22-38: template 'ce-oem-mtd/read-write-test-MTD_NAME', field 'template-summary', required field missing
advice: units/optee/jobs.pxu:98-112: template 'ce-oem-optee/xtest-suite-description', field 'template-summary', required field missing
advice: units/optee/jobs.pxu:114-128: template 'ce-oem-optee/xtest-pkcs11-description', field 'template-summary', required field missing
advice: units/otg/jobs.pxu:19-59: template 'ce-oem-otg/g_serial-USB_port', field 'template-summary', required field missing
advice: units/otg/jobs.pxu:61-93: template 'ce-oem-otg/g_mass_storage-USB_port', field 'template-summary', required field missing
advice: units/otg/jobs.pxu:95-129: template 'ce-oem-otg/g_ether-USB_port', field 'template-summary', required field missing
advice: units/ptp/jobs.pxu:33-63: template 'ce-oem-ptp/verify-PTP-support-for-eth-interface', field 'template-summary', required field missing
advice: units/ptp/jobs.pxu:65-108: template 'ce-oem-ptp/ptp4l-time-sync-for-eth-interface-auto', field 'template-summary', required field missing
advice: units/ptp/jobs.pxu:110-134: template 'ce-oem-ptp/ptp4l-time-sync-for-eth-interface-manual', field 'template-summary', required field missing
advice: units/socketcan/jobs.pxu:1-20: template 'ce-oem-socketcan/stress_fd_remote_interface', field 'template-summary', required field missing
advice: units/socketcan/jobs.pxu:22-40: template 'ce-oem-socketcan/stress_remote_interface', field 'template-summary', required field missing
advice: units/socketcan/jobs.pxu:42-58: template 'ce-oem-socketcan/bus_off_recovery_interface', field 'template-summary', required field missing
advice: units/stress/boot.pxu:59-87: template 'ce-oem-cold-boot-loop-by-pdu-rebootreboot_id', field 'template-summary', required field missing
advice: units/stress/boot.pxu:90-105: template 'ce-oem-post-cold-boot-loop-by-pdu-rebootreboot_id', field 'template-summary', required field missing
advice: units/strict-confinement/thermal-strict-confinement.pxu:1-20: template 'strict-confine/temperature-test', field 'template-summary', required field missing
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-server-22-04-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-caam-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-caam-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-iio-sensors-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-server-22-04-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-server-20-04-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-server-20-04-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-server-22-04-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-server-20-04-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-server-22-04-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-server-20-04-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-server-22-04-stress
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-server-20-04-stress
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-ubuntucore-22-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-ubuntucore-22-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-iot-ubuntucore-20-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-ubuntucore-20-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-ubuntucore-22-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-ubuntucore-20-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-ubuntucore-22-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-ubuntucore-20-automated
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-ubuntucore-22-stress
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.certification::client-cert-iot-ubuntucore-20-stress
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::ce-oem-caam-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-caam-manual
WARNING plainbox.unit.testplan: unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-iio-sensors-manual
advice: units/thermal-sensor/jobs.pxu:9-21: template 'ce-oem-thermal/temperature_name_type', field 'template-summary', required field missing
advice: units/touchscreen/jobs.pxu:1-18: template 'ce-oem-touchscreen/evdev/single-touch-tap-product_slug', field 'template-summary', required field missing
advice: units/touchscreen/jobs.pxu:20-44: template 'ce-oem-touchscreen/evdev/maximum-touch-tap-product_slug', field 'template-summary', required field missing
The provider seems to be valid
```

## Resolved issues
N/A
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests
N/A
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

