### PR TITLE
Add WIFI 7 (BE) Test Case and Plan (New)

### DIFF
--- a/providers/base/units/wireless/jobs.pxu
+++ b/providers/base/units/wireless/jobs.pxu
@@ -1,3 +1,4 @@
+
 id: wireless/detect
 category_id: com.canonical.plainbox::wireless
 plugin: shell
@@ -40,6 +41,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa_bg_nm_{{ interface }}
 template-id: wireless/wireless_connection_wpa_bg_nm_interface
+depends: wireless/detect
 _summary: Connect to WPA-encrypted 802.11b/g Wi-Fi network on {{ interface }}
 _purpose:
   Check system can connect to 802.11b/g AP with wpa security
@@ -64,6 +66,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_open_bg_nm_{{ interface }}
 template-id: wireless/wireless_connection_open_bg_nm_interface
+depends: wireless/detect
 _summary: Connect to an unencrypted 802.11b/g Wi-Fi network on {{ interface }}
 _purpose:
   Check the system can connect to an insecure 802.11b/g AP
@@ -88,6 +91,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa_n_nm_{{ interface }}
 template-id: wireless/wireless_connection_wpa_n_nm_interface
+depends: wireless/detect
 _summary: Connect to a WPA-encrypted 802.11n Wi-Fi network on {{ interface }}
 _purpose:
   Check if the system can connect to an 802.11n AP with WPA security.
@@ -112,6 +116,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_open_n_nm_{{ interface }}
 template-id: wireless/wireless_connection_open_n_nm_interface
+depends: wireless/detect
 _summary: Connect to an unencrypted 802.11n Wi-Fi network on {{ interface }}
 _purpose:
   Check if the system can connect to an unsecured 802.11n access point.
@@ -136,6 +141,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa_ac_nm_{{ interface }}
 template-id: wireless/wireless_connection_wpa_ac_nm_interface
+depends: wireless/detect
 _summary: Connect to WPA-encrypted 802.11ac Wi-Fi network on {{ interface }}
 _purpose:
   Check system can connect to 802.11ac AP with wpa security
@@ -161,6 +167,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_open_ac_nm_{{ interface }}
 template-id: wireless/wireless_connection_open_ac_nm_interface
+depends: wireless/detect
 _summary: Connect to unencrypted 802.11ac Wi-Fi network on {{ interface }}
 _purpose:
   Check system can connect to insecure 802.11ac AP
@@ -186,6 +193,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa_ax_nm_{{ interface }}
 template-id: wireless/wireless_connection_wpa_ax_nm_interface
+depends: wireless/detect
 _summary: Connect to WPA-encrypted 802.11ax Wi-Fi network on {{ interface }}
 _purpose:
   Check system can connect to 802.11ax AP with wpa security
@@ -211,6 +219,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa3_ax_nm_{{ interface }}
 template-id: wireless/wireless_connection_wpa3_ax_nm_interface
+depends: wireless/detect
 _summary: Connect to WPA3-encrypted 802.11ax Wi-Fi network on {{ interface }}
 _purpose:
   Check system can connect to 802.11ax AP with wpa3 security
@@ -235,6 +244,7 @@ template-filter: device.category == 'WIRELESS' and device.interface != 'UNKNOWN'
 template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_open_ax_nm_{{ interface }}
+depends: wireless/detect
 template-id: wireless/wireless_connection_open_ax_nm_interface
 _summary: Connect to unencrypted 802.11ax Wi-Fi network on {{ interface }}
 _purpose:
@@ -249,6 +259,84 @@ estimated_duration: 30.0
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_ax == 'supported'
+ {%- if __on_ubuntucore__ %}
+ connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager'
+ {%- endif %}
+ net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
+
+unit: template
+template-resource: device
+template-filter: device.category == 'WIRELESS' and device.interface != 'UNKNOWN'
+template-engine: jinja2
+template-unit: job
+id: wireless/wireless_connection_wpa_be_nm_{{ interface }}
+template-id: wireless/wireless_connection_wpa_be_nm_interface
+depends: wireless/detect
+_summary: Connect to WPA-encrypted 802.11be Wi-Fi network on {{ interface }}
+_purpose:
+  Check system can connect to 802.11be AP with wpa security
+plugin: shell
+user: root
+command:
+  net_driver_info.py "$NET_DRIVER_INFO"
+  wifi_nmcli_test.py secured {{ interface }} "$WPA_BE_SSID" "$WPA_BE_PSK"
+category_id: com.canonical.plainbox::wireless
+estimated_duration: 30.0
+flags: preserve-locale also-after-suspend
+requires:
+ wireless_sta_protocol.{{ interface }}_be == 'supported'
+ {%- if __on_ubuntucore__ %}
+ connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager'
+ {%- endif %}
+ net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
+
+unit: template
+template-resource: device
+template-filter: device.category == 'WIRELESS' and device.interface != 'UNKNOWN'
+template-engine: jinja2
+template-unit: job
+id: wireless/wireless_connection_wpa3_be_nm_{{ interface }}
+template-id: wireless/wireless_connection_wpa3_be_nm_interface
+depends: wireless/detect
+_summary: Connect to WPA3-encrypted 802.11be Wi-Fi network on {{ interface }}
+_purpose:
+  Check system can connect to 802.11be AP with wpa3 security
+plugin: shell
+user: root
+command:
+  net_driver_info.py "$NET_DRIVER_INFO"
+  wifi_nmcli_test.py secured {{ interface }} "$WPA3_BE_SSID" "$WPA3_BE_PSK" --exchange sae
+category_id: com.canonical.plainbox::wireless
+estimated_duration: 30.0
+flags: preserve-locale also-after-suspend
+requires:
+ wireless_sta_protocol.{{ interface }}_be == 'supported'
+ {%- if __on_ubuntucore__ %}
+ connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager'
+ {%- endif %}
+ net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
+
+unit: template
+template-resource: device
+template-filter: device.category == 'WIRELESS' and device.interface != 'UNKNOWN'
+template-engine: jinja2
+template-unit: job
+id: wireless/wireless_connection_open_be_nm_{{ interface }}
+depends: wireless/detect
+template-id: wireless/wireless_connection_open_be_nm_interface
+_summary: Connect to unencrypted 802.11be Wi-Fi network on {{ interface }}
+_purpose:
+  Check system can connect to insecure 802.11be AP
+plugin: shell
+user: root
+command:
+  net_driver_info.py "$NET_DRIVER_INFO"
+  wifi_nmcli_test.py open {{ interface }} "$OPEN_BE_SSID"
+category_id: com.canonical.plainbox::wireless
+estimated_duration: 30.0
+flags: preserve-locale also-after-suspend
+requires:
+ wireless_sta_protocol.{{ interface }}_be == 'supported'
  {%- if __on_ubuntucore__ %}
  connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager'
  {%- endif %}

--- a/providers/base/units/wireless/test-plan.pxu
+++ b/providers/base/units/wireless/test-plan.pxu
@@ -138,7 +138,7 @@ unit: test plan
 _name: Automated tests for wireless
 _description:
  Automated connection tests for unencrypted or WPA-encrypted 802.11 bg, n, ac, ax
- networks.
+ , be networks.
 include:
     wireless/detect
     wireless/wireless_scanning_.*
@@ -154,12 +154,15 @@ include:
     wireless/wireless_connection_wpa_ac_nm_.*
     wireless/wireless_connection_wpa_bg_nm_.*
     wireless/wireless_connection_wpa_n_nm_.*
+    wireless/wireless_connection_open_be_np_interface
     wireless/wireless_connection_open_ax_np_.*
     wireless/wireless_connection_open_ac_np_.*
     wireless/wireless_connection_open_bg_np_.*
     wireless/wireless_connection_open_n_np_.*
     wireless/wireless_connection_wpa_ax_np_.*
     wireless/wireless_connection_wpa3_ax_np_.*
