### PR TITLE
Replace category == 'AUDIO' with has_audio_playback (bugfix)

### DIFF
--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -339,6 +339,7 @@ imports: from com.canonical.plainbox import manifest
 requires:
  (manifest.has_line_in == 'True' or manifest.has_headset == 'True')
  manifest.has_audio_playback == 'True'
+ manifest.has_audio_capture == 'True'
  package.name == 'alsa-base'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -409,6 +410,7 @@ estimated_duration: 120.0
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_audio_playback == 'True'
+ manifest.has_audio_capture == 'True'
  package.name == 'alsa-base'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -732,6 +734,7 @@ requires:
  package.name == 'alsa-base'
  package.name in ['pulseaudio-utils', 'pipewire']
  manifest.has_audio_playback == 'True'
+ manifest.has_audio_capture == 'True'
 command: audio_test.py
   if check_audio_daemon.sh ; then
     pipewire_test.py

--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -2,8 +2,9 @@ plugin: shell
 category_id: com.canonical.plainbox::audio
 id: audio/list_devices
 estimated_duration: 1.0
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
 command: cat /proc/asound/cards
 _purpose: Test to detect audio devices
@@ -12,8 +13,9 @@ _summary: Check if audio devices can be detected.
 plugin: shell
 category_id: com.canonical.plainbox::audio
 id: audio/valid-sof-firmware-sig
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'linux-firmware'
 command:
  fail=0
@@ -40,7 +42,7 @@ depends: audio/list_devices
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_internal_speakers == 'True'
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -78,7 +80,7 @@ estimated_duration: 30.0
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_hdmi == 'True'
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -115,7 +117,7 @@ estimated_duration: 30.0
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_dp == 'True'
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -152,7 +154,7 @@ imports: from com.canonical.plainbox import manifest
 estimated_duration: 30.0
 requires:
  manifest.has_thunderbolt == 'True'
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -189,7 +191,7 @@ imports: from com.canonical.plainbox import manifest
 estimated_duration: 30.0
 requires:
  manifest.has_thunderbolt3 == 'True'
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -226,7 +228,7 @@ imports: from com.canonical.plainbox import manifest
 estimated_duration: 30.0
 requires:
  manifest.has_usbc_video == 'True'
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -263,7 +265,7 @@ imports: from com.canonical.plainbox import manifest
 estimated_duration: 30.0
 requires:
  manifest.has_usbc_video == 'True'
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -300,7 +302,7 @@ depends: audio/list_devices
 imports: from com.canonical.plainbox import manifest
 requires:
  (manifest.has_line_in == 'True' or manifest.has_headset == 'True')
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -336,7 +338,7 @@ depends: audio/playback_auto
 imports: from com.canonical.plainbox import manifest
 requires:
  (manifest.has_line_in == 'True' or manifest.has_headset == 'True')
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -356,7 +358,7 @@ command:
 _description:
 _purpose:
     This test will check that recording sound using the onboard microphone works correctly
-_steps: 
+_steps:
     1. Disconnect any external microphones that you have plugged in
     2. Click "Test", then speak into your internal microphone
     3. After a few seconds, your speech will be played back to you.
@@ -373,7 +375,7 @@ depends: audio/playback_headphones
 imports: from com.canonical.plainbox import manifest
 requires:
  (manifest.has_line_in == 'True' or manifest.has_headset == 'True')
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -404,8 +406,9 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/alsa_record_playback_usb
 estimated_duration: 120.0
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -437,6 +440,7 @@ id: audio/alsa_record_playback_automated
 flags: also-after-suspend
 depends: audio/detect_sinks audio/detect_sources
 estimated_duration: 10.0
+imports: from com.canonical.plainbox import manifest
 requires:
  package.name == 'python3-gi'
  package.name == 'gir1.2-gstreamer-1.0'
@@ -444,9 +448,9 @@ requires:
  package.name == 'gstreamer1.0-plugins-good'
  package.name in ['gstreamer1.0-pulseaudio', 'gstreamer1.0-pipewire']
  package.name == 'alsa-base'
- device.category == 'AUDIO'
  package.name in ['pulseaudio-utils', 'pipewire']
-command: 
+ manifest.has_audio_playback == 'True'
+command:
   if check_audio_daemon.sh ; then
     pipewire_test.py
   else
