### PR TITLE
Adding rt test plan (New)

### DIFF
--- a/providers/base/units/rt-performance-tests/jobs.pxu
+++ b/providers/base/units/rt-performance-tests/jobs.pxu
@@ -1,7 +1,13 @@
 id: rt-performance-tests/cyclictest_rt_latency
 category_id: rt-performance-tests
+estimated_duration: 24h
 _summary:
     Run cyclictest to test scheduling latency. Default run time is 24 hours.
+_purpose:
+    This test executes the cyclictest command for a long period of time to 
+    evaluate the system's ability to maintain scheduling latency. It checks
+    that the maximum latency did not exceed the threshold and that there are no
+    overflows (scheduling misses) for each thread.
 plugin: shell
 requires:
     package.name == 'rt-tests'
@@ -13,8 +19,14 @@ command:
 
 id: rt-performance-tests/cyclictest_rt
 category_id: rt-performance-tests
+estimated_duration: 60s
 _summary:
-    Run cyclictest to ensure that real time test can be executed.
+    A short-duration cyclictest to validate the system's real-time capabilities.
+_purpose:
+    This test runs for 60 seconds to provide a rapid assessment of the system's
+    real-time performance. It uses the cyclictest tool to measure the scheduling
+    latency and overflow occurrences. The goal is to ensure that basic real-time
+    functions can be executed without latency spikes.
 plugin: shell
 requires:
     package.name == 'rt-tests'

--- a/providers/base/units/rt-performance-tests/jobs.pxu
+++ b/providers/base/units/rt-performance-tests/jobs.pxu
@@ -9,3 +9,15 @@ user: root
 environ: CYCLICTEST_DURATION
 command:
     run_cyclictest.py --duration "${CYCLICTEST_DURATION:-86400}"
+
+
+id: rt-performance-tests/cyclictest_rt
+category_id: rt-performance-tests
+_summary:
+    Run cyclictest to ensure that real time test can be executed.
+plugin: shell
+requires:
+    package.name == 'rt-tests'
+user: root
+command:
+    run_cyclictest.py --duration 1

--- a/providers/base/units/rt-performance-tests/jobs.pxu
+++ b/providers/base/units/rt-performance-tests/jobs.pxu
@@ -20,4 +20,4 @@ requires:
     package.name == 'rt-tests'
 user: root
 command:
-    run_cyclictest.py --duration 1
+    run_cyclictest.py --duration 60

--- a/providers/base/units/rt-performance-tests/test-plan.pxu
+++ b/providers/base/units/rt-performance-tests/test-plan.pxu
@@ -17,6 +17,7 @@ id: rt-performance-tests-automated
 _name: Realtime Performance Tests (Automated)
 unit: test plan
 include:
+    rt-performance-tests/cyclictest_rt
 bootstrap_include:
 
 id: rt-performance-tests-stress

--- a/providers/sru/units/sru-rt.pxu
+++ b/providers/sru/units/sru-rt.pxu
@@ -1,0 +1,39 @@
+id: sru-rt
+_name: All SRU Tests (Ubuntu Real-time)
+unit: test plan
+_description:
+    This test plan contains tests that are useful for validating a Stable
+    Release Update (SRU) on Ubuntu Certified systems.  This test plan is not
+    recommended for, nor will it be accepted for self-testing purposes.
+include:
+    # Following jobs all run first before the nested parts
+    # Please keep it short and avoid jobs triggering suspend or reboots
+    # Whenever possible prefer the use of nested parts instead
+    audio/alsa_record_playback_automated
+    recovery_info_attachment
+    miscellanea/submission-resources
+    info/systemd-analyze
+    info/systemd-analyze-critical-chain
+    net_if_management_attachment
+    install/apt-get-gets-updates
+    miscellanea/dkms_build_validation
+    networking/http
+    networking/gateway_ping
+    thunderbolt3/storage-preinserted
+nested_part:
+    sru
+    rt-performance-tests-automated
+bootstrap_include:
+    device
+    graphics_card
+    net_if_management
+exclude:
+    cpu/clocktest
+    disk/stats_.*
+    disk/storage_device_.*
+    installer_debug.gz
+    stress/memory_stress_ng
+    audio/valid-sof-firmware-sig
+    miscellanea/check_prerelease
+    suspend/bluetooth_obex_.*
+    miscellanea/debsums


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

To test the real-time kernel, we have to include RT tests into the generic providers and create a SRU specific to RT devices.

The rt-performance tests are already in canonical/checkbox under the base provider and the TSN and TGPIO tests will be included in the future.

At the moment, the `sru-rt` will only include the rt-performance tests, but the TSN and TGPIO will be added in the future. 

Since the `rt-performance-tests-stress` takes 24 hours to complete, the `sru-rt` only includes `rt-performance-tests-automated` with a shorter version of the cyclic test for latency. Once we have tested the `sru-rt` on some devices and we ensure it is stable, we should probably add this test back, but taking into consideration that test runs using this test are going to take more than one day.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

There are no changes to the documentation

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

To list the RT jobs currently present on checkbox:
```
checkbox-cli expand com.canonical.certification::rt-performance-tests-full
```
To list the jobs currently in `sru-rt`:
```
checkbox-cli expand com.canonical.certification::sru-rt
...
Job 'com.canonical.certification::recovery_info_attachment'
Job 'com.canonical.certification::rt-performance-tests/cyclictest_rt'
Job 'com.canonical.certification::stress/cpu_stress_ng_test'
...
```


