### PR TITLE
Fix cold reboot on no wake by rtc (BugFix)

### DIFF
--- a/providers/base/units/power-management/jobs.pxu
+++ b/providers/base/units/power-management/jobs.pxu
@@ -372,9 +372,11 @@ _summary: Cold reboot
 _description: This tests powers off the system and then powers it on using RTC
 unit: job
 plugin: shell
-requires: rtc.state == 'supported'
+requires:
+ rtc.state == 'supported'
+ rtc.wakealarm == 'supported'
 command:
- rtcwake --mode no -s 120
+ rtcwake --mode no -s "${COLD_REBOOT_DELAY:-120}"
  sleep 5
  rtcwake -m show
  sleep 5

--- a/providers/base/units/power-management/jobs.pxu
+++ b/providers/base/units/power-management/jobs.pxu
@@ -383,6 +383,7 @@ command:
  dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1 "org.freedesktop.login1.Manager.PowerOff" boolean:true
 user: root
 flags: preserve-locale noreturn autorestart
+environ: COLD_REBOOT_DELAY
 estimated_duration: 300
 
 id: power-management/post-cold-reboot

--- a/providers/resource/jobs/resource.pxu
+++ b/providers/resource/jobs/resource.pxu
@@ -301,6 +301,13 @@ command:
   else
       echo "state: unsupported"
   fi
+  # even with RTC being available to the system, the wakealarm may not be
+  if [ -e /sys/class/rtc/rtc*/wakealarm ]
+  then
+      echo "wakealarm: supported"
+  else
+      echo "wakealarm: unsupported"
+  fi
 _summary: Creates resource info for RTC
 
 id: requirements

--- a/providers/resource/jobs/resource.pxu
+++ b/providers/resource/jobs/resource.pxu
@@ -302,7 +302,7 @@ command:
       echo "state: unsupported"
   fi
   # even with RTC being available to the system, the wakealarm may not be
-  if [ -e /sys/class/rtc/rtc*/wakealarm ]
+  if [ -e /sys/class/rtc/rtc0/wakealarm ]
   then
       echo "wakealarm: supported"
   else


### PR DESCRIPTION
## Description
This PR fixes two problems with the cold-reboot job.
1. It introduces a new field reported by the RTC resource job that informs about presence of the `wakealarm` functionality necessary to boot the machine after it's shutdown (this is what cold-reboot job does).
2. It changes the hard-coded two-minute alarm setting in favor of a variable that can be defined in configs, launcher, or the calling environment. The default behavior stays the sam - 120s. This fixes a problem where on slow devices it took longer to power off the host than what the delay was (inlcuding two sleeps). Now on those devices we can raise make the delay longer.

## Resolved issues

Resolves: [CHECKBOX-1425](https://warthogs.atlassian.net/jira/software/c/projects/CHECKBOX/boards/590?selectedIssue=CHECKBOX-1425)

## Documentation
No documentation changes.

## Tests

For the problem no 1. I tested the "happy case" only, because I have no access to a device with broken `wakealarm`.
The second problem I managed to test by adding sleeps before the `poweroff` call.

[CHECKBOX-1425]: https://warthogs.atlassian.net/browse/CHECKBOX-1425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