@@ -533,9 +537,10 @@ plugin: shell
 category_id: com.canonical.plainbox::audio
 id: audio/check_volume
 estimated_duration: 1.0
+imports: from com.canonical.plainbox import manifest
 requires:
  package.name == 'pulseaudio-utils'
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
 command: volume_test.py --minvol 1 --maxvol 100
 _purpose:
  This test will verify that the volume levels are at an acceptable level on
@@ -576,7 +581,7 @@ imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_line_in == 'True'
  dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower','Space-saving','All In One','All-In-One','AIO']
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -612,9 +617,9 @@ estimated_duration: 60.0
 imports: from com.canonical.plainbox import manifest
 requires:
  (manifest.has_line_out == 'True' or manifest.has_headset == 'True')
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name in ['pulseaudio-utils', 'pipewire']
-command: 
+command:
   if check_audio_daemon.sh ; then
     pipewire_utils.py monitor -t 30 -m sinks
   else
@@ -641,9 +646,9 @@ estimated_duration: 60.0
 imports: from com.canonical.plainbox import manifest
 requires:
  (manifest.has_line_in == 'True' or manifest.has_headset == 'True')
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name in ['pulseaudio-utils', 'pipewire']
-command: 
+command:
   if check_audio_daemon.sh ; then
     pipewire_utils.py monitor -t 30 -m sources
   else
@@ -668,8 +673,9 @@ category_id: com.canonical.plainbox::audio
 id: audio/list_devices_after_suspend_30_cycles
 estimated_duration: 1.0
 depends: power-management/suspend_30_cycles
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
 command: cat /proc/asound/cards
 _purpose: Test to detect audio devices after suspending 30 times.
@@ -680,8 +686,9 @@ category_id: com.canonical.plainbox::audio
 id: audio/playback_auto_after_suspend_30_cycles
 estimated_duration: 5.0
 depends: audio/list_devices power-management/suspend_30_cycles
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -715,6 +722,7 @@ category_id: com.canonical.plainbox::audio
 id: audio/alsa_record_playback_automated_after_suspend_30_cycles
 estimated_duration: 10.0
 depends: power-management/suspend_30_cycles audio/detect_sinks_sources_after_suspend_30_cycles
+imports: from com.canonical.plainbox import manifest
 requires:
  package.name == 'python3-gi'
  package.name == 'gir1.2-gstreamer-1.0'
@@ -723,7 +731,7 @@ requires:
  package.name in ['gstreamer1.0-pulseaudio', 'gstreamer1.0-pipewire']
  package.name == 'alsa-base'
  package.name in ['pulseaudio-utils', 'pipewire']
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
 command: audio_test.py
   if check_audio_daemon.sh ; then
     pipewire_test.py
@@ -753,9 +761,10 @@ category_id: com.canonical.plainbox::audio
 id: audio/check_volume_after_suspend_30_cycles
 estimated_duration: 1.0
 depends: power-management/suspend_30_cycles
+imports: from com.canonical.plainbox import manifest
 requires:
  package.name == 'pulseaudio-utils'
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
 command: volume_test.py --minvol 1 --maxvol 100
 _purpose:
  This test will verify that the volume levels are at an acceptable level on
@@ -771,8 +780,9 @@ category_id: com.canonical.plainbox::audio
 id: audio/audio_after_suspend_30_cycles
 estimated_duration: 1.0
 depends: power-management/suspend_30_cycles
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
 _purpose: Record mixer settings after suspending 30 times.
 command:

--- a/providers/base/units/dock/jobs.pxu
+++ b/providers/base/units/dock/jobs.pxu
@@ -123,7 +123,7 @@ _steps:
     2. Switch display modes between in your Display Settings, check if it can be
        set to mirrored, extended, displayed on external or onboard only
 _verification:
-    Was the desktop displayed correctly on the screen connected 
+    Was the desktop displayed correctly on the screen connected
     using a "USB Type-C to DisplayPort" adapter in every mode?
 
 id: dock/monitor_type-c_hdmi
@@ -143,7 +143,7 @@ _steps:
     2. Switch display modes between in your Display Settings, check if it can be
        set to mirrored, extended, displayed on external or onboard only
 _verification:
-    Was the desktop displayed correctly on the screen connected 
+    Was the desktop displayed correctly on the screen connected
     using a "USB Type-C to HDMI" adapter in every mode?
 
 id: dock/monitor_type-c_vga
