### PR TITLE
Included firmware revision and hw revision for wwan resource job (Bugfix)

### DIFF
--- a/providers/base/bin/wwan_tests.py
+++ b/providers/base/bin/wwan_tests.py
@@ -116,6 +116,14 @@ class MMDbus:
         pi = self._modem_props_iface(mm_id)
         return pi.Get(DBUS_MM1_IF_MODEM, "Model")
 
+    def get_firmware_revision(self, mm_id):
+        pi = self._modem_props_iface(mm_id)
+        return pi.Get(DBUS_MM1_IF_MODEM, 'Revision').replace("\r\n", " ")
+
+    def get_hardware_revision(self, mm_id):
+        pi = self._modem_props_iface(mm_id)
+        return pi.Get(DBUS_MM1_IF_MODEM, 'HardwareRevision')
+
     def sim_present(self, mm_id):
         pi = self._modem_props_iface(mm_id)
         if pi.Get(DBUS_MM1_IF_MODEM, "Sim") != "/":
@@ -216,6 +224,12 @@ class MMCLI:
 
     def get_primary_port(self, mm_id):
         return _value_from_table("modem", mm_id, "primary port")
+
+    def get_firmware_revision(self, mm_id):
+        return _value_from_table('modem', mm_id, 'firmware revision')
+
+    def get_hardware_revision(self, mm_id):
+        return _value_from_table('modem', mm_id, 'h/w revision')
 
     def sim_present(self, mm_id):
         if self._get_sim_id(mm_id) is None:
@@ -384,6 +398,8 @@ class Resources:
             print("hw_id: {}".format(mm.get_equipment_id(m)))
             print("manufacturer: {}".format(mm.get_manufacturer(m)))
             print("model: {}".format(mm.get_model_name(m)))
+            print("firmware_revision: {}".format(mm.get_firmware_revision(m)))
+            print("hardware_revision: {}".format(mm.get_hardware_revision(m)))
             print()
 
 

--- a/providers/base/bin/wwan_tests.py
+++ b/providers/base/bin/wwan_tests.py
@@ -118,11 +118,11 @@ class MMDbus:
 
     def get_firmware_revision(self, mm_id):
         pi = self._modem_props_iface(mm_id)
-        return pi.Get(DBUS_MM1_IF_MODEM, 'Revision').replace("\r\n", " ")
+        return pi.Get(DBUS_MM1_IF_MODEM, "Revision").replace("\r\n", " ")
 
     def get_hardware_revision(self, mm_id):
         pi = self._modem_props_iface(mm_id)
-        return pi.Get(DBUS_MM1_IF_MODEM, 'HardwareRevision')
+        return pi.Get(DBUS_MM1_IF_MODEM, "HardwareRevision")
 
     def sim_present(self, mm_id):
         pi = self._modem_props_iface(mm_id)
@@ -226,10 +226,10 @@ class MMCLI:
         return _value_from_table("modem", mm_id, "primary port")
 
     def get_firmware_revision(self, mm_id):
-        return _value_from_table('modem', mm_id, 'firmware revision')
+        return _value_from_table("modem", mm_id, "firmware revision")
 
     def get_hardware_revision(self, mm_id):
-        return _value_from_table('modem', mm_id, 'h/w revision')
+        return _value_from_table("modem", mm_id, "h/w revision")
 
     def sim_present(self, mm_id):
         if self._get_sim_id(mm_id) is None:

--- a/providers/base/tests/test_wwan_tests.py
+++ b/providers/base/tests/test_wwan_tests.py
@@ -1,8 +1,11 @@
 import unittest
 import sys
-from unittest.mock import patch, call, Mock
+from unittest.mock import patch, call, Mock, MagicMock
 from io import StringIO
 from contextlib import redirect_stdout
+
+# Mock the dbus module due to is is not available on CI testing environment
+sys.modules["dbus"] = MagicMock()
 
 import wwan_tests
 

