### PR TITLE
Fall back from distutils -> packaging.version (bugfix)

### DIFF
--- a/providers/base/bin/wifi_nmcli_backup.py
+++ b/providers/base/bin/wifi_nmcli_backup.py
@@ -12,7 +12,11 @@ import shutil
 import subprocess as sp
 import sys
 
-from distutils.version import LooseVersion
+try:
+    from distutils.version import LooseVersion as version_parser
+except ModuleNotFoundError:
+    from packaging import version
+    version_parser = version.parse
 
 NM_CON_DIR = "/etc/NetworkManager/system-connections"
 SAVE_DIR = os.path.join(
@@ -25,12 +29,10 @@ SAVE_DIR = os.path.join(
 def legacy_nmcli():
     cmd = "nmcli -v"
     output = sp.check_output(cmd, shell=True)
-    version = LooseVersion(output.strip().split()[-1].decode())
+    version = version_parser(output.strip().split()[-1].decode())
     # check if using an earlier nmcli version with different api
     # nmcli in cosmic is 1.12.4, bionic is 1.10
-    if version < LooseVersion("1.12.0"):
-        return True
-    return False
+    return version < version_parser("1.12.0")
 
 
 # Creation of keyfile names can be found in:

--- a/providers/base/bin/wifi_nmcli_backup.py
+++ b/providers/base/bin/wifi_nmcli_backup.py
@@ -16,6 +16,7 @@ try:
     from distutils.version import LooseVersion as version_parser
 except ModuleNotFoundError:
     from packaging import version
+
     version_parser = version.parse
 
 NM_CON_DIR = "/etc/NetworkManager/system-connections"

--- a/providers/base/bin/wifi_nmcli_backup.py
+++ b/providers/base/bin/wifi_nmcli_backup.py
@@ -12,12 +12,8 @@ import shutil
 import subprocess as sp
 import sys
 
-try:
-    from distutils.version import LooseVersion as version_parser
-except ModuleNotFoundError:  # noqa: F821
-    from packaging import version
+from packaging import version as version_parser
 
-    version_parser = version.parse
 
 NM_CON_DIR = "/etc/NetworkManager/system-connections"
 SAVE_DIR = os.path.join(
@@ -30,10 +26,10 @@ SAVE_DIR = os.path.join(
 def legacy_nmcli():
     cmd = "nmcli -v"
     output = sp.check_output(cmd, shell=True)
-    version = version_parser(output.strip().split()[-1].decode())
+    version = version_parser.parse(output.strip().split()[-1].decode())
     # check if using an earlier nmcli version with different api
     # nmcli in cosmic is 1.12.4, bionic is 1.10
-    return version < version_parser("1.12.0")
+    return version < version_parser.parse("1.12.0")
 
 
 # Creation of keyfile names can be found in:

--- a/providers/base/bin/wifi_nmcli_backup.py
+++ b/providers/base/bin/wifi_nmcli_backup.py
@@ -14,7 +14,7 @@ import sys
 
 try:
     from distutils.version import LooseVersion as version_parser
-except ModuleNotFoundError: # noqa: F821
+except ModuleNotFoundError:  # noqa: F821
     from packaging import version
 
     version_parser = version.parse

--- a/providers/base/bin/wifi_nmcli_backup.py
+++ b/providers/base/bin/wifi_nmcli_backup.py
@@ -14,7 +14,7 @@ import sys
 
 try:
     from distutils.version import LooseVersion as version_parser
-except ModuleNotFoundError:
+except ModuleNotFoundError: # noqa: F821
     from packaging import version
 
     version_parser = version.parse

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -17,14 +17,10 @@ import subprocess as sp
 import sys
 import time
 
+from packaging import version as version_parser
+
 from gateway_ping_test import ping
 
-try:
-    from distutils.version import LooseVersion as version_parser
-except ModuleNotFoundError:  # noqa: F821
-    from packaging import version
-
-    version_parser = version.parse
 
 print = functools.partial(print, flush=True)
 
@@ -32,10 +28,10 @@ print = functools.partial(print, flush=True)
 def legacy_nmcli():
     cmd = "nmcli -v"
     output = sp.check_output(cmd, shell=True)
-    version = version_parser(output.strip().split()[-1].decode())
+    version = version_parser.parse(output.strip().split()[-1].decode())
     # check if using the 16.04 nmcli because of this bug
     # https://bugs.launchpad.net/plano/+bug/1896806
-    return version < version_parser("1.9.9")
+    return version < version_parser.parse("1.9.9")
 
 
 def print_head(txt):

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -21,7 +21,7 @@ from gateway_ping_test import ping
 
 try:
     from distutils.version import LooseVersion as version_parser
-except ModuleNotFoundError:
+except ModuleNotFoundError: # noqa: F821
     from packaging import version
 
     version_parser = version.parse

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -21,7 +21,7 @@ from gateway_ping_test import ping
 
 try:
     from distutils.version import LooseVersion as version_parser
-except ModuleNotFoundError: # noqa: F821
+except ModuleNotFoundError:  # noqa: F821
     from packaging import version
 
     version_parser = version.parse

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -17,8 +17,12 @@ import subprocess as sp
 import sys
 import time
 
-from distutils.version import LooseVersion
 from gateway_ping_test import ping
+try:
+    from distutils.version import LooseVersion as version_parser
+except ModuleNotFoundError:
+    from packaging import version
+    version_parser = version.parse
 
 print = functools.partial(print, flush=True)
 
@@ -26,12 +30,10 @@ print = functools.partial(print, flush=True)
 def legacy_nmcli():
     cmd = "nmcli -v"
     output = sp.check_output(cmd, shell=True)
-    version = LooseVersion(output.strip().split()[-1].decode())
+    version = version_parser(output.strip().split()[-1].decode())
     # check if using the 16.04 nmcli because of this bug
     # https://bugs.launchpad.net/plano/+bug/1896806
-    if version < LooseVersion("1.9.9"):
-        return True
-    return False
+    return version < version_parser("1.9.9")
 
 
 def print_head(txt):

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -18,10 +18,12 @@ import sys
 import time
 
 from gateway_ping_test import ping
+
 try:
     from distutils.version import LooseVersion as version_parser
 except ModuleNotFoundError:
     from packaging import version
+
     version_parser = version.parse
 
 print = functools.partial(print, flush=True)

--- a/providers/base/tests/test_wifi_nmcli_backup.py
+++ b/providers/base/tests/test_wifi_nmcli_backup.py
@@ -26,13 +26,13 @@ class WifiNmcliBackupTests(unittest.TestCase):
     @patch("wifi_nmcli_backup.sp")
     def test_legacy_nmcli_true(self, subprocess_mock):
         subprocess_mock.check_output.return_value = (
-            "nmcli tool, version 1.11.3-5"
+            b"nmcli tool, version 1.11.3-5"
         )
         self.assertTrue(legacy_nmcli())
 
     @patch("wifi_nmcli_backup.sp")
     def test_legacy_nmcli_false(self, subprocess_mock):
         subprocess_mock.check_output.return_value = (
-            "nmcli tool, version 1.46.0-2"
+            b"nmcli tool, version 1.46.0-2"
         )
         self.assertFalse(legacy_nmcli())

--- a/providers/base/tests/test_wifi_nmcli_backup.py
+++ b/providers/base/tests/test_wifi_nmcli_backup.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+from unittest.mock import patch
+
+from wifi_nmcli_backup import legacy_nmcli
+
+
+class WifiNmcliBackupTests(unittest.TestCase):
+    @patch("wifi_nmcli_backup.sp")
+    def test_legacy_nmcli_true(self, subprocess_mock):
+        subprocess_mock.check_output.return_value = (
+            "nmcli tool, version 1.11.3-5"
+        )
+        self.assertTrue(legacy_nmcli())
+
+    @patch("wifi_nmcli_backup.sp")
+    def test_legacy_nmcli_false(self, subprocess_mock):
+        subprocess_mock.check_output.return_value = (
+            "nmcli tool, version 1.46.0-2"
+        )
+        self.assertFalse(legacy_nmcli())

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -23,16 +23,16 @@ from wifi_nmcli_test import legacy_nmcli
 
 
 class WifiNmcliBackupTests(unittest.TestCase):
-    @patch("wifi_nmcli_backup.sp")
+    @patch("wifi_nmcli_test.sp")
     def test_legacy_nmcli_true(self, subprocess_mock):
         subprocess_mock.check_output.return_value = (
-            "nmcli tool, version 1.9.8-5"
+            b"nmcli tool, version 1.9.8-5"
         )
         self.assertTrue(legacy_nmcli())
 
-    @patch("wifi_nmcli_backup.sp")
+    @patch("wifi_nmcli_test.sp")
     def test_legacy_nmcli_false(self, subprocess_mock):
         subprocess_mock.check_output.return_value = (
-            "nmcli tool, version 1.46.0-2"
+            b"nmcli tool, version 1.46.0-2"
         )
         self.assertFalse(legacy_nmcli())

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+from unittest.mock import patch
+
+from wifi_nmcli_test import legacy_nmcli
+
+
+class WifiNmcliBackupTests(unittest.TestCase):
+    @patch("wifi_nmcli_backup.sp")
+    def test_legacy_nmcli_true(self, subprocess_mock):
+        subprocess_mock.check_output.return_value = (
+            "nmcli tool, version 1.9.8-5"
+        )
+        self.assertTrue(legacy_nmcli())
+
+    @patch("wifi_nmcli_backup.sp")
+    def test_legacy_nmcli_false(self, subprocess_mock):
+        subprocess_mock.check_output.return_value = (
+            "nmcli tool, version 1.46.0-2"
+        )
+        self.assertFalse(legacy_nmcli())


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Distutils is no longer available in python3.12. With this PR when distutils is not available, we fall back to packaging.version.

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/1193

## Documentation

N/A

## Tests

N/A
