### PR TITLE
Reset HID before running the keyboard test (BugFix)

### DIFF
--- a/providers/base/bin/zapper_keyboard_test.py
+++ b/providers/base/bin/zapper_keyboard_test.py
@@ -150,6 +150,7 @@ def main(argv):
     listener = KeyboardListener(zapper_kbd, events.append)
     listener.start()
 
+    zapper_run(argv[1], "reset_hid_state")
     try:
         assert_key_combo(argv[1], events)
         assert_type_string(argv[1], events)

--- a/providers/base/tests/test_zapper_keyboard.py
+++ b/providers/base/tests/test_zapper_keyboard.py
@@ -150,11 +150,11 @@ class ZapperKeyboardTests(unittest.TestCase):
         mock_combo.side_effect = AssertionError
         mock_type.side_effect = None
         with self.assertRaises(SystemExit):
-            zapper_keyboard_test.main([1, 2])
+            zapper_keyboard_test.main([1, "127.0.0.1"])
         mock_key.return_value.start.assert_called_once_with()
         mock_key.return_value.stop.assert_called_once_with()
         mock_key.return_value.join.assert_called_once_with()
-        mock_run.assert_called_once_with()
+        mock_run.assert_called_once_with("127.0.0.1", "reset_hid_state")
 
         mock_combo.side_effect = None
         mock_type.side_effect = AssertionError

--- a/providers/base/tests/test_zapper_keyboard.py
+++ b/providers/base/tests/test_zapper_keyboard.py
@@ -127,13 +127,20 @@ class ZapperKeyboardTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             zapper_keyboard_test.main([1, 2])
 
+    @patch("zapper_keyboard_test.zapper_run")
     @patch("zapper_keyboard_test.get_zapper_kbd_device")
     @patch("zapper_keyboard_test.assert_type_string")
     @patch("zapper_keyboard_test.assert_key_combo")
     @patch("zapper_keyboard_test.KeyboardListener")
     @patch("os.access")
     def test_main(
-        self, mock_access, mock_key, mock_combo, mock_type, mock_get_dev
+        self,
+        mock_access,
+        mock_key,
+        mock_combo,
+        mock_type,
+        mock_get_dev,
+        mock_run,
     ):
         """Check main exits with failure if any of the test fails."""
 
@@ -147,6 +154,7 @@ class ZapperKeyboardTests(unittest.TestCase):
         mock_key.return_value.start.assert_called_once_with()
         mock_key.return_value.stop.assert_called_once_with()
         mock_key.return_value.join.assert_called_once_with()
+        mock_run.assert_called_once_with()
 
         mock_combo.side_effect = None
         mock_type.side_effect = AssertionError


### PR DESCRIPTION
## Description

HID Keyboard test might be affected by the current state of the keyboard, especially if a modifier is for some reason kept pressed. This PR runs first the "reset hid" API so that we start from a clean environment.

## Resolved issues

Resolves [ZAP-858](https://warthogs.atlassian.net/browse/ZAP-858)

## Documentation

N/A

## Tests

Tested running from source on https://certification.canonical.com/hardware/202203-30003 with

[ZAP-858]: https://warthogs.atlassian.net/browse/ZAP-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