--- a/providers/base/tests/test_wwan_tests.py
+++ b/providers/base/tests/test_wwan_tests.py
@@ -17,35 +17,29 @@ class TestMMDbus(unittest.TestCase):
         fw_revision_pattern = "81600.0000.00.29.21.24_GC\r\nD24"
         mock_get = Mock(return_value=fw_revision_pattern)
         obj_mmdbus = wwan_tests.MMDbus()
-        obj_mmdbus._modem_props_iface = Mock(
-            return_value=Mock(Get=mock_get)
-        )
+        obj_mmdbus._modem_props_iface = Mock(return_value=Mock(Get=mock_get))
 
         resp = obj_mmdbus.get_firmware_revision(1)
 
         self.assertEqual(obj_mmdbus.__init__.call_count, 1)
         obj_mmdbus._modem_props_iface.assert_called_with(1)
-        mock_get.assert_called_with(
-            wwan_tests.DBUS_MM1_IF_MODEM, "Revision")
-        self.assertEqual(
-            resp, "81600.0000.00.29.21.24_GC D24"
-        )
+        mock_get.assert_called_with(wwan_tests.DBUS_MM1_IF_MODEM, "Revision")
+        self.assertEqual(resp, "81600.0000.00.29.21.24_GC D24")
 
     @patch("wwan_tests.MMDbus.__init__", Mock(return_value=None))
     def test_get_hardware_revision(self):
         hw_revision_pattern = "V1.0.6"
         mock_get = Mock(return_value=hw_revision_pattern)
         obj_mmdbus = wwan_tests.MMDbus()
-        obj_mmdbus._modem_props_iface = Mock(
-            return_value=Mock(Get=mock_get)
-        )
+        obj_mmdbus._modem_props_iface = Mock(return_value=Mock(Get=mock_get))
 
         resp = obj_mmdbus.get_hardware_revision(1)
 
         self.assertEqual(obj_mmdbus.__init__.call_count, 1)
         obj_mmdbus._modem_props_iface.assert_called_with(1)
         mock_get.assert_called_with(
-            wwan_tests.DBUS_MM1_IF_MODEM, "HardwareRevision")
+            wwan_tests.DBUS_MM1_IF_MODEM, "HardwareRevision"
+        )
         self.assertEqual(resp, hw_revision_pattern)
 
 
@@ -62,7 +56,8 @@ class TestMMCli(unittest.TestCase):
 
         self.assertEqual(obj_mmcli.__init__.call_count, 1)
         mock_value_from_table.assert_called_with(
-            "modem", 1, "firmware revision")
+            "modem", 1, "firmware revision"
+        )
         self.assertEqual(resp, fw_revision_pattern)
 
     @patch("wwan_tests.MMCLI.__init__", Mock(return_value=None))
@@ -75,129 +70,42 @@ class TestMMCli(unittest.TestCase):
         resp = obj_mmcli.get_hardware_revision(1)
 
         self.assertEqual(obj_mmcli.__init__.call_count, 1)
-        mock_value_from_table.assert_called_with(
-            "modem", 1, "h/w revision")
+        mock_value_from_table.assert_called_with("modem", 1, "h/w revision")
         self.assertEqual(resp, hw_revision_pattern)
 
 
 class TestResources(unittest.TestCase):
 
