### PR TITLE
Netplan support network manager 2404 PC Desktop Test case/plan (New)

### DIFF
--- a/providers/base/units/wireless/test-plan.pxu
+++ b/providers/base/units/wireless/test-plan.pxu
@@ -71,6 +71,47 @@ include:
     after-suspend-wireless/nm_connection_restore_.*
     after-suspend-wireless/check_iwlwifi_microcode_crash_.*
 
+id: wireless-netplan-cert-automated
+unit: test plan
+_name: Wireless netplan tests
+_description: Wireless connection tests via netplan
+bootstrap_include:
+    device
+include:
+    wireless/detect
+    wireless/wireless_connection_wpa_bg_np_.*      certification-status=blocker
+    wireless/wireless_connection_open_bg_np_.*     certification-status=blocker
+    wireless/wireless_connection_wpa_n_np_.*       certification-status=blocker
+    wireless/wireless_connection_open_n_np_.*      certification-status=blocker
+    wireless/wireless_connection_wpa_ac_np_.*      certification-status=blocker
+    wireless/wireless_connection_open_ac_np_.*     certification-status=blocker
+    wireless/wireless_connection_wpa_ax_np_.*      certification-status=blocker
+    wireless/wireless_connection_wpa3_ax_np_.*     certification-status=blocker
+    wireless/wireless_connection_open_ax_np_.*     certification-status=blocker
+    wireless/wireless_connection_wpa_be_np_.*      certification-status=blocker
+    wireless/wireless_connection_wpa3_be_np_.*     certification-status=blocker
+    wireless/wireless_connection_open_be_np_.*     certification-status=blocker
+
+id: after-suspend-wireless-netplan-cert-automated
+unit: test plan
+_name: Wireless netplan tests (after suspend, automated)
+_description: Wireless connection tests via netplan (after suspend, automated)
+bootstrap_include:
+    device
+include:
+    after-suspend-wireless/wireless_connection_wpa_bg_np_.*    certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_bg_np_.*   certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_n_np_.*     certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_n_np_.*    certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_ac_np_.*    certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_ac_np_.*   certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_ax_np_.*    certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa3_ax_np_.*   certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_ax_np_.*   certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_be_np_.*    certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa3_be_np_.*   certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_be_np_.*   certification-status=blocker
+
 id: wireless-cert-blockers
 unit: test plan
 _name: Wireless tests (certification blockers only)

--- a/providers/base/units/wireless/test-plan.pxu
+++ b/providers/base/units/wireless/test-plan.pxu
@@ -31,22 +31,22 @@ bootstrap_include:
     device
 include:
     wireless/detect
-    wireless/nm_connection_save_.*
-    wireless/wireless_scanning_.*                  certification-status=blocker
-    wireless/wireless_connection_wpa_bg_nm_.*      certification-status=blocker
-    wireless/wireless_connection_open_bg_nm_.*     certification-status=blocker
-    wireless/wireless_connection_wpa_n_nm_.*       certification-status=blocker
-    wireless/wireless_connection_open_n_nm_.*      certification-status=blocker
-    wireless/wireless_connection_wpa_ac_nm_.*      certification-status=blocker
-    wireless/wireless_connection_open_ac_nm_.*     certification-status=blocker
-    wireless/wireless_connection_wpa_ax_nm_.*      certification-status=blocker
-    wireless/wireless_connection_wpa3_ax_nm_.*     certification-status=blocker
-    wireless/wireless_connection_open_ax_nm_.*     certification-status=blocker
-    wireless/wireless_connection_wpa_be_nm_.*      certification-status=blocker
-    wireless/wireless_connection_wpa3_be_nm_.*     certification-status=blocker
-    wireless/wireless_connection_open_be_nm_.*     certification-status=blocker
-    wireless/nm_connection_restore_.*
-    wireless/check_iwlwifi_microcode_crash_.*
+    wireless/nm_connection_save_interface
+    wireless/wireless_scanning_interface                  certification-status=blocker
+    wireless/wireless_connection_wpa_bg_nm_interface      certification-status=blocker
+    wireless/wireless_connection_open_bg_nm_interface     certification-status=blocker
+    wireless/wireless_connection_wpa_n_nm_interface       certification-status=blocker
+    wireless/wireless_connection_open_n_nm_interface      certification-status=blocker
+    wireless/wireless_connection_wpa_ac_nm_interface      certification-status=blocker
+    wireless/wireless_connection_open_ac_nm_interface     certification-status=blocker
+    wireless/wireless_connection_wpa_ax_nm_interface      certification-status=blocker
+    wireless/wireless_connection_wpa3_ax_nm_interface     certification-status=blocker
+    wireless/wireless_connection_open_ax_nm_interface     certification-status=blocker
+    wireless/wireless_connection_wpa_be_nm_interface      certification-status=blocker
+    wireless/wireless_connection_wpa3_be_nm_interface     certification-status=blocker
+    wireless/wireless_connection_open_be_nm_interface     certification-status=blocker
+    wireless/nm_connection_restore_interface
+    wireless/check_iwlwifi_microcode_crash_interface
 
 id: after-suspend-wireless-cert-automated
 unit: test plan
@@ -55,21 +55,21 @@ _description: Wireless connection tests (after suspend, automated)
 bootstrap_include:
     device
 include:
-    after-suspend-wireless/nm_connection_save_.*
-    after-suspend-wireless/wireless_connection_wpa_bg_nm_.*    certification-status=blocker
-    after-suspend-wireless/wireless_connection_open_bg_nm_.*   certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa_n_nm_.*     certification-status=blocker
-    after-suspend-wireless/wireless_connection_open_n_nm_.*    certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa_ac_nm_.*    certification-status=blocker
-    after-suspend-wireless/wireless_connection_open_ac_nm_.*   certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa_ax_nm_.*    certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa3_ax_nm_.*   certification-status=blocker
-    after-suspend-wireless/wireless_connection_open_ax_nm_.*   certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa_be_nm_.*    certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa3_be_nm_.*   certification-status=blocker
-    after-suspend-wireless/wireless_connection_open_be_nm_.*   certification-status=blocker
-    after-suspend-wireless/nm_connection_restore_.*
-    after-suspend-wireless/check_iwlwifi_microcode_crash_.*
+    after-suspend-wireless/nm_connection_save_interface
+    after-suspend-wireless/wireless_connection_wpa_bg_nm_interface    certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_bg_nm_interface   certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_n_nm_interface     certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_n_nm_interface    certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_ac_nm_interface    certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_ac_nm_interface   certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_ax_nm_interface    certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa3_ax_nm_interface   certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_ax_nm_interface   certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_be_nm_interface    certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa3_be_nm_interface   certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_be_nm_interface   certification-status=blocker
+    after-suspend-wireless/nm_connection_restore_interface
+    after-suspend-wireless/check_iwlwifi_microcode_crash_interface
 
 id: wireless-netplan-cert-automated
 unit: test plan
