### PR TITLE
Add cert-blocker status based on coverage guide for IoT test plans (BugFix)

### DIFF
--- a/providers/base/units/audio/test-plan.pxu
+++ b/providers/base/units/audio/test-plan.pxu
@@ -106,7 +106,7 @@ unit: test plan
 _name: Manual audio tests
 _description: Manual audio tests for Snappy Ubuntu Core devices
 include:
-    audio/alsa-playback
+    audio/alsa-playback    certification-status=blocker
 
 id: audio-pa-manual
 unit: test plan
@@ -126,7 +126,7 @@ _description: Automated audio tests for Snappy Ubuntu Core devices
 include:
     audio/detect-playback-devices
     audio/detect-capture-devices
-    audio/alsa-loopback-automated
+    audio/alsa-loopback-automated    certification-status=blocker
 
 id: after-suspend-audio-full
 unit: test plan

--- a/providers/base/units/bluetooth/test-plan.pxu
+++ b/providers/base/units/bluetooth/test-plan.pxu
@@ -56,7 +56,7 @@ _name: Manual Bluetooth tests
 _description: Manual QA tests for Bluetooth
 estimated_duration: 5m
 include:
-    bluetooth/keyboard-manual
+    bluetooth/keyboard-manual    certification-status=blocker
 
 id: bluez-automated
 unit: test plan
@@ -77,7 +77,7 @@ include:
     # bluetooth/bluez-internal-mgmt-tests_.*
     bluetooth/bluez-internal-uc-tests_.*
     bluetooth/bluez-internal-bnep-tests_.*
-    bluetooth4/beacon_eddystone_url_.*
+    bluetooth4/beacon_eddystone_url_.*    certification-status=blocker
     bluetooth/bluetooth_obex_send
 bootstrap_include:
     device

--- a/providers/base/units/ethernet/test-plan.pxu
+++ b/providers/base/units/ethernet/test-plan.pxu
@@ -69,8 +69,8 @@ _name: Automated ethernet tests
 _description: Automated ethernet tests for Ubuntu Core devices
 estimated_duration: 1m
 include:
-    ethernet/detect
-    ethernet/ping_.*
+    ethernet/detect    certification-status=blocker
+    ethernet/ping_.*   certification-status=blocker
 bootstrap_include:
     device
 

--- a/providers/base/units/i2c/test-plan.pxu
+++ b/providers/base/units/i2c/test-plan.pxu
@@ -18,5 +18,5 @@ unit: test plan
 _name: Automated I²C tests
 _description: Automated I²C tests for Ubuntu Core devices
 include:
-    i2c/i2c-bus-detect
-    i2c/i2c-device-detect
+    i2c/i2c-bus-detect       certification-status=blocker
+    i2c/i2c-device-detect    certification-status=blocker

--- a/providers/base/units/led/test-plan.pxu
+++ b/providers/base/units/led/test-plan.pxu
@@ -104,10 +104,10 @@ unit: test plan
 _name: Manual LED tests for IoT
 _description: Manual LED tests for IoT devices
 include:
-    led/power
+    led/power                         certification-status=blocker
     led/power-blink-suspend
     led/wireless
-    led/serial
+    led/serial                        certification-status=blocker
     led/fn
     led/sysfs_led_brightness_on_.*
     led/sysfs_led_brightness_off_.*

--- a/providers/base/units/memory/test-plan.pxu
+++ b/providers/base/units/memory/test-plan.pxu
@@ -17,7 +17,7 @@ unit: test plan
 _name: Automated memory tests
 _description: Automated memory tests for Ubuntu Core devices
 include:
-    memory/info
+    memory/info    certification-status=blocker
 
 id: server-memory
 unit: test plan

--- a/providers/base/units/monitor/test-plan.pxu
+++ b/providers/base/units/monitor/test-plan.pxu
@@ -359,11 +359,11 @@ unit: test plan
 _name: Manual monitor tests
 _description: Manual monitor tests for Snappy Ubuntu Core devices
 include:
-    monitor/dvi
-    monitor/hdmi
+    monitor/dvi                  certification-status=blocker
+    monitor/hdmi                 certification-status=blocker
     monitor/dvi-to-vga
     monitor/hdmi-to-vga
-    monitor/displayport_hotplug
+    monitor/displayport_hotplug  certification-status=blocker
     monitor/vga
 
 id: after-suspend-monitor-full

--- a/providers/base/units/power-management/test-plan.pxu
+++ b/providers/base/units/power-management/test-plan.pxu
@@ -98,10 +98,10 @@ unit: test plan
 _name: Automated power tests
 _description: Automated power tests for Snappy Ubuntu Core devices
 include:
-    power-management/warm-reboot
-    power-management/post-warm-reboot
-    power-management/cold-reboot
-    power-management/post-cold-reboot
+    power-management/warm-reboot         certification-status=blocker
+    power-management/post-warm-reboot    certification-status=blocker
+    power-management/cold-reboot         certification-status=blocker
+    power-management/post-cold-reboot    certification-status=blocker
 
 id: power-manual
 unit: test plan