-    def _sorted_resouce_data(self, data):
-        resources = data.strip("\n").split("\n\n")
-        for index in range(len(resources)):
-            tmp_dict = {}
-            for dt in resources[index].split("\n"):
-                k, v = dt.split(":", 1)
-                tmp_dict.update({k: v.strip()})
-
-            resources[index] = tmp_dict
-
-        return resources
-
-    @patch("wwan_tests.MMCLI.__init__")
-    @patch("wwan_tests.MMCLI.get_hardware_revision")
-    @patch("wwan_tests.MMCLI.get_firmware_revision")
-    @patch("wwan_tests.MMCLI.get_model_name")
-    @patch("wwan_tests.MMCLI.get_manufacturer")
-    @patch("wwan_tests.MMCLI.get_equipment_id")
-    @patch("wwan_tests.MMCLI.get_modem_ids")
-    def test_invoked_with_mmcli(
-            self, mock_get_modem_ids, mock_get_equipment_id,
-            mock_get_manufacturer, mock_get_model_name,
-            mock_get_firmware_revision, mock_get_hardware_revision,
-            mock_mmcli_init):
-
-        values = {
-            "mm_id": [1, 2],
-            "hw_id": ["d43f035387373e", None],
-            "manufacturer": ["generic", "sierra"],
-            "model": ["MBIM [14C3:4D75]", "MBIM [14C3:9999]"],
-            "firmware_revision": [
-                "81600.0000.00.29.21.24_GC",
-                "81600.0000.00.29.21.25_GC"],
-            "hardware_revision": ["V1.0.6", "V1.0.7"]
-        }
-
-        mock_mmcli_init.return_value = None
-        mock_get_modem_ids.return_value = values["mm_id"]
-        mock_get_equipment_id.side_effect = values["hw_id"]
-        mock_get_manufacturer.side_effect = values["manufacturer"]
-        mock_get_model_name.side_effect = values["model"]
-        mock_get_firmware_revision.side_effect = values["firmware_revision"]
-        mock_get_hardware_revision.side_effect = values["hardware_revision"]
+    @patch("wwan_tests.MMCLI")
+    def test_invoked_with_mmcli(self, mock_mmcli):
+        mmcli_instance = Mock()
+        mmcli_instance.get_modem_ids.return_value = ["test"]
+        mock_mmcli.return_value = mmcli_instance
 
         sys.argv = ["wwan_tests.py", "resources", "--use-cli"]
-        with redirect_stdout(StringIO()) as stdout:
+
+        with redirect_stdout(StringIO()):
             wwan_tests.Resources().invoked()
+            self.assertTrue(mock_mmcli.called)
+            self.assertTrue(mmcli_instance.get_equipment_id.called)
+            self.assertTrue(mmcli_instance.get_manufacturer.called)
+            self.assertTrue(mmcli_instance.get_model_name.called)
+            self.assertTrue(mmcli_instance.get_firmware_revision.called)
+            self.assertTrue(mmcli_instance.get_hardware_revision.called)
 
-        mock_mmcli_init.assert_called_with()
-        mock_get_modem_ids.assert_called_with()
-        calls = [call(1), call(2)]
-
-        mock_get_equipment_id.assert_has_calls(calls)
-        mock_get_manufacturer.assert_has_calls(calls)
-        mock_get_model_name.assert_has_calls(calls)
-        mock_get_firmware_revision.assert_has_calls(calls)
-        mock_get_hardware_revision.assert_has_calls(calls)
-
-        resps = self._sorted_resouce_data(stdout.getvalue())
-        self.assertEqual(len(resps), 2)
-
-        for i in range(2):
-            self.assertEqual(set(resps[i].keys()), set(values.keys()))
-            for key in values.keys():
-                self.assertEqual(str(values[key][i]), resps[i][key])
-
-    @patch("wwan_tests.MMDbus.__init__")
-    @patch("wwan_tests.MMDbus.get_hardware_revision")
-    @patch("wwan_tests.MMDbus.get_firmware_revision")
-    @patch("wwan_tests.MMDbus.get_model_name")
-    @patch("wwan_tests.MMDbus.get_manufacturer")
-    @patch("wwan_tests.MMDbus.get_equipment_id")
-    @patch("wwan_tests.MMDbus.get_modem_ids")
-    def test_invoked_with_mmdbus(
-            self, mock_get_modem_ids, mock_get_equipment_id,
-            mock_get_manufacturer, mock_get_model_name,
-            mock_get_firmware_revision, mock_get_hardware_revision,
-            mock_mmdbus_init):
-
-        values = {
-            "mm_id": [1, 2],
-            "hw_id": ["d43f035387373e", "335464"],
-            "manufacturer": ["generic", "sierra"],
-            "model": ["MBIM [14C3:4D75]", "MBIM [14C3:9999]"],
-            "firmware_revision": [
-                "81600.0000.00.29.21.24_GC",
-                "81600.0000.00.29.21.25_GC"],
-            "hardware_revision": ["V1.0.6", "V1.0.7"]
-        }
-
-        mock_mmdbus_init.return_value = None
-        mock_get_modem_ids.return_value = values["mm_id"]
-        mock_get_equipment_id.side_effect = values["hw_id"]
-        mock_get_manufacturer.side_effect = values["manufacturer"]
-        mock_get_model_name.side_effect = values["model"]
-        mock_get_firmware_revision.side_effect = values["firmware_revision"]
-        mock_get_hardware_revision.side_effect = values["hardware_revision"]
+    @patch("wwan_tests.MMDbus")
+    def test_invoked_with_mmdbus(self, mock_mmdbus):
+        mmdbus_instance = Mock()
+        mmdbus_instance.get_modem_ids.return_value = ["test"]
+        mock_mmdbus.return_value = mmdbus_instance
 
         sys.argv = ["wwan_tests.py", "resources"]
