### PR TITLE
Usb tests change base script (BugFix)

### DIFF
--- a/.github/workflows/tox-checkbox-support.yaml
+++ b/.github/workflows/tox-checkbox-support.yaml
@@ -49,6 +49,10 @@ jobs:
           PIP_TRUSTED_HOST: pypi.python.org pypi.org files.pythonhosted.org
       - name: Install tox
         run: pip install tox
+      - name: Install python systemd
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsystemd-dev python3-systemd
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/tox-checkbox-support.yaml
+++ b/.github/workflows/tox-checkbox-support.yaml
@@ -49,10 +49,10 @@ jobs:
           PIP_TRUSTED_HOST: pypi.python.org pypi.org files.pythonhosted.org
       - name: Install tox
         run: pip install tox
-      - name: Install python systemd
+      - name: Install libsystemd-dev
         run: |
           sudo apt-get update
-          sudo apt-get install -y libsystemd-dev python3-systemd
+          sudo apt-get install -y libsystemd-dev
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/tox-provider-base.yaml
+++ b/.github/workflows/tox-provider-base.yaml
@@ -47,6 +47,10 @@ jobs:
           python-version: ${{ matrix.python }}
         env:
           PIP_TRUSTED_HOST: pypi.python.org pypi.org files.pythonhosted.org
+      - name: Install libsystemd-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsystemd-dev
       - name: Install tox
         run: pip install tox
       - name: Run tox

--- a/.github/workflows/tox-provider-genio.yaml
+++ b/.github/workflows/tox-provider-genio.yaml
@@ -48,6 +48,10 @@ jobs:
           python-version: ${{ matrix.python }}
         env:
           PIP_TRUSTED_HOST: pypi.python.org pypi.org files.pythonhosted.org
