### PR TITLE
describe the black workflow better (infra)

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,4 +1,4 @@
-name: Black formatting (79 chars lines)
+name: Check formatting with Black
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  black:
+  check-with-black:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The previously used naming was misleading, suggesting we're formatting with black, and that the formatting action failed.
And even when interpreted properly (as a check) there was the mention of the line length even when the code was actually fitting in 79 chars.
Also `black` as an action is a bit too terse.
