### PR TITLE
add qep, edac, mei, ishtp and va-api into IoT test plans and ODM test plans (New)

### DIFF
--- a/providers/certification-client/units/client-cert-iot-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-iot-desktop-24-04.pxu
@@ -43,7 +43,9 @@ nested_part:
   camera-manual
   cpu-manual
   disk-manual
+  edac-manual
   ethernet-manual
+  ishtp-manual
   led-indicator-manual
   led-manual
   monitor-integrated-gpu-cert-manual
@@ -51,8 +53,10 @@ nested_part:
   graphics-discrete-gpu-cert-manual
   monitor-discrete-gpu-cert-manual
   mediacard-manual
+  mei-manual
   memory-manual
   networking-manual
+  qep-manual
   rtc-manual
   self-manual
   serial-manual
@@ -69,6 +73,7 @@ nested_part:
   wireless-manual
   wireless-wifi-master-mode-manual
   wwan-manual
+  va-api-manual
   after-suspend-audio-manual
   after-suspend-bluetooth-cert-manual
   after-suspend-ethernet-manual
@@ -127,6 +132,7 @@ nested_part:
   cpu-automated
   disk-automated
   docker-automated
+  edac-automated
   eeprom-automated
   ethernet-automated
   graphics-discrete-gpu-cert-automated
@@ -134,13 +140,16 @@ nested_part:
   gpio-automated
   iot-fwts-automated
   i2c-automated
+  ishtp-automated
   mediacard-automated
+  mei-automated
   memory-automated
   misc-client-cert-automated
   monitor-discrete-gpu-cert-automated
   monitor-integrated-gpu-cert-automated
   networking-automated
   power-automated
+  qep-automated
   rtc-automated
   self-automated
   serial-automated
@@ -155,6 +164,7 @@ nested_part:
   wireless-automated
   wireless-wifi-master-mode-auto
   wwan-automated
+  va-api-automated
   zapper-enabled-automated
   after-suspend-audio-automated
   after-suspend-bluez-automated

--- a/providers/certification-client/units/client-cert-iot-server-24-04.pxu
+++ b/providers/certification-client/units/client-cert-iot-server-24-04.pxu
@@ -43,13 +43,17 @@ nested_part:
   camera-manual
   cpu-manual
   disk-manual
+  edac-manual
   ethernet-manual
+  ishtp-manual
   led-indicator-manual
   led-manual
   mediacard-manual
+  mei-manual
   memory-manual
   monitor-manual
   networking-manual
+  qep-manual
   rtc-manual
   self-manual
   serial-manual
@@ -121,16 +125,20 @@ nested_part:
   cpu-automated
   disk-automated
   docker-automated
+  edac-automated
   eeprom-automated
   ethernet-automated
   gpio-automated
   iot-fwts-automated
   i2c-automated
+  ishtp-automated
   mediacard-automated
+  mei-automated
   memory-automated
   misc-client-cert-automated
   networking-automated
   power-automated
+  qep-automated
   rtc-automated
   self-automated
   serial-automated

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-24.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-24.pxu
@@ -40,13 +40,17 @@ nested_part:
   camera-manual
   cpu-manual
   disk-manual
+  edac-manual
   ethernet-manual
+  ishtp-manual
   led-indicator-manual
   led-manual
   mediacard-manual
+  mei-manual
   memory-manual
   monitor-manual
   networking-manual
+  qep-manual
   rtc-manual
   self-manual
   serial-manual
@@ -122,16 +126,20 @@ nested_part:
   cpu-automated
   disk-automated
   docker-automated
+  edac-automated
   eeprom-automated
   ethernet-automated
   gpio-automated
   iot-fwts-automated
   i2c-automated
+  ishtp-automated
   kernel-snap-automated
   mediacard-automated
+  mei-automated
   memory-automated
   networking-automated
   power-automated
+  qep-automated
   rtc-automated
   self-automated
   serial-automated

--- a/providers/certification-client/units/client-cert-odm-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-desktop-24-04.pxu
@@ -12,6 +12,7 @@ nested_part:
     bluetooth-cert-manual
     camera-cert-manual
     edac-manual