+    wireless/wireless_connection_wpa_be_np_interface
+    wireless/wireless_connection_wpa3_be_np_interface
     wireless/wireless_connection_wpa_ac_np_.*
     wireless/wireless_connection_wpa_bg_np_.*
     wireless/wireless_connection_wpa_n_np_.*
@@ -172,7 +175,7 @@ unit: test plan
 _name: Automated tests for wireless using netplan
 _description:
  Automated connection tests for unencrypted or WPA-encrypted 802.11 bg, n, ac, ax
- networks using netplan.
+ , be networks using netplan.
 include:
     wireless/detect
     wireless/wireless_scanning_.*
@@ -188,12 +191,15 @@ include:
     wireless/wireless_connection_wpa_ac_nm_.*
     wireless/wireless_connection_wpa_bg_nm_.*
     wireless/wireless_connection_wpa_n_nm_.*
+    wireless/wireless_connection_open_be_np_interface
     wireless/wireless_connection_open_ax_np_.*
     wireless/wireless_connection_open_ac_np_.*
     wireless/wireless_connection_open_bg_np_.*
     wireless/wireless_connection_open_n_np_.*
     wireless/wireless_connection_wpa_ax_np_.*
     wireless/wireless_connection_wpa3_ax_np_.*
+    wireless/wireless_connection_wpa_be_np_interface
+    wireless/wireless_connection_wpa3_be_np_interface
     wireless/wireless_connection_wpa_ac_np_.*
     wireless/wireless_connection_wpa_bg_np_.*
     wireless/wireless_connection_wpa_n_np_.*
@@ -347,7 +353,7 @@ unit: test plan
 _name: Automated tests for wireless (after suspend)
 _description:
  Automated connection tests for unencrypted or WPA-encrypted 802.11 bg, n, ac, ax
- networks.
+ , be networks.
 include:
     after-suspend-wireless/wireless_scanning_.*
     wireless/wireless_connection_open_be_nm_interface
@@ -362,12 +368,15 @@ include:
     after-suspend-wireless/wireless_connection_wpa_ac_nm_.*
     after-suspend-wireless/wireless_connection_wpa_bg_nm_.*
     after-suspend-wireless/wireless_connection_wpa_n_nm_.*
+    wireless/wireless_connection_open_be_np_interface
     after-suspend-wireless/wireless_connection_open_ax_np_.*
     after-suspend-wireless/wireless_connection_open_ac_np_.*
     after-suspend-wireless/wireless_connection_open_bg_np_.*
     after-suspend-wireless/wireless_connection_open_n_np_.*
     after-suspend-wireless/wireless_connection_wpa_ax_np_.*
     after-suspend-wireless/wireless_connection_wpa3_ax_np_.*
+    wireless/wireless_connection_wpa_be_np_interface
+    wireless/wireless_connection_wpa3_be_np_interface
     after-suspend-wireless/wireless_connection_wpa_ac_np_.*
     after-suspend-wireless/wireless_connection_wpa_bg_np_.*
     after-suspend-wireless/wireless_connection_wpa_n_np_.*
@@ -380,7 +389,7 @@ unit: test plan
 _name: Automated tests for wireless using netplan (after suspend)
 _description:
  Automated connection tests for unencrypted or WPA-encrypted 802.11 bg, n, ac, ax
- networks using netplan.
+ , be networks using netplan.
 include:
     after-suspend-wireless/wireless_scanning_.*
     wireless/wireless_connection_open_be_nm_interface
@@ -395,12 +404,15 @@ include:
     after-suspend-wireless/wireless_connection_wpa_ac_nm_.*
     after-suspend-wireless/wireless_connection_wpa_bg_nm_.*
     after-suspend-wireless/wireless_connection_wpa_n_nm_.*