-        with redirect_stdout(StringIO()) as stdout:
+
+        with redirect_stdout(StringIO()):
             wwan_tests.Resources().invoked()
-
-        mock_mmdbus_init.assert_called_with()
-        mock_get_modem_ids.assert_called_with()
-        calls = [call(1), call(2)]
-
-        mock_get_equipment_id.assert_has_calls(calls)
-        mock_get_manufacturer.assert_has_calls(calls)
-        mock_get_model_name.assert_has_calls(calls)
-        mock_get_firmware_revision.assert_has_calls(calls)
-        mock_get_hardware_revision.assert_has_calls(calls)
-
-        resps = self._sorted_resouce_data(stdout.getvalue())
-        self.assertEqual(len(resps), 2)
-
-        for i in range(2):
-            self.assertEqual(set(resps[i].keys()), set(values.keys()))
-            for key in values.keys():
-                self.assertEqual(str(values[key][i]), resps[i][key])
+            self.assertTrue(mock_mmdbus.called)
+            self.assertTrue(mmdbus_instance.get_equipment_id.called)
+            self.assertTrue(mmdbus_instance.get_manufacturer.called)
+            self.assertTrue(mmdbus_instance.get_model_name.called)
+            self.assertTrue(mmdbus_instance.get_firmware_revision.called)
+            self.assertTrue(mmdbus_instance.get_hardware_revision.called)

