### PR TITLE
Convert wan/3gpp-scan test as a automated test (New)

### DIFF
--- a/providers/base/bin/wwan_tests.py
+++ b/providers/base/bin/wwan_tests.py
@@ -362,6 +362,45 @@ class ThreeGppConnection:
         sys.exit(ret_code)
 
 
+class ThreeGppScanTest:
+
+    def register_argument(self):
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "hw_id", type=str, help="The hardware ID of the modem"
+        )
+        parser.add_argument(
+            "--timeout",
+            type=int,
+            default=300,
+            help="timeout for 3gpp-scan",
+        )
+        return parser.parse_args(sys.argv[2:])
+
+    def invoked(self):
+
+        args = self.register_argument()
+        ret_code = 1
+        try:
+            mm = MMCLI()
+            mm_id = mm.equipment_id_to_mm_id(args.hw_id)
+            _wwan_radio_on()
+            cmd = [
+                "mmcli",
+                "-m",
+                str(mm_id),
+                "--3gpp-scan",
+                "--timeout",
+                str(args.timeout),
+            ]
+            ret_code = subprocess.check_call(cmd)
+        except subprocess.CalledProcessError:
+            pass
+        _wwan_radio_off()
+        sys.exit(ret_code)
+
+
 class CountModems:
 
     def invoked(self):
@@ -462,6 +501,7 @@ class WWANTests:
             "count": CountModems,
             "resources": Resources,
             "3gpp-connection": ThreeGppConnection,
+            "3gpp-scan": ThreeGppScanTest,
             "sim-present": SimPresent,
             "sim-info": SimInfo,
         }

--- a/providers/base/bin/wwan_tests.py
+++ b/providers/base/bin/wwan_tests.py
@@ -427,11 +427,7 @@ class ThreeGppScanTest:
                     cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
                 )
                 print(ret_sp.stdout.decode("utf-8"))
-                if (
-                    ret_sp.returncode == 0
-                    and b"error" not in ret_sp.stdout.lower()
-                ):
-                    ret_code = 0
+                ret_code = ret_sp.returncode
         except subprocess.CalledProcessError:
             pass
 

--- a/providers/base/tests/test_wwan_tests.py
+++ b/providers/base/tests/test_wwan_tests.py
@@ -1,6 +1,6 @@
 import unittest
 import sys
-from unittest.mock import patch, call, Mock, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 from io import StringIO
 from contextlib import redirect_stdout
 import argparse
@@ -113,6 +113,70 @@ class TestResources(unittest.TestCase):
             self.assertTrue(mmdbus_instance.get_hardware_revision.called)
 
 
