### PR TITLE
Fix config loading local when resumable session available (Bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -253,10 +253,10 @@ class Launcher(MainLoopStage, ReportsStage):
             # replace the previously built SA with the defaults
             self._configure_restart(ctx)
             self._prepare_transports()
-            ctx.sa.use_alternate_configuration(self.configuration)
             self.resume_candidates = list(ctx.sa.get_resumable_sessions())
             if not self._auto_resume_session(self.resume_candidates):
                 something_got_chosen = False
+                ctx.sa.use_alternate_configuration(self.configuration)
                 while not something_got_chosen:
                     try:
                         self._start_new_session()

--- a/metabox/metabox/scenarios/config/resume.py
+++ b/metabox/metabox/scenarios/config/resume.py
@@ -81,7 +81,7 @@ class ConfigLoadedAlsoWhenResumableSessionAvailable(Scenario):
         launcher_version = 1
         stock_reports = text
         [test plan]
-        unit = 2021.com.canonical.certification::config-automated
+        unit = 2021.com.canonical.certification::config-slow-automated
         forced = yes
         [test selection]
         forced = yes


### PR DESCRIPTION
## Description

When Checkbox has a manually resumable session or an incompatible automatically resumable session on the machine, it is unable to use any configuration. This is because any loaded configuration is "used" by the session assistant created when Checkbox is launched that is then discarded when probing to see if a session is automatically resumable. This fixes the issue by postponing the `use_alternate_configuration` call.

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/1115
Relates to: https://github.com/canonical/checkbox/pull/1119
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

N/A

## Tests

This adds a new metabox scenario that fails in main and passes after the patch.