--- a/providers/base/tests/test_wwan_tests.py
+++ b/providers/base/tests/test_wwan_tests.py
@@ -1,0 +1,189 @@
+import unittest
+import sys
+from unittest.mock import patch, call, Mock
+from io import StringIO
+from contextlib import redirect_stdout
+
+import wwan_tests
+
+
+class TestMMDbus(unittest.TestCase):
+
+    @patch("wwan_tests.MMDbus.__init__", Mock(return_value=None))
+    def test_get_firmware_revision(self):
+        fw_revision_pattern = "81600.0000.00.29.21.24_GC\r\nD24"
+        mock_get = Mock(return_value=fw_revision_pattern)
+        obj_mmdbus = wwan_tests.MMDbus()
+        obj_mmdbus._modem_props_iface = Mock(
+            return_value=Mock(Get=mock_get)
+        )
+
+        resp = obj_mmdbus.get_firmware_revision(1)
+
+        self.assertEqual(obj_mmdbus.__init__.call_count, 1)
+        obj_mmdbus._modem_props_iface.assert_called_with(1)
+        mock_get.assert_called_with(
+            wwan_tests.DBUS_MM1_IF_MODEM, "Revision")
+        self.assertEqual(
+            resp, "81600.0000.00.29.21.24_GC D24"
+        )
+
+    @patch("wwan_tests.MMDbus.__init__", Mock(return_value=None))
+    def test_get_hardware_revision(self):
+        hw_revision_pattern = "V1.0.6"
+        mock_get = Mock(return_value=hw_revision_pattern)
+        obj_mmdbus = wwan_tests.MMDbus()
+        obj_mmdbus._modem_props_iface = Mock(
+            return_value=Mock(Get=mock_get)
+        )
+
+        resp = obj_mmdbus.get_hardware_revision(1)
+
+        self.assertEqual(obj_mmdbus.__init__.call_count, 1)
+        obj_mmdbus._modem_props_iface.assert_called_with(1)
+        mock_get.assert_called_with(
+            wwan_tests.DBUS_MM1_IF_MODEM, "HardwareRevision")
+        self.assertEqual(resp, hw_revision_pattern)
+
+
+class TestMMCli(unittest.TestCase):
+
+    @patch("wwan_tests.MMCLI.__init__", Mock(return_value=None))
+    @patch("wwan_tests._value_from_table")
+    def test_get_firmware_revision(self, mock_value_from_table):
+        fw_revision_pattern = "81600.0000.00.29.21.24_GC"
+        obj_mmcli = wwan_tests.MMCLI()
+        mock_value_from_table.return_value = fw_revision_pattern
+
+        resp = obj_mmcli.get_firmware_revision(1)
+
+        self.assertEqual(obj_mmcli.__init__.call_count, 1)
+        mock_value_from_table.assert_called_with(
+            "modem", 1, "firmware revision")
+        self.assertEqual(resp, fw_revision_pattern)
+
+    @patch("wwan_tests.MMCLI.__init__", Mock(return_value=None))
+    @patch("wwan_tests._value_from_table")
+    def test_get_hardware_revision(self, mock_value_from_table):
+        hw_revision_pattern = "81600.0000.00.29.21.24_GC"
+        obj_mmcli = wwan_tests.MMCLI()
+        mock_value_from_table.return_value = hw_revision_pattern
+
+        resp = obj_mmcli.get_hardware_revision(1)
+
+        self.assertEqual(obj_mmcli.__init__.call_count, 1)
+        mock_value_from_table.assert_called_with(
+            "modem", 1, "h/w revision")
+        self.assertEqual(resp, hw_revision_pattern)
+
+
+class TestResources(unittest.TestCase):
+
+    @patch("wwan_tests.MMCLI.__init__")
+    @patch("wwan_tests.MMCLI.get_hardware_revision")
+    @patch("wwan_tests.MMCLI.get_firmware_revision")
+    @patch("wwan_tests.MMCLI.get_model_name")
+    @patch("wwan_tests.MMCLI.get_manufacturer")
+    @patch("wwan_tests.MMCLI.get_equipment_id")
+    @patch("wwan_tests.MMCLI.get_modem_ids")
+    def test_invoked_with_mmcli(
+            self, mock_get_modem_ids, mock_get_equipment_id,
+            mock_get_manufacturer, mock_get_model_name,
+            mock_get_firmware_revision, mock_get_hardware_revision,
+            mock_mmcli_init):
+
+        values = {
+            "mm_id": [1, 2],
+            "hw_id": ["d43f035387373e", None],
+            "manufacturer": ["generic", "sierra"],
+            "model": ["MBIM [14C3:4D75]", "MBIM [14C3:9999]"],
+            "firmware_revision": [
+                "81600.0000.00.29.21.24_GC",
+                "81600.0000.00.29.21.25_GC"],
+            "hardware_revision": ["V1.0.6", "V1.0.7"]
+        }
+
+        mock_mmcli_init.return_value = None
+        mock_get_modem_ids.return_value = values["mm_id"]
+        mock_get_equipment_id.side_effect = values["hw_id"]
+        mock_get_manufacturer.side_effect = values["manufacturer"]
+        mock_get_model_name.side_effect = values["model"]
+        mock_get_firmware_revision.side_effect = values["firmware_revision"]
+        mock_get_hardware_revision.side_effect = values["hardware_revision"]
+
+        sys.argv = ["wwan_tests.py", "resources", "--use-cli"]
+        with redirect_stdout(StringIO()) as stdout:
+            wwan_tests.Resources().invoked()
+
+        mock_mmcli_init.assert_called_with()
+        mock_get_modem_ids.assert_called_with()
+        calls = [call(1), call(2)]
+
+        mock_get_equipment_id.assert_has_calls(calls)
+        mock_get_manufacturer.assert_has_calls(calls)
+        mock_get_model_name.assert_has_calls(calls)
+        mock_get_firmware_revision.assert_has_calls(calls)
+        mock_get_hardware_revision.assert_has_calls(calls)
+
+        expected_info = []
+        for i in range(2):
+            expected_info.append("\n".join(
+                ["{}: {}".format(k, v[i]) for k, v in values.items()]
+            ))
+        expected_info = "{}\n\n".format("\n\n".join(expected_info))
+
+        self.assertEqual(expected_info, stdout.getvalue())
+
+    @patch("wwan_tests.MMDbus.__init__")
+    @patch("wwan_tests.MMDbus.get_hardware_revision")
+    @patch("wwan_tests.MMDbus.get_firmware_revision")
+    @patch("wwan_tests.MMDbus.get_model_name")
+    @patch("wwan_tests.MMDbus.get_manufacturer")
+    @patch("wwan_tests.MMDbus.get_equipment_id")
+    @patch("wwan_tests.MMDbus.get_modem_ids")
+    def test_invoked_with_mmdbus(
+            self, mock_get_modem_ids, mock_get_equipment_id,
+            mock_get_manufacturer, mock_get_model_name,
+            mock_get_firmware_revision, mock_get_hardware_revision,
+            mock_mmdbus_init):
+
+        values = {
+            "mm_id": [1, 2],
+            "hw_id": ["d43f035387373e", "335464"],
+            "manufacturer": ["generic", "sierra"],
+            "model": ["MBIM [14C3:4D75]", "MBIM [14C3:9999]"],
+            "firmware_revision": [
+                "81600.0000.00.29.21.24_GC",
+                "81600.0000.00.29.21.25_GC"],
+            "hardware_revision": ["V1.0.6", "V1.0.7"]
+        }
+
+        mock_mmdbus_init.return_value = None
+        mock_get_modem_ids.return_value = values["mm_id"]
+        mock_get_equipment_id.side_effect = values["hw_id"]
+        mock_get_manufacturer.side_effect = values["manufacturer"]
+        mock_get_model_name.side_effect = values["model"]
+        mock_get_firmware_revision.side_effect = values["firmware_revision"]
+        mock_get_hardware_revision.side_effect = values["hardware_revision"]
+
+        sys.argv = ["wwan_tests.py", "resources"]
+        with redirect_stdout(StringIO()) as stdout:
+            wwan_tests.Resources().invoked()
+
+        mock_mmdbus_init.assert_called_with()
+        mock_get_modem_ids.assert_called_with()
+        calls = [call(1), call(2)]
+
+        mock_get_equipment_id.assert_has_calls(calls)
+        mock_get_manufacturer.assert_has_calls(calls)
+        mock_get_model_name.assert_has_calls(calls)
+        mock_get_firmware_revision.assert_has_calls(calls)
+        mock_get_hardware_revision.assert_has_calls(calls)
+
+        expected_info = []
+        for i in range(2):
+            expected_info.append("\n".join(
+                ["{}: {}".format(k, v[i]) for k, v in values.items()]
+            ))
+        expected_info = "{}\n\n".format("\n\n".join(expected_info))
+        self.assertEqual(expected_info, stdout.getvalue())