+class TestCommonFunctions(unittest.TestCase):
+
+    @patch("subprocess.run")
+    def test_wwan_radio_status(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=b"disabled", stderr=b""
+        )
+        with redirect_stdout(StringIO()):
+            status = wwan_tests._wwan_radio_status()
+        self.assertEqual(status, "disabled")
+
+    @patch("subprocess.run")
+    def test_wwan_radio_status_exception(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(1, "cmd")
+        with redirect_stdout(StringIO()):
+            with self.assertRaises(subprocess.CalledProcessError):
+                wwan_tests._wwan_radio_status()
+
+
+class TestWWANTestCtx(unittest.TestCase):
+
+    @patch("wwan_tests._wwan_radio_off")
+    @patch("wwan_tests._wwan_radio_on")
+    @patch("wwan_tests._wwan_radio_status")
+    @patch("wwan_tests.MMDbus")
+    def test_wwan_ctx_init_with_dbus(
+        self, mock_mmdbus, mock_r_status, mock_r_on, mock_r_off
+    ):
+        mmdbus_instance = Mock()
+        mmdbus_instance.equipment_id_to_mm_id.return_value = "0"
+        mock_mmdbus.return_value = mmdbus_instance
+        mock_r_status.return_value = "enabled"
+
+        with wwan_tests.WWANTestCtx("test_id", False):
+            pass
+
+        mmdbus_instance.equipment_id_to_mm_id.assert_called_with("test_id")
+        self.assertTrue(mock_mmdbus.called)
+        self.assertFalse(mock_r_on.called)
+        self.assertFalse(mock_r_off.called)
+        self.assertTrue(mock_r_status.called)
+
+    @patch("wwan_tests._wwan_radio_off")
+    @patch("wwan_tests._wwan_radio_on")
+    @patch("wwan_tests._wwan_radio_status")
+    @patch("wwan_tests.MMCLI")
+    def test_wwan_ctx_init_with_mmcli(
+        self, mock_mmcli, mock_r_status, mock_r_on, mock_r_off
+    ):
+        mmcli_instance = Mock()
+        mmcli_instance.equipment_id_to_mm_id.return_value = "0"
+        mock_mmcli.return_value = mmcli_instance
+        mock_r_status.return_value = "disabled"
+
+        with wwan_tests.WWANTestCtx("test_id", True, True):
+            pass
+
+        mmcli_instance.equipment_id_to_mm_id.assert_called_with("test_id")
+        self.assertTrue(mock_mmcli.called)
+        self.assertTrue(mock_r_on.called)
+        self.assertTrue(mock_r_off.called)
+        self.assertTrue(mock_r_status.called)
+
+
 class TestThreeGppScanTest(unittest.TestCase):
 
     def test_register_argument(self):
@@ -123,86 +187,108 @@ class TestThreeGppScanTest(unittest.TestCase):
         self.assertEqual(ret_args.hw_id, "2")
         self.assertEqual(ret_args.timeout, 600)
 
-    @patch("subprocess.check_call")
-    @patch("wwan_tests._wwan_radio_off")
-    @patch("wwan_tests._wwan_radio_on")
-    @patch("wwan_tests.MMCLI")
+    @patch("subprocess.run")
+    @patch("wwan_tests.WWANTestCtx")
     @patch("wwan_tests.ThreeGppScanTest.register_argument")
-    def test_invoked_successfully(
-        self, mock_arg, mock_mmcli, mock_r_on, mock_r_off, mock_subprocess
-    ):
+    def test_invoked_successfully(self, mock_arg, mock_mmctx, mock_run):
         mock_arg.return_value = argparse.Namespace(hw_id="2", timeout=200)
-
         mmcli_instance = Mock()
-        mmcli_instance.equipment_id_to_mm_id.return_value = "0"
-        mock_mmcli.return_value = mmcli_instance
-        mock_subprocess.return_value = 0
+        mmcli_instance.modem_idx = "0"
+        mock_mmctx.return_value.__enter__.return_value = mmcli_instance
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=b"output", stderr=b""
+        )
 
-        with self.assertRaises(SystemExit) as context:
-            obj_3gppscan = wwan_tests.ThreeGppScanTest()
-            obj_3gppscan.invoked()
+        with redirect_stdout(StringIO()):
+            with self.assertRaises(SystemExit) as context:
+                obj_3gppscan = wwan_tests.ThreeGppScanTest()
+                obj_3gppscan.invoked()
 
         self.assertEqual(context.exception.code, 0)
