### PR TITLE
Support both networkd and NetworkManger in netplan (New)

### DIFF
--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -255,6 +255,9 @@ def _get_nmcli_state(interface):
 
 
 def _check_routable_state(interface, renderer):
+    """
+    Check if the interface is in a routable state depending on the renderer
+    """
     routable = False
     state = ""
     if renderer == "networkd":

--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -68,6 +68,10 @@ def netplan_renderer():
 
 
 def check_and_get_renderer(renderer):
+    """
+    Check if the renderer provided matches the one used by netplan. If the
+    renderer is set to "AutoDetect", it will return the detected renderer.
+    """
     machine_renderer = netplan_renderer()
 
     if renderer == "AutoDetect":

--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -49,13 +49,13 @@ NETPLAN_CFG_PATHS = ("/etc/netplan", "/lib/netplan", "/run/netplan")
 NETPLAN_TEST_CFG = "/etc/netplan/99-CREATED-BY-CHECKBOX.yaml"
 
 
+def netplan_renderer():
     """
     Check the renderer used by netplan on the system.
     This function looks for the renderer used in the yaml files located in the
     NETPLAN_CFG_PATHS directories, and returns the first renderer found. If the
     renderer is not found, it defaults to "networked".
     """
-def netplan_renderer():
     for basedir in NETPLAN_CFG_PATHS:
         if os.path.exists(basedir):
             files = glob.glob(os.path.join(basedir, "*.yaml"))
@@ -133,7 +133,7 @@ def netplan_config_restore():
     if files:
         print("Restoring:")
         for f in files:
-            restore_loc = f[len(TMP_PATH) :]
+            restore_loc = f[len(TMP_PATH):]
             print(" ", restore_loc)
             try:
                 shutil.move(f, restore_loc)
@@ -233,7 +233,7 @@ def _get_networkctl_state(interface):
     cmd = "networkctl status --no-pager --no-legend {}".format(interface)
     output = sp.check_output(cmd, shell=True)
     for line in output.decode(sys.stdout.encoding).splitlines():
-        # Skip lines that don't have a "key: value" format 
+        # Skip lines that don't have a "key: value" format
         if ":" not in line:
             continue
         key, val = line.strip().split(":", maxsplit=1)

--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -54,7 +54,7 @@ def netplan_renderer():
     Check the renderer used by netplan on the system.
     This function looks for the renderer used in the yaml files located in the
     NETPLAN_CFG_PATHS directories, and returns the first renderer found. If the
-    renderer is not found, it defaults to "networked".
+    renderer is not found, it defaults to "networkd".
     """
     for basedir in NETPLAN_CFG_PATHS:
         if os.path.exists(basedir):

--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -49,6 +49,12 @@ NETPLAN_CFG_PATHS = ("/etc/netplan", "/lib/netplan", "/run/netplan")
 NETPLAN_TEST_CFG = "/etc/netplan/99-CREATED-BY-CHECKBOX.yaml"
 
 
+    """
+    Check the renderer used by netplan on the system.
+    This function looks for the renderer used in the yaml files located in the
+    NETPLAN_CFG_PATHS directories, and returns the first renderer found. If the
+    renderer is not found, it defaults to "networked".
+    """
 def netplan_renderer():
     for basedir in NETPLAN_CFG_PATHS:
         if os.path.exists(basedir):

--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -233,6 +233,7 @@ def _get_networkctl_state(interface):
     cmd = "networkctl status --no-pager --no-legend {}".format(interface)
     output = sp.check_output(cmd, shell=True)
     for line in output.decode(sys.stdout.encoding).splitlines():
+        # Skip lines that don't have a "key: value" format 
         if ":" not in line:
             continue
         key, val = line.strip().split(":", maxsplit=1)

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -18,10 +18,24 @@
 
 import textwrap
 from unittest import TestCase
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, mock_open, ANY
+import datetime
 
-
-from wifi_client_test_netplan import generate_test_config, parse_args
+from wifi_client_test_netplan import (
+    netplan_renderer,
+    check_and_get_renderer,
+    netplan_config_backup,
+    _get_networkctl_state,
+    _get_nmcli_state,
+    _check_routable_state,
+    wait_for_routable,
+    get_gateway,
+    perform_ping_test,
+    generate_test_config,
+    parse_args,
+    print_journal_entries,
+    main,
+)
 
 
 class WifiClientTestNetplanTests(TestCase):
@@ -30,6 +44,7 @@ class WifiClientTestNetplanTests(TestCase):
             """
             # This is the network config written by checkbox
             network:
+              renderer: networkd
               version: 2
               wifis:
                 eth0:
@@ -40,7 +55,9 @@ class WifiClientTestNetplanTests(TestCase):
             """
         )
 
-        result = generate_test_config("eth0", "my_ap", None, "", True, False)
+        result = generate_test_config(
+            "eth0", "my_ap", None, "", True, False, "networkd"
+        )
         self.assertEqual(result.strip(), expected_output.strip())
 
     def test_private_ap_with_dhcp(self):
@@ -48,6 +65,7 @@ class WifiClientTestNetplanTests(TestCase):
             """
             # This is the network config written by checkbox
             network:
+              renderer: networkd
               version: 2
               wifis:
                 eth0:
@@ -61,7 +79,7 @@ class WifiClientTestNetplanTests(TestCase):
             """
         )
         result = generate_test_config(
-            "eth0", "my_ap", "s3cr3t", "", True, False
+            "eth0", "my_ap", "s3cr3t", "", True, False, "networkd"
         )
         self.assertEqual(result.strip(), expected_output.strip())
 
@@ -70,6 +88,7 @@ class WifiClientTestNetplanTests(TestCase):
             """
             # This is the network config written by checkbox
             network:
+              renderer: networkd
               version: 2
               wifis:
                 eth0:
@@ -83,7 +102,7 @@ class WifiClientTestNetplanTests(TestCase):
             """
         )
         result = generate_test_config(
-            "eth0", "my_ap_wpa3", "s3cr3t", "", False, True
+            "eth0", "my_ap_wpa3", "s3cr3t", "", False, True, "networkd"
         )
         self.assertEqual(result.strip(), expected_output.strip())
 
@@ -92,6 +111,7 @@ class WifiClientTestNetplanTests(TestCase):
             """
             # This is the network config written by checkbox
             network:
