### PR TITLE
Add disconnect function to snapd class (New)

### DIFF
--- a/checkbox-support/checkbox_support/snap_utils/snapd.py
+++ b/checkbox-support/checkbox_support/snap_utils/snapd.py
@@ -215,9 +215,7 @@ class Snapd:
             self._poll_change(r["change"])
 
     def connect(self, slot_snap, slot_slot, plug_snap, plug_plug):
-        self.connect_or_disconnect(
-            slot_snap, slot_slot, plug_snap, plug_plug
-        )
+        self.connect_or_disconnect(slot_snap, slot_slot, plug_snap, plug_plug)
 
     def disconnect(self, slot_snap, slot_slot, plug_snap, plug_plug):
         self.connect_or_disconnect(

--- a/checkbox-support/checkbox_support/snap_utils/snapd.py
+++ b/checkbox-support/checkbox_support/snap_utils/snapd.py
@@ -213,6 +213,16 @@ class Snapd:
         if r["type"] == "async" and r["status"] == "Accepted":
             self._poll_change(r["change"])
 
+    def disconnect(self, slot_snap, slot_slot, plug_snap, plug_plug):
+        data = {
+            "action": "disconnect",
+            "slots": [{"snap": slot_snap, "slot": slot_slot}],
+            "plugs": [{"snap": plug_snap, "plug": plug_plug}],
+        }
+        r = self._post(self._interfaces, json.dumps(data))
+        if r["type"] == "async" and r["status"] == "Accepted":
+            self._poll_change(r["change"])
+
     def get_assertions(self, assertion_type):
         path = self._assertions + "/" + assertion_type
         return self._get(path, decode=False)

--- a/checkbox-support/checkbox_support/snap_utils/tests/test_snapd.py
+++ b/checkbox-support/checkbox_support/snap_utils/tests/test_snapd.py
@@ -148,3 +148,28 @@ class TestSnapd(TestCase):
         Snapd.remove(mock_self, "test", revision="1")
         test_data = {"action": "remove", "revision": "1"}
         mock_self._post.assert_called_with(ANY, json.dumps(test_data))
+
+    def test_disconnect(self):
+        mock_self = MagicMock()
+        mock_self._poll_change = MagicMock()
+        mock_self._post.return_value = {
+            "type": "async",
+            "status": "Accepted",
+            "change": "1",
+        }
+        slot_snap = 'test_slot_snap'
+        slot_slot = 'test_slot'
+        plug_snap = 'test_plug_snap'
+        plug_plug = 'test_plug'
+
+        Snapd.disconnect(mock_self, slot_snap, slot_slot, plug_snap, plug_plug)
+        mock_self._post.assert_called_once_with(
+            mock_self._interfaces,
+            json.dumps({
+                "action": "disconnect",
+                "slots": [{"snap": slot_snap, "slot": slot_slot}],
+                "plugs": [{"snap": plug_snap, "plug": plug_plug}],
+            })
+        )
+
+        mock_self._poll_change.assert_called_with("1")

--- a/checkbox-support/checkbox_support/snap_utils/tests/test_snapd.py
+++ b/checkbox-support/checkbox_support/snap_utils/tests/test_snapd.py
@@ -149,7 +149,7 @@ class TestSnapd(TestCase):
         test_data = {"action": "remove", "revision": "1"}
         mock_self._post.assert_called_with(ANY, json.dumps(test_data))
 
-    def test_disconnect(self):
+    def test_disconnect_success(self):
         mock_self = MagicMock()
         mock_self._poll_change = MagicMock()
         mock_self._post.return_value = {
@@ -157,19 +157,46 @@ class TestSnapd(TestCase):
             "status": "Accepted",
             "change": "1",
         }
-        slot_snap = 'test_slot_snap'
-        slot_slot = 'test_slot'
-        plug_snap = 'test_plug_snap'
-        plug_plug = 'test_plug'
+        slot_snap = "test_slot_snap"
+        slot_slot = "test_slot"
+        plug_snap = "test_plug_snap"
+        plug_plug = "test_plug"
 
         Snapd.disconnect(mock_self, slot_snap, slot_slot, plug_snap, plug_plug)
         mock_self._post.assert_called_once_with(
             mock_self._interfaces,
-            json.dumps({
-                "action": "disconnect",
-                "slots": [{"snap": slot_snap, "slot": slot_slot}],
-                "plugs": [{"snap": plug_snap, "plug": plug_plug}],
-            })
+            json.dumps(
+                {
+                    "action": "disconnect",
+                    "slots": [{"snap": slot_snap, "slot": slot_slot}],
+                    "plugs": [{"snap": plug_snap, "plug": plug_plug}],
+                }
+            ),
         )
-
         mock_self._poll_change.assert_called_with("1")
+
+    def test_disconnect_fail(self):
+        mock_self = MagicMock()
+        mock_self._poll_change = MagicMock()
+        mock_self._post.return_value = {
+            "type": "async",
+            "status": "Not_Accepted",
+            "change": "1",
+        }
+        slot_snap = "test_slot_snap"
+        slot_slot = "test_slot"
+        plug_snap = "test_plug_snap"
+        plug_plug = "test_plug"
+
+        Snapd.disconnect(mock_self, slot_snap, slot_slot, plug_snap, plug_plug)
+        mock_self._post.assert_called_once_with(
+            mock_self._interfaces,
+            json.dumps(
+                {
+                    "action": "disconnect",
+                    "slots": [{"snap": slot_snap, "slot": slot_slot}],
+                    "plugs": [{"snap": plug_snap, "plug": plug_plug}],
+                }
+            ),
+        )
+        mock_self._poll_change.assert_not_called()

--- a/checkbox-support/checkbox_support/snap_utils/tests/test_snapd.py
+++ b/checkbox-support/checkbox_support/snap_utils/tests/test_snapd.py
@@ -271,7 +271,7 @@ class TestSnapd(TestCase):
         )
         mock_self._poll_change.assert_not_called()
 
