### PR TITLE
New mock_timeout (bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/timeout.py
+++ b/checkbox-support/checkbox_support/helpers/timeout.py
@@ -26,7 +26,9 @@ import os
 import subprocess
 import multiprocessing
 
+from functools import partial
 from contextlib import wraps
+from unittest.mock import patch
 
 
 def run_with_timeout(f, timeout_s, *args, **kwargs):
@@ -75,3 +77,14 @@ def timeout(timeout_s):
         return _f
 
     return timeout_timeout_s
+
+
+def fake_run_with_timeout(f, timeout_s, *args, **kwargs):
+    return f(*args, **kwargs)
+
+
+mock_timeout = partial(
+    patch,
+    "checkbox_support.helpers.timeout.run_with_timeout",
+    new=fake_run_with_timeout,
+)

--- a/checkbox-support/checkbox_support/tests/test_timeout.py
+++ b/checkbox-support/checkbox_support/tests/test_timeout.py
@@ -20,7 +20,11 @@ import time
 
 from unittest import TestCase
 
-from checkbox_support.helpers.timeout import run_with_timeout, timeout
+from checkbox_support.helpers.timeout import (
+    run_with_timeout,
+    timeout,
+    fake_run_with_timeout,
+)
 
 
 class ClassSupport:
@@ -58,7 +62,8 @@ class TestTimeoutExec(TestCase):
     def test_class_field_ok_return(self):
         some = ClassSupport(0)
         self.assertEqual(
-            run_with_timeout(some.heavy_function, 10), "ClassSupport return value"
+            run_with_timeout(some.heavy_function, 10),
+            "ClassSupport return value",
         )
 
     def test_function_timeouts(self):
@@ -67,7 +72,8 @@ class TestTimeoutExec(TestCase):
 
     def test_function_ok_return(self):
         self.assertEqual(
-            run_with_timeout(heavy_function, 10, 0), "ClassSupport return value"
+            run_with_timeout(heavy_function, 10, 0),
+            "ClassSupport return value",
         )
 
     def test_function_exception_propagation(self):
@@ -108,4 +114,12 @@ class TestTimeoutExec(TestCase):
             raise ValueError("error with first")
 
         with self.assertRaises(ValueError):
-            f(1,2,3)
+            f(1, 2, 3)
+
+    def test_identity(self):
+        def k(*args, **kwargs):
+            return (args, kwargs)
+
+        self.assertEqual(
+            k(1, 2, 3, abc=10), fake_run_with_timeout(k, 100, 1, 2, 3, abc=10)
+        )

--- a/providers/base/tests/test_camera_quality.py
+++ b/providers/base/tests/test_camera_quality.py
@@ -27,6 +27,7 @@ from unittest.mock import patch, MagicMock
 import cv2
 import numpy as np
 
+from checkbox_support.helpers.timeout import mock_timeout
 import camera_quality_test as cqt
 
 
@@ -39,6 +40,7 @@ score_path = "checkbox_support.vendor.brisque.brisque.BRISQUE.score"
 @patch("camera_quality_test.TIMEOUT", new=0.05)
 @patch("camera_quality_test.MIN_INTERVAL", new=0.01)
 @patch("builtins.print", new=MagicMock())
+@mock_timeout()
 class CameraQualityTests(unittest.TestCase):
     """This class provides test cases for the camera_quality_test module."""
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The timeout decorator spawns a new process undoing every mock that was applied to the module. This makes every test that uses it fail. This introduces a new decorator for tests called `mock_timeout` that mocks the timeout effect so that every test is still run in the same subprocess. Note that this doesn't make the timeout function timeout anymore, but given that the purpose of this decorator is to hard fail a procedure, that is not supposed to be a tested behaviour of a unit (it is always preferable to gently fail within the unit if possible rather than using this timeout, this is more of a last resort option)

## Resolved issues

Failing camera unit tests

## Documentation

N/A

## Tests

N/A