+              renderer: networkd
               version: 2
               wifis:
                 eth0:
@@ -107,15 +127,43 @@ class WifiClientTestNetplanTests(TestCase):
             """
         )
         result = generate_test_config(
-            "eth0", "my_ap", "s3cr3t", "192.168.1.1", False, False
+            "eth0", "my_ap", "s3cr3t", "192.168.1.1", False, False, "networkd"
         )
         self.assertEqual(result.strip(), expected_output.strip())
 
     def test_no_ssid_fails(self):
         with self.assertRaises(SystemExit):
             generate_test_config(
-                "eth0", "", "s3cr3t", "192.168.1.1", False, False
+                "eth0", "", "s3cr3t", "192.168.1.1", False, False, "networkd"
             )
+
+    @patch("subprocess.call")
+    def test_print_journal_entries_networkd(self, mock_call):
+        start_time = datetime.datetime(2021, 1, 1, 12, 0)
+        print_journal_entries(start_time, "networkd")
+        expected_command = (
+            "journalctl -q --no-pager -u systemd-networkd.service "
+            "-u wpa_supplicant.service "
+            '-u netplan-* --since "2021-01-01 12:00:00" '
+        )
+        mock_call.assert_called_once_with(expected_command, shell=True)
+
+    @patch("subprocess.call")
+    def test_print_journal_entries_networkmanager(self, mock_call):
+        start_time = datetime.datetime(2021, 1, 1, 12, 0)
+        print_journal_entries(start_time, "NetworkManager")
+        expected_command = (
+            "journalctl -q --no-pager -u NetworkManager.service "
+            "-u wpa_supplicant.service "
+            '-u netplan-* --since "2021-01-01 12:00:00" '
+        )
+        mock_call.assert_called_once_with(expected_command, shell=True)
+
+    def test_print_journal_entries_unknown_renderer(self):
+        start_time = datetime.datetime(2021, 1, 1, 12, 0)
+        with self.assertRaises(ValueError) as context:
+            print_journal_entries(start_time, "unknown")
+        self.assertTrue("Unknown renderer: unknown" in str(context.exception))
 
     def test_parser_psk_and_wpa3(self):
         with patch(
@@ -157,3 +205,468 @@ class WifiClientTestNetplanTests(TestCase):
         ):
             with self.assertRaises(SystemExit):
                 parse_args()
+
+    @patch(
+        "sys.argv",
+        [
+            "script.py",
+            "-i",
+            "wlan0",
+            "-s",
+            "SSID",
+            "-d",
+            "--renderer",
+            "networkd",
+        ],
+    )
+    def test_parser_networkd(self):
+        args = parse_args()
+        self.assertEqual(args.renderer, "networkd")
+        self.assertEqual(args.interface, "wlan0")
+        self.assertEqual(args.ssid, "SSID")
+        self.assertTrue(args.dhcp)
+        self.assertFalse(args.wpa3)
+        self.assertIsNone(args.psk)
+        self.assertEqual(args.address, "")
+
+    @patch(
+        "sys.argv",
+        [
+            "script.py",
+            "-i",
+            "wlan0",
+            "-s",
+            "SSID",
+            "-d",
+            "--renderer",
+            "NetworkManager",
+        ],
+    )
+    def test_parser_networkmanager(self):
+        args = parse_args()
+        self.assertEqual(args.renderer, "NetworkManager")
+        self.assertEqual(args.interface, "wlan0")
+        self.assertEqual(args.ssid, "SSID")
+        self.assertTrue(args.dhcp)
+        self.assertFalse(args.wpa3)
+        self.assertIsNone(args.psk)
+        self.assertEqual(args.address, "")
+
+    def test_parser_no_renderer(self):
+        with patch(
+            "sys.argv", ["script.py", "-i", "wlan0", "-s", "SSID", "-d"]
+        ):
+            args = parse_args()
+            self.assertEqual(args.renderer, "AutoDetect")
+            self.assertEqual(args.interface, "wlan0")
+            self.assertEqual(args.ssid, "SSID")
+            self.assertTrue(args.dhcp)
+            self.assertFalse(args.wpa3)
+            self.assertIsNone(args.psk)
+            self.assertEqual(args.address, "")
+
+    def test_parser_autodetect_renderer(self):
+        with patch(
+            "sys.argv",
+            [
+                "script.py",
+                "-i",
+                "wlan0",
+                "-s",
+                "SSID",
+                "-d",
+                "--renderer",
+                "AutoDetect",
+            ],
+        ):
+            args = parse_args()
+            self.assertEqual(args.renderer, "AutoDetect")
+            self.assertEqual(args.interface, "wlan0")
+            self.assertEqual(args.ssid, "SSID")
+            self.assertTrue(args.dhcp)
+            self.assertFalse(args.wpa3)
+            self.assertIsNone(args.psk)
+            self.assertEqual(args.address, "")
+
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data="network:\n  renderer: networkd",
+    )
+    @patch("glob.glob", return_value=["/etc/netplan/01-netcfg.yaml"])
+    @patch("os.path.exists", return_value=True)
+    def test_renderer_networkd(self, mock_exists, mock_glob, mock_open):
+        renderer = netplan_renderer()
+        self.assertEqual(renderer, "networkd")
+
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data="network:\n  renderer: NetworkManager",
+    )
+    @patch("glob.glob", return_value=["/etc/netplan/01-netcfg.yaml"])
+    @patch("os.path.exists", return_value=True)
+    def test_renderer_networkmanager(self, mock_exists, mock_glob, mock_open):
+        renderer = netplan_renderer()
+        self.assertEqual(renderer, "NetworkManager")
+
+    @patch("glob.glob", return_value=[])
+    @patch("os.path.exists", return_value=True)
+    def test_no_yaml_files(self, mock_exists, mock_glob):
+        renderer = netplan_renderer()
+        self.assertEqual(renderer, "networkd")
+
+    @patch(
+        "wifi_client_test_netplan.netplan_renderer", return_value="networkd"
+    )
+    def test_auto_detect_matches_networkd(self, mock_renderer):
+        self.assertEqual(check_and_get_renderer("AutoDetect"), "networkd")
+
+    @patch(
+        "wifi_client_test_netplan.netplan_renderer", return_value="networkd"
+    )
+    def test_explicit_networkd_matches(self, mock_renderer):
+        self.assertEqual(check_and_get_renderer("networkd"), "networkd")
+
+    @patch(
+        "wifi_client_test_netplan.netplan_renderer", return_value="networkd"
+    )
+    def test_explicit_network_manager_mismatch(self, mock_renderer):
+        with self.assertRaises(SystemExit):
+            check_and_get_renderer("NetworkManager")
+
+    @patch(
+        "wifi_client_test_netplan.netplan_renderer",
+        return_value="NetworkManager",
+    )
+    def test_auto_detect_matches_network_manager(self, mock_renderer):
+        self.assertEqual(
+            check_and_get_renderer("AutoDetect"), "NetworkManager"
+        )
+
+    @patch(
+        "wifi_client_test_netplan.netplan_renderer",
+        return_value="NetworkManager",
+    )
+    def test_explicit_network_manager_matches(self, mock_renderer):
+        self.assertEqual(
+            check_and_get_renderer("NetworkManager"), "NetworkManager"
+        )
+
+    @patch(
+        "wifi_client_test_netplan.netplan_renderer",
+        return_value="NetworkManager",
+    )
+    def test_explicit_networkd_mismatch_with_network_manager(
+        self, mock_renderer
+    ):
+        with self.assertRaises(SystemExit):
+            check_and_get_renderer("networkd")
+
+    @patch("shutil.rmtree", side_effect=lambda x: None)
+    @patch("shutil.copy")
+    @patch(
+        "os.path.exists", return_value=True
+    )  # Assuming the path always exists
+    @patch("glob.glob", return_value=["/etc/netplan/config.yaml"])
+    @patch("os.makedirs")
+    def test_netplan_config_backup_existing_backup(
+        self, mock_makedirs, mock_glob, mock_exists, mock_copy, mock_rmtree
+    ):
+        netplan_config_backup()
+        # Ensure the conditions under which shutil.copy is called only once
+        # are met
+        mock_copy.assert_called_with("/etc/netplan/config.yaml", ANY)
+
+    @patch("shutil.rmtree", side_effect=lambda x: None)
+    @patch("shutil.copy")
+    @patch(
+        "os.path.exists", return_value=True
+    )  # Adjust based on function logic
+    @patch("glob.glob", return_value=[])
+    @patch("os.makedirs")
+    def test_netplan_config_backup_no_config_files(
+        self, mock_makedirs, mock_glob, mock_exists, mock_copy, mock_rmtree
+    ):
+        netplan_config_backup()
+        # Assert based on expected behavior when no config files are found
+
+    @patch("shutil.rmtree", side_effect=lambda x: None)
+    @patch("shutil.copy")
+    @patch(
+        "os.path.exists",
+        side_effect=lambda x: (
+            False if x == "specific_condition_path" else True
+        ),
+    )
+    @patch("glob.glob", return_value=["/etc/netplan/config.yaml"])
+    @patch("os.makedirs")
+    def test_netplan_config_backup_no_existing_backup(
+        self, mock_makedirs, mock_glob, mock_exists, mock_copy, mock_rmtree
+    ):
+        netplan_config_backup()
+
+    @patch("subprocess.check_output")
+    def test_networkd_routable(self, mock_check_output):
+        mock_check_output.return_value = b"State: routable"
+        routable, state = _check_routable_state("wlan0", "networkd")
+        self.assertTrue(routable)
+        self.assertIn("routable", state)
+
+    @patch("subprocess.check_output")
+    def test_networkd_not_routable(self, mock_check_output):
+        mock_check_output.return_value = b"State: degraded"
+        routable, state = _check_routable_state("wlan0", "networkd")
+        self.assertFalse(routable)
+        self.assertIn("degraded", state)
+
+    @patch("subprocess.check_output")
+    def test_networkmanager_connected(self, mock_check_output):
+        mock_check_output.return_value = b"GENERAL.STATE: 100 (connected)"
+        routable, state = _check_routable_state("wlan0", "NetworkManager")
+        self.assertTrue(routable)
+        self.assertIn("connected", state)
+
+    @patch("subprocess.check_output")
+    def test_networkmanager_not_connected(self, mock_check_output):
+        mock_check_output.return_value = b"GENERAL.STATE: 30 (disconnected)"
+        routable, state = _check_routable_state("wlan0", "NetworkManager")
+        self.assertFalse(routable)
+        self.assertIn("disconnected", state)
+
+    def test_unknown_renderer(self):
+        with self.assertRaises(ValueError):
+            _check_routable_state("wlan0", "unknown_renderer")
+
+    @patch("subprocess.check_output")
+    def test_get_networkctl_state_success(self, mock_check_output):
+        mock_check_output.return_value = (
+            b"State: routable\nPath: pci-0000:02:00.0"
+        )
+        interface = "wlan0"
+        state = _get_networkctl_state(interface)
+        self.assertEqual(state, " routable", "Should return 'routable' state")
+
+    @patch("subprocess.check_output")
+    def test_get_networkctl_state_no_state_line(self, mock_check_output):
+        mock_check_output.return_value = (
+            b"Some other info: value\nsome more info"
+        )
+        interface = "wlan0"
+        state = _get_networkctl_state(interface)
+        self.assertIsNone(
+            state, "Should return None when 'State' line is missing"
+        )
+
+    @patch("subprocess.check_output")
+    def test_get_networkctl_state_empty_output(self, mock_check_output):
+        mock_check_output.return_value = b""
+        interface = "wlan0"
+        state = _get_networkctl_state(interface)
+        self.assertIsNone(state, "Should return None for empty command output")
+
+    @patch("subprocess.check_output", side_effect=Exception("Command failed"))
+    def test_get_networkctl_state_command_fails(self, mock_check_output):
+        interface = "wlan0"
+        with self.assertRaises(
+            Exception, msg="Should raise an exception for command failure"
+        ):
+            _get_networkctl_state(interface)
+
+    @patch("subprocess.check_output")
+    def test_get_nmcli_state_success(self, mock_check_output):
+        mock_check_output.return_value = (
+            b"GENERAL.MTU:                            1500\n"
+            b"some other info\n"
+            b"GENERAL.STATE:                          100 (connected)"
+        )
+        interface = "wlan0"
+        state = _get_nmcli_state(interface)
+        self.assertEqual(
+            state, "100 (connected)", "Should return '100 (connected)' state"
+        )
+
+    @patch("subprocess.check_output")
+    def test_get_nmcli_state_unexpected_output(self, mock_check_output):
+        mock_check_output.return_value = b"some unexpected output"
+        interface = "wlan0"
+        state = _get_nmcli_state(interface)
+        self.assertIsNone(
+            state,
+            "Should return None when expected state information is missing",
+        )
+
+    @patch("subprocess.check_output", side_effect=Exception("Command failed"))
+    def test_get_nmcli_state_command_fails(self, mock_check_output):
+        interface = "wlan0"
+        with self.assertRaises(
+            Exception, msg="Should raise an exception for command failure"
+        ):
+            _get_nmcli_state(interface)
+
+    @patch("wifi_client_test_netplan._check_routable_state")
+    @patch("wifi_client_test_netplan.time.sleep", return_value=None)
+    def test_wait_for_routable_networkd(
+        self, mock_sleep, mock_check_routable_state
+    ):
+        mock_check_routable_state.side_effect = [
+            (False, ""),
+            (False, ""),
+            (True, ""),
+        ]
+        result = wait_for_routable("wlan0", "networkd")
+        self.assertTrue(result)
+        self.assertEqual(mock_check_routable_state.call_count, 3)
+        mock_check_routable_state.assert_called_with("wlan0", "networkd")
+
+    @patch("wifi_client_test_netplan._check_routable_state")
+    @patch("wifi_client_test_netplan.time.sleep", return_value=None)
+    def test_wait_for_no_routable_networkd(
+        self, mock_sleep, mock_check_routable_state
+    ):
+        mock_check_routable_state.side_effect = [
+            (False, ""),
+            (False, ""),
+            (False, ""),
+        ]
+        result = wait_for_routable("wlan0", "networkd", 3)
+        self.assertFalse(result)
+        self.assertEqual(mock_check_routable_state.call_count, 3)
+        mock_check_routable_state.assert_called_with("wlan0", "networkd")
+
+    @patch("wifi_client_test_netplan._check_routable_state")
+    @patch("wifi_client_test_netplan.time.sleep", return_value=None)
+    def test_wait_for_routable_networkmanager(
+        self, mock_sleep, mock_check_routable_state
+    ):
+        mock_check_routable_state.side_effect = [
+            (False, ""),
+            (True, ""),
+        ]
+        result = wait_for_routable("wlan0", "NetworkManager", 3)
+        self.assertTrue(result)
+        self.assertEqual(mock_check_routable_state.call_count, 2)
+        mock_check_routable_state.assert_called_with("wlan0", "NetworkManager")
+
+    @patch("wifi_client_test_netplan._check_routable_state")
+    @patch("wifi_client_test_netplan.time.sleep", return_value=None)
+    def test_wait_for_no_routable_networkmanager(
+        self, mock_sleep, mock_check_routable_state
+    ):
+        mock_check_routable_state.side_effect = [
+            (False, ""),
+            (False, ""),
+            (False, ""),
+        ]
+        result = wait_for_routable("wlan0", "NetworkManager", 3)
+        self.assertFalse(result)
+        self.assertEqual(mock_check_routable_state.call_count, 3)
+        mock_check_routable_state.assert_called_with("wlan0", "NetworkManager")
+
+    @patch("subprocess.check_output")
+    def test_get_gateway_networkd(self, mock_check_output):
+        # Setup: Mock the subprocess output for networkd
+        mock_check_output.return_value = b"Gateway: 192.168.1.1\n"
+        interface = "wlan0"
+        renderer = "networkd"
+
+        # Execution: Call the get_gateway function
+        gateway = get_gateway(interface, renderer)
+
+        # Verification: Verify the correct gateway is returned
+        self.assertEqual(gateway, "192.168.1.1")
+
+    @patch("subprocess.check_output")
+    def test_get_gateway_networkd_failure(self, mock_check_output):
+        mock_check_output.return_value = b"ABC:123\n abc:zxc\n"
+        interface = "wlan0"
+        renderer = "networkd"
+
+        gateway = get_gateway(interface, renderer)
+        self.assertIsNone(gateway)
+
+    @patch("subprocess.check_output")
+    def test_get_gateway_networkmanager(self, mock_check_output):
+        mock_check_output.return_value = (
+            b"IP4.GATEWAY:                        192.168.1.1\n"
+        )
+        interface = "wlan0"
+        renderer = "NetworkManager"
+
+        gateway = get_gateway(interface, renderer)
+
+        self.assertEqual(gateway, "192.168.1.1")
+
+    @patch("subprocess.check_output")
+    def test_get_gateway_networkmanager_failure(self, mock_check_output):
+        mock_check_output.return_value = b"ABC:123\n abc:zxc\n"
+        interface = "wlan0"
+        renderer = "NetworkManager"
+        gateway = get_gateway(interface, renderer)
+        self.assertIsNone(gateway)
+
+    @patch("subprocess.check_output")
+    def test_get_gateway_unknown_renderer(self, mock_check_output):
+        interface = "wlan0"
+        renderer = "unknown_renderer"
+        with self.assertRaises(ValueError):
+            get_gateway(interface, renderer)
+
+    @patch("wifi_client_test_netplan.ping")
+    @patch("wifi_client_test_netplan.get_gateway")
+    def test_perform_ping_test_success_networkd(
+        self, mock_get_gateway, mock_ping
+    ):
+        mock_get_gateway.return_value = "192.168.1.1"
+        mock_ping.return_value = {"received": 5}
+        result = perform_ping_test("wlan0", "networkd")
+        self.assertTrue(result)
+
+    @patch("wifi_client_test_netplan.ping")
+    @patch("wifi_client_test_netplan.get_gateway")
+    def test_perform_ping_test_failure_networkd(
+        self, mock_get_gateway, mock_ping
+    ):
+        mock_get_gateway.return_value = "192.168.1.1"
+        mock_ping.return_value = {"received": 0}
+        result = perform_ping_test("wlan0", "networkd")
+        self.assertFalse(result)
+
+    @patch("wifi_client_test_netplan.ping")
+    @patch("wifi_client_test_netplan.get_gateway")
+    def test_perform_ping_test_success_networkmanager(
+        self, mock_get_gateway, mock_ping
+    ):
+        mock_get_gateway.return_value = "192.168.1.1"
+        mock_ping.return_value = {"received": 5}
+        result = perform_ping_test("wlan0", "NetworkManager")
+        self.assertTrue(result)
+
+    @patch("wifi_client_test_netplan.ping")
+    @patch("wifi_client_test_netplan.get_gateway")
+    def test_perform_ping_test_failure_networkmanager(
+        self, mock_get_gateway, mock_ping
+    ):
+        mock_get_gateway.return_value = "192.168.1.1"
+        mock_ping.return_value = {"received": 0}
+        result = perform_ping_test("wlan0", "NetworkManager")
+        self.assertFalse(result)
+
+
+class MainTests(TestCase):
+    @patch("wifi_client_test_netplan.wait_for_routable", return_value=True)
+    @patch("wifi_client_test_netplan.print_address_info")
+    @patch("wifi_client_test_netplan.print_route_info")
+    @patch("wifi_client_test_netplan.perform_ping_test", return_value=True)
+    @patch("wifi_client_test_netplan.delete_test_config")
+    @patch("wifi_client_test_netplan.netplan_config_restore")
+    @patch("wifi_client_test_netplan.print_journal_entries")
+    @patch("wifi_client_test_netplan.time.sleep", return_value=None)
+    @patch(
+        "wifi_client_test_netplan.parse_args",
+        return_value=MagicMock(renderer="NetworkManager"),
+    )
+    @patch("os.remove")
+    def test_main_success(self, *args):
+        with self.assertRaises(SystemExit) as cm:
+            main()

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -740,7 +740,7 @@ class TestMain(TestCase):
         self.assertEqual(mock_wipe.call_count, 1)
         self.assertEqual(mock_generate.call_count, 1)
         self.assertEqual(mock_write.call_count, 1)
-        mock_apply.assert_called()
+        self.assertGreaterEqual(mock_apply.call_count, 1)
         mock_wait_routable.assert_called_once_with("wlan0", "networkd")
         mock_print_address.assert_called_once_with("wlan0")
         self.assertEqual(mock_print_route.call_count, 1)

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -147,7 +147,7 @@ class WifiClientTestNetplanTests(TestCase):
         expected_command = (
             "journalctl -q --no-pager -u systemd-networkd.service "
             "-u wpa_supplicant.service "
-            "-u netplan-* --since \"2021-01-01 12:00:00\" "
+            '-u netplan-* --since "2021-01-01 12:00:00" '
         )
         mock_call.assert_called_once_with(expected_command, shell=True)
 
@@ -158,7 +158,7 @@ class WifiClientTestNetplanTests(TestCase):
         expected_command = (
             "journalctl -q --no-pager -u NetworkManager.service "
             "-u wpa_supplicant.service "
-            "-u netplan-* --since \"2021-01-01 12:00:00\" "
+            '-u netplan-* --since "2021-01-01 12:00:00" '
         )
         mock_call.assert_called_once_with(expected_command, shell=True)
 
@@ -718,7 +718,7 @@ class TestMain(TestCase):
         mock_wipe,
         mock_backup,
         mock_renderer,
-        mock_parse_args
+        mock_parse_args,
     ):
         # Setup
         mock_args = MagicMock()
@@ -774,7 +774,7 @@ class TestMain(TestCase):
         mock_wipe,
         mock_backup,
         mock_renderer,
-        mock_parse_args
+        mock_parse_args,
     ):
         # Setup
         mock_args = MagicMock()
@@ -818,7 +818,7 @@ class TestMain(TestCase):
         mock_wipe,
         mock_backup,
         mock_renderer,
-        mock_parse_args
+        mock_parse_args,
     ):
         # Setup
         mock_args = MagicMock()

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -390,6 +390,7 @@ class WifiClientTestNetplanTests(TestCase):
     ):
         netplan_config_backup()
         # Assert based on expected behavior when no config files are found
+        mock_copy.assert_not_called()
 
     @patch("shutil.rmtree", side_effect=lambda x: None)
     @patch("shutil.copy")

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -147,7 +147,7 @@ class WifiClientTestNetplanTests(TestCase):
         expected_command = (
             "journalctl -q --no-pager -u systemd-networkd.service "
             "-u wpa_supplicant.service "
-            '-u netplan-* --since "2021-01-01 12:00:00" '
+            "-u netplan-* --since \"2021-01-01 12:00:00\" "
         )
         mock_call.assert_called_once_with(expected_command, shell=True)
 
@@ -158,7 +158,7 @@ class WifiClientTestNetplanTests(TestCase):
         expected_command = (
             "journalctl -q --no-pager -u NetworkManager.service "
             "-u wpa_supplicant.service "
-            '-u netplan-* --since "2021-01-01 12:00:00" '
+            "-u netplan-* --since \"2021-01-01 12:00:00\" "
         )
         mock_call.assert_called_once_with(expected_command, shell=True)
 
@@ -509,14 +509,14 @@ class WifiClientTestNetplanTests(TestCase):
         with self.assertRaises(ValueError):
             get_interface_info(interface, renderer)
 
-    @patch('wifi_client_test_netplan.get_netplan_config_files')
-    @patch('wifi_client_test_netplan.os.remove')
-    @patch('wifi_client_test_netplan.print_head')
+    @patch("wifi_client_test_netplan.get_netplan_config_files")
+    @patch("wifi_client_test_netplan.os.remove")
+    @patch("wifi_client_test_netplan.print_head")
     def test_successful_wipe(
         self, mock_print_head, mock_remove, mock_get_files
     ):
         mock_get_files.side_effect = [
-            ['/etc/netplan/01-netcfg.yaml', '/etc/netplan/02-wifi.yaml'],
+            ["/etc/netplan/01-netcfg.yaml", "/etc/netplan/02-wifi.yaml"],
             [],
         ]
         captured_output = io.StringIO()
@@ -541,10 +541,10 @@ class WifiClientTestNetplanTests(TestCase):
             captured_output.getvalue(),
         )
 
-    @patch('wifi_client_test_netplan.get_netplan_config_files')
-    @patch('wifi_client_test_netplan.os.remove')
-    @patch('wifi_client_test_netplan.netplan_config_restore')
-    @patch('wifi_client_test_netplan.print_head')
+    @patch("wifi_client_test_netplan.get_netplan_config_files")
+    @patch("wifi_client_test_netplan.os.remove")
+    @patch("wifi_client_test_netplan.netplan_config_restore")
+    @patch("wifi_client_test_netplan.print_head")
     def test_failed_wipe(
         self,
         mock_print_head,
@@ -554,7 +554,7 @@ class WifiClientTestNetplanTests(TestCase):
     ):
         mock_get_files.side_effect = [
             ["/etc/netplan/01-netcfg.yaml", "/etc/netplan/02-wifi.yaml"],
-            ['/etc/netplan/02-wifi.yaml'],
+            ["/etc/netplan/02-wifi.yaml"],
         ]
         captured_output = io.StringIO()
         sys.stdout = captured_output
@@ -687,21 +687,21 @@ class WifiClientTestNetplanTests(TestCase):
 
 class TestMain(TestCase):
 
-    @patch('wifi_client_test_netplan.parse_args')
-    @patch('wifi_client_test_netplan.check_and_get_renderer')
-    @patch('wifi_client_test_netplan.netplan_config_backup')
-    @patch('wifi_client_test_netplan.netplan_config_wipe')
-    @patch('wifi_client_test_netplan.generate_test_config')
-    @patch('wifi_client_test_netplan.write_test_config')
-    @patch('wifi_client_test_netplan.netplan_apply_config')
-    @patch('wifi_client_test_netplan.time.sleep')
-    @patch('wifi_client_test_netplan.wait_for_routable')
-    @patch('wifi_client_test_netplan.print_address_info')
-    @patch('wifi_client_test_netplan.print_route_info')
-    @patch('wifi_client_test_netplan.perform_ping_test')
-    @patch('wifi_client_test_netplan.delete_test_config')
-    @patch('wifi_client_test_netplan.netplan_config_restore')
-    @patch('wifi_client_test_netplan.print_journal_entries')
+    @patch("wifi_client_test_netplan.parse_args")
+    @patch("wifi_client_test_netplan.check_and_get_renderer")
+    @patch("wifi_client_test_netplan.netplan_config_backup")
+    @patch("wifi_client_test_netplan.netplan_config_wipe")
+    @patch("wifi_client_test_netplan.generate_test_config")
+    @patch("wifi_client_test_netplan.write_test_config")
+    @patch("wifi_client_test_netplan.netplan_apply_config")
+    @patch("wifi_client_test_netplan.time.sleep")
+    @patch("wifi_client_test_netplan.wait_for_routable")
+    @patch("wifi_client_test_netplan.print_address_info")
+    @patch("wifi_client_test_netplan.print_route_info")
+    @patch("wifi_client_test_netplan.perform_ping_test")
+    @patch("wifi_client_test_netplan.delete_test_config")
+    @patch("wifi_client_test_netplan.netplan_config_restore")
+    @patch("wifi_client_test_netplan.print_journal_entries")
     def test_main_success(
         self, mock_print_journal, mock_restore, mock_delete,
         mock_ping, mock_print_route, mock_print_address,
@@ -711,10 +711,10 @@ class TestMain(TestCase):
     ):
         # Setup
         mock_args = MagicMock()
-        mock_args.renderer = 'networkd'
-        mock_args.interface = 'wlan0'
+        mock_args.renderer = "networkd"
+        mock_args.interface = "wlan0"
         mock_parse_args.return_value = mock_args
-        mock_renderer.return_value = 'networkd'
+        mock_renderer.return_value = "networkd"
         mock_wait_routable.return_value = True
         mock_ping.return_value = True
         mock_apply.return_value = True
@@ -724,32 +724,32 @@ class TestMain(TestCase):
 
         # Assert
         mock_parse_args.assert_called_once()
-        mock_renderer.assert_called_once_with('networkd')
+        mock_renderer.assert_called_once_with("networkd")
         mock_backup.assert_called_once()
         mock_wipe.assert_called_once()
         mock_generate.assert_called_once()
         mock_write.assert_called_once()
         mock_apply.assert_called()
-        mock_wait_routable.assert_called_once_with('wlan0', 'networkd')
-        mock_print_address.assert_called_once_with('wlan0')
+        mock_wait_routable.assert_called_once_with("wlan0", "networkd")
+        mock_print_address.assert_called_once_with("wlan0")
         mock_print_route.assert_called_once()
-        mock_ping.assert_called_once_with('wlan0', 'networkd')
+        mock_ping.assert_called_once_with("wlan0", "networkd")
         mock_delete.assert_called_once()
         mock_restore.assert_called_once()
         mock_print_journal.assert_called_once()
 
-    @patch('wifi_client_test_netplan.parse_args')
-    @patch('wifi_client_test_netplan.check_and_get_renderer')
-    @patch('wifi_client_test_netplan.netplan_config_backup')
-    @patch('wifi_client_test_netplan.netplan_config_wipe')
-    @patch('wifi_client_test_netplan.generate_test_config')
-    @patch('wifi_client_test_netplan.write_test_config')
-    @patch('wifi_client_test_netplan.netplan_apply_config')
-    @patch('wifi_client_test_netplan.time.sleep')
-    @patch('wifi_client_test_netplan.wait_for_routable')
-    @patch('wifi_client_test_netplan.delete_test_config')
-    @patch('wifi_client_test_netplan.netplan_config_restore')
-    @patch('wifi_client_test_netplan.print_journal_entries')
+    @patch("wifi_client_test_netplan.parse_args")
+    @patch("wifi_client_test_netplan.check_and_get_renderer")
+    @patch("wifi_client_test_netplan.netplan_config_backup")
+    @patch("wifi_client_test_netplan.netplan_config_wipe")
+    @patch("wifi_client_test_netplan.generate_test_config")
+    @patch("wifi_client_test_netplan.write_test_config")
+    @patch("wifi_client_test_netplan.netplan_apply_config")
+    @patch("wifi_client_test_netplan.time.sleep")
+    @patch("wifi_client_test_netplan.wait_for_routable")
+    @patch("wifi_client_test_netplan.delete_test_config")
+    @patch("wifi_client_test_netplan.netplan_config_restore")
+    @patch("wifi_client_test_netplan.print_journal_entries")
     def test_main_apply_config_failure(
         self, mock_print_journal, mock_restore, mock_delete,
         mock_wait_routable, mock_sleep, mock_apply, mock_write,
@@ -758,9 +758,9 @@ class TestMain(TestCase):
     ):
         # Setup
         mock_args = MagicMock()
-        mock_args.renderer = 'networkd'
+        mock_args.renderer = "networkd"
         mock_parse_args.return_value = mock_args
-        mock_renderer.return_value = 'networkd'
+        mock_renderer.return_value = "networkd"
         mock_apply.return_value = False
 
         # Execute and Assert
@@ -771,19 +771,19 @@ class TestMain(TestCase):
         mock_restore.assert_called_once()
         mock_print_journal.assert_called_once()
 
-    @patch('wifi_client_test_netplan.parse_args')
-    @patch('wifi_client_test_netplan.check_and_get_renderer')
-    @patch('wifi_client_test_netplan.netplan_config_backup')
-    @patch('wifi_client_test_netplan.netplan_config_wipe')
-    @patch('wifi_client_test_netplan.generate_test_config')
-    @patch('wifi_client_test_netplan.write_test_config')
-    @patch('wifi_client_test_netplan.netplan_apply_config')
-    @patch('wifi_client_test_netplan.time.sleep')
-    @patch('wifi_client_test_netplan.wait_for_routable')
-    @patch('wifi_client_test_netplan.delete_test_config')
-    @patch('wifi_client_test_netplan.netplan_config_restore')
-    @patch('wifi_client_test_netplan.print_journal_entries')
-    @patch('wifi_client_test_netplan.perform_ping_test')
+    @patch("wifi_client_test_netplan.parse_args")
+    @patch("wifi_client_test_netplan.check_and_get_renderer")
+    @patch("wifi_client_test_netplan.netplan_config_backup")
+    @patch("wifi_client_test_netplan.netplan_config_wipe")
+    @patch("wifi_client_test_netplan.generate_test_config")
+    @patch("wifi_client_test_netplan.write_test_config")
+    @patch("wifi_client_test_netplan.netplan_apply_config")
+    @patch("wifi_client_test_netplan.time.sleep")
+    @patch("wifi_client_test_netplan.wait_for_routable")
+    @patch("wifi_client_test_netplan.delete_test_config")
+    @patch("wifi_client_test_netplan.netplan_config_restore")
+    @patch("wifi_client_test_netplan.print_journal_entries")
+    @patch("wifi_client_test_netplan.perform_ping_test")
     def test_main_ping_test_failure(
         self, mock_ping, mock_print_journal, mock_restore, mock_delete,
         mock_wait_routable, mock_sleep, mock_apply, mock_write,
@@ -792,10 +792,10 @@ class TestMain(TestCase):
     ):
         # Setup
         mock_args = MagicMock()
-        mock_args.renderer = 'networkd'
-        mock_args.interface = 'wlan0'
+        mock_args.renderer = "networkd"
+        mock_args.interface = "wlan0"
         mock_parse_args.return_value = mock_args
-        mock_renderer.return_value = 'networkd'
+        mock_renderer.return_value = "networkd"
         mock_wait_routable.return_value = True
         mock_apply.return_value = True
         mock_ping.return_value = False
@@ -807,4 +807,4 @@ class TestMain(TestCase):
         mock_delete.assert_called_once()
         mock_restore.assert_called_once()
         mock_print_journal.assert_called_once()
-        mock_ping.assert_called_once_with('wlan0', 'networkd')
+        mock_ping.assert_called_once_with("wlan0", "networkd")

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -571,7 +571,7 @@ class WifiClientTestNetplanTests(TestCase):
                 call("/etc/netplan/02-wifi.yaml"),
             ]
         )
-        mock_restore.assert_called_once()
+        self.assertEqual(mock_restore.call_count, 1)
         self.assertIn(
             "ERROR: Failed to wipe netplan config files:",
             captured_output.getvalue(),
@@ -723,20 +723,20 @@ class TestMain(TestCase):
         main()
 
         # Assert
-        mock_parse_args.assert_called_once()
+        self.assertEqual(mock_parse_args.call_count, 1)
         mock_renderer.assert_called_once_with("networkd")
-        mock_backup.assert_called_once()
-        mock_wipe.assert_called_once()
-        mock_generate.assert_called_once()
-        mock_write.assert_called_once()
+        self.assertEqual(mock_backup.call_count, 1)
+        self.assertEqual(mock_wipe.call_count, 1)
+        self.assertEqual(mock_generate.call_count, 1)
+        self.assertEqual(mock_write.call_count, 1)
         mock_apply.assert_called()
         mock_wait_routable.assert_called_once_with("wlan0", "networkd")
         mock_print_address.assert_called_once_with("wlan0")
-        mock_print_route.assert_called_once()
+        self.assertEqual(mock_print_route.call_count, 1)
         mock_ping.assert_called_once_with("wlan0", "networkd")
-        mock_delete.assert_called_once()
-        mock_restore.assert_called_once()
-        mock_print_journal.assert_called_once()
+        self.assertEqual(mock_delete.call_count, 1)
+        self.assertEqual(mock_restore.call_count, 1)
+        self.assertEqual(mock_print_journal.call_count, 1)
 
     @patch("wifi_client_test_netplan.parse_args")
     @patch("wifi_client_test_netplan.check_and_get_renderer")
@@ -767,9 +767,9 @@ class TestMain(TestCase):
         with self.assertRaises(SystemExit):
             main()
 
-        mock_delete.assert_called_once()
-        mock_restore.assert_called_once()
-        mock_print_journal.assert_called_once()
+        self.assertEqual(mock_delete.call_count, 1)
+        self.assertEqual(mock_restore.call_count, 1)
+        self.assertEqual(mock_print_journal.call_count, 1)
 
     @patch("wifi_client_test_netplan.parse_args")
     @patch("wifi_client_test_netplan.check_and_get_renderer")
@@ -804,7 +804,7 @@ class TestMain(TestCase):
         with self.assertRaises(SystemExit):
             main()
 
-        mock_delete.assert_called_once()
-        mock_restore.assert_called_once()
-        mock_print_journal.assert_called_once()
+        self.assertEqual(mock_delete.call_count, 1)
+        self.assertEqual(mock_restore.call_count, 1)
+        self.assertEqual(mock_print_journal.call_count, 1)
         mock_ping.assert_called_once_with("wlan0", "networkd")

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -526,6 +526,10 @@ class TestMain(TestCase):
     @patch("wifi_client_test_netplan.generate_test_config")
     @patch("wifi_client_test_netplan.write_test_config")
     @patch("wifi_client_test_netplan.netplan_apply_config", return_value=True)
+    @patch(
+        "wifi_client_test_netplan.check_and_get_renderer",
+        return_value="NetworkManager",
+    )
     def test_main_success(
         self,
         mock_write_test_config,

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -703,10 +703,21 @@ class TestMain(TestCase):
     @patch("wifi_client_test_netplan.netplan_config_restore")
     @patch("wifi_client_test_netplan.print_journal_entries")
     def test_main_success(
-        self, mock_print_journal, mock_restore, mock_delete,
-        mock_ping, mock_print_route, mock_print_address,
-        mock_wait_routable, mock_sleep, mock_apply, mock_write,
-        mock_generate, mock_wipe, mock_backup, mock_renderer,
+        self,
+        mock_print_journal,
+        mock_restore,
+        mock_delete,
+        mock_ping,
+        mock_print_route,
+        mock_print_address,
+        mock_wait_routable,
+        mock_sleep,
+        mock_apply,
+        mock_write,
+        mock_generate,
+        mock_wipe,
+        mock_backup,
+        mock_renderer,
         mock_parse_args
     ):
         # Setup
@@ -751,9 +762,18 @@ class TestMain(TestCase):
     @patch("wifi_client_test_netplan.netplan_config_restore")
     @patch("wifi_client_test_netplan.print_journal_entries")
     def test_main_apply_config_failure(
-        self, mock_print_journal, mock_restore, mock_delete,
-        mock_wait_routable, mock_sleep, mock_apply, mock_write,
-        mock_generate, mock_wipe, mock_backup, mock_renderer,
+        self,
+        mock_print_journal,
+        mock_restore,
+        mock_delete,
+        mock_wait_routable,
+        mock_sleep,
+        mock_apply,
+        mock_write,
+        mock_generate,
+        mock_wipe,
+        mock_backup,
+        mock_renderer,
         mock_parse_args
     ):
         # Setup
@@ -785,9 +805,19 @@ class TestMain(TestCase):
     @patch("wifi_client_test_netplan.print_journal_entries")
     @patch("wifi_client_test_netplan.perform_ping_test")
     def test_main_ping_test_failure(
-        self, mock_ping, mock_print_journal, mock_restore, mock_delete,
-        mock_wait_routable, mock_sleep, mock_apply, mock_write,
-        mock_generate, mock_wipe, mock_backup, mock_renderer,
+        self,
+        mock_ping,
+        mock_print_journal,
+        mock_restore,
+        mock_delete,
+        mock_wait_routable,
+        mock_sleep,
+        mock_apply,
+        mock_write,
+        mock_generate,
+        mock_wipe,
+        mock_backup,
+        mock_renderer,
         mock_parse_args
     ):
         # Setup


### PR DESCRIPTION
## Description
Netplan serves as a network configuration abstraction renderer and was officially released in the 24.04 LTS version.
Netplan functions as a configuration tool for back-end daemons managing network interfaces, such as NetworkManager or systemd-networkd. 
In essence, Netplan acts as a configuration tool for back-end daemons managing network interfaces, independent of specific technologies.


In this PR, modify the `wifi_client_test_netplan.py` script to make it support both networkd and NetworkManger.
- Introduce an input parameter in this script to determine whether the renderer should be networkd or NetworkManager.
- Include a new input parameter for the func: `generate_test_config` to create the configuration with the specified renderer.
- Enhance the func: `wait_for_routable` to support both networkd and NetworkManager.
- Implement the func: `_get_nmcli_state` to retrieve the connection state for NetworkManager.
- Integrate the func: `check_routable_state` to determine the appropriate `_get_{nmcli | networkctl}_state` based on the renderer parameter.
- Update the func: `perform_ping_test` to accommodate both networkd and NetworkManager. (Obtain the Gateway method)
-  Separate the gateway retrieval into a new function `get_gateway`, which will select the appropriate `_get_{networkctl | nmcli}_gateway` based on the renderer parameter.
- Introduce the func: `_get_networkctl_gateway` extracted from the func: perform_ping_test to support this functionality.
- Implement the func: `_get_nmcli_gateway` to obtain the gateway IP address from NetworkManager.
- Update the func: `print_journal_entries` to cater to both network and NetworkManager scenarios.

> When utilizing this script in a test job, the renderer cannot be retrieved as an input parameter.
> There is a limitation regarding checkbox usage: **the outcome of the bootstrap resource job cannot be utilized in the command field.**
> 
> An alternative approach is required until the following issues are resolved:
> - The resource job: net_if_management needs to be split into two parts, one for wireless and the other for ethernet.
> - The script: net_if_management.py should only output either wireless or ethernet information.
> - Revise all jobs that utilize the output from: net_if_management
> 
> WIFI jobs (nm and np) should avoid using device as the template-resource, instead opt for net_if_management_wireless (currently unavailable).

According to the above issue, it need to add the following action:

-  Add an input parameter: renderer for AutoDetect
    - Auto-detection involves checking all .yaml files to identify any specific renderer (networkd, NetworkManger) definitions.
- Verify if the input renderer matches the one obtained from the .yaml file; if not AutoDetect, adjustments are necessary.



## Resolved issues
#1303 (Netplan missing the key-management: psk when wpa/wpa2)


## Documentation



## Tests
Run cmd on **systemd-networkd** machine [202405-34023](https://certification.canonical.com/hardware/202405-34023/)
- cmd: sudo ./wifi_client_test_netplan.py -i wlp1s0 -s {SSID} -k {SSID_PSK}  -d
- log: [networkd_202405-34023.log](https://github.com/user-attachments/files/15924226/networkd_202405-34023.log)

Run checkbox wireless test category on machine [202405-34023](https://certification.canonical.com/hardware/202405-34023/)
- submitssion: [autodetect_networkd_202405-34023](https://certification.canonical.com/hardware/202405-34023/submission/376087/)



