### PR TITLE
[checkbox-ce-oem] support raritan PDU for cold-reboot-pdu test (BugFix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/cold_reboot_by_pdu.sh
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/cold_reboot_by_pdu.sh
@@ -120,15 +120,15 @@ main() {
         exit 1
     fi
 
-    if [ "$pdu_type" == "apc" ]; then
-        cold_reboot_apc
-    elif [ "$pdu_type" == "raritan" ]; then
-        cold_reboot_raritan
-    else
-        echo -e "Error: Network PDU type is not supported!\n"
-        help_function
-        exit 1
-    fi
+    case "$pdu_type" in
+        apc) cold_reboot_apc;;
+        raritan) cold_reboot_raritan;;
+        *)
+            echo -e "Error: Network PDU type is not supported!\n"
+            help_function
+            exit 1
+            ;;
+    esac
 }
 
 help_function() {


### PR DESCRIPTION
## Description
A customer hardware is not able to wake-up by RTC, so we implemented a cold reboot related tests with APC network PDU while we are enable it. But the system is setup with a Raritan network PDU in Lab now, so we would like to have Raritan network PDU for cold-reboot related test with PDU as well.

## Resolved issues
- To be able to finish the SRU testing with Raritan network PDU.

## Documentation
N/A

## Tests
```
ubuntu@ubuntu:~$ bash cold_reboot_by_pdu.sh -t raritan -p 10.102.196.119:8 -d 60
Turn off the power of DUT by Raritan network PDU..
System should be back after around 60 seconds..

## change the duration of power reboot
changed the duration successfully!

## trigger a cold reboot by network PDU..
trigger a cold reboot successfully!
```
