### PR TITLE
Replaced open(Path, ...) with Path.open(...) (BugFix)

### DIFF
--- a/providers/base/bin/bt_list_adapters.py
+++ b/providers/base/bin/bt_list_adapters.py
@@ -28,7 +28,7 @@ from pathlib import Path
 BTDevice = namedtuple("BTDevice", ["sysfs_name", "device_name"])
 
 
-def get_node_content(path):
+def get_node_content(path: Path):
     """Retrieve the content from a sysfs path.
 
     :param path: path to the sysfs node
@@ -36,7 +36,7 @@ def get_node_content(path):
     :return: content of the sysfs node
     :rtype: str
     """
-    with open(path, "r") as f:
+    with path.open("r") as f:
         content = f.read().strip()
     return content
 

--- a/providers/base/tests/test_bt_list_adapters.py
+++ b/providers/base/tests/test_bt_list_adapters.py
@@ -7,16 +7,18 @@ import bt_list_adapters
 
 
 class BTTests(unittest.TestCase):
-    @patch("builtins.open", new_callable=mock_open, read_data=" test ")
+    @patch("pathlib.Path.open", new_callable=mock_open, read_data="test")
     def test_get_node_content(self, mock_open):
         content = bt_list_adapters.get_node_content(Path("test"))
         self.assertEqual(content, "test")
 
-    @patch("builtins.open", new_callable=mock_open, read_data="bluetooth")
+    @patch("pathlib.Path.open", new_callable=mock_open, read_data="bluetooth")
     def test_is_bluetooth_adapter(self, mock_open):
         self.assertTrue(bt_list_adapters.is_bluetooth_adapter(Path("test")))
 
-    @patch("builtins.open", new_callable=mock_open, read_data="not bluetooth")
+    @patch(
+        "pathlib.Path.open", new_callable=mock_open, read_data="not bluetooth"
+    )
     def test_is_not_bluetooth_adapter(self, mock_open):
         self.assertFalse(bt_list_adapters.is_bluetooth_adapter(Path("test")))
 


### PR DESCRIPTION
## Description

Built-in `open()` function does not support a `pathlib.Path`  as input prior to  [Python 3.6](https://docs.python.org/3/whatsnew/3.6.html#pep-519-adding-a-file-system-path-protocol). This PR fixes the problem using the `Path.open()` method instead.

## Resolved issues

N/A

## Documentation

N/A

## Tests

- Updated unit tests
- Tested locally running `bluetooth/detect`