### PR TITLE
Fix rpmsg tests (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpmsg_tests.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpmsg_tests.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import datetime
 import os
 import sys
 import time
@@ -10,7 +9,6 @@ import subprocess
 import shlex
 import select
 import logging
-import concurrent.futures
 import threading
 from systemd import journal
 from pathlib import Path
@@ -172,7 +170,7 @@ class RpmsgPingPongTest:
 
     def monitor_journal_pingpong_logs(self):
 
-        start_time = datetime.datetime.now()
+        start_time = time.time()
         logging.info("# start time: %s", start_time)
 
         self.pingpong_events = []
@@ -182,8 +180,8 @@ class RpmsgPingPongTest:
                 if self.lookup_pingpong_logs() is False:
                     return self.pingpong_events
 
-            cur_time = datetime.datetime.now()
-            if (cur_time - start_time).total_seconds() > 60:
+            cur_time = time.time()
+            if (cur_time - start_time) > 60:
                 return self.pingpong_events
 
     def pingpong_test(self):

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpmsg_tests.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpmsg_tests.py
@@ -214,7 +214,6 @@ class RpmsgPingPongTest:
                 target=self.monitor_journal_pingpong_logs
             )
             thread.start()
-            time.sleep(3)
             logging.info("# probe pingpong module with '%s'", self.probe_cmd)
 
             subprocess.Popen(shlex.split(self.probe_cmd))

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/serial_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/serial_test.py
@@ -105,7 +105,6 @@ class Serial:
     def recv(self) -> bytes:
         rcv = ""
         try:
-            self.ser.rts = False
             rcv = self.ser.read(self.data_size)
             if rcv:
                 logging.info("Received: {}".format(rcv.decode()))

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_rpmsg_tests.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_rpmsg_tests.py
@@ -1,10 +1,10 @@
 import unittest
 import sys
-from unittest.mock import patch, MagicMock
+import argparse
+from unittest.mock import patch, MagicMock, Mock
 
 sys.modules["systemd"] = MagicMock()
-sys.modules["serial_test"] = MagicMock()
-sys.modules["serial_test"].client_mode = MagicMock(side_effect=SystemExit(0))
+
 import rpmsg_tests
 
 
@@ -96,21 +96,129 @@ class RpmsgTests(unittest.TestCase):
         with self.assertRaisesRegex(SystemExit, "Unexpected CPU type."):
             rpmsg_tests.rpmsg_tty_test_supported("mtk")
 
+
+class TestRpmsgPingPong(unittest.TestCase):
+
+    @patch("rpmsg_tests.RpmsgPingPongTest.__init__")
+    @patch("rpmsg_tests.RpmsgPingPongTest.pingpong_test")
+    def test_pingpong_entry_imx(self, mock_pingpong, mock_init):
+
+        mock_init.return_value = None
+        rpmsg_tests.pingpong_test("imx")
+        mock_init.assert_called_with(
+            "imx_rpmsg_pingpong",
+            "modprobe imx_rpmsg_pingpong",
+            r"get .* \(src: (\w*)\)",
+            r"rpmsg.*: goodbye!",
+            51
+        )
+        mock_pingpong.assert_called_with()
+
+    @patch("rpmsg_tests.RpmsgPingPongTest.__init__")
+    @patch("rpmsg_tests.RpmsgPingPongTest.pingpong_test")
+    def test_pingpong_entry_ti(self, mock_pingpong, mock_init):
+
+        mock_init.return_value = None
+        rpmsg_tests.pingpong_test("ti")
+        mock_init.assert_called_with(
+            "rpmsg_client_sample",
+            "modprobe rpmsg_client_sample count=100",
+            r".*ti.ipc4.ping-pong.*src: (\w*)\)",
+            r"rpmsg.*: goodbye!",
+            100
+        )
+        mock_pingpong.assert_called_with()
+
+    @patch("rpmsg_tests.RpmsgPingPongTest.__init__")
+    @patch("rpmsg_tests.RpmsgPingPongTest.pingpong_test")
+    def test_pingpong_entry_failed(self, mock_pingpong, mock_init):
+
+        mock_init.return_value = None
+        with self.assertRaises(SystemExit):
+            rpmsg_tests.pingpong_test("unknown")
+        mock_init.assert_not_called()
+        mock_pingpong.assert_not_called()
+
+
+class TestRpmsgSerialTty(unittest.TestCase):
+
+    @patch("serial_test.client_mode")
+    @patch("serial_test.Serial")
     @patch("rpmsg_tests.check_rpmsg_tty_devices")
-    def test_no_rpmsg_devices(self, mock_check_rpmsg_tty_devices):
+    def test_no_rpmsg_devices(self, mock_check_rpmsg_tty_devices,
+                              mock_serial, mock_client_mode):
         """
         No RPMSG TTY devices found and raise SystemExit
         """
