### PR TITLE
removed requirement of udisks2 on core (BugFix)

### DIFF
--- a/providers/base/units/usb/usb.pxu
+++ b/providers/base/units/usb/usb.pxu
@@ -54,7 +54,9 @@ id: usb/insert
 flags: also-after-suspend fail-on-resource
 template-engine: jinja2
 requires:
+ {%- if not __on_ubuntucore__ %}
  package.name == 'udisks2' or snap.name == 'udisks2'
+ {% endif -%}
 _summary: USB 2.0 storage device insertion detected
 _purpose:
  Check system can detect USB 2.0 storage when inserted.


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

Acording to #1029, the test was failing on some ubuntu core devices, because they required having the udisks2 snap, but the udisks2 snap was not needed for devices that run ubuntu core, since they were using another script to test the USB.
In summary:
 - The removable_storage_watcher.py wouldn't work on core even if udisks2 snap is installed
 - The run_watcher.py wouldn't work on some desktop devices
 - On core devices, since they are using run_watcher.py, we do not require udisks2 snaps

## Resolved issues
#1029, https://warthogs.atlassian.net/browse/CHECKBOX-1279
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->
There are no documentation changes.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

When running:
```
checkbox.checkbox-cli run com.canonical.certification::usb/insert
```
Ubuntu Desktop requires the `udisks2` package or the `udisks2` snap, and fails if they don't exist
Ubuntu Core does not require this check.
