### PR TITLE
Workflow to build core24 snaps (infra)

### DIFF
--- a/.github/workflows/core24-builds.yml
+++ b/.github/workflows/core24-builds.yml
@@ -1,0 +1,82 @@
+name: checkbox core24 builder
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  snap:
+    strategy:
+      fail-fast: false
+      matrix:
+        type: [classic, uc]
+        releases: [24]
+        arch: [amd64, arm64]
+        tag: [X64, ARM64]
+        exclude:
+          - arch: amd64
+            tag: ARM64
+          - arch: arm64
+            tag: X64
+    runs-on:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - ${{ matrix.tag }}
+    timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
+    env:
+      SERIES: series${{ matrix.releases }}
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
+    name: Runtime (Core) ${{ matrix.releases }}-${{ matrix.arch }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Copy over the common files for series ${{ matrix.releases }}
+        run: |
+          cd checkbox-core-snap/
+          sudo apt update && sudo apt install -qq -y python3-setuptools-scm
+          ./prepare.sh $SERIES
+      - name: Add LP credentials
+        run: |
+          mkdir -p ~/.local/share/snapcraft/provider/launchpad/
+          echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
+          git config --global user.email "robot@lists.canonical.com"
+          git config --global user.name "Certification bot"
+      - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+        name: Build the snap
+        timeout-minutes: 600 # 10hours
+        with:
+          action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
+          attempt_delay: 600000 # 10min
+          attempt_limit: 5
+          with: |
+            path: checkbox-core-snap/series${{ matrix.releases }}
+            snapcraft-channel: 7.x/stable
+      - uses: actions/upload-artifact@v3
+        name: Upload logs on failure
+        if: failure()
+        with:
+          name: snapcraft-log-series${{ matrix.releases }}
+          path: |
+            /home/runner/.cache/snapcraft/log/
+            /home/runner/.local/state/snapcraft/log/
+            checkbox-core-snap/series${{ matrix.releases }}/checkbox*.txt
+      - uses: actions/upload-artifact@v3
+        name: Upload the snap as artifact
+        with:
+          name: series${{ matrix.releases }}
+          path: checkbox-core-snap/series${{ matrix.releases }}/*.snap
+      - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+        name: Upload the snap to the store
+        timeout-minutes: 600 # 10hours
+        with:
+          attempt_delay: 600000 # 10min
+          attempt_limit: 10
+          command: |
+            for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap ; \
+            do \
+              echo "Uploading $snap..." ; \
+              snapcraft upload $snap --release edge ; \
+            done


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This is a workflow to build and publish Core24 to the edge channel in the store. This is only includes the runtime for now and it is here to experiment (as github doesn't seem to add a workflow to the list of "runnables" till it is landed in main at least once).

## Resolved issues

Make core24 buildable automatically like the others.

## Documentation

N/A

## Tests

N/A