@@ -79,18 +79,18 @@ bootstrap_include:
     device
 include:
     wireless/detect
-    wireless/wireless_connection_wpa_bg_np_.*      certification-status=blocker
-    wireless/wireless_connection_open_bg_np_.*     certification-status=blocker
-    wireless/wireless_connection_wpa_n_np_.*       certification-status=blocker
-    wireless/wireless_connection_open_n_np_.*      certification-status=blocker
-    wireless/wireless_connection_wpa_ac_np_.*      certification-status=blocker
-    wireless/wireless_connection_open_ac_np_.*     certification-status=blocker
-    wireless/wireless_connection_wpa_ax_np_.*      certification-status=blocker
-    wireless/wireless_connection_wpa3_ax_np_.*     certification-status=blocker
-    wireless/wireless_connection_open_ax_np_.*     certification-status=blocker
-    wireless/wireless_connection_wpa_be_np_.*      certification-status=blocker
-    wireless/wireless_connection_wpa3_be_np_.*     certification-status=blocker
-    wireless/wireless_connection_open_be_np_.*     certification-status=blocker
+    wireless/wireless_connection_wpa_bg_np_interface      certification-status=blocker
+    wireless/wireless_connection_open_bg_np_interface     certification-status=blocker
+    wireless/wireless_connection_wpa_n_np_interface       certification-status=blocker
+    wireless/wireless_connection_open_n_np_interface      certification-status=blocker
+    wireless/wireless_connection_wpa_ac_np_interface      certification-status=blocker
+    wireless/wireless_connection_open_ac_np_interface     certification-status=blocker
+    wireless/wireless_connection_wpa_ax_np_interface      certification-status=blocker
+    wireless/wireless_connection_wpa3_ax_np_interface     certification-status=blocker
+    wireless/wireless_connection_open_ax_np_interface     certification-status=blocker
+    wireless/wireless_connection_wpa_be_np_interface      certification-status=blocker
+    wireless/wireless_connection_wpa3_be_np_interface     certification-status=blocker
+    wireless/wireless_connection_open_be_np_interface     certification-status=blocker
 
 id: after-suspend-wireless-netplan-cert-automated
 unit: test plan
@@ -99,18 +99,18 @@ _description: Wireless connection tests via netplan (after suspend, automated)
 bootstrap_include:
     device
 include:
-    after-suspend-wireless/wireless_connection_wpa_bg_np_.*    certification-status=blocker
-    after-suspend-wireless/wireless_connection_open_bg_np_.*   certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa_n_np_.*     certification-status=blocker
-    after-suspend-wireless/wireless_connection_open_n_np_.*    certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa_ac_np_.*    certification-status=blocker
-    after-suspend-wireless/wireless_connection_open_ac_np_.*   certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa_ax_np_.*    certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa3_ax_np_.*   certification-status=blocker
-    after-suspend-wireless/wireless_connection_open_ax_np_.*   certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa_be_np_.*    certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa3_be_np_.*   certification-status=blocker
-    after-suspend-wireless/wireless_connection_open_be_np_.*   certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_bg_np_interface    certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_bg_np_interface   certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_n_np_interface     certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_n_np_interface    certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_ac_np_interface    certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_ac_np_interface   certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_ax_np_interface    certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa3_ax_np_interface   certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_ax_np_interface   certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_be_np_interface    certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa3_be_np_interface   certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_be_np_interface   certification-status=blocker
 
 id: wireless-cert-blockers
 unit: test plan
@@ -119,21 +119,21 @@ _description: Wireless connection tests (certification blockers only)
 bootstrap_include:
     device
 include:
-    wireless/nm_connection_save_.*
-    wireless/wireless_scanning_.*                  certification-status=blocker
-    wireless/wireless_connection_wpa_bg_nm_.*      certification-status=blocker
-    wireless/wireless_connection_open_bg_nm_.*     certification-status=blocker
-    wireless/wireless_connection_wpa_n_nm_.*       certification-status=blocker
-    wireless/wireless_connection_open_n_nm_.*      certification-status=blocker
-    wireless/wireless_connection_wpa_ac_nm_.*      certification-status=blocker
-    wireless/wireless_connection_open_ac_nm_.*     certification-status=blocker
-    wireless/wireless_connection_wpa_ax_nm_.*      certification-status=blocker
-    wireless/wireless_connection_wpa3_ax_nm_.*     certification-status=blocker
-    wireless/wireless_connection_open_ax_nm_.*     certification-status=blocker
-    wireless/wireless_connection_wpa_be_nm_.*      certification-status=blocker
-    wireless/wireless_connection_wpa3_be_nm_.*     certification-status=blocker
-    wireless/wireless_connection_open_be_nm_.*     certification-status=blocker
-    wireless/nm_connection_restore_.*
+    wireless/nm_connection_save_interface
+    wireless/wireless_scanning_interface                  certification-status=blocker
+    wireless/wireless_connection_wpa_bg_nm_interface      certification-status=blocker
+    wireless/wireless_connection_open_bg_nm_interface     certification-status=blocker
+    wireless/wireless_connection_wpa_n_nm_interface       certification-status=blocker
+    wireless/wireless_connection_open_n_nm_interface      certification-status=blocker
+    wireless/wireless_connection_wpa_ac_nm_interface      certification-status=blocker
+    wireless/wireless_connection_open_ac_nm_interface     certification-status=blocker
+    wireless/wireless_connection_wpa_ax_nm_interface      certification-status=blocker
+    wireless/wireless_connection_wpa3_ax_nm_interface     certification-status=blocker
+    wireless/wireless_connection_open_ax_nm_interface     certification-status=blocker
+    wireless/wireless_connection_wpa_be_nm_interface      certification-status=blocker
+    wireless/wireless_connection_wpa3_be_nm_interface     certification-status=blocker
+    wireless/wireless_connection_open_be_nm_interface     certification-status=blocker
+    wireless/nm_connection_restore_interface
 
 id: after-suspend-wireless-cert-blockers
 unit: test plan
