### PR TITLE
Add camera submission for multiple resolution test (New)

### DIFF
--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -674,7 +674,7 @@ def parse_arguments(argv):
         "-o",
         "--output",
         default="",
-        help="Output directory to store the images",
+        help="Output directory to store a small debug image",
     )
     add_device_parameter(resolutions_parser)
     args = parser.parse_args(argv)

--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -401,9 +401,7 @@ class CameraTest:
         format = formats[0]
 
         if self.args.output:
-            self._save_debug_image(
-                format, self.args.device, self.args.output
-            )
+            self._save_debug_image(format, self.args.device, self.args.output)
 
         print(
             "Taking multiple images using the %s format"
@@ -414,8 +412,7 @@ class CameraTest:
             w = resolution[0]
             h = resolution[1]
             f = NamedTemporaryFile(
-                prefix="camera_test_%s%sx%s"
-                % (format["pixelformat"], w, h),
+                prefix="camera_test_%s%sx%s" % (format["pixelformat"], w, h),
                 suffix=".jpg",
                 delete=False,
             )
@@ -427,9 +424,7 @@ class CameraTest:
                 print("Validated image %s" % f.name)
                 os.remove(f.name)
             else:
-                print(
-                    "Failed to validate image %s" % f.name, file=sys.stderr
-                )
+                print("Failed to validate image %s" % f.name, file=sys.stderr)
                 os.remove(f.name)
                 return 1
         return 0

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -32,22 +32,22 @@ class CameraTestTests(unittest.TestCase):
     def setUp(self):
         self.camera_instance = CameraTest(None)
 
-    @patch("camera_test.CameraTest._supported_resolutions_to_string")
-    @patch("camera_test.CameraTest._get_supported_resolutions")
+    @patch("camera_test.CameraTest._supported_formats_to_string")
+    @patch("camera_test.CameraTest._get_supported_formats")
     def test_detect_and_show_camera_info_with_single_planar_capture_capability(
         self,
-        mock_get_supported_resolutions,
-        mock_supported_resolutions_to_string,
+        mock_get_supported_formats,
+        mock_supported_formats_to_string,
     ):
         """Test camera device supports the single planar capture capabilitiy"""
-        mock_get_supported_resolutions.return_value = [
+        mock_get_supported_formats.return_value = [
             {
                 "description": "fake",
                 "pixelformat": "fake",
                 "resolutions": [[123, 987]],
             }
         ]
-        mock_supported_resolutions_to_string.return_value = "Resolutions: fake"
+        mock_supported_formats_to_string.return_value = "Resolutions: fake"
 
         fake_device = "/dev/video0"
         fake_v4l2_capability = v4l2_capability()
@@ -60,22 +60,22 @@ class CameraTestTests(unittest.TestCase):
         )
         self.assertEqual(0, result)
 
-    @patch("camera_test.CameraTest._supported_resolutions_to_string")
-    @patch("camera_test.CameraTest._get_supported_resolutions")
+    @patch("camera_test.CameraTest._supported_formats_to_string")
+    @patch("camera_test.CameraTest._get_supported_formats")
     def test_detect_and_show_camera_info_with_multi_planar_capture_capability(
         self,
-        mock_get_supported_resolutions,
-        mock_supported_resolutions_to_string,
+        mock_get_supported_formats,
+        mock_supported_formats_to_string,
     ):
         """Test camera device supports the multi planar capture capabilitiy"""
-        mock_get_supported_resolutions.return_value = [
+        mock_get_supported_formats.return_value = [
             {
                 "description": "fake",
                 "pixelformat": "fake",
                 "resolutions": [[123, 987]],
             }
         ]
-        mock_supported_resolutions_to_string.return_value = "Resolutions: fake"
+        mock_supported_formats_to_string.return_value = "Resolutions: fake"
 
         fake_device = "/dev/video0"
         fake_v4l2_capability = v4l2_capability()
@@ -88,22 +88,22 @@ class CameraTestTests(unittest.TestCase):
         )
         self.assertEqual(0, result)
 
-    @patch("camera_test.CameraTest._supported_resolutions_to_string")
-    @patch("camera_test.CameraTest._get_supported_resolutions")
+    @patch("camera_test.CameraTest._supported_formats_to_string")
+    @patch("camera_test.CameraTest._get_supported_formats")
     def test_detect_and_show_camera_info_without_capture_capability(
         self,
-        mock_get_supported_resolutions,
-        mock_supported_resolutions_to_string,
+        mock_get_supported_formats,
+        mock_supported_formats_to_string,
     ):
         """Test camera device doesn't support the capture capabilitiy"""
-        mock_get_supported_resolutions.return_value = [
+        mock_get_supported_formats.return_value = [
             {
                 "description": "YUYV",
                 "pixelformat": "YUYV",
                 "resolutions": [[640, 480]],
             }
         ]
-        mock_supported_resolutions_to_string.return_value = "Resolutions: fake"
+        mock_supported_formats_to_string.return_value = "Resolutions: fake"
 
         fake_device = "/dev/video0"
         fake_v4l2_capability = v4l2_capability()

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -15,14 +15,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=protected-access
-
+import argparse
+import errno
+import logging
 import unittest
-import io
 import sys
 from unittest.mock import patch, MagicMock
 
-from camera_test import CameraTest, v4l2_capability
+from camera_test import (
+    CameraTest,
+    v4l2_capability,
+    V4L2_FRMSIZE_TYPE_DISCRETE,
+    V4L2_FRMSIZE_TYPE_STEPWISE,
+    parse_arguments,
+)
 
 
 @patch("builtins.print", new=MagicMock())
@@ -32,6 +38,390 @@ class CameraTestTests(unittest.TestCase):
     def setUp(self):
         self.camera_instance = CameraTest(None)
 
+    def test_supported_formats_to_string(self):
+        formats = [
+            {
+                "pixelformat": "YUYV",
+                "description": "YUYV",
+                "resolutions": [[640, 480], [320, 240]],
+            },
+            {
+                "pixelformat": "fake",
+                "description": "fake",
+                "resolutions": [[640, 480]],
+            },
+        ]
+        expected_str = (
+            "Format: YUYV (YUYV)\n"
+            "Resolutions: 640x480,320x240\n"
+            "Format: fake (fake)\n"
+            "Resolutions: 640x480\n"
+        )
+        return_str = self.camera_instance._supported_formats_to_string(formats)
+        self.assertEqual(return_str, expected_str)
+
+    @patch("tempfile.NamedTemporaryFile", MagicMock())
+    def test_resolutions(self):
+        mock_camera = MagicMock()
+        mock_camera._get_supported_formats.return_value = [
+            {
+                "pixelformat": "YUYV",
+                "description": "YUYV",
+                "resolutions": [[640, 480], [320, 240]],
+            }
+        ]
+        mock_camera._validate_image.return_value = True
+
+        self.assertEqual(CameraTest.resolutions(mock_camera), 0)
+
+        self.assertEqual(mock_camera._get_supported_formats.call_count, 1)
+        self.assertEqual(
+            mock_camera._supported_formats_to_string.call_count, 1
+        )
+        self.assertEqual(mock_camera._save_debug_image.call_count, 1)
+        self.assertEqual(mock_camera._still_helper.call_count, 2)
+        self.assertEqual(mock_camera._validate_image.call_count, 2)
+
+        # Test that the function also works with no output
+        mock_camera.args.output = None
+        self.assertEqual(CameraTest.resolutions(mock_camera), 0)
+
+    @patch("tempfile.NamedTemporaryFile", MagicMock())
+    def test_resolutions_wrong_validation(self):
+        mock_camera = MagicMock()
+        mock_camera._get_supported_formats.return_value = [
+            {
+                "pixelformat": "YUYV",
+                "description": "YUYV",
+                "resolutions": [[640, 480], [320, 240]],
+            }
+        ]
+        mock_camera._validate_image.return_value = False
+
+        self.assertEqual(CameraTest.resolutions(mock_camera), 1)
+
+    def test_resolutions_no_formats(self):
+        mock_camera = MagicMock()
+        mock_camera._get_supported_formats.return_value = []
+
+        with self.assertRaises(SystemExit):
+            CameraTest.resolutions(mock_camera)
+
+    @patch("camera_test.os.path.exists")
+    def test_save_debug_image(self, mock_exists):
+        mock_exists.return_value = True
+        mock_camera = MagicMock()
+        format = {
+            "pixelformat": "YUYV",
+            "description": "YUYV",
+            "resolutions": [[640, 480], [320, 240]],
+        }
+        CameraTest._save_debug_image(
+            mock_camera, format, "/dev/video0", "/tmp"
+        )
+        self.assertEqual(mock_camera._still_helper.call_count, 1)
+
+    @patch("camera_test.os.path.exists")
+    def test_save_debug_image_fails_if_path_not_exists(self, mock_exists):
+        mock_exists.return_value = False
+        mock_camera = MagicMock()
+        format = {
+            "pixelformat": "YUYV",
+            "description": "YUYV",
+            "resolutions": [[640, 480], [320, 240]],
+        }
+        with self.assertRaises(SystemExit):
+            CameraTest._save_debug_image(
+                mock_camera, format, "/dev/video0", "/tmp"
+            )
+
+    def ioctl_enum_format_side_effect(self, fd, request, fmt):
+        # Define format details based on the index
+        formats = [
+            (b"YUV 4:2:2", 0x56595559),
+            (b"YUV 4:2:0", 0x3231564E),
+        ]
+        if fmt.index < len(formats):
+            fmt.description, fmt.pixelformat = formats[fmt.index]
+            return 0  # Success
+        else:
+            raise IOError(errno.EINVAL, "No more formats")
+
+    @patch("fcntl.ioctl")
+    @patch("builtins.open", MagicMock())
+    def test_get_supported_pixel_formats(self, mock_ioctl):
+        mock_ioctl.side_effect = self.ioctl_enum_format_side_effect
+
+        expected_pixel_formats = [
+            {
+                "pixelformat": "YUYV",
+                "pixelformat_int": 1448695129,
+                "description": "YUV 4:2:2",
+            },
+            {
+                "pixelformat": "NV12",
+                "pixelformat_int": 842094158,
+                "description": "YUV 4:2:0",
+            },
+        ]
+
+        pixel_formats = CameraTest._get_supported_pixel_formats(
+            MagicMock(), "/dev/video0", 5
+        )
+        self.assertEqual(pixel_formats, expected_pixel_formats)
+
+    @patch("fcntl.ioctl")
+    @patch("builtins.open", MagicMock())
+    def test_get_supported_pixel_formats_max_formats(self, mock_ioctl):
+        mock_ioctl.side_effect = self.ioctl_enum_format_side_effect
+        expected_pixel_formats = [
+            {
+                "pixelformat": "YUYV",
+                "pixelformat_int": 1448695129,
+                "description": "YUV 4:2:2",
+            }
+        ]
+        pixel_formats = CameraTest._get_supported_pixel_formats(
+            MagicMock(), "/dev/video0", 1
+        )
+        self.assertEqual(pixel_formats, expected_pixel_formats)
+
+    @patch("fcntl.ioctl")
+    @patch("builtins.open", MagicMock())
+    def test_get_supported_pixel_formats_unexpected_error(self, mock_ioctl):
+        mock_ioctl.side_effect = IOError(errno.EIO, "Unexpected error")
+        pixel_formats = CameraTest._get_supported_pixel_formats(
+            MagicMock(), "/dev/video0", 5
+        )
+        self.assertEqual(pixel_formats, [])
+
+    # def _get_supported_formats(self, device):
+    #     """
+    #     Query the camera for supported format info for a given pixel_format.
+    #     Data is returned in a list of dictionaries with supported pixel
+    #     formats as the following example shows:
+    #     format_info['pixelformat'] = "YUYV"
+    #     format_info['description'] = "(YUV 4:2:2 (YUYV))"
+    #     format_info['resolutions'] = [[width, height], [640, 480], [1280, 720]]
+
+    #     If we are unable to gather any information from the driver, then we
+    #     return YUYV and 640x480 which seems to be a safe default.
+    #     Per the v4l2 spec the ioctl used here is experimental
+    #     but seems to be well supported.
+    #     """
+    #     supported_formats_info = self._get_supported_pixel_formats(device)
+
+    #     # If we can't get any formats, we will return YUYV and 640x480
+    #     if not supported_formats_info:
+    #         format_info = {}
+    #         format_info["description"] = "YUYV"
+    #         format_info["pixelformat"] = "YUYV"
+    #         format_info["resolutions"] = [[640, 480]]
+    #         return [format_info]
+
+    #     for supported_format in supported_formats_info:
+    #         resolutions = []
+    #         framesize = v4l2_frmsizeenum()
+    #         framesize.index = 0
+    #         framesize.pixel_format = supported_format["pixelformat_int"]
+    #         with open(device, "r") as vd:
+    #             try:
+    #                 while (
+    #                     fcntl.ioctl(vd, VIDIOC_ENUM_FRAMESIZES, framesize) == 0
+    #                 ):
+    #                     if framesize.type == V4L2_FRMSIZE_TYPE_DISCRETE:
+    #                         resolutions.append(
+    #                             [
+    #                                 framesize.discrete.width,
+    #                                 framesize.discrete.height,
+    #                             ]
+    #                         )
+    #                     # for continuous and stepwise, let's just use min and
+    #                     # max they use the same structure and only return
+    #                     # one result
+    #                     elif framesize.type in (
+    #                         V4L2_FRMSIZE_TYPE_CONTINUOUS,
+    #                         V4L2_FRMSIZE_TYPE_STEPWISE,
+    #                     ):
+    #                         resolutions.append(
+    #                             [
+    #                                 framesize.stepwise.min_width,
+    #                                 framesize.stepwise.min_height,
+    #                             ]
+    #                         )
+    #                         resolutions.append(
+    #                             [
+    #                                 framesize.stepwise.max_width,
+    #                                 framesize.stepwise.max_height,
+    #                             ]
+    #                         )
+    #                         break
+    #                     framesize.index = framesize.index + 1
+    #             except IOError as e:
+    #                 # EINVAL is the ioctl's way of telling us that there are no
+    #                 # more formats, so we ignore it
+    #                 if e.errno != errno.EINVAL:
+    #                     print(
+    #                         "Unable to determine supported framesizes "
+    #                         "(resolutions), this may be a driver issue."
+    #                     )
+    #         supported_format["resolutions"] = resolutions
+    #     return supported_formats_info
+
+    def ioctl_enum_framesizes_side_effect(self, fd, request, fmt):
+        if fmt.pixel_format == 1448695129:  # YUYV
+            if fmt.index == 0:
+                fmt.type = V4L2_FRMSIZE_TYPE_DISCRETE
+                fmt.discrete.width = 640
+                fmt.discrete.height = 480
+            elif fmt.index == 1:
+                fmt.type = V4L2_FRMSIZE_TYPE_DISCRETE
+                fmt.discrete.width = 1280
+                fmt.discrete.height = 720
+            else:
+                raise IOError(errno.EINVAL, "No more frame sizes")
+        elif fmt.pixel_format == 842094158:  # NV12
+            if fmt.index == 0:
+                fmt.type = V4L2_FRMSIZE_TYPE_STEPWISE
+                fmt.stepwise.min_width = 320
+                fmt.stepwise.min_height = 240
+                fmt.stepwise.max_width = 640
+                fmt.stepwise.max_height = 480
+            else:
+                raise IOError(errno.EINVAL, "No more frame sizes")
+        return 0
+
+    @patch("fcntl.ioctl")
+    def test_get_supported_formats(self, mock_ioctl):
+        mock_camera = MagicMock()
+        mock_camera._get_supported_pixel_formats.return_value = [
+            {
+                "pixelformat": "YUYV",
+                "pixelformat_int": 1448695129,
+                "description": "YUV 4:2:2",
+            },
+            {
+                "pixelformat": "NV12",
+                "pixelformat_int": 842094158,
+                "description": "YUV 4:2:0",
+            },
+        ]
+        mock_ioctl.side_effect = self.ioctl_enum_framesizes_side_effect
+
+        expected_formats = [
+            {
+                "pixelformat": "YUYV",
+                "pixelformat_int": 1448695129,
+                "description": "YUV 4:2:2",
+                "resolutions": [[640, 480], [1280, 720]],
+            },
+            {
+                "pixelformat": "NV12",
+                "description": "YUV 4:2:0",
+                "pixelformat_int": 842094158,
+                "resolutions": [[320, 240], [640, 480]],
+            },
+        ]
+
+        with patch("builtins.open", MagicMock()):
+            formats = CameraTest._get_supported_formats(
+                mock_camera, "/dev/video0"
+            )
+        self.assertEqual(formats, expected_formats)
+
+    @patch("fcntl.ioctl")
+    def test_get_supported_formats_unexpected_error(self, mock_ioctl):
+        mock_camera = MagicMock()
+        mock_camera._get_supported_pixel_formats.return_value = [
+            {
+                "pixelformat": "YUYV",
+                "pixelformat_int": 1448695129,
+                "description": "YUV 4:2:2",
+            }
+        ]
+        expected_formats = [
+            {
+                "pixelformat": "YUYV",
+                "pixelformat_int": 1448695129,
+                "description": "YUV 4:2:2",
+                "resolutions": [],
+            }
+        ]
+        mock_ioctl.side_effect = IOError(errno.EIO, "Unexpected error")
+        with patch("builtins.open", MagicMock()):
+            formats = CameraTest._get_supported_formats(
+                mock_camera, "/dev/video0"
+            )
+        self.assertEqual(formats, expected_formats)
+
+    @patch("fcntl.ioctl")
+    def test_get_supported_formats_no_formats(self, mock_ioctl):
+        mock_camera = MagicMock()
+        mock_camera._get_supported_pixel_formats.return_value = []
+        mock_ioctl.side_effect = self.ioctl_enum_framesizes_side_effect
+
+        expected_formats = [
+            {
+                "pixelformat": "YUYV",
+                "description": "YUYV",
+                "resolutions": [[640, 480]],
+            }
+        ]
+
+        with patch("builtins.open", MagicMock()):
+            formats = CameraTest._get_supported_formats(
+                mock_camera, "/dev/video0"
+            )
+        self.assertEqual(formats, expected_formats)
+
+    @patch("camera_test.glob")
+    def test_device_options(self, mock_glob):
+        # Setup mock for glob to simulate available devices
+        mock_glob.return_value = ["/dev/video0", "/dev/video1"]
+
+        # Test highest device
+        argv = ["led", "--highest-device"]
+        args = parse_arguments(argv)
+        self.assertEqual(args.device, "/dev/video1")
+
+        # Test lowest device
+        argv = ["led", "--lowest-device"]
+        args = parse_arguments(argv)
+        self.assertEqual(args.device, "/dev/video0")
+
+    def test_still_subparser(self):
+        argv = [
+            "still",
+            "--device",
+            "/dev/video2",
+            "-f",
+            "/tmp/test.jpg",
+            "-q",
+        ]
+        args = parse_arguments(argv)
+        self.assertEqual(args.device, "/dev/video2")
+        self.assertEqual(args.filename, "/tmp/test.jpg")
+        self.assertEqual(args.quiet, True)
+
+    def test_debug_flag(self):
+        argv = ["detect"]
+        args = parse_arguments(argv)
+        self.assertEqual(args.log_level, logging.INFO)
+
+        argv = ["--debug", "detect"]
+        args = parse_arguments(argv)
+        self.assertEqual(args.log_level, logging.DEBUG)
+
+    def test_default_device(self):
+        argv = ["display"]
+        args = parse_arguments(argv)
+        self.assertEqual(args.device, "/dev/video0")
+
+    def test_output_directory(self):
+        argv = ["resolutions", "--output", "output_dir"]
+        args = parse_arguments(argv)
+        self.assertEqual(args.output, "output_dir")
+
     @patch("camera_test.CameraTest._supported_formats_to_string")
     @patch("camera_test.CameraTest._get_supported_formats")
     def test_detect_and_show_camera_info_with_single_planar_capture_capability(
@@ -39,7 +429,7 @@ class CameraTestTests(unittest.TestCase):
         mock_get_supported_formats,
         mock_supported_formats_to_string,
     ):
-        """Test camera device supports the single planar capture capabilitiy"""
+        """Test camera device supports the single planar capture capability"""
         mock_get_supported_formats.return_value = [
             {
                 "description": "fake",
@@ -67,7 +457,7 @@ class CameraTestTests(unittest.TestCase):
         mock_get_supported_formats,
         mock_supported_formats_to_string,
     ):
-        """Test camera device supports the multi planar capture capabilitiy"""
+        """Test camera device supports the multi planar capture capability"""
         mock_get_supported_formats.return_value = [
             {
                 "description": "fake",
@@ -95,7 +485,7 @@ class CameraTestTests(unittest.TestCase):
         mock_get_supported_formats,
         mock_supported_formats_to_string,
     ):
-        """Test camera device doesn't support the capture capabilitiy"""
+        """Test camera device doesn't support the capture capability"""
         mock_get_supported_formats.return_value = [
             {
                 "description": "YUYV",

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -51,12 +51,14 @@ class CameraTestTests(unittest.TestCase):
                 "resolutions": [[640, 480]],
             },
         ]
-        expected_str = (
-            "Format: YUYV (YUYV)\n"
-            "Resolutions: 640x480,320x240\n"
-            "Format: fake (fake)\n"
-            "Resolutions: 640x480\n"
-        )
+        expected_str = textwrap.dedent(
+            """
+            Format: YUYV (YUYV)
+            Resolutions: 640x480,320x240
+            Format: fake (fake)
+            Resolutions: 640x480
+            """
+        ).lstrip()
         return_str = self.camera_instance._supported_formats_to_string(formats)
         self.assertEqual(return_str, expected_str)
 
@@ -194,79 +196,6 @@ class CameraTestTests(unittest.TestCase):
             MagicMock(), "/dev/video0", 5
         )
         self.assertEqual(pixel_formats, [])
-
-    # def _get_supported_formats(self, device):
-    #     """
-    #     Query the camera for supported format info for a given pixel_format.
-    #     Data is returned in a list of dictionaries with supported pixel
-    #     formats as the following example shows:
-    #     format_info['pixelformat'] = "YUYV"
-    #     format_info['description'] = "(YUV 4:2:2 (YUYV))"
-    #     format_info['resolutions'] = [[width, height], [640, 480], [1280, 720]]
-
-    #     If we are unable to gather any information from the driver, then we
-    #     return YUYV and 640x480 which seems to be a safe default.
-    #     Per the v4l2 spec the ioctl used here is experimental
-    #     but seems to be well supported.
-    #     """
-    #     supported_formats_info = self._get_supported_pixel_formats(device)
-
-    #     # If we can't get any formats, we will return YUYV and 640x480
-    #     if not supported_formats_info:
-    #         format_info = {}
-    #         format_info["description"] = "YUYV"
-    #         format_info["pixelformat"] = "YUYV"
-    #         format_info["resolutions"] = [[640, 480]]
-    #         return [format_info]
-
-    #     for supported_format in supported_formats_info:
-    #         resolutions = []
-    #         framesize = v4l2_frmsizeenum()
-    #         framesize.index = 0
-    #         framesize.pixel_format = supported_format["pixelformat_int"]
-    #         with open(device, "r") as vd:
-    #             try:
-    #                 while (
-    #                     fcntl.ioctl(vd, VIDIOC_ENUM_FRAMESIZES, framesize) == 0
-    #                 ):
-    #                     if framesize.type == V4L2_FRMSIZE_TYPE_DISCRETE:
-    #                         resolutions.append(
-    #                             [
-    #                                 framesize.discrete.width,
-    #                                 framesize.discrete.height,
-    #                             ]
-    #                         )
-    #                     # for continuous and stepwise, let's just use min and
-    #                     # max they use the same structure and only return
-    #                     # one result
-    #                     elif framesize.type in (
-    #                         V4L2_FRMSIZE_TYPE_CONTINUOUS,
-    #                         V4L2_FRMSIZE_TYPE_STEPWISE,
-    #                     ):
-    #                         resolutions.append(
-    #                             [
-    #                                 framesize.stepwise.min_width,
-    #                                 framesize.stepwise.min_height,
-    #                             ]
-    #                         )
-    #                         resolutions.append(
-    #                             [
-    #                                 framesize.stepwise.max_width,
-    #                                 framesize.stepwise.max_height,
-    #                             ]
-    #                         )
-    #                         break
-    #                     framesize.index = framesize.index + 1
-    #             except IOError as e:
-    #                 # EINVAL is the ioctl's way of telling us that there are no
-    #                 # more formats, so we ignore it
-    #                 if e.errno != errno.EINVAL:
-    #                     print(
-    #                         "Unable to determine supported framesizes "
-    #                         "(resolutions), this may be a driver issue."
-    #                     )
-    #         supported_format["resolutions"] = resolutions
-    #     return supported_formats_info
 
     def ioctl_enum_framesizes_side_effect(self, fd, request, fmt):
         if fmt.pixel_format == 1448695129:  # YUYV

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import argparse
+import textwrap
 import errno
 import logging
 import unittest

--- a/providers/base/units/camera/jobs.pxu
+++ b/providers/base/units/camera/jobs.pxu
@@ -102,10 +102,28 @@ _summary: Webcam multiple resolution capture test for {product_slug}
 estimated_duration: 1.2
 depends: camera/detect
 command:
-  camera_test.py resolutions -d /dev/{name}
+  camera_test.py resolutions -d /dev/{name} -o "$PLAINBOX_SESSION_SHARE"
 _description:
   Takes multiple pictures based on the resolutions supported by the camera and
   validates their size and that they are of a valid format.
+
+unit: template
+template-resource: device
+template-filter: device.category == 'CAPTURE' and device.name != ''
+template-unit: job
+plugin: attachment
+category_id: com.canonical.plainbox::camera
+id: camera/multiple-resolution-images-attachment_{name}
+flags: also-after-suspend
+_summary: Attach an image from the multiple resolution images test for {product_slug}
+estimated_duration: 1s
+after: camera/multiple-resolution-images_{name}
+command:
+  [ -f "$PLAINBOX_SESSION_SHARE"/resolution_test_image_{name}.jpg ] &&
+  cat "$PLAINBOX_SESSION_SHARE"/resolution_test_image_{name}.jpg
+_description:
+  This test will attach one of the images used for the multiple resolution
+  images test.
 
 unit: template
 template-resource: device
@@ -142,6 +160,8 @@ requires: lsb.release >= '22.04'
 command:
   [ -f "$PLAINBOX_SESSION_SHARE"/quality_image_{name}.jpg ] &&
   cat "$PLAINBOX_SESSION_SHARE"/quality_image_{name}.jpg
+_description:
+  This test will attach the image used for the BRISQUE score.
 
 unit: template
 template-resource: device
@@ -161,6 +181,25 @@ _description:
   Takes multiple pictures based on the resolutions supported by the camera and
   validates their size and that they are of a valid format.
 user: root
+
+unit: template
+template-resource: device
+template-filter: device.category == 'MMAL' and device.name != ''
+template-unit: job
+plugin: attachment
+category_id: com.canonical.plainbox::camera
+id: camera/multiple-resolution-images-rpi-attachment_{name}
+flags: also-after-suspend
+_summary: Attach an image from the multiple resolution images test for {product_slug}
+estimated_duration: 1s
+after: camera/multiple-resolution-images-rpi_{name}
+requires: cpuinfo.platform == 'armv7l'
+command:
+  [ -f "$PLAINBOX_SESSION_SHARE"/picam_6.jpg ] &&
+  cat "$PLAINBOX_SESSION_SHARE"/picam_6.jpg
+_description:
+  This test will attach one of the images used for the multiple resolution
+  images test.
 
 unit: template
 template-engine: jinja2

--- a/providers/base/units/camera/jobs.pxu
+++ b/providers/base/units/camera/jobs.pxu
@@ -189,8 +189,8 @@ template-unit: job
 plugin: attachment
 category_id: com.canonical.plainbox::camera
 id: camera/multiple-resolution-images-rpi-attachment_{name}
-flags: also-after-suspend
-_summary: Attach an image from the multiple resolution images test for {product_slug}
+template-id: camera/multiple-resolution-images-rpi-attachment_name
+_summary: Attach an image from the multiple resolution images test on rpi
 estimated_duration: 1s
 after: camera/multiple-resolution-images-rpi_{name}
 requires: cpuinfo.platform == 'armv7l'

--- a/providers/base/units/camera/test-plan.pxu
+++ b/providers/base/units/camera/test-plan.pxu
@@ -36,6 +36,7 @@ _description: Camera tests (automated)
 include:
  camera/detect                                     certification-status=blocker
  camera/multiple-resolution-images_.*              certification-status=blocker
+ camera/multiple-resolution-images-attachment_.*   certification-status=non-blocker
  camera/camera-quality_.*                          certification-status=non-blocker
  camera/camera-quality-image_.*                    certification-status=non-blocker
 bootstrap_include:
@@ -70,6 +71,7 @@ _description: Camera tests After Suspend (automated)
 include:
  after-suspend-camera/detect                                     certification-status=blocker
  after-suspend-camera/multiple-resolution-images_.*              certification-status=blocker
+ after-suspend-camera/multiple-resolution-images-attachment_.*   certification-status=non-blocker
  after-suspend-camera/camera-quality_.*                          certification-status=non-blocker
  after-suspend-camera/camera-quality-image_.*                    certification-status=non-blocker 
 bootstrap_include:
@@ -98,6 +100,7 @@ estimated_duration: 1h30m
 include:
     camera/multiple-resolution-images_.*
     camera/multiple-resolution-images-rpi_.*
+    camera/multiple-resolution-images-rpi-attachment_.*
     camera/roundtrip-qrcode_.*
 bootstrap_include:
     device


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The camera_test.py script has been modified to store one image each time it runs the multiple_resolution test.
We have fixed some bugs, renamed some variables to increase clarity and added tests
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

https://warthogs.atlassian.net/browse/CHECKBOX-1369

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

N/A

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
### Run the tests
```
cd providers/base
manage.py test -u
```

### Test the behavior
Run the camera automated tests:
```
com.canonical.certification::camera-cert-automated
```
Check that the multiple-resolution test image has been created in the PLAINBOX_SESSION_SHARE directory