### PR TITLE
Add a new function to find which renderer is running the process (New)

### DIFF
--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -134,15 +134,15 @@ class PrimeOffloader:
         self, cmd: list, card_id: str, card_name: str, timeout: int
     ):
         """
-        Use to check provided command is executed on specific GPU.
+        Used to check if the provided command is executed on a specific GPU.
 
-        :param cmd: command that running under prime offload
+        :param cmd: command to be run under prime offload
 
-        :param card_id: card id of dri device
+        :param card_id: card ID of the DRI device
 
-        :param card_name: card name of dri device
+        :param card_name: card name of the DRI device
 
-        :param timeout: timeout for offloaded command
+        :param timeout: timeout for the offloaded command
         """
         delay = timeout / 10
 

--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -168,10 +168,10 @@ class PrimeOffloader:
         :param card: in /sys/kernel/debug/dri/<card id>/clients format
 
         """
-        data_in_name = self._run_command(
-            ["cat", card.replace("clients", "name")]
-        )
-        return data_in_name.split()[1].split("=")[1]
+    filename = card.replace("clients", "name")
+    with open(filename, "r") as f:
+        data_in_name = f.read()
+    return data_in_name.split()[1].split("=")[1]
 
     def find_offload(self, cmd: str, timeout: int):
         """

--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -17,10 +17,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
+from checkbox_support.helpers.timeout import run_with_timeout
 import subprocess
 import threading
 import argparse
 import logging
+import fnmatch
 import time
 import json
 import sys
@@ -44,25 +46,32 @@ class PrimeOffloader:
     logger = logging.getLogger()
     check_result = False
 
-    def _run_command(self, cmd: list, shell=False) -> str:
+    def _if_file_contain(
+        self, directory: str, file_name_pattern: str, contain_str: str
+    ) -> str:
         """
-        use subprocess.check_output to execute command
+        find the file that contains the specific string
 
-        :param cmd: the command will be executed
+        :param directory: directory that will be searched
 
-        :param shell: enable shell or not
+        :param file_name_pattern: the filename pattern
 
-        :returns: Output of command
+        :param contain_str: the string should be in the file
+
+        :returns: the file name with path
         """
