### PR TITLE
Remove many warnings (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/exporter/jinja2.py
+++ b/checkbox-ng/plainbox/impl/exporter/jinja2.py
@@ -78,7 +78,7 @@ def json_load_ordered_dict(text):
 
 def highlight_keys(text):
     """A filter for rendering keys as bold html text."""
-    return re.sub('(\w+:\s)', r'<b>\1</b>', text)
+    return re.sub(r'(\w+:\s)', r'<b>\1</b>', text)
 
 
 class Jinja2SessionStateExporter(SessionStateExporterBase):

--- a/checkbox-ng/plainbox/impl/exporter/xlsx.py
+++ b/checkbox-ng/plainbox/impl/exporter/xlsx.py
@@ -239,30 +239,30 @@ class XLSXSessionStateExporter(SessionStateExporterBase):
         if resource in data['attachment_map']:
             lspci = data['attachment_map'][resource]
             content = standard_b64decode(lspci.encode()).decode("UTF-8")
-            match = re.search('ISA bridge.*?:\s(?P<chipset>.*?)\sLPC', content)
+            match = re.search(r'ISA bridge.*?:\s(?P<chipset>.*?)\sLPC', content)
             if match:
                 hw_info['chipset'] = match.group('chipset')
             match = re.search(
-                'Audio device.*?:\s(?P<audio>.*?)\s\[\w+:\w+]', content)
+                r'Audio device.*?:\s(?P<audio>.*?)\s\[\w+:\w+]', content)
             if match:
                 hw_info['audio'] = match.group('audio')
             match = re.search(
-                'Ethernet controller.*?:\s(?P<nic>.*?)\s\[\w+:\w+]', content)
+                r'Ethernet controller.*?:\s(?P<nic>.*?)\s\[\w+:\w+]', content)
             if match:
                 hw_info['nic'] = match.group('nic')
             match = re.search(
-                'Network controller.*?:\s(?P<wireless>.*?)\s\[\w+:\w+]',
+                r'Network controller.*?:\s(?P<wireless>.*?)\s\[\w+:\w+]',
                 content)
             if match:
                 hw_info['wireless'] = match.group('wireless')
             for i, match in enumerate(re.finditer(
-                'VGA compatible controller.*?:\s(?P<video>.*?)\s\[\w+:\w+]',
+                r'VGA compatible controller.*?:\s(?P<video>.*?)\s\[\w+:\w+]',
                 content), start=1
             ):
                 hw_info['video{}'.format(i)] = match.group('video')
             vram = 0
             for match in re.finditer(
-                    'Memory.+ prefetchable\) \[size=(?P<vram>\d+)M\]',
+                    r'Memory.+ prefetchable\) \[size=(?P<vram>\d+)M\]',
                     content):
                 vram += int(match.group('vram'))
             if vram:

--- a/checkbox-ng/plainbox/impl/result.py
+++ b/checkbox-ng/plainbox/impl/result.py
@@ -57,13 +57,13 @@ logger = logging.getLogger("plainbox.result")
 # NOTE: we don't want to match certain control characters (newlines, carriage
 # returns, tabs or vertical tabs).
 CONTROL_CODE_RE_STR = re.compile(
-    "(?![\n\r\t\v])[\u0000-\u001F]|[\u007F-\u009F]")
+    r"(?![\n\r\t\v])[\u0000-\u001F]|[\u007F-\u009F]")
 
 # Regular expression that matches ANSI Escape Sequences (e.g. arrow keys)
 # For more info, see <http://stackoverflow.com/a/33925425>
 #
 # We use this to sanitize comments entered during testing
-ANSI_ESCAPE_SEQ_RE_STR = re.compile("(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]")
+ANSI_ESCAPE_SEQ_RE_STR = re.compile(r"(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]")
 
 # Tuple representing entries in the JobResult.io_log
 # Each entry has three fields:
@@ -353,7 +353,7 @@ class _JobResultBase(IJobResult):
     def comments(self):
         """
         Get the comments of the test operator.
-        
+
         The comments are sanitized to remove control characters that would
         cause problems when parsing the submission file.
         """