+        mock_serial.return_value = []
         mock_check_rpmsg_tty_devices.return_value = []
         with self.assertRaisesRegex(SystemExit, "No RPMSG TTY devices found."):
             rpmsg_tests.serial_tty_test("imx", 64)
+            mock_serial.assert_not_called()
+            mock_client_mode.assert_not_called()
 
+    @patch("serial_test.client_mode")
+    @patch("serial_test.Serial")
     @patch("rpmsg_tests.check_rpmsg_tty_devices")
-    def test_rpmsg_test_passed(self, mock_check_rpmsg_tty_devices):
+    def test_rpmsg_tty_test_passed(self, mock_check_rpmsg_tty_devices,
+                                   mock_serial, mock_client_mode):
         """
         String-ECHO test passed through RPMSG TTY device
         """
-        mock_check_rpmsg_tty_devices.return_value = ["/dev/ttyRPMSG30"]
+        serial_dev = "serial-dev"
+        tty_device = "/dev/ttyRPMSG30"
+        mock_check_rpmsg_tty_devices.return_value = [tty_device]
+        mock_serial.return_value = serial_dev
 
-        with self.assertRaises(SystemExit):
-            rpmsg_tests.serial_tty_test("imx", 64)
+        rpmsg_tests.serial_tty_test("imx", 64)
+        mock_serial.assert_called_with(
+            tty_device, "rpmsg-tty", [], 115200, 8, "N", 1, 3, 1024)
+        mock_client_mode.assert_called_with(serial_dev, 64)
+
+    @patch("rpmsg_tests.serial_tty_test")
+    @patch("rpmsg_tests.pingpong_test")
+    @patch("rpmsg_tests.check_rpmsg_device")
+    def test_launch_check_rpmsg_device(self, mock_check_rpmsg,
+                                       mock_pingpong, mock_stty):
+
+        mock_args = Mock(return_value=argparse.Namespace(type="detect"))
+        rpmsg_tests.main(mock_args())
+        mock_check_rpmsg.assert_called_with()
+        mock_pingpong.assert_not_called()
+        mock_stty.assert_not_called()
+
+    @patch("rpmsg_tests.serial_tty_test")
+    @patch("rpmsg_tests.check_rpmsg_device")
+    @patch("rpmsg_tests.detect_arm_processor_type")
+    @patch("rpmsg_tests.pingpong_test")
+    def test_launch_pingpong_test(self, mock_pingpong, mock_detect_arch,
+                                  mock_check_rpmsg, mock_stty):
+
+        mock_args = Mock(return_value=argparse.Namespace(type="pingpong"))
+        mock_detect_arch.return_value = "imx"
+        rpmsg_tests.main(mock_args())
+        mock_pingpong.assert_called_with("imx")
+        mock_detect_arch.assert_called_with()
+        mock_check_rpmsg.assert_not_called()
+        mock_stty.assert_not_called()
+
+    @patch("rpmsg_tests.check_rpmsg_device")
+    @patch("rpmsg_tests.pingpong_test")
+    @patch("rpmsg_tests.detect_arm_processor_type")
+    @patch("rpmsg_tests.serial_tty_test")
+    def test_launch_serial_tty_test(self, mock_stty, mock_detect_arch,
+                                    mock_pingpong, mock_check_rpmsg):
+
+        mock_args = Mock(return_value=argparse.Namespace(type="serial-tty"))
+        mock_detect_arch.return_value = "imx"
+        rpmsg_tests.main(mock_args())
+        mock_stty.assert_called_with("imx", 1024)
+        mock_detect_arch.assert_called_with()
+        mock_pingpong.assert_not_called()
+        mock_check_rpmsg.assert_not_called()
+
+    def test_argument_parser(self):
+        sys.argv = ["rpmsg_tests.py", "--type", "detect"]
+        args = rpmsg_tests.register_arguments()
+
+        self.assertEqual(args.type, "detect")

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_rpmsg_tests.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_rpmsg_tests.py
@@ -110,7 +110,7 @@ class TestRpmsgPingPong(unittest.TestCase):
             "modprobe imx_rpmsg_pingpong",
             r"get .* \(src: (\w*)\)",
             r"rpmsg.*: goodbye!",
-            51
+            51,
         )
         mock_pingpong.assert_called_with()
 
@@ -123,9 +123,9 @@ class TestRpmsgPingPong(unittest.TestCase):
         mock_init.assert_called_with(
             "rpmsg_client_sample",
             "modprobe rpmsg_client_sample count=100",
-            r".*ti.ipc4.ping-pong.*src: (\w*)\)",
+            r".*ti.ipc4.ping-pong.*\(src: (\w*)\)",
             r"rpmsg.*: goodbye!",
-            100
+            100,
         )
         mock_pingpong.assert_called_with()
 