-        try:
-            return subprocess.check_output(
-                cmd, shell=shell, universal_newlines=True
+        for root, dirs, files in os.walk(directory):
+            print(
+                f"++++++++++++++++++++{root}:{dirs}:{files}+++++++++++++++++++"
             )
-
-        except (subprocess.CalledProcessError, FileNotFoundError) as e:
-            raise SystemExit(
-                "Running command:{} failed due to {}".format(cmd, repr(e))
-            )
+            for file_name in fnmatch.filter(files, file_name_pattern):
+                file_path = os.path.join(root, file_name)
+                # Check if the search string is in the file
+                with open(
+                    file_path, "r", encoding="utf-8", errors="ignore"
+                ) as file:
+                    if contain_str in file.read():
+                        return file_path
 
     def find_card_id(self, pci_bdf: str) -> str:
         """
@@ -77,15 +86,9 @@ class PrimeOffloader:
             raise SystemExit("pci BDF format error")
 
         try:
-            cmd = [
-                "grep",
-                "-lr",
-                "--include=name",
-                pci_bdf,
-                "/sys/kernel/debug/dri",
-            ]
-
-            card_path = self._run_command(cmd)
+            card_path = self._if_file_contain(
+                "/sys/kernel/debug/dri", "name", pci_bdf
+            )
             return card_path.split("/")[5]
         except IndexError as e:
             raise SystemExit("return value format error {}".format(repr(e)))
@@ -100,7 +103,9 @@ class PrimeOffloader:
         """
         cmd = ["lshw", "-c", "display", "-numeric", "-json"]
         try:
-            card_infos = self._run_command(cmd)
+            card_infos = subprocess.check_output(
+                cmd, shell=False, universal_newlines=True
+            )
             infos = json.loads(card_infos)
             for info in infos:
                 if pci_bdf in info["businfo"]:
@@ -108,6 +113,10 @@ class PrimeOffloader:
             raise SystemExit("Card name not found")
         except (KeyError, TypeError, json.decoder.JSONDecodeError) as e:
             raise SystemExit("return value format error {}".format(e))
+        except (subprocess.CalledProcessError, FileNotFoundError) as e:
+            raise SystemExit(
+                "Running command:{} failed due to {}".format(cmd, repr(e))
+            )
 
     def get_clients(self, card_id: str) -> str:
         """
@@ -122,13 +131,12 @@ class PrimeOffloader:
             and the process could be found in
             /sys/kernel/debug/dri/<card id>/clients
 
-        :param cmd: command that running under prime offload
+        :param card_id: card id shows in debugfs
         """
-        read_clients_cmd = [
-            "cat",
-            "/sys/kernel/debug/dri/{}/clients".format(card_id),
-        ]
-        return self._run_command(read_clients_cmd)
+        filename = "/sys/kernel/debug/dri/{}/clients".format(card_id)
+        with open(filename, "r") as f:
+            return f.read()
+        return ""
 
     def check_offload(
         self, cmd: list, card_id: str, card_name: str, timeout: int
@@ -161,17 +169,16 @@ class PrimeOffloader:
         self.logger.info("  Couldn't find process [{}]".format(cmd))
         self.check_result = True
 
-    def _find_bdf(self, card: str):
+    def _find_bdf(self, card_id: str):
         """
         Use the /sys/kernel/debug/dri/<card id>/name to get pci BDF.
 
-        :param card: in /sys/kernel/debug/dri/<card id>/clients format
-
+        :param card_id: card id shows in debugfs
         """
-    filename = card.replace("clients", "name")
-    with open(filename, "r") as f:
-        data_in_name = f.read()
-    return data_in_name.split()[1].split("=")[1]
+        filename = "/sys/kernel/debug/dri/{}/name".format(card_id)
+        with open(filename, "r") as f:
+            data_in_name = f.read()
+        return data_in_name.split()[1].split("=")[1]
 
     def find_offload(self, cmd: str, timeout: int):
         """
@@ -181,29 +188,24 @@ class PrimeOffloader:
 
         :param timeout: timeout for command
         """
+        directory = "/sys/kernel/debug/dri"
+
         delay = timeout / 10
 
         deadline = time.time() + timeout
 
         cmd = cmd.split()
 
-        find_cmd = [
-            "grep",
-            "-lr",
-            "--include=clients",
-            cmd[0],
-            "/sys/kernel/debug/dri",
-        ]
-
         while time.time() < deadline:
             time.sleep(delay)
-            card_path = self._run_command(find_cmd)
-            if "/sys/kernel/debug/dri" in card_path:
+            card_path = self._if_file_contain(directory, "clients", cmd[0])
+            if directory in card_path:
                 try:
                     # The graphic will be shown such as 0 and 128
                     # at the same time. Therefore, pick up the first one
                     first_card = card_path.splitlines()[0]
-                    bdf = self._find_bdf(first_card)
+                    card_id = first_card.split("/")[5]
+                    bdf = self._find_bdf(card_id)
                     self.logger.info("Process is running on:")
                     self.logger.info("  process:[{}]".format(cmd))
                     self.logger.info(
@@ -250,36 +252,6 @@ class PrimeOffloader:
                 "No prime-select, it should be ok to run prime offload"
             )
 
-    def _reformat_cmd_timeout(self, cmd: str, timeout: int) -> (list, int):
-        """
-        use to reformat the command with correct timeout setting
-
-        :param cmd: the command will be executed
-
-        :param timeout: timeout
-
-        :returns: reformated command and real timeout
-        """
-        if "timeout" in cmd:
-            raise SystemExit("Put timeout in command isn't allowed")
-
-        cmd = cmd.split()
-
-        if timeout > 0:
-            offload_cmd = ["timeout", str(timeout)] + cmd
-        else:
-            # if timeout <=0 will make check_offload failed.
-            # Set the timeout to the default value
-            log_str = (
-                "Timeout {}s is invalid,"
-                " remove the timeout setting"
-                " and change check_offload to run 20s".format(timeout)
-            )
-            self.logger.info(log_str)
-            timeout = 20
-            offload_cmd = cmd
-        return (offload_cmd, timeout)
-
     def cmd_runner(self, cmd: list, env: dict = None):
         """
         use to execute command and piping the output to the screen.
@@ -314,14 +286,18 @@ class PrimeOffloader:
 
         :param timeout: timeout for offloaded command
         """
-        (modified_cmd, timeout) = self._reformat_cmd_timeout(cmd, timeout)
+        if "timeout" in cmd:
+            raise SystemExit("Put timeout in command isn't allowed")
 
         # use other thread to find offload
         find_thread = threading.Thread(
             target=self.find_offload, args=(cmd, timeout)
         )
         find_thread.start()
-        self.cmd_runner(modified_cmd)
+        try:
+            run_with_timeout(self.cmd_runner, timeout, cmd.split())
+        except TimeoutError:
+            self.logger.info("Test finished")
         find_thread.join()
 
         if self.check_result:
@@ -345,7 +321,8 @@ class PrimeOffloader:
         # run offload command in other process
         dri_pci_bdf_format = re.sub("[:.]", "_", pci_bdf)
 
-        (modified_cmd, timeout) = self._reformat_cmd_timeout(cmd, timeout)
+        if "timeout" in cmd:
+            raise SystemExit("Put timeout in command isn't allowed")
 
         env = os.environ.copy()
         if driver in ("nvidia", "pcieport"):
@@ -367,7 +344,10 @@ class PrimeOffloader:
             target=self.check_offload, args=(cmd, card_id, card_name, timeout)
         )
         check_thread.start()
-        self.cmd_runner(modified_cmd, env)
+        try:
+            run_with_timeout(self.cmd_runner, timeout, cmd.split(), env)
+        except TimeoutError:
+            self.logger.info("Test finished")
         check_thread.join()
 
         if self.check_result:
@@ -431,7 +411,9 @@ class PrimeOffloader:
 
         if args.pci and args.driver:
             # cmd_checker("glxgears", "0000:00:02.0", "i915", 0)
-            self.cmd_checker(args.command, args.pci, args.driver, args.timeout)
+            self.cmd_checker(
+                args.command, args.pci, args.driver, args.timeout
+            )
         else:
             # cmd_finder("glxgears", 0)
             self.cmd_finder(args.command, args.timeout)

--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -421,9 +421,7 @@ class PrimeOffloader:
 
         if args.pci and args.driver:
             # cmd_checker("glxgears", "0000:00:02.0", "i915", 0)
-            self.cmd_checker(
-                args.command, args.pci, args.driver, args.timeout
-            )
+            self.cmd_checker(args.command, args.pci, args.driver, args.timeout)
         else:
             # cmd_finder("glxgears", 0)
             self.cmd_finder(args.command, args.timeout)

--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -131,7 +131,7 @@ class PrimeOffloader:
         return self._run_command(read_clients_cmd)
 
     def check_offload(
-        self, cmd: list, card_id: str, card_name: str, timeout: str
+        self, cmd: list, card_id: str, card_name: str, timeout: int
     ):
         """
         Use to check provided command is executed on specific GPU.

--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -61,9 +61,6 @@ class PrimeOffloader:
         :returns: the file name with path
         """
         for root, dirs, files in os.walk(directory):
-            print(
-                f"++++++++++++++++++++{root}:{dirs}:{files}+++++++++++++++++++"
-            )
             for file_name in fnmatch.filter(files, file_name_pattern):
                 file_path = os.path.join(root, file_name)
                 # Check if the search string is in the file
@@ -411,9 +408,7 @@ class PrimeOffloader:
 
         if args.pci and args.driver:
             # cmd_checker("glxgears", "0000:00:02.0", "i915", 0)
-            self.cmd_checker(
-                args.command, args.pci, args.driver, args.timeout
-            )
+            self.cmd_checker(args.command, args.pci, args.driver, args.timeout)
         else:
             # cmd_finder("glxgears", 0)
             self.cmd_finder(args.command, args.timeout)

--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -175,7 +175,7 @@ class PrimeOffloader:
 
     def find_offload(self, cmd: str, timeout: int):
         """
-        Use to find provided command is executed on which GPU.
+        Find the card that the command is running on.
 
         :param cmd: command that is running
 

--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -46,19 +46,18 @@ class PrimeOffloader:
     logger = logging.getLogger()
     check_result = False
 
-    def _if_file_contain(
-        self, directory: str, file_name_pattern: str, contain_str: str
-    ) -> str:
-        """
-        find the file that contains the specific string
+def find_file_containing_string(
+    self, search_directory: str, filename_pattern: str, search_string: str
+) -> str:
+    """
+    Search for a file matching a specific pattern that contains a given string.
 
-        :param directory: directory that will be searched
-
-        :param file_name_pattern: the filename pattern
-
-        :param contain_str: the string should be in the file
-
-        :returns: the file name with path
+    :param search_directory: The directory to search through.
+    :param filename_pattern: The pattern that filenames should match.
+    :param search_string: The string to search for within the file's contents.
+    
+    :returns: The full path of the file that contains the string, or None if no file is found.
+    """
         """
         for root, dirs, files in os.walk(directory):
             for file_name in fnmatch.filter(files, file_name_pattern):

--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -50,7 +50,7 @@ class PrimeOffloader:
 
         :param cmd: the command will be executed
 
-        :param shell: enbale shell or not
+        :param shell: enable shell or not
 
         :returns: Ouput of command
         """

--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -52,7 +52,7 @@ class PrimeOffloader:
 
         :param shell: enable shell or not
 
-        :returns: Ouput of command
+        :returns: Output of command
         """
         try:
             return subprocess.check_output(

--- a/providers/base/tests/test_prime_offload_tester.py
+++ b/providers/base/tests/test_prime_offload_tester.py
@@ -523,6 +523,7 @@ class CmdCheckerTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             po.cmd_checker("timeout 10 echo", "0000:00:00.0", "driver", 0)
 
+    @patch("prime_offload_tester.run_with_timeout", MagicMock())
     def test_nv_env_fail_check(self):
         po = PrimeOffloader()
         # check_nv_offload_env failed
@@ -532,6 +533,7 @@ class CmdCheckerTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             po.cmd_checker("echo", "0000:00:00.0", "driver", 0)
 
+    @patch("prime_offload_tester.run_with_timeout", MagicMock())
     def test_non_nv_driver_check(self):
         # non NV driver
         po = PrimeOffloader()
@@ -544,7 +546,7 @@ class CmdCheckerTests(unittest.TestCase):
         # check check_offload function get correct args
         po.check_offload.assert_called_with("glxgears", "0", "Intel", 0)
 
-    @patch("checkbox_support.helpers.timeout.run_with_timeout", MagicMock())
+    @patch("prime_offload_tester.run_with_timeout", MagicMock())
     def test_nv_driver_check(self):
         # NV driver
         po = PrimeOffloader()
@@ -557,7 +559,7 @@ class CmdCheckerTests(unittest.TestCase):
         # check check_offload function get correct args
         po.check_offload.assert_called_with("glxgears", "0", "NV", 1)
 
-    @patch("checkbox_support.helpers.timeout.run_with_timeout")
+    @patch("prime_offload_tester.run_with_timeout")
     @patch("threading.Thread")
     def test_not_found(self, mock_thread, mock_run_timeout):
         po = PrimeOffloader()

--- a/providers/base/tests/test_prime_offload_tester.py
+++ b/providers/base/tests/test_prime_offload_tester.py
@@ -26,7 +26,7 @@ sys.modules["checkbox_support.helpers.timeout"] = MagicMock()
 from prime_offload_tester import *
 
 
-class IfFileContain(unittest.TestCase):
+class FindFileContainingString(unittest.TestCase):
     """
     This function should work like "grep -l"
     """
@@ -37,7 +37,7 @@ class IfFileContain(unittest.TestCase):
         po = PrimeOffloader()
         with patch("builtins.open", mock_open(read_data="test")) as mock_file:
             self.assertEqual(
-                po._if_file_contain("/foo/bar", "spam", "test"),
+                po.find_file_containing_string("/foo/bar", "spam", "test"),
                 "/foo/bar/spam",
             )
         mock_file.assert_called_with(
@@ -50,7 +50,7 @@ class IfFileContain(unittest.TestCase):
         po = PrimeOffloader()
         with patch("builtins.open", mock_open(read_data="test")) as mock_file:
             self.assertEqual(
-                po._if_file_contain("/foo/bar", "spam", "xxx"), None
+                po.find_file_containing_string("/foo/bar", "spam", "xxx"), None
             )
         mock_file.assert_called_with(
             "/foo/bar/spam", "r", encoding="utf-8", errors="ignore"
@@ -63,7 +63,7 @@ class FindCardIdTests(unittest.TestCase):
     (pci bus information)
     """
 
-    @patch("prime_offload_tester.PrimeOffloader._if_file_contain")
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
     def test_pci_name_format_check(self, mock_cmd):
         po = PrimeOffloader()
         # correct format
@@ -75,14 +75,14 @@ class FindCardIdTests(unittest.TestCase):
             "0000:00:00.0",
         )
 
