### PR TITLE
netplan bugfix declare auth for non wpa3 (bugfix)

### DIFF
--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -131,6 +131,8 @@ def generate_test_config(interface, ssid, psk, address, dhcp, wpa3):
         # Set the key-management to "sae" when WPA3 is used
         if wpa3:
             access_point[ssid]["auth"]["key-management"] = "sae"
+        else:
+            access_point[ssid]["auth"]["key-management"] = "psk"
 
     # Define the interface_info
     interface_info = {

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -54,6 +54,7 @@ class WifiClientTestNetplanTests(TestCase):
                   access-points:
                     my_ap:
                       auth:
+                        key-management: psk
                         password: s3cr3t
                   dhcp4: true
                   nameservers: {}
@@ -97,6 +98,7 @@ class WifiClientTestNetplanTests(TestCase):
                   access-points:
                     my_ap:
                       auth:
+                        key-management: psk
                         password: s3cr3t
                   addresses:
                   - 192.168.1.1


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This is a bugfix ported from #1301

The issue is that by not declaring the auth kind, the netbplan is not correctly parsed.

## Resolved issues

Fixes: CHECKBOX-1471

## Documentation

N/A

## Tests

@p-gentili is testing this to see if it works in production, unit tests were updated
