### PR TITLE
[checkbox-ce-oem] Add moredetail for ce-oem-mtd/chec-total-numbers (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/mtd.sh
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/mtd.sh
@@ -17,6 +17,8 @@ countMtd() {
         echo "The number of MTD is correct!"
     else
         echo "The number of MTD is incorrect!"
+        echo "Expected: ${1}"
+        echo "Actual: ${count}"
         exit 1 
     fi
 }

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/mtd.sh
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/mtd.sh
@@ -15,12 +15,14 @@ countMtd() {
     count=$( listAllMtd | grep "MTD_NAME" | wc -l )
     if [ "${1}" == "$count" ]; then
         echo "The number of MTD is correct!"
+        ret=0
     else
         echo "The number of MTD is incorrect!"
-        echo "Expected: ${1}"
-        echo "Actual: ${count}"
-        exit 1 
+        ret=1 
     fi
+    echo "Expected: ${1}"
+    echo "Actual: ${count}"
+    exit "$ret"
 }
 
 # This function will get the size of MTD. (Unit: byte)

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/mtd/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/mtd/jobs.pxu
@@ -9,6 +9,8 @@ plugin: shell
 user: root
 flags: also-after-suspend
 estimated_duration: 5
+requires: manifest.has_mtd == 'True'
+imports: from com.canonical.plainbox import manifest
 command:
   if [ -z "${TOTAL_MTD_NUM}" ]; then
       echo "TOTAL_MTD_NUM is not defined!"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/mtd/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/mtd/jobs.pxu
@@ -9,7 +9,13 @@ plugin: shell
 user: root
 flags: also-after-suspend
 estimated_duration: 5
-command: mtd.sh count "$TOTAL_MTD_NUM"
+command:
+  if [ -z "${TOTAL_MTD_NUM}" ]; then
+      echo "TOTAL_MTD_NUM is not defined!"
+      exit 1
+  else
+      mtd.sh count "$TOTAL_MTD_NUM"
+  fi  
 
 id: ce-oem-mtd/mtd-list
 plugin: resource


### PR DESCRIPTION
## Description
Add more details for the job, so it will be easy to debug.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
Add more details
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
When not setting TOTAL_MTD_NUM
```terminal
===========================[ Running Selected Jobs ]============================
==============[ Running job 1 / 1. Estimated time left: 0:00:05 ]===============
----------------[ Check the total MTD numbers for the platform ]----------------
ID: com.canonical.contrib::ce-oem-mtd/check-total-numbers
Category: com.canonical.contrib::mtd
... 8< -------------------------------------------------------------------------
TOTAL_MTD_NUM is not defined!
------------------------------------------------------------------------- >8 ---
Outcome: job failed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-05-31T06.56.32
==================================[ Results ]===================================
 ☒ : Check the total MTD numbers for the platform
```
When setting the wrong TOTAL_MTD_NUM
```
===========================[ Running Selected Jobs ]============================
==============[ Running job 1 / 1. Estimated time left: 0:00:05 ]===============
----------------[ Check the total MTD numbers for the platform ]----------------
ID: com.canonical.contrib::ce-oem-mtd/check-total-numbers
Category: com.canonical.contrib::mtd
... 8< -------------------------------------------------------------------------
The number of MTD is incorrect!
Expected: 5
Actual: 17
------------------------------------------------------------------------- >8 ---
Outcome: job failed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-05-31T07.02.07
==================================[ Results ]===================================
 ☒ : Check the total MTD numbers for the platform
```
When setting the right TOTAL_MTD_NUM
```
===========================[ Running Selected Jobs ]============================
==============[ Running job 1 / 1. Estimated time left: 0:00:05 ]===============
----------------[ Check the total MTD numbers for the platform ]----------------
ID: com.canonical.contrib::ce-oem-mtd/check-total-numbers
Category: com.canonical.contrib::mtd
... 8< -------------------------------------------------------------------------
The number of MTD is correct!
Expected: 17
Actual: 17
------------------------------------------------------------------------- >8 ---
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-05-31T07.05.47
==================================[ Results ]===================================
 ☑ : Check the total MTD numbers for the platform
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
