### PR TITLE
Fix the issue networking_info_.* always run after suspend (Bugfix)

### DIFF
--- a/providers/base/units/networking/test-plan.pxu
+++ b/providers/base/units/networking/test-plan.pxu
@@ -60,6 +60,10 @@ unit: test plan
 _name: Manual networking tests for devices
 _description: Manual networking tests for devices
 include:
+  networking/info_device.*                       certification-status=blocker
+bootstrap_include:
+  device
+  executable
 
 id: networking-automated
 unit: test plan


### PR DESCRIPTION
## Description
Add include for `networking-manual` to make it right ordered.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
#1266 
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

### Before
```terminal
(base) vincent@vincent-XPS-9320:~$ checkbox.checkbox-cli list-bootstrapped com.canonical.certification::client-cert-iot-server-24-04-manual
$PROVIDERPATH is defined, so following provider sources are ignored ['/home/vincent/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Skipped file: /snap/checkbox24/current/providers/checkbox-provider-base/units/stress/suspend_cycles_reboot.md
Enter sudo password:

com.canonical.plainbox::manifest
com.canonical.certification::executable
com.canonical.certification::interface
com.canonical.certification::connections
com.canonical.certification::model_assertion
com.canonical.certification::serial_assertion
com.canonical.certification::net_if_management
com.canonical.certification::net_if_management_attachment
com.canonical.certification::lspci_attachment
com.canonical.certification::lsusb_attachment
com.canonical.certification::rtc
com.canonical.certification::sleep
com.canonical.certification::parts_meta_info_attachment
com.canonical.certification::miscellanea/device_check
com.canonical.certification::uname
com.canonical.certification::meminfo
com.canonical.certification::cdimage
com.canonical.certification::lsb
com.canonical.certification::kernel_cmdline_attachment
com.canonical.certification::efi
com.canonical.certification::dmi_present
com.canonical.certification::dmi_attachment
com.canonical.certification::udev_attachment
com.canonical.certification::cpuinfo
com.canonical.certification::system_info_json
com.canonical.certification::package
com.canonical.certification::modprobe_json
com.canonical.certification::raw_devices_dmi_json
com.canonical.certification::udev_json
com.canonical.certification::dpkg
com.canonical.certification::environment
com.canonical.certification::lspci_standard_config_json
com.canonical.certification::snap
com.canonical.certification::dkms_info_json
com.canonical.certification::device
com.canonical.certification::dmi
com.canonical.certification::lsblk_attachment
com.canonical.certification::module
com.canonical.certification::requirements
com.canonical.certification::sysfs_attachment
com.canonical.certification::miscellanea/submission-resources
com.canonical.certification::info/systemd-analyze
com.canonical.certification::info/systemd-analyze-critical-chain
com.canonical.certification::ubuntucore/sshd
com.canonical.certification::audio/detect-playback-devices
com.canonical.certification::audio/alsa-playback
com.canonical.certification::bluetooth/keyboard-manual
com.canonical.certification::ethernet/wol_S5_enxcc96e5c32b21
com.canonical.certification::ethernet/wol_S4_enxcc96e5c32b21
com.canonical.certification::ethernet/wol_S3_enxcc96e5c32b21
com.canonical.certification::ethernet/hotplug-enxcc96e5c32b21
com.canonical.certification::led/power
com.canonical.certification::led/power-blink-suspend
com.canonical.certification::led/bluetooth
com.canonical.certification::led/serial
com.canonical.certification::led/fn
com.canonical.certification::mediacard/cf-insert
com.canonical.certification::mediacard/cf-storage
com.canonical.certification::mediacard/cf-remove
com.canonical.certification::mediacard/mmc-insert
com.canonical.certification::mediacard/mmc-storage
com.canonical.certification::mediacard/mmc-remove
com.canonical.certification::mediacard/ms-insert
com.canonical.certification::mediacard/ms-storage
com.canonical.certification::mediacard/ms-remove
com.canonical.certification::mediacard/msp-insert
com.canonical.certification::mediacard/msp-storage
com.canonical.certification::mediacard/msp-remove
com.canonical.certification::mediacard/sd-insert
com.canonical.certification::mediacard/sd-storage
com.canonical.certification::mediacard/sd-remove
com.canonical.certification::mediacard/sdhc-insert
com.canonical.certification::mediacard/sdhc-storage
com.canonical.certification::mediacard/sdhc-remove
com.canonical.certification::mediacard/sdxc-insert
com.canonical.certification::mediacard/sdxc-storage
com.canonical.certification::mediacard/sdxc-remove
com.canonical.certification::mediacard/xd-insert
com.canonical.certification::mediacard/xd-storage
com.canonical.certification::mediacard/xd-remove
com.canonical.certification::monitor/dvi
com.canonical.certification::monitor/hdmi
com.canonical.certification::monitor/dvi-to-vga
com.canonical.certification::monitor/hdmi-to-vga
com.canonical.certification::monitor/displayport_hotplug
com.canonical.certification::monitor/vga
com.canonical.certification::rtc/battery
com.canonical.certification::serial/rs232-console
com.canonical.certification::usb/hid
com.canonical.certification::usb/insert
com.canonical.certification::usb/storage-automated
com.canonical.certification::usb/remove
com.canonical.certification::usb-c/c-to-a-adapter/hid
com.canonical.certification::usb
com.canonical.certification::usb-c/c-to-a-adapter/insert
com.canonical.certification::usb-c/c-to-a-adapter/storage-automated
com.canonical.certification::usb-c/c-to-a-adapter/remove
com.canonical.certification::usb-c/hid
com.canonical.certification::usb-c/insert
com.canonical.certification::usb-c/storage-automated
com.canonical.certification::usb-c/remove
com.canonical.certification::usb-c-otg/g_serial
com.canonical.certification::usb-c-otg/g_serial-cleanup
com.canonical.certification::usb-c-otg/g_mass_storage
com.canonical.certification::usb-c-otg/g_mass_storage-cleanup
com.canonical.certification::usb-c-otg/g_ether
com.canonical.certification::usb-c-otg/g_ether-cleanup
com.canonical.certification::usb3/insert
com.canonical.certification::usb3/storage-automated
com.canonical.certification::usb3/remove
com.canonical.certification::thunderbolt3/insert
com.canonical.certification::thunderbolt3/storage-test
com.canonical.certification::thunderbolt3/remove
com.canonical.certification::wifi_interface_mode
com.canonical.certification::wireless/wifi_ap_open_b_no_sta_wlp0s20f3_manual
com.canonical.certification::wireless/wifi_ap_open_g_no_sta_wlp0s20f3_manual
com.canonical.certification::wireless/wifi_ap_wpa_b_no_sta_wlp0s20f3_manual
com.canonical.certification::wireless/wifi_ap_wpa_g_no_sta_wlp0s20f3_manual
com.canonical.certification::wwan/detect-manual
com.canonical.certification::wwan/check-sim-present-manual
com.canonical.certification::wwan/scan-networks-manual
com.canonical.certification::wwan/gsm-connection-interrupted-manual
com.canonical.certification::suspend/suspend_advanced_auto
com.canonical.certification::after-suspend-audio/alsa-playback
com.canonical.certification::after-suspend-bluetooth/keyboard-manual
com.canonical.certification::ethernet/detect
com.canonical.certification::after-suspend-ethernet/detect
com.canonical.certification::after-suspend-ethernet/hotplug-enxcc96e5c32b21
com.canonical.certification::after-suspend-monitor/dvi
com.canonical.certification::after-suspend-monitor/hdmi
com.canonical.certification::after-suspend-monitor/dvi-to-vga
com.canonical.certification::after-suspend-monitor/hdmi-to-vga
com.canonical.certification::after-suspend-monitor/displayport_hotplug
com.canonical.certification::after-suspend-monitor/vga
com.canonical.certification::networking/info_device1_enxcc96e5c32b21  <---------------------------- Here
com.canonical.certification::after-suspend-networking/info_device1_enxcc96e5c32b21
com.canonical.certification::after-suspend-serial/rs232-console
com.canonical.certification::after-suspend-usb/hid
com.canonical.certification::after-suspend-usb/insert
com.canonical.certification::after-suspend-usb/storage-automated
com.canonical.certification::after-suspend-usb/remove
com.canonical.certification::after-suspend-usb-c/c-to-a-adapter/hid
com.canonical.certification::after-suspend-usb-c/c-to-a-adapter/insert
com.canonical.certification::after-suspend-usb-c/c-to-a-adapter/storage-automated
com.canonical.certification::after-suspend-usb-c/c-to-a-adapter/remove
com.canonical.certification::after-suspend-usb-c/hid
com.canonical.certification::after-suspend-usb-c/insert
com.canonical.certification::after-suspend-usb-c/storage-automated
com.canonical.certification::after-suspend-usb-c/remove
com.canonical.certification::after-suspend-usb-c-otg/g_serial
com.canonical.certification::after-suspend-usb-c-otg/g_serial-cleanup
com.canonical.certification::after-suspend-usb-c-otg/g_mass_storage
com.canonical.certification::after-suspend-usb-c-otg/g_mass_storage-cleanup
com.canonical.certification::after-suspend-usb-c-otg/g_ether
com.canonical.certification::after-suspend-usb-c-otg/g_ether-cleanup
com.canonical.certification::after-suspend-usb3/insert
com.canonical.certification::after-suspend-usb3/storage-automated
com.canonical.certification::after-suspend-usb3/remove
com.canonical.certification::after-suspend-thunderbolt3/insert
com.canonical.certification::after-suspend-thunderbolt3/storage-test
com.canonical.certification::after-suspend-thunderbolt3/remove
com.canonical.certification::after-suspend-wireless/wifi_ap_open_b_no_sta_wlp0s20f3_manual
com.canonical.certification::after-suspend-wireless/wifi_ap_open_g_no_sta_wlp0s20f3_manual
com.canonical.certification::after-suspend-wireless/wifi_ap_wpa_b_no_sta_wlp0s20f3_manual
com.canonical.certification::after-suspend-wireless/wifi_ap_wpa_g_no_sta_wlp0s20f3_manual
com.canonical.certification::after-suspend-wwan/detect-manual
com.canonical.certification::after-suspend-wwan/scan-networks-manual
com.canonical.certification::after-suspend-wwan/check-sim-present-manual
com.canonical.certification::after-suspend-wwan/gsm-connection-interrupted-manual
```