@@ -143,20 +143,20 @@ _description:
 bootstrap_include:
     device
 include:
-    after-suspend-wireless/nm_connection_save_.*
-    after-suspend-wireless/wireless_connection_wpa_bg_nm_.*    certification-status=blocker
-    after-suspend-wireless/wireless_connection_open_bg_nm_.*   certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa_n_nm_.*     certification-status=blocker
-    after-suspend-wireless/wireless_connection_open_n_nm_.*    certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa_ac_nm_.*    certification-status=blocker
-    after-suspend-wireless/wireless_connection_open_ac_nm_.*   certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa_ax_nm_.*    certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa3_ax_nm_.*   certification-status=blocker
-    after-suspend-wireless/wireless_connection_open_ax_nm_.*   certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa_be_nm_.*    certification-status=blocker
-    after-suspend-wireless/wireless_connection_wpa3_be_nm_.*   certification-status=blocker
-    after-suspend-wireless/wireless_connection_open_be_nm_.*   certification-status=blocker
-    after-suspend-wireless/nm_connection_restore_.*
+    after-suspend-wireless/nm_connection_save_interface
+    after-suspend-wireless/wireless_connection_wpa_bg_nm_interface    certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_bg_nm_interface   certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_n_nm_interface     certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_n_nm_interface    certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_ac_nm_interface    certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_ac_nm_interface   certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_ax_nm_interface    certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa3_ax_nm_interface   certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_ax_nm_interface   certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_be_nm_interface    certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa3_be_nm_interface   certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_be_nm_interface   certification-status=blocker
+    after-suspend-wireless/nm_connection_restore_interface
 
 id: wireless-full
 unit: test plan
@@ -182,32 +182,32 @@ _description:
  , be networks.
 include:
     wireless/detect                                    certification-status=blocker
-    wireless/wireless_scanning_.*
-    wireless/wireless_connection_open_be_nm_.*
-    wireless/wireless_connection_open_ax_nm_.*
-    wireless/wireless_connection_open_ac_nm_.*
-    wireless/wireless_connection_open_bg_nm_.*
-    wireless/wireless_connection_open_n_nm_.*
-    wireless/wireless_connection_wpa_be_nm_.*
-    wireless/wireless_connection_wpa3_be_nm_.*
-    wireless/wireless_connection_wpa_ax_nm_.*
-    wireless/wireless_connection_wpa3_ax_nm_.*
-    wireless/wireless_connection_wpa_ac_nm_.*
-    wireless/wireless_connection_wpa_bg_nm_.*
-    wireless/wireless_connection_wpa_n_nm_.*
-    wireless/wireless_connection_open_be_np_.*
-    wireless/wireless_connection_open_ax_np_.*
-    wireless/wireless_connection_open_ac_np_.*
-    wireless/wireless_connection_open_bg_np_.*
-    wireless/wireless_connection_open_n_np_.*
-    wireless/wireless_connection_wpa_ax_np_.*
-    wireless/wireless_connection_wpa3_ax_np_.*
-    wireless/wireless_connection_wpa_be_np_.*
-    wireless/wireless_connection_wpa3_be_np_.*
-    wireless/wireless_connection_wpa_ac_np_.*
-    wireless/wireless_connection_wpa_bg_np_.*
-    wireless/wireless_connection_wpa_n_np_.*
-    wireless/check_iwlwifi_microcode_crash_.*
+    wireless/wireless_scanning_interface
+    wireless/wireless_connection_open_be_nm_interface
+    wireless/wireless_connection_open_ax_nm_interface
+    wireless/wireless_connection_open_ac_nm_interface
+    wireless/wireless_connection_open_bg_nm_interface
+    wireless/wireless_connection_open_n_nm_interface
+    wireless/wireless_connection_wpa_be_nm_interface
+    wireless/wireless_connection_wpa3_be_nm_interface
+    wireless/wireless_connection_wpa_ax_nm_interface
+    wireless/wireless_connection_wpa3_ax_nm_interface
+    wireless/wireless_connection_wpa_ac_nm_interface
+    wireless/wireless_connection_wpa_bg_nm_interface
+    wireless/wireless_connection_wpa_n_nm_interface
+    wireless/wireless_connection_open_be_np_interface
+    wireless/wireless_connection_open_ax_np_interface
+    wireless/wireless_connection_open_ac_np_interface
+    wireless/wireless_connection_open_bg_np_interface
+    wireless/wireless_connection_open_n_np_interface
+    wireless/wireless_connection_wpa_ax_np_interface
+    wireless/wireless_connection_wpa3_ax_np_interface
+    wireless/wireless_connection_wpa_be_np_interface
+    wireless/wireless_connection_wpa3_be_np_interface
+    wireless/wireless_connection_wpa_ac_np_interface
+    wireless/wireless_connection_wpa_bg_np_interface
+    wireless/wireless_connection_wpa_n_np_interface
+    wireless/check_iwlwifi_microcode_crash_interface
 bootstrap_include:
     device
 
@@ -219,31 +219,31 @@ _description:
  , be networks using netplan.
 include:
     wireless/detect
