### PR TITLE
Fix missing link (Infra)

### DIFF
--- a/docs/reference/units/job.rst
+++ b/docs/reference/units/job.rst
@@ -14,7 +14,7 @@ File format and location
 
 Jobs are expressed as sections in text files that conform somewhat to the
 ``rfc822`` specification format. Our variant of the format is described in
-rfc822. Each record defines a single job.
+:ref:`rfc822`. Each record defines a single job.
 
 Job Fields
 ==========


### PR DESCRIPTION
The text "rfc822" is fairly obviously intended to be a link to the part of the documentation describing the variant of RFC-822 in use.