-    @patch("prime_offload_tester.PrimeOffloader._if_file_contain")
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
     def test_pci_name_hex_format_check(self, mock_cmd):
         po = PrimeOffloader()
         # should work with hex vaule
         mock_cmd.return_value = "/sys/kernel/debug/dri/0/name"
         self.assertEqual(po.find_card_id("0000:c6:F0.0"), "0")
 
-    @patch("prime_offload_tester.PrimeOffloader._if_file_contain")
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
     def test_pci_name_non_hex_format_check(self, mock_cmd):
         po = PrimeOffloader()
         # error format - with alphabet
@@ -90,7 +90,7 @@ class FindCardIdTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             po.find_card_id("000r:00:00.0")
 
-    @patch("prime_offload_tester.PrimeOffloader._if_file_contain")
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
     def test_pci_name_digital_error_format_check(self, mock_cmd):
         po = PrimeOffloader()
         # error format - digital position error
@@ -98,7 +98,7 @@ class FindCardIdTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             po.find_card_id("0000:00:000.0")
 
-    @patch("prime_offload_tester.PrimeOffloader._if_file_contain")
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
     def test_empty_string_id_not_found(self, mock_cmd):
         po = PrimeOffloader()
         # empty string
@@ -111,7 +111,7 @@ class FindCardIdTests(unittest.TestCase):
             "0000:00:00.0",
         )
 