@@ -163,7 +163,7 @@ _steps:
     2. Switch display modes between in your Display Settings, check if it can be
        set to mirrored, extended, displayed on external or onboard only
 _verification:
-    Was the desktop displayed correctly on the screen connected 
+    Was the desktop displayed correctly on the screen connected
     using a "USB Type-C to VGA" adapter in every mode?
 
 id: dock/monitor-thunderbolt3
@@ -240,8 +240,9 @@ category_id: dock-audio
 estimated_duration: 1.0
 _summary: List audio devices
 depends: dock/cold-plug
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
 command: cat /proc/asound/cards
 _description: Test to detect audio devices
@@ -249,8 +250,9 @@ _description: Test to detect audio devices
 id: dock/audio-playback-hdmi
 category_id: dock-audio
 depends: dock/cold-plug
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -283,8 +285,9 @@ _verification:
 id: dock/audio-playback-displayport
 category_id: dock-audio
 depends: dock/cold-plug
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -320,7 +323,7 @@ depends: dock/cold-plug
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_usbc_video == 'True'
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -355,7 +358,7 @@ depends: dock/cold-plug
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_usbc_video == 'True'
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -390,7 +393,7 @@ category_id: dock-audio
 depends: dock/cold-plug
 imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -429,8 +432,9 @@ flags: also-after-suspend
 estimated_duration: 30.0
 _summary: Headphones output test
 depends: dock/audio-list-devices
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -464,8 +468,9 @@ estimated_duration: 30.0
 flags: also-after-suspend
 _summary: External microphone plugged to the dock to record sound test
 depends: dock/audio-playback-headphones
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -538,8 +543,9 @@ category_id: dock-audio
 depends: dock/cold-plug
 estimated_duration: 120.0
 _summary: Line-in connection test
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -572,8 +578,9 @@ plugin: user-interact
 depends: dock/cold-plug
 estimated_duration: 60.0
 _summary: Headphones recognized when plugged to the dock test
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_daemon.sh ; then
@@ -600,8 +607,9 @@ plugin: user-interact
 depends: dock/cold-plug
 estimated_duration: 60.0
 _summary: Microphone recognized when plugged to the dock test
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_daemon.sh ; then
@@ -677,7 +685,7 @@ _steps:
 _verification:
     1. Is the Passthrough MAC Address the same as MAC address found in step 4?
     2. If BIOS doesn't have Passthrough MAC Address in BIOS setup, a bug should be filed.
-    3. If dock ethernet MAC address is not the same as BIOS Passthrough MAC Address, a 
+    3. If dock ethernet MAC address is not the same as BIOS Passthrough MAC Address, a
     bug should be filed.
 
 ### USB Tests ###
@@ -1183,8 +1191,9 @@ _verification:
 id: dock/hotplug-playback-type-c-displayport
 category_id: dock-hotplug
 depends: dock/hot-plug
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -1217,8 +1226,9 @@ _verification:
 id: dock/hotplug-playback-thumderbolt3
 category_id: dock-hotplug
 depends: dock/hot-plug
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -1251,8 +1261,9 @@ _verification:
 id: dock/hotplug-playback-displayport
 category_id: dock-hotplug
 depends: dock/hot-plug
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -1285,8 +1296,9 @@ _verification:
 id: dock/hotplug-playback-hdmi
 category_id: dock-hotplug
 depends: dock/hot-plug
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -1332,8 +1344,9 @@ id: dock/audio-before-suspend
 category_id: dock-audio
 estimated_duration: 1.0
 _summary: Audio status before suspend
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
 _description: Record mixer settings before suspending.
 command: audio_settings.py store --file="$PLAINBOX_SESSION_SHARE"/audio_settings_before_suspend
@@ -1555,7 +1568,7 @@ _steps:
     2. Switch display modes between in your Display Settings, check if it can be
        set to mirrored, extended, displayed on external or onboard only
 _verification:
-    Was the desktop displayed correctly on the screen connected 
+    Was the desktop displayed correctly on the screen connected
     using a "USB Type-C to DisplayPort" adapter in every mode?
 
 id: dock/monitor_type-c_hdmi-after-suspend
@@ -1573,7 +1586,7 @@ _steps:
     2. Switch display modes between in your Display Settings, check if it can be
        set to mirrored, extended, displayed on external or onboard only
 _verification:
-    Was the desktop displayed correctly on the screen connected 
+    Was the desktop displayed correctly on the screen connected
     using a "USB Type-C to HDMI" adapter in every mode?
 
 id: dock/monitor_type-c_vga-after-suspend
@@ -1591,7 +1604,7 @@ _steps:
     2. Switch display modes between in your Display Settings, check if it can be
        set to mirrored, extended, displayed on external or onboard only
 _verification:
-    Was the desktop displayed correctly on the screen connected 
+    Was the desktop displayed correctly on the screen connected
     using a "USB Type-C to VGA" adapter in every mode?
 
 id: dock/monitor-dual-head-after-suspend
@@ -1804,8 +1817,9 @@ id: dock/audio-after-suspend-undock-resume
 category_id: dock-audio
 estimated_duration: 1.0
 _summary: Audio after resuming test
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
 depends: dock/suspend-undock-resume dock/audio-before-suspend
 _description: Verify that mixer settings after suspend are the same as before suspend.
@@ -1819,7 +1833,9 @@ category_id: dock-audio
 estimated_duration: 10.0
 _summary: Record playback after resuming
 depends: dock/suspend-undock-resume
+imports: from com.canonical.plainbox import manifest
 requires:
+ manifest.has_audio_playback == 'True'
  package.name == 'python3-gi'
  package.name == 'gir1.2-gstreamer-1.0'
  package.name == 'libgstreamer1.0-0'
@@ -1827,7 +1843,6 @@ requires:
  package.name in ['gstreamer1.0-pulseaudio', 'gstreamer1.0-pipewire']
  package.name == 'alsa-base'
  package.name in ['pulseaudio-utils', 'pipewire']
- device.category == 'AUDIO'
 command:
   if check_audio_daemon.sh ; then
     pipewire_test.py
@@ -2039,7 +2054,7 @@ _steps:
     1. Insert appropriate non-blank media into your optical drive(s). Movie and Audio Disks may not work. Self-created data disks have the greatest chance of working.
     2. Try to copy a few files from the optical media to the computer.
 _verification:
-    Are the files properly copied to the computer?    
+    Are the files properly copied to the computer?
 
 plugin: manual
 id: dock/optical-write
@@ -2282,7 +2297,7 @@ _purpose:
 _steps:
     1. Suspend the laptop (e.g. by closing its lid)
     2. Unplug docking station
-    3. Plug in docking station 
+    3. Plug in docking station
     4. Resume the laptop (e.g. by pressing the Power button on the dock)
 _verification:
     Is the device working as expected after being docked and resumed?
@@ -2538,8 +2553,9 @@ _siblings:
 
 id: dock/all-init-monitor-multi-head-audio-playback
 category_id: dock-audio
+imports: from com.canonical.plainbox import manifest
 requires:
-    device.category == 'AUDIO'
+    manifest.has_audio_playback == 'True'
     package.name in ['pulseaudio-utils', 'pipewire']
 _summary: Multiple monitor audio test
 plugin: user-interact-verify
@@ -2854,8 +2870,9 @@ category_id: dock-audio
 plugin: user-interact
 estimated_duration: 60.0
 _summary: Headphones recognized when plugged to the dock test
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_daemon.sh ; then
@@ -2888,8 +2905,9 @@ flags: also-after-suspend
 estimated_duration: 30.0
 _summary: Headphones output test
 depends: dock/all-init-audio-speaker-headphone-plug-detection
+imports: from com.canonical.plainbox import manifest
 requires:
-    device.category == 'AUDIO'
+    manifest.has_audio_playback == 'True'
     package.name == 'alsa-base'
     package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
     package.name in ['pulseaudio-utils', 'pipewire']
@@ -2930,8 +2948,9 @@ category_id: dock-audio
 plugin: user-interact
 estimated_duration: 60.0
 _summary: Microphone recognized when plugged to the dock test
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_daemon.sh ; then
@@ -2965,8 +2984,9 @@ estimated_duration: 30.0
 flags: also-after-suspend
 _summary: External microphone plugged to the dock to record sound test
 depends: dock/all-init-audio-microphone-plug-detection
+imports: from com.canonical.plainbox import manifest
 requires:
-    device.category == 'AUDIO'
+    manifest.has_audio_playback == 'True'
     package.name == 'alsa-base'
     package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
     package.name in ['pulseaudio-utils', 'pipewire']

