### PR TITLE
Fix the wrong output from suspend cycles (Bugfix)

### DIFF
--- a/providers/base/bin/suspend.sh
+++ b/providers/base/bin/suspend.sh
@@ -8,6 +8,7 @@ if [ "$architecture" = "x86_64" ] || [ "$architecture" = "i386" ]; then
     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/usr/lib/fwts"
     set -o pipefail
     checkbox-support-fwts_test -f none -s s3 --s3-device-check --s3-device-check-delay="${STRESS_S3_WAIT_DELAY:-45}" --s3-sleep-delay="${STRESS_S3_SLEEP_DELAY:-30}"
+    rm /tmp/fwts_results.log
 else
     rtcwake -v -m mem -s "${STRESS_S3_SLEEP_DELAY:-30}"
 fi


### PR DESCRIPTION
## Description
The bug numbers of `sleep_test_log_check.py` summary are wrong.
For the following case, it only run 30 suspend with 3 reboot, and it total suspend number is 90.
But the failures number is much larger than 90.
```
Critical failures:
  s3: 30 failures
========================================
    Expected /sys/power/suspend_stats/total_hw_sleep to increase from 4234715566, got 4234715566. (x 15)
    CRITICAL Kernel message: [ 1969.104760] PM: Some devices failed to suspend, or early wake event detected (x 15)
High failures:
  s3: 1129 failures
========================================
    Expected /sys/power/suspend_stats/last_hw_sleep to be at least 70% of the last sleep cycle, got 0.14%. (x 29)
  <..skip..>
    Expected /sys/power/suspend_stats/last_hw_sleep to be at least 70% of the last sleep cycle, got 68.83%. (x 10)
```

```
## Test the 30 suspend with 3 reboot, so the total suspend number should 90.
./submission_202312-33226_365937 $ grep "Iteration" attachment_files/com.canonical.certification__stress-tests_suspend-30-cycles-with-reboot-3-log-attach| nl 
     1  ================================= Iteration 1 ==================================
     2  ================================= Iteration 1 ==================================
     3  ================================= Iteration 1 ==================================
<...skip...>
  1393  ================================= Iteration 1 ==================================
  1394  ================================= Iteration 1 ==================================
  1395  ================================= Iteration 1 ==================================

## How does the 1395 come?
Coz the log will be append in next time, and this log will only destory when reboot/poweroff.
Each reboot will have the (1+30)*30/2 times of fwts log.
Total:
(1+30)*30/2 * 3 (with 3 reboot)= 1395

```

The RC of this issue is:
checkbox-support-fwts_test script will default restore the log (`/tmp/fwts_results.log`), and this log will be append in next time.
Only need to remove the `/tmp/fwts_results.log`, and this issue will not hanppen.




## Resolved issues
Wrong number of fwts bug summary.



## Documentation


## Tests
https://certification.canonical.com/hardware/202312-33226/submission/366229/
```
## Test the 10 suspend with 3 reboot, so the total suspend number will be 30.

./submission_202312-33226_366229 $ grep "Iteration" attachment_files/com.canonical.certification__stress-tests_suspend-10-cycles-with-reboot-3-log-attach|nl                                                      
     1  ================================= Iteration 1 ==================================
     2  ================================= Iteration 1 ==================================
     3  ================================= Iteration 1 ==================================
     4  ================================= Iteration 1 ==================================
     5  ================================= Iteration 1 ==================================
     6  ================================= Iteration 1 ==================================
     7  ================================= Iteration 1 ==================================
     8  ================================= Iteration 1 ==================================
     9  ================================= Iteration 1 ==================================
    10  ================================= Iteration 1 ==================================
    11  ================================= Iteration 1 ==================================
    12  ================================= Iteration 1 ==================================
    13  ================================= Iteration 1 ==================================
    14  ================================= Iteration 1 ==================================
    15  ================================= Iteration 1 ==================================
    16  ================================= Iteration 1 ==================================
    17  ================================= Iteration 1 ==================================
    18  ================================= Iteration 1 ==================================
    19  ================================= Iteration 1 ==================================
    20  ================================= Iteration 1 ==================================
    21  ================================= Iteration 1 ==================================
    22  ================================= Iteration 1 ==================================
    23  ================================= Iteration 1 ==================================
    24  ================================= Iteration 1 ==================================
    25  ================================= Iteration 1 ==================================
    26  ================================= Iteration 1 ==================================
    27  ================================= Iteration 1 ==================================
    28  ================================= Iteration 1 ==================================
    29  ================================= Iteration 1 ==================================
    30  ================================= Iteration 1 ==================================

```


