### PR TITLE
Return error on timeout (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -177,7 +177,7 @@ class RemoteController(ReportsStage, MainLoopStage):
                 print(".", end="", flush=True)
                 time.sleep(1)
         else:
-            print(_("\nConnection timed out."))
+            raise SystemExit(_("\nConnection timed out."))
 
     def check_remote_api_match(self):
         """


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

If checkbox times out connecting to the agent, it prints an error but exists with return code 0. This is an issue because we can't rely on `$?` in this situation (like our canary pipeline does) and it clearly a bug. This fixes said bug.

## Resolved issues

Fixes: CHECKBOX-1468

## Documentation

N/A

## Tests

This adds a test for the "new" situation