@@ -145,8 +145,9 @@ class TestRpmsgSerialTty(unittest.TestCase):
     @patch("serial_test.client_mode")
     @patch("serial_test.Serial")
     @patch("rpmsg_tests.check_rpmsg_tty_devices")
-    def test_no_rpmsg_devices(self, mock_check_rpmsg_tty_devices,
-                              mock_serial, mock_client_mode):
+    def test_no_rpmsg_devices(
+        self, mock_check_rpmsg_tty_devices, mock_serial, mock_client_mode
+    ):
         """
         No RPMSG TTY devices found and raise SystemExit
         """
@@ -160,8 +161,9 @@ class TestRpmsgSerialTty(unittest.TestCase):
     @patch("serial_test.client_mode")
     @patch("serial_test.Serial")
     @patch("rpmsg_tests.check_rpmsg_tty_devices")
-    def test_rpmsg_tty_test_passed(self, mock_check_rpmsg_tty_devices,
-                                   mock_serial, mock_client_mode):
+    def test_rpmsg_tty_test_passed(
+        self, mock_check_rpmsg_tty_devices, mock_serial, mock_client_mode
+    ):
         """
         String-ECHO test passed through RPMSG TTY device
         """
@@ -172,14 +174,16 @@ class TestRpmsgSerialTty(unittest.TestCase):
 
         rpmsg_tests.serial_tty_test("imx", 64)
         mock_serial.assert_called_with(
-            tty_device, "rpmsg-tty", [], 115200, 8, "N", 1, 3, 1024)
+            tty_device, "rpmsg-tty", [], 115200, 8, "N", 1, 3, 1024
+        )
         mock_client_mode.assert_called_with(serial_dev, 64)
 
     @patch("rpmsg_tests.serial_tty_test")
     @patch("rpmsg_tests.pingpong_test")
     @patch("rpmsg_tests.check_rpmsg_device")
-    def test_launch_check_rpmsg_device(self, mock_check_rpmsg,
-                                       mock_pingpong, mock_stty):
+    def test_launch_check_rpmsg_device(
+        self, mock_check_rpmsg, mock_pingpong, mock_stty
+    ):
 
         mock_args = Mock(return_value=argparse.Namespace(type="detect"))
         rpmsg_tests.main(mock_args())
@@ -191,8 +195,9 @@ class TestRpmsgSerialTty(unittest.TestCase):
     @patch("rpmsg_tests.check_rpmsg_device")
     @patch("rpmsg_tests.detect_arm_processor_type")
     @patch("rpmsg_tests.pingpong_test")
-    def test_launch_pingpong_test(self, mock_pingpong, mock_detect_arch,
-                                  mock_check_rpmsg, mock_stty):
+    def test_launch_pingpong_test(
+        self, mock_pingpong, mock_detect_arch, mock_check_rpmsg, mock_stty
+    ):
 
         mock_args = Mock(return_value=argparse.Namespace(type="pingpong"))
         mock_detect_arch.return_value = "imx"
@@ -206,8 +211,9 @@ class TestRpmsgSerialTty(unittest.TestCase):
     @patch("rpmsg_tests.pingpong_test")
     @patch("rpmsg_tests.detect_arm_processor_type")
     @patch("rpmsg_tests.serial_tty_test")
-    def test_launch_serial_tty_test(self, mock_stty, mock_detect_arch,
-                                    mock_pingpong, mock_check_rpmsg):
+    def test_launch_serial_tty_test(
+        self, mock_stty, mock_detect_arch, mock_pingpong, mock_check_rpmsg
+    ):
 
         mock_args = Mock(return_value=argparse.Namespace(type="serial-tty"))
         mock_detect_arch.return_value = "imx"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/rpmsg/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/rpmsg/test-plan.pxu
@@ -20,3 +20,4 @@ _description: Automated RPMSG framework tests
 include:
     ce-oem-rpmsg/detect-device
     ce-oem-rpmsg/serial-tty
+    ce-oem-rpmsg/pingpong


### PR DESCRIPTION
Fix rpmsg tests (Bugfix)

## Description
The RPMSG TTY tests failed due to the serial tests scripts has been modified few week ago, and we did not noticed that might import the RPMSG TTY tests. 

Moreover, I had restructure the RPMSG ping pong test to make it easy to maintain and adding some unit tests in this PR.

## Resolved issues
N/A

## Documentation
N/A

## Tests
RPMSG TTY test on X8 MED PDK
https://certification.canonical.com/hardware/202403-33847/submission/364314/

