### PR TITLE
Fetch last passing daily build before rebuilding (infra)

### DIFF
--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -17,8 +17,11 @@ jobs:
           fetch-depth: 0
       - name: Check for commits
         id: commit_check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          commit_count=$(git log --since="24 hours ago" --oneline -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap | wc -l)
+          export LAST_PASS_DAILY_BUILD=`gh api repos/canonical/checkbox/actions/runs --paginate --jq '.workflow_runs[] | select(.path = ".github/workflows/daily-builds.yml") | select(.conclusion = "success") | .run_started_at | .[:-1]' | head -1`
+          commit_count=$(git log --since="$LAST_PASS_DAILY_BUILD" --oneline -- checkbox-ng checkbox-support providers checkbox-core-snap checkbox-snap | wc -l)
           echo "new_commit_count=$commit_count" | tee $GITHUB_OUTPUT
 
   checkbox-core-snap-daily:


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The daily build workflow always rebuilds if there were changes in the last 24h, this implies that:
- If a daily build fail, the next one doesn't take this fact into consideration, leading to some daily builds being skipped while it would be beneficial if they actually did run
- If a daily build is triggered manually, the next one may be reduntant and lead to failures (for example, duplicated deb source uploads for the same version get automatically rejected)

With this change we will now fetch the last time the "daily-builds.yaml" workflow passed, and use that as the since barrier to see if we should re-build or not.

> Note: this does not 100% solve the duplicated source uploads for debs. If the deb workflow fails after uploading, this will lead to the same rejection but this is not a problem of the trigger (that will now be correct) rather the deb workflow, that should check if the source is in the ppa and put an `~rc` postfix (or something to that effect) to the source version

## Resolved issues

N/A

## Documentation

N/A

## Tests

Tested this offline, this  currently yields true (as would the 24 hours check) but now with the correct number of commits 6 instead of 3. This is because yesterday's daily build failed, so today we must take that into consideration
