### PR TITLE
Fix: Make checkbox-ce-oem uc20 as a runnable checkbox (BugFix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/config/config_vars
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/config/config_vars
@@ -1,0 +1,41 @@
+# follow KEY=value syntax
+WIFI_INTERFACE=wlan0
+# WATCHDOG_KERNEL_MOD=iTCO_wdt
+# ALSADEVICE=hw:CARD=bytrt5660,DEV=0
+OPEN_N_SSID=ubuntu-cert-n-open-tpelab
+OPEN_BG_SSID=ubuntu-cert-bg-open-tpelab
+OPEN_AC_SSID=ubuntu-cert-ac-open-tpelab
+OPEN_AX_SSID=ubuntu-cert-ax-open
+WPA_N_SSID=ubuntu-cert-n-wpa-tpelab
+WPA_BG_SSID=ubuntu-cert-bg-wpa-tpelab
+WPA_AC_SSID=ubuntu-cert-ac-wpa-tpelab
+WPA_AX_SSID=ubuntu-cert-ax-wpa
+WPA_N_PSK=insecure
+WPA_BG_PSK=insecure
+WPA_AC_PSK=insecure
+WPA_AX_PSK=insecure
+BTDEVADDR=C0:B5:D7:C1:74:38
+# obex server in office: C0:B5:D7:C1:74:38
+# obex server in lab: 28:3A:4D:46:79:C0, 7C:B2:7D:4B:14:95
+WWAN_APN=internet
+WWAN_NET_IF=ppp0
+WWAN_CONTROL_IF=ttyACM3
+STRESS_BOOT_ITERATIONS=100
+STRESS_S3_ITERATIONS=100
+STRESS_S4_ITERATIONS=100
+TEST_TARGET_IPERF=10.102.88.25,10.102.182.100,10.102.182.137,10.102.182.101
+# iperf server in office: 10.102.88.25
+# iperf server in lab: 10.102.182.100, 10.102.182.137
+STRESS_S4_WAIT_DELAY=120
+STRESS_S4_SLEEP_DELAY=60
+STRESS_S3_SLEEP_DELAY=60
+STRESS_BOOT_WAKEUP_DELAY=120
+STRESS_S3_WAIT_DELAY=150
+STRESS_BOOT_WAIT_DELAY=150
+WIFI_AP_SETUPTIME=30
+WWAN_SETUPTIME=30
+TPM2TOOLS_TCTI_NAME=device
+TPM2TOOLS_DEVICE_FILE=/dev/tpm0
+MODEL_GRADE=signed
+WATCHDOG_TYPE=wdat_wdt
+WATCHDOG_IDENTITY=wdat_wdt

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/launchers/checkbox-cli-wrapper
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/launchers/checkbox-cli-wrapper
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec checkbox-cli "$@"

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/launchers/configure
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/launchers/configure
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright 2018-2022 Canonical Ltd.
+# All rights reserved.
+#
+# Written by:
+#   Maciej Kisielewski <maciej.kisielewski@canonical.com>
+#   Sylvain Pineau <sylvain.pineau@canonical.com>
+import os
+import re
+import sys
+
+sys.path.append(os.path.expandvars("$SNAP/usr/lib/python3/dist-packages"))
+sitepkgpath = "$SNAP/lib/python{}.{}/site-packages".format(
+    sys.version_info[0], sys.version_info[1])
+sys.path.append(os.path.expandvars(sitepkgpath))
+
+sys.path.append(os.path.expandvars(
+    "$SNAP/checkbox-runtime/usr/lib/python3/dist-packages"))
+runtimepath = "$SNAP/checkbox-runtime/lib/python{}.{}/site-packages".format(
+    sys.version_info[0], sys.version_info[1])
+sys.path.append(os.path.expandvars(runtimepath))
+
+try:
+    from checkbox_support.snap_utils.config import update_configuration
+    from checkbox_support.snap_utils.config import print_checkbox_conf
+except ImportError:
+    msg = """
+checkbox-support not found!
+You need to connect this snap to the checkbox20 snap.
+
+You can do this with those commands:
+
+snap connect $SNAP_NAME:checkbox-runtime  checkbox20:checkbox-runtime
+snap connect $SNAP_NAME:provider-resource checkbox20:provider-resource
+snap connect $SNAP_NAME:provider-checkbox checkbox20:provider-checkbox
+snap connect $SNAP_NAME:provider-tpm2     checkbox20:provider-tpm2
+snap connect $SNAP_NAME:provider-certification-client checkbox20:provider-certification-client
+    """
+    print(os.path.expandvars(msg), file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    # we need run as root to be able to write to /var/snap/...
+    if os.geteuid() != 0:
+        print('You have to run this command with sudo')
+        return
+
+    if len(sys.argv) > 1 and sys.argv[1] == '-l':
+        print_checkbox_conf()
+        return
+
+    key_re = re.compile(r"^(?:[A-Z0-9]+_?)*[A-Z](?:_?[A-Z0-9])*$")
+    vars_to_set = dict()
+    for pair in sys.argv[1:]:
+        k, _, v = pair.partition('=')
+        if not key_re.match(k) or not v:
+            raise SystemExit("'%s' is not a valid configuration entry. "
+                             "Should be KEY=val" % pair)
+        k = k.replace('_', '-').lower()
+        vars_to_set[k] = v
+    update_configuration(vars_to_set)
+
+
+if __name__ == '__main__':
+    main()

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/launchers/shell-wrapper
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/launchers/shell-wrapper
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "$SNAP_NAME runtime shell, type 'exit' to quit the session"
+exec bash

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/launchers/test-runner
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/launchers/test-runner
@@ -1,0 +1,12 @@
+#!/usr/bin/env checkbox-cli-wrapper
+[launcher]
+app_id = com.canonical.qa.ceoem:checkbox
+launcher_version = 1
+stock_reports = text, submission_files, certification
+
+[test plan]
+unit = com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-20-automated
+filter = com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-20
+         com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-20-manual
+         com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-20-automated
+         com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-20-stress

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/launchers/wrapper_local
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/launchers/wrapper_local
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+case "$SNAP_ARCH" in
+    "amd64") ARCH='x86_64-linux-gnu'
+    ;;
+    "i386") ARCH='i386-linux-gnu'
+    ;;
+    "arm64") ARCH='aarch64-linux-gnu'
+    ;;
+    "armhf") ARCH='arm-linux-gnueabihf'
+    ;;
+    *)
+        echo "Unsupported architecture: $SNAP_ARCH"
+    ;;
+esac
+
+################################################
+# Launcher common exports for any checkbox app #
+################################################
+
+if [ -d $SNAP/checkbox-runtime ]; then
+  RUNTIME=$SNAP/checkbox-runtime
+  if [ ! -d $RUNTIME/usr ]; then
+    echo "You need to connect this snap to the checkbox20 snap."
+    echo ""
+    echo "You can do this with those commands:"
+    echo "snap install checkbox20"
+    echo "snap connect $SNAP_NAME:checkbox-runtime checkbox20:checkbox-runtime"
+    exit 1
+  fi
+fi
+
+export LC_ALL=C.UTF-8
+PERL_VERSION=$(perl -e '$^V=~/^v(\d+\.\d+)/;print $1')
+export PERL5LIB="$PERL5LIB:$SNAP/usr/lib/$ARCH/perl/$PERL_VERSION:$SNAP/usr/lib/$ARCH/perl5/$PERL_VERSION:$SNAP/usr/share/perl/$PERL_VERSION:$SNAP/usr/share/perl5"
+export GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepository-1.0
+export PATH="$PATH:$SNAP/usr/bin:$SNAP/usr/sbin:$SNAP/sbin:/snap/bin"
+export PYTHONPATH="$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH"
+
+if [ -e $RUNTIME/wrapper_common ]; then
+  . $RUNTIME/wrapper_common
+else
+  CGROUP_NAME=$(cat /proc/self/cgroup | grep -e "^1:name")
+  if [[ "$CGROUP_NAME" == *"hook.configure"* ]]; then
+    echo "Running in configure hook, wrapper_common not required"
+  else
+    echo "ERROR: no $RUNTIME/wrapper_common found"
+    exit 0
+  fi
+fi
+
+exec "$@"

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/snap/hooks/configure
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/snap/hooks/configure
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright 2017-2022 Canonical Ltd.
+# All rights reserved.
+
+"""
+This hook reads `config_vars` file from the root of a snap and reenters this
+configuration using snapd's config facilities and rewrites the file to a
+checkbox config format in `$SNAP_DATA/checkbox.conf`.
+
+config_vars should list all the configuration variables in a `key=value`
+syntax. The line can list variable name only, if the variable should not have a
+default value. All keys should comprise of CAPS, numbers and undescores (_).
+E.g.:
+
+OPEN_N_SSID
+OPEN_BG_SSID
+STRESS_S3_WAIT_DELAY=60
+
+To change those values use the configure launcher.
+E.g.
+    $ checkbox-ce-oem.configure OPEN_N_SSID=my-wifi
+
+If you __really__ need to change those values using `snap set` command,
+you need to change CAPS to lowercase and underscores to dashes (-).
+
+E.g.
+    $ snap set checkbox-ce-oem open-n-ssid=my-wifi
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.expandvars("$SNAP/usr/lib/python3/dist-packages"))
+sitepkgpath = "$SNAP/lib/python{}.{}/site-packages".format(
+    sys.version_info[0], sys.version_info[1])
+sys.path.append(os.path.expandvars(sitepkgpath))
+
+sys.path.append(os.path.expandvars(
+    "$SNAP/checkbox-runtime/usr/lib/python3/dist-packages"))
+runtimepath = "$SNAP/checkbox-runtime/lib/python{}.{}/site-packages".format(
+    sys.version_info[0], sys.version_info[1])
+sys.path.append(os.path.expandvars(runtimepath))
+
+try:
+    from checkbox_support.snap_utils.config import refresh_configuration
+except ImportError:
+    msg = """
+checkbox-support not found!
+You need to connect this snap to the checkbox22 snap.
+
+You can do this with those commands:
+
+snap connect $SNAP_NAME:checkbox-runtime  checkbox22:checkbox-runtime
+snap connect $SNAP_NAME:provider-resource checkbox22:provider-resource
+snap connect $SNAP_NAME:provider-checkbox checkbox22:provider-checkbox
+snap connect $SNAP_NAME:provider-tpm2     checkbox22:provider-tpm2
+snap connect $SNAP_NAME:provider-certification-client checkbox22:provider-certification-client
+    """
+    print(os.path.expandvars(msg), file=sys.stderr)
+    sys.exit(0)
+refresh_configuration()

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/snap/hooks/install
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/snap/hooks/install
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+set -e
+snapctl set slave=disabled

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/snap/snapcraft.yaml
@@ -8,6 +8,57 @@ version: '1.0-focal'
 
 base: core20
 
+plugs:
+  checkbox-runtime:
+    interface: content
+    target: $SNAP/checkbox-runtime
+    default-provider: checkbox20
+  provider-resource:
+    interface: content
+    target: $SNAP/providers/plainbox-provider-resource
+    default-provider: checkbox20
+  provider-checkbox:
+    interface: content
+    target: $SNAP/providers/plainbox-provider-checkbox
+    default-provider: checkbox20
+  provider-tpm2:
+    interface: content
+    target: $SNAP/providers/plainbox-provider-tpm2
+    default-provider: checkbox20
+  provider-certification-client:
+    interface: content
+    target: $SNAP/providers/plainbox-provider-certification-client
+    default-provider: checkbox20
+apps:
+  checkbox-cli:
+    command-chain: [bin/wrapper_local]
+    command: bin/checkbox-cli-wrapper
+    plugs: &standard [home, network-bind, hardware-observe, bluez, bluetooth-control,
+      gpio, modem-manager, mount-observe, network-manager, pulseaudio, serial-port,
+      system-observe, tpm, timezone-control, timeserver-control]
+  configure:
+    command-chain: [bin/wrapper_local]
+    command: bin/configure
+  remote-slave:
+    command-chain: [bin/wrapper_local]
+    command: bin/checkbox-cli-wrapper slave
+    daemon: simple
+    restart-condition: on-failure
+    plugs: *standard
+  shell:
+    command-chain: [bin/wrapper_local]
+    command: bin/shell-wrapper
+    plugs: *standard
+  test-runner:
+    command-chain: [bin/wrapper_local]
+    command: bin/test-runner
+    plugs: *standard
+
+passthrough:
+  hooks:
+    configure:
+      command-chain: [bin/wrapper_local]
+
 slots:
   provider-ce-oem:
     interface: content
@@ -56,3 +107,31 @@ parts:
       PART_SRC=${SNAPCRAFT_PROJECT_DIR}/parts/checkbox-provider-ce-oem/src
       gcc ${PART_SRC}/src/input-pcspkr.c -o ${PART_SRC}/src/beep
       cp -v ${PART_SRC}/src/beep ${SNAPCRAFT_PART_INSTALL}/usr/bin/
+
+  parts-meta-info:
+    plugin: nil
+    override-build: |
+      snapcraftctl build
+      for p in `ls -d ../../*`; do
+          if [ -d $p/src ]; then
+            (cd $p/src
+                if [ -d $p/src/.git ]; then
+                    (echo `basename $p`\: && git show --pretty=format:"%h%d %aN %ci%n%s%n" -q ; echo ) >> $SNAPCRAFT_PART_INSTALL/parts_meta_info
+                fi # for additional `source-type` support, elif them here
+            )
+          fi
+      done
+    after: [checkbox-provider-ce-oem]
+  launchers:
+    plugin: dump
+    source: launchers/
+    organize:
+      '*': bin/
+  config-variables:
+    plugin: dump
+    source: config/
+
+layout:
+  # This is an workaround to access alsa config on UC22 core image
+  /usr/share/alsa:
+    bind: $SNAP/usr/share/alsa


### PR DESCRIPTION
## Description
make checkbox-ce-oem/uc20 as a runnable checkbox, so we could use it as our checkbox runtime if needed.

## Resolved issues
N/A

## Documentation
N/A

## Tests
N/A