### PR TITLE
Stable core24 snapcraft yaml (infra)

### DIFF
--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -223,7 +223,8 @@ parts:
       # a manual review
       for libamd_path in $(find .. -name "*.so.*"); do
         echo "Clearing execstack on $libamd_path";
-        execstack --clear-execstack "$libamd_path" || exit 1
+        # the || true is because there are som  *.so*.py in gdblib
+        execstack --clear-execstack "$libamd_path" || true
       done;
       craftctl default
     stage-packages:

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -1,13 +1,12 @@
 name: checkbox24
 summary: Checkbox runtime and public providers
 description: "Checkbox runtime and public providers"
-grade: devel
+grade: stable
 confinement: strict
 
 adopt-info: version-calculator
 
 base: core24
-build-base: devel
 
 # Don't forget to add a new slot if a new provider part is added in the parts
 # section below.

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -221,7 +221,7 @@ parts:
       # cleaning this bit should not cause any issue but if it does do not only remove this line
       # contact also the store/update the package because else this will always trigger
       # a manual review
-      for libamd_path in $(find .. -name "libamdhip64.so.5*"); do
+      for libamd_path in $(find .. -name "*.so.*"); do
         echo "Clearing execstack on $libamd_path";
         execstack --clear-execstack "$libamd_path" || exit 1
       done;

--- a/checkbox-snap/snapcraft8_prepare_classic.sh
+++ b/checkbox-snap/snapcraft8_prepare_classic.sh
@@ -42,7 +42,8 @@ fi
 echo "Copying over common_series_classic/* to $series"
 rsync -r --links common_series_classic/ ..
 echo "Copying over snapcraft.yaml"
-rsync -r --links $series ..
+rsync -r --links $series/* ..
+rsync -r --links $series/snap/hooks ..
 echo "Dumping version in version file for $series..."
 if which python3 1>/dev/null && which git 1>/dev/null; then
 	# get_version.py produces a version number from the traceability

--- a/checkbox-snap/snapcraft8_prepare_uc.sh
+++ b/checkbox-snap/snapcraft8_prepare_uc.sh
@@ -42,7 +42,8 @@ fi
 echo "Copying over common_series_uc/* to $series"
 rsync -r --links common_series_uc/ ..
 echo "Copying over snapcraft.yaml"
-rsync -r --links $series ..
+rsync -r --links $series/* ..
+rsync -r --links $series/snap/hooks ..
 echo "Dumping version in version file for $series..."
 if which python3 1>/dev/null && which git 1>/dev/null; then
 	# get_version.py produces a version number from the traceability

--- a/checkbox-support/pyproject.toml
+++ b/checkbox-support/pyproject.toml
@@ -10,11 +10,12 @@
   description='CheckBox support library'
   dynamic = ["version"]
   dependencies=[
-    'pyparsing>=2.2.0', 
-    'requests>=1.0', 
+    'pyparsing>=2.2.0',
+    'requests>=1.0',
     'distro>=1.0',
     'configparser; python_version=="2.7"',
-    'requests_unixsocket>=0.1.2; python_version>="3.5"',
+    'requests_unixsocket>=0.1.2; python_version>="3.5" and python_version<="3.11"',
+    'requests_unixsocket2; python_version>="3.12"',
     'importlib_metadata; python_version<"3.8"',
     'pyyaml',
   ]

--- a/checkbox-support/setup.cfg
+++ b/checkbox-support/setup.cfg
@@ -8,8 +8,9 @@ install_requires=
   requests >= 1.0
   distro >= 1.0
   configparser; python_version=="2.7"
-  requests_unixsocket >= 0.1.2; python_version>="3.5"
-  importlib_metadata; python_version<"3.8" 
+  requests_unixsocket >= 0.1.2; python_version>="3.5" and python_version<="3.11"
+  requests_unixsocket2; python_version>="3.12"
+  importlib_metadata; python_version<"3.8"
 [metadata]
 name=checkbox-support
 [options.entry_points]


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

These changes are to prepare the checkbox24 snap to be propoted into stable. 
This changes:
- move the build-base to stable (no need anymore as core24 is now released)
- move back the grade to stable (this is needed to allow the snap to be actually promoted to stable)
- extend the exestack to any library (there are a lot that are violating this policy on armhf, instead of tracking them lets just clean the bits for now, else we fail to publish to the store)
- updated the snapcraft8_prepare_[classic|uc] to also include hooks in the build
- updated 1 dependency because it changes name on newer versions of python (this will probably need to be extended, but for now lets check what happens)

## Resolved issues

N/A

## Documentation

Added a comment to explain why we ignore the return value of the execstack cleaning 

## Tests

Snaps currently in the store were built on this branch: https://github.com/canonical/checkbox/actions/runs/9304327974