-    wireless/wireless_scanning_.*
-    wireless/wireless_connection_open_be_nm_.*
-    wireless/wireless_connection_open_ax_nm_.*
-    wireless/wireless_connection_open_ac_nm_.*
-    wireless/wireless_connection_open_bg_nm_.*
-    wireless/wireless_connection_open_n_nm_.*
-    wireless/wireless_connection_wpa_be_nm_.*
-    wireless/wireless_connection_wpa3_be_nm_.*
-    wireless/wireless_connection_wpa_ax_nm_.*
-    wireless/wireless_connection_wpa3_ax_nm_.*
-    wireless/wireless_connection_wpa_ac_nm_.*
-    wireless/wireless_connection_wpa_bg_nm_.*
-    wireless/wireless_connection_wpa_n_nm_.*
-    wireless/wireless_connection_open_be_np_.*
-    wireless/wireless_connection_open_ax_np_.*
-    wireless/wireless_connection_open_ac_np_.*
-    wireless/wireless_connection_open_bg_np_.*
-    wireless/wireless_connection_open_n_np_.*
-    wireless/wireless_connection_wpa_ax_np_.*
-    wireless/wireless_connection_wpa3_ax_np_.*
-    wireless/wireless_connection_wpa_be_np_.*
-    wireless/wireless_connection_wpa3_be_np_.*
-    wireless/wireless_connection_wpa_ac_np_.*
-    wireless/wireless_connection_wpa_bg_np_.*
-    wireless/wireless_connection_wpa_n_np_.*
+    wireless/wireless_scanning_interface
+    wireless/wireless_connection_open_be_nm_interface
+    wireless/wireless_connection_open_ax_nm_interface
+    wireless/wireless_connection_open_ac_nm_interface
+    wireless/wireless_connection_open_bg_nm_interface
+    wireless/wireless_connection_open_n_nm_interface
+    wireless/wireless_connection_wpa_be_nm_interface
+    wireless/wireless_connection_wpa3_be_nm_interface
+    wireless/wireless_connection_wpa_ax_nm_interface
+    wireless/wireless_connection_wpa3_ax_nm_interface
+    wireless/wireless_connection_wpa_ac_nm_interface
+    wireless/wireless_connection_wpa_bg_nm_interface
+    wireless/wireless_connection_wpa_n_nm_interface
+    wireless/wireless_connection_open_be_np_interface
+    wireless/wireless_connection_open_ax_np_interface
+    wireless/wireless_connection_open_ac_np_interface
+    wireless/wireless_connection_open_bg_np_interface
+    wireless/wireless_connection_open_n_np_interface
+    wireless/wireless_connection_wpa_ax_np_interface
+    wireless/wireless_connection_wpa3_ax_np_interface
+    wireless/wireless_connection_wpa_be_np_interface
+    wireless/wireless_connection_wpa3_be_np_interface
+    wireless/wireless_connection_wpa_ac_np_interface
+    wireless/wireless_connection_wpa_bg_np_interface
+    wireless/wireless_connection_wpa_n_np_interface
 bootstrap_include:
     device
 
@@ -396,32 +396,32 @@ _description:
  Automated connection tests for unencrypted or WPA-encrypted 802.11 bg, n, ac, ax
  , be networks.
 include:
-    after-suspend-wireless/wireless_scanning_.*
-    after-suspend-wireless/wireless_connection_open_be_nm_.*
-    after-suspend-wireless/wireless_connection_open_ax_nm_.*
-    after-suspend-wireless/wireless_connection_open_ac_nm_.*
-    after-suspend-wireless/wireless_connection_open_bg_nm_.*
-    after-suspend-wireless/wireless_connection_open_n_nm_.*
-    after-suspend-wireless/wireless_connection_wpa_be_nm_.*
-    after-suspend-wireless/wireless_connection_wpa3_be_nm_.*
-    after-suspend-wireless/wireless_connection_wpa_ax_nm_.*
-    after-suspend-wireless/wireless_connection_wpa3_ax_nm_.*
-    after-suspend-wireless/wireless_connection_wpa_ac_nm_.*
-    after-suspend-wireless/wireless_connection_wpa_bg_nm_.*
-    after-suspend-wireless/wireless_connection_wpa_n_nm_.*
-    after-suspend-wireless/wireless_connection_open_be_np_.*
-    after-suspend-wireless/wireless_connection_open_ax_np_.*
-    after-suspend-wireless/wireless_connection_open_ac_np_.*
-    after-suspend-wireless/wireless_connection_open_bg_np_.*
-    after-suspend-wireless/wireless_connection_open_n_np_.*
-    after-suspend-wireless/wireless_connection_wpa_ax_np_.*
-    after-suspend-wireless/wireless_connection_wpa3_ax_np_.*
-    after-suspend-wireless/wireless_connection_wpa_be_np_.*
-    after-suspend-wireless/wireless_connection_wpa3_be_np_.*
-    after-suspend-wireless/wireless_connection_wpa_ac_np_.*
-    after-suspend-wireless/wireless_connection_wpa_bg_np_.*
-    after-suspend-wireless/wireless_connection_wpa_n_np_.*
-    after-suspend-wireless/check_iwlwifi_microcode_crash_.*
+    after-suspend-wireless/wireless_scanning_interface
+    after-suspend-wireless/wireless_connection_open_be_nm_interface
+    after-suspend-wireless/wireless_connection_open_ax_nm_interface
+    after-suspend-wireless/wireless_connection_open_ac_nm_interface
+    after-suspend-wireless/wireless_connection_open_bg_nm_interface
+    after-suspend-wireless/wireless_connection_open_n_nm_interface
+    after-suspend-wireless/wireless_connection_wpa_be_nm_interface
+    after-suspend-wireless/wireless_connection_wpa3_be_nm_interface
+    after-suspend-wireless/wireless_connection_wpa_ax_nm_interface
+    after-suspend-wireless/wireless_connection_wpa3_ax_nm_interface
+    after-suspend-wireless/wireless_connection_wpa_ac_nm_interface
+    after-suspend-wireless/wireless_connection_wpa_bg_nm_interface
+    after-suspend-wireless/wireless_connection_wpa_n_nm_interface
+    after-suspend-wireless/wireless_connection_open_be_np_interface
+    after-suspend-wireless/wireless_connection_open_ax_np_interface
+    after-suspend-wireless/wireless_connection_open_ac_np_interface
+    after-suspend-wireless/wireless_connection_open_bg_np_interface
+    after-suspend-wireless/wireless_connection_open_n_np_interface
+    after-suspend-wireless/wireless_connection_wpa_ax_np_interface
+    after-suspend-wireless/wireless_connection_wpa3_ax_np_interface
+    after-suspend-wireless/wireless_connection_wpa_be_np_interface
+    after-suspend-wireless/wireless_connection_wpa3_be_np_interface
+    after-suspend-wireless/wireless_connection_wpa_ac_np_interface
+    after-suspend-wireless/wireless_connection_wpa_bg_np_interface
+    after-suspend-wireless/wireless_connection_wpa_n_np_interface
+    after-suspend-wireless/check_iwlwifi_microcode_crash_interface
 bootstrap_include:
     device
 
@@ -432,30 +432,30 @@ _description:
  Automated connection tests for unencrypted or WPA-encrypted 802.11 bg, n, ac, ax
  , be networks using netplan.
 include:
-    after-suspend-wireless/wireless_scanning_.*
-    after-suspend-wireless/wireless_connection_open_be_nm_.*
-    after-suspend-wireless/wireless_connection_open_ax_nm_.*
-    after-suspend-wireless/wireless_connection_open_ac_nm_.*
-    after-suspend-wireless/wireless_connection_open_bg_nm_.*
-    after-suspend-wireless/wireless_connection_open_n_nm_.*
-    after-suspend-wireless/wireless_connection_wpa_be_nm_.*
-    after-suspend-wireless/wireless_connection_wpa3_be_nm_.*
-    after-suspend-wireless/wireless_connection_wpa_ax_nm_.*
-    after-suspend-wireless/wireless_connection_wpa3_ax_nm_.*
-    after-suspend-wireless/wireless_connection_wpa_ac_nm_.*
-    after-suspend-wireless/wireless_connection_wpa_bg_nm_.*
-    after-suspend-wireless/wireless_connection_wpa_n_nm_.*
-    after-suspend-wireless/wireless_connection_open_be_np_.*
-    after-suspend-wireless/wireless_connection_open_ax_np_.*
-    after-suspend-wireless/wireless_connection_open_ac_np_.*
-    after-suspend-wireless/wireless_connection_open_bg_np_.*
-    after-suspend-wireless/wireless_connection_open_n_np_.*
-    after-suspend-wireless/wireless_connection_wpa_ax_np_.*
-    after-suspend-wireless/wireless_connection_wpa3_ax_np_.*
-    after-suspend-wireless/wireless_connection_wpa_be_np_.*
-    after-suspend-wireless/wireless_connection_wpa3_be_np_.*
-    after-suspend-wireless/wireless_connection_wpa_ac_np_.*
-    after-suspend-wireless/wireless_connection_wpa_bg_np_.*
-    after-suspend-wireless/wireless_connection_wpa_n_np_.*
+    after-suspend-wireless/wireless_scanning_interface
+    after-suspend-wireless/wireless_connection_open_be_nm_interface
+    after-suspend-wireless/wireless_connection_open_ax_nm_interface
+    after-suspend-wireless/wireless_connection_open_ac_nm_interface
+    after-suspend-wireless/wireless_connection_open_bg_nm_interface
+    after-suspend-wireless/wireless_connection_open_n_nm_interface
+    after-suspend-wireless/wireless_connection_wpa_be_nm_interface
+    after-suspend-wireless/wireless_connection_wpa3_be_nm_interface
+    after-suspend-wireless/wireless_connection_wpa_ax_nm_interface
+    after-suspend-wireless/wireless_connection_wpa3_ax_nm_interface
+    after-suspend-wireless/wireless_connection_wpa_ac_nm_interface
+    after-suspend-wireless/wireless_connection_wpa_bg_nm_interface
+    after-suspend-wireless/wireless_connection_wpa_n_nm_interface
+    after-suspend-wireless/wireless_connection_open_be_np_interface
+    after-suspend-wireless/wireless_connection_open_ax_np_interface
+    after-suspend-wireless/wireless_connection_open_ac_np_interface
+    after-suspend-wireless/wireless_connection_open_bg_np_interface
+    after-suspend-wireless/wireless_connection_open_n_np_interface
+    after-suspend-wireless/wireless_connection_wpa_ax_np_interface
+    after-suspend-wireless/wireless_connection_wpa3_ax_np_interface
+    after-suspend-wireless/wireless_connection_wpa_be_np_interface
+    after-suspend-wireless/wireless_connection_wpa3_be_np_interface
+    after-suspend-wireless/wireless_connection_wpa_ac_np_interface
+    after-suspend-wireless/wireless_connection_wpa_bg_np_interface
+    after-suspend-wireless/wireless_connection_wpa_n_np_interface
 bootstrap_include:
     device

--- a/providers/base/units/wireless/test-plan.pxu
+++ b/providers/base/units/wireless/test-plan.pxu
@@ -31,7 +31,6 @@ bootstrap_include:
     device
 include:
     wireless/detect
-    wireless/nm_connection_save_interface
     wireless/wireless_scanning_interface                  certification-status=blocker
     wireless/wireless_connection_wpa_bg_nm_interface      certification-status=blocker
     wireless/wireless_connection_open_bg_nm_interface     certification-status=blocker
@@ -45,7 +44,6 @@ include:
     wireless/wireless_connection_wpa_be_nm_interface      certification-status=blocker
     wireless/wireless_connection_wpa3_be_nm_interface     certification-status=blocker
     wireless/wireless_connection_open_be_nm_interface     certification-status=blocker
-    wireless/nm_connection_restore_interface
     wireless/check_iwlwifi_microcode_crash_interface
 
 id: after-suspend-wireless-cert-automated
@@ -55,7 +53,6 @@ _description: Wireless connection tests (after suspend, automated)
 bootstrap_include:
     device
 include:
-    after-suspend-wireless/nm_connection_save_interface
     after-suspend-wireless/wireless_connection_wpa_bg_nm_interface    certification-status=blocker
     after-suspend-wireless/wireless_connection_open_bg_nm_interface   certification-status=blocker
     after-suspend-wireless/wireless_connection_wpa_n_nm_interface     certification-status=blocker
@@ -68,7 +65,6 @@ include:
     after-suspend-wireless/wireless_connection_wpa_be_nm_interface    certification-status=blocker
     after-suspend-wireless/wireless_connection_wpa3_be_nm_interface   certification-status=blocker
     after-suspend-wireless/wireless_connection_open_be_nm_interface   certification-status=blocker
-    after-suspend-wireless/nm_connection_restore_interface
     after-suspend-wireless/check_iwlwifi_microcode_crash_interface
 
 id: wireless-netplan-cert-automated
@@ -119,7 +115,6 @@ _description: Wireless connection tests (certification blockers only)
 bootstrap_include:
     device
 include:
-    wireless/nm_connection_save_interface
     wireless/wireless_scanning_interface                  certification-status=blocker
     wireless/wireless_connection_wpa_bg_nm_interface      certification-status=blocker
     wireless/wireless_connection_open_bg_nm_interface     certification-status=blocker
@@ -133,7 +128,6 @@ include:
     wireless/wireless_connection_wpa_be_nm_interface      certification-status=blocker
     wireless/wireless_connection_wpa3_be_nm_interface     certification-status=blocker
     wireless/wireless_connection_open_be_nm_interface     certification-status=blocker
-    wireless/nm_connection_restore_interface
 
 id: after-suspend-wireless-cert-blockers
 unit: test plan
@@ -143,7 +137,6 @@ _description:
 bootstrap_include:
     device
 include:
-    after-suspend-wireless/nm_connection_save_interface
     after-suspend-wireless/wireless_connection_wpa_bg_nm_interface    certification-status=blocker
     after-suspend-wireless/wireless_connection_open_bg_nm_interface   certification-status=blocker
     after-suspend-wireless/wireless_connection_wpa_n_nm_interface     certification-status=blocker
@@ -156,7 +149,6 @@ include:
     after-suspend-wireless/wireless_connection_wpa_be_nm_interface    certification-status=blocker
     after-suspend-wireless/wireless_connection_wpa3_be_nm_interface   certification-status=blocker
     after-suspend-wireless/wireless_connection_open_be_nm_interface   certification-status=blocker
-    after-suspend-wireless/nm_connection_restore_interface
 
 id: wireless-full
 unit: test plan

--- a/providers/base/units/wireless/test-plan.pxu
+++ b/providers/base/units/wireless/test-plan.pxu
@@ -42,9 +42,9 @@ include:
     wireless/wireless_connection_wpa_ax_nm_.*      certification-status=blocker
     wireless/wireless_connection_wpa3_ax_nm_.*     certification-status=blocker
     wireless/wireless_connection_open_ax_nm_.*     certification-status=blocker
-    wireless/wireless_connection_wpa_be_nm_interface  certification-status=blocker
-    wireless/wireless_connection_wpa3_be_nm_interface certification-status=blocker
-    wireless/wireless_connection_open_be_nm_interface certification-status=blocker
+    wireless/wireless_connection_wpa_be_nm_.*      certification-status=blocker
+    wireless/wireless_connection_wpa3_be_nm_.*     certification-status=blocker
+    wireless/wireless_connection_open_be_nm_.*     certification-status=blocker
     wireless/nm_connection_restore_.*
     wireless/check_iwlwifi_microcode_crash_.*
 
@@ -65,9 +65,9 @@ include:
     after-suspend-wireless/wireless_connection_wpa_ax_nm_.*    certification-status=blocker
     after-suspend-wireless/wireless_connection_wpa3_ax_nm_.*   certification-status=blocker
     after-suspend-wireless/wireless_connection_open_ax_nm_.*   certification-status=blocker
-    wireless/wireless_connection_wpa_be_nm_interface  certification-status=blocker
-    wireless/wireless_connection_wpa3_be_nm_interface certification-status=blocker
-    wireless/wireless_connection_open_be_nm_interface certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_be_nm_.*    certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa3_be_nm_.*   certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_be_nm_.*   certification-status=blocker
     after-suspend-wireless/nm_connection_restore_.*
     after-suspend-wireless/check_iwlwifi_microcode_crash_.*
 
@@ -130,9 +130,9 @@ include:
     wireless/wireless_connection_wpa_ax_nm_.*      certification-status=blocker
     wireless/wireless_connection_wpa3_ax_nm_.*     certification-status=blocker
     wireless/wireless_connection_open_ax_nm_.*     certification-status=blocker
-    wireless/wireless_connection_wpa_be_nm_interface  certification-status=blocker
-    wireless/wireless_connection_wpa3_be_nm_interface certification-status=blocker
-    wireless/wireless_connection_open_be_nm_interface certification-status=blocker
+    wireless/wireless_connection_wpa_be_nm_.*      certification-status=blocker
+    wireless/wireless_connection_wpa3_be_nm_.*     certification-status=blocker
+    wireless/wireless_connection_open_be_nm_.*     certification-status=blocker
     wireless/nm_connection_restore_.*
 
 id: after-suspend-wireless-cert-blockers
@@ -153,9 +153,9 @@ include:
     after-suspend-wireless/wireless_connection_wpa_ax_nm_.*    certification-status=blocker
     after-suspend-wireless/wireless_connection_wpa3_ax_nm_.*   certification-status=blocker
     after-suspend-wireless/wireless_connection_open_ax_nm_.*   certification-status=blocker
-    wireless/wireless_connection_wpa_be_nm_interface  certification-status=blocker
-    wireless/wireless_connection_wpa3_be_nm_interface certification-status=blocker
-    wireless/wireless_connection_open_be_nm_interface certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa_be_nm_.*    certification-status=blocker
+    after-suspend-wireless/wireless_connection_wpa3_be_nm_.*   certification-status=blocker
+    after-suspend-wireless/wireless_connection_open_be_nm_.*   certification-status=blocker
     after-suspend-wireless/nm_connection_restore_.*
 
 id: wireless-full
@@ -183,30 +183,30 @@ _description:
 include:
     wireless/detect                                    certification-status=blocker
     wireless/wireless_scanning_.*
-    wireless/wireless_connection_open_be_nm_interface  certification-status=blocker
-    wireless/wireless_connection_open_ax_nm_.*         certification-status=blocker
-    wireless/wireless_connection_open_ac_nm_.*         certification-status=blocker
-    wireless/wireless_connection_open_bg_nm_.*         certification-status=blocker
-    wireless/wireless_connection_open_n_nm_.*          certification-status=blocker
-    wireless/wireless_connection_wpa_be_nm_interface   certification-status=blocker
-    wireless/wireless_connection_wpa3_be_nm_interface  certification-status=blocker
-    wireless/wireless_connection_wpa_ax_nm_.*          certification-status=blocker
-    wireless/wireless_connection_wpa3_ax_nm_.*         certification-status=blocker
-    wireless/wireless_connection_wpa_ac_nm_.*          certification-status=blocker
-    wireless/wireless_connection_wpa_bg_nm_.*          certification-status=blocker
-    wireless/wireless_connection_wpa_n_nm_.*           certification-status=blocker
-    wireless/wireless_connection_open_be_np_interface  certification-status=blocker
-    wireless/wireless_connection_open_ax_np_.*         certification-status=blocker
-    wireless/wireless_connection_open_ac_np_.*         certification-status=blocker
-    wireless/wireless_connection_open_bg_np_.*         certification-status=blocker
-    wireless/wireless_connection_open_n_np_.*          certification-status=blocker
-    wireless/wireless_connection_wpa_ax_np_.*          certification-status=blocker
-    wireless/wireless_connection_wpa3_ax_np_.*         certification-status=blocker
-    wireless/wireless_connection_wpa_be_np_interface   certification-status=blocker
-    wireless/wireless_connection_wpa3_be_np_interface  certification-status=blocker
-    wireless/wireless_connection_wpa_ac_np_.*          certification-status=blocker
-    wireless/wireless_connection_wpa_bg_np_.*          certification-status=blocker
-    wireless/wireless_connection_wpa_n_np_.*           certification-status=blocker
+    wireless/wireless_connection_open_be_nm_.*
+    wireless/wireless_connection_open_ax_nm_.*
+    wireless/wireless_connection_open_ac_nm_.*
+    wireless/wireless_connection_open_bg_nm_.*
+    wireless/wireless_connection_open_n_nm_.*
+    wireless/wireless_connection_wpa_be_nm_.*
+    wireless/wireless_connection_wpa3_be_nm_.*
+    wireless/wireless_connection_wpa_ax_nm_.*
+    wireless/wireless_connection_wpa3_ax_nm_.*
+    wireless/wireless_connection_wpa_ac_nm_.*
+    wireless/wireless_connection_wpa_bg_nm_.*
+    wireless/wireless_connection_wpa_n_nm_.*
+    wireless/wireless_connection_open_be_np_.*
+    wireless/wireless_connection_open_ax_np_.*
+    wireless/wireless_connection_open_ac_np_.*
+    wireless/wireless_connection_open_bg_np_.*
+    wireless/wireless_connection_open_n_np_.*
+    wireless/wireless_connection_wpa_ax_np_.*
+    wireless/wireless_connection_wpa3_ax_np_.*
+    wireless/wireless_connection_wpa_be_np_.*
+    wireless/wireless_connection_wpa3_be_np_.*
+    wireless/wireless_connection_wpa_ac_np_.*
+    wireless/wireless_connection_wpa_bg_np_.*
+    wireless/wireless_connection_wpa_n_np_.*
     wireless/check_iwlwifi_microcode_crash_.*
 bootstrap_include:
     device