+    wireless/wireless_connection_open_be_np_interface
     after-suspend-wireless/wireless_connection_open_ax_np_.*
     after-suspend-wireless/wireless_connection_open_ac_np_.*
     after-suspend-wireless/wireless_connection_open_bg_np_.*
     after-suspend-wireless/wireless_connection_open_n_np_.*
     after-suspend-wireless/wireless_connection_wpa_ax_np_.*
     after-suspend-wireless/wireless_connection_wpa3_ax_np_.*
+    wireless/wireless_connection_wpa_be_np_interface
+    wireless/wireless_connection_wpa3_be_np_interface
     after-suspend-wireless/wireless_connection_wpa_ac_np_.*
     after-suspend-wireless/wireless_connection_wpa_bg_np_.*
     after-suspend-wireless/wireless_connection_wpa_n_np_.*

--- a/providers/base/units/wireless/test-plan.pxu
+++ b/providers/base/units/wireless/test-plan.pxu
@@ -42,6 +42,9 @@ include:
     wireless/wireless_connection_wpa_ax_nm_.*      certification-status=blocker
     wireless/wireless_connection_wpa3_ax_nm_.*     certification-status=blocker
     wireless/wireless_connection_open_ax_nm_.*     certification-status=blocker
+    wireless/wireless_connection_wpa_be_nm_interface  certification-status=blocker
+    wireless/wireless_connection_wpa3_be_nm_interface certification-status=blocker
+    wireless/wireless_connection_open_be_nm_interface certification-status=blocker
     wireless/nm_connection_restore_.*
     wireless/check_iwlwifi_microcode_crash_.*
 
@@ -62,6 +65,9 @@ include:
     after-suspend-wireless/wireless_connection_wpa_ax_nm_.*    certification-status=blocker
     after-suspend-wireless/wireless_connection_wpa3_ax_nm_.*   certification-status=blocker
     after-suspend-wireless/wireless_connection_open_ax_nm_.*   certification-status=blocker
+    wireless/wireless_connection_wpa_be_nm_interface  certification-status=blocker
+    wireless/wireless_connection_wpa3_be_nm_interface certification-status=blocker
+    wireless/wireless_connection_open_be_nm_interface certification-status=blocker
     after-suspend-wireless/nm_connection_restore_.*
     after-suspend-wireless/check_iwlwifi_microcode_crash_.*
 
@@ -83,6 +89,9 @@ include:
     wireless/wireless_connection_wpa_ax_nm_.*      certification-status=blocker
     wireless/wireless_connection_wpa3_ax_nm_.*     certification-status=blocker
     wireless/wireless_connection_open_ax_nm_.*     certification-status=blocker
+    wireless/wireless_connection_wpa_be_nm_interface  certification-status=blocker
+    wireless/wireless_connection_wpa3_be_nm_interface certification-status=blocker
+    wireless/wireless_connection_open_be_nm_interface certification-status=blocker
     wireless/nm_connection_restore_.*
 
 id: after-suspend-wireless-cert-blockers
@@ -103,6 +112,9 @@ include:
     after-suspend-wireless/wireless_connection_wpa_ax_nm_.*    certification-status=blocker
     after-suspend-wireless/wireless_connection_wpa3_ax_nm_.*   certification-status=blocker
     after-suspend-wireless/wireless_connection_open_ax_nm_.*   certification-status=blocker
+    wireless/wireless_connection_wpa_be_nm_interface  certification-status=blocker
+    wireless/wireless_connection_wpa3_be_nm_interface certification-status=blocker
+    wireless/wireless_connection_open_be_nm_interface certification-status=blocker
     after-suspend-wireless/nm_connection_restore_.*
 
 id: wireless-full
@@ -130,10 +142,13 @@ _description:
 include:
     wireless/detect
     wireless/wireless_scanning_.*