--- a/providers/base/units/rtc/test-plan.pxu
+++ b/providers/base/units/rtc/test-plan.pxu
@@ -12,7 +12,7 @@ unit: test plan
 _name: Manual RTC tests
 _description: Manual RTC tests for Snappy Ubuntu Core devices
 include:
-    rtc/battery
+    rtc/battery    certification-status=blocker
 
 id: rtc-automated
 unit: test plan

--- a/providers/base/units/serial/test-plan.pxu
+++ b/providers/base/units/serial/test-plan.pxu
@@ -12,14 +12,14 @@ unit: test plan
 _name: Manual serial tests
 _description: Manual serial tests for Snappy Ubuntu Core devices
 include:
-    serial/rs232-console
+    serial/rs232-console    certification-status=blocker
 
 id: serial-automated
 unit: test plan
 _name: Automated serial tests
 _description: Automated serial tests for Snappy Ubuntu Core devices
 include:
-    serial/loopback-.*
+    serial/loopback-.*    certification-status=blocker
 bootstrap_include:
     serial_ports_static
 

--- a/providers/base/units/usb/test-plan.pxu
+++ b/providers/base/units/usb/test-plan.pxu
@@ -220,10 +220,10 @@ unit: test plan
 _name: Manual USB tests
 _description: Manual USB tests for Ubuntu Core devices
 include:
-    usb/hid
-    usb/insert
-    usb/storage-automated # depends on manual one, so not automated
-    usb/remove
+    usb/hid                  certification-status=blocker
+    usb/insert               certification-status=blocker
+    usb/storage-automated    certification-status=blocker # depends on manual one, so not automated
+    usb/remove               certification-status=blocker
 
 id: usb-automated
 unit: test plan

--- a/providers/base/units/wireless/test-plan.pxu
+++ b/providers/base/units/wireless/test-plan.pxu
@@ -140,32 +140,32 @@ _description:
  Automated connection tests for unencrypted or WPA-encrypted 802.11 bg, n, ac, ax
  , be networks.
 include:
-    wireless/detect
+    wireless/detect                                    certification-status=blocker
     wireless/wireless_scanning_.*
-    wireless/wireless_connection_open_be_nm_interface
-    wireless/wireless_connection_open_ax_nm_.*
-    wireless/wireless_connection_open_ac_nm_.*
-    wireless/wireless_connection_open_bg_nm_.*
-    wireless/wireless_connection_open_n_nm_.*
-    wireless/wireless_connection_wpa_be_nm_interface
-    wireless/wireless_connection_wpa3_be_nm_interface
-    wireless/wireless_connection_wpa_ax_nm_.*
-    wireless/wireless_connection_wpa3_ax_nm_.*
-    wireless/wireless_connection_wpa_ac_nm_.*
-    wireless/wireless_connection_wpa_bg_nm_.*
-    wireless/wireless_connection_wpa_n_nm_.*
-    wireless/wireless_connection_open_be_np_interface
-    wireless/wireless_connection_open_ax_np_.*
-    wireless/wireless_connection_open_ac_np_.*
-    wireless/wireless_connection_open_bg_np_.*
-    wireless/wireless_connection_open_n_np_.*
-    wireless/wireless_connection_wpa_ax_np_.*
-    wireless/wireless_connection_wpa3_ax_np_.*
-    wireless/wireless_connection_wpa_be_np_interface
-    wireless/wireless_connection_wpa3_be_np_interface
-    wireless/wireless_connection_wpa_ac_np_.*
-    wireless/wireless_connection_wpa_bg_np_.*
-    wireless/wireless_connection_wpa_n_np_.*
+    wireless/wireless_connection_open_be_nm_interface  certification-status=blocker
+    wireless/wireless_connection_open_ax_nm_.*         certification-status=blocker
+    wireless/wireless_connection_open_ac_nm_.*         certification-status=blocker
+    wireless/wireless_connection_open_bg_nm_.*         certification-status=blocker
+    wireless/wireless_connection_open_n_nm_.*          certification-status=blocker
+    wireless/wireless_connection_wpa_be_nm_interface   certification-status=blocker
+    wireless/wireless_connection_wpa3_be_nm_interface  certification-status=blocker
+    wireless/wireless_connection_wpa_ax_nm_.*          certification-status=blocker
+    wireless/wireless_connection_wpa3_ax_nm_.*         certification-status=blocker
+    wireless/wireless_connection_wpa_ac_nm_.*          certification-status=blocker
+    wireless/wireless_connection_wpa_bg_nm_.*          certification-status=blocker
+    wireless/wireless_connection_wpa_n_nm_.*           certification-status=blocker
+    wireless/wireless_connection_open_be_np_interface  certification-status=blocker
+    wireless/wireless_connection_open_ax_np_.*         certification-status=blocker
+    wireless/wireless_connection_open_ac_np_.*         certification-status=blocker
+    wireless/wireless_connection_open_bg_np_.*         certification-status=blocker
+    wireless/wireless_connection_open_n_np_.*          certification-status=blocker
+    wireless/wireless_connection_wpa_ax_np_.*          certification-status=blocker
+    wireless/wireless_connection_wpa3_ax_np_.*         certification-status=blocker
+    wireless/wireless_connection_wpa_be_np_interface   certification-status=blocker
+    wireless/wireless_connection_wpa3_be_np_interface  certification-status=blocker
+    wireless/wireless_connection_wpa_ac_np_.*          certification-status=blocker
+    wireless/wireless_connection_wpa_bg_np_.*          certification-status=blocker
+    wireless/wireless_connection_wpa_n_np_.*           certification-status=blocker
     wireless/check_iwlwifi_microcode_crash_.*
 bootstrap_include:
     device