@@ -220,27 +220,27 @@ _description:
 include:
     wireless/detect
     wireless/wireless_scanning_.*
-    wireless/wireless_connection_open_be_nm_interface
+    wireless/wireless_connection_open_be_nm_.*
     wireless/wireless_connection_open_ax_nm_.*
     wireless/wireless_connection_open_ac_nm_.*
     wireless/wireless_connection_open_bg_nm_.*
     wireless/wireless_connection_open_n_nm_.*
-    wireless/wireless_connection_wpa_be_nm_interface
-    wireless/wireless_connection_wpa3_be_nm_interface
+    wireless/wireless_connection_wpa_be_nm_.*
+    wireless/wireless_connection_wpa3_be_nm_.*
     wireless/wireless_connection_wpa_ax_nm_.*
     wireless/wireless_connection_wpa3_ax_nm_.*
     wireless/wireless_connection_wpa_ac_nm_.*
     wireless/wireless_connection_wpa_bg_nm_.*
     wireless/wireless_connection_wpa_n_nm_.*
-    wireless/wireless_connection_open_be_np_interface
+    wireless/wireless_connection_open_be_np_.*
     wireless/wireless_connection_open_ax_np_.*
     wireless/wireless_connection_open_ac_np_.*
     wireless/wireless_connection_open_bg_np_.*
     wireless/wireless_connection_open_n_np_.*
     wireless/wireless_connection_wpa_ax_np_.*
     wireless/wireless_connection_wpa3_ax_np_.*
-    wireless/wireless_connection_wpa_be_np_interface
-    wireless/wireless_connection_wpa3_be_np_interface
+    wireless/wireless_connection_wpa_be_np_.*
+    wireless/wireless_connection_wpa3_be_np_.*
     wireless/wireless_connection_wpa_ac_np_.*
     wireless/wireless_connection_wpa_bg_np_.*
     wireless/wireless_connection_wpa_n_np_.*
@@ -397,27 +397,27 @@ _description:
  , be networks.
 include:
     after-suspend-wireless/wireless_scanning_.*
-    wireless/wireless_connection_open_be_nm_interface
+    after-suspend-wireless/wireless_connection_open_be_nm_.*
     after-suspend-wireless/wireless_connection_open_ax_nm_.*
     after-suspend-wireless/wireless_connection_open_ac_nm_.*
     after-suspend-wireless/wireless_connection_open_bg_nm_.*
     after-suspend-wireless/wireless_connection_open_n_nm_.*
-    wireless/wireless_connection_wpa_be_nm_interface
-    wireless/wireless_connection_wpa3_be_nm_interface
+    after-suspend-wireless/wireless_connection_wpa_be_nm_.*
+    after-suspend-wireless/wireless_connection_wpa3_be_nm_.*
     after-suspend-wireless/wireless_connection_wpa_ax_nm_.*
     after-suspend-wireless/wireless_connection_wpa3_ax_nm_.*
     after-suspend-wireless/wireless_connection_wpa_ac_nm_.*
     after-suspend-wireless/wireless_connection_wpa_bg_nm_.*
     after-suspend-wireless/wireless_connection_wpa_n_nm_.*
-    wireless/wireless_connection_open_be_np_interface
+    after-suspend-wireless/wireless_connection_open_be_np_.*
     after-suspend-wireless/wireless_connection_open_ax_np_.*
     after-suspend-wireless/wireless_connection_open_ac_np_.*
     after-suspend-wireless/wireless_connection_open_bg_np_.*
     after-suspend-wireless/wireless_connection_open_n_np_.*
     after-suspend-wireless/wireless_connection_wpa_ax_np_.*
     after-suspend-wireless/wireless_connection_wpa3_ax_np_.*
-    wireless/wireless_connection_wpa_be_np_interface
-    wireless/wireless_connection_wpa3_be_np_interface
+    after-suspend-wireless/wireless_connection_wpa_be_np_.*
+    after-suspend-wireless/wireless_connection_wpa3_be_np_.*
     after-suspend-wireless/wireless_connection_wpa_ac_np_.*
     after-suspend-wireless/wireless_connection_wpa_bg_np_.*
     after-suspend-wireless/wireless_connection_wpa_n_np_.*
@@ -433,27 +433,27 @@ _description:
  , be networks using netplan.
 include:
     after-suspend-wireless/wireless_scanning_.*
-    wireless/wireless_connection_open_be_nm_interface
+    after-suspend-wireless/wireless_connection_open_be_nm_.*
     after-suspend-wireless/wireless_connection_open_ax_nm_.*
     after-suspend-wireless/wireless_connection_open_ac_nm_.*
     after-suspend-wireless/wireless_connection_open_bg_nm_.*
     after-suspend-wireless/wireless_connection_open_n_nm_.*