+    wireless/wireless_connection_open_be_nm_interface
     wireless/wireless_connection_open_ax_nm_.*
     wireless/wireless_connection_open_ac_nm_.*
     wireless/wireless_connection_open_bg_nm_.*
     wireless/wireless_connection_open_n_nm_.*
+    wireless/wireless_connection_wpa_be_nm_interface
+    wireless/wireless_connection_wpa3_be_nm_interface
     wireless/wireless_connection_wpa_ax_nm_.*
     wireless/wireless_connection_wpa3_ax_nm_.*
     wireless/wireless_connection_wpa_ac_nm_.*
@@ -161,10 +176,13 @@ _description:
 include:
     wireless/detect
     wireless/wireless_scanning_.*
+    wireless/wireless_connection_open_be_nm_interface
     wireless/wireless_connection_open_ax_nm_.*
     wireless/wireless_connection_open_ac_nm_.*
     wireless/wireless_connection_open_bg_nm_.*
     wireless/wireless_connection_open_n_nm_.*
+    wireless/wireless_connection_wpa_be_nm_interface
+    wireless/wireless_connection_wpa3_be_nm_interface
     wireless/wireless_connection_wpa_ax_nm_.*
     wireless/wireless_connection_wpa3_ax_nm_.*
     wireless/wireless_connection_wpa_ac_nm_.*
@@ -332,10 +350,13 @@ _description:
  networks.
 include:
     after-suspend-wireless/wireless_scanning_.*
+    wireless/wireless_connection_open_be_nm_interface
     after-suspend-wireless/wireless_connection_open_ax_nm_.*
     after-suspend-wireless/wireless_connection_open_ac_nm_.*
     after-suspend-wireless/wireless_connection_open_bg_nm_.*
     after-suspend-wireless/wireless_connection_open_n_nm_.*
+    wireless/wireless_connection_wpa_be_nm_interface
+    wireless/wireless_connection_wpa3_be_nm_interface
     after-suspend-wireless/wireless_connection_wpa_ax_nm_.*
     after-suspend-wireless/wireless_connection_wpa3_ax_nm_.*
     after-suspend-wireless/wireless_connection_wpa_ac_nm_.*
@@ -362,10 +383,13 @@ _description:
  networks using netplan.
 include:
     after-suspend-wireless/wireless_scanning_.*
+    wireless/wireless_connection_open_be_nm_interface
     after-suspend-wireless/wireless_connection_open_ax_nm_.*
     after-suspend-wireless/wireless_connection_open_ac_nm_.*
     after-suspend-wireless/wireless_connection_open_bg_nm_.*
     after-suspend-wireless/wireless_connection_open_n_nm_.*
+    wireless/wireless_connection_wpa_be_nm_interface
+    wireless/wireless_connection_wpa3_be_nm_interface
     after-suspend-wireless/wireless_connection_wpa_ax_nm_.*
     after-suspend-wireless/wireless_connection_wpa3_ax_nm_.*
     after-suspend-wireless/wireless_connection_wpa_ac_nm_.*

--- a/providers/base/units/wireless/wireless-connection-netplan.pxu
+++ b/providers/base/units/wireless/wireless-connection-netplan.pxu
@@ -3,6 +3,30 @@ template-resource: device
 template-filter: device.category == 'WIRELESS' and device.interface != 'UNKNOWN'
 template-engine: jinja2
 template-unit: job
+id: wireless/wireless_connection_open_be_np_{{ interface }}
+template-id: wireless/wireless_connection_open_be_np_interface
+_summary:
+ Connect to unencrypted 802.11be Wi-Fi network on {{ interface }} - netplan
+_purpose:
+ Check system can connect to insecure 802.11be AP using netplan
+plugin: shell
+command:
+    net_driver_info.py "$NET_DRIVER_INFO"
+    wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_BE_SSID" -d
+user: root
+environ: LD_LIBRARY_PATH OPEN_BE_SSID NET_DRIVER_INFO
+category_id: com.canonical.plainbox::wireless
+estimated_duration: 15
+flags: preserve-locale also-after-suspend
+requires:
+ wireless_sta_protocol.{{ interface }}_be == 'supported'
+ net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
+
+unit: template
+template-resource: device
+template-filter: device.category == 'WIRELESS' and device.interface != 'UNKNOWN'
+template-engine: jinja2
+template-unit: job
 id: wireless/wireless_connection_open_ax_np_{{ interface }}
 template-id: wireless/wireless_connection_open_ax_np_interface
 _summary:
