### PR TITLE
Core24 builds action (infra)

### DIFF
--- a/.github/workflows/core24-builds.yml
+++ b/.github/workflows/core24-builds.yml
@@ -19,7 +19,7 @@ jobs:
             tag: X64
     runs-on:
       group: "Canonical self-hosted runners"
-      lables:
+      labels:
         - self-hosted
         - linux
         - jammy

--- a/.github/workflows/core24-builds.yml
+++ b/.github/workflows/core24-builds.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        type: [classic, uc]
         releases: [24]
         arch: [amd64, arm64]
         tag: [X64, ARM64]
@@ -19,6 +18,8 @@ jobs:
           - arch: arm64
             tag: X64
     runs-on:
+      group: "Canonical self-hosted runners"
+      lables:
         - self-hosted
         - linux
         - jammy
@@ -54,7 +55,7 @@ jobs:
           with: |
             path: checkbox-core-snap/series${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload logs on failure
         if: failure()
         with:
@@ -63,10 +64,10 @@ jobs:
             /home/runner/.cache/snapcraft/log/
             /home/runner/.local/state/snapcraft/log/
             checkbox-core-snap/series${{ matrix.releases }}/checkbox*.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload the snap as artifact
         with:
-          name: series${{ matrix.releases }}
+          name: checkbox${{ matrix.releases }}_${{ matrix.arch }}
           path: checkbox-core-snap/series${{ matrix.releases }}/*.snap
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
         name: Upload the snap to the store

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -226,13 +226,12 @@ parts:
       # cleaning this bit should not cause any issue but if it does do not only remove this line
       # contact also the store/update the package because else this will always trigger
       # a manual review
-      export LIBAMDHIP64=$(find usr/lib -name "libamdhip64.so.5*")
-      for libamd_path in $LIBAMDHIP64; do
-        execstack --clear-execstack "$libamd_path"
-      done
+      for libamd_path in $(find .. -name "libamdhip64.so.5*"); do
+        echo "Clearing execstack on $libamd_path";
+        execstack --clear-execstack "$libamd_path" || exit 1
+      done;
       craftctl default
     stage-packages:
-      - execstack # needed to clear the execstack
       - python3-opencv
       - bc
       - bonnie++
@@ -309,6 +308,7 @@ parts:
       - on arm64:
         - python3-rpi.gpio # only in focal
     build-packages:
+      - execstack # needed to clear the execstack
       - libasound2-dev
       - libcap-dev
     organize:

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -222,12 +222,15 @@ parts:
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-base --root="$CRAFT_PART_INSTALL"
     override-prime: |
-      craftctl default
       # needed because else this will trigger the store autoreviewer and be autorejected
       # cleaning this bit should not cause any issue but if it does do not only remove this line
       # contact also the store/update the package because else this will always trigger
       # a manual review
-      [ -f usr/lib/x86_64-linux-gnu/libamdhip64.so.5* ] && execstack --clear-execstack usr/lib/x86_64-linux-gnu/libamdhip64.so.5* || true
+      export LIBAMDHIP64=$(find usr/lib -name "libamdhip64.so.5*")
+      for libamd_path in $LIBAMDHIP64; do
+        execstack --clear-execstack "$libamd_path"
+      done
+      craftctl default
     stage-packages:
       - execstack # needed to clear the execstack
       - python3-opencv

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -227,7 +227,7 @@ parts:
       # cleaning this bit should not cause any issue but if it does do not only remove this line
       # contact also the store/update the package because else this will always trigger
       # a manual review
-      [ -f usr/lib/x86_64-linux-gnu/libamdhip64.so.5.2.* ] && execstack --clear-execstack usr/lib/x86_64-linux-gnu/libamdhip64.so.5.2.* || true
+      [ -f usr/lib/x86_64-linux-gnu/libamdhip64.so.5* ] && execstack --clear-execstack usr/lib/x86_64-linux-gnu/libamdhip64.so.5* || true
     stage-packages:
       - execstack # needed to clear the execstack
       - python3-opencv


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This updates the core24 build action so that it works, fixing several problems:
- artifact upload v3 is deprecated -> moved to v4 (renamed the artifact as the new v4 action doesn't allow to have multiple uploads with the same name)
- sloppy copy paste in matrix strategy, runtime has no classic/uc devide
- Use `group` to avoid building on testflinger runners (several reasons, firewall issues and overall not their purpose)
- Fix the `libamdhip64` workaroud by installing `execstack` in `build-packages` instead of `stage-packages`
- Error checking on the execstack bitsetting (nice to have)
- Fix the workaroud by running the prime part AFTER setting the bit instead of before

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1420

## Documentation

N/A

## Tests

Checkbox24 currently in the store was built from this branch
