### PR TITLE
Modify bluetooth/bluetooth_obex_send job able to run on both classic and core (BugFix)

### DIFF
--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -423,9 +423,10 @@ category_id: com.canonical.plainbox::bluetooth
 id: bluetooth/bluetooth_obex_send
 depends: bluetooth/detect-output
 estimated_duration: 10.0
+environ: BTDEVADDR PLAINBOX_PROVIDER_DATA
 requires:
- package.name == 'bluez'
- executable.name == 'obexftp'
+ package.name == 'bluez' or snap.name == 'bluez'
+ executable.name == 'obexftp' and executable.name == 'hcitool'
  device.category == 'BLUETOOTH'
 command:
   if [ -z "$BTDEVADDR" ]
@@ -436,7 +437,7 @@ command:
   for bt in $(echo "${BTDEVADDR}" | cut -d = -f 2 | sed s/,/\\n/g)
   do
     echo "Host:[${bt}]"
-    if echo 'u' | sudo -S l2ping -c 5 -t 5 "${bt}"
+    if hcitool inq | grep -q "${bt}"
         then
         echo "Get available BTDEVADDR:[${bt}]"
         set -o pipefail


### PR DESCRIPTION
Modify bluetooth/bluetooth_obex_send job able to run on both classic and core

Replace l2ping command with hcitool inq.

Because l2ping tool is not a part of bluez snap

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
OBEX is able to test on Ubuntu core, but the current job can only run on classic images.
And replace `l2ping` command with `hcitool inq` which is able to inquire the Bluetooth devices. Since `l2ping` does not include in Bluez snap. And the reason that we don't use `hcitool scan` is because the `inq` is faster than `scan`.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests
Test with desktop image
pass: https://certification.canonical.com/hardware/202311-32337/submission/363603/test-results/
fail: https://certification.canonical.com/hardware/202311-32337/submission/363616/test-results/

Test with core image
pass: https://certification.canonical.com/hardware/202401-33430/submission/363604/test-results/
fail: https://certification.canonical.com/hardware/202401-33430/submission/363617/test-results/
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