--- a/providers/base/units/wwan/test-plan.pxu
+++ b/providers/base/units/wwan/test-plan.pxu
@@ -15,9 +15,9 @@ _name: Automated wwan tests
 _description: Automated wwan tests for Snappy Ubuntu Core devices
 include:
     # Note these tests require snap calling snap support
-    wwan/detect
+    wwan/detect    certification-status=blocker
     wwan/3gpp-scan-manufacturer-model-hw_id-auto
-    wwan/gsm-connection-.*-auto
+    wwan/gsm-connection-.*-auto    certification-status=blocker
     wwan/check-sim-present-.*-auto
 bootstrap_include:
     wwan_resource

--- a/providers/certification-client/units/client-cert-iot-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-iot-desktop-24-04.pxu
@@ -7,6 +7,8 @@ include:
 nested_part:
   client-cert-iot-desktop-24-04-manual
   client-cert-iot-desktop-24-04-automated
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-desktop-24-04-manual
@@ -96,6 +98,8 @@ nested_part:
   after-suspend-wwan-manual
 exclude:
   snappy/os-.*
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-desktop-24-04-automated
@@ -180,6 +184,8 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-desktop-24-04-stress
@@ -190,3 +196,5 @@ _description:
 include:
 nested_part:
   stress-full
+certification_status_overrides:
+  apply blocker to .*

--- a/providers/certification-client/units/client-cert-iot-server-16-04.pxu
+++ b/providers/certification-client/units/client-cert-iot-server-16-04.pxu
@@ -7,6 +7,8 @@ include:
 nested_part:
   client-cert-iot-server-16-04-manual
   client-cert-iot-server-16-04-automated
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-server-16-04-manual
@@ -18,6 +20,8 @@ include:
 nested_part:
   # until there is reason to diverge, nest these plans
   client-cert-iot-ubuntucore-16-manual
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-server-16-04-automated
@@ -30,6 +34,8 @@ nested_part:
   # until there is reason to diverge, nest these plans
   client-cert-iot-ubuntucore-16-automated
   ## snappy-snap-automated-lightweight ??
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-server-16-04-stress
@@ -40,3 +46,5 @@ _description:
 include:
 nested_part:
   stress-full
+certification_status_overrides:
+  apply blocker to .*

--- a/providers/certification-client/units/client-cert-iot-server-18-04.pxu
+++ b/providers/certification-client/units/client-cert-iot-server-18-04.pxu
@@ -7,6 +7,8 @@ include:
 nested_part:
   client-cert-iot-server-18-04-manual
   client-cert-iot-server-18-04-automated
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-server-18-04-manual
@@ -18,6 +20,8 @@ include:
 nested_part:
   # until there is reason to diverge, nest these plans
   client-cert-iot-ubuntucore-18-manual
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-server-18-04-automated
@@ -30,6 +34,8 @@ nested_part:
   # until there is reason to diverge, nest these plans
   client-cert-iot-ubuntucore-18-automated
   ## snappy-snap-automated-lightweight ??
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-server-18-04-stress
@@ -40,3 +46,5 @@ _description:
 include:
 nested_part:
   stress-full
+certification_status_overrides:
+  apply blocker to .*

--- a/providers/certification-client/units/client-cert-iot-server-20-04.pxu
+++ b/providers/certification-client/units/client-cert-iot-server-20-04.pxu
@@ -7,6 +7,8 @@ include:
 nested_part:
   client-cert-iot-server-20-04-manual
   client-cert-iot-server-20-04-automated
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-server-20-04-manual
@@ -21,6 +23,8 @@ nested_part:
 exclude:
   ubuntucore/os-.*
   snappy/os-.*
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-server-20-04-automated
@@ -33,6 +37,8 @@ nested_part:
   # until there is reason to diverge, nest these plans
   client-cert-iot-ubuntucore-20-automated
   ## snappy-snap-automated-lightweight ??
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-server-20-04-stress
@@ -43,3 +49,5 @@ _description:
 include:
 nested_part:
   stress-full
+certification_status_overrides:
+  apply blocker to .*

--- a/providers/certification-client/units/client-cert-iot-server-22-04.pxu
+++ b/providers/certification-client/units/client-cert-iot-server-22-04.pxu
@@ -7,6 +7,8 @@ include:
 nested_part:
   client-cert-iot-server-22-04-manual
   client-cert-iot-server-22-04-automated
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-server-22-04-manual
@@ -21,6 +23,8 @@ nested_part:
 exclude:
   ubuntucore/os-.*
   snappy/os-.*
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-server-22-04-automated
@@ -33,6 +37,8 @@ nested_part:
   # until there is reason to diverge, nest these plans
   client-cert-iot-ubuntucore-22-automated
   ## snappy-snap-automated-lightweight ??
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-server-22-04-stress
@@ -43,3 +49,5 @@ _description:
 include:
 nested_part:
   stress-full