--- a/providers/base/tests/test_wwan_tests.py
+++ b/providers/base/tests/test_wwan_tests.py
@@ -82,6 +82,18 @@ class TestMMCli(unittest.TestCase):
 
 class TestResources(unittest.TestCase):
 
+    def _sorted_resouce_data(self, data):
+        resources = data.strip("\n").split("\n\n")
+        for index in range(len(resources)):
+            tmp_dict = {}
+            for dt in resources[index].split("\n"):
+                k, v = dt.split(":", 1)
+                tmp_dict.update({k: v.strip()})
+
+            resources[index] = tmp_dict
+
+        return resources
+
     @patch("wwan_tests.MMCLI.__init__")
     @patch("wwan_tests.MMCLI.get_hardware_revision")
     @patch("wwan_tests.MMCLI.get_firmware_revision")
@@ -128,14 +140,13 @@ class TestResources(unittest.TestCase):
         mock_get_firmware_revision.assert_has_calls(calls)
         mock_get_hardware_revision.assert_has_calls(calls)
 
-        expected_info = []
-        for i in range(2):
-            expected_info.append("\n".join(
-                ["{}: {}".format(k, v[i]) for k, v in values.items()]
-            ))
-        expected_info = "{}\n\n".format("\n\n".join(expected_info))
+        resps = self._sorted_resouce_data(stdout.getvalue())
+        self.assertEqual(len(resps), 2)
 