-    @patch("prime_offload_tester.PrimeOffloader._if_file_contain")
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
     def test_indexerror_id_not_found(self, mock_cmd):
         po = PrimeOffloader()
         # IndexError
@@ -351,7 +351,7 @@ class FindOffloadTests(unittest.TestCase):
     """
 
     @patch("time.sleep", return_value=None)
-    @patch("prime_offload_tester.PrimeOffloader._if_file_contain")
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
     def test_found(self, mock_file, mock_sleep):
         cmd = "echo"
         po = PrimeOffloader()
@@ -365,7 +365,7 @@ class FindOffloadTests(unittest.TestCase):
         self.assertEqual(po.check_result, False)
 
     @patch("time.sleep", return_value=None)
-    @patch("prime_offload_tester.PrimeOffloader._if_file_contain")
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
     def test_not_found(self, mock_file, mock_sleep):
         cmd = "echo"
         po = PrimeOffloader()

--- a/providers/base/tests/test_prime_offload_tester.py
+++ b/providers/base/tests/test_prime_offload_tester.py
@@ -517,7 +517,7 @@ class CmdFinderTests(unittest.TestCase):
             po.cmd_finder("glxgears", 1)
         # check check_offload function get correct args
         mock_thread.assert_called_with(
-            target=po.check_offload, args=("glxgears", 1)
+            target=po.find_offload, args=("glxgears", 1)
         )
 
 

--- a/providers/base/tests/test_prime_offload_tester.py
+++ b/providers/base/tests/test_prime_offload_tester.py
@@ -533,7 +533,6 @@ class CmdCheckerTests(unittest.TestCase):
             po.cmd_checker("echo", "0000:00:00.0", "driver", 0)
 
     def test_non_nv_driver_check(self):
-
         # non NV driver
         po = PrimeOffloader()
         po.find_card_id = MagicMock(return_value="0")
@@ -545,8 +544,8 @@ class CmdCheckerTests(unittest.TestCase):
         # check check_offload function get correct args
         po.check_offload.assert_called_with("glxgears", "0", "Intel", 0)
 
+    @patch("checkbox_support.helpers.timeout.run_with_timeout", MagicMock())
     def test_nv_driver_check(self):
-
         # NV driver
         po = PrimeOffloader()
         po.find_card_id = MagicMock(return_value="0")
@@ -560,7 +559,7 @@ class CmdCheckerTests(unittest.TestCase):
 
     @patch("checkbox_support.helpers.timeout.run_with_timeout")
     @patch("threading.Thread")
-    def test_not_found(self, mock_thread, mock_timeout):
+    def test_not_found(self, mock_thread, mock_run_timeout):
         po = PrimeOffloader()
         po.find_card_id = MagicMock(return_value="0")
         po.find_card_name = MagicMock(return_value="NV")
@@ -568,7 +567,7 @@ class CmdCheckerTests(unittest.TestCase):
         po.check_nv_offload_env = MagicMock(return_value=None)
         os.environ.copy = MagicMock(return_value={})
         po.check_result = True
-        mock_timeout.side_effect = TimeoutError
+        mock_run_timeout.side_effect = TimeoutError
         with self.assertRaises(SystemExit):
             po.cmd_checker("glxgears", "0000:00:00.0", "nvidia", 1)
         # check check_offload function get correct args

--- a/providers/base/tests/test_prime_offload_tester.py
+++ b/providers/base/tests/test_prime_offload_tester.py
@@ -510,18 +510,14 @@ class CmdFinderTests(unittest.TestCase):
     @patch("threading.Thread")
     def test_not_found(self, mock_thread, mock_run_timeout):
         po = PrimeOffloader()
-        po.find_card_id = MagicMock(return_value="0")
-        po.find_card_name = MagicMock(return_value="NV")
         po.check_offload = MagicMock(return_value="")
-        po.check_nv_offload_env = MagicMock(return_value=None)
-        os.environ.copy = MagicMock(return_value={})
         po.check_result = True
         mock_run_timeout.side_effect = TimeoutError
         with self.assertRaises(SystemExit):
-            po.cmd_finder("glxgears", "0000:00:00.0", "nvidia", 1)
+            po.cmd_finder("glxgears", 1)
         # check check_offload function get correct args
         mock_thread.assert_called_with(
-            target=po.check_offload, args=("glxgears", "0", "NV", 1)
+            target=po.check_offload, args=("glxgears", 1)
         )
 
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
While testing without pci id, user couldn't know the process is running
on which renderer. Therefore, this change is going to:
* add a new function to get which GPU is executing the command that could help user to make sure the renderer is not llvmpipe.
* refactor some codes to make reuse easier.
* add PCI ID in the log to make verify easier.

The jobs.pxu and test-plan.pxu will be in another PR, and the draft jobs and test-plan that use this new function as below:

```
plugin: shell
category_id: com.canonical.plainbox::graphics
id: graphics/auto_glxgears
flags: also-after-suspend
user: root
requires:
    executable.name == 'glxgears'
    dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower','Space-saving']
command:
    prime_offload_tester.py -c glxgears -t 30
summary:
    Test that glxgears works for current video card
purpose:
     Tests the basic 3D capabilities of your current video card. This test covers all devices without an integrated display, such as desktops.

plugin: shell
category_id: com.canonical.plainbox::graphics
id: graphics/auto_glxgears_fullscreen
flags: also-after-suspend
user: root
requires:
    executable.name == 'glxgears'
    dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower','Space-saving']
command:
     prime_offload_tester.py -c "glxgears -fullscreen" -t 30
summary:
    Test that glxgears works in full screen mode for current video card
purpose:
     Tests the basic full screen 3D capabilities of your current video card. This test covers all devices without an integrated display, such as desktops.
plugin: user-interact-verify
category_id: com.canonical.plainbox::graphics
id: graphics/valid_glxgears
flags: also-after-suspend
user: root
requires:
    executable.name == 'glxgears'
    dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower','Space-saving']
command:
     prime_offload_tester.py -c glxgears -t 30
summary:
    Test that glxgears works for current video card
purpose:
     Tests the basic 3D capabilities of your current video card. This test covers all devices without an integrated display, such as desktops.
steps:
     1. Click "Test" to execute an OpenGL demo. Press ESC at any time to close.
     2. Verify that the animation is not jerky or slow.
verification:
     1. Did the 3d animation appear?
     2. Was the animation free from slowness/jerkiness?

plugin: user-interact-verify
category_id: com.canonical.plainbox::graphics
id: graphics/valid_glxgears_fullscreen
flags: also-after-suspend
user: root
requires:
    executable.name == 'glxgears'
    dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower','Space-saving']
command:
     prime_offload_tester.py -c "glxgears -fullscreen" -t 30
summary:
    Test that glxgears works in full screen mode for current video card
purpose:
     Tests the basic full screen 3D capabilities of your current video card. This test covers all devices without an integrated display, such as desktops.
steps:
     1. Click "Test" to execute an OpenGL demo. Press ESC at any time to close.
     2. Verify that the animation is not jerky or slow.
verification:
     1. Did the 3d animation appear?
     2. Was the animation free from slowness/jerkiness?
```

```
id: graphics-gpu-cert-automated
unit: test plan
_name: Graphics tests (Automated)
_description:
 Graphics tests (Automated)
include:
~ skip ~
 graphics/auto_glxgears                         certification-status=blocker
 graphics/auto_glxgears_fullscreen              certification-status=blocker
~ skip ~
bootstrap_include:
    graphics_card

id: graphics-gpu-cert-manual
unit: test plan
_name: Graphics tests (Manual)
_description:
 Graphics tests (Manual)
include:
~ skip ~
 graphics/valid_glxgears                        certification-status=blocker
 graphics/valid_glxgears_fullscreen             certification-status=blocker
~ skip ~
bootstrap_include:
    graphics_card
```

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
Unit test and
laptop: [auto](https://certification.canonical.com/hardware/202001-27667/submission/369177/), [manual](https://certification.canonical.com/hardware/202001-27667/submission/369178/)
desktop: [auto](https://certification.canonical.com/hardware/202401-33394/submission/369179/), [manual](https://certification.canonical.com/hardware/202401-33394/submission/369181/)