+certification_status_overrides:
+  apply blocker to .*

--- a/providers/certification-client/units/client-cert-iot-server-24-04.pxu
+++ b/providers/certification-client/units/client-cert-iot-server-24-04.pxu
@@ -7,6 +7,8 @@ include:
 nested_part:
   client-cert-iot-server-24-04-manual
   client-cert-iot-server-24-04-automated
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-server-24-04-manual
@@ -89,6 +91,8 @@ exclude:
   bluetooth4/HOGP-mouse
   snappy/os-.*
   after-suspend-bluetooth4/HOGP-mouse
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-server-24-04-automated
@@ -164,6 +168,8 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-server-24-04-stress
@@ -174,3 +180,5 @@ _description:
 include:
 nested_part:
   stress-full
+certification_status_overrides:
+  apply blocker to .*

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-16.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-16.pxu
@@ -7,6 +7,8 @@ include:
 nested_part:
   client-cert-iot-ubuntucore-16-manual
   client-cert-iot-ubuntucore-16-automated
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-ubuntucore-16-manual
@@ -74,6 +76,8 @@ nested_part:
   after-suspend-wireless-manual
   after-suspend-wireless-wifi-master-mode-manual
   after-suspend-wwan-manual
+certification_status_overrides:
+  apply blocker to .*
 
 id: client-cert-iot-ubuntucore-16-automated
 _name: IoT Client Certification for Ubuntu Core 16 (Automated Tests)
@@ -141,6 +145,8 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
+certification_status_overrides:
+  apply blocker to .*
 
 id: client-cert-iot-ubuntucore-16-stress
 _name: IoT Client Certification for Ubuntu Core 16 (Stress Tests)
@@ -150,3 +156,5 @@ _description:
 include:
 nested_part:
   stress-full
+certification_status_overrides:
+  apply blocker to .*

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-18.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-18.pxu
@@ -7,6 +7,8 @@ include:
 nested_part:
   client-cert-iot-ubuntucore-18-manual
   client-cert-iot-ubuntucore-18-automated
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-ubuntucore-18-manual
@@ -76,6 +78,8 @@ nested_part:
   after-suspend-wireless-manual
   after-suspend-wireless-wifi-master-mode-manual
   after-suspend-wwan-manual
+certification_status_overrides:
+  apply blocker to .*
 
 id: client-cert-iot-ubuntucore-18-automated
 _name: IoT Client Certification for Ubuntu Core 18 (Automated Tests)
@@ -144,6 +148,8 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
+certification_status_overrides:
+  apply blocker to .*
 
 id: client-cert-iot-ubuntucore-18-stress
 _name: IoT Client Certification for Ubuntu Core 18 (Stress Tests)
@@ -153,3 +159,5 @@ _description:
 include:
 nested_part:
   stress-full
+certification_status_overrides:
+  apply blocker to .*

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-20.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-20.pxu
@@ -7,6 +7,8 @@ include:
 nested_part:
   client-cert-iot-ubuntucore-20-manual
   client-cert-iot-ubuntucore-20-automated
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-ubuntucore-20-manual
@@ -77,6 +79,8 @@ nested_part:
   after-suspend-wireless-manual
   after-suspend-wireless-wifi-master-mode-manual
   after-suspend-wwan-manual
+certification_status_overrides:
+  apply blocker to .*
 
 id: client-cert-iot-ubuntucore-20-automated
 _name: IoT Client Certification for Ubuntu Core 20 (Automated Tests)
@@ -146,6 +150,8 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
+certification_status_overrides:
+  apply blocker to .*
 
 id: client-cert-iot-ubuntucore-20-stress
 _name: IoT Client Certification for Ubuntu Core 20 (Stress Tests)
@@ -155,3 +161,5 @@ _description:
 include:
 nested_part:
   stress-full
+certification_status_overrides:
+  apply blocker to .*

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu
@@ -7,6 +7,8 @@ include:
 nested_part:
   client-cert-iot-ubuntucore-22-manual
   client-cert-iot-ubuntucore-22-automated
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-ubuntucore-22-manual
@@ -77,6 +79,8 @@ nested_part:
   after-suspend-wireless-manual
   after-suspend-wireless-wifi-master-mode-manual
   after-suspend-wwan-manual
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-ubuntucore-22-automated
@@ -148,6 +152,8 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-ubuntucore-22-stress
@@ -158,3 +164,5 @@ _description:
 include:
 nested_part:
   stress-full
+certification_status_overrides:
+  apply blocker to .*

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-24.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-24.pxu
@@ -7,6 +7,8 @@ include:
 nested_part:
   client-cert-iot-ubuntucore-24-manual
   client-cert-iot-ubuntucore-24-automated
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-ubuntucore-24-manual
@@ -86,6 +88,8 @@ nested_part:
 exclude:
   bluetooth4/HOGP-mouse
   after-suspend-bluetooth4/HOGP-mouse
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-ubuntucore-24-automated
@@ -165,6 +169,8 @@ nested_part:
   after-suspend-usb-automated
   after-suspend-wireless-automated
   after-suspend-wwan-automated