--- a/checkbox-ng/plainbox/impl/secure/providers/v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/v1.py
@@ -597,7 +597,7 @@ class ProviderContentLoader:
             or (self.provider.data_dir and filename.startswith(self.provider.data_dir))
             or (self.provider.bin_dir and filename.startswith(self.provider.bin_dir))
             or (self.provider.locale_dir and filename.startswith(self.provider.locale_dir))):
-            logger.warn("Skipped file: %s", filename)
+            logger.warning("Skipped file: %s", filename)
 
     def _load_file(self, filename, text, plugin_kwargs):
         # NOTE: text is lazy, call str() or iter() to see the real content This
@@ -1116,7 +1116,7 @@ class IQNValidator(PatternValidator):
 
     def __init__(self):
         super(IQNValidator, self).__init__(
-            "^([0-9]{4}\.)?[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+:[a-z][a-z0-9-]*$")
+            r"^([0-9]{4}\.)?[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+:[a-z][a-z0-9-]*$")
 
     def __call__(self, variable, new_value):
         if super(IQNValidator, self).__call__(variable, new_value):
@@ -1136,11 +1136,11 @@ class ProviderNameValidator(PatternValidator):
     """
 
     _PATTERN = (
-        "^"
-        "(([0-9]{4}\.)?[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+:[a-z][a-z0-9-]*)"
-        "|"
-        "([a-z0-9-]+)"
-        "$"
+        r"^"
+        r"(([0-9]{4}\.)?[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+:[a-z][a-z0-9-]*)"
+        r"|"
+        r"([a-z0-9-]+)"
+        r"$"
     )
 
     def __init__(self):
@@ -1160,34 +1160,34 @@ class VersionValidator(PatternValidator):
     """
 
     _PATTERN = (
-        "v?"
-        "(?:"
-        "(?:(?P<epoch>[0-9]+)!)?"                           # epoch
-        "(?P<release>[0-9]+(?:\.[0-9]+)*)"                  # release segment
-        "(?P<pre>"                                          # pre-release
-        "[-_\.]?"
-        "(?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))"
-        "[-_\.]?"
-        "(?P<pre_n>[0-9]+)?"
-        ")?"
-        "(?P<post>"                                         # post release
-        "(?:-(?P<post_n1>[0-9]+))"
-        "|"
-        "(?:"
-        "[-_\.]?"
-        "(?P<post_l>post|rev|r)"
-        "[-_\.]?"
-        "(?P<post_n2>[0-9]+)?"
-        ")"
-        ")?"
-        "(?P<dev>"                                          # dev release
-        "[-_\.]?"
-        "(?P<dev_l>dev)"
-        "[-_\.]?"
-        "(?P<dev_n>[0-9]+)?"
-        ")?"
-        ")"
-        "(?:\+(?P<local>[a-z0-9]+(?:[-_\.][a-z0-9]+)*))?"   # local version
+        r"v?"
+        r"(?:"
+        r"(?:(?P<epoch>[0-9]+)!)?"                           # epoch
+        r"(?P<release>[0-9]+(?:\.[0-9]+)*)"                  # release segment
+        r"(?P<pre>"                                          # pre-release
+        r"[-_\.]?"
+        r"(?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))"
+        r"[-_\.]?"
+        r"(?P<pre_n>[0-9]+)?"
+        r")?"
+        r"(?P<post>"                                         # post release
+        r"(?:-(?P<post_n1>[0-9]+))"
+        r"|"
+        r"(?:"
+        r"[-_\.]?"
+        r"(?P<post_l>post|rev|r)"
+        r"[-_\.]?"
+        r"(?P<post_n2>[0-9]+)?"
+        r")"
+        r")?"
+        r"(?P<dev>"                                          # dev release
+        r"[-_\.]?"
+        r"(?P<dev_l>dev)"
+        r"[-_\.]?"
+        r"(?P<dev_n>[0-9]+)?"
+        r")?"
+        r")"
+        r"(?:\+(?P<local>[a-z0-9]+(?:[-_\.][a-z0-9]+)*))?"   # local version
     )
 
     def __init__(self):

