### PR TITLE
Fix core22 not building issue (infra)

### DIFF
--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -502,27 +502,9 @@ parts:
   gnome-randr:
     source: https://github.com/maxwellainatchi/gnome-randr-rust.git
     plugin: rust
+    rust-channel: nightly
     build-packages:
       - libdbus-1-dev
-    after: [rust-deps]
-################################################################################
-  rust-deps:
-    plugin: nil
-    build-packages:
-      - wget
-    override-pull: |
-      # Do not use rustup to work around https://forum.snapcraft.io/t/armhf-builds-on-launchpad-timing-out/31008
-      REQUIRED_RUST_VERSION=nightly
-      ROOT=https://static.rust-lang.org/dist/rust-$REQUIRED_RUST_VERSION
-      if [ $SNAPCRAFT_TARGET_ARCH = "amd64" ]; then
-        BINARIES_SUFFIX=x86_64-unknown-linux-gnu
-      elif [ $SNAPCRAFT_TARGET_ARCH = "armhf" ]; then
-        BINARIES_SUFFIX=armv7-unknown-linux-gnueabihf
-      elif [ $SNAPCRAFT_TARGET_ARCH = "arm64" ]; then
-        BINARIES_SUFFIX=aarch64-unknown-linux-gnu
-      fi
-      wget -O - $ROOT-$BINARIES_SUFFIX.tar.gz | tar -x -z --strip-components=1
-      ./install.sh --prefix=/usr --destdir=$SNAPCRAFT_STAGE
 ################################################################################
   rpi-support-binaries:
     plugin: nil


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The core22 build is broken because now snapcraft doesn't use the bodge that we created for armhf anymore nor does it set a default rust channel for rustup. This fixes it by removing the bodge (that is no longer needed) and sets the rust channel

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CER-2608

## Documentation

N/A

## Tests

I have built the snap on armhf and the build surpassed the part


