### PR TITLE
Force tox numpy version workaroud np 2.0 (infra)

### DIFF
--- a/providers/base/tox.ini
+++ b/providers/base/tox.ini
@@ -84,6 +84,7 @@ deps =
     MarkupSafe == 2.0.1
     natsort == 8.0.2
     opencv_python == 4.8.0.76
+    numpy == 1.26.4
     requests == 2.25.1
     tqdm == 4.57.0
     urwid == 2.1.2


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The current version of opencv doesn't support the latest version of numpy but doesn't enforce the version of numpy to be installed, therefore pulling latest. This hardcodes the version waiting for [this](https://github.com/opencv/opencv-python/issues/997) to be fixed.

## Resolved issues

N/A

## Documentation

N/A

## Tests

This is a tox change, this is the test.
