### PR TITLE
Fix wpa3 netplan test (Bugfix)

### DIFF
--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -264,7 +264,7 @@ def print_journal_entries(start):
     sp.call(cmd, shell=True)
 
 
-def main():
+def parse_args():
     # Read arguments
     parser = argparse.ArgumentParser(
         description=(
@@ -319,7 +319,12 @@ def main():
         help=("Configure WPA3 key management for the network"),
         default=False,
     )
-    args = parser.parse_args()
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
 
     start_time = datetime.datetime.now()
 

--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -121,6 +121,8 @@ def generate_test_config(interface, ssid, psk, address, dhcp, wpa3):
             dhcp4: true
             nameservers: {}
     """
+    if not ssid:
+        raise SystemExit("A SSID is required for the test")
     # Define the access-point with the ssid
     access_point = {ssid: {}}
     # If psk is provided, add it to the "auth" section

--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -148,7 +148,7 @@ def generate_test_config(interface, ssid, psk, address, dhcp, wpa3):
     }
 
     # Serialize the dictionary to a YAML string using pyyaml
-    yaml_output = yaml.safe_dump(network_config)
+    yaml_output = yaml.safe_dump(network_config, default_flow_style=False)
     output = textwrap.dedent(
         "# This is the network config written by checkbox\n" + yaml_output
     )

--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -109,46 +109,17 @@ def generate_test_config(interface, ssid, psk, address, dhcp, wpa3):
     Produce valid netplan yaml from arguments provided
 
     Typical open ap with dhcp:
-
-    >>> print(generate_test_config("eth0", "my_ap", None, "", True))
     # This is the network config written by checkbox
     network:
       version: 2
-      wifis:
-        eth0:
-          access-points:
-            my_ap: {}
-          addresses: []
-          dhcp4: True
-          nameservers: {}
-
-    Typical private ap with dhcp:
-
-    >>> print(generate_test_config("eth0", "my_ap", "s3cr3t", "", True))
-    # This is the network config written by checkbox
-    network:
-      version: 2
-      wifis:
-        eth0:
-          access-points:
-            my_ap: {password: s3cr3t}
-          addresses: []
-          dhcp4: True
-          nameservers: {}
-
-    Static IP no dhcp:
-    >>> print(generate_test_config(
-        "eth0", "my_ap", "s3cr3t", "192.168.1.1", False))
-    # This is the network config written by checkbox
-    network:
-      version: 2
-      wifis:
-        eth0:
-          access-points:
-            my_ap: {password: s3cr3t}
-          addresses: [192.168.1.1]
-          dhcp4: False
-          nameservers: {}
+        wifis:
+          eth0:
+            access-points:
+            my_ap:
+              auth:
+                password: s3cr3t
+            dhcp4: true
+            nameservers: {}
     """
     # Define the access-point with the ssid
     access_point = {ssid: {}}

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+from unittest import TestCase
+
+from wifi_client_test_netplan import generate_test_config
+
+
+class WifiClientTestNetplanTests(TestCase):
+    def test_open_ap_with_dhcp(self):
+        expected_output = textwrap.dedent(
+            """
+            # This is the network config written by checkbox
+            network:
+              version: 2
+              wifis:
+                eth0:
+                  access-points:
+                    my_ap: {}
+                  dhcp4: true
+                  nameservers: {}
+            """
+        )
+
+        result = generate_test_config("eth0", "my_ap", None, "", True, False)
+        self.assertEqual(result.strip(), expected_output.strip())
+
+    def test_private_ap_with_dhcp(self):
+        expected_output = textwrap.dedent(
+            """
+            # This is the network config written by checkbox
+            network:
+              version: 2
+              wifis:
+                eth0:
+                  access-points:
+                    my_ap:
+                      auth:
+                        password: s3cr3t
+                  dhcp4: true
+                  nameservers: {}
+            """
+        )
+        result = generate_test_config(
+            "eth0", "my_ap", "s3cr3t", "", True, False
+        )
+        self.assertEqual(result.strip(), expected_output.strip())
+
+    def test_private_ap_with_wpa3(self):
+        expected_output = textwrap.dedent(
+            """
+            # This is the network config written by checkbox
+            network:
+              version: 2
+              wifis:
+                eth0:
+                  access-points:
+                    my_ap_wpa3:
+                      auth:
+                        key-management: sae
+                        password: s3cr3t
+                  dhcp4: false
+                  nameservers: {}
+            """
+        )
+        result = generate_test_config(
+            "eth0", "my_ap_wpa3", "s3cr3t", "", False, True
+        )
+        self.assertEqual(result.strip(), expected_output.strip())
+
+    def test_static_ip_no_dhcp(self):
+        expected_output = textwrap.dedent(
+            """
+            # This is the network config written by checkbox
+            network:
+              version: 2
+              wifis:
+                eth0:
+                  access-points:
+                    my_ap:
+                      auth:
+                        password: s3cr3t
+                  addresses:
+                  - 192.168.1.1
+                  dhcp4: false
+                  nameservers: {}
+            """
+        )
+        result = generate_test_config(
+            "eth0", "my_ap", "s3cr3t", "192.168.1.1", False, False
+        )
+        self.assertEqual(result.strip(), expected_output.strip())

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -109,6 +109,12 @@ class WifiClientTestNetplanTests(TestCase):
         )
         self.assertEqual(result.strip(), expected_output.strip())
 
+    def test_no_ssid_fails(self):
+        with self.assertRaises(SystemExit):
+            generate_test_config(
+                "eth0", "", "s3cr3t", "192.168.1.1", False, False
+            )
+
     def test_parser_psk_and_wpa3(self):
         with patch(
             "sys.argv",

--- a/providers/base/units/wireless/wireless-connection-netplan.pxu
+++ b/providers/base/units/wireless/wireless-connection-netplan.pxu
@@ -136,7 +136,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
-    wifi_client_test_netplan.py -i {{ interface }} -s "$WPA3_AX_SSID" -k "$WPA3_AX_PSK" -d
+    wifi_client_test_netplan.py -i {{ interface }} -s "$WPA3_AX_SSID" -k "$WPA3_AX_PSK" -d --wpa3
 user: root
 environ: LD_LIBRARY_PATH WPA3_AX_SSID WPA3_AX_PSK NET_DRIVER_INFO
 category_id: com.canonical.plainbox::wireless


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

Netplan had [a bug](https://bugs.launchpad.net/netplan/+bug/2023238) preventing it from supporting WPA3 connections. This was addressed with https://github.com/canonical/netplan/pull/369 and the fix landed in Jammy with netplan 0.106.1.

To get it to work, the yaml netplan config must include key-management: sae in the auth section (see [example](https://github.com/canonical/netplan/blob/main/examples/wireless_wpa3.yaml#L8)).

We have modified the netplan yaml to include this new section.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

#811, [CHECKBOX-1424](https://warthogs.atlassian.net/browse/CHECKBOX-1424)

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

No changes in documentation

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

The wpa3 has been tested with [Eurotech - DynaCOR 44-11](https://certification.canonical.com/hardware/202308-31999/) 
[submission_2024-05-09T09.21.41.702067.zip](https://github.com/canonical/checkbox/files/15260717/submission_2024-05-09T09.21.41.702067.zip)



[CHECKBOX-1424]: https://warthogs.atlassian.net/browse/CHECKBOX-1424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