+certification_status_overrides:
+  apply blocker to .*
 
 
 id: client-cert-iot-ubuntucore-24-stress
@@ -175,3 +181,5 @@ _description:
 include:
 nested_part:
   stress-full
+certification_status_overrides:
+  apply blocker to .*

--- a/providers/tpm2/units/test-plan.pxu
+++ b/providers/tpm2/units/test-plan.pxu
@@ -89,7 +89,11 @@ _description:
  Clevis encryption tests
 estimated_duration: 1m
 include:
-    clevis.*
+    clevis-encrypt-tpm2/precheck    certification-status=blocker
+    clevis-encrypt-tpm2/detect-rsa-capabilities    certification-status=blocker
+    clevis-encrypt-tpm2/rsa    certification-status=blocker
+    clevis-encrypt-tpm2/detect-ecc-capabilities    certification-status=blocker
+    clevis-encrypt-tpm2/ecc    certification-status=blocker
 mandatory_include:
     com.canonical.plainbox::manifest
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->
## Description

The "[Internet of Things Certified Hardware Coverage for Ubuntu Core 22 / Ubuntu 22.04](https://canonical-certification-docs.readthedocs-hosted.com/preview/iot/Coverage_Guide_IoT-22.04/)" document specifies what jobs should be considered as blockers.

For IoT devices, the after-suspend jobs are not considered blockers, so they have been left out.

### Considerations

The document I used as a "source of truth" specifies a few things that look suspicious. Feedback from other teams would be appreciated:

