### PR TITLE
Core24 SH build for frontend (infra)

### DIFF
--- a/.github/workflows/core24-builds.yml
+++ b/.github/workflows/core24-builds.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
 
 jobs:
-  snap:
+  snap_runtime:
     strategy:
       fail-fast: false
       matrix:
@@ -31,7 +31,7 @@ jobs:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
     name: Runtime (Core) ${{ matrix.releases }}-${{ matrix.arch }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Copy over the common files for series ${{ matrix.releases }}
@@ -80,4 +80,92 @@ jobs:
             do \
               echo "Uploading $snap..." ; \
               snapcraft upload $snap --release edge ; \
+            done
+  snap_frontend:
+    strategy:
+      fail-fast: false
+      matrix:
+        type: [classic, uc]
+        releases: [24]
+        arch: [amd64, arm64]
+        tag: [X64, ARM64]
+        exclude:
+          - arch: amd64
+            tag: ARM64
+          - arch: arm64
+            tag: X64
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - ${{ matrix.tag }}
+    timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
+    env:
+      SERIES: series_${{ matrix.type }}${{ matrix.releases }}
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
+    name: Frontend ${{ matrix.type }}${{ matrix.releases }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Copy over the common files for series ${{ matrix.type }}${{ matrix.releases }}
+        run: |
+          cd checkbox-snap/
+          sudo apt update && sudo apt install -qq -y python3-setuptools-scm
+          ./prepare_${{ matrix.type }}.sh $SERIES
+      - name: Add LP credentials
+        run: |
+          mkdir -p ~/.local/share/snapcraft/provider/launchpad/
+          echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
+          git config --global user.email "robot@lists.canonical.com"
+          git config --global user.name "Certification bot"
+      - name: Print Launchpad build repository
+        run: |
+          echo "Building at: https://git.launchpad.net/~ce-certification-qa/+snap/$SNAPCRAFT_BUILDER_ID"
+      - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+        name: Building the snaps
+        timeout-minutes: 600 # 10hours
+        with:
+          action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
+          attempt_delay: 600000 # 10min
+          attempt_limit: 5
+          with: |
+            path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}
+            snapcraft-channel: 7.x/stable
+      - uses: actions/upload-artifact@v4
+        name: Upload logs on failure
+        if: failure()
+        with:
+          name: snapcraft-log-series-${{ matrix.type }}${{ matrix.releases }}${{ matrix.arch }}
+          path: |
+            /home/runner/.cache/snapcraft/log/
+            /home/runner/.local/state/snapcraft/log/
+            checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/checkbox*.txt
+      - uses: actions/upload-artifact@v4
+        name: Upload the snaps as artefacts
+        with:
+          name: series_${{ matrix.type }}${{ matrix.releases }}${{ matrix.arch }}
+          path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
+      - uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+        name: Upload the snaps to the store
+        timeout-minutes: 600 # 10hours
+        with:
+          attempt_delay: 600000 # 10min
+          attempt_limit: 10
+          command: |
+            for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap ; \
+            do \
+              echo "Uploading $snap..." ; \
+              if [ ${{ matrix.type }} = 'classic' ]; then \
+                if [ ${{ matrix.releases }} = '22' ]; then \
+                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge ; \
+                else \
+                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge ; \
+                fi \
+              else \
+                snapcraft upload $snap --release ${{ matrix.type }}${{ matrix.releases }}/edge ; \
+              fi ; \
             done


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This mirrors what was done for the backend snap to the frontend one. Namely, indroduce an automated way to build and publish the snaps for all configurations/arch we support.

## Resolved issues

Frontend snap for classic 22.04 on armhf was actually a core snap. I have ran this issue and confirmed that it fixes the problem. 

## Documentation

N/A

## Tests

Last run: https://github.com/canonical/checkbox/actions/runs/8936471962
