### PR TITLE
Require one of the lxd or lxd-installer debs or the lxd snap for the virtualization tests. (BugFix)

### DIFF
--- a/providers/base/units/virtualization/jobs.pxu
+++ b/providers/base/units/virtualization/jobs.pxu
@@ -5,7 +5,7 @@ environ: LXD_TEMPLATE KVM_IMAGE
 estimated_duration: 60.0
 requires:
  executable.name == 'lxc'
- snap.name == 'lxd'
+ package.name == 'lxd-installer' or snap.name == 'lxd'
 command: virtualization.py --debug lxdvm
 _description:
  Verifies that an LXD Virtual Machine can be created and launched
@@ -19,7 +19,7 @@ environ: LXD_TEMPLATE LXD_ROOTFS
 estimated_duration: 30.0
 requires:
  executable.name == 'lxc'
- package.name == 'lxd' or snap.name == 'lxd'
+ package.name == 'lxd' or package.name == 'lxd-installer' or snap.name == 'lxd'
 command: virtualization.py --debug lxd
 _description:
  Verifies that an LXD container can be created and launched


### PR DESCRIPTION
## Description
Noble does not provide the lxd snap by default now in the server images, instead it provides a wrapper called lxd-installer that triggers the snap install the first time a user tries using either the lxc or lxd commands.  

The jobs were not looking for the lxd-installer package, instead they were looking for the lxd snap or the old lxd package.  This changes the constraints so that the jobs will run if only lxd-installer is present (on noble server) . In this case, the 'lxd init' commands that virtualization.py runs will trigger the snap install on server, and then tests proceed as expected.

Added a check to run the job if lxd-installer is on the system, since on Noble, the lxd snap and deb will not be there at first.

## Resolved issues

#1022 
CHECKBOX-1275

## Documentation

NO docs changes needed.

## Tests

Manually  modified jobs.pxu on a fresh noble install to add the package lxd-installer to the requires section for the virtualization jobs.

Ran test-virtualization to call both lxd and lxdvm tests.

Before changes, the tests are skipped because the lxd snap is not installed.
After the changes, the tests are executed.