- Are we supposed to [support USB-C DP connection on IoT devices?](https://canonical-certification-docs.readthedocs-hosted.com/preview/iot/Coverage_Guide_IoT-22.04/#usb-type-c-usb-3-1)
- Same question as above for [Thunderbolt on IoT devices](https://canonical-certification-docs.readthedocs-hosted.com/preview/iot/Coverage_Guide_IoT-22.04/#thunderbolt)

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues


CER-2593
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
Running a `list-bootstrapped` of the `client-cert-iot-ubuntucore-22` test plan on my laptop yields the following output:

*Notes:*

- I'm using checkbox from #1204 to have a default certification_status of `non-blocker`
- My laptop does not have WWAN, Serial, I2C, etc, so these tests get skipped when using `list-bootstrapped`, that's why they don't appear below

```
checkbox-cli list-bootstrapped -f "{id} [{certification_status}]\n" "com.canonical.certification::client-cert-iot-ubuntucore-22"
(...)
manifest [non-blocker]
executable [non-blocker]
interface [non-blocker]
connections [non-blocker]
model_assertion [non-blocker]
serial_assertion [non-blocker]
net_if_management [non-blocker]
net_if_management_attachment [non-blocker]
lspci_attachment [non-blocker]
lsusb_attachment [non-blocker]
rtc [non-blocker]
sleep [non-blocker]
parts_meta_info_attachment [non-blocker]
miscellanea/device_check [non-blocker]
requirements [non-blocker]
cpuinfo [non-blocker]
dpkg [non-blocker]
sysfs_attachment [non-blocker]
lspci_standard_config_json [non-blocker]
efi [non-blocker]
lsblk_attachment [non-blocker]
snap [non-blocker]
device [non-blocker]
dmi_present [non-blocker]
raw_devices_dmi_json [non-blocker]
udev_attachment [non-blocker]
lsb [non-blocker]
uname [non-blocker]
modprobe_json [non-blocker]
meminfo [non-blocker]
environment [non-blocker]
udev_json [non-blocker]
dmi [non-blocker]
kernel_cmdline_attachment [non-blocker]
dmi_attachment [non-blocker]
package [non-blocker]
module [non-blocker]
system_info_json [non-blocker]
cdimage [non-blocker]
dkms_info_json [non-blocker]
miscellanea/submission-resources [non-blocker]
info/systemd-analyze [non-blocker]
info/systemd-analyze-critical-chain [non-blocker]
ubuntucore/os-reinstall-mode [non-blocker]
ubuntucore/os-recovery-mode [non-blocker]
ubuntucore/sshd [non-blocker]
audio/detect-playback-devices [non-blocker]
audio/alsa-playback [blocker]
bluetooth/keyboard-manual [blocker]
ethernet/wol_S5_enp0s31f6 [non-blocker]
ethernet/wol_S4_enp0s31f6 [non-blocker]
ethernet/wol_S3_enp0s31f6 [non-blocker]
ethernet/hotplug-enp0s31f6 [non-blocker]
led/power [blocker]
led/power-blink-suspend [non-blocker]
led/bluetooth [non-blocker]
led/serial [blocker]
led/fn [non-blocker]
mediacard/cf-insert [non-blocker]
mediacard/cf-storage [non-blocker]
mediacard/cf-remove [non-blocker]
mediacard/mmc-insert [non-blocker]
mediacard/mmc-storage [non-blocker]
mediacard/mmc-remove [non-blocker]
mediacard/ms-insert [non-blocker]
mediacard/ms-storage [non-blocker]
mediacard/ms-remove [non-blocker]
mediacard/msp-insert [non-blocker]
mediacard/msp-storage [non-blocker]
mediacard/msp-remove [non-blocker]
mediacard/sd-insert [non-blocker]
mediacard/sd-storage [non-blocker]
mediacard/sd-remove [non-blocker]
mediacard/sdhc-insert [non-blocker]
mediacard/sdhc-storage [non-blocker]
mediacard/sdhc-remove [non-blocker]
mediacard/sdxc-insert [non-blocker]
mediacard/sdxc-storage [non-blocker]
mediacard/sdxc-remove [non-blocker]
mediacard/xd-insert [non-blocker]
mediacard/xd-storage [non-blocker]
mediacard/xd-remove [non-blocker]
monitor/dvi [blocker]
monitor/hdmi [blocker]
monitor/dvi-to-vga [non-blocker]
monitor/hdmi-to-vga [non-blocker]
monitor/displayport_hotplug [blocker]
monitor/vga [non-blocker]
rtc/battery [blocker]
serial/rs232-console [blocker]
snappy/os-refresh [non-blocker]
snappy/os-revert [non-blocker]
usb/hid [blocker]
usb/insert [blocker]
usb/storage-automated [blocker]
usb/remove [blocker]
usb-c/c-to-a-adapter/hid [non-blocker]
usb [non-blocker]
usb-c/c-to-a-adapter/insert [non-blocker]
usb-c/c-to-a-adapter/storage-automated [non-blocker]
usb-c/c-to-a-adapter/remove [non-blocker]
usb-c/hid [non-blocker]
usb-c/insert [non-blocker]
usb-c/storage-automated [non-blocker]
usb-c/remove [non-blocker]
usb-c-otg/g_serial [non-blocker]
usb-c-otg/g_serial-cleanup [non-blocker]
usb-c-otg/g_mass_storage [non-blocker]
usb-c-otg/g_mass_storage-cleanup [non-blocker]
usb-c-otg/g_ether [non-blocker]
usb-c-otg/g_ether-cleanup [non-blocker]
usb3/insert [non-blocker]
usb3/storage-automated [non-blocker]
usb3/remove [non-blocker]
thunderbolt3/insert [blocker]
thunderbolt3/storage-test [blocker]
thunderbolt3/remove [blocker]
wifi_interface_mode [non-blocker]
wireless/wifi_ap_open_b_no_sta_wlp0s20f3_manual [non-blocker]
wireless/wifi_ap_open_g_no_sta_wlp0s20f3_manual [non-blocker]
wireless/wifi_ap_wpa_b_no_sta_wlp0s20f3_manual [non-blocker]
wireless/wifi_ap_wpa_g_no_sta_wlp0s20f3_manual [non-blocker]
wwan/detect-manual [non-blocker]
wwan/check-sim-present-manual [non-blocker]
wwan/scan-networks-manual [non-blocker]
wwan/gsm-connection-interrupted-manual [non-blocker]
cpu/clocktest [non-blocker]
disk/stats_dm-1 [non-blocker]
wireless_sta_protocol [non-blocker]
wireless/wireless_connection_wpa_ac_nm_wlp0s20f3 [blocker]
wireless/wireless_connection_wpa_ax_nm_wlp0s20f3 [blocker]
wireless/wireless_connection_wpa3_ax_nm_wlp0s20f3 [blocker]
ethernet/ping_enp0s31f6 [blocker]
wireless/wireless_connection_wpa_bg_nm_wlp0s20f3 [blocker]
wireless/wireless_connection_wpa_n_nm_wlp0s20f3 [blocker]
wireless/wireless_connection_wpa_ax_np_wlp0s20f3 [blocker]
location/status [non-blocker]
cpu/topology [blocker]
wireless/wifi_ap_wpa_g_no_sta_wlp0s20f3_auto [non-blocker]
wireless/wifi_ap_open_b_no_sta_wlp0s20f3_auto [non-blocker]
wireless/wifi_ap_wpa_g_with_sta_wlp0s20f3_auto [non-blocker]
wireless/wireless_connection_open_ac_np_wlp0s20f3 [blocker]
wireless/wifi_ap_wpa_b_with_sta_wlp0s20f3_auto [non-blocker]
wireless/wireless_connection_open_ax_np_wlp0s20f3 [blocker]
wireless/wireless_connection_open_bg_nm_wlp0s20f3 [blocker]
audio/detect-capture-devices [non-blocker]
wireless/wireless_scanning_wlp0s20f3 [non-blocker]
disk/read_performance_dm-1 [non-blocker]
wireless/wireless_connection_wpa_ac_np_wlp0s20f3 [blocker]
wwan/detect [blocker]
wireless/wireless_connection_open_n_nm_wlp0s20f3 [blocker]
socketcan/modprobe_vcan [non-blocker]
socketcan/send_packet_local_eff_virtual [non-blocker]
wireless/wifi_ap_setup_wizard_wlp0s20f3_auto [non-blocker]
wireless/wireless_connection_wpa_n_np_wlp0s20f3 [blocker]
wireless/wifi_ap_open_g_no_sta_wlp0s20f3_auto [non-blocker]
wireless/check_iwlwifi_microcode_crash_wlp0s20f3 [non-blocker]
wireless/wireless_connection_open_ax_nm_wlp0s20f3 [blocker]
wireless/nmcli_wifi_ap_bg_wlp0s20f3 [non-blocker]
socketcan/send_packet_local_sff_virtual [non-blocker]
wireless/wireless_connection_open_bg_np_wlp0s20f3 [blocker]
bluetooth/detect-output [non-blocker]
bluetooth/bluetooth_obex_send [non-blocker]
disk/storage_device_dm-1 [non-blocker]
wireless/wireless_connection_open_n_np_wlp0s20f3 [blocker]
audio/alsa-loopback-automated [blocker]
socketcan/send_packet_local_fd_virtual [non-blocker]
wireless/wireless_connection_wpa3_ax_np_wlp0s20f3 [blocker]
ethernet/detect [blocker]
disk/detect [non-blocker]
wireless/wireless_connection_wpa_bg_np_wlp0s20f3 [blocker]
ipv6_detect [non-blocker]
ipv6_link_local_address_enp0s31f6 [non-blocker]
cpu_offlining [non-blocker]
cpu/offlining_test [non-blocker]
camera/detect [non-blocker]
camera/multiple-resolution-images_video0 [non-blocker]
wireless/detect [blocker]
usb/storage-detect [non-blocker]
wireless/nmcli_wifi_ap_a_wlp0s20f3 [non-blocker]
wireless/wifi_ap_wpa_b_no_sta_wlp0s20f3_auto [non-blocker]
wireless/wireless_connection_open_ac_nm_wlp0s20f3 [blocker]
suspend/suspend_advanced_auto [non-blocker]
after-suspend-audio/alsa-playback [blocker]
after-suspend-bluetooth/keyboard-manual [non-blocker]
after-suspend-ethernet/detect [blocker]
after-suspend-ethernet/hotplug-enp0s31f6 [blocker]
after-suspend-monitor/dvi [non-blocker]
after-suspend-monitor/hdmi [non-blocker]
after-suspend-monitor/dvi-to-vga [non-blocker]
after-suspend-monitor/hdmi-to-vga [non-blocker]
after-suspend-monitor/displayport_hotplug [non-blocker]
after-suspend-monitor/vga [non-blocker]
networking/info_device1_enp0s31f6 [non-blocker]
after-suspend-networking/info_device1_enp0s31f6 [blocker]
after-suspend-serial/rs232-console [non-blocker]
after-suspend-usb/hid [non-blocker]
after-suspend-usb/insert [non-blocker]
after-suspend-usb/storage-automated [non-blocker]
after-suspend-usb/remove [non-blocker]
after-suspend-usb-c/c-to-a-adapter/hid [non-blocker]
after-suspend-usb-c/c-to-a-adapter/insert [non-blocker]
after-suspend-usb-c/c-to-a-adapter/storage-automated [non-blocker]
after-suspend-usb-c/c-to-a-adapter/remove [non-blocker]
after-suspend-usb-c/hid [non-blocker]
after-suspend-usb-c/insert [non-blocker]
after-suspend-usb-c/storage-automated [non-blocker]
after-suspend-usb-c/remove [non-blocker]
after-suspend-usb-c-otg/g_serial [non-blocker]
after-suspend-usb-c-otg/g_serial-cleanup [non-blocker]
after-suspend-usb-c-otg/g_mass_storage [non-blocker]
after-suspend-usb-c-otg/g_mass_storage-cleanup [non-blocker]
after-suspend-usb-c-otg/g_ether [non-blocker]
after-suspend-usb-c-otg/g_ether-cleanup [non-blocker]
after-suspend-usb3/insert [non-blocker]
after-suspend-usb3/storage-automated [non-blocker]
after-suspend-usb3/remove [non-blocker]
after-suspend-thunderbolt3/insert [blocker]
after-suspend-thunderbolt3/storage-test [blocker]
after-suspend-thunderbolt3/remove [blocker]
after-suspend-wireless/wifi_ap_open_b_no_sta_wlp0s20f3_manual [non-blocker]
after-suspend-wireless/wifi_ap_open_g_no_sta_wlp0s20f3_manual [non-blocker]
after-suspend-wireless/wifi_ap_wpa_b_no_sta_wlp0s20f3_manual [non-blocker]
after-suspend-wireless/wifi_ap_wpa_g_no_sta_wlp0s20f3_manual [non-blocker]
after-suspend-wwan/detect-manual [non-blocker]
after-suspend-wwan/scan-networks-manual [non-blocker]
after-suspend-wwan/check-sim-present-manual [non-blocker]
after-suspend-wwan/gsm-connection-interrupted-manual [non-blocker]
firmware/fwts_desktop_diagnosis [non-blocker]
firmware/fwts_desktop_diagnosis_results.log.gz [non-blocker]
acpi/oem_osi [non-blocker]
bluetooth/detect [non-blocker]
bluetooth/bluez-controller-detect [non-blocker]
camera/roundtrip-qrcode_video0 [non-blocker]
cpu/scaling_test [blocker]
cpu/scaling_test-log-attach [non-blocker]
cpu/maxfreq_test [blocker]
cpu/maxfreq_test-log-attach [non-blocker]
cpu/cstates [blocker]
cpu/cstates_results.log [non-blocker]
disk/check-software-raid [non-blocker]
docker/info [non-blocker]
docker/version [non-blocker]
docker/run_ [non-blocker]
docker/interative_ [non-blocker]
docker/diff_ [non-blocker]
docker/copy_ [non-blocker]
docker/inspect_ [non-blocker]
docker/kill_ [non-blocker]
docker/build-single_ [non-blocker]
docker/start-stop_ [non-blocker]
docker/deploy-registry_ [non-blocker]
docker/export-and-import_ [non-blocker]
docker/save-and-load_ [non-blocker]
docker/commit_ [non-blocker]
docker/update_ [non-blocker]
docker/restart-on-failure_ [non-blocker]
docker/restart-always_ [non-blocker]
docker/compose-single_ [non-blocker]
docker/compose-and-basic_ [non-blocker]
docker/compose-restart_ [non-blocker]
i2c/i2c-bus-detect [blocker]
i2c/i2c-device-detect [blocker]
ubuntu_core_features [non-blocker]
kernel-snap/booted-kernel-matches-current-grub [non-blocker]
memory/info [blocker]
networking/predictable_names [non-blocker]
power-management/warm-reboot [blocker]
power-management/post-warm-reboot [blocker]
power-management/cold-reboot [blocker]
power-management/post-cold-reboot [blocker]
snappy/snap-list [non-blocker]
snappy/snap-search [non-blocker]
snappy/snap-install [non-blocker]
snappy/snap-refresh-automated [non-blocker]
snappy/snap-revert-automated [non-blocker]
snappy/snap-reupdate-automated [non-blocker]
snappy/snap-remove [non-blocker]
snappy/test-store-install-beta [non-blocker]
snappy/test-store-install-edge [non-blocker]
snappy/test-system-confinement [non-blocker]
snappy/test-snaps-confinement [non-blocker]
snap_revision_info [non-blocker]
snapd/snap-refresh-snapd-snapd-to-base-rev [non-blocker]
snapd/log-attach-after-snap-refresh-snapd-snapd-to-base-rev [non-blocker]
snapd/snap-verify-after-refresh-snapd-snapd-to-base-rev [non-blocker]
snapd/snap-revert-snapd-snapd-from-base-rev [non-blocker]
snapd/log-attach-after-snap-revert-snapd-snapd-from-base-rev [non-blocker]
snapd/snap-verify-after-revert-snapd-snapd-from-base-rev [non-blocker]
snapd/snap-refresh-snapd-snapd-to-stable-rev [non-blocker]
snapd/log-attach-after-snap-refresh-snapd-snapd-to-stable-rev [non-blocker]
tpm2/fwts-event-log-dump [non-blocker]
clevis-encrypt-tpm2/precheck [blocker]
clevis-encrypt-tpm2/detect-rsa-capabilities [blocker]
clevis-encrypt-tpm2/rsa [blocker]
clevis-encrypt-tpm2/detect-ecc-capabilities [blocker]
clevis-encrypt-tpm2/ecc [blocker]
watchdog/detect [non-blocker]
watchdog/systemd-config [non-blocker]
watchdog/trigger-system-reset-auto [non-blocker]
watchdog/post-trigger-system-reset-auto [non-blocker]
after-suspend-audio/detect-playback-devices [non-blocker]
after-suspend-audio/detect-capture-devices [non-blocker]
after-suspend-audio/alsa-loopback-automated [non-blocker]
after-suspend-bluetooth/bluetooth_obex_send [non-blocker]
after-suspend-ethernet/ping_enp0s31f6 [blocker]
after-suspend-location/status [non-blocker]
after-suspend-usb/storage-detect [non-blocker]
after-suspend-wireless/wireless_scanning_wlp0s20f3 [non-blocker]
after-suspend-wireless/wireless_connection_open_ax_nm_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_open_ac_nm_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_open_bg_nm_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_open_n_nm_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_wpa_ax_nm_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_wpa3_ax_nm_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_wpa_ac_nm_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_wpa_bg_nm_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_wpa_n_nm_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_open_ax_np_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_open_ac_np_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_open_bg_np_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_open_n_np_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_wpa_ax_np_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_wpa3_ax_np_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_wpa_ac_np_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_wpa_bg_np_wlp0s20f3 [blocker]
after-suspend-wireless/wireless_connection_wpa_n_np_wlp0s20f3 [blocker]
after-suspend-wireless/check_iwlwifi_microcode_crash_wlp0s20f3 [non-blocker]
after-suspend-wwan/detect [non-blocker]
```


## WARNING: This modifies com.canonical.certification::sru-server