-    @patch.object(Snapd, 'connect_or_disconnect')
+    @patch.object(Snapd, "connect_or_disconnect")
     def test_connect_called(self, mock_connect_or_disconnect):
         snapd = Snapd()
         slot_snap = "test_slot_snap"
@@ -284,7 +284,7 @@ class TestSnapd(TestCase):
             slot_snap, slot_slot, plug_snap, plug_plug
         )
 
-    @patch.object(Snapd, 'connect_or_disconnect')
+    @patch.object(Snapd, "connect_or_disconnect")
     def test_disconnect_called(self, mock_connect_or_disconnect):
         snapd = Snapd()
         slot_snap = "test_slot_snap"

--- a/checkbox-support/checkbox_support/snap_utils/tests/test_snapd.py
+++ b/checkbox-support/checkbox_support/snap_utils/tests/test_snapd.py
@@ -149,6 +149,62 @@ class TestSnapd(TestCase):
         test_data = {"action": "remove", "revision": "1"}
         mock_self._post.assert_called_with(ANY, json.dumps(test_data))
 
+    def test_connect_success(self):
+        mock_self = MagicMock()
+        mock_self._poll_change = MagicMock()
+        mock_self._post.return_value = {
+            "type": "async",
+            "status": "Accepted",
+            "change": "1",
+        }
+        slot_snap = "test_slot_snap"
+        slot_slot = "test_slot"
+        plug_snap = "test_plug_snap"
+        plug_plug = "test_plug"
+
+        Snapd.connect_or_disconnect(
+            mock_self, slot_snap, slot_slot, plug_snap, plug_plug
+        )
+        mock_self._post.assert_called_once_with(
+            mock_self._interfaces,
+            json.dumps(
+                {
+                    "action": "connect",
+                    "slots": [{"snap": slot_snap, "slot": slot_slot}],
+                    "plugs": [{"snap": plug_snap, "plug": plug_plug}],
+                }
+            ),
+        )
+        mock_self._poll_change.assert_called_with("1")
+
+    def test_connect_fail(self):
+        mock_self = MagicMock()
+        mock_self._poll_change = MagicMock()
+        mock_self._post.return_value = {
+            "type": "async",
+            "status": "Not_Accepted",
+            "change": "1",
+        }
+        slot_snap = "test_slot_snap"
+        slot_slot = "test_slot"
+        plug_snap = "test_plug_snap"
+        plug_plug = "test_plug"
+
+        Snapd.connect_or_disconnect(
+            mock_self, slot_snap, slot_slot, plug_snap, plug_plug
+        )
+        mock_self._post.assert_called_once_with(
+            mock_self._interfaces,
+            json.dumps(
+                {
+                    "action": "connect",
+                    "slots": [{"snap": slot_snap, "slot": slot_slot}],
+                    "plugs": [{"snap": plug_snap, "plug": plug_plug}],
+                }
+            ),
+        )
+        mock_self._poll_change.assert_not_called()
+
     def test_disconnect_success(self):
         mock_self = MagicMock()
         mock_self._poll_change = MagicMock()
