### PR TITLE
Remove iot-cert-image-automated from ODM Server Test Plan (BugFix)

### DIFF
--- a/providers/base/units/image/jobs.pxu
+++ b/providers/base/units/image/jobs.pxu
@@ -2,6 +2,8 @@
 id: image/kernel-publisher-canonical
 category_id: image
 _summary: Check that the kernel snap publisher is Canonical
+requires:
+ lsb.distributor_id == "Ubuntu Core" and int(lsb.release) >= 20
 _description:
   During certification testing IoT devices must be running a kernel supplied
   by Canonical
@@ -14,6 +16,8 @@ flags: preserve-locale
 id: image/kernel-tracking-stable
 category_id: image
 _summary: Check that the kernel snap is tracking stable channel
+requires:
+ lsb.distributor_id == "Ubuntu Core" and int(lsb.release) >= 20
 _description:
   During certification testing IoT devices must be running a kernel that is on
   a stable channel
@@ -26,6 +30,8 @@ flags: preserve-locale
 id: image/gadget-publisher-canonical
 category_id: image
 _summary: Check that the gadget snap publisher is Canonical
+requires:
+ lsb.distributor_id == "Ubuntu Core" and int(lsb.release) >= 20
 _description:
   During certification testing IoT devices must be running a kernel supplied
   by Canonical
@@ -38,6 +44,8 @@ flags: preserve-locale
 id: image/gadget-tracking-stable
 category_id: image
 _summary: Check that the gadget snap is tracking stable channel
+requires:
+ lsb.distributor_id == "Ubuntu Core" and int(lsb.release) >= 20
 _description:
   During certification testing IoT devices must be running a gadget that is on
   a stable channel
@@ -50,6 +58,8 @@ flags: preserve-locale
 id: image/model-authority-canonical
 category_id: image
 _summary: Check that model authority-id is canonical
+requires:
+ lsb.distributor_id == "Ubuntu Core" and int(lsb.release) >= 20
 _description:
   The authority-id declares on whose authority this assertion is made. This
   must be Canonical for the certification of IoT devices.
@@ -62,6 +72,8 @@ flags: preserve-locale
 id: image/model-brand-canonical
 category_id: image
 _summary: Check the model brand-id is canoncial
+requires:
+ lsb.distributor_id == "Ubuntu Core" and int(lsb.release) >= 20
 _description:
   For the certification of IoT devices canonical provided generic images must
   be used. Hence, the brand-id must be canonical.

--- a/providers/base/units/image/jobs.pxu
+++ b/providers/base/units/image/jobs.pxu
@@ -2,8 +2,6 @@
 id: image/kernel-publisher-canonical
 category_id: image
 _summary: Check that the kernel snap publisher is Canonical
-requires:
- lsb.distributor_id == "Ubuntu Core" and int(lsb.release) >= 20
 _description:
   During certification testing IoT devices must be running a kernel supplied
   by Canonical
@@ -16,8 +14,6 @@ flags: preserve-locale
 id: image/kernel-tracking-stable
 category_id: image
 _summary: Check that the kernel snap is tracking stable channel
-requires:
- lsb.distributor_id == "Ubuntu Core" and int(lsb.release) >= 20
 _description:
   During certification testing IoT devices must be running a kernel that is on
   a stable channel
@@ -30,8 +26,6 @@ flags: preserve-locale
 id: image/gadget-publisher-canonical
 category_id: image
 _summary: Check that the gadget snap publisher is Canonical
-requires:
- lsb.distributor_id == "Ubuntu Core" and int(lsb.release) >= 20
 _description:
   During certification testing IoT devices must be running a kernel supplied
   by Canonical
@@ -44,8 +38,6 @@ flags: preserve-locale
 id: image/gadget-tracking-stable
 category_id: image
 _summary: Check that the gadget snap is tracking stable channel
-requires:
- lsb.distributor_id == "Ubuntu Core" and int(lsb.release) >= 20
 _description:
   During certification testing IoT devices must be running a gadget that is on
   a stable channel
@@ -58,8 +50,6 @@ flags: preserve-locale
 id: image/model-authority-canonical
 category_id: image
 _summary: Check that model authority-id is canonical
-requires:
- lsb.distributor_id == "Ubuntu Core" and int(lsb.release) >= 20
 _description:
   The authority-id declares on whose authority this assertion is made. This
   must be Canonical for the certification of IoT devices.
@@ -72,8 +62,6 @@ flags: preserve-locale
 id: image/model-brand-canonical
 category_id: image
 _summary: Check the model brand-id is canoncial
-requires:
- lsb.distributor_id == "Ubuntu Core" and int(lsb.release) >= 20
 _description:
   For the certification of IoT devices canonical provided generic images must
   be used. Hence, the brand-id must be canonical.

--- a/providers/certification-client/units/client-cert-odm-server-22-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-server-22-04.pxu
@@ -104,7 +104,6 @@ nested_part:
     cpu-automated
     disk-automated
     ethernet-automated
-    iot-cert-image-automated
     i2c-automated
     memory-automated
     networking-automated

--- a/providers/certification-client/units/client-cert-odm-server-24-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-server-24-04.pxu
@@ -104,7 +104,6 @@ nested_part:
     cpu-automated
     disk-automated
     ethernet-automated
-    iot-cert-image-automated
     i2c-automated
     memory-automated
     networking-automated


### PR DESCRIPTION
## Description

Since the jobs included in `iot-cert-image-automated` test plan is suitable for `Ubuntu Core` image only, therefore, remove it from `client-cert-odm-server-22-04.pxu` and `client-cert-odm-server-24-04.pxu` plans.

## Resolved issues

This is the submission tested on G1200 Server Image
  - https://certification.canonical.com/hardware/202404-33953/submission/367230/test-results/

Since there's no Gadget Kernel snaps in Server image, hence, all the jobs are failed except `image/model-grade` is skip.

## Documentation

N/A

## Tests

- Sideload test result shows that no image related jobs be included in  `client-cert-odm-server-22-04.pxu` 
  - https://pastebin.canonical.com/p/k23YntKcgR/
- Sideload test result shows that no image related jobs be included in  `client-cert-odm-server-24-04.pxu` 
  - https://pastebin.canonical.com/p/PzZDp49VDt// 


