### PR TITLE
Correct the alsa_info user (BugFix)

### DIFF
--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -490,6 +490,7 @@ category_id: com.canonical.plainbox::audio
 id: audio/alsa_info_collect
 estimated_duration: 2.0
 command: alsa_info --no-dialog --no-upload --output "${PLAINBOX_SESSION_SHARE}"/alsa_info.log
+user: root
 _purpose:
  Collect audio-related system information. This data can be used to
  simulate this computer's audio subsystem and perform more detailed tests


### PR DESCRIPTION
## Description
Change the `alsa_info` user to root.

**Before change:**
```
===========================[ Running Selected Jobs ]============================
==============[ Running job 1 / 1. Estimated time left: 0:00:02 ]===============
[ Collect audio-related system information for simulation and detailed testing. ]
ID: com.canonical.certification::audio/alsa_info_collect
Category: com.canonical.plainbox::audio
... 8< -------------------------------------------------------------------------
dmesg: read kernel buffer failed: Operation not permitted


Your ALSA information is in /var/tmp/checkbox-ng/sessions/checkbox-run-2024-04-03T06.15.33.session/session-share/alsa_info.log

------------------------------------------------------------------------- >8 ---
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-04-03T06.15.33
==================================[ Results ]===================================
 ☑ : Collect audio-related system information for simulation and detailed testing.

```
It will show the `dmesg: read kernel buffer failed: Operation not permitted`.
We should use the root user to get the dmesg which `alsa_info` will do.

**After change:**
Slide load
```
===========================[ Running Selected Jobs ]============================
==============[ Running job 1 / 1. Estimated time left: 0:00:02 ]===============
[ Collect audio-related system information for simulation and detailed testing. ]
ID: com.canonical.certification::audio/alsa_info_collect
Category: com.canonical.plainbox::audio
... 8< -------------------------------------------------------------------------


Your ALSA information is in /var/tmp/checkbox-ng/sessions/checkbox-run-2024-04-03T06.17.54.session/session-share/alsa_info.log

------------------------------------------------------------------------- >8 ---
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-04-03T06.17.54
==================================[ Results ]===================================
 ☑ : Collect audio-related system information for simulation and detailed testing.

```


## Resolved issues


## Documentation



## Tests


