### PR TITLE
Make networking/http test more resilient (bugfix)

### DIFF
--- a/providers/base/bin/networking_http.py
+++ b/providers/base/bin/networking_http.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+#
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Pierre Equoy <pierre.equoy@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import argparse
+import subprocess
+import sys
+
+
+class HTTPConnection:
+    def __init__(self, url, max_retries: int = 3):
+        """
+        A class that will try to connect to `url` up to `max_retries` times
+        using `wget`. Each time connection fails, the timeout parameter of
+        wget raises (10s the first time, 20s the second time, then 30s...)
+        """
+        self.url = url
+        self.max_retries = max_retries
+        self.current_run = 1
+
+    def http_connect(self):
+        if self.current_run > self.max_retries:
+            raise SystemExit("Failed to connect to {}!".format(self.url))
+        try:
+            timeout = self.current_run * 10
+            msg = "Trying to connect to {} (timeout: {}s, tentative {}/{})"
+            print(
+                msg.format(
+                    self.url, timeout, self.current_run, self.max_retries
+                )
+            )
+            subprocess.run(
+                [
+                    "wget",
+                    "--timeout",
+                    str(timeout),
+                    "-SO",
+                    "/dev/null",
+                    self.url,
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            print(exc)
+            print()
+            self.current_run += 1
+            self.http_connect()
+
+
+def main(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("url", help="URL to try to connect to")
+    parser.add_argument(
+        "--retries",
+        default="3",
+        help="Number of connection tentatives to try (default %(default)s)",
+    )
+    args = parser.parse_args(args)
+    connection_test = HTTPConnection(args.url, int(args.retries))
+    connection_test.http_connect()
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/providers/base/bin/networking_http.py
+++ b/providers/base/bin/networking_http.py
@@ -38,14 +38,13 @@ class HTTPConnection:
     def http_connect(self):
         if self.current_run > self.max_retries:
             raise SystemExit("Failed to connect to {}!".format(self.url))
-        try:
-            timeout = self.current_run * 10
-            msg = "Trying to connect to {} (timeout: {}s, tentative {}/{})"
-            print(
-                msg.format(
-                    self.url, timeout, self.current_run, self.max_retries
-                )
+        timeout = self.current_run * 10
+        print(
+            "Trying to connect to {} (timeout: {}s, tentative {}/{})".format(
+                self.url, timeout, self.current_run, self.max_retries
             )
+        )
+        try:
             subprocess.run(
                 [
                     "wget",

--- a/providers/base/tests/test_networking_http.py
+++ b/providers/base/tests/test_networking_http.py
@@ -35,7 +35,15 @@ class NetworkingHTTPTests(TestCase):
 
     @patch("networking_http.subprocess.run")
     @patch("networking_http.time.sleep")
-    def test_http_connect(self, mock_sleep, mock_run):
+    def test_http_connect_success(self, mock_sleep, mock_run):
+        """
+        Test that `http_connect` returns safely if the wget command returns 0
+        """
+        self.assertEqual(networking_http.http_connect("test", 3), None)
+
+    @patch("networking_http.subprocess.run")
+    @patch("networking_http.time.sleep")
+    def test_http_connect_failure(self, mock_sleep, mock_run):
         """
         Test that if set to 3 retries, the connection command (wget, run
         through subprocess.run) will be called 3 times

--- a/providers/base/tests/test_networking_http.py
+++ b/providers/base/tests/test_networking_http.py
@@ -28,25 +28,25 @@ import networking_http
 
 class NetworkingHTTPTests(TestCase):
     @patch("networking_http.subprocess.run")
-    def test_http_connect_max_retries(self, mock_subprocess_run):
-        connection_test = networking_http.HTTPConnection("test", 0)
+    @patch("networking_http.time.sleep")
+    def test_http_connect_max_retries(self, mock_sleep, mock_run):
         with self.assertRaises(SystemExit):
-            connection_test.http_connect()
+            networking_http.http_connect("test", 0)
 
     @patch("networking_http.subprocess.run")
-    def test_http_connect(self, mock_subprocess_run):
+    @patch("networking_http.time.sleep")
+    def test_http_connect(self, mock_sleep, mock_run):
         """
         Test that if set to 3 retries, the connection command (wget, run
         through subprocess.run) will be called 3 times
         """
-        mock_subprocess_run.side_effect = subprocess.CalledProcessError(1, "")
-        connection_test = networking_http.HTTPConnection("test", 3)
+        mock_run.side_effect = subprocess.CalledProcessError(1, "")
         with self.assertRaises(SystemExit):
-            connection_test.http_connect()
-        self.assertEqual(mock_subprocess_run.call_count, 3)
+            networking_http.http_connect("test", 3)
+        self.assertEqual(mock_run.call_count, 3)
 
-    @patch("networking_http.HTTPConnection")
-    def test_main(self, mock_HTTPConnection):
-        args = ["test", "--retries", "5"]
+    @patch("networking_http.http_connect")
+    def test_main(self, mock_http_connect):
+        args = ["test", "--attempts", "6"]
         networking_http.main(args)
-        mock_HTTPConnection.assert_called_with("test", 5)
+        mock_http_connect.assert_called_with("test", 6)

--- a/providers/base/tests/test_networking_http.py
+++ b/providers/base/tests/test_networking_http.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+#
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Pierre Equoy <pierre.equoy@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import subprocess
+from unittest import TestCase
+from unittest.mock import patch
+
+import networking_http
+
+
+class NetworkingHTTPTests(TestCase):
+    @patch("networking_http.subprocess.run")
+    def test_http_connect_max_retries(self, mock_subprocess_run):
+        connection_test = networking_http.HTTPConnection("test", 0)
+        with self.assertRaises(SystemExit):
+            connection_test.http_connect()
+
+    @patch("networking_http.subprocess.run")
+    def test_http_connect(self, mock_subprocess_run):
+        """
+        Test that if set to 3 retries, the connection command (wget, run
+        through subprocess.run) will be called 3 times
+        """
+        mock_subprocess_run.side_effect = subprocess.CalledProcessError(1, "")
+        connection_test = networking_http.HTTPConnection("test", 3)
+        with self.assertRaises(SystemExit):
+            connection_test.http_connect()
+        self.assertEqual(mock_subprocess_run.call_count, 3)
+
+    @patch("networking_http.HTTPConnection")
+    def test_main(self, mock_HTTPConnection):
+        args = ["test", "--retries", "5"]
+        networking_http.main(args)
+        mock_HTTPConnection.assert_called_with("test", 5)

--- a/providers/base/units/networking/jobs.pxu
+++ b/providers/base/units/networking/jobs.pxu
@@ -59,7 +59,8 @@ user: root
 plugin: shell
 category_id: com.canonical.plainbox::networking
 id: networking/http
-command: wget -SO /dev/null http://"$TRANSFER_SERVER"
+environ: TRANSFER_SERVER
+command: networking_http.py http://"$TRANSFER_SERVER"
 _description:
  Automated test case to make sure that it's possible to download files through HTTP
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->



## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

This job often fails, usually because of connectivity issues.

It is now replaced with a Python script that automatically runs the `wget` command 5 times, adding backoff+jitter after each attempt to prevent the test server to misbehave in case too many devices would run this test at the same time.


## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

Fixes https://warthogs.atlassian.net/browse/CHECKBOX-1419

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
- Unit tests
- Ran using checkbox from `main` (in the test below, I run checkbox while disconnected from the Internet, and I connect to a WiFi after a few seconds):

```
$ TRANSFER_SERVER=cdimage.ubuntu.com checkbox-cli run com.canonical.certification::networking/http
(...)
===========================[ Running Selected Jobs ]============================
=========[ Running job 1 / 1. Estimated time left (at least): 0:00:00 ]=========
------------------------------[ networking/http ]-------------------------------
ID: com.canonical.certification::networking/http
Category: com.canonical.plainbox::networking
... 8< -------------------------------------------------------------------------
--2024-04-29 16:15:06--  http://cdimage.ubuntu.com/
Resolving cdimage.ubuntu.com (cdimage.ubuntu.com)... failed: Temporary failure in name resolution.
wget: unable to resolve host address ‘cdimage.ubuntu.com’
--2024-04-29 16:15:09--  http://cdimage.ubuntu.com/
Resolving cdimage.ubuntu.com (cdimage.ubuntu.com)... failed: Temporary failure in name resolution.
wget: unable to resolve host address ‘cdimage.ubuntu.com’
--2024-04-29 16:15:13--  http://cdimage.ubuntu.com/
Resolving cdimage.ubuntu.com (cdimage.ubuntu.com)... failed: Temporary failure in name resolution.
wget: unable to resolve host address ‘cdimage.ubuntu.com’
--2024-04-29 16:15:24--  http://cdimage.ubuntu.com/
Resolving cdimage.ubuntu.com (cdimage.ubuntu.com)... 2001:67c:1562::25, 2001:67c:1562::28, 2620:2d:4000:1::1a, ...
Connecting to cdimage.ubuntu.com (cdimage.ubuntu.com)|2001:67c:1562::25|:80... connected.
HTTP request sent, awaiting response... 
  HTTP/1.1 200 OK
  Date: Mon, 29 Apr 2024 08:15:25 GMT
  Server: Apache/2.4.29 (Ubuntu)
  Vary: Accept-Encoding
  Content-Length: 1706
  Keep-Alive: timeout=2, max=10
  Connection: Keep-Alive
  Content-Type: text/html;charset=UTF-8
Length: 1706 (1.7K) [text/html]
Saving to: ‘/dev/null’

     0K .                                                     100% 90.2M=0s

2024-04-29 16:15:25 (90.2 MB/s) - ‘/dev/null’ saved [1706/1706]

Trying to connect to http://cdimage.ubuntu.com (attempt 1/5)
Attempt 1 failed: Command '['wget', '-SO', '/dev/null', 'http://cdimage.ubuntu.com']' returned non-zero exit status 4.

Waiting for 2.51 seconds before retrying...
Trying to connect to http://cdimage.ubuntu.com (attempt 2/5)
Attempt 2 failed: Command '['wget', '-SO', '/dev/null', 'http://cdimage.ubuntu.com']' returned non-zero exit status 4.

Waiting for 4.60 seconds before retrying...
Trying to connect to http://cdimage.ubuntu.com (attempt 3/5)
Attempt 3 failed: Command '['wget', '-SO', '/dev/null', 'http://cdimage.ubuntu.com']' returned non-zero exit status 4.

Waiting for 10.99 seconds before retrying...
Trying to connect to http://cdimage.ubuntu.com (attempt 4/5)
------------------------------------------------------------------------- >8 ---
Outcome: job passed
```