### PR TITLE
Add systemd-analyze critical-chain job (New)

### DIFF
--- a/providers/base/units/canary/test-plan.pxu
+++ b/providers/base/units/canary/test-plan.pxu
@@ -54,6 +54,7 @@ include:
  com.canonical.certification::lsb
  com.canonical.certification::miscellanea/submission-resources
  com.canonical.certification::info/systemd-analyze
+ com.canonical.certification::info/systemd-analyze-critical-chain
  com.canonical.certification::firmware/fwts_desktop_diagnosis
  com.canonical.certification::firmware/fwts_desktop_diagnosis_results.log.gz
  com.canonical.certification::acpi/oem_osi

--- a/providers/base/units/info/jobs.pxu
+++ b/providers/base/units/info/jobs.pxu
@@ -464,6 +464,19 @@ command:
  timeout 60 systemctl is-system-running --wait > /dev/null
  systemd-analyze
 
+plugin: shell
+category_id: com.canonical.plainbox::info
+id: info/systemd-analyze-critical-chain
+estimated_duration: 0.2
+_summary: Print the tree of the time-critical chain of SystemD
+_purpose:
+ This job prints a tree of the time-critical chain of SystemD units.
+command:
+ # Wait for boot to complete
+ # https://github.com/systemd/systemd/pull/9796
+ timeout 60 systemctl is-system-running --wait > /dev/null
+ systemd-analyze critical-chain
+
 id: lstopo_verbose_attachment
 plugin: attachment
 category_id: com.canonical.plainbox::info

--- a/providers/base/units/miscellanea/test-plan.pxu
+++ b/providers/base/units/miscellanea/test-plan.pxu
@@ -92,4 +92,5 @@ mandatory_include:
     miscellanea/apport-directory               certification-status=non-blocker
     miscellanea/ipmi_test                      certification-status=blocker
     info/systemd-analyze                       certification-status=non-blocker
+    info/systemd-analyze-critical-chain        certification-status=non-blocker
 include:

--- a/providers/base/units/submission/test-plan.pxu
+++ b/providers/base/units/submission/test-plan.pxu
@@ -24,3 +24,4 @@ mandatory_include:
     # Meta-job to include required resources, don't remove.
     miscellanea/submission-resources
     info/systemd-analyze                  certification-status=non-blocker
+    info/systemd-analyze-critical-chain   certification-status=non-blocker

--- a/providers/sru/units/sru.pxu
+++ b/providers/sru/units/sru.pxu
@@ -29,6 +29,7 @@ include:
     recovery_info_attachment
     miscellanea/submission-resources
     info/systemd-analyze
+    info/systemd-analyze-critical-chain
     net_if_management_attachment
     audio/alsa_record_playback_automated
     install/apt-get-gets-updates
@@ -107,6 +108,7 @@ include:
     recovery_info_attachment
     miscellanea/submission-resources
     info/systemd-analyze
+    info/systemd-analyze-critical-chain
     net_if_management_attachment
     audio/alsa_record_playback_automated
     graphics/xorg-version


### PR DESCRIPTION
## New systemd-analyze job

This PR adds a job that prints the critical-chain systemd tree.

## Testing
Tested by running on two systems. Example output:

```
=============[ Running job 1 / 2. Estimated time left: 0:00:00 ]===============
-------------------[ System boot-up performance statistics ]--------------------
ID: com.canonical.certification::info/systemd-analyze                                                                          
Category: com.canonical.plainbox::info                                                                                         
... 8< -------------------------------------------------------------------------
Startup finished in 11.573s (firmware) + 11.386s (loader) + 3.699s (kernel) + 9.756s (userspace) = 36.415s 
graphical.target reached after 9.699s in userspace. 
------------------------------------------------------------------------- >8 ---
Outcome: job passed                                                                                                            
==============[ Running job 2 / 2. Estimated time left: 0:00:00 ]===============                                        
------------[ Print the tree of the time-critical chain of SystemD ]------------                                              
ID: com.canonical.certification::info/systemd-analyze-critical-chain                                                       
Category: com.canonical.plainbox::info                                                                                         
... 8< -------------------------------------------------------------------------                                   
The time when unit became active or started is printed after the "@" character.                                      
The time the unit took to start is printed after the "+" character.                                                                                                                                                                                           
                                                                                                                                                                                                                                                              
graphical.target @9.699s                                                                                                                                                                                                                                      
└─multi-user.target @9.699s                                                                                                                                                                                                                                   
  └─plymouth-quit-wait.service @2.648s +3.829s                                                                                                                                                                                                                
    └─systemd-user-sessions.service @2.644s +2ms                                                                                                                                                                                                              
      └─network.target @2.587s                                                                                                                                                                                                                                
        └─NetworkManager.service @2.396s +191ms                                                                                                                                                                                                               
          └─dbus.service @2.373s +17ms                                                                                                                                                                                                                        
            └─basic.target @2.357s                                                                                                                                                                                                                            
              └─sockets.target @2.357s                                                                                                                                                                                                                        
                └─snapd.socket @2.302s +54ms                                                                                                                                                                                                                  
                  └─sysinit.target @2.300s                                                                                                                                                                                                                    
                    └─systemd-resolved.service @2.241s +59ms                                                                                                                                                                                                  
                      └─systemd-tmpfiles-setup.service @2.205s +32ms                                                                                                                                                                                          
                        └─local-fs.target @2.201s                                                                                                                                                                                                             
                          └─run-snapd-ns-snapd\x2ddesktop\x2dintegration.mnt.mount @5.308s                                                                                                                                                                    
                            └─run-snapd-ns.mount @2.659s                                                                                                                                                                                                      
                              └─local-fs-pre.target @378ms                                                                                                                                                                                                    
                                └─systemd-tmpfiles-setup-dev.service @372ms +5ms                                                                                                                                                                              
                                  └─systemd-sysusers.service @366ms +5ms                                                                                                                                                                                      
                                    └─systemd-remount-fs.service @292ms +55ms                                                                                                                                                                                 
                                      └─systemd-journald.socket @284ms                                                                                                                                                                                        
                                        └─-.mount @241ms                                                                                                                                                                                                      
                                          └─-.slice @241ms                                                                                                                                                                                                    
------------------------------------------------------------------------- >8 ---                                                                                                                                                                              
Outcome: job passed                                                                                                                                                                                                                                           
 ☑ : System boot-up performance statistics                                                                                                                                                                                                                    
 ☑ : Print the tree of the time-critical chain of SystemD  
```
## Resolved issues

Resolves: https://warthogs.atlassian.net/jira/software/c/projects/CHECKBOX/boards/590?selectedIssue=CHECKBOX-1372