### PR TITLE
Add requires to ce-oem-gpio check-slots job (BugFix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
@@ -25,6 +25,12 @@ _description:
     This GPIO list will be used to check if the GPIO nodes have
     been exported after connecting the interfaces.
 estimated_duration: 0.02
+imports:
+  from com.canonical.certification import lsb
+  from com.canonical.plainbox import manifest
+requires:
+  manifest.has_gpio_slot_been_defined == 'True'
+  lsb.distributor_id == 'Ubuntu Core'
 category_id: com.canonical.certification::gpio
 plugin: resource
 command: check_gpio.py dump
@@ -37,6 +43,12 @@ id: ce-oem-gpio/node-export-test-{slot}
 _summary: To test node of GPIO {gpio_number} been exported
 plugin: shell
 user: root
+imports:
+  from com.canonical.certification import lsb
+  from com.canonical.plainbox import manifest
+requires:
+  manifest.has_gpio_slot_been_defined == 'True'
+  lsb.distributor_id == 'Ubuntu Core'
 category_id: com.canonical.certification::gpio
 estimated_duration: 5s
 flags: also-after-suspend

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
@@ -4,6 +4,12 @@ plugin: shell
 user: root
 estimated_duration: 5
 environ: EXPECTED_GADGET_GPIO
+imports:
+  from com.canonical.certification import lsb
+  from com.canonical.plainbox import manifest
+requires:
+  manifest.has_gpio_slot_been_defined == 'True'
+  lsb.distributor_id == 'Ubuntu Core'
 _summary: Check gadget snap defined GPIO slots.
 _purpose: Check if expected GPIO slots been defined in gadget snap
 _description:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/manifest.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/manifest.pxu
@@ -1,0 +1,4 @@
+unit: manifest entry
+id: has_gpio_slot_been_defined
+_name: Does platform has GPIO slots been defined in Gadget snap?
+value-type: bool


### PR DESCRIPTION
## Description

Improve the requires of ce-oem-gpio/check-slots job

## Resolved issues

[[OEMQA-4418]](https://warthogs.atlassian.net/browse/OEMQA-4418)

## Documentation

## Tests

Sideload results

- Skip if image is not Ubuntu Core: https://certification.canonical.com/hardware/202404-33953/submission/371621/test-results/?term=ce-oem-gpio%2Fcheck-slots
- Skip if manifest definition not True: https://certification.canonical.com/hardware/202404-33953/submission/371656/test-results/?term=ce-oem-gpio%2Fcheck-slots


[OEMQA-4418]: https://warthogs.atlassian.net/browse/OEMQA-4418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