### PR TITLE
Remove poitless job from canary (bugfix)

### DIFF
--- a/providers/base/units/canary/test-plan.pxu
+++ b/providers/base/units/canary/test-plan.pxu
@@ -57,7 +57,6 @@ include:
  com.canonical.certification::info/systemd-analyze-critical-chain
  com.canonical.certification::firmware/fwts_desktop_diagnosis
  com.canonical.certification::firmware/fwts_desktop_diagnosis_results.log.gz
- com.canonical.certification::acpi/oem_osi
  com.canonical.certification::audio/detect-playback-devices
  com.canonical.certification::audio/detect-capture-devices
  com.canonical.certification::audio/alsa-loopback-automated


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This job fails on many machines, including some that are certified. I think we can remove it as it makes finding canary running candidates harder

## Resolved issues

Canary failing on target queue

## Documentation

N/A

## Tests

N/A