### PR TITLE
Get the host keyboard device path dinamically (BugFix)

### DIFF
--- a/providers/base/tests/test_zapper_keyboard.py
+++ b/providers/base/tests/test_zapper_keyboard.py
@@ -118,9 +118,11 @@ class ZapperKeyboardTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             zapper_keyboard_test.main([1, 2])
 
+    @patch("zapper_keyboard_test.get_zapper_kbd_device")
     @patch("os.access")
-    def test_main_no_file_or_permission(self, mock_access):
+    def test_main_no_file_or_permission(self, mock_access, mock_get_dev):
         """Check main exits with failure if Zapper keyboard is missing."""
+        mock_get_dev.return_value = "/dev/input/by-id/keyboard"
         mock_access.return_value = False
         with self.assertRaises(SystemExit):
             zapper_keyboard_test.main([1, 2])

--- a/providers/base/tests/test_zapper_keyboard.py
+++ b/providers/base/tests/test_zapper_keyboard.py
@@ -111,6 +111,13 @@ class ZapperKeyboardTests(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             zapper_keyboard_test.get_zapper_kbd_device()
 
+    @patch("zapper_keyboard_test.get_zapper_kbd_device")
+    def test_main_no_keyboard(self, mock_get_dev):
+        """Check main exits with failure if Zapper keyboard is missing."""
+        mock_get_dev.side_effect = FileNotFoundError
+        with self.assertRaises(SystemExit):
+            zapper_keyboard_test.main([1, 2])
+
     @patch("os.access")
     def test_main_no_file_or_permission(self, mock_access):
         """Check main exits with failure if Zapper keyboard is missing."""
@@ -118,13 +125,17 @@ class ZapperKeyboardTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             zapper_keyboard_test.main([1, 2])
 
+    @patch("zapper_keyboard_test.get_zapper_kbd_device")
     @patch("zapper_keyboard_test.assert_type_string")
     @patch("zapper_keyboard_test.assert_key_combo")
     @patch("zapper_keyboard_test.KeyboardListener")
     @patch("os.access")
-    def test_main(self, mock_access, mock_key, mock_combo, mock_type):
+    def test_main(
+        self, mock_access, mock_key, mock_combo, mock_type, mock_get_dev
+    ):
         """Check main exits with failure if any of the test fails."""
 
+        mock_get_dev.return_value = "/dev/input/by-id/keyboard"
         mock_access.return_value = True
 
         mock_combo.side_effect = AssertionError

--- a/providers/base/tests/test_zapper_keyboard.py
+++ b/providers/base/tests/test_zapper_keyboard.py
@@ -4,6 +4,7 @@ import os
 import struct
 import threading
 import unittest
+from pathlib import Path
 from unittest.mock import patch, Mock
 
 import zapper_keyboard_test
@@ -58,6 +59,57 @@ class ZapperKeyboardTests(unittest.TestCase):
         """Check main exits with failure if input is missing."""
         with self.assertRaises(SystemExit):
             zapper_keyboard_test.main([1])
+
+    @patch("zapper_keyboard_test.Path")
+    def test_get_zapper_kbd_device(self, mock_path):
+        """
+        Test whether the function returns a path to the Zapper
+        keyboard device when it's the only Zapper HID device.
+        """
+
+        mock_path.return_value.glob.return_value = [
+            Path(
+                "/dev/input/by-id/"
+                "usb-Canonical_Zapper_main_board_123456-event-kbd",
+            )
+        ]
+        device = zapper_keyboard_test.get_zapper_kbd_device()
+        self.assertEqual(
+            device,
+            "/dev/input/by-id/"
+            "usb-Canonical_Zapper_main_board_123456-event-kbd",
+        )
+
+    @patch("zapper_keyboard_test.Path")
+    def test_get_zapper_kbd_device_if01(self, mock_path):
+        """
+        Test whether the function returns a path to the Zapper
+        keyboard device when it's the second Zapper HID device.
+        """
+
+        mock_path.return_value.glob.return_value = [
+            Path(
+                "/dev/input/by-id/"
+                "usb-Canonical_Zapper_main_board_123456-if01-event-kbd"
+            ),
+        ]
+        device = zapper_keyboard_test.get_zapper_kbd_device()
+        self.assertEqual(
+            device,
+            "/dev/input/by-id/"
+            "usb-Canonical_Zapper_main_board_123456-if01-event-kbd",
+        )
+
+    @patch("zapper_keyboard_test.Path")
+    def test_get_zapper_kbd_device_not_found(self, mock_path):
+        """
+        Test whether the function raises an exception if no
+        Zapper keyboard can be found.
+        """
+
+        mock_path.return_value.glob.return_value = []
+        with self.assertRaises(FileNotFoundError):
+            zapper_keyboard_test.get_zapper_kbd_device()
 
     @patch("os.access")
     def test_main_no_file_or_permission(self, mock_access):


### PR DESCRIPTION
## Description

This PR adapts the `input/keyboard` to the latest changes in host mainboard FW (especially https://warthogs.atlassian.net/browse/ZAP-717). It's now possible to reconfigure the HID devices provided by host which means the device ID of host keyboard can change depending on the device order.

The path to the keyboard device is now obtained via pattern matching, making it compatible with different interface number.

## Resolved issues

N/A

## Documentation

N/A

## Tests

- Added unit tests for the new function.
- Tested on HW in two scenarios:
    -  With keyboard as first HID device, as before
    - With keyboard as second HID device
