### PR TITLE
Limit the platform to perform the sleepgraph test (BugFix)

### DIFF
--- a/providers/base/units/stress/jobs.pxu
+++ b/providers/base/units/stress/jobs.pxu
@@ -607,51 +607,67 @@ plugin:shell
 category_id: com.canonical.plainbox::stress
 id: stress/s2idle_pm-graph_30
 estimated_duration: 10m
-requires: 
+requires:
+ cpuinfo.type == 'GenuineIntel'
  executable.name == 'sleepgraph'
  sleep.mem_sleep == 's2idle'
 user: root
 _summary: Resume from idle by using Intel pm-graph
 command:
- sleepgraph -m freeze -rtcwake 10 -sync -gzip -multi 30 0 -skiphtml -o "$PLAINBOX_SESSION_SHARE"/s2idle_pm-graph/s2idle-"$(date -d today +%Y-%m-%d-%H%M)"
+ if [ ! -f /proc/driver/nvidia/suspend ]; then
+     sleepgraph -m freeze -rtcwake 60 -sync -gzip -multi 30 30 -skiphtml -o "$PLAINBOX_SESSION_SHARE"/s2idle_pm-graph/s2idle-"$(date -d today +%Y-%m-%d-%H%M)"
+ else
+     echo "The platform has Nvidia driver loaded, which is not capable of running sleepgraph. Exiting..."
+ fi
 
 plugin: attachment
 category_id: com.canonical.plainbox::stress
 id: stress/s2idle_pm-graph_30.tar.xz
 estimated_duration: 1
-requires: 
+requires:
+ cpuinfo.type == 'GenuineIntel'
  sleep.mem_sleep == 's2idle'
 after:
  stress/s2idle_pm-graph_30
 user: root
 _summary: Attach pm-graph logs (s2idle)
 command:
- tar Jcf "$PLAINBOX_SESSION_SHARE"/s2idle_pm-graph_30.tar.xz "$PLAINBOX_SESSION_SHARE"/s2idle_pm-graph && cat "$PLAINBOX_SESSION_SHARE"/s2idle_pm-graph_30.tar.xz
+ if [ -d "$PLAINBOX_SESSION_SHARE"/s2idle_pm-graph ]; then
+     tar Jcf "$PLAINBOX_SESSION_SHARE"/s2idle_pm-graph_30.tar.xz "$PLAINBOX_SESSION_SHARE"/s2idle_pm-graph && cat "$PLAINBOX_SESSION_SHARE"/s2idle_pm-graph_30.tar.xz
+ fi
 
 plugin:shell
 category_id: com.canonical.plainbox::stress
 id: stress/s3_pm-graph_30
 estimated_duration: 10m
 requires:
+ cpuinfo.type == 'GenuineIntel'
  executable.name == 'sleepgraph'
  sleep.mem_sleep == 'deep'
 user: root
 _summary: Resume from suspend by using Intel pm-graph
 command:
- sleepgraph -m mem -rtcwake 10 -sync -gzip -multi 30 0 -skiphtml -o "$PLAINBOX_SESSION_SHARE"/s3_pm-graph/suspend-"$(date -d today +%Y-%m-%d-%H%M)"
+ if [ ! -f /proc/driver/nvidia/suspend ]; then
+     sleepgraph -m mem -rtcwake 60 -sync -gzip -multi 30 30 -skiphtml -o "$PLAINBOX_SESSION_SHARE"/s3_pm-graph/suspend-"$(date -d today +%Y-%m-%d-%H%M)"
+ else
+     echo "The platform has Nvidia driver loaded, which is not capable of running sleepgraph. Exiting..."
+ fi
 
 plugin: attachment
 category_id: com.canonical.plainbox::stress
 id: stress/s3_pm-graph_30.tar.xz
 estimated_duration: 1
 requires:
+ cpuinfo.type == 'GenuineIntel'
  sleep.mem_sleep == 'deep'
 after:
  stress/s3_pm-graph_30
 user: root
 _summary: Attach pm-graph logs (s3)
 command:
- tar Jcf "$PLAINBOX_SESSION_SHARE"/s3_pm-graph_30.tar.xz "$PLAINBOX_SESSION_SHARE"/s3_pm-graph && cat "$PLAINBOX_SESSION_SHARE"/s3_pm-graph_30.tar.xz
+ if [ -d "$PLAINBOX_SESSION_SHARE"/s3_pm-graph ]; then
+     tar Jcf "$PLAINBOX_SESSION_SHARE"/s3_pm-graph_30.tar.xz "$PLAINBOX_SESSION_SHARE"/s3_pm-graph && cat "$PLAINBOX_SESSION_SHARE"/s3_pm-graph_30.tar.xz
+ fi
 
 unit: job
 id: stress/wireless_bluetooth_coex_connect_stress


### PR DESCRIPTION
Limit the platform to perform the sleepgraph test (BugFix) (#1054)

* Filter cpuinfo to GenuineIntel only

* Align the sleep delay time with Windows, https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/modern-standby-stress-and-long-duration-validation#test-operation

## Description

- sleepgraph trigger suspend by utilizing sysfs node without notifying systemd (an [upstream bug has been opened for this](https://github.com/intel/pm-graph/issues/28))
- However, Nvidia uses a userspace daemon that relies on systemd status, so triggering suspend using sysfs directly may lead to issues on devices with Nvidia graphics cards
- Align the sleep delay with Windows

## Resolved issues

https://github.com/canonical/checkbox/issues/1054

## Documentation

https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/modern-standby-stress-and-long-duration-validation#test-operation

## Tests

Verify the test by running the plan

$ checkbox-cli run com.canonical.certification::stress-pm-graph