--- a/providers/base/units/dock/jobs.pxu
+++ b/providers/base/units/dock/jobs.pxu
@@ -471,6 +471,7 @@ depends: dock/audio-playback-headphones
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_audio_playback == 'True'
+ manifest.has_audio_capture == 'True'
  package.name == 'alsa-base'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
  package.name in ['pulseaudio-utils', 'pipewire']
@@ -2987,6 +2988,7 @@ depends: dock/all-init-audio-microphone-plug-detection
 imports: from com.canonical.plainbox import manifest
 requires:
     manifest.has_audio_playback == 'True'
+    manifest.has_audio_capture == 'True'
     package.name == 'alsa-base'
     package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
     package.name in ['pulseaudio-utils', 'pipewire']

--- a/providers/base/units/info/jobs.pxu
+++ b/providers/base/units/info/jobs.pxu
@@ -321,10 +321,11 @@ _summary: Gather touchpad name, driver name, and driver version information.
 plugin: attachment
 category_id: com.canonical.plainbox::info
 id: info/audio_device_driver
+imports: from com.canonical.plainbox import manifest
 requires:
  package.name == 'pulseaudio-utils'
  package.name == 'kmod' or package.name == 'module-init-tools'
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
 command: audio_driver_info.py
 estimated_duration: 0.177
 _purpose: Lists the device driver and version for all audio devices.

--- a/providers/base/units/keys/jobs.pxu
+++ b/providers/base/units/keys/jobs.pxu
@@ -226,7 +226,7 @@ estimated_duration: 60.0
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_special_keys == 'True'
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name in ['pulseaudio-utils', 'pipewire']
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
@@ -284,7 +284,7 @@ _purpose:
 _steps:
  1. Press the keyboard overhead light key or switch on the light
  2. Check that the keyboard overhead light turns on correctly
- 3. Press the key or switch again to toggle off the light 
+ 3. Press the key or switch again to toggle off the light
 _verification:
  Did the keyboard overhead light key or switch turn on and off the light?
 _summary: Test the functionality of the keyboard overhead light key or switch.

--- a/providers/base/units/suspend/suspend.pxu
+++ b/providers/base/units/suspend/suspend.pxu
@@ -30,8 +30,9 @@ plugin: shell
 category_id: com.canonical.plainbox::suspend
 id: suspend/audio_before_suspend
 estimated_duration: 1.0
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name in ['pulseaudio-utils', 'pipewire']
 _summary: Record mixer settings before suspending.
@@ -444,8 +445,9 @@ plugin: shell
 category_id: com.canonical.plainbox::suspend
 id: suspend/audio_after_suspend
 estimated_duration: 1.0
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name in ['pulseaudio-utils', 'pipewire']
 depends: suspend/suspend_advanced_auto suspend/audio_before_suspend
@@ -464,8 +466,9 @@ plugin: shell
 category_id: com.canonical.plainbox::suspend
 id: suspend/audio_after_suspend_auto
 estimated_duration: 1.2
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name in ['pulseaudio-utils', 'pipewire']
 depends: suspend/suspend_advanced_auto suspend/audio_before_suspend
@@ -485,8 +488,9 @@ category_id: com.canonical.plainbox::suspend
 id: suspend/speaker-headphone-plug-detection-after-suspend
 depends: suspend/suspend_advanced_auto
 estimated_duration: 60.0
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'pulseaudio-utils'
 command: pulse_active_port_change.py sinks
 _purpose:
@@ -508,8 +512,9 @@ category_id: com.canonical.plainbox::suspend
 id: suspend/microphone-plug-detection-after-suspend
 depends: suspend/suspend_advanced_auto
 estimated_duration: 60.0
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'pulseaudio-utils'
 command: pulse_active_port_change.py sources
 _purpose:
@@ -531,8 +536,9 @@ category_id: com.canonical.plainbox::suspend
 id: suspend/playback_headphones-after-suspend
 estimated_duration: 20.0
 depends: audio/list_devices suspend/suspend_advanced_auto
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
  package.name == 'pulseaudio-utils'
@@ -557,8 +563,9 @@ category_id: com.canonical.plainbox::suspend
 id: suspend/alsa_record_playback_external-after-suspend
 estimated_duration: 20.0
 depends: suspend/playback_headphones-after-suspend suspend/suspend_advanced_auto