-    wireless/wireless_connection_wpa_be_nm_interface
-    wireless/wireless_connection_wpa3_be_nm_interface
+    after-suspend-wireless/wireless_connection_wpa_be_nm_.*
+    after-suspend-wireless/wireless_connection_wpa3_be_nm_.*
     after-suspend-wireless/wireless_connection_wpa_ax_nm_.*
     after-suspend-wireless/wireless_connection_wpa3_ax_nm_.*
     after-suspend-wireless/wireless_connection_wpa_ac_nm_.*
     after-suspend-wireless/wireless_connection_wpa_bg_nm_.*
     after-suspend-wireless/wireless_connection_wpa_n_nm_.*
-    wireless/wireless_connection_open_be_np_interface
+    after-suspend-wireless/wireless_connection_open_be_np_.*
     after-suspend-wireless/wireless_connection_open_ax_np_.*
     after-suspend-wireless/wireless_connection_open_ac_np_.*
     after-suspend-wireless/wireless_connection_open_bg_np_.*
     after-suspend-wireless/wireless_connection_open_n_np_.*
     after-suspend-wireless/wireless_connection_wpa_ax_np_.*
     after-suspend-wireless/wireless_connection_wpa3_ax_np_.*
-    wireless/wireless_connection_wpa_be_np_interface
-    wireless/wireless_connection_wpa3_be_np_interface
+    after-suspend-wireless/wireless_connection_wpa_be_np_.*
+    after-suspend-wireless/wireless_connection_wpa3_be_np_.*
     after-suspend-wireless/wireless_connection_wpa_ac_np_.*
     after-suspend-wireless/wireless_connection_wpa_bg_np_.*
     after-suspend-wireless/wireless_connection_wpa_n_np_.*

--- a/providers/base/units/wireless/wireless-connection-netplan.pxu
+++ b/providers/base/units/wireless/wireless-connection-netplan.pxu
@@ -20,7 +20,7 @@ estimated_duration: 15
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_be == 'supported'
- net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
+ (net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd') or lsb.release >= "24"
 
 unit: template
 template-resource: device
@@ -44,7 +44,7 @@ estimated_duration: 15
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_ax == 'supported'
- net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
+ (net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd') or lsb.release >= "24"
 
 unit: template
 template-resource: device
@@ -68,7 +68,7 @@ estimated_duration: 15
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_ac == 'supported'
- net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
+ (net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd') or lsb.release >= "24"
 
 unit: template
 template-resource: device
@@ -91,7 +91,7 @@ category_id: com.canonical.plainbox::wireless
 estimated_duration: 15
 flags: preserve-locale also-after-suspend
 requires:
- net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
+ (net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd') or lsb.release >= "24"
 
 unit: template
 template-resource: device
@@ -114,7 +114,7 @@ category_id: com.canonical.plainbox::wireless
 estimated_duration: 15
 flags: preserve-locale also-after-suspend
 requires:
- net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
+ (net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd') or lsb.release >= "24"
 
 unit: template
 template-resource: device
@@ -138,7 +138,7 @@ estimated_duration: 15
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_be == 'supported'
- net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
+ (net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd') or lsb.release >= "24"
 
 unit: template
 template-resource: device
@@ -162,7 +162,7 @@ estimated_duration: 15
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_ax == 'supported'
- net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
+ (net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd') or lsb.release >= "24"
 
 unit: template
 template-resource: device
@@ -186,7 +186,7 @@ estimated_duration: 15
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_be == 'supported'
- net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
+ (net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd') or lsb.release >= "24"
 
 unit: template
 template-resource: device
@@ -210,7 +210,7 @@ estimated_duration: 15
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_ax == 'supported'
- net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
+ (net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd') or lsb.release >= "24"
 
 unit: template
 template-resource: device
@@ -234,7 +234,7 @@ estimated_duration: 15
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_ac == 'supported'
- net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
+ (net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd') or lsb.release >= "24"
 
 unit: template
 template-resource: device
@@ -257,7 +257,7 @@ category_id: com.canonical.plainbox::wireless
 estimated_duration: 15
 flags: preserve-locale also-after-suspend
 requires:
- net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
+ (net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd') or lsb.release >= "24"
 
 unit: template
 template-resource: device
@@ -280,4 +280,4 @@ category_id: com.canonical.plainbox::wireless
 estimated_duration: 15
 flags: preserve-locale also-after-suspend
 requires:
- net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
+ (net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd') or lsb.release >= "24"

--- a/providers/certification-client/units/client-cert-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-24-04.pxu
@@ -115,6 +115,7 @@ nested_part:
     usb-cert-automated
     usb-automated
     wireless-cert-automated
+    wireless-netplan-cert-automated
     # start of suspend related tests
     before-suspend-reference-cert-full
     # suspend point
@@ -135,6 +136,7 @@ nested_part:
     after-suspend-usb-cert-automated
     after-suspend-usb-automated
     after-suspend-wireless-cert-automated
+    after-suspend-wireless-netplan-cert-automated
     after-suspend-bluetooth-cert-automated
     after-suspend-camera-cert-automated
     # The following tests should run BEFORE the automated tests. The reboot and


### PR DESCRIPTION
## Description

This PR only change/add the test case/plan to support the netplan test cases can be run in the 24.04 PC desktop test plan.
**It need the #1301 PR script will make the script can support on the NetworkManager.**
**This PR need to wait the #1324 PR, or it will meet this issue:[OEMQA-4582 NetworkManager test case impact in 24.04 Desktop](https://warthogs.atlassian.net/browse/OEMQA-4582)**

## WARNING: This modifies com.canonical.certification::sru-server

Change the requires field in bellow test cases:
- `{after-suspend-}wireless/wireless_connection_{open|WPA}_{bg|n|ac}_np_.*`
- `{after-suspend-}wireless/wireless_connection_{open|WPA|WPA3}_{ax|be}_np_.*`

From:
```
requires:
 wireless_sta_protocol.{{ interface }}_be == 'supported'
 net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd'
```
TO:
```
requires:
 wireless_sta_protocol.{{ interface }}_be == 'supported'
 (net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'networkd') or lsb.release >= "24"
```

Add a new test plan `{after-suspend-}wireless-netplan-cert-automated` to support the following test cases:
- `{after-suspend-}wireless/wireless_connection_{open|WPA}_{bg|n|ac}_np_.*`
- `{after-suspend-}wireless/wireless_connection_{open|WPA|WPA3}_{ax|be}_np_.*`

## Resolved issues

## Documentation



## Tests