+    ishtp-manual
     thunderbolt-cert-manual
     monitor-gpu-cert-manual
     graphics-gpu-cert-manual
@@ -20,11 +21,13 @@ nested_part:
     keys-cert-manual
     led-cert-manual
     mediacard-cert-manual
+    mei-manual
     mobilebroadband-cert-manual
     ethernet-cert-manual
     networking-cert-manual
     optical-cert-manual
     power-management-precheck-cert-manual
+    qep-manual
     snappy-snap-automated
     # touchpad-cert-manual
     # touchscreen-cert-manual
@@ -33,6 +36,7 @@ nested_part:
     usb-c-cert-full # no manual only
     usb-dwc3-manual
     wireless-cert-manual
+    va-api-manual
     # start of suspend related tests
     before-suspend-reference-cert-full
     # suspend point
@@ -110,15 +114,18 @@ nested_part:
     monitor-gpu-cert-automated
     graphics-gpu-cert-automated
     input-cert-automated
+    ishtp-automated
     disk-cert-manual
     keys-cert-automated
     led-cert-automated
     mediacard-cert-automated
+    mei-automated
     mobilebroadband-cert-automated
     ethernet-cert-automated
     networking-cert-automated
     optical-cert-automated
     power-management-precheck-cert-automated
+    qep-automated
     # touchpad-cert-automated
     # touchscreen-cert-automated
     usb-cert-automated
@@ -126,6 +133,7 @@ nested_part:
     # usb-c-cert-automated # only usb-c-cert-full
     usb-dwc3-automated
     wireless-cert-automated
+    va-api-automated
     # start of suspend related tests
     before-suspend-reference-cert-full
     # suspend point

--- a/providers/certification-client/units/client-cert-odm-server-24-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-server-24-04.pxu
@@ -31,8 +31,11 @@ nested_part:
     bluetooth-manual
     camera-manual
     edac-manual
+    ishtp-manual
     led-manual
     mediacard-manual
+    mei-manual
+    qep-manual
     rtc-manual
     serial-manual
     usb-c-manual
@@ -91,7 +94,9 @@ nested_part:
     bluez-automated
     camera-automated
     edac-automated
+    ishtp-automated
     mediacard-automated
+    mei-automated
     rtc-automated
     serial-automated
     usb-c-automated
@@ -107,6 +112,7 @@ nested_part:
     i2c-automated
     memory-automated
     networking-automated
+    qep-automated
     snappy-snap-automated
     wireless-automated
     wireless-wifi-master-mode-auto

--- a/providers/certification-client/units/client-cert-odm-ubuntucore-24.pxu
+++ b/providers/certification-client/units/client-cert-odm-ubuntucore-24.pxu
@@ -31,8 +31,11 @@ nested_part:
     bluetooth-manual
     camera-manual
     edac-manual
+    ishtp-manual
     led-manual
     mediacard-manual
+    mei-manual
+    qep-manual
     rtc-manual
     serial-manual
     usb-c-manual
@@ -105,9 +108,12 @@ nested_part:
     ethernet-automated
     iot-cert-image-automated
     i2c-automated
+    ishtp-automated
     gpio-automated
+    mei-automated
     memory-automated
     networking-automated
+    qep-automated
     snappy-snap-automated
     wireless-automated
     wireless-wifi-master-mode-auto


### PR DESCRIPTION
include qep, edac, mei, ishtp and va-api into IoT test plans and ODM test plans

## Description
Following test plans has been created in the base provider and iiotg provider, but not listed in the nested part of IoT test plans and ODM test plans.
- https://github.com/canonical/checkbox/blob/main/providers/base/units/ishtp/testplan.pxu
- https://github.com/canonical/checkbox/blob/main/providers/base/units/mei/test-plan.pxu
- https://github.com/canonical/checkbox/blob/main/providers/base/units/qep/test-plan.pxu
- https://github.com/canonical/checkbox/blob/main/providers/base/units/va-api/test-plan.pxu
- https://github.com/canonical/checkbox/blob/main/providers/iiotg/units/edac/test-plan.pxu

## Resolved issues
N/A

## Documentation
N/A

## Tests
N/A
