### PR TITLE
Unplug the test monitor at the end of the EDID test (BugFix)

### DIFF
--- a/providers/base/tests/test_edid_cycle.py
+++ b/providers/base/tests/test_edid_cycle.py
@@ -334,9 +334,10 @@ class ZapperEdidCycleTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             edid_cycle.main(args)
 
+    @patch("edid_cycle.zapper_monitor")
     @patch("edid_cycle.test_edid")
     @patch("edid_cycle.discover_video_output_device")
-    def test_main(self, mock_discover, mock_test_edid):
+    def test_main(self, mock_discover, mock_test_edid, mock_monitor):
         """
         Test if main function run the EDID test for every available EDID file.
         """
@@ -358,3 +359,17 @@ class ZapperEdidCycleTests(unittest.TestCase):
 
         mock_test_edid.side_effect = AssertionError("Mismatch")
         self.assertTrue(edid_cycle.main(args))
+
+        mock_monitor.assert_called_with("zapper-ip")
+
+    @patch("edid_cycle._clear_edid")
+    def test_zapper_monitor(self, mock_clear):
+        """
+        Test whether this context manager unplugs the Zapper monitor
+        at exit.
+        """
+
+        with edid_cycle.zapper_monitor("zapper-ip"):
+            pass
+
+        mock_clear.assert_called_with("zapper-ip")


### PR DESCRIPTION
## Description

The EDID job leaves the "monitor" connected at the end of the test, making tests like "resolution_after_suspend" fail. This PR introduces a simple context manager to clear the environment at the end of the test.

## Resolved issues

Resolves [CHECKBOX-1436](https://warthogs.atlassian.net/browse/CHECKBOX-1436)

## Documentation

Tests are included and functions documented.

## Tests

Locally, side-loading the provider and running in sequence
```
DISPLAY=:0 xrandr -q | grep "[*]" | awk '{{print $1}}'
DISPLAY=:0 checkbox.checkbox-cli run com.canonical.certification::monitor/edid
DISPLAY=:0 xrandr -q | grep "[*]" | awk '{{print $1}}'
```


[CHECKBOX-1436]: https://warthogs.atlassian.net/browse/CHECKBOX-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