### PR TITLE
Remove pm-graph from SRU test plans (bugfix)

### DIFF
--- a/providers/sru/units/sru.pxu
+++ b/providers/sru/units/sru.pxu
@@ -75,7 +75,6 @@ nested_part:
     # with.
     power-automated
     tpm-cert-automated
-    stress-pm-graph
     stress-ng-cert-automated
     stress-10-reboot-poweroff-automated
 bootstrap_include:


### PR DESCRIPTION
Removes pm-graph tests from SRU server plan from where it is inherited by the plan used for desktop machines.

## Description

pm-graph has been described as "designed with single user mode not graphics multi-user mode" and it is found to often block test session completion which slows ability to approve kernels.

If this is needed for any specific benchmarking reasons it needs to be made more reliable on all machines that run the test plan and potential run separately from SRU

Also note that this does not remove pm-graph from the Certification test plans.

## Resolved issues


## Documentation


## Tests

