### PR TITLE
Fix and test unpickleable case (bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/timeout.py
+++ b/checkbox-support/checkbox_support/helpers/timeout.py
@@ -23,7 +23,6 @@ Utility class that provides functionalities connected to placing timeouts on
 functions
 """
 import os
-import time
 import traceback
 import subprocess
 import multiprocessing
@@ -65,7 +64,7 @@ def run_with_timeout(f, timeout_s, *args, **kwargs):
                                 "unable to propagate this un-picklable "
                                 "exception:\n"
                             ]
-                            + traceback.format_exception(e)
+                            + traceback.format_exception(type(e), e, None)
                         )
                     )
                 )

--- a/checkbox-support/checkbox_support/helpers/timeout.py
+++ b/checkbox-support/checkbox_support/helpers/timeout.py
@@ -51,12 +51,12 @@ def run_with_timeout(f, timeout_s, *args, **kwargs):
         except BaseException as e:
             try:
                 exception_queue.put(e)
-            except AttributeError:
+            except BaseException:
                 # raised by pickle.dumps in put when an exception is not
                 # pickleable. This raises SystemExit as we can't preserve the
                 # exception type, so any exception handler in the function
                 # user will not work (or will wrongly handle the exception
-                # if we change the type
+                # if we change the type)
                 exception_queue.put(
                     SystemExit(
                         "".join(

--- a/checkbox-support/checkbox_support/helpers/timeout.py
+++ b/checkbox-support/checkbox_support/helpers/timeout.py
@@ -25,11 +25,11 @@ functions
 import os
 import traceback
 import subprocess
-import multiprocessing
 
 from functools import partial
 from contextlib import wraps
 from unittest.mock import patch
+from multiprocessing import Process, SimpleQueue
 
 
 def run_with_timeout(f, timeout_s, *args, **kwargs):
@@ -40,8 +40,8 @@ def run_with_timeout(f, timeout_s, *args, **kwargs):
 
     Note: the function, *args and **kwargs must be picklable to use this.
     """
-    result_queue = multiprocessing.SimpleQueue()
-    exception_queue = multiprocessing.SimpleQueue()
+    result_queue = SimpleQueue()
+    exception_queue = SimpleQueue()
 
     def _f(*args, **kwargs):
         os.setsid()
@@ -69,9 +69,7 @@ def run_with_timeout(f, timeout_s, *args, **kwargs):
                     )
                 )
 
-    process = multiprocessing.Process(
-        target=_f, args=args, kwargs=kwargs, daemon=True
-    )
+    process = Process(target=_f, args=args, kwargs=kwargs, daemon=True)
     process.start()
     process.join(timeout_s)
 

--- a/checkbox-support/checkbox_support/tests/test_timeout.py
+++ b/checkbox-support/checkbox_support/tests/test_timeout.py
@@ -130,9 +130,11 @@ class TestTimeoutExec(TestCase):
         function to another process. Trying to return an un-picklable object
         will raise a pickle error.
         """
+
         @timeout(1)
         def k():
             return lambda x: ...
+
         with self.assertRaises(AttributeError):
             k()
 
@@ -142,8 +144,10 @@ class TestTimeoutExec(TestCase):
         function to another process. Trying to raise an un-picklable object
         will raise a pickle error.
         """
+
         @timeout(1)
         def k():
-            raise ValueError(lambda x:...)
+            raise ValueError(lambda x: ...)
+
         with self.assertRaises(SystemExit):
             k()

--- a/checkbox-support/checkbox_support/tests/test_timeout.py
+++ b/checkbox-support/checkbox_support/tests/test_timeout.py
@@ -123,3 +123,27 @@ class TestTimeoutExec(TestCase):
         self.assertEqual(
             k(1, 2, 3, abc=10), fake_run_with_timeout(k, 100, 1, 2, 3, abc=10)
         )
+
+    def test_unpicklable_return_raises(self):
+        """
+        The reason why this raises is that the timeout decorator pushes the
+        function to another process. Trying to return an un-picklable object
+        will raise a pickle error.
+        """
+        @timeout(1)
+        def k():
+            return lambda x: ...
+        with self.assertRaises(AttributeError):
+            k()
+
+    def test_unpicklable_raise_raises(self):
+        """
+        The reason why this raises is that the timeout decorator pushes the
+        function to another process. Trying to raise an un-picklable object
+        will raise a pickle error.
+        """
+        @timeout(1)
+        def k():
+            raise ValueError(lambda x:...)
+        with self.assertRaises(SystemExit):
+            k()


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