@@ -97,6 +121,30 @@ template-resource: device
 template-filter: device.category == 'WIRELESS' and device.interface != 'UNKNOWN'
 template-engine: jinja2
 template-unit: job
+id: wireless/wireless_connection_wpa_be_np_{{ interface }}
+template-id: wireless/wireless_connection_wpa_be_np_interface
+_summary:
+ Connect to WPA-encrypted 802.11be Wi-Fi network on {{ interface }} - netplan
+_purpose:
+ Check system can connect to 802.11be AP with wpa security using netplan
+plugin: shell
+command:
+    net_driver_info.py "$NET_DRIVER_INFO"
+    wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_BE_SSID" -k "$WPA_BE_PSK" -d
+user: root
+environ: LD_LIBRARY_PATH WPA_BE_SSID WPA_BE_PSK NET_DRIVER_INFO
+category_id: com.canonical.plainbox::wireless
+estimated_duration: 15
+flags: preserve-locale also-after-suspend
+requires:
+ wireless_sta_protocol.{{ interface }}_be == 'supported'
+ net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
+
+unit: template
+template-resource: device
+template-filter: device.category == 'WIRELESS' and device.interface != 'UNKNOWN'
+template-engine: jinja2
+template-unit: job
 id: wireless/wireless_connection_wpa_ax_np_{{ interface }}
 template-id: wireless/wireless_connection_wpa_ax_np_interface
 _summary:
@@ -114,6 +162,30 @@ estimated_duration: 15
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_ax == 'supported'
+ net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
+
+unit: template
+template-resource: device
+template-filter: device.category == 'WIRELESS' and device.interface != 'UNKNOWN'
+template-engine: jinja2
+template-unit: job
+id: wireless/wireless_connection_wpa3_be_np_{{ interface }}
+template-id: wireless/wireless_connection_wpa3_be_np_interface
+_summary:
+ Connect to WPA3-encrypted 802.11be Wi-Fi network on {{ interface }} - netplan
+_purpose:
+ Check system can connect to 802.11be AP with wpa3 security using netplan
+plugin: shell
+command:
+    net_driver_info.py "$NET_DRIVER_INFO"
+    wifi_client_test_netplan.py -i {{ interface }} -s "$WPA3_BE_SSID" -k "$WPA3_BE_PSK" -d --wpa3
+user: root
+environ: LD_LIBRARY_PATH WPA3_BE_SSID WPA3_BE_PSK NET_DRIVER_INFO
+category_id: com.canonical.plainbox::wireless
+estimated_duration: 15
+flags: preserve-locale also-after-suspend
+requires:
+ wireless_sta_protocol.{{ interface }}_be == 'supported'
  net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
 
 unit: template


### PR DESCRIPTION
## Description
- Add WIFI 7 (BE) test case with open WPA WPA3
- Add the depends for each wifi connection test to make sure these test case should not be run when `wireless/detect` failed
**This PR only can work until #1175 merged.**

For now, `wifi_nmcli_test.py` will not check the connection protocal and the band.
This feature will be done in next PR, and I will work on this

## Resolved issues



## Documentation



## Tests

Run Desktop auto test plan (client-cert-desktop-22-04-automated)
only select the wireless category

[202201-29926 QCN765 only support up to AC](https://certification.canonical.com/hardware/202201-29926/submission/363902/)
[202402-33474 BE200 in noble support up to BE](https://certification.canonical.com/hardware/202402-33474/submission/363903/)
