### PR TITLE
Add platform-userguide-test (New)

### DIFF
--- a/contrib/pc-sanity/bin/platform_userguide_test
+++ b/contrib/pc-sanity/bin/platform_userguide_test
@@ -1,0 +1,40 @@
+#!/bin/bash
+failed()
+{
+    [ -n "$1" ] && echo "$1"
+    echo "$0 failed!"
+    exit 1
+}
+
+passed()
+{
+    [ -n "$1" ] && echo "$1"
+    echo "$0 passed!"
+    exit 0
+}
+
+# Check userguide package if installed in sutton project
+# https://warthogs.atlassian.net/browse/OEX86-301
+check_sutton_userguide() {
+    # userguide package will depend on a oem-sutton-common-doc package
+    for pkg in $(dpkg-query -W -f='${Package}\n'  "oem-sutton-*-doc" 2> /dev/null); do
+        platform_name=$(echo "${pkg}" | cut -d'-' -f3)
+        if [ "$platform_name" = "common" ]; then
+            # Ignore common doc package
+            continue
+        fi
+        if dpkg-query -W -f='${Status}\n' "${pkg}" 2> /dev/null | grep -q "install ok installed"; then
+            passed "Found the platform userguide package: ${pkg}"
+        fi
+    done
+    # No platform userguide package found, then fail the test
+    failed "Missing platform userguide packages!!!"
+}
+
+main() {
+    check_sutton_userguide
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    main "$@"
+fi

--- a/contrib/pc-sanity/bin/platform_userguide_test
+++ b/contrib/pc-sanity/bin/platform_userguide_test
@@ -1,14 +1,14 @@
 #!/bin/bash
 failed()
 {
-    [ -n "$1" ] && echo "$1"
-    echo "$0 failed!"
+    >&2 echo "$*"
+    >&2 "$0 failed!"
     exit 1
 }
 
 passed()
 {
-    [ -n "$1" ] && echo "$1"
+    echo "$*"
     echo "$0 passed!"
     exit 0
 }

--- a/contrib/pc-sanity/test/platform_userguide_test.bats
+++ b/contrib/pc-sanity/test/platform_userguide_test.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+# execute this test file by `bats test/platform_userguide_test`
+BIN_FOLDER="contrib/pc-sanity/bin"
+
+function setup() {
+    source "$BIN_FOLDER"/platform_userguide_test
+}
+
+# A autotest for check_sutton_userguide in bats
+@test "test_check_sutton_userguide: Pass if userguide package is installed" {
+    set -e
+    function dpkg-query() {
+        opts="$*"
+        if [ -z ${opts##*Package*} ]; then
+            echo "oem-sutton-common-doc"
+            echo "oem-sutton-foo-doc"
+        elif [ -z ${opts##*oem-sutton-foo-doc*} ];then
+            echo "install ok installed"
+        fi
+    }
+
+    run check_sutton_userguide
+    [ "$status" -eq 0 ]
+}
+
+@test "test_check_sutton_userguide: Error if userguide package is not removed" {
+    set -e
+    function dpkg-query() {
+        opts="$*"
+        if [ -z ${opts##*Package*} ]; then
+            echo "oem-sutton-common-doc"
+            echo "oem-sutton-foo-doc"
+        elif [ -z ${opts##*oem-sutton-foo-doc*} ];then
+            echo "unknown ok not-installed"
+        fi
+    }
+
+    run check_sutton_userguide
+    [ "$status" -eq 1 ]
+}
+
+@test "test_check_sutton_userguide: Error if userguide package is not installed" {
+    set -e
+    status=0
+    function dpkg-query() {
+        opts="$*"
+        if [ -z ${opts##*Package*} ]; then
+            echo ""
+        fi
+    }
+
+    run check_sutton_userguide
+    [ "$status" -eq 1 ]
+}

--- a/contrib/pc-sanity/units/pc-sanity/pc-sanity-check-env.pxu
+++ b/contrib/pc-sanity/units/pc-sanity/pc-sanity-check-env.pxu
@@ -7,6 +7,16 @@ command:
 _description: Check if the platform metapackage is installed.
 
 plugin: shell
+id: miscellanea/platform-userguide-test
+category_id: com.canonical.plainbox::miscellanea
+requires:
+ lsb.release >= "20.04"
+ dmi.vendor == 'LENOVO'
+command:
+ platform_userguide_test
+_description: Check if the platform userguide package is installed.
+
+plugin: shell
 category_id: com.canonical.plainbox::miscellanea
 id: miscellanea/gate_rste_raid
 command:

--- a/contrib/pc-sanity/units/pc-sanity/pc-sanity.pxu
+++ b/contrib/pc-sanity/units/pc-sanity/pc-sanity.pxu
@@ -9,6 +9,7 @@ include:
     com.canonical.certification::miscellanea/side-load-changes
     com.canonical.certification::somerville-installation
     com.canonical.certification::somerville/platform-meta-test
+    com.canonical.certification::miscellanea/platform-userguide-test
     com.canonical.certification::miscellanea/cvescan
     com.canonical.certification::miscellanea/check-nvidia
     com.canonical.certification::miscellanea/check-gpu-driver                   certification-status=blocker


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

A new testcase to check if userguide package is installed

## Resolved issues

https://warthogs.atlassian.net/browse/OEX86-301

## Documentation


## Tests
```
=========[ Running job 4 / 4. Estimated time left (at least): 0:00:00 ]=========
--------------------[ miscellanea/platform-userguide-test ]---------------------
ID: com.canonical.certification::miscellanea/platform-userguide-test
Category: com.canonical.plainbox::miscellanea
... 8< -------------------------------------------------------------------------
Found the platform userguide package: oem-sutton-castro-doc
/tmp/nest-biwxewx3.43eea1fe921e92beedc650f60ad4d0ee2ba1e4925cb9bacfcbf157e09292eabb/platform_userguide_test passed!
------------------------------------------------------------------------- >8 ---
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-06-07T07.29.16
==================================[ Results ]===================================
 ☑ : Resource to detect if dmi data is present
 ☑ : Collect information about hardware devices (DMI)
 ☑ : Collect information about installed system (lsb-release)
 ☑ : miscellanea/platform-userguide-test
```
```
=========[ Running job 4 / 4. Estimated time left (at least): 0:00:00 ]=========
--------------------[ miscellanea/platform-userguide-test ]---------------------
ID: com.canonical.certification::miscellanea/platform-userguide-test
Category: com.canonical.plainbox::miscellanea
... 8< -------------------------------------------------------------------------
Missing platform userguide packages!!!
/tmp/nest-nbc4iyl6.43eea1fe921e92beedc650f60ad4d0ee2ba1e4925cb9bacfcbf157e09292eabb/platform_userguide_test failed!
------------------------------------------------------------------------- >8 ---
Outcome: job failed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-06-07T07.51.55
==================================[ Results ]===================================
 ☑ : Resource to detect if dmi data is present
 ☑ : Collect information about hardware devices (DMI)
 ☑ : Collect information about installed system (lsb-release)
 ☒ : miscellanea/platform-userguide-test
```