### PR TITLE
Fix checkbox remote running memory stress test (Bugfix)

### DIFF
--- a/checkbox-ng/debian/checkbox-ng.service
+++ b/checkbox-ng/debian/checkbox-ng.service
@@ -10,6 +10,7 @@ Restart=always
 RestartSec=1
 TimeoutStopSec=30
 Type=simple
+OOMPolicy=continue
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Description

Once a sub process of checkbox-ng service got killed by OOM killer, the service will be stopped, because of `DefaultOOMPolicy=stop`, and the memory stress test will be marked as crashed, or the whole test plan will start over after the service restarts.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

This PR explicitly set `OOMPolicy=continue` so the service will be able to remain alive, and checkbox remote could finish the memory stress test.

## Resolved issues

Fixes: #571

> systemd[1]: checkbox-ng.service: A process of this unit has been killed by the OOM killer.
> kernel: oom_reaper: reaped process 908499 (stress-ng-stack), now anon-rss:15720kB, file-rss:704kB, shmem-rss:0kB
> systemd[1]: checkbox-ng.service: State 'final-sigterm' timed out. Killing.
> systemd[1]: checkbox-ng.service: Killing process 908487 (stress-ng) with signal SIGKILL.
> systemd[1]: checkbox-ng.service: Killing process 908488 (stress-ng-stack) with signal SIGKILL.
> systemd[1]: checkbox-ng.service: Killing process 908489 (stress-ng-stack) with signal SIGKILL.

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## References

> systemd[1]: checkbox-ng.service: A process of this unit has been killed by the OOM killer.

Logged from [systemd source](https://github.com/systemd/systemd/blob/v249.11/src/core/cgroup.c#L2998).

OOMPolicy part of `man systemd.service`:
```
 OOMPolicy=
     Configure the out-of-memory (OOM) killing policy for the kernel and the
     userspace OOM killer systemd‐oomd.service(8). On Linux, when memory becomes
     scarce to the point that the kernel has trouble allocating memory for
     itself, it might decide to kill a running process in order to free up memory
     and reduce memory pressure. Note that systemd-oomd.service is a more
     flexible solution that aims to prevent out-of-memory situations for the
     userspace too, not just the kernel, by attempting to terminate services
     earlier, before the kernel would have to act.

     This setting takes one of continue, stop or kill. If set to continue and a
     process in the unit is killed by the OOM killer, this is logged but the unit
     continues running. If set to stop the event is logged but the unit is
     terminated cleanly by the service manager. If set to kill and one of the
     unit's processes is killed by the OOM killer the kernel is instructed to
     kill all remaining processes of the unit too, by setting the
     memory.oom.group attribute to 1; also see kernel documentation[2].

     Defaults to the setting DefaultOOMPolicy= in systemd‐system.conf(5) is set
     to, except for units where Delegate= is turned on, where it defaults to
     continue.

     Use the OOMScoreAdjust= setting to configure whether processes of the unit
     shall be considered preferred or less preferred candidates for process
     termination by the Linux OOM killer logic. See systemd.exec(5) for details.

     This setting also applies to systemd‐oomd.service(8). Similarly to the
     kernel OOM kills performed by the kernel, this setting determines the state
     of the unit after systemd-oomd kills a cgroup associated with it.
```

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
Control group: https://certification.canonical.com/hardware/202303-31332/submission/363424/

Experiment group: https://certification.canonical.com/hardware/202303-31332/submission/363564/

The `stress-ng` stressors got killed but `checkbox-ng.service` remain alive. Kindly check [dmesg-after-memory-stress.txt](https://github.com/canonical/checkbox/files/14926707/after-memory-stress.txt) for more.