### PR TITLE
Fix timeout children (bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/timeout.py
+++ b/checkbox-support/checkbox_support/helpers/timeout.py
@@ -75,14 +75,3 @@ def timeout(timeout_s):
         return _f
 
     return timeout_timeout_s
-
-
-@timeout(1)
-def main():
-    import subprocess
-
-    subprocess.check_call(["sleep", "10000"])
-
-
-if __name__ == "__main__":
-    main()

--- a/checkbox-support/checkbox_support/helpers/timeout.py
+++ b/checkbox-support/checkbox_support/helpers/timeout.py
@@ -53,7 +53,7 @@ def run_with_timeout(f, timeout_s, *args, **kwargs):
     process.join(timeout_s)
 
     if process.is_alive():
-        subprocess.run(["kill", "-9", "-{}".format(os.getsid(process.pid))])
+        subprocess.run("bash -c 'kill -9 -- -{}'".format(process.pid), shell=True)
         raise SystemExit(
             "Task unable to finish in {}s".format(timeout_s)
         ) from TimeoutError

--- a/checkbox-support/checkbox_support/helpers/timeout.py
+++ b/checkbox-support/checkbox_support/helpers/timeout.py
@@ -53,7 +53,7 @@ def run_with_timeout(f, timeout_s, *args, **kwargs):
     process.join(timeout_s)
 
     if process.is_alive():
-        subprocess.run("bash -c 'kill -9 -- -{}'".format(process.pid), shell=True)
+        subprocess.run("kill -9 -- -{}".format(process.pid), shell=True)
         raise SystemExit(
             "Task unable to finish in {}s".format(timeout_s)
         ) from TimeoutError

--- a/checkbox-support/checkbox_support/tests/test_timeout.py
+++ b/checkbox-support/checkbox_support/tests/test_timeout.py
@@ -72,7 +72,7 @@ class TestTimeoutExec(TestCase):
 
     def test_function_exception_propagation(self):
         with self.assertRaises(ValueError):
-            run_with_timeout(some_exception_raiser, 0)
+            run_with_timeout(some_exception_raiser, 1)
 
     def test_function_systemexit_propagation(self):
         with self.assertRaises(SystemExit):

--- a/checkbox-support/checkbox_support/tests/test_timeout.py
+++ b/checkbox-support/checkbox_support/tests/test_timeout.py
@@ -52,7 +52,7 @@ def kwargs_args_support(first, second, third=3):
 class TestTimeoutExec(TestCase):
     def test_class_field_timeouts(self):
         some = ClassSupport(1)
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(TimeoutError):
             run_with_timeout(some.heavy_function, 0)
 
     def test_class_field_ok_return(self):
@@ -62,7 +62,7 @@ class TestTimeoutExec(TestCase):
         )
 
     def test_function_timeouts(self):
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(TimeoutError):
             run_with_timeout(heavy_function, 0, 10)
 
     def test_function_ok_return(self):
@@ -99,7 +99,7 @@ class TestTimeoutExec(TestCase):
             time.sleep(100)
             return (first, second, third)
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(TimeoutError):
             f(1, 2, 3)
 
     def test_decorator_exception(self):


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

When a process spawns childrens and it is killed, if the childrens were non-deamons they are re-parented by the super reaper to the closest relative, falling back on init if none are found. This behaviour is not what we want for our timeout decorator, namely, when a function times out, all processes spawned by the decorated functions must be killed. This updates the decorator so that this happens.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1250

## Documentation

Updated docstring with the new limitations and features

## Tests

All tests are still passing

