### PR TITLE
[checkbox-ce-oem] Modify tcpecho_stress script (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/tcpecho_stress.sh
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/tcpecho_stress.sh
@@ -9,9 +9,10 @@ get_active_interfaces() {
 disable_net() {
     local target_interface=$1
     local default_net_state=$2
+    parent_eth=$(grep -oP "(?<=$target_interface@)\w+" "$default_net_state")
     # Disable all network interfaces that are not under test
     while IFS= read -r line; do
-        if [[ "$line" != *"$target_interface"* ]]; then
+        if [[ "$line" != *"$target_interface"* ]] && [[ "$line" != "$parent_eth" ]]; then
             echo "Attempting to disable $line"
             ip link set down dev "$line"
             sleep 3

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/tcpecho_stress.sh
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/tcpecho_stress.sh
@@ -39,7 +39,7 @@ restore_net() {
     done < "$default_net_state"
 }
 
-check_resote_net() {
+check_restore_net() {
     for ((i=1; i <= 5; i++))
     do
         net_check=0
@@ -126,7 +126,7 @@ main() {
     if [ "$ping_state" -ne 0 ]; then
         echo "Error: target $dst_ip is unavaliable"
         echo "Info: Restore default network ..."
-        check_resote_net
+        check_restore_net
         exit 1
     fi
     echo "Info: Starting to test TCP ping stress."
@@ -145,7 +145,7 @@ main() {
     seconds=$((interval % 60))
     echo "Time interval: $hours hours, $minutes minutes, $seconds seconds"
     echo "Info: Restore default network ..."
-    check_resote_net
+    check_restore_net
     if [ "$status" -ne 0 ]; then
         exit 1
     fi

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/tcpecho_stress.sh
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/tcpecho_stress.sh
@@ -9,8 +9,14 @@ get_active_interfaces() {
 disable_net() {
     local target_interface=$1
     local default_net_state=$2
+    # Get the parent eth name here to prevent issues on platforms with multi-port
+    # switches. If the platform has multi-port switches, the parent eth cannot be
+    # disabled; otherwise, the entire switch will become unusable.
+
     parent_eth=$(grep -oP "(?<=$target_interface@)\w+" "$default_net_state")
-    # Disable all network interfaces that are not under test
+
+    # Disable all network interfaces that are not under test except for the
+    # parent interface of the node under test.
     while IFS= read -r line; do
         if [[ "$line" != *"$target_interface"* ]] && [[ "$line" != "$parent_eth" ]]; then
             echo "Attempting to disable $line"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/tcpecho_stress.sh
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/tcpecho_stress.sh
@@ -61,7 +61,6 @@ check_restore_net() {
     fi
 }
 
-
 tcp_echo() {
     local target=$1
     local port=$2
@@ -104,18 +103,18 @@ tcp_echo() {
 
 main() {
     echo "Info: Attempting to test TCP echo stress ..."
-    echo "Info: Disabling network interfaces that not under test ..."
+    echo "Info: Disabling network interfaces that are not under test ..."
     original_net_state=$(mktemp)
     current_net_state=$(mktemp)
     get_active_interfaces "$original_net_state"
     disable_net "$src_if" "$original_net_state"
-    echo "Info: Checking if target is avaliable ..."
+    echo "Info: Checking if target is available ..."
     start_time=$(date +%s)
     for ((i=1; i <= 5; i++))
     do
         ping_state=0
         if ping -I "$src_if" "$dst_ip" -c 3; then
-            echo "Info: target is avaliable!"
+            echo "Info: target is available!"
             break
         else
             echo "Error: Retry ping!"
@@ -124,12 +123,12 @@ main() {
         fi
     done
     if [ "$ping_state" -ne 0 ]; then
-        echo "Error: target $dst_ip is unavaliable"
-        echo "Info: Restore default network ..."
+        echo "Error: target $dst_ip is unavailable"
+        echo "Info: Restoring default network ..."
         check_restore_net
         exit 1
     fi
-    echo "Info: Starting to test TCP ping stress."
+    echo "Info: Starting to test TCP echo stress."
     echo "Info: It will take time so please be patient."
     echo "Info: Will print out log when failed."
     if tcp_echo "$dst_ip" "$dst_port" "$loop" "$file"; then
@@ -144,7 +143,7 @@ main() {
     minutes=$((interval % 3600 / 60))
     seconds=$((interval % 60))
     echo "Time interval: $hours hours, $minutes minutes, $seconds seconds"
-    echo "Info: Restore default network ..."
+    echo "Info: Restoring default network ..."
     check_restore_net
     if [ "$status" -ne 0 ]; then
         exit 1
@@ -152,7 +151,7 @@ main() {
 }
 
 help_function() {
-    echo "This script is uses for TCP echo stress test."
+    echo "This script is used for TCP echo stress test."
     echo "Run nc command on the server before you start to test"
     echo "The following command can listen on certain port and direct message to log file."
     echo " $ nc -lk -p {port} | tee test.log"
@@ -176,8 +175,7 @@ while getopts "s:i:p:l:o:" opt; do
 done
 
 if [[ -z "$src_if" || -z "$dst_ip" || -z "$dst_port" || -z "$loop" || -z "$file" ]]; then
-    echo "Error: Source network interface, Destination IP address,port,\
- Number of test loop and the output file are needed!"
+    echo "Error: Source network interface, Destination IP address, port, Number of test loop and the output file are needed!"
     help_function
     exit 1
 fi


### PR DESCRIPTION
To prevent parent eth of ethernet switch been disable

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
Add condition to not disable parent interface for test multi-ports switch.
e.g. We have  a platform which have 7-ports switch as follows. As it shows, `eth0` is the parent interface of `lan1 to lan6`. In this case, we can not disable `eth0` if we are intend to test `lan1 to lan6`.
```
beats@ubuntu:~$ ip -c a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1502 qdisc mq state UP group default qlen 1000
    link/ether 52:28:41:56:75:47 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::5028:41ff:fe56:7547/64 scope link 
       valid_lft forever preferred_lft forever
3: mstp1: <BROADCAST,NOARP> mtu 1497 qdisc noop state DOWN group default qlen 10
    link/[261] 78 brd ff
4: mstp2: <BROADCAST,NOARP> mtu 1497 qdisc noop state DOWN group default qlen 10
    link/[261] 78 brd ff
5: lan1@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 52:28:41:56:75:47 brd ff:ff:ff:ff:ff:ff
    inet 10.102.89.216/23 brd 10.102.89.255 scope global dynamic lan1
       valid_lft 376sec preferred_lft 376sec
    inet6 fe80::5028:41ff:fe56:7547/64 scope link 
       valid_lft forever preferred_lft forever
6: lan2@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state LOWERLAYERDOWN group default qlen 1000
    link/ether 52:28:41:56:75:47 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::5028:41ff:fe56:7547/64 scope link 
       valid_lft forever preferred_lft forever
7: lan3@eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether 52:28:41:56:75:47 brd ff:ff:ff:ff:ff:ff
8: lan4@eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether 52:28:41:56:75:47 brd ff:ff:ff:ff:ff:ff
9: lan5@eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether 52:28:41:56:75:47 brd ff:ff:ff:ff:ff:ff
10: lan6@eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether 52:28:41:56:75:47 brd ff:ff:ff:ff:ff:ff
```


<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
Test result: https://certification.canonical.com/hardware/202402-33505/submission/366205/test-results/pass/
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