--- a/checkbox-ng/plainbox/impl/secure/qualifiers.py
+++ b/checkbox-ng/plainbox/impl/secure/qualifiers.py
@@ -155,7 +155,7 @@ class RegExpJobQualifier(SimpleQualifier):
             # XXX: This is a bit crazy but this lets us have identical error
             # messages across python3.2 all the way to 3.5. I really really
             # wish there was a better way at fixing this.
-            exc.args = (re.sub(" at position \d+", "", exc.args[0]), )
+            exc.args = (re.sub(r" at position \d+", "", exc.args[0]), )
             raise exc
         self._pattern_text = pattern
 

--- a/checkbox-ng/plainbox/impl/secure/rfc822.py
+++ b/checkbox-ng/plainbox/impl/secure/rfc822.py
@@ -46,7 +46,7 @@ def normalize_rfc822_value(value):
     # values, so let's run those operations only on multi-line values
     if value.count('\n') > 1:
         # Remove the multi-line dot marker
-        value = re.sub('^(\s*)\.$', '\\1', value, flags=re.M)
+        value = re.sub(r'^(\s*)\.$', '\\1', value, flags=re.M)
         # Remove consistent indentation
         value = textwrap.dedent(value)
     # Strip the remaining whitespace

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -352,7 +352,7 @@ class SessionAssistant:
 
         :param ctrl_setup_list:
             An iterable with tuples, where each tuple represents a class of
-            controller to instantiate, together with \*args and \*\*kwargs to
+            controller to instantiate, together with *args and **kwargs to
             use when calling its __init__.
         :raises UnexpectedMethodCall:
             If the call is made at an unexpected time. Do not catch this error.

--- a/checkbox-ng/plainbox/impl/session/resume.py
+++ b/checkbox-ng/plainbox/impl/session/resume.py
@@ -999,7 +999,7 @@ class SessionResumeHelper1(MetaDataHelper1MixIn):
     @classmethod
     def _rewrite_pathname(cls, pathname, location):
         return re.sub(
-            '.*\/\.cache\/plainbox\/sessions/[^//]+', location, pathname)
+            r'.*\/\.cache\/plainbox\/sessions/[^//]+', location, pathname)
 
     @classmethod
     def _build_IOLogRecord(cls, record_repr):

