### PR TITLE
Fix base provider's unit tests (BugFix)

### DIFF
--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -122,17 +122,13 @@ class PrimeOffloader:
             )
 
     def check_offload(
-        self, cmd: list, card_id: str, card_name: str, timeout: str
+        self, cmd: list, card_id: str, card_name: str, timeout: int
     ):
         """
-        Use to check provided command is executed on specific GPU.
-
-        :param cmd: command that running under prime offload
-
+        Check provided command is executed on specific GPU.
+        :param cmd: command to check if it's running on specific GPU
         :param card_id: card id of dri device
-
         :param card_name: card name of dri device
-
         :param timeout: timeout for offloaded command
         """
         delay = timeout / 10

--- a/providers/base/tests/test_cpuid.py
+++ b/providers/base/tests/test_cpuid.py
@@ -20,7 +20,7 @@ from cpuid import cpuid_to_human_friendly, main
 
 class CpuidTests(unittest.TestCase):
     def test_hygon_dhyana_plus(self):
-        self.assertEquals(
+        self.assertEqual(
             cpuid_to_human_friendly("0x900f22"), "Hygon Dhyana Plus"
         )
 

--- a/providers/base/tests/test_get_firmware_info_fwupd.py
+++ b/providers/base/tests/test_get_firmware_info_fwupd.py
@@ -178,8 +178,6 @@ class TestGetFirmwareInfo(unittest.TestCase):
         mock_snapd.return_value = False
         mock_fwupd_ver.return_value = (1, 7, 9)
 
-        # SNAP env is empty
-        self.assertIsNone(os.environ.get("SNAP"))
         get_firmware_info_fwupd.get_firmware_info_fwupd()
         mock_snapd.assert_called_with("fwupd")
         mock_subporcess.assert_called_with(

--- a/providers/base/tests/test_led_control_test.py
+++ b/providers/base/tests/test_led_control_test.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+from datetime import datetime
 from unittest.mock import patch, Mock
 from pathlib import PosixPath, Path
 from led_control_test import SysFsLEDController
@@ -132,9 +133,17 @@ class TestSysFsLEDController(unittest.TestCase):
         self.led_controller._get_initial_state()
         self.assertEqual(expected_data, self.led_controller.initial_state)
 
+    @patch("time.sleep", return_value=0)
+    @patch("led_control_test.datetime")
     @patch("led_control_test.SysFsLEDController.off")
     @patch("led_control_test.SysFsLEDController.on")
-    def test_blinking_test(self, mock_on, mock_off):
+    def test_blinking_test(self, mock_on, mock_off, mock_datetime, mock_sleep):
+        mock_datetime.now = Mock()
+        mock_datetime.now.side_effect = [
+            datetime(2020, 1, 1, 0, 0, 0),
+            datetime(2020, 1, 1, 0, 0, 1),
+            datetime(2020, 1, 1, 0, 0, 2),
+        ]
 
         self.led_controller.blinking(1, 0.5)
         mock_on.assert_called_with()

--- a/providers/base/tests/test_prime_offload_tester.py
+++ b/providers/base/tests/test_prime_offload_tester.py
@@ -249,9 +249,10 @@ class CheckOffloadTests(unittest.TestCase):
         )
         self.assertEqual(po.check_result, False)
 
+    @patch("time.time", side_effect=[1,2,3,4])
     @patch("time.sleep", return_value=None)
     @patch("prime_offload_tester.PrimeOffloader.get_clients")
-    def test_offload_fail_check(self, mock_client, mock_sleep):
+    def test_offload_fail_check(self, mock_client, mock_sleep, mock_time):
         cmd = ["echo"]
         # get_clients return string that doesn't include cmd
         mock_client.return_value = ""

--- a/providers/base/tests/test_prime_offload_tester.py
+++ b/providers/base/tests/test_prime_offload_tester.py
@@ -249,7 +249,7 @@ class CheckOffloadTests(unittest.TestCase):
         )
         self.assertEqual(po.check_result, False)
 
-    @patch("time.time", side_effect=[1,2,3,4])
+    @patch("time.time", side_effect=[1, 2, 3, 4])
     @patch("time.sleep", return_value=None)
     @patch("prime_offload_tester.PrimeOffloader.get_clients")
     def test_offload_fail_check(self, mock_client, mock_sleep, mock_time):


### PR DESCRIPTION
## Description

Over the course of last 2 months, yet again, tests that calling `sleep` or other unmocked time-related functions had been committed to the repository making the iteration time unnecessary long.
One of the test also made the whole thing unable to be run from within editors or IDEs that are running from a snap, because it actually asserted we're not running from snap (and of course the CI let it through, as it runs the tests not within a snap.

# Overall this PR makes the tests run  **20x** faster.

See individual commits for details.