### PR TITLE
Allow bypassing the check via manual trigger (infra)

### DIFF
--- a/.github/workflows/checkbox-beta-release.yml
+++ b/.github/workflows/checkbox-beta-release.yml
@@ -29,7 +29,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          tools/release/can_promote_edge.py
+          # check if can_promote but ignore (only print an error) if the workflow was manually triggered
+          tools/release/can_promote_edge.py || ${{ github.event_name == 'workflow_dispatch' }}
 
   release-notes:
     needs: should-run


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Sometimes the beta release is created via other means, for instance the last one, due to a snapcraft regression, was partially built locally. When this happens, the last successful daily build is not "the one that originated the beta currently in the store/ppa". This adds the possibility to "force" the release of beta by manually triggering the workflow.

## Resolved issues

Sometimes we need to bypass this check when the build was put together manually

## Documentation
N/A

## Tests

This is the workaround I always use to release when we don't have a "clean" daily build
