### PR TITLE
Carry over all QT variables in child process (BugFix)

### DIFF
--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -535,6 +535,10 @@ def get_execution_environment(job, environ, session_id, nest_dir):
                 "LD_LIBRARY_PATH",
                 "GI_TYPELIB_PATH",
                 "PERL5LIB",
+                "QT_PLUGIN_PATH",
+                "QT_QPA_PLATFORM",
+                "QT_QPA_PLATFORMTHEME",
+                "QT_DEBUG_PLUGINS",
             ]
             for key, value in env.items():
                 if key in copy_vars or key.startswith("SNAP"):
@@ -632,6 +636,10 @@ def get_differential_execution_environment(
             "PROVIDERPATH",
             "PYTHONPATH",
             "PERL5LIB",
+            "QT_PLUGIN_PATH",
+            "QT_QPA_PLATFORM",
+            "QT_QPA_PLATFORMTHEME",
+            "QT_DEBUG_PLUGINS",
         ]
         for key, value in base_env.items():
             if key in copy_vars or key.startswith("SNAP"):


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Checkbox Remote, when running from a snap, is unable to start any QT window. This is because, although the environment variables are set in the wrapper, they are not explicitly propagated to the subshell nor requested by the jobs   (as they are not explicitly necessary in a non-snapped scenario). 

This introduces a few new exceptions to the environment preparation funciton so that it propagates QT-related environment variables to the sub shell.

Minor: this also propagates the debug plugin environment variable that is unset most of the times, but it is handy to debug what is going wrong with the setup if anything

## Resolved issues

Fixes: CHECKBOX-1325
Fixes: https://github.com/canonical/checkbox/issues/728

## Documentation

N/A

## Tests

This by re-building the snap and selecting the touchscreen testplan. If the touchscreen testing window pops up, then the test is fixed. 

Pre-built snap: https://drive.google.com/file/d/1Zf1L5qpk_YHvqykAj2h0EH0E0IdhiWHM/view?usp=sharing