-        self.assertEqual(expected_info, stdout.getvalue())
+        for i in range(2):
+            self.assertEqual(set(resps[i].keys()), set(values.keys()))
+            for key in values.keys():
+                self.assertEqual(str(values[key][i]), resps[i][key])
 
     @patch("wwan_tests.MMDbus.__init__")
     @patch("wwan_tests.MMDbus.get_hardware_revision")
@@ -183,10 +194,10 @@ class TestResources(unittest.TestCase):
         mock_get_firmware_revision.assert_has_calls(calls)
         mock_get_hardware_revision.assert_has_calls(calls)
 
-        expected_info = []
+        resps = self._sorted_resouce_data(stdout.getvalue())
+        self.assertEqual(len(resps), 2)
+
         for i in range(2):
-            expected_info.append("\n".join(
-                ["{}: {}".format(k, v[i]) for k, v in values.items()]
-            ))
-        expected_info = "{}\n\n".format("\n\n".join(expected_info))
-        self.assertEqual(expected_info, stdout.getvalue())
+            self.assertEqual(set(resps[i].keys()), set(values.keys()))
+            for key in values.keys():
+                self.assertEqual(str(values[key][i]), resps[i][key])


### PR DESCRIPTION
## Description
We would like to collect the firmware revision and hardware revision in the wwan resource job, so we could have the enough information to identify any regression issues related WWAN device.

## Resolved issues
N/A

## Documentation
N/A

## Tests
Tested on one x86 platform running server image
```
u@u-Alder-Lake-Client-Platform:~$ checkbox-iiotg-classic.checkbox-cli run com.canonical.certification::wwan_resource
$PROVIDERPATH is defined, so following provider sources are ignored ['/snap/checkbox-iiotg-classic/79/providers/checkbox-provider-intliotg', '/home/u/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Using sideloaded provider: checkbox-provider-base, version 4.0.0.dev194 from /var/tmp/checkbox-providers/base
===========================[ Running Selected Jobs ]============================
==============[ Running job 1 / 1. Estimated time left: 0:00:03 ]===============
--------------------[ Gather device info about WWAN modems ]--------------------
ID: com.canonical.certification::wwan_resource
Category: com.canonical.certification::wwan
... 8< -------------------------------------------------------------------------
mm_id: 0
hw_id: 
manufacturer: generic
model: MBIM [14C3:4D75]
firmware_revision: 81600.0000.00.29.21.24_GC D24
hardware_revision: V1.0.6

------------------------------------------------------------------------- >8 ---
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-04-10T03.28.23
==================================[ Results ]===================================
 ☑ : Gather device info about WWAN modems

# To ensure we could get the information through mmcli
u@u-Alder-Lake-Client-Platform:~$ python3 /var/tmp/checkbox-providers/base/bin/wwan_tests.py resources --use-cli
mm_id: 0
hw_id: None
manufacturer: generic
model: MBIM[14C3:4D75]
firmware_revision: 81600.0000.00.29.21.24_GC
hardware_revision: V1.0.6

# To ensure we could get the information through dbus
u@u-Alder-Lake-Client-Platform:~$ python3 /var/tmp/checkbox-providers/base/bin/wwan_tests.py resources 
mm_id: 0
hw_id: 
manufacturer: generic
model: MBIM [14C3:4D75]
firmware_revision: 81600.0000.00.29.21.24_GC D24
hardware_revision: V1.0.6
```

