### PR TITLE
Use version manually in setup.py when provided (infra)

### DIFF
--- a/checkbox-ng/setup.py
+++ b/checkbox-ng/setup.py
@@ -1,6 +1,12 @@
 # This helps older pip version properly install editable version of checkbox
 # inside the venv with `pip install -e .`
 
+import os
 from setuptools import setup
 
-setup()
+# this version adoption is a no-op in non-debian build as setuptools-scm does
+# the same. Some pybuild versions are not triggering this behaviour correctly
+# so this makes it uniform. Note that if this variable is missing the fallback
+# to setuptools-scm is unchanged also in debian packages (so the package will
+# get the default version calculated from setuptools-scm)
+setup(version=os.getenv("SETUPTOOLS_SCM_PRETEND_VERSION"))

--- a/checkbox-support/setup.py
+++ b/checkbox-support/setup.py
@@ -1,6 +1,12 @@
 # This helps older pip version properly install editable version of checkbox
 # inside the venv with `pip install -e .`
 
+import os
 from setuptools import setup
 
-setup()
+# this version adoption is a no-op in non-debian build as setuptools-scm does
+# the same. Some pybuild versions are not triggering this behaviour correctly
+# so this makes it uniform. Note that if this variable is missing the fallback
+# to setuptools-scm is unchanged also in debian packages (so the package will
+# get the default version calculated from setuptools-scm)
+setup(version=os.getenv("SETUPTOOLS_SCM_PRETEND_VERSION"))


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

By default we adopt the package version via setuptools scm. This tool reads the SETUPTOOLS_SCM_PRETEND_VERSION environment variable and, if it is provided, it adopts it as the version without doing any further calculation. This is useful to pre-compute the version before building like we do in snaps and debs. This mechanism seems to not be used on some versions of pybuild (the debian plugin we use to build the package) that ignores the setuptools-scm version and simply uses a `0.0.0` version string. 

This PR adopts the version from the variable in setup.py manually. Note that if the variable is not provided setuptools-scm is still used, preserving the functionality of "source" installs.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1444
Fixes: https://github.com/canonical/checkbox/issues/1250

## Documentation

This also adds a comment to explain why this is done.

## Tests

To try this start a lxd container and build the package:
```bash
$ add-apt-repository ppa:checkbox-dev/edge
$ apt update
$ apt install dpkg-dev
$ cd checkbox
$ mv checkbox-ng/debian .  
$ dpkg-buildpackage -S
[...]  # this it will complain about missing build deps
$ apt install debhelper dh-python pybuild-plugin-pyproject python3-all python3-distutils-extra python3-docutils python3-importlib-metadata python3-packaging python3-padme python3-psutil python3-requests-oauthlib python3-setuptools python3-setuptools-scm python3-sphinx python3-tk python3-tqdm python3-urwid python3-xlsxwriter
$ dpkg-buildpackage -S
$ dpkg-buildpackage -b
$ cd ..
$ dpkg -i python3-checkbox-ng_2.8_all.deb checkbox-ng_2.8_all.deb
```
To verify that all went well run:
```
$ checkbox-cli --version
2.8
```

> Note: the version is adopted from the debian changelog that is automatically updated by launchpad. Locally the version will always be 2.8 (as that is the last version that was "manually" updated). 