### PR TITLE
exclude debsmum test from the SRU testplan. (BugFix)

### DIFF
--- a/providers/sru/units/sru.pxu
+++ b/providers/sru/units/sru.pxu
@@ -90,6 +90,7 @@ exclude:
     audio/valid-sof-firmware-sig
     miscellanea/check_prerelease
     suspend/bluetooth_obex_.*
+    miscellanea/debsums
 
 id: sru
 _name: All SRU Tests (Ubuntu Desktop)
@@ -148,3 +149,4 @@ exclude:
     audio/valid-sof-firmware-sig
     miscellanea/check_prerelease
     suspend/bluetooth_obex_.*
+    miscellanea/debsums


### PR DESCRIPTION
## Description

Current debsums test is noisy and it can't reflect anything regarding the modification of image.
So we decided to exclude it from the SRU test plan.

## Resolved issues

https://warthogs.atlassian.net/browse/CHECKBOX-1285