-        self.assertTrue(mock_mmcli.called)
-        self.assertTrue(mmcli_instance.equipment_id_to_mm_id.called)
-        self.assertTrue(mock_r_on.called)
-        self.assertTrue(mock_r_off.called)
-        mock_subprocess.assert_called_with(
-            ["mmcli", "-m", "0", "--3gpp-scan", "--timeout", "200"]
+        mock_mmctx.assert_called_with("2", True, True)
+        mock_run.assert_called_with(
+            ["mmcli", "-m", "0", "--3gpp-scan", "--timeout", "200"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
         )
 
-    @patch("subprocess.check_call")
-    @patch("wwan_tests._wwan_radio_off")
-    @patch("wwan_tests._wwan_radio_on")
-    @patch("wwan_tests.MMCLI")
+    @patch("subprocess.run")
+    @patch("wwan_tests.WWANTestCtx")
     @patch("wwan_tests.ThreeGppScanTest.register_argument")
-    def test_invoked_failed(
-        self, mock_arg, mock_mmcli, mock_r_on, mock_r_off, mock_subprocess
-    ):
+    def test_invoked_failed_exit_code(self, mock_arg, mock_mmctx, mock_run):
         mock_arg.return_value = argparse.Namespace(hw_id="2", timeout=200)
-
         mmcli_instance = Mock()
-        mmcli_instance.equipment_id_to_mm_id.return_value = "0"
-        mock_mmcli.return_value = mmcli_instance
-        mock_subprocess.return_value = 1
-
-        with self.assertRaises(SystemExit) as context:
-            obj_3gppscan = wwan_tests.ThreeGppScanTest()
-            obj_3gppscan.invoked()
-
-        self.assertEqual(context.exception.code, 1)
-        self.assertTrue(mock_mmcli.called)
-        self.assertTrue(mmcli_instance.equipment_id_to_mm_id.called)
-        self.assertTrue(mock_r_on.called)
-        self.assertTrue(mock_r_off.called)
-        mock_subprocess.assert_called_with(
-            ["mmcli", "-m", "0", "--3gpp-scan", "--timeout", "200"]
+        mmcli_instance.modem_idx = "0"
+        mock_mmctx.return_value.__enter__.return_value = mmcli_instance
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout=b"output", stderr=b""
         )
 
-    @patch("subprocess.check_call")
-    @patch("wwan_tests._wwan_radio_off")
-    @patch("wwan_tests._wwan_radio_on")
-    @patch("wwan_tests.MMCLI")
-    @patch("wwan_tests.ThreeGppScanTest.register_argument")
-    def test_invoked_call_error(
-        self, mock_arg, mock_mmcli, mock_r_on, mock_r_off, mock_subprocess
-    ):
-        mock_arg.return_value = argparse.Namespace(hw_id="2", timeout=200)
-
-        mmcli_instance = Mock()
-        mmcli_instance.equipment_id_to_mm_id.return_value = "0"
-        mock_mmcli.return_value = mmcli_instance
-        mock_subprocess.side_effect = subprocess.CalledProcessError(1, "cmd")
-
-        with self.assertRaises(SystemExit) as context:
-            obj_3gppscan = wwan_tests.ThreeGppScanTest()
-            obj_3gppscan.invoked()
+        with redirect_stdout(StringIO()):
+            with self.assertRaises(SystemExit) as context:
+                obj_3gppscan = wwan_tests.ThreeGppScanTest()
+                obj_3gppscan.invoked()
 
         self.assertEqual(context.exception.code, 1)
-        self.assertTrue(mock_mmcli.called)
-        self.assertTrue(mmcli_instance.equipment_id_to_mm_id.called)
-        self.assertTrue(mock_r_on.called)
-        self.assertTrue(mock_r_off.called)
-        mock_subprocess.assert_called_with(
-            ["mmcli", "-m", "0", "--3gpp-scan", "--timeout", "200"]
+        mock_mmctx.assert_called_with("2", True, True)
+        mock_run.assert_called_with(
+            ["mmcli", "-m", "0", "--3gpp-scan", "--timeout", "200"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+    @patch("subprocess.run")
+    @patch("wwan_tests.WWANTestCtx")
+    @patch("wwan_tests.ThreeGppScanTest.register_argument")
+    def test_invoked_failed_msg(self, mock_arg, mock_mmctx, mock_run):
+        mock_arg.return_value = argparse.Namespace(hw_id="2", timeout=200)
+        mmcli_instance = Mock()
+        mmcli_instance.modem_idx = "0"
+        mock_mmctx.return_value.__enter__.return_value = mmcli_instance
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=b"output\nerror: modem disabled",
+            stderr=b"",
+        )
+
+        with redirect_stdout(StringIO()):
+            with self.assertRaises(SystemExit) as context:
+                obj_3gppscan = wwan_tests.ThreeGppScanTest()
+                obj_3gppscan.invoked()
+
+        self.assertEqual(context.exception.code, 1)
+        mock_mmctx.assert_called_with("2", True, True)
+        mock_run.assert_called_with(
+            ["mmcli", "-m", "0", "--3gpp-scan", "--timeout", "200"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+    @patch("subprocess.run")
+    @patch("wwan_tests.WWANTestCtx")
+    @patch("wwan_tests.ThreeGppScanTest.register_argument")
+    def test_invoked_call_error(self, mock_arg, mock_mmctx, mock_run):
+        mock_arg.return_value = argparse.Namespace(hw_id="2", timeout=200)
+        mmcli_instance = Mock()
+        mmcli_instance.modem_idx = "0"
+        mock_mmctx.return_value.__enter__.return_value = mmcli_instance
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout=b"output",
+            stderr=b"",
+        )
+
+        with redirect_stdout(StringIO()):
+            with self.assertRaises(SystemExit) as context:
+                obj_3gppscan = wwan_tests.ThreeGppScanTest()
+                obj_3gppscan.invoked()
+
+        self.assertEqual(context.exception.code, 1)
+        mock_mmctx.assert_called_with("2", True, True)
+        mock_run.assert_called_with(
+            ["mmcli", "-m", "0", "--3gpp-scan", "--timeout", "200"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
         )

--- a/providers/base/tests/test_wwan_tests.py
+++ b/providers/base/tests/test_wwan_tests.py
@@ -240,34 +240,6 @@ class TestThreeGppScanTest(unittest.TestCase):
     @patch("subprocess.run")
     @patch("wwan_tests.WWANTestCtx")
     @patch("wwan_tests.ThreeGppScanTest.register_argument")
-    def test_invoked_failed_msg(self, mock_arg, mock_mmctx, mock_run):
-        mock_arg.return_value = argparse.Namespace(hw_id="2", timeout=200)
-        mmcli_instance = Mock()
-        mmcli_instance.modem_idx = "0"
-        mock_mmctx.return_value.__enter__.return_value = mmcli_instance
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[],
-            returncode=0,
-            stdout=b"output\nerror: modem disabled",
-            stderr=b"",
-        )
-
-        with redirect_stdout(StringIO()):
-            with self.assertRaises(SystemExit) as context:
-                obj_3gppscan = wwan_tests.ThreeGppScanTest()
-                obj_3gppscan.invoked()
-
-        self.assertEqual(context.exception.code, 1)
-        mock_mmctx.assert_called_with("2", True, True)
-        mock_run.assert_called_with(
-            ["mmcli", "-m", "0", "--3gpp-scan", "--timeout", "200"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
-
-    @patch("subprocess.run")
-    @patch("wwan_tests.WWANTestCtx")
-    @patch("wwan_tests.ThreeGppScanTest.register_argument")
     def test_invoked_call_error(self, mock_arg, mock_mmctx, mock_run):
         mock_arg.return_value = argparse.Namespace(hw_id="2", timeout=200)
         mmcli_instance = Mock()

--- a/providers/base/units/wwan/jobs.pxu
+++ b/providers/base/units/wwan/jobs.pxu
@@ -101,6 +101,27 @@ requires:
   manifest.has_wwan_module == 'True'
   snap.name == 'modem-manager' or package.name == 'modemmanager'
 
+unit: template
+template-resource: wwan_resource
+template-unit: job
+id: wwan/3gpp-scan-{manufacturer}-{model}-{hw_id}-auto
+template-id: wwan/3gpp-scan-manufacturer-model-hw_id-auto
+_summary:  Scan for available 3GPP networks with the modem
+_template-summary: Scan for available 3GPP networks with the {model} modem
+_description:
+  Scan for available 3GPP networks with the target modem
+plugin: shell
+command: wwan_tests.py 3gpp-scan {hw_id}
+environ: LD_LIBRARY_PATH
+user: root
+estimated_duration: 10.0
+category_id: wwan
+flags: preserve-locale also-after-suspend preserve-cwd
+imports: from com.canonical.plainbox import manifest
+requires:
+  manifest.has_wwan_module == 'True'
+  snap.name == 'modem-manager' or package.name == 'modemmanager'
+
 id: wwan/detect-manual
 plugin: manual
 _summary: Check if WWAN module is available
@@ -162,26 +183,6 @@ _steps:
  5. Run `fg` to jump back to Checkbox (if you're running in the same terminal)
 _verification:
  Did the ping come back?
-estimated_duration: 120s
-flags:  also-after-suspend
-category_id: wwan
-imports: from com.canonical.plainbox import manifest
-requires:
-    manifest.has_wwan_module == 'True'
-depends:
-    wwan/check-sim-present-manual
-
-id: wwan/scan-networks-manual
-plugin: manual
-_summary: Verify that modem can scan for available networks
-_purpose:
- Ensure that the modem can scan/find available networks
-_steps:
- 1. Open another terminal on SUT (or press ctrl+z to suspend Checkbox)
- 2. Run `sudo mmcli -m 0 --3gpp-scan --timeout=300`
- 3. Run `fg` to jump back to checkbox (if you're running in the same terminal)
-_verification:
- Were available networks listed?
 estimated_duration: 120s
 flags:  also-after-suspend
 category_id: wwan

--- a/providers/base/units/wwan/jobs.pxu
+++ b/providers/base/units/wwan/jobs.pxu
@@ -51,6 +51,7 @@ estimated_duration: 10.0
 category_id: wwan
 flags: preserve-locale also-after-suspend preserve-cwd
 imports: from com.canonical.plainbox import manifest
+depends: wwan/check-sim-present-{manufacturer}-{model}-{hw_id}-auto
 requires:
   manifest.has_wwan_module == 'True'
   snap.name == 'modem-manager' or package.name == 'modemmanager'

--- a/providers/base/units/wwan/jobs.pxu
+++ b/providers/base/units/wwan/jobs.pxu
@@ -117,7 +117,8 @@ environ: LD_LIBRARY_PATH
 user: root
 estimated_duration: 10.0
 category_id: wwan
-flags: preserve-locale also-after-suspend preserve-cwd
+flags: preserve-locale also-after-suspend
+depends: wwan/check-sim-present-{manufacturer}-{model}-{hw_id}-auto
 imports: from com.canonical.plainbox import manifest
 requires:
   manifest.has_wwan_module == 'True'

--- a/providers/base/units/wwan/test-plan.pxu
+++ b/providers/base/units/wwan/test-plan.pxu
@@ -16,6 +16,7 @@ _description: Automated wwan tests for Snappy Ubuntu Core devices
 include:
     # Note these tests require snap calling snap support
     wwan/detect
+    wwan/3gpp-scan-.*-auto
     wwan/gsm-connection-.*-auto
     wwan/check-sim-present-.*-auto
 bootstrap_include:
@@ -36,6 +37,8 @@ _name: Automated wwan tests (after suspend)
 _description: Automated wwan tests for Snappy Ubuntu Core devices
 include:
     after-suspend-wwan/detect
+    after-suspend-wwan/check-sim-present-.*-auto
+    after-suspend-wwan/3gpp-scan-.*-auto
     after-suspend-wwan/gsm-connection-.*-auto
 bootstrap_include:
     wwan_resource
@@ -46,7 +49,6 @@ _name: Manual wwan tests
 _description: Manual wwan tests for Snappy Ubuntu Core devices
 include:
     wwan/detect-manual
-    wwan/scan-networks-manual
     wwan/check-sim-present-manual
     wwan/gsm-connection-interrupted-manual
 
@@ -56,6 +58,5 @@ _name: Manual wwan tests (after suspend)
 _description: Manual wwan tests for Snappy Ubuntu Core devices
 include:
     after-suspend-wwan/detect-manual
-    after-suspend-wwan/scan-networks-manual
     after-suspend-wwan/check-sim-present-manual
     after-suspend-wwan/gsm-connection-interrupted-manual

--- a/providers/base/units/wwan/test-plan.pxu
+++ b/providers/base/units/wwan/test-plan.pxu
@@ -16,7 +16,7 @@ _description: Automated wwan tests for Snappy Ubuntu Core devices
 include:
     # Note these tests require snap calling snap support
     wwan/detect
-    wwan/3gpp-scan-.*-auto
+    wwan/3gpp-scan-manufacturer-model-hw_id-auto
     wwan/gsm-connection-.*-auto
     wwan/check-sim-present-.*-auto
 bootstrap_include:

--- a/providers/base/units/wwan/test-plan.pxu
+++ b/providers/base/units/wwan/test-plan.pxu
@@ -37,8 +37,8 @@ _name: Automated wwan tests (after suspend)
 _description: Automated wwan tests for Snappy Ubuntu Core devices
 include:
     after-suspend-wwan/detect
-    after-suspend-wwan/check-sim-present-.*-auto
-    after-suspend-wwan/3gpp-scan-.*-auto
+    after-suspend-wwan/check-sim-present-manufacturer-model-hw_id-auto
+    after-suspend-wwan/3gpp-scan-manufacturer-model-hw_id-auto
     after-suspend-wwan/gsm-connection-.*-auto
 bootstrap_include:
     wwan_resource


### PR DESCRIPTION
## Description
Convert wan/3gpp-scan test as a automated test (New)

## Resolved issues
[OEMQA-4494](https://warthogs.atlassian.net/browse/OEMQA-4494)

## Documentation
N/A

## Tests
Please refer following submission for the test results (w/ side loaded provider)
https://certification.canonical.com/hardware/202302-31253/submission/379312/ (Updated on 2024/07/08)

[OEMQA-4494]: https://warthogs.atlassian.net/browse/OEMQA-4494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