### PR TITLE
Use checkout action v4 instead of v3 (infra)

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -11,7 +11,7 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
           options: "--check --diff --line-length 79 --extend-exclude '/vendor/'"

--- a/.github/workflows/checkbox-beta-release.yml
+++ b/.github/workflows/checkbox-beta-release.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y gh
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Verify Promotion Conditions
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup the gh repository and install gh
@@ -67,7 +67,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Copy deb packages from edge to beta ppa
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/checkbox-ce-oem-daily-build.yml
+++ b/.github/workflows/checkbox-ce-oem-daily-build.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       new_commit_count: ${{ steps.commit_check.outputs.new_commit_count }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Check for commits

--- a/.github/workflows/checkbox-ce-oem-edge-builds.yml
+++ b/.github/workflows/checkbox-ce-oem-edge-builds.yml
@@ -22,7 +22,7 @@ jobs:
       SNAPCRAFT_BUILDER_ID: checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ github.run_id }}
     name: Frontend ${{ matrix.type }}${{ matrix.releases }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Add LP credentials

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -21,7 +21,7 @@ jobs:
       SNAPCRAFT_BUILDER_ID: checkbox${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
     name: Runtime (Core) ${{ matrix.releases }}-${{ matrix.arch }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Copy over the common files for series ${{ matrix.releases }}

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -22,7 +22,7 @@ jobs:
       SNAPCRAFT_BUILDER_ID: checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ github.run_id }}
     name: Frontend ${{ matrix.type }}${{ matrix.releases }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Copy over the common files for series ${{ matrix.type }}${{ matrix.releases }}

--- a/.github/workflows/checkbox-stable-release.yml
+++ b/.github/workflows/checkbox-stable-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, large]
     steps:
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Copy deb packages from testing to stable ppa
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/core24-builds.yml
+++ b/.github/workflows/core24-builds.yml
@@ -31,7 +31,7 @@ jobs:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
     name: Runtime (Core) ${{ matrix.releases }}-${{ matrix.arch }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Copy over the common files for series ${{ matrix.releases }}

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       new_commit_count: ${{ steps.commit_check.outputs.new_commit_count }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Check for commits

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -15,7 +15,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
@@ -52,7 +52,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Aspell
         run: |
@@ -42,7 +42,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, large]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: woke
         uses: get-woke/woke-action@v0
@@ -60,7 +60,7 @@ jobs:
         working-directory: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install the doc framework
         working-directory: docs/

--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       required_run: ${{ steps.check_diff.outputs.required_run }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use git diff to see if there are any changes in the metabox and checkbox-ng directories
@@ -49,7 +49,7 @@ jobs:
       PYCHARM_HOSTED: True
     steps:
       - name: Checkout Checkbox monorepo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup LXD
         uses: canonical/setup-lxd@v0.1.1
       - name: Add ZFS storage

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, large]
     steps:
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup the gh repository and install gh

--- a/.github/workflows/tox-checkbox-ng.yaml
+++ b/.github/workflows/tox-checkbox-ng.yaml
@@ -31,7 +31,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tox-checkbox-support.yaml
+++ b/.github/workflows/tox-checkbox-support.yaml
@@ -31,7 +31,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tox-contrib-provider-ce-oem.yaml
+++ b/.github/workflows/tox-contrib-provider-ce-oem.yaml
@@ -24,7 +24,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tox-provider-base.yaml
+++ b/.github/workflows/tox-provider-base.yaml
@@ -31,7 +31,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tox-provider-certification-client.yaml
+++ b/.github/workflows/tox-provider-certification-client.yaml
@@ -31,7 +31,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tox-provider-certification-server.yaml
+++ b/.github/workflows/tox-provider-certification-server.yaml
@@ -31,7 +31,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tox-provider-docker.yaml
+++ b/.github/workflows/tox-provider-docker.yaml
@@ -31,7 +31,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tox-provider-genio.yaml
+++ b/.github/workflows/tox-provider-genio.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tox-provider-gpgpu.yaml
+++ b/.github/workflows/tox-provider-gpgpu.yaml
@@ -31,7 +31,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tox-provider-iiotg.yaml
+++ b/.github/workflows/tox-provider-iiotg.yaml
@@ -31,7 +31,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tox-provider-resource.yaml
+++ b/.github/workflows/tox-provider-resource.yaml
@@ -31,7 +31,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tox-provider-sru.yaml
+++ b/.github/workflows/tox-provider-sru.yaml
@@ -31,7 +31,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tox-provider-tpm2.yaml
+++ b/.github/workflows/tox-provider-tpm2.yaml
@@ -31,7 +31,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tox-tools-release.yaml
+++ b/.github/workflows/tox-tools-release.yaml
@@ -19,7 +19,7 @@ jobs:
         working-directory: tools/release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/validate_workflows.yaml
+++ b/.github/workflows/validate_workflows.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install action-validator with asdf
         uses: asdf-vm/actions/install@v3
         with:


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

We are getting quite a few warnings because we use the outdated checkout action (the Node this is based on is outdated). This fixes the warning

## Resolved issues

Node warnings in action runs

## Documentation

N/A

## Tests

N/A