@@ -162,7 +218,14 @@ class TestSnapd(TestCase):
         plug_snap = "test_plug_snap"
         plug_plug = "test_plug"
 
-        Snapd.disconnect(mock_self, slot_snap, slot_slot, plug_snap, plug_plug)
+        Snapd.connect_or_disconnect(
+            mock_self,
+            slot_snap,
+            slot_slot,
+            plug_snap,
+            plug_plug,
+            action="disconnect",
+        )
         mock_self._post.assert_called_once_with(
             mock_self._interfaces,
             json.dumps(
@@ -188,7 +251,14 @@ class TestSnapd(TestCase):
         plug_snap = "test_plug_snap"
         plug_plug = "test_plug"
 
-        Snapd.disconnect(mock_self, slot_snap, slot_slot, plug_snap, plug_plug)
+        Snapd.connect_or_disconnect(
+            mock_self,
+            slot_snap,
+            slot_slot,
+            plug_snap,
+            plug_plug,
+            action="disconnect",
+        )
         mock_self._post.assert_called_once_with(
             mock_self._interfaces,
             json.dumps(
@@ -200,3 +270,33 @@ class TestSnapd(TestCase):
             ),
         )
         mock_self._poll_change.assert_not_called()
+
+    @patch.object(Snapd, 'connect_or_disconnect')
+    def test_connect_called(self, mock_connect_or_disconnect):
+        snapd = Snapd()
+        slot_snap = "test_slot_snap"
+        slot_slot = "test_slot"
+        plug_snap = "test_plug_snap"
+        plug_plug = "test_plug"
+        snapd.connect(slot_snap, slot_slot, plug_snap, plug_plug)
+
+        mock_connect_or_disconnect.assert_called_once_with(
+            slot_snap, slot_slot, plug_snap, plug_plug
+        )
+
+    @patch.object(Snapd, 'connect_or_disconnect')
+    def test_disconnect_called(self, mock_connect_or_disconnect):
+        snapd = Snapd()
+        slot_snap = "test_slot_snap"
+        slot_slot = "test_slot"
+        plug_snap = "test_plug_snap"
+        plug_plug = "test_plug"
+        snapd.disconnect(slot_snap, slot_slot, plug_snap, plug_plug)
+
+        mock_connect_or_disconnect.assert_called_once_with(
+            slot_snap,
+            slot_slot,
+            plug_snap,
+            plug_plug,
+            action="disconnect",
+        )


### PR DESCRIPTION
Add disconnect function to snapd class 

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
We intend to test the slots for SNAP, and the disconnect slots will be a part of our test scenario.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
-->

## Tests
We tried to call this function and that works fine.
#### Test script #####
```
#!/usr/bin/env python3
from snapd import Snapd
import os
import requests

def disconnect_interface(gpio_slot, gadget_name):
    """
    Connect GPIO plugs of checkbox to GPIO slots of gadget snap.

    Args:
        gpio_slot: A GPIO slot information.
        gadget_name: The name of the gadget snap.

    Raises:
        SystemExit: If failed to connect any GPIO.
    """

    # Get the snap name of checkbox
    timeout = int(os.environ.get('SNAPD_TASK_TIMEOUT', 60))

    print("Attempting disconnect gpio to {}:{}".format(gadget_name, gpio_slot))
    try:
        Snapd(task_timeout=timeout).disconnect(
            gadget_name,
            gpio_slot,
            "checkbox",
            "gpio"
            )
        print("Success")
    except requests.HTTPError:
        print("Failed to connect {}".format(gpio_slot))
        raise SystemExit(1)

def main():
    disconnect_interface('gpio-510', 'gadget')

if __name__ == "__main__":
    main()
```

#### Test result #####
```
root@ubuntu:/home/ceqa/snap_utils# snap connections checkbox|grep gpio-510
gpio                                    checkbox:gpio                          gadget:gpio-510      manual
root@ubuntu:/home/ceqa/snap_utils# python3 test.py 
Attempting disconnect gpio to gadget:gpio-510
Success
root@ubuntu:/home/ceqa/snap_utils# snap connections gadget|grep gpio-510
gpio                     -                                                    gadget:gpio-510    
```

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

