### PR TITLE
Force workflow on x64 runners (infra)

### DIFF
--- a/.github/workflows/checkbox-ce-oem-daily-build.yml
+++ b/.github/workflows/checkbox-ce-oem-daily-build.yml
@@ -7,7 +7,14 @@ on:
 
 jobs:
   check_for_commits:
-    runs-on: [self-hosted, linux, jammy, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     name: Check for commits
     outputs:
       new_commit_count: ${{ steps.commit_check.outputs.new_commit_count }}

--- a/.github/workflows/checkbox-ce-oem-edge-builds.yml
+++ b/.github/workflows/checkbox-ce-oem-edge-builds.yml
@@ -11,7 +11,14 @@ jobs:
       matrix:
         type: [classic, uc]
         releases: [20, 22]
-    runs-on: [self-hosted, linux, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     env:
       SERIES: series_${{ matrix.type }}${{ matrix.releases }}

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -11,7 +11,14 @@ jobs:
       matrix:
         releases: [16, 18, 20, 22]
         arch: [amd64, arm64, armhf]
-    runs-on: [self-hosted, linux, jammy, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     env:
       SERIES: series${{ matrix.releases }}

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -11,7 +11,14 @@ jobs:
       matrix:
         type: [classic, uc]
         releases: [16, 18, 20, 22]
-    runs-on: [self-hosted, linux, jammy, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     env:
       SERIES: series_${{ matrix.type }}${{ matrix.releases }}

--- a/.github/workflows/checkbox-stable-release.yml
+++ b/.github/workflows/checkbox-stable-release.yml
@@ -7,7 +7,14 @@ on:
 jobs:
   release:
     name: Publish the release
-    runs-on: [self-hosted, linux, jammy, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     steps:
       - name: Checkout checkbox monorepo
         uses: actions/checkout@v4
@@ -31,7 +38,14 @@ jobs:
 
   checkbox_deb_packages:
     name: Checkbox Debian packages
-    runs-on: [self-hosted, linux, jammy, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     steps:
       - name: Install dependencies
         run: |
@@ -49,7 +63,14 @@ jobs:
 
   checkbox_core_snap:
     name: Checkbox core snap packages
-    runs-on: [self-hosted, linux, jammy, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
     steps:
@@ -69,7 +90,14 @@ jobs:
 
   checkbox_snap:
     name: Checkbox snap packages
-    runs-on: [self-hosted, linux, jammy, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
     steps:

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -7,7 +7,14 @@ on:
 
 jobs:
   check_for_commits:
-    runs-on: [self-hosted, linux, jammy, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     name: Check for commits
     outputs:
       new_commit_count: ${{ steps.commit_check.outputs.new_commit_count }}

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -7,7 +7,14 @@ on:
 jobs:
   ppa_update:
     name: Sync PPA history with monorepo
-    runs-on: [self-hosted, linux, jammy, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     steps:
       - name: Install dependencies
@@ -30,7 +37,14 @@ jobs:
             tools/release/lp_request_import.py "~checkbox-dev/checkbox/+git/checkbox"
   ppa_build:
     name: Trigger and monitor PPA builds
-    runs-on: [self-hosted, linux, jammy, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     needs: ppa_update
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     strategy:

--- a/.github/workflows/documentation-build-readthedocs.io.yml
+++ b/.github/workflows/documentation-build-readthedocs.io.yml
@@ -11,7 +11,14 @@ on:
 jobs:
   if_merged:
     if: github.event.pull_request.merged == true
-    runs-on: [self-hosted, linux, jammy, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     steps:
     - run: |
         curl -X POST -d "branches=latest" -d "token=${{ secrets.RTD_TOKEN }}" https://readthedocs.org/api/v2/webhook/checkbox/137367/

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -13,7 +13,14 @@ concurrency:
 jobs:
   spellcheck:
     name: Spelling check
-    runs-on: [self-hosted, linux, jammy, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     defaults:
       run:
         working-directory: docs
@@ -39,7 +46,14 @@ jobs:
 
   woke:
     name: Inclusive language check
-    runs-on: [self-hosted, linux, jammy, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,7 +68,14 @@ jobs:
 
   linkcheck:
     name: Link check
-    runs-on: [self-hosted, linux, jammy, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     defaults:
       run:
         working-directory: docs

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -9,7 +9,14 @@ on:
 
 jobs:
   Release:
-    runs-on: [self-hosted, linux, jammy, large]
+    runs-on:
+      group: "Canonical self-hosted runners"
+      labels:
+        - self-hosted
+        - linux
+        - jammy
+        - large
+        - X64
     steps:
       - name: Checkout checkbox monorepo
         uses: actions/checkout@v4


### PR DESCRIPTION
Arm64 runners are few and slow, better not use them for workflows that don't actually need them

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

We recently got some `large` ARM64 runners. We are curretly using them (by mistake) in a few workflows due to labels overlapping. This should be avoided as they are few and slightly less reliable than their amd64 counterparts.

Minor: this also sets the `label:` of the self hosted runners. We only have one label for now (testflinger runners are un-labeled), but this could come back to hunt us in the future.

## Resolved issues

Some workflows failing due to ARM64 runner reconciliation / proxy instability. 

## Documentation

N/A

## Tests

N/A