When the timeout decorator is used to time out the bluetooth test, the process seems to hang forever after raising an exception. The reason is that the exception is a custom un-picklable exception, so the decorator is unable to propagate it up, crashing silently (as it is doing so in a separate thread) when trying to push it (as we were using a Queue and not a SimpleQueue). Subsequently the other process detects that the child is dead but not finding anything in the exception queue (as the child died while trying to push to it) it hangs waiting for a result forever. This tests and fixes this issue (note that removing the fix, the test will fail 100% of the times)

## Resolved issues

Fixes: CHECKBOX-1449
Fixes: https://github.com/canonical/checkbox/issues/1263

## Documentation

Added comments to explain what is going on and why things are done the way they are

## Tests

This adds 2 test cases for this new situation

Also tested on device:
Reproduce:
```
$ snap install checkbox20 --beta
$ snap install checkbox --channel=20.04/beta
$ checkbox.checkbox-cli run com.canonical.certification::device  com.canonical.certification::bluetooth4/beacon_eddystone_url_hci0
[...]
==============[ Running job 1 / 1. Estimated time left: 0:00:10 ]===============
[ Test system can get beacon EddyStone URL advertisements on the hci0 adapter ]-
ID: com.canonical.certification::bluetooth4/beacon_eddystone_url_hci0
Category: com.canonical.plainbox::bluetooth
... 8< -------------------------------------------------------------------------
Enter sudo password:

Exception in thread Thread-1:
Traceback (most recent call last):
  File "/snap/checkbox20/current/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/snap/checkbox20/current/lib/python3.8/site-packages/checkbox_support/vendor/beacontools/scanner.py", line 148, in run
    self.hci_version = self.get_hci_version()
  File "/snap/checkbox20/current/lib/python3.8/site-packages/checkbox_support/vendor/beacontools/scanner.py", line 173, in get_hci_version
    resp = self.backend.send_req(self.socket, OGF_INFO_PARAM, OCF_READ_LOCAL_VERSION,
  File "/snap/checkbox20/current/lib/python3.8/site-packages/checkbox_support/vendor/beacontools/backend/linux.py", line 23, in send_req
    return bluez.hci_send_req(socket, group_field, command_field, event, rlen, params, timeout)
_bluetooth.error: (100, 'Network is down')
Function failed but the timeout decorator is unable to propagate this un-picklable exception:
_bluetooth.error: (100, 'Network is down')

// process hangs forever
```
Fix it live:
```
$ snap install overlay
$ /snap/overlay/current/overlay /snap/checkbox20/current/
$ sudo vim /snap/checkbox20/current/lib/python3.8/site-packages/checkbox_support/helpers/timeout.py

// replace this file with the one in this PR

$ checkbox.checkbox-cli run com.canonical.certification::device  com.canonical.certification::bluetooth4/beacon_eddystone_url_hci0
[...]
==============[ Running job 1 / 1. Estimated time left: 0:00:10 ]===============
[ Test system can get beacon EddyStone URL advertisements on the hci0 adapter ]-
ID: com.canonical.certification::bluetooth4/beacon_eddystone_url_hci0
Category: com.canonical.plainbox::bluetooth
... 8< -------------------------------------------------------------------------
Enter sudo password:

Exception in thread Thread-1:
Traceback (most recent call last):
  File "/snap/checkbox20/current/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/snap/checkbox20/current/lib/python3.8/site-packages/checkbox_support/vendor/beacontools/scanner.py", line 148, in run
    self.hci_version = self.get_hci_version()
  File "/snap/checkbox20/current/lib/python3.8/site-packages/checkbox_support/vendor/beacontools/scanner.py", line 173, in get_hci_version
    resp = self.backend.send_req(self.socket, OGF_INFO_PARAM, OCF_READ_LOCAL_VERSION,
  File "/snap/checkbox20/current/lib/python3.8/site-packages/checkbox_support/vendor/beacontools/backend/linux.py", line 23, in send_req
    return bluez.hci_send_req(socket, group_field, command_field, event, rlen, params, timeout)
_bluetooth.error: (100, 'Network is down')
Function failed but the timeout decorator is unable to propagate this un-picklable exception:
_bluetooth.error: (100, 'Network is down')

------------------------------------------------------------------------- >8 ---
Outcome: job failed
[...] // session goes on as normal
```
