### PR TITLE
Remove double install of the wrong package (bugfix)

### DIFF
--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -99,7 +99,6 @@ parts:
       # actual requirements
       - python3-bluez
       - python3-pyparsing
-      - python3-requests-unixsocket
       - python3-systemd
       # added to stage python:
       - libpython3-stdlib
@@ -185,7 +184,6 @@ parts:
       - dmidecode
       - libjson-xs-perl
       - pciutils
-      - python3-requests-unixsocket
       - smartmontools
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The new version of requests broke requests-unixsocket. We fixed this in the pyproject.toml of checkbox-support but the snapcraft recipe is still installing the packaged version (twice) along with the dependencies installed from pyproject.

## Resolved issues

Fixes snappy testplan

## Documentation

N/A

## Tests

New core24 snap built and tested.[ Install this on core24 and run any snappy automated testplan](https://drive.google.com/file/d/1BtjfqEqIDPCvEsGowd0qPnb4Vmnk7W1H/view?usp=sharing)