--- a/checkbox-ng/plainbox/impl/unit/exporter.py
+++ b/checkbox-ng/plainbox/impl/unit/exporter.py
@@ -131,7 +131,7 @@ class ExporterUnit(UnitWithId):
                 concrete_validators.present,
                 concrete_validators.untranslatable,
                 CorrectFieldValueValidator(
-                    lambda extension: re.search("^[\w\.\-]+$", extension),
+                    lambda extension: re.search(r"^[\w\.\-]+$", extension),
                     Problem.syntax_error, Severity.error),
             ],
             fields.options: [

--- a/checkbox-ng/plainbox/impl/unit/job.py
+++ b/checkbox-ng/plainbox/impl/unit/job.py
@@ -432,7 +432,7 @@ class JobDefinition(UnitWithId, IJobDefinition):
             return value
         elif value is None:
             return None
-        match = re.match('^(\d+h)?[ :]*(\d+m)?[ :]*(\d+s)?$', value)
+        match = re.match(r'^(\d+h)?[ :]*(\d+m)?[ :]*(\d+s)?$', value)
         if match:
             g_hours = match.group(1)
             if g_hours:
@@ -532,7 +532,7 @@ class JobDefinition(UnitWithId, IJobDefinition):
         Return a set of requested environment variables
         """
         if self.environ is not None:
-            return {variable for variable in re.split('[\s,]+', self.environ)}
+            return {variable for variable in re.split(r'[\s,]+', self.environ)}
         else:
             return set()
 
@@ -542,7 +542,7 @@ class JobDefinition(UnitWithId, IJobDefinition):
         Return a set of flags associated with this job
         """
         if self.flags is not None:
-            return {flag for flag in re.split('[\s,]+', self.flags)}
+            return {flag for flag in re.split(r'[\s,]+', self.flags)}
         else:
             return set()
 

--- a/checkbox-ng/plainbox/impl/unit/testplan.py
+++ b/checkbox-ng/plainbox/impl/unit/testplan.py
@@ -225,7 +225,7 @@ class TestPlanUnit(UnitWithId):
         value = self.get_record_value('estimated_duration')
         if value is None:
             return None
-        match = re.match('^(\d+h)?[ :]*(\d+m)?[ :]*(\d+s)?$', value)
+        match = re.match(r'^(\d+h)?[ :]*(\d+m)?[ :]*(\d+s)?$', value)
         if match:
             g_hours = match.group(1)
             if g_hours:

--- a/checkbox-ng/plainbox/impl/xparsers.py
+++ b/checkbox-ng/plainbox/impl/xparsers.py
@@ -230,7 +230,7 @@ class Re(Node):
             # XXX: This is a bit crazy but this lets us have identical error
             # messages across python3.2 all the way to 3.5. I really really
             # wish there was a better way at fixing this.
-            exc.args = (re.sub(" at position \d+", "", exc.args[0]), )
+            exc.args = (re.sub(r" at position \d+", "", exc.args[0]), )
             return ReErr(lineno, col_offset, text, exc)
         else:
             # Check if the AST of this regular expression is composed

--- a/checkbox-ng/plainbox/provider_manager.py
+++ b/checkbox-ng/plainbox/provider_manager.py
@@ -249,7 +249,7 @@ class InstallCommand(ManageCommand):
                 for src, dest in sorted(layout.items())
             )
         return re.sub(
-            '@LAYOUT\[(\w+)]@',
+            r'@LAYOUT\[(\w+)]@',
             lambda m: format_layout(self._INSTALL_LAYOUT[m.group(1)]),
             super().get_command_epilog())
 

--- a/checkbox-ng/plainbox/vendor/sphinxarg/parser.py
+++ b/checkbox-ng/plainbox/vendor/sphinxarg/parser.py
@@ -10,7 +10,7 @@ def parser_navigate(parser_result, path, current_path=None):
     if isinstance(path, str):
         if path == '':
             return parser_result
-        path = re.split('\s+', path)
+        path = re.split(r'\s+', path)
     current_path = current_path or []
     if len(path) == 0:
         return parser_result

--- a/checkbox-support/checkbox_support/parsers/pactl.py
+++ b/checkbox-support/checkbox_support/parsers/pactl.py
@@ -417,7 +417,7 @@ VolumeAttributeValue = (
             p.Or([
                 p.Literal("(invalid)"),
                 p.Regex(r"([\w\-]+: [0-9]+ / +[0-9]+%(?: /"
-                        " +-?([0-9]+\.[0-9]+|inf) dB)?,? *)+")
+                        r" +-?([0-9]+\.[0-9]+|inf) dB)?,? *)+")
             ])
         ])
         + p.LineEnd()

--- a/providers/base/bin/audio_driver_info.py
+++ b/providers/base/bin/audio_driver_info.py
@@ -24,9 +24,9 @@ from checkbox_support.parsers.modinfo import ModinfoParser
 
 TYPES = ("source", "sink")
 
-entries_regex = re.compile("index.*?(?=device.icon_name)", re.DOTALL)
-driver_regex = re.compile("(?<=driver_name = )\"(.*)\"")
-name_regex = re.compile("(?<=name:).*")
+entries_regex = re.compile(r"index.*?(?=device.icon_name)", re.DOTALL)
+driver_regex = re.compile(r"(?<=driver_name = )\"(.*)\"")
+name_regex = re.compile(r"(?<=name:).*")
 
 
 class PacmdAudioDevice():


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Python3.12 has started waring for new syntax errors in the source. Many are non-raw string regexes that contain unexcaped escape sequences. (ex. `"\d"` instead of `"\\d"` or `r"\d"`). Many were reported, some more I found, this fixes any I could spot.

## Resolved issues

Fixes: CHECKBOX-1353

## Documentation

N/A

## Tests

I've ran pytest, this reduces the amount of warnings significantly.

