### PR TITLE
Migrate setup.py to pyproject.toml (infra)

### DIFF
--- a/metabox/pyproject.toml
+++ b/metabox/pyproject.toml
@@ -3,7 +3,6 @@
   build-backend = "setuptools.build_meta"
 [project]
   name = "metabox"
-  #url="https://launchpad.net/checkbox-ng/"
   authors = [
       {name = 'Maciej Kisielewski', email='maciej.kisielewski@canonical.com'},
       {name = 'Sylvain Pineau', email = 'sylvain.pineau@canonical.com'}
@@ -15,9 +14,7 @@
     "pyyaml",
     "urllib3 >= 1.26.0, < 2.0.0",
   ]
-  #test_suite='checkbox_ng.tests.test_suite'
   license={"text" = "GPLv3"}
-  #platforms=["POSIX"]
   description="Checkbox Integration Testing Tool"
   version='1.0'
 [tool.setuptools_scm]

--- a/metabox/pyproject.toml
+++ b/metabox/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+  requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4"]
+  build-backend = "setuptools.build_meta"
+[project]
+  name = "metabox"
+  #url="https://launchpad.net/checkbox-ng/"
+  authors = [
+      {name = 'Maciej Kisielewski', email='maciej.kisielewski@canonical.com'},
+      {name = 'Sylvain Pineau', email = 'sylvain.pineau@canonical.com'}
+  ]
+  dependencies = [
+    "importlib-resources",
+    "loguru",
+    "pylxd",
+    "pyyaml",
+    "urllib3 >= 1.26.0, < 2.0.0",
+  ]
+  #test_suite='checkbox_ng.tests.test_suite'
+  license={"text" = "GPLv3"}
+  #platforms=["POSIX"]
+  description="Checkbox Integration Testing Tool"
+  version='1.0'
+[tool.setuptools_scm]
+  root=".."
+[tool.setuptools.packages.find]
+  exclude = ["debian*"]
+[project.scripts]
+  metabox = "metabox.main:main"

--- a/metabox/setup.py
+++ b/metabox/setup.py
@@ -18,26 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
-setup(
-    name="metabox",
-    version="0.3",
-    packages=find_packages(),
-    install_requires=[
-        "importlib-resources",
-        "loguru",
-        "pylxd",
-        "pyyaml",
-        "urllib3 >= 1.26.0, < 2.0.0",
-    ],
-    entry_points={
-        "console_scripts": [
-            "metabox = metabox.main:main",
-        ]
-    },
-    include_package_data=True,
-    package_data={
-        "": ["metabox/metabox-provider/*"],
-    },
-)
+setup()


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Metabox is still using setup.py, this moves everything to pyproject.toml

## Resolved issues

N/A

## Documentation

N/A

## Tests

N/A