+      - name: Install libsystemd-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsystemd-dev
       - name: Install tox
         run: pip install tox
       - name: Run tox

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,28 +1,5 @@
 {
     "[markdown]": {
         "editor.formatOnSave": false
-    },
-    "python.testing.pytestArgs": [
-        "checkbox-ng",
-        "checkbox-support",
-        "providers/genio/",
-        "providers/base/",
-        // "providers/sru/",
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true,
-    "python.analysis.extraPaths": [
-        "${workspaceFolder}/providers/base/bin",
-        "${workspaceFolder}/providers/genio/bin",
-        "${workspaceFolder}/checkbox-ng",
-        "${workspaceFolder}/providers/base",
-        // "${workspaceFolder}/providers/sru/bin",
-    ],
-    "cSpell.ignoreWords": [
-        "bluz",
-        "clazz",
-        "pipewire",
-        "rtype"
-    ],
-    "cmake.configureOnOpen": false,
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,28 @@
 {
     "[markdown]": {
         "editor.formatOnSave": false
-    }
+    },
+    "python.testing.pytestArgs": [
+        "checkbox-ng",
+        "checkbox-support",
+        "providers/genio/",
+        "providers/base/",
+        // "providers/sru/",
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.analysis.extraPaths": [
+        "${workspaceFolder}/providers/base/bin",
+        "${workspaceFolder}/providers/genio/bin",
+        "${workspaceFolder}/checkbox-ng",
+        "${workspaceFolder}/providers/base",
+        // "${workspaceFolder}/providers/sru/bin",
+    ],
+    "cSpell.ignoreWords": [
+        "bluz",
+        "clazz",
+        "pipewire",
+        "rtype"
+    ],
+    "cmake.configureOnOpen": false,
 }

--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -39,27 +39,27 @@ class StorageInterface(ABC):
     """
 
     @abstractmethod
-    def _check_logs_for_insertion(self, line_str):
+    def _parse_journal_line(self, line_str):
         """
-        callback that looks for the expected log lines in the journal during
-        the insertion test.
-        """
-        pass
+        Parse the journal line and update the attributes based on the line
+        content.
 
-    @abstractmethod
-    def _check_logs_for_removal(self, line_str):
-        """
-        callback that looks for the expected log lines in the journal during
-        the removal test.
+        :param line_str: str of the scanned log lines.
         """
         pass
 
     @abstractmethod
     def _validate_insertion(self):
+        """
+        Check if the that the storage was inserted correctly.
+        """
         pass
 
     @abstractmethod
     def _validate_removal(self):
+        """
+        Check if the that the storage was removed correctly.
+        """
         pass
 
 
@@ -112,6 +112,10 @@ class StorageWatcher(StorageInterface):
             )
 
     def _process_lines(self, lines):
+        """
+        Process the lines from the journal and call the callback function to
+        validate the insertion or removal of the storage.
+        """
         for line in lines:
             line_str = str(line)
             logger.debug(line_str)
@@ -220,8 +224,6 @@ class USBStorage(StorageWatcher):
 
         It uses dictionaries to match the expected log lines with the
         attributes.
-
-        :param line_str: str of the scanned log lines.
         """
 
         device_log_dict = {

--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -257,7 +257,7 @@ class USBStorage(StorageWatcher):
             self.action = "removal"
 
         # Extract the partition name. Looking for string like "sdb: sdb1"
-        part_re = re.compile("sd\w+:.*(?P<part_name>sd\w+)")
+        part_re = re.compile(r"sd\w+:.*(?P<part_name>sd\w+)")
         match = re.search(part_re, line_str)
         if match:
             self.mounted_partition = match.group("part_name")
@@ -304,7 +304,7 @@ class MediacardStorage(StorageWatcher):
         """
 
         # Extract the partition name. Looking for string like "mmcblk0: p1"
-        part_re = re.compile("mmcblk(?P<dev_num>\d)+: (?P<part_name>p\d+)")
+        part_re = re.compile(r"mmcblk(?P<dev_num>\d)+: (?P<part_name>p\d+)")
         match = re.search(part_re, line_str)
         if match:
             self.mounted_partition = "mmcblk{}{}".format(
@@ -313,7 +313,7 @@ class MediacardStorage(StorageWatcher):
 
         # Look for insertion action
         insertion_re = re.compile(
-            "new (?P<device>.*) card at address (?P<address>[0-9a-fA-F]+)"
+            r"new (?P<device>.*) card at address (?P<address>[0-9a-fA-F]+)"
         )
         insertion_match = re.search(insertion_re, line_str)
         if re.search(insertion_re, line_str):
@@ -322,7 +322,7 @@ class MediacardStorage(StorageWatcher):
             self.address = insertion_match.group("address")
 
         # Look for removal action
-        removal_re = re.compile("card ([0-9a-fA-F]+) removed")
+        removal_re = re.compile(r"card ([0-9a-fA-F]+) removed")
         if re.search(removal_re, line_str):
             self.action = "removal"
 
@@ -360,7 +360,7 @@ class ThunderboltStorage(StorageWatcher):
     def _parse_journal_line(self, line_str):
 
         # Extract the partition name. Looking for string like "nvme0n1: p1"
-        part_re = re.compile("(?P<dev_num>nvme\w+): (?P<part_name>p\d+)")
+        part_re = re.compile(r"(?P<dev_num>nvme\w+): (?P<part_name>p\d+)")
         match = re.search(part_re, line_str)
         if match:
             self.mounted_partition = "{}{}".format(
@@ -368,13 +368,13 @@ class ThunderboltStorage(StorageWatcher):
             )
 
         # Prefix of the thunderbolt device for regex matching
-        RE_PREFIX = "thunderbolt \d+-\d+:"
+        RE_PREFIX = r"thunderbolt \d+-\d+:"
 
-        insertion_re = re.compile("{} new device found".format(RE_PREFIX))
+        insertion_re = re.compile(r"{} new device found".format(RE_PREFIX))
         if re.search(insertion_re, line_str):
             self.action = "insertion"
 
-        removal_re = re.compile("{} device disconnected".format(RE_PREFIX))
+        removal_re = re.compile(r"{} device disconnected".format(RE_PREFIX))
         if re.search(removal_re, line_str):
             self.action = "removal"
 

--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -9,7 +9,6 @@
 this script monitors the systemd journal to catch insert/removal USB events
 """
 import argparse
-import contextlib
 import logging
 import os
 import pathlib
@@ -19,7 +18,6 @@ import sys
 import time
 from systemd import journal
 from abc import ABC, abstractmethod
-from enum import Enum
 
 from checkbox_support.helpers.timeout import timeout
 from checkbox_support.scripts.zapper_proxy import zapper_run
@@ -175,7 +173,7 @@ class StorageWatcher(StorageInterface):
 
 class USBStorage(StorageWatcher):
     """
-    USBStorage handles the insertion and removal of usb2, usb3 and mediacard.
+    USBStorage handles the insertion and removal of usb2 and usb3.
     """
 
     def __init__(self, *args):
@@ -351,7 +349,7 @@ class ThunderboltStorage(StorageWatcher):
             self._store_storage_info(self.mounted_partition)
             sys.exit()
 
-    def _validate_removal(self, line_str):
+    def _validate_removal(self):
         if self.action == "removal":
             logger.info("Thunderbolt removal test passed.")
 

--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -52,7 +52,7 @@ class StorageInterface(ABC):
 
 class StorageWatcher:
     """
-    StorageWatcher watches the journal message and triggeres the callback
+    StorageWatcher watches the journal message and triggers the callback
     function to detect the insertion and removal of storage.
 
     """
@@ -123,7 +123,7 @@ class StorageWatcher:
 
 class USBStorage(StorageInterface):
     """
-    USBStorage hanldes the insertion and removal of usb2, usb3 and mediacard.
+    USBStorage handles the insertion and removal of usb2, usb3 and mediacard.
     """
 
     MOUNTED_PARTITION = None
@@ -163,7 +163,7 @@ class USBStorage(StorageInterface):
                     driver = key
             logger.info("{} was inserted {} controller".format(device, driver))
             logger.info("usable partition: {}".format(self.MOUNTED_PARTITION))
-            # judge the detection by the expection
+            # judge the detection by the expectation
             if self.args.storage_type == "usb2" and device in (
                 "new SuperSpeed USB device number",
                 "new SuperSpeed Gen 1 USB device number",
@@ -298,7 +298,7 @@ class ThunderboltStorage(StorageInterface):
             # success until the requirement of new device string and partition
             # marked as true
             if self.find_insertion_string and self.find_partition:
-                logger.info("Tunderbolt insertion test passed.")
+                logger.info("Thunderbolt insertion test passed.")
                 sys.exit()
         elif self.args.testcase == "removal":
             self.report_removal(line_str)

--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -35,9 +35,9 @@ class StorageInterface(ABC):
     """
 
     @abstractmethod
-    def do_callback(self, line_str):
+    def callback(self, line_str):
         """
-        do_callback handles the line string from journal.
+        callback handles the line string from journal.
         """
         pass
 
@@ -96,13 +96,15 @@ class StorageWatcher:
         while p.poll():
             if j.process() != journal.APPEND:
                 continue
-            self._callback([e["MESSAGE"] for e in j if e and "MESSAGE" in e])
+            self._process_lines(
+                [e["MESSAGE"] for e in j if e and "MESSAGE" in e]
+            )
 
-    def _callback(self, lines):
+    def _process_lines(self, lines):
         for line in lines:
             line_str = str(line)
             logger.debug(line_str)
-            self._storage_strategy.do_callback(line_str)
+            self._storage_strategy.callback(line_str)
 
     def _no_storage_timeout(self, signum, frame):
         """
@@ -139,7 +141,7 @@ class USBStorage(StorageInterface):
     def __init__(self, args):
         self.args = args
 
-    def do_callback(self, line_str):
+    def callback(self, line_str):
         self._refresh_detection(line_str)
         self._get_partition_info(line_str)
         self._report_detection()
@@ -230,7 +232,7 @@ class MediacardStorage(StorageInterface):
     def __init__(self, args):
         self.args = args
 
-    def do_callback(self, line_str):
+    def callback(self, line_str):
         if self.args.testcase == "insertion":
             self._get_partition_info(line_str)
             self.report_insertion()
@@ -287,7 +289,7 @@ class ThunderboltStorage(StorageInterface):
         self.find_insertion_string = 0
         self.find_partition = 0
 
-    def do_callback(self, line_str):
+    def callback(self, line_str):
         if self.args.testcase == "insertion":
             self._get_partition_info(line_str)
             self.report_insertion(line_str)

--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -162,20 +162,20 @@ class USBStorage(StorageInterface):
             logger.info("{} was inserted {} controller".format(device, driver))
             logger.info("usable partition: {}".format(self.MOUNTED_PARTITION))
             # judge the detection by the expection
-            if (
-                self.args.storage_type == "usb2"
-                and device == "new high-speed USB device number"
+            if self.args.storage_type == "usb2" and device in (
+                "new SuperSpeed USB device number",
+                "new SuperSpeed Gen 1 USB device number",
+                "new high-speed USB device number",
             ):
                 logger.info("USB2 insertion test passed.")
 
-            if self.args.storage_type == "usb3" and (
-                device
-                in (
-                    "new SuperSpeed USB device number",
-                    "new SuperSpeed Gen 1 USB device number",
-                )
+            elif self.args.storage_type == "usb3" and device in (
+                "new SuperSpeed USB device number",
+                "new SuperSpeed Gen 1 USB device number",
             ):
                 logger.info("USB3 insertion test passed.")
+            else:
+                sys.exit("Wrong USB")
 
             # backup the storage info
             storage_info_helper(

--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -379,8 +379,7 @@ class ThunderboltStorage(StorageWatcher):
             self.action = "removal"
 
 
-@timeout(ACTION_TIMEOUT)  # 30 seconds timeout
-def main():
+def launch_watcher():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "testcase",
@@ -413,6 +412,11 @@ def main():
             args.testcase, args.storage_type, args.zapper_usb_address
         )
     watcher.run()
+
+
+@timeout(ACTION_TIMEOUT)  # 30 seconds timeout
+def main():
+    launch_watcher()
 
 
 if __name__ == "__main__":

--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -51,7 +51,7 @@ class StorageInterface(ABC):
         pass
 
 
-class StorageWatcher:
+class StorageWatcher(StorageInterface):
     """
     StorageWatcher watches the journal message and triggers the callback
     function to detect the insertion and removal of storage.
@@ -61,9 +61,8 @@ class StorageWatcher:
     ACTION_TIMEOUT = 30  # sec
     logger.info("Timeout: {} seconds".format(ACTION_TIMEOUT))
 
-    def __init__(self, args, storage_strategy):
+    def __init__(self, args):
         self.args = args
-        self._storage_strategy = storage_strategy
         signal.signal(signal.SIGALRM, self._no_storage_timeout)
         signal.alarm(self.ACTION_TIMEOUT)
 
@@ -105,7 +104,7 @@ class StorageWatcher:
         for line in lines:
             line_str = str(line)
             logger.debug(line_str)
-            self._storage_strategy.callback(line_str)
+            self.callback(line_str)
 
     def _no_storage_timeout(self, signum, frame):
         """
@@ -428,11 +427,11 @@ def main():
 
     watcher = None
     if args.storage_type == "thunderbolt":
-        watcher = StorageWatcher(args, ThunderboltStorage(args))
+        watcher = ThunderboltStorage(args)
     elif args.storage_type == "mediacard":
-        watcher = StorageWatcher(args, MediacardStorage(args))
+        watcher = MediacardStorage(args)
     else:
-        watcher = StorageWatcher(args, USBStorage(args))
+        watcher = USBStorage(args)
     watcher.run()
 
 

--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -240,11 +240,11 @@ class USBStorage(StorageWatcher):
         if self.action == USBStorage.Action.REMOVAL:
             logger.info("Removal test passed.")
 
-        # remove the storage info
-        self._storage_info_helper(
-            reserve=False, storage_type=self.args.storage_type
-        )
-        sys.exit()
+            # remove the storage info
+            self._storage_info_helper(
+                reserve=False, storage_type=self.args.storage_type
+            )
+            sys.exit()
 
     def _get_partition_info(self, line_str):
         """get partition info."""
@@ -314,11 +314,11 @@ class MediacardStorage(StorageWatcher):
         if match:
             logger.info("Mediacard removal test passed.")
 
-        # remove the storage info
-        self._storage_info_helper(
-            reserve=False, storage_type=self.args.storage_type
-        )
-        sys.exit()
+            # Storage removal info
+            self._storage_info_helper(
+                reserve=False, storage_type=self.args.storage_type
+            )
+            sys.exit()
 
     def _get_partition_info(self, line_str):
         """get partition info."""
@@ -383,7 +383,7 @@ class ThunderboltStorage(StorageWatcher):
         match = re.search(remove_re, line_str)
         if match:
             logger.info("Thunderbolt removal test passed.")
-            # remove the storage info
+            # Storage removal info
             self._storage_info_helper(
                 reserve=False, storage_type=self.args.storage_type
             )

--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -167,7 +167,6 @@ class USBStorage(StorageInterface):
                 and self.device == self.Device.HIGH_SPEED_USB
             ):
                 logger.info("USB2 insertion test passed.")
-
             elif self.args.storage_type == "usb3" and self.device in [
                 self.Device.SUPER_SPEED_USB,
                 self.Device.SUPER_SPEED_GEN1_USB,

--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -154,7 +154,10 @@ class USBStorage(StorageInterface):
         self._report_detection()
 
     def report_insertion(self):
-        if self.mounted_partition and self.action == self.Action.INSERTION:
+        if (
+            self.mounted_partition
+            and self.action == USBStorage.Action.INSERTION
+        ):
             logger.info(
                 "{} was inserted {} controller".format(
                     self.device.value, self.driver.value
@@ -164,12 +167,12 @@ class USBStorage(StorageInterface):
             # judge the detection by the expectation
             if (
                 self.args.storage_type == "usb2"
-                and self.device == self.Device.HIGH_SPEED_USB
+                and self.device == USBStorage.Device.HIGH_SPEED_USB
             ):
                 logger.info("USB2 insertion test passed.")
             elif self.args.storage_type == "usb3" and self.device in [
-                self.Device.SUPER_SPEED_USB,
-                self.Device.SUPER_SPEED_GEN1_USB,
+                USBStorage.Device.SUPER_SPEED_USB,
+                USBStorage.Device.SUPER_SPEED_GEN1_USB,
             ]:
                 logger.info("USB3 insertion test passed.")
             else:

--- a/checkbox-support/checkbox_support/scripts/usb_read_write.py
+++ b/checkbox-support/checkbox_support/scripts/usb_read_write.py
@@ -32,10 +32,7 @@ import errno
 import contextlib
 
 
-PLAINBOX_SESSION_SHARE = os.environ.get(
-    "PLAINBOX_SESSION_SHARE",
-    "/var/tmp/checkbox-ng/sessions/checkbox-run-2024-06-12T14.45.29.session/session-share",
-)
+PLAINBOX_SESSION_SHARE = os.environ.get("PLAINBOX_SESSION_SHARE", "")
 FOLDER_TO_MOUNT = tempfile.mkdtemp()
 REPETITION_NUM = 5  # number to repeat the read/write test units.
 # Prepare a random file which size is RANDOM_FILE_SIZE.

--- a/checkbox-support/checkbox_support/tests/test_run_watcher.py
+++ b/checkbox-support/checkbox_support/tests/test_run_watcher.py
@@ -60,10 +60,10 @@ class TestRunWatcher(unittest.TestCase):
     def test_usb2_storage_report_insertion(self):
         mock_usb_storage = MagicMock()
         mock_usb_storage.args.storage_type = "usb2"
-        mock_usb_storage.device = USBStorage.Device.HIGH_SPEED_USB
+        mock_usb_storage.device = "high_speed_usb"
         mock_usb_storage.mounted_partition = "mounted_partition"
-        mock_usb_storage.action = USBStorage.Action.INSERTION
-        mock_usb_storage.driver = USBStorage.Driver.USING_EHCI_HCD
+        mock_usb_storage.action = "insertion"
+        mock_usb_storage.driver = "ehci_hcd"
         with self.assertRaises(SystemExit) as cm:
             USBStorage.report_insertion(mock_usb_storage)
         self.assertEqual(cm.exception.code, None)
@@ -71,10 +71,10 @@ class TestRunWatcher(unittest.TestCase):
     def test_usb3_storage_report_insertion(self):
         mock_usb_storage = MagicMock()
         mock_usb_storage.args.storage_type = "usb3"
-        mock_usb_storage.device = USBStorage.Device.SUPER_SPEED_USB
+        mock_usb_storage.device = "super_speed_usb"
         mock_usb_storage.mounted_partition = "mounted_partition"
-        mock_usb_storage.action = USBStorage.Action.INSERTION
-        mock_usb_storage.driver = USBStorage.Driver.USING_XHCI_HCD
+        mock_usb_storage.action = "insertion"
+        mock_usb_storage.driver = "xhci_hcd"
         with self.assertRaises(SystemExit) as cm:
             USBStorage.report_insertion(mock_usb_storage)
         self.assertEqual(cm.exception.code, None)
@@ -82,17 +82,17 @@ class TestRunWatcher(unittest.TestCase):
     def test_usb_storage_report_insertion_wrong_usb_type(self):
         mock_usb_storage = MagicMock()
         mock_usb_storage.args.storage_type = "usb2"
-        mock_usb_storage.device = USBStorage.Device.SUPER_SPEED_USB
+        mock_usb_storage.device = "super_speed_usb"
         mock_usb_storage.mounted_partition = "mounted_partition"
-        mock_usb_storage.action = USBStorage.Action.INSERTION
-        mock_usb_storage.driver = USBStorage.Driver.USING_XHCI_HCD
+        mock_usb_storage.action = "insertion"
+        mock_usb_storage.driver = "ehci_hcd"
         with self.assertRaises(SystemExit) as cm:
             USBStorage.report_insertion(mock_usb_storage)
         cm.exception.args[0] == "Wrong USB type detected."
 
     def test_usb_storage_report_removal(self):
         mock_usb_storage = MagicMock()
-        mock_usb_storage.action = USBStorage.Action.REMOVAL
+        mock_usb_storage.action = "removal"
         with self.assertRaises(SystemExit) as cm:
             USBStorage.report_removal(mock_usb_storage)
         self.assertEqual(cm.exception.code, None)
@@ -105,17 +105,17 @@ class TestRunWatcher(unittest.TestCase):
 
     def test_usb_storage_refresh_detection(self):
         mock_usb_storage = MagicMock()
-        line_str = "new high-speed USB device number 2 using xhci_hcd"
+        line_str = "new high-speed USB device number 2 using ehci_hcd"
         USBStorage._refresh_detection(mock_usb_storage, line_str)
         self.assertEqual(
-            mock_usb_storage.driver, USBStorage.Driver.USING_XHCI_HCD
+            mock_usb_storage.driver, "ehci_hcd"
         )
         self.assertEqual(
-            mock_usb_storage.device, USBStorage.Device.HIGH_SPEED_USB
+            mock_usb_storage.device, "high_speed_usb"
         )
         line_str = "USB Mass Storage device detected"
         USBStorage._refresh_detection(mock_usb_storage, line_str)
-        self.assertEqual(mock_usb_storage.action, USBStorage.Action.INSERTION)
+        self.assertEqual(mock_usb_storage.action, "insertion")
 
     def test_usb_storage_report_detection_insertion(self):
         mock_usb_storage = MagicMock()

--- a/checkbox-support/checkbox_support/tests/test_run_watcher.py
+++ b/checkbox-support/checkbox_support/tests/test_run_watcher.py
@@ -3,7 +3,7 @@
 #
 # Copyright 2024 Canonical Ltd.
 # Authors:
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
@@ -33,114 +33,6 @@ from checkbox_support.scripts.run_watcher import (
 
 
 class TestRunWatcher(unittest.TestCase):
-    # class StorageWatcher(StorageInterface):
-    # """
-    # StorageWatcher watches the journal message and triggers the callback
-    # function to detect the insertion and removal of storage.
-    # """
-
-    # def __init__(self, testcase, storage_type, zapper_usb_address):
-    #     self.testcase = testcase
-    #     self.storage_type = storage_type
-    #     self.zapper_usb_address = zapper_usb_address
-
-    # def run(self):
-    #     j = journal.Reader()
-    #     j.seek_realtime(time.time())
-    #     p = select.poll()
-    #     p.register(j, j.get_events())
-    #     if self.zapper_usb_address:
-    #         zapper_host = os.environ.get("ZAPPER_ADDRESS")
-    #         if not zapper_host:
-    #             raise SystemExit(
-    #                 "ZAPPER_ADDRESS environment variable not found!"
-    #             )
-    #         usb_address = self.zapper_usb_address
-    #         if self.testcase == "insertion":
-    #             print("Calling zapper to connect the USB device")
-    #             zapper_run(
-    #                 zapper_host, "typecmux_set_state", usb_address, "DUT"
-    #             )
-    #         elif self.testcase == "removal":
-    #             print("Calling zapper to disconnect the USB device")
-    #             zapper_run(
-    #                 zapper_host, "typecmux_set_state", usb_address, "OFF"
-    #             )
-    #     else:
-    #         if self.testcase == "insertion":
-    #             print("\n\nINSERT NOW\n\n", flush=True)
-    #         elif self.testcase == "removal":
-    #             print("\n\nREMOVE NOW\n\n", flush=True)
-    #         else:
-    #             raise SystemExit("Invalid test case")
-    #         print("Timeout: {} seconds".format(ACTION_TIMEOUT), flush=True)
-    #     while p.poll():
-    #         if j.process() != journal.APPEND:
-    #             continue
-    #         self._process_lines(
-    #             [e["MESSAGE"] for e in j if e and "MESSAGE" in e]
-    #         )
-
-    # def _process_lines(self, lines):
-    #     """
-    #     Process the lines from the journal and call the callback function to
-    #     validate the insertion or removal of the storage.
-    #     """
-    #     for line in lines:
-    #         line_str = str(line)
-    #         logger.debug(line_str)
-    #         if self.testcase == "insertion":
-    #             self._parse_journal_line(line_str)
-    #             self._validate_insertion()
-    #         elif self.testcase == "removal":
-    #             self._parse_journal_line(line_str)
-    #             self._validate_removal()
-
-    # def _store_storage_info(self, mounted_partition=""):
-    #     """
-    #     Store the mounted partition info to the shared directory.
-    #     """
-
-    #     plainbox_session_share = os.environ.get("PLAINBOX_SESSION_SHARE")
-    #     # TODO: Should name the file by the value of storage_type variable as
-    #     #       prefix. e.g. thunderbolt_insert_info, mediacard_insert_info.
-    #     #       Since usb_insert_info is used by usb_read_write script, we
-    #     #       should refactor usb_read_write script to adopt different files
-    #     file_name = "usb_insert_info"
-
-    #     if not plainbox_session_share:
-    #         logger.error("no env var PLAINBOX_SESSION_SHARE")
-    #         sys.exit(1)
-
-    #     # backup the storage partition info
-    #     if mounted_partition:
-    #         logger.info(
-    #             "cache file {} is at: {}".format(
-    #                 file_name, plainbox_session_share
-    #             )
-    #         )
-    #         file_path = pathlib.Path(plainbox_session_share, file_name)
-    #         with open(file_path, "w") as file_to_share:
-    #             file_to_share.write(mounted_partition + "\n")
-
-    # def _remove_storage_info(self):
-    #     """Remove the file containing the storage info from the shared
-    #     directory.
-    #     """
-
-    #     plainbox_session_share = os.environ.get("PLAINBOX_SESSION_SHARE")
-    #     file_name = "usb_insert_info"
-
-    #     if not plainbox_session_share:
-    #         logger.error("no env var PLAINBOX_SESSION_SHARE")
-    #         sys.exit(1)
-
-    #     file_path = pathlib.Path(plainbox_session_share, file_name)
-    #     if pathlib.Path(file_path).exists():
-    #         os.remove(file_path)
-    #         logger.info("cache file {} removed".format(file_name))
-    #     else:
-    #         logger.error("cache file {} not found".format(file_name))
 
     @patch("systemd.journal.Reader")
     @patch("select.poll")

--- a/checkbox-support/checkbox_support/tests/test_run_watcher.py
+++ b/checkbox-support/checkbox_support/tests/test_run_watcher.py
@@ -33,115 +33,6 @@ from checkbox_support.scripts.run_watcher import (
 
 class TestRunWatcher(unittest.TestCase):
 
-    # class StorageWatcher(StorageInterface):
-    #     """
-    #     StorageWatcher watches the journal message and triggers the callback
-    #     function to detect the insertion and removal of storage.
-    #     """
-
-    #     def __init__(self, testcase, storage_type, zapper_usb_address):
-    #         self.testcase = testcase
-    #         self.storage_type = storage_type
-    #         self.zapper_usb_address = zapper_usb_address
-
-    #     def run(self):
-    #         j = journal.Reader()
-    #         j.seek_realtime(time.time())
-    #         p = select.poll()
-    #         p.register(j, j.get_events())
-    #         if self.zapper_usb_address:
-    #             zapper_host = os.environ.get("ZAPPER_ADDRESS")
-    #             if not zapper_host:
-    #                 raise SystemExit(
-    #                     "ZAPPER_ADDRESS environment variable not found!"
-    #                 )
-    #             usb_address = self.zapper_usb_address
-    #             if self.testcase == "insertion":
-    #                 print("Calling zapper to connect the USB device")
-    #                 zapper_run(
-    #                     zapper_host, "typecmux_set_state", usb_address, "DUT"
-    #                 )
-    #             elif self.testcase == "removal":
-    #                 print("Calling zapper to disconnect the USB device")
-    #                 zapper_run(
-    #                     zapper_host, "typecmux_set_state", usb_address, "OFF"
-    #                 )
-    #         else:
-    #             if self.testcase == "insertion":
-    #                 print("\n\nINSERT NOW\n\n", flush=True)
-    #             elif self.testcase == "removal":
-    #                 print("\n\nREMOVE NOW\n\n", flush=True)
-    #             else:
-    #                 raise SystemExit("Invalid test case")
-    #             print("Timeout: {} seconds".format(ACTION_TIMEOUT), flush=True)
-    #         while p.poll():
-    #             if j.process() != journal.APPEND:
-    #                 continue
-    #             self._process_lines(
-    #                 [e["MESSAGE"] for e in j if e and "MESSAGE" in e]
-    #             )
-
-    #     def _process_lines(self, lines):
-    #         """
-    #         Process the lines from the journal and call the callback function to
-    #         validate the insertion or removal of the storage.
-    #         """
-    #         for line in lines:
-    #             line_str = str(line)
-    #             logger.debug(line_str)
-    #             if self.testcase == "insertion":
-    #                 self._parse_journal_line(line_str)
-    #                 self._validate_insertion()
-    #             elif self.testcase == "removal":
-    #                 self._parse_journal_line(line_str)
-    #                 self._validate_removal()
-
-    #     def _store_storage_info(self, mounted_partition=""):
-    #         """
-    #         Store the mounted partition info to the shared directory.
-    #         """
-
-    #         plainbox_session_share = os.environ.get("PLAINBOX_SESSION_SHARE")
-    #         # TODO: Should name the file by the value of storage_type variable as
-    #         #       prefix. e.g. thunderbolt_insert_info, mediacard_insert_info.
-    #         #       Since usb_insert_info is used by usb_read_write script, we
-    #         #       should refactor usb_read_write script to adopt different files
-    #         file_name = "usb_insert_info"
-
-    #         if not plainbox_session_share:
-    #             logger.error("no env var PLAINBOX_SESSION_SHARE")
-    #             sys.exit(1)
-
-    #         # backup the storage partition info
-    #         if mounted_partition:
-    #             logger.info(
-    #                 "cache file {} is at: {}".format(
-    #                     file_name, plainbox_session_share
-    #                 )
-    #             )
-    #             file_path = pathlib.Path(plainbox_session_share, file_name)
-    #             with open(file_path, "w") as file_to_share:
-    #                 file_to_share.write(mounted_partition + "\n")
-
-    #     def _remove_storage_info(self):
-    #         """Remove the file containing the storage info from the shared
-    #         directory.
-    #         """
-
-    #         plainbox_session_share = os.environ.get("PLAINBOX_SESSION_SHARE")
-    #         file_name = "usb_insert_info"
-
-    #         if not plainbox_session_share:
-    #             logger.error("no env var PLAINBOX_SESSION_SHARE")
-    #             sys.exit(1)
-
-    #         file_path = pathlib.Path(plainbox_session_share, file_name)
-    #         if pathlib.Path(file_path).exists():
-    #             os.remove(file_path)
-    #             logger.info("cache file {} removed".format(file_name))
-    #         else:
-    #             logger.error("cache file {} not found".format(file_name))
-
     def test_storage_watcher_process_lines(self):
         lines = ["line1", "line2", "line3"]
 
@@ -152,16 +43,6 @@ class TestRunWatcher(unittest.TestCase):
         mock_insertion_watcher._parse_journal_line.assert_has_calls(
             [call("line1"), call("line2"), call("line3")]
         )
-        mock_insertion_watcher._validate_insertion.assert_called()
-
-        mock_removal_watcher = MagicMock()
-        mock_removal_watcher._parse_journal_line = MagicMock()
-        mock_removal_watcher.testcase = "removal"
-        StorageWatcher._process_lines(mock_removal_watcher, lines)
-        mock_removal_watcher._parse_journal_line.assert_has_calls(
-            [call("line1"), call("line2"), call("line3")]
-        )
-        mock_insertion_watcher._validate_insertion.assert_called()
 
     @patch("os.environ.get")
     def test_storage_watcher_store_storage_info(self, mock_get):
@@ -331,57 +212,6 @@ class TestRunWatcher(unittest.TestCase):
         MediacardStorage._parse_journal_line(mock_mediacard_storage, line_str)
         self.assertEqual(mock_mediacard_storage.action, "removal")
 
-    # class ThunderboltStorage(StorageWatcher):
-    #     """
-    #     ThunderboltStorage handles the insertion and removal of thunderbolt
-    #     storage.
-    #     """
-
-    #     def __init__(self, *args):
-    #         super().__init__(*args)
-    #         self.mounted_partition = None
-    #         self.action = None
-
-    #     def _validate_insertion(self):
-    #         # The insertion will be valid if the insertion action is detected and
-    #         # the mounted partition is found.
-    #         if self.action == "insertion" and self.mounted_partition:
-    #             logger.info("usable partition: {}".format(self.mounted_partition))
-    #             logger.info("Thunderbolt insertion test passed.")
-
-    #             # backup the storage info
-    #             self._store_storage_info(self.mounted_partition)
-    #             sys.exit()
-
-    #     def _validate_removal(self, line_str):
-    #         if self.action == "removal":
-    #             logger.info("Thunderbolt removal test passed.")
-
-    #             # remove the storage info
-    #             self._remove_storage_info()
-    #             sys.exit()
-
-    #     def _parse_journal_line(self, line_str):
-
-    #         # Extract the partition name. Looking for string like "nvme0n1: p1"
-    #         part_re = re.compile("(?P<dev_num>nvme\w+): (?P<part_name>p\d+)")
-    #         match = re.search(part_re, line_str)
-    #         if match:
-    #             self.mounted_partition = "{}{}".format(
-    #                 match.group("dev_num"), match.group("part_name")
-    #             )
-
-    #         # Prefix of the thunderbolt device for regex matching
-    #         RE_PREFIX = "thunderbolt \d+-\d+:"
-
-    #         insertion_re = re.compile("{} new device found".format(RE_PREFIX))
-    #         if re.search(insertion_re, line_str):
-    #             self.action = "insertion"
-
-    #         removal_re = re.compile("{} device disconnected".format(RE_PREFIX))
-    #         if re.search(removal_re, line_str):
-    #             self.action = "removal"
-
     def test_thunderbolt_storage_init(self):
         thunderbolt_storage = ThunderboltStorage(
             "insertion", "thunderbolt", "zapper_addr"
@@ -417,6 +247,29 @@ class TestRunWatcher(unittest.TestCase):
         mock_thunderbolt_storage = MagicMock()
         mock_thunderbolt_storage.action = ""
         ThunderboltStorage._validate_removal(mock_thunderbolt_storage)
+
+    def test_thunderbolt_storage_parse_journal_line(self):
+        mock_thunderbolt_storage = MagicMock()
+
+        line_str = "nvme0n1: p1"
+        ThunderboltStorage._parse_journal_line(
+            mock_thunderbolt_storage, line_str
+        )
+        self.assertEqual(
+            mock_thunderbolt_storage.mounted_partition, "nvme0n1p1"
+        )
+
+        line_str = "thunderbolt 1-1: new device found"
+        ThunderboltStorage._parse_journal_line(
+            mock_thunderbolt_storage, line_str
+        )
+        self.assertEqual(mock_thunderbolt_storage.action, "insertion")
+
+        line_str = "thunderbolt 1-1: device disconnected"
+        ThunderboltStorage._parse_journal_line(
+            mock_thunderbolt_storage, line_str
+        )
+        self.assertEqual(mock_thunderbolt_storage.action, "removal")
 
     @patch("checkbox_support.scripts.run_watcher.USBStorage", spec=USBStorage)
     def test_main_usb(self, mock_usb_storage):

--- a/checkbox-support/checkbox_support/tests/test_run_watcher.py
+++ b/checkbox-support/checkbox_support/tests/test_run_watcher.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Authors:
+#   Fernando Bravo <daniel.manrique@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+from checkbox_support.scripts.run_watcher import (
+    StorageWatcher,
+    USBStorage,
+    MediacardStorage,
+    ThunderboltStorage,
+    main,
+)
+
+
+class TestRunWatcher(unittest.TestCase):
+
+    def test_process_lines(self):
+        mock_storage_watcher = MagicMock()
+        mock_storage_watcher.callback = MagicMock()
+        lines = ["line1", "line2", "line3"]
+        StorageWatcher._process_lines(mock_storage_watcher, lines)
+        mock_storage_watcher.callback.assert_called()
+
+    def test_usb_storage_init(self):
+        usb_storage = USBStorage("args")
+        self.assertEqual(usb_storage.args, "args")
+        self.assertIsNone(usb_storage.mounted_partition)
+        self.assertIsNone(usb_storage.device)
+        self.assertIsNone(usb_storage.number)
+        self.assertIsNone(usb_storage.driver)
+        self.assertIsNone(usb_storage.action)
+
+    def test_usb_storage_callback(self):
+        mock_usb_storage = MagicMock()
+        line_str = "line_str"
+        USBStorage.callback(mock_usb_storage, line_str)
+        mock_usb_storage._refresh_detection.assert_called_with(line_str)
+        mock_usb_storage._get_partition_info.assert_called_with(line_str)
+        mock_usb_storage._report_detection.assert_called()
+
+    def test_usb2_storage_report_insertion(self):
+        mock_usb_storage = MagicMock()
+        mock_usb_storage.args.storage_type = "usb2"
+        mock_usb_storage.device = USBStorage.Device.HIGH_SPEED_USB
+        mock_usb_storage.mounted_partition = "mounted_partition"
+        mock_usb_storage.action = USBStorage.Action.INSERTION
+        mock_usb_storage.driver = USBStorage.Driver.USING_EHCI_HCD
+        with self.assertRaises(SystemExit):
+            USBStorage.report_insertion(mock_usb_storage)
+        mock_usb_storage._storage_info_helper.assert_called()
+
+    def test_usb3_storage_report_insertion(self):
+        mock_usb_storage = MagicMock()
+        mock_usb_storage.args.storage_type = "usb3"
+        mock_usb_storage.device = USBStorage.Device.SUPER_SPEED_USB
+        mock_usb_storage.mounted_partition = "mounted_partition"
+        mock_usb_storage.action = USBStorage.Action.INSERTION
+        mock_usb_storage.driver = USBStorage.Driver.USING_XHCI_HCD
+        with self.assertRaises(SystemExit):
+            USBStorage.report_insertion(mock_usb_storage)
+        mock_usb_storage._storage_info_helper.assert_called()
+
+    def test_usb_storage_report_insertion_wrong_usb_type(self):
+        mock_usb_storage = MagicMock()
+        mock_usb_storage.args.storage_type = "usb2"
+        mock_usb_storage.device = USBStorage.Device.SUPER_SPEED_USB
+        mock_usb_storage.mounted_partition = "mounted_partition"
+        mock_usb_storage.action = USBStorage.Action.INSERTION
+        mock_usb_storage.driver = USBStorage.Driver.USING_XHCI_HCD
+        with self.assertRaises(SystemExit) as cm:
+            USBStorage.report_insertion(mock_usb_storage)
+        cm.exception.args[0] == "Wrong USB type detected."
+
+    def test_usb_storage_report_removal(self):
+        mock_usb_storage = MagicMock()
+        mock_usb_storage.action = USBStorage.Action.REMOVAL
+        with self.assertRaises(SystemExit):
+            USBStorage.report_removal(mock_usb_storage)
+        mock_usb_storage._storage_info_helper.assert_called()
+
+    def test_usb_storage_get_partition_info(self):
+        mock_usb_storage = MagicMock()
+        line_str = "sdb: sdb1"
+        USBStorage._get_partition_info(mock_usb_storage, line_str)
+        self.assertEqual(mock_usb_storage.mounted_partition, "sdb1")
+
+    def test_usb_storage_refresh_detection(self):
+        mock_usb_storage = MagicMock()
+        line_str = "new high-speed USB device number 2 using xhci_hcd"
+        USBStorage._refresh_detection(mock_usb_storage, line_str)
+        self.assertEqual(
+            mock_usb_storage.driver, USBStorage.Driver.USING_XHCI_HCD
+        )
+        self.assertEqual(
+            mock_usb_storage.device, USBStorage.Device.HIGH_SPEED_USB
+        )
+        line_str = "USB Mass Storage device detected"
+        USBStorage._refresh_detection(mock_usb_storage, line_str)
+        self.assertEqual(mock_usb_storage.action, USBStorage.Action.INSERTION)
+
+    def test_usb_storage_report_detection_insertion(self):
+        mock_usb_storage = MagicMock()
+        mock_usb_storage.args.testcase = "insertion"
+        USBStorage._report_detection(mock_usb_storage)
+        mock_usb_storage.report_insertion.assert_called()
+
+    def test_usb_storage_report_detection_removal(self):
+        mock_usb_storage = MagicMock()
+        mock_usb_storage.args.testcase = "removal"
+        USBStorage._report_detection(mock_usb_storage)
+        mock_usb_storage.report_removal.assert_called()
+
+    def test_mediacard_storage_callback_insertion(self):
+        mock_mediacard_storage = MagicMock()
+        line_str = "line_str"
+        mock_mediacard_storage.args.testcase = "insertion"
+        MediacardStorage.callback(mock_mediacard_storage, line_str)
+        mock_mediacard_storage._get_partition_info.assert_called_with(line_str)
+        mock_mediacard_storage.report_insertion.assert_called()
+
+    def test_mediacard_storage_callback_removal(self):
+        mock_mediacard_storage = MagicMock()
+        line_str = "line_str"
+        mock_mediacard_storage.args.testcase = "removal"
+        MediacardStorage.callback(mock_mediacard_storage, line_str)
+        mock_mediacard_storage.report_removal.assert_called_with(line_str)
+
+    def test_mediacard_storage_report_insertion(self):
+        mock_mediacard_storage = MagicMock()
+        mock_mediacard_storage.mounted_partition = "mounted_partition"
+        with self.assertRaises(SystemExit):
+            MediacardStorage.report_insertion(mock_mediacard_storage)
+
+    def test_mediacard_storage_no_insertion(self):
+        mock_mediacard_storage = MagicMock()
+        mock_mediacard_storage.mounted_partition = None
+        MediacardStorage.report_insertion(mock_mediacard_storage)
+
+    def test_mediacard_storage_report_removal(self):
+        mock_mediacard_storage = MagicMock()
+        line_str = "card 12 removed"
+        with self.assertRaises(SystemExit):
+            MediacardStorage.report_removal(mock_mediacard_storage, line_str)
+        mock_mediacard_storage._storage_info_helper.assert_called()
+
+    def test_mediacard_storage_no_removal(self):
+        mock_mediacard_storage = MagicMock()
+        line_str = ""
+        MediacardStorage.report_removal(mock_mediacard_storage, line_str)
+
+    def test_mediacard_storage_get_partition_info(self):
+        mock_mediacard_storage = MagicMock()
+        line_str = "mmcblk0: p1"
+        MediacardStorage._get_partition_info(mock_mediacard_storage, line_str)
+        self.assertEqual(mock_mediacard_storage.mounted_partition, "mmcblk0p1")
+        mock_mediacard_storage._storage_info_helper.assert_called()
+
+    def test_thunderbolt_storage_init(self):
+        thunderbolt_storage = ThunderboltStorage("args")
+        self.assertEqual(thunderbolt_storage.args, "args")
+        self.assertEqual(thunderbolt_storage.find_insertion_string, 0)
+        self.assertEqual(thunderbolt_storage.find_partition, 0)
+
+    def test_thunderbolt_storage_report_insertion(self):
+        mock_thunderbolt_storage = MagicMock()
+        mock_thunderbolt_storage.RE_PREFIX = "thunderbolt \d+-\d+:"
+        mock_thunderbolt_storage.args.testcase = "insertion"
+        line_str = "thunderbolt 1-1: new device found"
+        ThunderboltStorage.report_insertion(mock_thunderbolt_storage, line_str)
+        self.assertEqual(mock_thunderbolt_storage.find_insertion_string, 1)
+
+    def test_thunderbolt_storage_report_removal(self):
+        mock_thunderbolt_storage = MagicMock()
+        mock_thunderbolt_storage.RE_PREFIX = "thunderbolt \d+-\d+:"
+        mock_thunderbolt_storage.args.testcase = "removal"
+        line_str = "thunderbolt 1-1: device disconnected"
+        with self.assertRaises(SystemExit):
+            ThunderboltStorage.report_removal(
+                mock_thunderbolt_storage, line_str
+            )
+        mock_thunderbolt_storage._storage_info_helper.assert_called()
+
+    @patch("checkbox_support.scripts.run_watcher.USBStorage", spec=USBStorage)
+    def test_main_usb(self, mock_usb_storage):
+        with patch("sys.argv", ["run_watcher.py", "insertion", "usb2"]):
+            main()
+        # get the watcher object from main
+        watcher = mock_usb_storage.return_value
+        # check that the watcher is an USBStorage object
+        self.assertIsInstance(watcher, USBStorage)
+
+    @patch(
+        "checkbox_support.scripts.run_watcher.MediacardStorage",
+        spec=MediacardStorage,
+    )
+    def test_main_mediacard(self, mock_mediacard_storage):
+        with patch("sys.argv", ["run_watcher.py", "insertion", "mediacard"]):
+            main()
+        # get the watcher object from main
+        watcher = mock_mediacard_storage.return_value
+        # check that the watcher is an MediacardStorage object
+        self.assertIsInstance(watcher, MediacardStorage)
+
+    @patch(
+        "checkbox_support.scripts.run_watcher.ThunderboltStorage",
+        spec=ThunderboltStorage,
+    )
+    def test_main_thunderbolt(self, mock_thunderbolt_storage):
+        with patch("sys.argv", ["run_watcher.py", "insertion", "thunderbolt"]):
+            main()
+        # get the watcher object from main
+        watcher = mock_thunderbolt_storage.return_value
+        # check that the watcher is an ThunderboltStorage object
+        self.assertIsInstance(watcher, ThunderboltStorage)

--- a/checkbox-support/checkbox_support/tests/test_run_watcher.py
+++ b/checkbox-support/checkbox_support/tests/test_run_watcher.py
@@ -27,7 +27,7 @@ from checkbox_support.scripts.run_watcher import (
     USBStorage,
     MediacardStorage,
     ThunderboltStorage,
-    main,
+    launch_watcher
 )
 
 
@@ -274,7 +274,7 @@ class TestRunWatcher(unittest.TestCase):
     @patch("checkbox_support.scripts.run_watcher.USBStorage", spec=USBStorage)
     def test_main_usb(self, mock_usb_storage):
         with patch("sys.argv", ["run_watcher.py", "insertion", "usb2"]):
-            main()
+            launch_watcher()
         # get the watcher object from main
         watcher = mock_usb_storage.return_value
         # check that the watcher is an USBStorage object
@@ -286,7 +286,7 @@ class TestRunWatcher(unittest.TestCase):
     )
     def test_main_mediacard(self, mock_mediacard_storage):
         with patch("sys.argv", ["run_watcher.py", "insertion", "mediacard"]):
-            main()
+            launch_watcher()
         # get the watcher object from main
         watcher = mock_mediacard_storage.return_value
         # check that the watcher is an MediacardStorage object
@@ -298,7 +298,7 @@ class TestRunWatcher(unittest.TestCase):
     )
     def test_main_thunderbolt(self, mock_thunderbolt_storage):
         with patch("sys.argv", ["run_watcher.py", "insertion", "thunderbolt"]):
-            main()
+            launch_watcher()
         # get the watcher object from main
         watcher = mock_thunderbolt_storage.return_value
         # check that the watcher is an ThunderboltStorage object

--- a/checkbox-support/checkbox_support/tests/test_usb_read_write.py
+++ b/checkbox-support/checkbox_support/tests/test_usb_read_write.py
@@ -3,7 +3,7 @@
 #
 # Copyright 2024 Canonical Ltd.
 # Authors:
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/checkbox-support/checkbox_support/tests/test_usb_read_write.py
+++ b/checkbox-support/checkbox_support/tests/test_usb_read_write.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Authors:
+#   Fernando Bravo <daniel.manrique@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import patch, MagicMock
+import subprocess
+
+
+from checkbox_support.scripts.usb_read_write import (
+    write_test_unit,
+)
+
+
+class TestUsbReadWrite(unittest.TestCase):
+
+    @patch("os.path")
+    @patch("subprocess.Popen")
+    @patch("subprocess.check_output")
+    @patch("subprocess.run")
+    def test_write_test_unit(
+        self, mock_run, mock_check_output, mock_popen, mock_os
+    ):
+        mock_os.join.return_value = "output_file"
+
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (
+            b"2048+1 records in\n2048+1 records out\n1049076 bytes (1.0 MB) "
+            b"copied, 0.00473357 s, 222 MB/s\n",
+            None,
+        )
+        mock_popen.return_value = mock_process
+
+        random_file = MagicMock()
+        random_file.tfile.name = "random_file"
+        write_test_unit(random_file)
+
+        mock_popen.assert_called_once_with(
+            [
+                "dd",
+                "if=random_file",
+                "of=output_file",
+                "bs=1M",
+                "oflag=sync",
+            ],
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            env={"LC_NUMERIC": "C"},
+        )
+        mock_popen.return_value.communicate.assert_called_with()
+
+    @patch("os.path")
+    @patch("subprocess.Popen")
+    @patch("subprocess.check_output")
+    @patch("subprocess.run")
+    def test_write_test_unit_wrong_units(
+        self, mock_run, mock_check_output, mock_popen, mock_os
+    ):
+        mock_os.join.return_value = "output_file"
+
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (
+            b"2048+1 records in\n2048+1 records out\n1049076 bytes (1.0 MB) "
+            b"copied, 0.00473357 s, 222 ***/s\n",
+            None,
+        )
+        mock_popen.return_value = mock_process
+
+        random_file = MagicMock()
+        random_file.tfile.name = "random_file"
+        with self.assertRaises(SystemExit):
+            write_test_unit(random_file)
+
+    @patch("os.path")
+    @patch("subprocess.Popen")
+    @patch("subprocess.check_output")
+    @patch("subprocess.run")
+    def test_write_test_unit_io_error(
+        self, mock_run, mock_check_output, mock_popen, mock_os
+    ):
+        mock_os.join.return_value = "output_file"
+
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (
+            b"2048+1 records in\n2048+1 records out\n1049076 bytes (1.0 MB) "
+            b"copied, 0.00473357 s, 222 MBs\n",
+            None,
+        )
+        mock_popen.return_value = mock_process
+
+        dmesg = MagicMock()
+        dmesg.stdout.decode.return_value = "I/O error"
+        mock_run.return_value = dmesg
+
+        random_file = MagicMock()
+        random_file.tfile.name = "random_file"
+        with self.assertRaises(SystemExit):
+            write_test_unit(random_file)

--- a/checkbox-support/debian/control
+++ b/checkbox-support/debian/control
@@ -40,6 +40,7 @@ Depends: gir1.2-gudev-1.0,
          python3-yaml,
          udev,
          udisks2,
+         libsystemd-dev
          ${misc:Depends},
          ${python3:Depends}
 Description: collection of Python modules used by PlainBox providers

--- a/checkbox-support/pyproject.toml
+++ b/checkbox-support/pyproject.toml
@@ -17,6 +17,8 @@
     'requests_unixsocket>=0.1.2; python_version>="3.5" and python_version<="3.11"',
     'requests_unixsocket2; python_version>="3.12"',
     'importlib_metadata; python_version<"3.8"',
+    'systemd-python==232; python_version=="3.5"',
+    'systemd-python>=235; python_version>="3.6"',
     'pyyaml',
   ]
 [metadata]

--- a/checkbox-support/setup.cfg
+++ b/checkbox-support/setup.cfg
@@ -11,6 +11,8 @@ install_requires=
   requests_unixsocket >= 0.1.2; python_version>="3.5" and python_version<="3.11"
   requests_unixsocket2; python_version>="3.12"
   importlib_metadata; python_version<"3.8"
+  systemd-python == 232; python_version=="3.5"
+  systemd-python == 235; python_version>="3.6"
 [metadata]
 name=checkbox-support
 [options.entry_points]

--- a/checkbox-support/tox.ini
+++ b/checkbox-support/tox.ini
@@ -30,7 +30,7 @@ setenv=
 [testenv:py36]
 deps =
     pytest
-    systemd-python
+    systemd-python == 235
     coverage == 5.5
     pytest-cov == 3.0.0
     requests == 2.18.4
@@ -42,7 +42,7 @@ deps =
 [testenv:py38]
 deps =
     pytest
-    systemd-python
+    systemd-python == 235
     coverage == 7.3.0
     pytest-cov == 4.1.0
     requests == 2.22.0
@@ -53,7 +53,7 @@ deps =
 [testenv:py310]
 deps =
     pytest
-    systemd-python
+    systemd-python == 235
     coverage == 7.3.0
     pytest-cov == 4.1.0
     requests == 2.25.1

--- a/checkbox-support/tox.ini
+++ b/checkbox-support/tox.ini
@@ -14,6 +14,7 @@ commands =
 [testenv:py35]
 deps =
     pytest
+    systemd-python == 232
     coverage == 5.5
     pytest-cov == 2.12.1
     requests == 2.9.1
@@ -29,6 +30,7 @@ setenv=
 [testenv:py36]
 deps =
     pytest
+    systemd-python
     coverage == 5.5
     pytest-cov == 3.0.0
     requests == 2.18.4
@@ -40,6 +42,7 @@ deps =
 [testenv:py38]
 deps =
     pytest
+    systemd-python
     coverage == 7.3.0
     pytest-cov == 4.1.0
     requests == 2.22.0
@@ -50,6 +53,7 @@ deps =
 [testenv:py310]
 deps =
     pytest
+    systemd-python
     coverage == 7.3.0
     pytest-cov == 4.1.0
     requests == 2.25.1

--- a/providers/base/units/dock/jobs.pxu
+++ b/providers/base/units/dock/jobs.pxu
@@ -2066,7 +2066,7 @@ depends: dock/cold-plug
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 flags: also-after-suspend
-command: removable_storage_watcher.py insert --timeout 40 scsi
+command: checkbox-support-run_watcher insertion thunderbolt
 _summary: Thunderbolt3 storage insertion detection
 _purpose:
     This test will check if the connection of a Thunderbolt3 HDD to the dock could be detected
@@ -2088,7 +2088,7 @@ depends: dock/thunderbolt3-insert
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 flags: also-after-suspend
-command: removable_storage_test.py -s 268400000 scsi
+command: checkbox-support-usb_read_write
 _summary: Thunderbolt3 storage test
 _description:
  This is an automated test which performs read/write operations on an attached
@@ -2102,7 +2102,7 @@ depends: dock/thunderbolt3-insert
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 flags: also-after-suspend
-command: removable_storage_watcher.py remove scsi
+command: checkbox-support-run_watcher removal thunderbolt
 _summary: Thunderbolt3 storage removal detection
 _purpose:
     This test will check the system can detect the removal of a Thunderbolt3 HDD
@@ -2625,7 +2625,7 @@ plugin: user-interact
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 flags: also-after-suspend
-command: removable_storage_watcher.py insert --timeout 40 scsi
+command: checkbox-support-run_watcher insertion thunderbolt
 _summary: Thunderbolt3 storage insertion detection
 _purpose:
     This test will check if the connection of a Thunderbolt3 HDD to the dock could be detected
@@ -2652,7 +2652,7 @@ depends: dock/all-init-thunderbolt3-insert
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 flags: also-after-suspend
-command: removable_storage_test.py -s 268400000 scsi
+command: checkbox-support-usb_read_write
 _summary: Thunderbolt3 storage test
 _description:
     This is an automated test which performs read/write operations on an attached
@@ -2675,7 +2675,7 @@ depends: dock/all-init-thunderbolt3-insert
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 flags: also-after-suspend
-command: removable_storage_watcher.py remove scsi
+command: checkbox-support-run_watcher removal thunderbolt
 _summary: Thunderbolt3 storage removal detection
 _purpose:
     This test will check the system can detect the removal of a Thunderbolt3 storage.

--- a/providers/base/units/mediacard/jobs.pxu
+++ b/providers/base/units/mediacard/jobs.pxu
@@ -1,14 +1,9 @@
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/mmc-insert
 estimated_duration: 30.0
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher insertion mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard insert sdio usb scsi
- {% endif -%}
+ checkbox-support-run_watcher insertion mediacard
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_card_reader == 'True'
@@ -26,7 +21,6 @@ _verification:
 _summary: Test the system's media card reader for MMC insertion detection.
 
 plugin: shell
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/mmc-storage
 estimated_duration: 30.0
@@ -34,11 +28,7 @@ depends: mediacard/mmc-insert
 user: root
 flags: preserve-cwd reset-locale
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-usb_read_write
- {%- else %}
-     removable_storage_test.py -s 67120000 --memorycard sdio usb scsi --auto-reduce-size
- {% endif -%}
+ checkbox-support-usb_read_write
 _purpose:
  This test is automated and executes after the mediacard/mmc-insert
  test is run. It tests reading and writing to the MMC card.
@@ -46,17 +36,12 @@ _summary:
  Test automated execution for reading and writing to the MMC card.
 
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/mmc-remove
 estimated_duration: 30.0
 depends: mediacard/mmc-insert
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher removal mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard remove sdio usb scsi
- {% endif -%}
+ checkbox-support-run_watcher removal mediacard
 user: root
 _purpose:
      This test will check that the system correctly detects
@@ -70,16 +55,11 @@ _verification:
 _summary: Test the detection of MMC card removal from the system's card reader.
 
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/sd-insert
 estimated_duration: 30.0
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher insertion mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard insert sdio usb scsi --unmounted
- {% endif -%}
+ checkbox-support-run_watcher insertion mediacard
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_card_reader == 'True'
@@ -97,7 +77,6 @@ _verification:
  automatically selected result.
 
 plugin: shell
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/sd-storage
 estimated_duration: 30.0
@@ -105,28 +84,19 @@ depends: mediacard/sd-insert
 user: root
 flags: preserve-cwd reset-locale
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-usb_read_write
- {%- else %}
-     removable_storage_test.py -s 268400000 --memorycard sdio usb scsi --auto-reduce-size
- {% endif -%}
+ checkbox-support-usb_read_write
 _summary: Test reading & writing to an SD Card
 _purpose:
  This test is automated and executes after the mediacard/sd-insert
  test is run. It tests reading and writing to the SD card.
 
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/sd-remove
 estimated_duration: 30.0
 depends: mediacard/sd-insert
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher removal mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard remove sdio usb scsi --unmounted
- {% endif -%}
+ checkbox-support-run_watcher removal mediacard
 user: root
 _summary: Test that removal of an SD card is detected
 _purpose:
@@ -158,17 +128,12 @@ _purpose:
  It is intended for SRU automated testing.
 
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/sdhc-insert
 flags: also-after-suspend
 estimated_duration: 30.0
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher insertion mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard insert sdio usb scsi --unmounted
- {% endif -%}
+ checkbox-support-run_watcher insertion mediacard
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_card_reader == 'True'
@@ -187,7 +152,6 @@ _verification:
  automatically selected result.
 
 plugin: shell
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/sdhc-storage
 estimated_duration: 30.0
@@ -195,29 +159,20 @@ depends: mediacard/sdhc-insert
 user: root
 flags: preserve-cwd reset-locale also-after-suspend
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-usb_read_write
- {%- else %}
-     removable_storage_test.py -s 268400000 --memorycard sdio usb scsi --auto-reduce-size
- {% endif -%}
+ checkbox-support-usb_read_write
 _summary: Test reading & writing to a SDHC Card
 _description:
  This test is automated and executes after the mediacard/sdhc-insert
  test is run. It tests reading and writing to the SDHC card.
 
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/sdhc-remove
 flags: also-after-suspend
 estimated_duration: 30.0
 depends: mediacard/sdhc-insert
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher removal mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard remove sdio usb scsi --unmounted
- {% endif -%}
+ checkbox-support-run_watcher removal mediacard
 user: root
 _summary: Test that removal of an SDHC card is detected
 _purpose:
@@ -231,16 +186,11 @@ _verification:
  automatically selected result.
 
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/cf-insert
 estimated_duration: 30.0
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher insertion mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard insert sdio usb scsi
- {% endif -%}
+ checkbox-support-run_watcher insertion mediacard
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_card_reader == 'True'
@@ -258,7 +208,6 @@ _verification:
 _summary: Verify the system's media card reader can detect a Compact Flash card insertion.
 
 plugin: shell
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/cf-storage
 estimated_duration: 30.0
@@ -266,28 +215,19 @@ depends: mediacard/cf-insert
 user: root
 flags: preserve-cwd reset-locale
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-usb_read_write
- {%- else %}
-     removable_storage_test.py -s 268400000 --memorycard sdio usb scsi --auto-reduce-size
- {% endif -%}
+ checkbox-support-usb_read_write
 _purpose:
  This test is automated and executes after the mediacard/cf-insert
  test is run. It tests reading and writing to the CF card.
 _summary: Automate testing for reading and writing to the CF card after mediacard/cf-insert test.
 
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/cf-remove
-depends: mediacard/cf-storage
+depends: mediacard/cf-insert
 estimated_duration: 30.0
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher removal mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard remove sdio usb scsi
- {% endif -%}
+ checkbox-support-run_watcher removal mediacard
 user: root
 _purpose:
  This test will check that the system correctly detects
@@ -301,16 +241,11 @@ _verification:
 _summary: Ensure the system detects CF card removal from the card reader correctly.
 
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/sdxc-insert
 estimated_duration: 30.0
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher insertion mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard insert sdio usb scsi --unmounted
- {% endif -%}
+ checkbox-support-run_watcher insertion mediacard
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_card_reader == 'True'
@@ -328,7 +263,6 @@ _verification:
  automatically selected result.
 
 plugin: shell
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/sdxc-storage
 estimated_duration: 30.0
@@ -336,28 +270,19 @@ depends: mediacard/sdxc-insert
 user: root
 flags: preserve-cwd reset-locale
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-usb_read_write
- {%- else %}
-     removable_storage_test.py -s 268400000 --memorycard sdio usb scsi --auto-reduce-size
- {% endif -%}
+ checkbox-support-usb_read_write
 _summary: Test reading & writing to an SDXC Card
 _purpose:
  This test is automated and executes after the mediacard/sdxc-insert
  test is run. It tests reading and writing to the SDXC card.
 
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/sdxc-remove
 estimated_duration: 30.0
 depends: mediacard/sdxc-insert
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher removal mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard remove sdio usb scsi --unmounted
- {% endif -%}
+ checkbox-support-run_watcher removal mediacard
 user: root
 _summary: Test that removal of an SDXC card is detected
 _purpose:
@@ -371,16 +296,11 @@ _verification:
  automatically selected result.
 
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/ms-insert
 estimated_duration: 30.0
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher insertion mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard insert sdio usb scsi
- {% endif -%}
+ checkbox-support-run_watcher insertion mediacard
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_card_reader == 'True'
@@ -399,7 +319,6 @@ _summary:
  Verify the detection of Memory Stick (MS) card insertion by the system's media card reader.
 
 plugin: shell
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/ms-storage
 estimated_duration: 30.0
@@ -407,28 +326,19 @@ depends: mediacard/ms-insert
 user: root
 flags: preserve-cwd reset-locale
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-usb_read_write
- {%- else %}
-     removable_storage_test.py -s 268400000 --memorycard sdio usb scsi --auto-reduce-size
- {% endif -%}
+ checkbox-support-usb_read_write
 _purpose:
  This test is automated and executes after the mediacard/ms-insert
  test is run. It tests reading and writing to the MS card.
 _summary: Automated test for reading and writing to the MS card after mediacard/ms-insert test.
 
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/ms-remove
 estimated_duration: 30.0
 depends: mediacard/ms-insert
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher removal mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard remove sdio usb scsi
- {% endif -%}
+ checkbox-support-run_watcher removal mediacard
 user: root
 _description:
 _purpose:
@@ -443,16 +353,11 @@ _verification:
 _summary: Test if the system detects the removal of an MS card correctly.
 
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/msp-insert
 estimated_duration: 30.0
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher insertion mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard insert sdio usb scsi
- {% endif -%}
+ checkbox-support-run_watcher insertion mediacard
 user: root
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -471,7 +376,6 @@ _verification:
 _summary: Verify the system's media card reader can detect a Memory Stick Pro (MSP) card insertion.
 
 plugin: shell
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/msp-storage
 estimated_duration: 30.0
@@ -479,28 +383,19 @@ depends: mediacard/msp-insert
 user: root
 flags: preserve-cwd reset-locale
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-usb_read_write
- {%- else %}
-     removable_storage_test.py -s 268400000 --memorycard sdio usb scsi --auto-reduce-size
- {% endif -%}
+ checkbox-support-usb_read_write
 _purpose:
  This test is automated and executes after the mediacard/msp-insert
  test is run. It tests reading and writing to the MSP card.
 _summary: Automated test for reading and writing to the MSP card after mediacard/msp-insert test.
 
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/msp-remove
 estimated_duration: 30.0
 depends: mediacard/msp-insert
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher removal mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard remove sdio usb scsi
- {% endif -%}
+ checkbox-support-run_watcher removal mediacard
 user: root
 _description:
 _purpose:
@@ -515,16 +410,11 @@ _verification:
 _summary: Ensure MSP card removal is correctly detected by the system.
 
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/xd-insert
 estimated_duration: 30.0
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher insertion mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard insert sdio usb scsi
- {% endif -%}
+ checkbox-support-run_watcher insertion mediacard
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_card_reader == 'True'
@@ -542,7 +432,6 @@ _verification:
 _summary: Ensure the system's media card reader detects the insertion of an xD media card.
 
 plugin: shell
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/xd-storage
 estimated_duration: 30.0
@@ -550,27 +439,18 @@ depends: mediacard/xd-insert
 user: root
 flags: preserve-cwd reset-locale
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-usb_read_write
- {%- else %}
-     removable_storage_test.py -s 268400000 --memorycard sdio usb scsi --auto-reduce-size
- {% endif -%}
+ checkbox-support-usb_read_write
 _purpose:
  This test is automated and executes after the mediacard/xd-insert test is run. It tests reading and writing to the xD card.
 _summary: Automated test to verify reading and writing functionality of the xD card after mediacard/xd-insert test.
 
 plugin: user-interact
-template-engine: jinja2
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/xd-remove
 estimated_duration: 30.0
 depends: mediacard/xd-insert
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher removal mediacard
- {%- else %}
-     removable_storage_watcher.py --memorycard remove sdio usb scsi
- {% endif -%}
+ checkbox-support-run_watcher removal mediacard
 user: root
 _purpose:
      This test will check that the system correctly detects

--- a/providers/base/units/thunderbolt/jobs.pxu
+++ b/providers/base/units/thunderbolt/jobs.pxu
@@ -5,7 +5,6 @@ user: root
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt == 'True'
 estimated_duration: 20.0
-template-engine: jinja2
 command:
  checkbox-support-run_watcher insertion thunderbolt
 _siblings: [
@@ -33,13 +32,8 @@ imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt == 'True'
 depends: thunderbolt/insert
 estimated_duration: 45.0
-template-engine: jinja2
 command:
-    {%- if __on_ubuntucore__ %}
-        checkbox-support-usb_read_write
-    {%- else %}
-        removable_storage_test.py -s 268400000 scsi
-    {% endif -%}
+ checkbox-support-usb_read_write
 _siblings: [
     { "id": "after-suspend-thunderbolt/storage-test",
       "_summary": "thunderbolt/storage-test after suspend",
@@ -56,7 +50,6 @@ imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt == 'True'
 depends: thunderbolt/insert
 estimated_duration: 10.0
-template-engine: jinja2
 command:
  checkbox-support-run_watcher insertion thunderbolt
 _summary: Storage removal detection on Thunderbolt
@@ -105,7 +98,6 @@ user: root
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 estimated_duration: 20.0
-template-engine: jinja2
 command:
  checkbox-support-run_watcher insertion thunderbolt
 _summary: Storage insert detection on Thunderbolt 3 port
@@ -129,13 +121,8 @@ imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 depends: thunderbolt3/insert
 estimated_duration: 45.0
-template-engine: jinja2
 command:
-    {%- if __on_ubuntucore__ %}
-        checkbox-support-usb_read_write
-    {%- else %}
-        removable_storage_test.py -s 268400000 scsi
-    {% endif -%}
+ checkbox-support-usb_read_write
 _summary: Storage test on Thunderbolt 3
 _purpose: This is an automated test which performs read/write operations on an attached Thunderbolt HDD
 
@@ -161,7 +148,6 @@ imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 depends: thunderbolt3/insert
 estimated_duration: 10.0
-template-engine: jinja2
 command:
  checkbox-support-run_watcher removal thunderbolt
 _summary: Storage removal detection on Thunderbolt 3 port

--- a/providers/base/units/usb/test-plan.pxu
+++ b/providers/base/units/usb/test-plan.pxu
@@ -370,7 +370,7 @@ include:
 
 id: after-suspend-usb-automated
 unit: test plan
-_name: Automated USB tests
+_name: Automated USB tests (after suspend)
 _description: Automated USB tests for Ubuntu Core devices
 include:
     after-suspend-usb/storage-detect

--- a/providers/base/units/usb/usb-c.pxu
+++ b/providers/base/units/usb/usb-c.pxu
@@ -35,11 +35,7 @@ plugin: user-interact
 flags: also-after-suspend
 user: root
 command:
- if [[ -v SNAP ]]; then
-     checkbox-support-run_watcher insertion usb3
- else
-     removable_storage_watcher.py -m 500000000 insert usb
- fi
+ checkbox-support-run_watcher insertion usb3
 category_id: com.canonical.plainbox::usb
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -56,11 +52,7 @@ plugin: shell
 flags: also-after-suspend
 user: root
 command:
- if [[ -v SNAP ]]; then
-     checkbox-support-usb_read_write
- else
-     removable_storage_test.py -s 268400000 -m 500000000 usb --driver xhci_hcd
- fi
+ checkbox-support-usb_read_write
 category_id: com.canonical.plainbox::usb
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -86,11 +78,7 @@ plugin: user-interact
 flags: also-after-suspend
 user: root
 command:
- if [[ -v SNAP ]]; then
-     checkbox-support-run_watcher removal usb3
- else
-     removable_storage_watcher.py -m 500000000 remove usb
- fi
+ checkbox-support-run_watcher removal usb3
 category_id: com.canonical.plainbox::usb
 depends: usb-c/c-to-a-adapter/insert
 imports: from com.canonical.plainbox import manifest
@@ -135,11 +123,7 @@ plugin: user-interact
 flags: also-after-suspend
 user: root
 command:
- if [[ -v SNAP ]]; then
-     checkbox-support-run_watcher insertion usb3
- else
-     removable_storage_watcher.py -m 500000000 insert usb
- fi
+ checkbox-support-run_watcher insertion usb3
 category_id: com.canonical.plainbox::usb
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -155,11 +139,7 @@ plugin: shell
 flags: also-after-suspend
 user: root
 command:
- if [[ -v SNAP ]]; then
-     checkbox-support-usb_read_write
- else
-     removable_storage_test.py -s 268400000 -m 500000000 usb --driver xhci_hcd
- fi
+ checkbox-support-usb_read_write
 category_id: com.canonical.plainbox::usb
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -183,11 +163,7 @@ plugin: user-interact
 flags: also-after-suspend
 user: root
 command:
- if [[ -v SNAP ]]; then
-     checkbox-support-run_watcher removal usb3
- else
-     removable_storage_watcher.py -m 500000000 remove usb
- fi
+ checkbox-support-run_watcher removal usb3
 category_id: com.canonical.plainbox::usb
 depends: usb-c/insert
 imports: from com.canonical.plainbox import manifest

--- a/providers/base/units/usb/usb.pxu
+++ b/providers/base/units/usb/usb.pxu
@@ -53,7 +53,6 @@ _summary: Verify USB HID devices functionality by performing specified actions.
 
 id: usb/insert
 flags: also-after-suspend fail-on-resource
-template-engine: jinja2
 _summary: USB 2.0 storage device insertion detected
 _purpose:
  Check system can detect USB 2.0 storage when inserted.
@@ -75,7 +74,6 @@ estimated_duration: 120
 
 id: usb3/insert
 flags: also-after-suspend
-template-engine: jinja2
 requires:
  usb.usb3 == 'supported'
 _summary: USB 3.0 storage device insertion detected
@@ -99,7 +97,6 @@ estimated_duration: 120
 
 id: usb/remove
 flags: also-after-suspend
-template-engine: jinja2
 _summary: USB 2.0 storage device removal detected
 _purpose:
  Check system can detect removal of a USB 2.0 storage device
@@ -120,7 +117,6 @@ estimated_duration: 120
 
 id: usb3/remove
 flags: also-after-suspend
-template-engine: jinja2
 _summary: USB 3.0 storage device removal detected
 _purpose:
  Check system can detect removal of a USB 3.0 storage device

--- a/providers/base/units/usb/usb.pxu
+++ b/providers/base/units/usb/usb.pxu
@@ -54,10 +54,6 @@ _summary: Verify USB HID devices functionality by performing specified actions.
 id: usb/insert
 flags: also-after-suspend fail-on-resource
 template-engine: jinja2
-requires:
- {%- if not __on_ubuntucore__ %}
- package.name == 'udisks2' or snap.name == 'udisks2'
- {% endif -%}
 _summary: USB 2.0 storage device insertion detected
 _purpose:
  Check system can detect USB 2.0 storage when inserted.
@@ -73,11 +69,7 @@ _verification:
 plugin: user-interact
 user: root
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher insertion usb2
- {%- else %}
-     removable_storage_watcher.py --unmounted insert usb
- {% endif -%}
+ checkbox-support-run_watcher insertion usb2
 category_id: com.canonical.plainbox::usb
 estimated_duration: 120
 
@@ -101,11 +93,7 @@ _verification:
 plugin: user-interact
 user: root
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher insertion usb3
- {%- else %}
-     removable_storage_watcher.py --unmounted -m 500000000 insert usb
- {% endif -%}
+ checkbox-support-run_watcher insertion usb3
 category_id: com.canonical.plainbox::usb
 estimated_duration: 120
 

--- a/providers/base/units/usb/usb.pxu
+++ b/providers/base/units/usb/usb.pxu
@@ -114,11 +114,7 @@ plugin: user-interact
 depends: usb/insert
 user: root
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher removal usb2
- {%- else %}
-     removable_storage_watcher.py --unmounted remove usb
- {% endif -%}
+ checkbox-support-run_watcher removal usb2
 category_id: com.canonical.plainbox::usb
 estimated_duration: 120
 
@@ -139,11 +135,7 @@ plugin: user-interact
 depends: usb3/insert
 user: root
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-run_watcher removal usb3
- {%- else %}
-     removable_storage_watcher.py --unmounted -m 500000000 remove usb
- {% endif -%}
+ checkbox-support-run_watcher removal usb3
 category_id: com.canonical.plainbox::usb
 estimated_duration: 120
 
@@ -189,7 +181,6 @@ _summary: Check the USB 3.0 connection and data transfer capability.
 
 id: usb/storage-automated
 flags: also-after-suspend
-template-engine: jinja2
 _summary: USB 2.0 storage device read & write works
 _purpose:
  Check system can read/write to USB 2.0 storage correctly
@@ -201,17 +192,12 @@ plugin: shell
 depends: usb/insert
 user: root
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-usb_read_write
- {%- else %}
-     removable_storage_test.py -s 268400000 usb
- {% endif -%}
+ checkbox-support-usb_read_write
 category_id: com.canonical.plainbox::usb
 estimated_duration: 300
 
 id: usb3/storage-automated
 flags: also-after-suspend
-template-engine: jinja2
 _summary: USB 3.0 storage device read & write works
 _purpose:
  Check system can read/write to USB 3.0 storage devices correctly
@@ -223,11 +209,7 @@ plugin: shell
 depends: usb3/insert
 user: root
 command:
- {%- if __on_ubuntucore__ %}
-     checkbox-support-usb_read_write
- {%- else %}
-     removable_storage_test.py -s 268400000 -m 500000000 usb --driver xhci_hcd
- {% endif -%}
+ checkbox-support-usb_read_write
 category_id: com.canonical.plainbox::usb
 estimated_duration: 300
 

--- a/providers/genio/bin/boot_partition.py
+++ b/providers/genio/bin/boot_partition.py
@@ -4,7 +4,7 @@
 # Copyright 2024 Canonical Ltd.
 # Authors:
 #   Patrick Chang <patrick.chang@canonical.com>
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/genio/bin/brightness_test.py
+++ b/providers/genio/bin/brightness_test.py
@@ -6,7 +6,7 @@
 #   Alberto Milone <alberto.milone@canonical.com>
 #   Sylvain Pineau <sylvain.pineau@canonical.com>
 #   Patrick Chang <patrick.chang@canonical.com>
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/genio/bin/cpu_idle.py
+++ b/providers/genio/bin/cpu_idle.py
@@ -4,7 +4,7 @@
 # Copyright 2024 Canonical Ltd.
 # Authors:
 #   Patrick Chang <patrick.chang@canonical.com>
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/genio/bin/dvfs_gpu_check_governors.py
+++ b/providers/genio/bin/dvfs_gpu_check_governors.py
@@ -4,7 +4,7 @@
 # Copyright 2024 Canonical Ltd.
 # Authors:
 #   Patrick Chang <patrick.chang@canonical.com>
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/genio/bin/gpio_loopback_test.py
+++ b/providers/genio/bin/gpio_loopback_test.py
@@ -4,7 +4,7 @@
 # Copyright 2024 Canonical Ltd.
 # Authors:
 #   Patrick Chang <patrick.chang@canonical.com>
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/genio/bin/hdmirx_output_checker.sh
+++ b/providers/genio/bin/hdmirx_output_checker.sh
@@ -4,7 +4,7 @@
 # Copyright 2014 Canonical Ltd.
 # Authors:
 #   Patrick Chang <patrick.chang@canonical.com>
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/genio/bin/hdmirx_tool_runner.sh
+++ b/providers/genio/bin/hdmirx_tool_runner.sh
@@ -4,7 +4,7 @@
 # Copyright 2014 Canonical Ltd.
 # Authors:
 #   Patrick Chang <patrick.chang@canonical.com>
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/genio/bin/linux_ccf.py
+++ b/providers/genio/bin/linux_ccf.py
@@ -4,7 +4,7 @@
 # Copyright 2024 Canonical Ltd.
 # Authors:
 #   Patrick Chang <patrick.chang@canonical.com>
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/genio/bin/pmic_regulator.py
+++ b/providers/genio/bin/pmic_regulator.py
@@ -4,7 +4,7 @@
 # Copyright 2024 Canonical Ltd.
 # Authors:
 #   Patrick Chang <patrick.chang@canonical.com>
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/genio/bin/serialcheck.py
+++ b/providers/genio/bin/serialcheck.py
@@ -4,7 +4,7 @@
 # Copyright 2024 Canonical Ltd.
 # Authors:
 #   Patrick Chang <patrick.chang@canonical.com>
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/genio/bin/set_as_performance_mode.sh
+++ b/providers/genio/bin/set_as_performance_mode.sh
@@ -4,7 +4,7 @@
 # Copyright 2014 Canonical Ltd.
 # Authors:
 #   Patrick Chang <patrick.chang@canonical.com>
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/genio/bin/spidev_test.py
+++ b/providers/genio/bin/spidev_test.py
@@ -4,7 +4,7 @@
 # Copyright 2024 Canonical Ltd.
 # Authors:
 #   Patrick Chang <patrick.chang@canonical.com>
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/genio/bin/verify-mt8188-ccf.sh
+++ b/providers/genio/bin/verify-mt8188-ccf.sh
@@ -5,7 +5,7 @@
 # Authors:
 #   Amjad Ouled-Ameur <ouledameur.amjad@baylibre.com>
 #   Patrick Chang <patrick.chang@canonical.com>
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/genio/bin/verify-mt8195-ccf.sh
+++ b/providers/genio/bin/verify-mt8195-ccf.sh
@@ -5,7 +5,7 @@
 # Authors:
 #   Amjad Ouled-Ameur <ouledameur.amjad@baylibre.com>
 #   Patrick Chang <patrick.chang@canonical.com>
-#   Fernando Bravo <daniel.manrique@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

The insert/remove/storage tests were failing on devices without `udisks2` since that was the main tool we used for these tests (removable_storage_watcher.py). Since the addition of core devices, we have a secondary script for this kind of tests (run_watcher.py) that just looks at journalctl messages instead of requiring `udisks2` to asses the insertion/removal of a USB device.

The main requirement for this PR was to use `run_watcher.py` only for devices without `udisks2`, but I extended the usage of this script for all the devices, but only for the jobs that were already using `run_watcher.py` on ubuntu core.

We did the same for the "usb_read_write.py" script.

I've also modified both of the scripts to fix some bugs and increase the clarity.

The `removable_storage_test.py` is still used for some automated tests, this PR focuses on removing the `udisks2` from tests that were already run on ubuntu_core.

I also removed the `usb/disk_detect` job, since it seemed to be a copy of usb/detect and it was not included in any other test-plan
 
 ## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/CER-2624
https://github.com/canonical/checkbox/issues/1029

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

A selection of the tests have been tested on core and on classic.
The thunderbolt tests have not been tested, since I don't have access to a thunderbolt drive.
To run the modified tests:
```
checkbox-cli run com.canonical.certification::usb/insert
checkbox-cli run com.canonical.certification::usb/remove
checkbox-cli run com.canonical.certification::usb/storage-automated
```
Also available for:
 - usb3
 - usbc
 - mediacard
 - thunderbolt