### After
```terminal
(base) vincent@vincent-XPS-9320:~$ checkbox.checkbox-cli list-bootstrapped com.canonical.certification::client-cert-iot-server-24-04-manual
$PROVIDERPATH is defined, so following provider sources are ignored ['/home/vincent/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Using sideloaded provider: checkbox-provider-base, version 4.0.0.dev264 from /var/tmp/checkbox-providers/base
Skipped file: /var/tmp/checkbox-providers/base/units/stress/suspend_cycles_reboot.md
Using sideloaded provider: checkbox-provider-base, version 4.0.0.dev264 from /var/tmp/checkbox-providers/base
Skipped file: /var/tmp/checkbox-providers/base/units/stress/suspend_cycles_reboot.md
Enter sudo password:

com.canonical.plainbox::manifest
com.canonical.certification::executable
com.canonical.certification::interface
com.canonical.certification::connections
com.canonical.certification::model_assertion
com.canonical.certification::serial_assertion
com.canonical.certification::net_if_management
com.canonical.certification::net_if_management_attachment
com.canonical.certification::lspci_attachment
com.canonical.certification::lsusb_attachment
com.canonical.certification::rtc
com.canonical.certification::sleep
com.canonical.certification::parts_meta_info_attachment
com.canonical.certification::miscellanea/device_check
com.canonical.certification::environment
com.canonical.certification::udev_attachment
com.canonical.certification::requirements
com.canonical.certification::dmi_present
com.canonical.certification::dmi
com.canonical.certification::cdimage
com.canonical.certification::modprobe_json
com.canonical.certification::cpuinfo
com.canonical.certification::system_info_json
com.canonical.certification::snap
com.canonical.certification::lsb
com.canonical.certification::meminfo
com.canonical.certification::module
com.canonical.certification::dkms_info_json
com.canonical.certification::udev_json
com.canonical.certification::package
com.canonical.certification::device
com.canonical.certification::efi
com.canonical.certification::dmi_attachment
com.canonical.certification::kernel_cmdline_attachment
com.canonical.certification::sysfs_attachment
com.canonical.certification::lspci_standard_config_json
com.canonical.certification::dpkg
com.canonical.certification::uname
com.canonical.certification::raw_devices_dmi_json
com.canonical.certification::lsblk_attachment
com.canonical.certification::miscellanea/submission-resources
com.canonical.certification::info/systemd-analyze
com.canonical.certification::info/systemd-analyze-critical-chain
com.canonical.certification::ubuntucore/sshd
com.canonical.certification::audio/detect-playback-devices
com.canonical.certification::audio/alsa-playback
com.canonical.certification::bluetooth/keyboard-manual
com.canonical.certification::ethernet/wol_S5_enxcc96e5c32b21
com.canonical.certification::ethernet/wol_S4_enxcc96e5c32b21
com.canonical.certification::ethernet/wol_S3_enxcc96e5c32b21
com.canonical.certification::ethernet/hotplug-enxcc96e5c32b21
com.canonical.certification::led/power
com.canonical.certification::led/power-blink-suspend
com.canonical.certification::led/bluetooth
com.canonical.certification::led/serial
com.canonical.certification::led/fn
com.canonical.certification::mediacard/cf-insert
com.canonical.certification::mediacard/cf-storage
com.canonical.certification::mediacard/cf-remove
com.canonical.certification::mediacard/mmc-insert
com.canonical.certification::mediacard/mmc-storage
com.canonical.certification::mediacard/mmc-remove
com.canonical.certification::mediacard/ms-insert
com.canonical.certification::mediacard/ms-storage
com.canonical.certification::mediacard/ms-remove
com.canonical.certification::mediacard/msp-insert
com.canonical.certification::mediacard/msp-storage
com.canonical.certification::mediacard/msp-remove
com.canonical.certification::mediacard/sd-insert
com.canonical.certification::mediacard/sd-storage
com.canonical.certification::mediacard/sd-remove
com.canonical.certification::mediacard/sdhc-insert
com.canonical.certification::mediacard/sdhc-storage
com.canonical.certification::mediacard/sdhc-remove
com.canonical.certification::mediacard/sdxc-insert
com.canonical.certification::mediacard/sdxc-storage
com.canonical.certification::mediacard/sdxc-remove
com.canonical.certification::mediacard/xd-insert
com.canonical.certification::mediacard/xd-storage
com.canonical.certification::mediacard/xd-remove
com.canonical.certification::monitor/dvi
com.canonical.certification::monitor/hdmi
com.canonical.certification::monitor/dvi-to-vga
com.canonical.certification::monitor/hdmi-to-vga
com.canonical.certification::monitor/displayport_hotplug
com.canonical.certification::monitor/vga
com.canonical.certification::networking/info_device1_enxcc96e5c32b21  <------------------------ Here
com.canonical.certification::rtc/battery
com.canonical.certification::serial/rs232-console
com.canonical.certification::usb/hid
com.canonical.certification::usb/insert
com.canonical.certification::usb/storage-automated
com.canonical.certification::usb/remove
com.canonical.certification::usb-c/c-to-a-adapter/hid
com.canonical.certification::usb
com.canonical.certification::usb-c/c-to-a-adapter/insert
com.canonical.certification::usb-c/c-to-a-adapter/storage-automated
com.canonical.certification::usb-c/c-to-a-adapter/remove
com.canonical.certification::usb-c/hid
com.canonical.certification::usb-c/insert
com.canonical.certification::usb-c/storage-automated
com.canonical.certification::usb-c/remove
com.canonical.certification::usb-c-otg/g_serial
com.canonical.certification::usb-c-otg/g_serial-cleanup
com.canonical.certification::usb-c-otg/g_mass_storage
com.canonical.certification::usb-c-otg/g_mass_storage-cleanup
com.canonical.certification::usb-c-otg/g_ether
com.canonical.certification::usb-c-otg/g_ether-cleanup
com.canonical.certification::usb3/insert
com.canonical.certification::usb3/storage-automated
com.canonical.certification::usb3/remove
com.canonical.certification::thunderbolt3/insert
com.canonical.certification::thunderbolt3/storage-test
com.canonical.certification::thunderbolt3/remove
com.canonical.certification::wifi_interface_mode
com.canonical.certification::wireless/wifi_ap_open_b_no_sta_wlp0s20f3_manual
com.canonical.certification::wireless/wifi_ap_open_g_no_sta_wlp0s20f3_manual
com.canonical.certification::wireless/wifi_ap_wpa_b_no_sta_wlp0s20f3_manual
com.canonical.certification::wireless/wifi_ap_wpa_g_no_sta_wlp0s20f3_manual
com.canonical.certification::wwan/detect-manual
com.canonical.certification::wwan/check-sim-present-manual
com.canonical.certification::wwan/scan-networks-manual
com.canonical.certification::wwan/gsm-connection-interrupted-manual
com.canonical.certification::suspend/suspend_advanced_auto
com.canonical.certification::after-suspend-audio/alsa-playback
com.canonical.certification::after-suspend-bluetooth/keyboard-manual
com.canonical.certification::ethernet/detect
com.canonical.certification::after-suspend-ethernet/detect
com.canonical.certification::after-suspend-ethernet/hotplug-enxcc96e5c32b21
com.canonical.certification::after-suspend-monitor/dvi
com.canonical.certification::after-suspend-monitor/hdmi
com.canonical.certification::after-suspend-monitor/dvi-to-vga
com.canonical.certification::after-suspend-monitor/hdmi-to-vga
com.canonical.certification::after-suspend-monitor/displayport_hotplug
com.canonical.certification::after-suspend-monitor/vga
com.canonical.certification::after-suspend-networking/info_device1_enxcc96e5c32b21
com.canonical.certification::after-suspend-serial/rs232-console
com.canonical.certification::after-suspend-usb/hid
com.canonical.certification::after-suspend-usb/insert
com.canonical.certification::after-suspend-usb/storage-automated
com.canonical.certification::after-suspend-usb/remove
com.canonical.certification::after-suspend-usb-c/c-to-a-adapter/hid
com.canonical.certification::after-suspend-usb-c/c-to-a-adapter/insert
com.canonical.certification::after-suspend-usb-c/c-to-a-adapter/storage-automated
com.canonical.certification::after-suspend-usb-c/c-to-a-adapter/remove
com.canonical.certification::after-suspend-usb-c/hid
com.canonical.certification::after-suspend-usb-c/insert
com.canonical.certification::after-suspend-usb-c/storage-automated
com.canonical.certification::after-suspend-usb-c/remove
com.canonical.certification::after-suspend-usb-c-otg/g_serial
com.canonical.certification::after-suspend-usb-c-otg/g_serial-cleanup
com.canonical.certification::after-suspend-usb-c-otg/g_mass_storage
com.canonical.certification::after-suspend-usb-c-otg/g_mass_storage-cleanup
com.canonical.certification::after-suspend-usb-c-otg/g_ether
com.canonical.certification::after-suspend-usb-c-otg/g_ether-cleanup
com.canonical.certification::after-suspend-usb3/insert
com.canonical.certification::after-suspend-usb3/storage-automated
com.canonical.certification::after-suspend-usb3/remove
com.canonical.certification::after-suspend-thunderbolt3/insert
com.canonical.certification::after-suspend-thunderbolt3/storage-test
com.canonical.certification::after-suspend-thunderbolt3/remove
com.canonical.certification::after-suspend-wireless/wifi_ap_open_b_no_sta_wlp0s20f3_manual
com.canonical.certification::after-suspend-wireless/wifi_ap_open_g_no_sta_wlp0s20f3_manual
com.canonical.certification::after-suspend-wireless/wifi_ap_wpa_b_no_sta_wlp0s20f3_manual
com.canonical.certification::after-suspend-wireless/wifi_ap_wpa_g_no_sta_wlp0s20f3_manual
com.canonical.certification::after-suspend-wwan/detect-manual
com.canonical.certification::after-suspend-wwan/scan-networks-manual
com.canonical.certification::after-suspend-wwan/check-sim-present-manual
com.canonical.certification::after-suspend-wwan/gsm-connection-interrupted-manual
```