+imports: from com.canonical.plainbox import manifest
 requires:
- device.category == 'AUDIO'
+ manifest.has_audio_playback == 'True'
  package.name == 'alsa-base'
  package.name == 'pulseaudio-utils'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
@@ -1217,14 +1224,15 @@ category_id: com.canonical.plainbox::suspend
 id: suspend/record_playback_after_suspend
 estimated_duration: 10.0
 depends: suspend/suspend_advanced_auto
+imports: from com.canonical.plainbox import manifest
 requires:
+ manifest.has_audio_playback == 'True'
  package.name == 'python3-gi'
  package.name == 'gir1.2-gstreamer-1.0'
  package.name == 'libgstreamer1.0-0'
  package.name == 'gstreamer1.0-plugins-good'
  package.name == 'gstreamer1.0-pulseaudio'
  package.name == 'alsa-base'
- device.category == 'AUDIO'
 command: audio_test.py
 _purpose:
  This will check to make sure that your audio device works properly after a suspend and resume. This may work fine with speakers and onboard microphone, however, it works best if used with a cable connecting the audio-out jack to the audio-in jack.
@@ -1235,14 +1243,15 @@ category_id: com.canonical.plainbox::suspend
 id: suspend/record_playback_after_suspend_auto
 estimated_duration: 10.0
 depends: suspend/suspend_advanced_auto
+imports: from com.canonical.plainbox import manifest
 requires:
+ manifest.has_audio_playback == 'True'
  package.name == 'python3-gi'
  package.name == 'gir1.2-gstreamer-1.0'
  package.name == 'libgstreamer1.0-0'
  package.name == 'gstreamer1.0-plugins-good'
  package.name == 'gstreamer1.0-pulseaudio'
  package.name == 'alsa-base'
- device.category == 'AUDIO'
 command: audio_test.py
 _purpose: This will check to make sure that your audio device works properly after a suspend and resume. This may work fine with speakers and onboard microphone, however, it works best if used with a cable connecting the audio-out jack to the audio-in jack.
 _summary: Ensure audio device works correctly after suspend and resume cycle.
@@ -1949,7 +1958,7 @@ command: removable_storage_watcher.py --memorycard remove sdio usb scsi
 _purpose:
  This test will check that the system correctly detects the removal
  of a MS card from the system's card reader after the system has been suspended.
-_steps: 
+_steps:
  1. Click "Test" and remove the MS card from the reader.
     (Note: this test will time-out after 20 seconds.)
 _verification:

--- a/providers/base/units/suspend/suspend.pxu
+++ b/providers/base/units/suspend/suspend.pxu
@@ -566,6 +566,7 @@ depends: suspend/playback_headphones-after-suspend suspend/suspend_advanced_auto
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_audio_playback == 'True'
+ manifest.has_audio_capture == 'True'
  package.name == 'alsa-base'
  package.name == 'pulseaudio-utils'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
@@ -1227,6 +1228,7 @@ depends: suspend/suspend_advanced_auto
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_audio_playback == 'True'
+ manifest.has_audio_capture == 'True'
  package.name == 'python3-gi'
  package.name == 'gir1.2-gstreamer-1.0'
  package.name == 'libgstreamer1.0-0'
@@ -1246,6 +1248,7 @@ depends: suspend/suspend_advanced_auto
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_audio_playback == 'True'
+ manifest.has_audio_capture == 'True'
  package.name == 'python3-gi'
  package.name == 'gir1.2-gstreamer-1.0'
  package.name == 'libgstreamer1.0-0'


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

As suggested by [this comment](https://github.com/canonical/checkbox/issues/971#issuecomment-2128844608), this PR replaces the `device.category == 'AUDIO'`  with the `has_audio_playback` manifest entry. This manifest entry was selected because it seems to be used to exactly the same purpose (say if a machine is able to reproduce audio via any mean). 

> Note: this works also because the category was used to skip/execute tests but not as a template-filter 

## Resolved issues

Fixes: CHECKBOX-1224
Fixes: https://github.com/canonical/checkbox/issues/971 

## Documentation

N/A

## Tests

Bestide the statical analysis I've ran the tests on my device with no changes. 

Marking this as draft while I test it on a device that was previously skipping the test.

For the reviewer: please double check I imported the manifest everywhere, I already did multiple times, but it is better safe than sorry!
