### PR TITLE
[checkbox-ce-oem] Create checkbox-ce-oem edge build workflow (Infra)

### DIFF
--- a/.github/workflows/checkbox-ce-oem-edge-builds.yml
+++ b/.github/workflows/checkbox-ce-oem-edge-builds.yml
@@ -1,0 +1,86 @@
+name: checkbox-ce-oem snap edge build
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'contrib/checkbox-ce-oem**'
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  snap:
+    strategy:
+      fail-fast: false
+      matrix:
+        type: [classic, uc]
+        releases: [20, 22]
+    runs-on: [self-hosted, linux, large]
+    timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
+    env:
+      SERIES: series_${{ matrix.type }}${{ matrix.releases }}
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
+      # snapcraft remote-build will create a repository with the name decided by the --build-id arg
+      # URL to this repo echoed below to help debug builds (does not change if the workflow is re-run)
+      # as the run_id will not change
+      SNAPCRAFT_BUILDER_ID: checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ github.run_id }}
+    name: Frontend ${{ matrix.type }}${{ matrix.releases }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Add LP credentials
+        run: |
+          mkdir -p ~/.local/share/snapcraft/provider/launchpad/
+          echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
+          git config --global user.email "robot@lists.canonical.com"
+          git config --global user.name "Certification bot"
+      - name: Print Launchpad build repository
+        run: |
+          echo "Building at: https://git.launchpad.net/~ce-certification-qa/+snap/$SNAPCRAFT_BUILDER_ID"
+      - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+        name: Building the snaps
+        timeout-minutes: 600 # 10hours
+        with:
+          action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
+          attempt_delay: 600000 # 10min
+          attempt_limit: 5
+          with: |
+            path: contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_${{ matrix.type }}${{ matrix.releases }}
+            snapcraft-channel: 7.x/stable
+            snapcraft-args: remote-build --build-for amd64,arm64,armhf --launchpad-accept-public-upload --build-id $SNAPCRAFT_BUILDER_ID
+      - uses: actions/upload-artifact@v3
+        name: Upload logs on failure
+        if: failure()
+        with:
+          name: snapcraft-log-series-${{ matrix.type }}${{ matrix.releases }}
+          path: |
+            /home/runner/.cache/snapcraft/log/
+            /home/runner/.local/state/snapcraft/log/
+            contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_${{ matrix.type }}${{ matrix.releases }}/checkbox*.txt
+      - uses: actions/upload-artifact@v3
+        name: Upload the snaps as artefacts
+        with:
+          name: series_${{ matrix.type }}${{ matrix.releases }}
+          path: contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
+      - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+        name: Upload the snaps to the store
+        timeout-minutes: 600 # 10hours
+        with:
+          attempt_delay: 600000 # 10min
+          attempt_limit: 10
+          command: |
+            for snap in contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap ; \
+            do \
+              echo "Uploading $snap..." ; \
+              if [ ${{ matrix.type }} = 'classic' ]; then \
+                snapcraft upload $snap --release ${{ matrix.releases }}.04/edge ; \
+              else \
+                if [ ${{ matrix.releases }} = '22' ]; then \
+                  snapcraft upload $snap --release latest/edge ; \
+                else \
+                  snapcraft upload $snap --release focal/edge ; \
+                fi \
+              fi ; \
+            done


### PR DESCRIPTION
## Description
Create github workflow for checkbox-ce-oem to build and publish to edge channel.

I have tried to build it successfully and have published to edge channel.

```
(base) vincent@vincent-XPS-9320:~$ snap info checkbox-ce-oem
name:      checkbox-ce-oem
summary:   Collection of tests to be run on both IoT and PC devices
publisher: Canonical Certification Team (ce-certification-qa)
store-url: https://snapcraft.io/checkbox-ce-oem
license:   unset
description: |
  Checkbox tests built from checkbox-provider-ce-oem in contrib area of
  checkbox monorepo
commands:
  - checkbox-ce-oem.checkbox-cli
  - checkbox-ce-oem.configure
  - checkbox-ce-oem.shell
  - checkbox-ce-oem.test-runner
services:
  checkbox-ce-oem.remote-slave: simple, enabled, inactive
snap-id:      aewWvpVAqcqwgdxK6vObwWWoDwBJF2or
tracking:     latest/edge
refresh-date: 3 days ago, at 15:43 CST
channels:
  latest/stable:    0.12-jammy 2024-03-25 (146) 16MB -
  latest/candidate: ↑                                
  latest/beta:      0.12-jammy 2024-03-25 (146) 16MB -
  latest/edge:      1.0-jammy  2024-04-04 (169) 16MB -
  focal/stable:     0.12-focal 2024-03-25 (144) 18MB -
  focal/candidate:  ↑                                
  focal/beta:       0.12-focal 2024-03-25 (144) 18MB -
  focal/edge:       1.0-focal  2024-04-04 (170) 18MB -
  22.04/stable:     0.12-jammy 2024-03-25 (143) 16MB classic
  22.04/candidate:  ↑                                
  22.04/beta:       0.12-jammy 2024-03-25 (143) 16MB classic
  22.04/edge:       1.0-jammy  2024-04-04 (178) 16MB classic
  20.04/stable:     0.12-focal 2024-03-25 (142) 18MB classic
  20.04/candidate:  ↑                                
  20.04/beta:       0.12-focal 2024-03-25 (142) 18MB classic
  20.04/edge:       1.0-focal  2024-04-04 (175) 18MB classic
installed:          1.0-jammy             (169) 16MB -
```
## Resolved issues
N/A

## Documentation
N/A

## Tests
N/A

