### PR TITLE
Fix wifi nmcli backup/restore /delete on 24.04 Desktop (BugFix)

### DIFF
--- a/providers/base/bin/wifi_nmcli_backup.py
+++ b/providers/base/bin/wifi_nmcli_backup.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess as sp
 import sys
 import glob
+from pathlib import Path
 
 from packaging import version as version_parser
 
@@ -77,9 +78,8 @@ def save_connections(keyfile_list):
             continue
 
         print("  Found file {}".format(f))
-
-        basedir = os.path.dirname(f)
-        backup_loc = os.path.join(SAVE_DIR, *basedir.split("/"))
+        basedir = Path(f).parent
+        backup_loc = SAVE_DIR / basedir
 
         os.makedirs(backup_loc, exist_ok=True)
         save_f = shutil.copy(f, backup_loc)
@@ -94,9 +94,11 @@ def restore_connections():
         print("No stored 802.11 connections found")
         return
     for f in saved_list:
-        save_f = f[len(SAVE_DIR) :]
+        f_path = Path(f)
+        save_f = f_path.relative_to(SAVE_DIR)
+        dest_path = Path("/") / save_f
         print("Restore connection {}".format(save_f))
-        shutil.move(f, save_f)
+        shutil.move(f, dest_path)
 
 
 if __name__ == "__main__":

--- a/providers/base/bin/wifi_nmcli_backup.py
+++ b/providers/base/bin/wifi_nmcli_backup.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import subprocess as sp
 import sys
+import glob
 
 from packaging import version as version_parser
 
@@ -62,37 +63,43 @@ def reload_nm_connections():
 
 
 def save_connections(keyfile_list):
-    if not os.path.exists(SAVE_DIR):
-        os.makedirs(SAVE_DIR)
-    if len(keyfile_list) == 0:
+    os.makedirs(SAVE_DIR, exist_ok=True)
+
+    if not keyfile_list:
         print("No stored 802.11 connections to save")
         return
+
     for f in keyfile_list:
         print("Save connection {}".format(f))
+
         if not os.path.exists(f):
-            print("  No stored connection fount at {}".format(f))
+            print("  No stored connection found at {}".format(f))
             continue
+
         print("  Found file {}".format(f))
-        save_f = shutil.copy(f, SAVE_DIR)
+
+        basedir = os.path.dirname(f)
+        backup_loc = os.path.join(SAVE_DIR, *basedir.split("/"))
+
+        if not os.path.exists(backup_loc):
+            os.makedirs(backup_loc)
+        save_f = shutil.copy(f, backup_loc)
         print("  Saved copy at {}".format(save_f))
 
 
 def restore_connections():
-    saved_list = [
-        f
-        for f in os.listdir(SAVE_DIR)
-        if os.path.isfile(os.path.join(SAVE_DIR, f))
-    ]
+    saved_list = glob.glob(
+        "{}/**/*.nmconnection".format(SAVE_DIR), recursive=True
+    )
     if len(saved_list) == 0:
         print("No stored 802.11 connections found")
         return
     for f in saved_list:
-        save_f = os.path.join(SAVE_DIR, f)
+        print(SAVE_DIR)
+        print(len(SAVE_DIR))
+        save_f = f[len(SAVE_DIR) :]
         print("Restore connection {}".format(save_f))
-        restore_f = shutil.copy(save_f, NM_CON_DIR)
-        print("  Restored file at {}".format(restore_f))
-        os.remove(save_f)
-        print("  Removed copy from {}".format(save_f))
+        shutil.move(f, save_f)
 
 
 if __name__ == "__main__":

--- a/providers/base/bin/wifi_nmcli_backup.py
+++ b/providers/base/bin/wifi_nmcli_backup.py
@@ -81,8 +81,7 @@ def save_connections(keyfile_list):
         basedir = os.path.dirname(f)
         backup_loc = os.path.join(SAVE_DIR, *basedir.split("/"))
 
-        if not os.path.exists(backup_loc):
-            os.makedirs(backup_loc)
+        os.makedirs(backup_loc, exist_ok=True)
         save_f = shutil.copy(f, backup_loc)
         print("  Saved copy at {}".format(save_f))
 
@@ -95,8 +94,6 @@ def restore_connections():
         print("No stored 802.11 connections found")
         return
     for f in saved_list:
-        print(SAVE_DIR)
-        print(len(SAVE_DIR))
         save_f = f[len(SAVE_DIR) :]
         print("Restore connection {}".format(save_f))
         shutil.move(f, save_f)

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -111,7 +111,7 @@ def delete_test_ap_ssid_connection():
         sp.call(shlex.split(cmd))
         print("TEST_CON is deleted")
     except Exception as e:
-        print("Can't delect TEST_CON : {}".format(str(e)))
+        print("Can't delete TEST_CON : {}".format(str(e)))
 
 
 def device_rescan():

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -234,7 +234,7 @@ def open_connection(args):
         "nmcli c add con-name TEST_CON "
         "ifname {} "
         "type wifi "
-        "ssid '{}' "
+        "ssid {} "
         "-- "
         "ipv4.method auto "
         "ipv4.dhcp-timeout 30 "
@@ -247,7 +247,7 @@ def open_connection(args):
     turn_up_connection("TEST_CON")
 
     print_head("Ensure interface is connected")
-    reached_connected = wait_for_connected(args.device, args.essid)
+    reached_connected = wait_for_connected(args.device, "TEST_CON")
 
     rc = 1
     if reached_connected:
@@ -278,7 +278,7 @@ def secured_connection(args):
         "nmcli c add con-name TEST_CON "
         "ifname {} "
         "type wifi "
-        "ssid '{}' "
+        "ssid {} "
         "-- "
         "wifi-sec.key-mgmt {} "
         "wifi-sec.psk {} "
@@ -295,7 +295,7 @@ def secured_connection(args):
     turn_up_connection("TEST_CON")
 
     print_head("Ensure interface is connected")
-    reached_connected = wait_for_connected(args.device, args.essid)
+    reached_connected = wait_for_connected(args.device, "TEST_CON")
 
     rc = 1
     if reached_connected:

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -27,7 +27,7 @@ print = functools.partial(print, flush=True)
 
 def legacy_nmcli():
     cmd = "nmcli -v"
-    output = sp.check_output(cmd, shell=True)
+    output = sp.check_output(cmd.split())
     version = version_parser.parse(output.strip().split()[-1].decode())
     # check if using the 16.04 nmcli because of this bug
     # https://bugs.launchpad.net/plano/+bug/1896806
@@ -45,7 +45,7 @@ def print_cmd(cmd):
 def _get_nm_wireless_connections():
     cmd = "nmcli -t -f TYPE,UUID,NAME,STATE connection"
     print_cmd(cmd)
-    output = sp.check_output(cmd, shell=True)
+    output = sp.check_output(cmd.split())
     connections = {}
     for line in output.decode(sys.stdout.encoding).splitlines():
         type, uuid, name, state = line.strip().split(":", 3)
@@ -77,7 +77,7 @@ def turn_up_connection(uuid):
         return None
     try:
         print_cmd(cmd)
-        sp.call(cmd, shell=True)
+        sp.call(cmd.split())
     except Exception as e:
         print("Can't turn on {}: {}".format(uuid, str(e)))
 
@@ -91,7 +91,7 @@ def turn_down_nm_connections():
         try:
             cmd = "nmcli c down {}".format(uuid)
             print_cmd(cmd)
-            sp.call(cmd, shell=True)
+            sp.call(cmd.split())
             print("{} {} is down now".format(name, uuid))
         except Exception as e:
             print("Can't down {}: {}".format(uuid, str(e)))
@@ -107,7 +107,7 @@ def delete_test_ap_ssid_connection():
     try:
         cmd = "nmcli c delete TEST_CON"
         print_cmd(cmd)
-        sp.call(cmd, shell=True)
+        sp.call(cmd.split())
         print("TEST_CON is deleted")
     except Exception as e:
         print("Can't delect TEST_CON : {}".format(str(e)))
@@ -117,7 +117,7 @@ def device_rescan():
     print_head("Calling a rescan")
     cmd = "nmcli d wifi rescan"
     print_cmd(cmd)
-    retcode = sp.call(cmd, shell=True)
+    retcode = sp.call(cmd.split())
     if retcode != 0:
         # Most often the rescan request fails because NM has itself started
         # a scan in recent past, we should let these operations complete before
@@ -132,7 +132,7 @@ def list_aps(ifname, essid=None):
     aps_dict = {}
     fields = "SSID,CHAN,FREQ,SIGNAL"
     cmd = "nmcli -t -f {} d wifi list ifname {}".format(fields, ifname)
-    output = sp.check_output(cmd, shell=True)
+    output = sp.check_output(cmd.split())
     for line in output.decode(sys.stdout.encoding).splitlines():
         # lp bug #1723372 - extra line in output on zesty
         if line.strip() == ifname:  # Skip device name line
@@ -157,14 +157,14 @@ def show_aps(aps_dict):
 def print_address_info(interface):
     cmd = "ip address show dev {}".format(interface)
     print_cmd(cmd)
-    sp.call(cmd, shell=True)
+    sp.call(cmd.split())
     print()
 
 
 def print_route_info():
     cmd = "ip route"
     print_cmd(cmd)
-    sp.call(cmd, shell=True)
+    sp.call(cmd.split())
     print()
 
 
@@ -172,7 +172,7 @@ def perform_ping_test(interface):
     target = None
     cmd = "nmcli --mode tabular --terse --fields IP4.GATEWAY c show TEST_CON"
     print_cmd(cmd)
-    output = sp.check_output(cmd, shell=True)
+    output = sp.check_output(cmd.split())
     target = output.decode(sys.stdout.encoding).strip()
     print("Got gateway address: {}".format(target))
 
@@ -194,7 +194,7 @@ def wait_for_connected(interface, essid, max_wait=5):
             "d show {}".format(interface)
         )
         print_cmd(cmd)
-        output = sp.check_output(cmd, shell=True)
+        output = sp.check_output(cmd.split())
         state, ssid = output.decode(sys.stdout.encoding).strip().splitlines()
 
         if state.startswith("100") and ssid == essid:
@@ -241,7 +241,7 @@ def open_connection(args):
         "ipv6.method ignore".format(args.device, args.essid)
     )
     print_cmd(cmd)
-    sp.call(cmd, shell=True)
+    sp.call(cmd.split())
 
     # Make sure the connection is brought up
     turn_up_connection("TEST_CON")
@@ -289,7 +289,7 @@ def secured_connection(args):
         )
     )
     print_cmd(cmd)
-    sp.call(cmd, shell=True)
+    sp.call(cmd.split())
 
     # Make sure the connection is brought up
     turn_up_connection("TEST_CON")
@@ -322,7 +322,7 @@ def hotspot(args):
         " ssid CHECKBOX_AP".format(args.device)
     )
     print_cmd(cmd)
-    retcode = sp.call(cmd, shell=True)
+    retcode = sp.call(cmd.split())
     if retcode != 0:
         print("Connection creation failed\n")
         return retcode
@@ -331,7 +331,7 @@ def hotspot(args):
         " 802-11-wireless.band {}".format(args.band)
     )
     print_cmd(cmd)
-    retcode = sp.call(cmd, shell=True)
+    retcode = sp.call(cmd.split())
     if retcode != 0:
         print("Set band failed\n")
         return retcode
@@ -340,13 +340,11 @@ def hotspot(args):
         'wifi-sec.psk "ubuntu1234"'
     )
     print_cmd(cmd)
-    retcode = sp.call(cmd, shell=True)
+    retcode = sp.call(cmd.split())
     if retcode != 0:
         print("Setting up wifi security failed\n")
         return retcode
-    cmd = "nmcli connection up TEST_CON"
-    print_cmd(cmd)
-    retcode = sp.call(cmd, shell=True)
+    turn_up_connection("TEST_CON")
     if retcode != 0:
         print("Failed to bring up connection\n")
     print()
@@ -363,7 +361,7 @@ def print_journal_entries(start):
         '--since "{}" '.format(start.strftime("%Y-%m-%d %H:%M:%S"))
     )
     print_cmd(cmd)
-    sp.call(cmd, shell=True)
+    sp.call(cmd.split())
 
 
 def parser_args():

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -94,7 +94,7 @@ def turn_down_nm_connections():
             print_cmd(cmd)
             sp.call(shlex.split(cmd))
             print("{} {} is down now".format(name, uuid))
-        except Exception as e:
+        except sp.CalledProcessError as e:
             print("Can't down {}: {}".format(uuid, str(e)))
     print()
 

--- a/providers/base/tests/test_wifi_nmcli_backup.py
+++ b/providers/base/tests/test_wifi_nmcli_backup.py
@@ -17,9 +17,13 @@
 
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, call, ANY
 
-from wifi_nmcli_backup import legacy_nmcli
+from wifi_nmcli_backup import (
+    legacy_nmcli,
+    save_connections,
+    restore_connections,
+)
 
 
 class WifiNmcliBackupTests(unittest.TestCase):
@@ -36,3 +40,115 @@ class WifiNmcliBackupTests(unittest.TestCase):
             b"nmcli tool, version 1.46.0-2"
         )
         self.assertFalse(legacy_nmcli())
+
+    @patch("wifi_nmcli_backup.os.makedirs")
+    @patch("wifi_nmcli_backup.print")
+    def test_save_connections_empty_list(self, mock_print, mock_makedirs):
+        save_connections([])
+        mock_print.assert_called_once_with(
+            "No stored 802.11 connections to save"
+        )
+        mock_makedirs.assert_called_once()
+
+    @patch("wifi_nmcli_backup.os.makedirs")
+    @patch("wifi_nmcli_backup.os.path.exists", return_value=True)
+    def test_save_connections_savedir_exists(self, mock_makedirs, mock_exists):
+        mock_makedirs.assert_not_called()
+
+    @patch("wifi_nmcli_backup.os.path.exists", return_value=False)
+    @patch("wifi_nmcli_backup.print")
+    @patch("wifi_nmcli_backup.os.makedirs")
+    def test_save_connections_non_existing_files(
+        self, mock_makedirs, mock_print, mock_exists
+    ):
+        keyfile_list = [
+            "/fake/path/to/connection1",
+            "/fake/path/to/connection2",
+        ]
+
+        save_connections(keyfile_list)
+        expected_calls = [
+            call("Save connection {}".format(f)) for f in keyfile_list
+        ]
+        expected_calls += [
+            call("  No stored connection found at {}".format(f))
+            for f in keyfile_list
+        ]
+        mock_print.assert_has_calls(expected_calls, any_order=True)
+        mock_makedirs.assert_called_once()
+
+    @patch(
+        "wifi_nmcli_backup.shutil.copy",
+        return_value="/fake/backup/location/connection1",
+    )
+    @patch(
+        "wifi_nmcli_backup.os.path.exists",
+        side_effect=lambda path: True if "connection" in path else False,
+    )
+    @patch("wifi_nmcli_backup.print")
+    @patch("wifi_nmcli_backup.os.makedirs")
+    def test_save_connections_existing_files(
+        self, mock_makedirs, mock_print, mock_exists, mock_copy
+    ):
+        keyfile_list = ["/etc/NetworkManager/system-connections/connection1"]
+        save_connections(keyfile_list)
+        mock_makedirs.assert_called_once()
+        mock_copy.assert_called_once_with(
+            "/etc/NetworkManager/system-connections/connection1", ANY
+        )
+
+        expected_print_calls = [
+            call(
+                "Save connection "
+                "/etc/NetworkManager/system-connections/connection1"
+            ),
+            call(
+                "  Found file "
+                "/etc/NetworkManager/system-connections/connection1"
+            ),
+            call("  Saved copy at /fake/backup/location/connection1"),
+        ]
+        mock_print.assert_has_calls(expected_print_calls, any_order=True)
+
+    @patch("wifi_nmcli_backup.print")
+    @patch("wifi_nmcli_backup.glob.glob", return_value=[])
+    def test_restore_connections_no_stored_connections(
+        self, mock_glob, mock_print
+    ):
+        restore_connections()
+        mock_print.assert_called_once_with(
+            "No stored 802.11 connections found"
+        )
+
+    @patch("wifi_nmcli_backup.shutil.move")
+    @patch("wifi_nmcli_backup.SAVE_DIR", "/stored-system-connections")
+    @patch(
+        "wifi_nmcli_backup.glob.glob",
+        return_value=[
+            "/stored-system-connections/etc/NetworkManager/system-connections"
+            "/connection1.nmconnection",
+            "/stored-system-connections/run/NetworkManager/system-connections"
+            "/connection2.nmconnection",
+        ],
+    )
+    @patch("wifi_nmcli_backup.print")
+    def test_restore_connections_existing_files(
+        self, mock_print, mock_glob, mock_move
+    ):
+        restore_connections()
+        expected_calls = [
+            call(
+                "/stored-system-connections/etc/NetworkManager"
+                "/system-connections/connection1.nmconnection",
+                "/etc/NetworkManager/system-connections"
+                "/connection1.nmconnection",
+            ),
+            call(
+                "/stored-system-connections/run/NetworkManager"
+                "/system-connections/connection2.nmconnection",
+                "/run/NetworkManager/system-connections"
+                "/connection2.nmconnection",
+            ),
+        ]
+
+        mock_move.assert_has_calls(expected_calls, any_order=True)

--- a/providers/base/tests/test_wifi_nmcli_backup.py
+++ b/providers/base/tests/test_wifi_nmcli_backup.py
@@ -141,14 +141,18 @@ class WifiNmcliBackupTests(unittest.TestCase):
             call(
                 "/stored-system-connections/etc/NetworkManager/"
                 "system-connections/connection1.nmconnection",
-                Path("/etc/NetworkManager/system-connections/"
-                     "connection1.nmconnection"),
+                Path(
+                    "/etc/NetworkManager/system-connections/"
+                    "connection1.nmconnection"
+                ),
             ),
             call(
                 "/stored-system-connections/run/NetworkManager/"
                 "system-connections/connection2.nmconnection",
-                Path("/run/NetworkManager/system-connections/"
-                     "connection2.nmconnection"),
+                Path(
+                    "/run/NetworkManager/system-connections/"
+                    "connection2.nmconnection"
+                ),
             ),
         ]
 

--- a/providers/base/tests/test_wifi_nmcli_backup.py
+++ b/providers/base/tests/test_wifi_nmcli_backup.py
@@ -17,6 +17,7 @@
 
 
 import unittest
+from pathlib import Path
 from unittest.mock import patch, call, ANY
 
 from wifi_nmcli_backup import (
@@ -120,34 +121,34 @@ class WifiNmcliBackupTests(unittest.TestCase):
             "No stored 802.11 connections found"
         )
 
-    @patch("wifi_nmcli_backup.shutil.move")
     @patch("wifi_nmcli_backup.SAVE_DIR", "/stored-system-connections")
-    @patch(
-        "wifi_nmcli_backup.glob.glob",
-        return_value=[
-            "/stored-system-connections/etc/NetworkManager/system-connections"
-            "/connection1.nmconnection",
-            "/stored-system-connections/run/NetworkManager/system-connections"
-            "/connection2.nmconnection",
-        ],
-    )
+    @patch("wifi_nmcli_backup.shutil.move")
+    @patch("wifi_nmcli_backup.glob.glob")
     @patch("wifi_nmcli_backup.print")
     def test_restore_connections_existing_files(
         self, mock_print, mock_glob, mock_move
     ):
+        mock_glob.return_value = [
+            "/stored-system-connections/etc/NetworkManager/system-connections/"
+            "connection1.nmconnection",
+            "/stored-system-connections/run/NetworkManager/system-connections/"
+            "connection2.nmconnection",
+        ]
+
         restore_connections()
+
         expected_calls = [
             call(
-                "/stored-system-connections/etc/NetworkManager"
-                "/system-connections/connection1.nmconnection",
-                "/etc/NetworkManager/system-connections"
-                "/connection1.nmconnection",
+                "/stored-system-connections/etc/NetworkManager/"
+                "system-connections/connection1.nmconnection",
+                Path("/etc/NetworkManager/system-connections/"
+                     "connection1.nmconnection"),
             ),
             call(
-                "/stored-system-connections/run/NetworkManager"
-                "/system-connections/connection2.nmconnection",
-                "/run/NetworkManager/system-connections"
-                "/connection2.nmconnection",
+                "/stored-system-connections/run/NetworkManager/"
+                "system-connections/connection2.nmconnection",
+                Path("/run/NetworkManager/system-connections/"
+                     "connection2.nmconnection"),
             ),
         ]
 

--- a/providers/base/tests/test_wifi_nmcli_backup.py
+++ b/providers/base/tests/test_wifi_nmcli_backup.py
@@ -48,7 +48,7 @@ class WifiNmcliBackupTests(unittest.TestCase):
         mock_print.assert_called_once_with(
             "No stored 802.11 connections to save"
         )
-        mock_makedirs.assert_called_once()
+        self.assertEqual(mock_makedirs.call_count, 1)
 
     @patch("wifi_nmcli_backup.os.makedirs")
     @patch("wifi_nmcli_backup.os.path.exists", return_value=True)
@@ -75,7 +75,7 @@ class WifiNmcliBackupTests(unittest.TestCase):
             for f in keyfile_list
         ]
         mock_print.assert_has_calls(expected_calls, any_order=True)
-        mock_makedirs.assert_called_once()
+        self.assertEqual(mock_makedirs.call_count, 1)
 
     @patch(
         "wifi_nmcli_backup.shutil.copy",
@@ -92,7 +92,7 @@ class WifiNmcliBackupTests(unittest.TestCase):
     ):
         keyfile_list = ["/etc/NetworkManager/system-connections/connection1"]
         save_connections(keyfile_list)
-        mock_makedirs.assert_called_once()
+        self.assertEqual(mock_makedirs.call_count, 2)
         mock_copy.assert_called_once_with(
             "/etc/NetworkManager/system-connections/connection1", ANY
         )

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -25,6 +25,7 @@ from wifi_nmcli_test import (
     turn_up_connection,
     turn_down_nm_connections,
     delete_test_ap_ssid_connection,
+    device_rescan,
     list_aps,
     show_aps,
     wait_for_connected,
@@ -113,7 +114,7 @@ class TestTurnUpConnection(unittest.TestCase):
         self, get_nm_activate_connection_mock, sp_call_mock
     ):
         turn_up_connection("uuid2")
-        sp_call_mock.assert_called_with("nmcli c up uuid2", shell=True)
+        sp_call_mock.assert_called_with("nmcli c up uuid2".split())
 
     @patch("wifi_nmcli_test.sp.call", side_effect=Exception("Command failed"))
     @patch("wifi_nmcli_test.get_nm_activate_connection", return_value="")
@@ -145,7 +146,7 @@ class TestTurnDownNmConnections(unittest.TestCase):
     ):
         turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
-        sp_call_mock.assert_called_once_with("nmcli c down uuid1", shell=True)
+        sp_call_mock.assert_called_once_with("nmcli c down uuid1".split())
 
     @patch(
         "wifi_nmcli_test.sp.call", side_effect=Exception("Error turning down")
@@ -159,7 +160,7 @@ class TestTurnDownNmConnections(unittest.TestCase):
     ):
         turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
-        sp_call_mock.assert_called_once_with("nmcli c down uuid1", shell=True)
+        sp_call_mock.assert_called_once_with("nmcli c down uuid1".split())
 
     @patch("wifi_nmcli_test.sp.call")
     @patch(
@@ -175,8 +176,8 @@ class TestTurnDownNmConnections(unittest.TestCase):
         turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
         calls = [
-            call("nmcli c down uuid1", shell=True),
-            call("nmcli c down uuid2", shell=True),
+            call("nmcli c down uuid1".split()),
+            call("nmcli c down uuid2".split()),
         ]
         sp_call_mock.assert_has_calls(calls, any_order=True)
 
@@ -517,6 +518,7 @@ class TestMainFunction(unittest.TestCase):
     @patch("wifi_nmcli_test.turn_up_connection")
     @patch("wifi_nmcli_test.list_aps", return_value={})
     @patch("wifi_nmcli_test.sys.argv", ["wifi_nmcli_test.py", "scan", "wlan0"])
+    @patch("wifi_nmcli_test.device_rescan")
     def test_main_scan_no_aps_found(
         self,
         list_aps_mock,
@@ -524,6 +526,7 @@ class TestMainFunction(unittest.TestCase):
         turn_down_nm_connections_mock,
         get_nm_activate_connection_mock,
         delete_test_ap_ssid_connection_mock,
+        mock_device_rescan,
     ):
         main()
 
@@ -542,6 +545,7 @@ class TestMainFunction(unittest.TestCase):
         },
     )
     @patch("wifi_nmcli_test.sys.argv", ["wifi_nmcli_test.py", "scan", "wlan0"])
+    @patch("wifi_nmcli_test.device_rescan")
     def test_main_scan_aps_found(
         self,
         list_aps_mock,
@@ -549,6 +553,7 @@ class TestMainFunction(unittest.TestCase):
         turn_down_nm_connections_mock,
         get_nm_activate_connection_mock,
         delete_test_ap_ssid_connection_mock,
+        mock_device_rescan,
     ):
         main()
 
@@ -563,6 +568,7 @@ class TestMainFunction(unittest.TestCase):
         "wifi_nmcli_test.sys.argv",
         ["wifi_nmcli_test.py", "open", "wlan0", "TestSSID"],
     )
+    @patch("wifi_nmcli_test.device_rescan")
     def test_main_open_no_aps_found(
         self,
         list_aps_mock,
@@ -570,6 +576,7 @@ class TestMainFunction(unittest.TestCase):
         turn_down_nm_connections_mock,
         get_nm_activate_connection_mock,
         delete_test_ap_ssid_connection_mock,
+        mock_device_rescan,
     ):
         main()
 
@@ -592,6 +599,7 @@ class TestMainFunction(unittest.TestCase):
         ["wifi_nmcli_test.py", "open", "wlan0", "TestSSID"],
     )
     @patch("wifi_nmcli_test.open_connection", return_value=0)
+    @patch("wifi_nmcli_test.device_rescan")
     def test_main_open_aps_found(
         self,
         list_aps_mock,
@@ -600,5 +608,6 @@ class TestMainFunction(unittest.TestCase):
         get_nm_activate_connection_mock,
         delete_test_ap_ssid_connection_mock,
         mock_open_connection,
+        mock_device_rescan,
     ):
         main()

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -132,7 +132,7 @@ class TestTurnDownNmConnections(unittest.TestCase):
         self, get_connections_mock, sp_call_mock
     ):
         turn_down_nm_connections()
-        get_connections_mock.assert_called_once()
+        self.assertEqual(get_connections_mock.call_count, 1)
         sp_call_mock.assert_not_called()
 
     @patch("wifi_nmcli_test.sp.call")
@@ -144,7 +144,7 @@ class TestTurnDownNmConnections(unittest.TestCase):
         self, get_connections_mock, sp_call_mock
     ):
         turn_down_nm_connections()
-        get_connections_mock.assert_called_once()
+        self.assertEqual(get_connections_mock.call_count, 1)
         sp_call_mock.assert_called_once_with("nmcli c down uuid1", shell=True)
 
     @patch(
@@ -158,7 +158,7 @@ class TestTurnDownNmConnections(unittest.TestCase):
         self, get_connections_mock, sp_call_mock
     ):
         turn_down_nm_connections()
-        get_connections_mock.assert_called_once()
+        self.assertEqual(get_connections_mock.call_count, 1)
         sp_call_mock.assert_called_once_with("nmcli c down uuid1", shell=True)
 
     @patch("wifi_nmcli_test.sp.call")
@@ -173,7 +173,7 @@ class TestTurnDownNmConnections(unittest.TestCase):
         self, get_connections_mock, sp_call_mock
     ):
         turn_down_nm_connections()
-        get_connections_mock.assert_called_once()
+        self.assertEqual(get_connections_mock.call_count, 1)
         calls = [
             call("nmcli c down uuid1", shell=True),
             call("nmcli c down uuid2", shell=True),
@@ -358,9 +358,11 @@ class TestOpenConnection(unittest.TestCase):
     @patch("wifi_nmcli_test.wait_for_connected", return_value=False)
     @patch("wifi_nmcli_test.print_head")
     @patch("wifi_nmcli_test.print_cmd")
+    @patch("wifi_nmcli_test.turn_up_connection")
     def test_open_connection_failed_to_connect(
         self,
         print_cmd_mock,
+        turn_up_mock,
         print_head_mock,
         wait_for_connected_mock,
         sp_call_mock,
@@ -397,7 +399,6 @@ class TestSecuredConnection(unittest.TestCase):
         args.psk = "password123"
         rc = secured_connection(args)
         self.assertEqual(rc, 0)
-        sp_call_mock.assert_called()
         wait_for_connected_mock.assert_called_with("wlan0", "TestSSID")
         perform_ping_test_mock.assert_called_with("wlan0")
 
@@ -425,7 +426,6 @@ class TestSecuredConnection(unittest.TestCase):
         args.psk = "password123"
         rc = secured_connection(args)
         self.assertEqual(rc, 1)
-        sp_call_mock.assert_called()
         wait_for_connected_mock.assert_called_with("wlan0", "TestSSID")
         perform_ping_test_mock.assert_not_called()
 
@@ -453,7 +453,6 @@ class TestSecuredConnection(unittest.TestCase):
         args.psk = "password123"
         rc = secured_connection(args)
         self.assertEqual(rc, 1)
-        sp_call_mock.assert_called()
         wait_for_connected_mock.assert_called_with("wlan0", "TestSSID")
         perform_ping_test_mock.assert_not_called()
 

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -17,9 +17,23 @@
 
 
 import unittest
-from unittest.mock import patch
-
-from wifi_nmcli_test import legacy_nmcli
+from unittest.mock import patch, call, MagicMock
+from wifi_nmcli_test import (
+    legacy_nmcli,
+    _get_nm_wireless_connections,
+    get_nm_activate_connection,
+    turn_up_connection,
+    turn_down_nm_connections,
+    delete_test_ap_ssid_connection,
+    list_aps,
+    show_aps,
+    wait_for_connected,
+    open_connection,
+    secured_connection,
+    hotspot,
+    parser_args,
+    main,
+)
 
 
 class WifiNmcliBackupTests(unittest.TestCase):
@@ -36,3 +50,556 @@ class WifiNmcliBackupTests(unittest.TestCase):
             b"nmcli tool, version 1.46.0-2"
         )
         self.assertFalse(legacy_nmcli())
+
+
+class TestGetNmWirelessConnections(unittest.TestCase):
+    @patch("wifi_nmcli_test.sp.check_output", return_value=b"")
+    def test_no_wireless_connections(self, check_output_mock):
+        expected = {}
+        self.assertEqual(_get_nm_wireless_connections(), expected)
+
+    @patch(
+        "wifi_nmcli_test.sp.check_output",
+        return_value=(
+            b"802-11-wireless:uuid1:Wireless1:activated\n"
+            b"802-3-ethernet:uuid2:Ethernet1:activated\n"
+            b"802-11-wireless:uuid3:Wireless2:deactivated\n"
+        ),
+    )
+    def test_multiple_wireless_connections(self, check_output_mock):
+        expected = {
+            "Wireless1": {"uuid": "uuid1", "state": "activated"},
+            "Wireless2": {"uuid": "uuid3", "state": "deactivated"},
+        }
+        self.assertEqual(_get_nm_wireless_connections(), expected)
+
+
+class TestGetNmActivateConnection(unittest.TestCase):
+    @patch("wifi_nmcli_test._get_nm_wireless_connections", return_value={})
+    def test_no_active_connections(self, _):
+        self.assertEqual(get_nm_activate_connection(), "")
+
+    @patch(
+        "wifi_nmcli_test._get_nm_wireless_connections",
+        return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
+    )
+    def test_single_active_connection(self, _):
+        self.assertEqual(get_nm_activate_connection(), "uuid1")
+
+    @patch(
+        "wifi_nmcli_test._get_nm_wireless_connections",
+        return_value={
+            "Wireless1": {"uuid": "uuid1", "state": "deactivated"},
+            "Wireless2": {"uuid": "uuid2", "state": "activated"},
+            "Wireless3": {"uuid": "uuid3", "state": "deactivated"},
+        },
+    )
+    def test_multiple_connections_one_active(self, _):
+        self.assertEqual(get_nm_activate_connection(), "uuid2")
+
+
+class TestTurnUpConnection(unittest.TestCase):
+    @patch("wifi_nmcli_test.sp.call")
+    @patch("wifi_nmcli_test.get_nm_activate_connection", return_value="uuid1")
+    def test_connection_already_activated(
+        self, get_nm_activate_connection_mock, sp_call_mock
+    ):
+        turn_up_connection("uuid1")
+        sp_call_mock.assert_not_called()
+
+    @patch("wifi_nmcli_test.sp.call", return_value=0)
+    @patch("wifi_nmcli_test.get_nm_activate_connection", return_value="")
+    def test_connection_activation_succeeds(
+        self, get_nm_activate_connection_mock, sp_call_mock
+    ):
+        turn_up_connection("uuid2")
+        sp_call_mock.assert_called_with("nmcli c up uuid2", shell=True)
+
+    @patch("wifi_nmcli_test.sp.call", side_effect=Exception("Command failed"))
+    @patch("wifi_nmcli_test.get_nm_activate_connection", return_value="")
+    def test_connection_activation_fails_due_to_exception(
+        self,
+        get_nm_activate_connection_mock,
+        sp_call_mock,
+    ):
+        turn_up_connection("uuid3")
+
+
+class TestTurnDownNmConnections(unittest.TestCase):
+    @patch("wifi_nmcli_test.sp.call")
+    @patch("wifi_nmcli_test._get_nm_wireless_connections", return_value={})
+    def test_no_connections_to_turn_down(
+        self, get_connections_mock, sp_call_mock
+    ):
+        turn_down_nm_connections()
+        get_connections_mock.assert_called_once()
+        sp_call_mock.assert_not_called()
+
+    @patch("wifi_nmcli_test.sp.call")
+    @patch(
+        "wifi_nmcli_test._get_nm_wireless_connections",
+        return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
+    )
+    def test_turn_down_single_connection(
+        self, get_connections_mock, sp_call_mock
+    ):
+        turn_down_nm_connections()
+        get_connections_mock.assert_called_once()
+        sp_call_mock.assert_called_once_with("nmcli c down uuid1", shell=True)
+
+    @patch(
+        "wifi_nmcli_test.sp.call", side_effect=Exception("Error turning down")
+    )
+    @patch(
+        "wifi_nmcli_test._get_nm_wireless_connections",
+        return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
+    )
+    def test_turn_down_single_connection_with_exception(
+        self, get_connections_mock, sp_call_mock
+    ):
+        turn_down_nm_connections()
+        get_connections_mock.assert_called_once()
+        sp_call_mock.assert_called_once_with("nmcli c down uuid1", shell=True)
+
+    @patch("wifi_nmcli_test.sp.call")
+    @patch(
+        "wifi_nmcli_test._get_nm_wireless_connections",
+        return_value={
+            "Wireless1": {"uuid": "uuid1", "state": "activated"},
+            "Wireless2": {"uuid": "uuid2", "state": "activated"},
+        },
+    )
+    def test_turn_down_multiple_connections(
+        self, get_connections_mock, sp_call_mock
+    ):
+        turn_down_nm_connections()
+        get_connections_mock.assert_called_once()
+        calls = [
+            call("nmcli c down uuid1", shell=True),
+            call("nmcli c down uuid2", shell=True),
+        ]
+        sp_call_mock.assert_has_calls(calls, any_order=True)
+
+
+class TestDeleteTestApSsidConnection(unittest.TestCase):
+    @patch("wifi_nmcli_test.sp.call", return_value=0)
+    @patch(
+        "wifi_nmcli_test._get_nm_wireless_connections",
+        return_value={
+            "TEST_CON": {"uuid": "uuid-test", "state": "deactivated"}
+        },
+    )
+    @patch("wifi_nmcli_test.print")
+    def test_delete_existing_test_con(
+        self, get_nm_wireless_connections_mock, sp_call_mock, print_mock
+    ):
+        delete_test_ap_ssid_connection()
+
+    @patch("wifi_nmcli_test.sp.call", side_effect=Exception("Deletion failed"))
+    @patch(
+        "wifi_nmcli_test._get_nm_wireless_connections",
+        return_value={
+            "TEST_CON": {"uuid": "uuid-test", "state": "deactivated"}
+        },
+    )
+    def test_delete_test_con_exception(
+        self, get_nm_wireless_connections_mock, sp_call_mock
+    ):
+        delete_test_ap_ssid_connection()
+
+    @patch("wifi_nmcli_test._get_nm_wireless_connections", return_value={})
+    def test_no_test_con_to_delete(self, get_nm_wireless_connections_mock):
+        delete_test_ap_ssid_connection()
+
+
+class TestListAps(unittest.TestCase):
+    @patch("wifi_nmcli_test.sp.check_output")
+    def test_list_aps_no_essid(self, check_output_mock):
+        check_output_mock.return_value = (
+            b"wlan0 \nSSID1:1:2412:60\nSSID2:6:2437:70\nSSID3:11:2462:80"
+        )
+        expected = {
+            "SSID1": {"Chan": "1", "Freq": "2412", "Signal": "60"},
+            "SSID2": {"Chan": "6", "Freq": "2437", "Signal": "70"},
+            "SSID3": {"Chan": "11", "Freq": "2462", "Signal": "80"},
+        }
+        self.assertEqual(list_aps("wlan0"), expected)
+
+    @patch("wifi_nmcli_test.sp.check_output")
+    def test_list_aps_with_essid(self, check_output_mock):
+        check_output_mock.return_value = (
+            b"SSID1:1:2412:60\nSSID2:6:2437:70\nSSID3:11:2462:80"
+        )
+        expected = {
+            "SSID2": {"Chan": "6", "Freq": "2437", "Signal": "70"},
+        }
+        self.assertEqual(list_aps("wlan0", "SSID2"), expected)
+
+    @patch("wifi_nmcli_test.sp.check_output")
+    def test_list_aps_empty_output(self, check_output_mock):
+        check_output_mock.return_value = b""
+        expected = {}
+        self.assertEqual(list_aps("wlan0"), expected)
+
+
+class TestShowAps(unittest.TestCase):
+    @patch("wifi_nmcli_test.print")
+    def test_show_aps_empty(self, mock_print):
+        aps_dict = {}
+        show_aps(aps_dict)
+
+    @patch("wifi_nmcli_test.print")
+    def test_show_aps_multiple_aps(self, mock_print):
+        aps_dict = {
+            "AP1": {"Chan": "1", "Freq": "2412", "Signal": "-40"},
+            "AP2": {"Chan": "6", "Freq": "2437", "Signal": "-50"},
+        }
+        show_aps(aps_dict)
+        expected_calls = [
+            call("SSID: AP1 Chan: 1 Freq: 2412 Signal: -40"),
+            call("SSID: AP2 Chan: 6 Freq: 2437 Signal: -50"),
+        ]
+        mock_print.assert_has_calls(expected_calls, any_order=True)
+
+
+class TestWaitForConnected(unittest.TestCase):
+    @patch("wifi_nmcli_test.sp.check_output")
+    @patch("wifi_nmcli_test.print_cmd")
+    @patch("wifi_nmcli_test.time.sleep", return_value=None)
+    def test_wait_for_connected_success(
+        self, mock_sleep, mock_print_cmd, mock_check_output
+    ):
+        mock_check_output.side_effect = [
+            b"100:connected\nTestESSID",
+        ]
+        interface = "wlan0"
+        essid = "TestESSID"
+        self.assertTrue(wait_for_connected(interface, essid))
+
+    @patch(
+        "wifi_nmcli_test.sp.check_output",
+        return_value=b"30:disconnected\nTestESSID",
+    )
+    @patch("wifi_nmcli_test.print_cmd")
+    @patch("wifi_nmcli_test.time.sleep", return_value=None)
+    def test_wait_for_connected_failure_due_to_timeout(
+        self, mock_sleep, mock_print_cmd, mock_check_output
+    ):
+        interface = "wlan0"
+        essid = "TestESSID"
+        self.assertFalse(wait_for_connected(interface, essid, max_wait=3))
+
+    @patch(
+        "wifi_nmcli_test.sp.check_output",
+        return_value=b"100:connected\nWrongESSID",
+    )
+    @patch("wifi_nmcli_test.print_cmd")
+    @patch("wifi_nmcli_test.time.sleep", return_value=None)
+    def test_wait_for_connected_failure_due_to_essid_mismatch(
+        self, mock_sleep, mock_print_cmd, mock_check_output
+    ):
+        interface = "wlan0"
+        essid = "TestESSID"
+        self.assertFalse(wait_for_connected(interface, essid))
+
+
+class TestOpenConnection(unittest.TestCase):
+    @patch("wifi_nmcli_test.sp.call")
+    @patch("wifi_nmcli_test.perform_ping_test", return_value=True)
+    @patch("wifi_nmcli_test.wait_for_connected", return_value=True)
+    @patch("wifi_nmcli_test.print_address_info")
+    @patch("wifi_nmcli_test.print_route_info")
+    @patch("wifi_nmcli_test.turn_up_connection")
+    @patch("wifi_nmcli_test.print_head")
+    @patch("wifi_nmcli_test.print_cmd")
+    def test_open_connection_success(
+        self,
+        print_cmd_mock,
+        print_head_mock,
+        turn_up_mock,
+        print_route_info_mock,
+        print_address_info_mock,
+        wait_for_connected_mock,
+        perform_ping_test_mock,
+        sp_call_mock,
+    ):
+        args = type("", (), {})()
+        args.device = "wlan0"
+        args.essid = "TestESSID"
+        rc = open_connection(args)
+        self.assertEqual(rc, 0)
+
+    @patch("wifi_nmcli_test.sp.call")
+    @patch("wifi_nmcli_test.perform_ping_test", return_value=False)
+    @patch("wifi_nmcli_test.wait_for_connected", return_value=True)
+    @patch("wifi_nmcli_test.print_address_info")
+    @patch("wifi_nmcli_test.print_route_info")
+    @patch("wifi_nmcli_test.turn_up_connection")
+    @patch("wifi_nmcli_test.print_head")
+    @patch("wifi_nmcli_test.print_cmd")
+    def test_open_connection_failed_ping(
+        self,
+        print_cmd_mock,
+        print_head_mock,
+        turn_up_mock,
+        print_route_info_mock,
+        print_address_info_mock,
+        wait_for_connected_mock,
+        perform_ping_test_mock,
+        sp_call_mock,
+    ):
+        args = type("", (), {})()
+        args.device = "wlan0"
+        args.essid = "TestESSID"
+        rc = open_connection(args)
+        self.assertEqual(rc, 1)
+
+    @patch("wifi_nmcli_test.sp.call")
+    @patch("wifi_nmcli_test.wait_for_connected", return_value=False)
+    @patch("wifi_nmcli_test.print_head")
+    @patch("wifi_nmcli_test.print_cmd")
+    def test_open_connection_failed_to_connect(
+        self,
+        print_cmd_mock,
+        print_head_mock,
+        wait_for_connected_mock,
+        sp_call_mock,
+    ):
+        args = type("", (), {})()
+        args.device = "wlan0"
+        args.essid = "TestESSID"
+        rc = open_connection(args)
+        self.assertEqual(rc, 1)
+
+
+class TestSecuredConnection(unittest.TestCase):
+    @patch("wifi_nmcli_test.sp.call")
+    @patch("wifi_nmcli_test.wait_for_connected", return_value=True)
+    @patch("wifi_nmcli_test.perform_ping_test", return_value=True)
+    @patch("wifi_nmcli_test.print_route_info")
+    @patch("wifi_nmcli_test.print_address_info")
+    @patch("wifi_nmcli_test.turn_up_connection")
+    @patch("wifi_nmcli_test.sp.check_output")
+    def test_secured_connection_success(
+        self,
+        check_output_mock,
+        turn_up_connection_mock,
+        print_address_info_mock,
+        print_route_info_mock,
+        perform_ping_test_mock,
+        wait_for_connected_mock,
+        sp_call_mock,
+    ):
+        args = type("", (), {})()
+        args.device = "wlan0"
+        args.essid = "TestSSID"
+        args.exchange = "wpa-psk"
+        args.psk = "password123"
+        rc = secured_connection(args)
+        self.assertEqual(rc, 0)
+        sp_call_mock.assert_called()
+        wait_for_connected_mock.assert_called_with("wlan0", "TestSSID")
+        perform_ping_test_mock.assert_called_with("wlan0")
+
+    @patch("wifi_nmcli_test.sp.call")
+    @patch("wifi_nmcli_test.wait_for_connected", return_value=False)
+    @patch("wifi_nmcli_test.perform_ping_test", return_value=False)
+    @patch("wifi_nmcli_test.print_route_info")
+    @patch("wifi_nmcli_test.print_address_info")
+    @patch("wifi_nmcli_test.turn_up_connection")
+    @patch("wifi_nmcli_test.sp.check_output")
+    def test_secured_connection_fail_to_connect(
+        self,
+        check_output_mock,
+        turn_up_connection_mock,
+        print_address_info_mock,
+        print_route_info_mock,
+        perform_ping_test_mock,
+        wait_for_connected_mock,
+        sp_call_mock,
+    ):
+        args = type("", (), {})()
+        args.device = "wlan0"
+        args.essid = "TestSSID"
+        args.exchange = "wpa-psk"
+        args.psk = "password123"
+        rc = secured_connection(args)
+        self.assertEqual(rc, 1)
+        sp_call_mock.assert_called()
+        wait_for_connected_mock.assert_called_with("wlan0", "TestSSID")
+        perform_ping_test_mock.assert_not_called()
+
+    @patch("wifi_nmcli_test.sp.call")
+    @patch("wifi_nmcli_test.wait_for_connected", return_value=False)
+    @patch("wifi_nmcli_test.perform_ping_test", return_value=True)
+    @patch("wifi_nmcli_test.print_route_info")
+    @patch("wifi_nmcli_test.print_address_info")
+    @patch("wifi_nmcli_test.turn_up_connection")
+    @patch("wifi_nmcli_test.sp.check_output")
+    def test_secured_connection_command_failure(
+        self,
+        check_output_mock,
+        turn_up_connection_mock,
+        print_address_info_mock,
+        print_route_info_mock,
+        perform_ping_test_mock,
+        wait_for_connected_mock,
+        sp_call_mock,
+    ):
+        args = type("", (), {})()
+        args.device = "wlan0"
+        args.essid = "TestSSID"
+        args.exchange = "wpa-psk"
+        args.psk = "password123"
+        rc = secured_connection(args)
+        self.assertEqual(rc, 1)
+        sp_call_mock.assert_called()
+        wait_for_connected_mock.assert_called_with("wlan0", "TestSSID")
+        perform_ping_test_mock.assert_not_called()
+
+
+class TestParserArgs(unittest.TestCase):
+    @patch("sys.argv", ["wifi_nmcli_test.py", "scan", "wlan0"])
+    def test_parser_args_scan(self):
+        args = parser_args()
+        self.assertEqual(args.test_type, "scan")
+        self.assertEqual(args.device, "wlan0")
+
+    @patch("sys.argv", ["wifi_nmcli_test.py", "open", "wlan0", "TestSSID"])
+    def test_parser_args_open(self):
+        args = parser_args()
+        self.assertEqual(args.test_type, "open")
+        self.assertEqual(args.device, "wlan0")
+        self.assertEqual(args.essid, "TestSSID")
+
+    @patch(
+        "sys.argv",
+        ["wifi_nmcli_test.py", "secured", "wlan0", "TestSSID", "TestPSK"],
+    )
+    def test_parser_args_secured(self):
+        args = parser_args()
+        self.assertEqual(args.test_type, "secured")
+        self.assertEqual(args.device, "wlan0")
+        self.assertEqual(args.essid, "TestSSID")
+        self.assertEqual(args.psk, "TestPSK")
+        self.assertEqual(args.exchange, "wpa-psk")
+
+    @patch(
+        "sys.argv",
+        [
+            "wifi_nmcli_test.py",
+            "secured",
+            "wlan0",
+            "TestSSID",
+            "TestPSK",
+            "--exchange",
+            "wpa2-psk",
+        ],
+    )
+    def test_parser_args_secured_with_exchange(self):
+        args = parser_args()
+        self.assertEqual(args.exchange, "wpa2-psk")
+
+    @patch("sys.argv", ["wifi_nmcli_test.py", "ap", "wlan0", "5GHz"])
+    def test_parser_args_ap(self):
+        args = parser_args()
+        self.assertEqual(args.test_type, "ap")
+        self.assertEqual(args.device, "wlan0")
+        self.assertEqual(args.band, "5GHz")
+
+
+class TestMainFunction(unittest.TestCase):
+
+    @patch("wifi_nmcli_test.delete_test_ap_ssid_connection")
+    @patch(
+        "wifi_nmcli_test.get_nm_activate_connection", return_value="uuid123"
+    )
+    @patch("wifi_nmcli_test.turn_down_nm_connections")
+    @patch("wifi_nmcli_test.turn_up_connection")
+    @patch("wifi_nmcli_test.list_aps", return_value={})
+    @patch("wifi_nmcli_test.sys.argv", ["wifi_nmcli_test.py", "scan", "wlan0"])
+    def test_main_scan_no_aps_found(
+        self,
+        list_aps_mock,
+        turn_up_connection_mock,
+        turn_down_nm_connections_mock,
+        get_nm_activate_connection_mock,
+        delete_test_ap_ssid_connection_mock,
+    ):
+        main()
+
+    @patch("wifi_nmcli_test.delete_test_ap_ssid_connection")
+    @patch(
+        "wifi_nmcli_test.get_nm_activate_connection", return_value="uuid123"
+    )
+    @patch("wifi_nmcli_test.turn_down_nm_connections")
+    @patch("wifi_nmcli_test.turn_up_connection")
+    @patch(
+        "wifi_nmcli_test.list_aps",
+        return_value={
+            "SSID1": {"Chan": "1", "Freq": "2412", "Signal": "60"},
+            "SSID2": {"Chan": "6", "Freq": "2437", "Signal": "70"},
+            "SSID3": {"Chan": "11", "Freq": "2462", "Signal": "80"},
+        },
+    )
+    @patch("wifi_nmcli_test.sys.argv", ["wifi_nmcli_test.py", "scan", "wlan0"])
+    def test_main_scan_aps_found(
+        self,
+        list_aps_mock,
+        turn_up_connection_mock,
+        turn_down_nm_connections_mock,
+        get_nm_activate_connection_mock,
+        delete_test_ap_ssid_connection_mock,
+    ):
+        main()
+
+    @patch("wifi_nmcli_test.delete_test_ap_ssid_connection")
+    @patch(
+        "wifi_nmcli_test.get_nm_activate_connection", return_value="uuid123"
+    )
+    @patch("wifi_nmcli_test.turn_down_nm_connections")
+    @patch("wifi_nmcli_test.turn_up_connection")
+    @patch("wifi_nmcli_test.list_aps", return_value={})
+    @patch(
+        "wifi_nmcli_test.sys.argv",
+        ["wifi_nmcli_test.py", "open", "wlan0", "TestSSID"],
+    )
+    def test_main_open_no_aps_found(
+        self,
+        list_aps_mock,
+        turn_up_connection_mock,
+        turn_down_nm_connections_mock,
+        get_nm_activate_connection_mock,
+        delete_test_ap_ssid_connection_mock,
+    ):
+        main()
+
+    @patch("wifi_nmcli_test.delete_test_ap_ssid_connection")
+    @patch(
+        "wifi_nmcli_test.get_nm_activate_connection", return_value="uuid123"
+    )
+    @patch("wifi_nmcli_test.turn_down_nm_connections")
+    @patch("wifi_nmcli_test.turn_up_connection")
+    @patch(
+        "wifi_nmcli_test.list_aps",
+        return_value={
+            "SSID1": {"Chan": "1", "Freq": "2412", "Signal": "60"},
+            "SSID2": {"Chan": "6", "Freq": "2437", "Signal": "70"},
+            "TestSSID": {"Chan": "11", "Freq": "2462", "Signal": "80"},
+        },
+    )
+    @patch(
+        "wifi_nmcli_test.sys.argv",
+        ["wifi_nmcli_test.py", "open", "wlan0", "TestSSID"],
+    )
+    @patch("wifi_nmcli_test.open_connection", return_value=0)
+    def test_main_open_aps_found(
+        self,
+        list_aps_mock,
+        turn_up_connection_mock,
+        turn_down_nm_connections_mock,
+        get_nm_activate_connection_mock,
+        delete_test_ap_ssid_connection_mock,
+        mock_open_connection,
+    ):
+        main()

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -280,9 +280,7 @@ class TestWaitForConnected(unittest.TestCase):
     @patch("wifi_nmcli_test.print_cmd", new=MagicMock())
     @patch("wifi_nmcli_test.sp.check_output")
     @patch("wifi_nmcli_test.time.sleep", return_value=None)
-    def test_wait_for_connected_success(
-        self, mock_sleep, mock_check_output
-    ):
+    def test_wait_for_connected_success(self, mock_sleep, mock_check_output):
         mock_check_output.side_effect = [
             b"100:connected\nTestESSID",
         ]

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -305,24 +305,16 @@ class TestWaitForConnected(unittest.TestCase):
 
 
 class TestOpenConnection(unittest.TestCase):
-    @patch("wifi_nmcli_test.sp.call")
+    @patch("wifi_nmcli_test.sp.call", new=MagicMock())
+    @patch("wifi_nmcli_test.print_address_info", new=MagicMock())
+    @patch("wifi_nmcli_test.print_route_info", new=MagicMock())
+    @patch("wifi_nmcli_test.turn_up_connection", new=MagicMock())
+    @patch("wifi_nmcli_test.print_head", new=MagicMock())
+    @patch("wifi_nmcli_test.print_cmd", new=MagicMock())
     @patch("wifi_nmcli_test.perform_ping_test", return_value=True)
     @patch("wifi_nmcli_test.wait_for_connected", return_value=True)
-    @patch("wifi_nmcli_test.print_address_info")
-    @patch("wifi_nmcli_test.print_route_info")
-    @patch("wifi_nmcli_test.turn_up_connection")
-    @patch("wifi_nmcli_test.print_head")
-    @patch("wifi_nmcli_test.print_cmd")
     def test_open_connection_success(
-        self,
-        print_cmd_mock,
-        print_head_mock,
-        turn_up_mock,
-        print_route_info_mock,
-        print_address_info_mock,
-        wait_for_connected_mock,
-        perform_ping_test_mock,
-        sp_call_mock,
+        self, perform_ping_test_mock, wait_for_connected_mock
     ):
         args = type("", (), {})()
         args.device = "wlan0"

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -400,7 +400,7 @@ class TestSecuredConnection(unittest.TestCase):
         args.psk = "password123"
         rc = secured_connection(args)
         self.assertEqual(rc, 0)
-        wait_for_connected_mock.assert_called_with("wlan0", "TestSSID")
+        wait_for_connected_mock.assert_called_with("wlan0", "TEST_CON")
         perform_ping_test_mock.assert_called_with("wlan0")
 
     @patch("wifi_nmcli_test.sp.call")
@@ -427,7 +427,7 @@ class TestSecuredConnection(unittest.TestCase):
         args.psk = "password123"
         rc = secured_connection(args)
         self.assertEqual(rc, 1)
-        wait_for_connected_mock.assert_called_with("wlan0", "TestSSID")
+        wait_for_connected_mock.assert_called_with("wlan0", "TEST_CON")
         perform_ping_test_mock.assert_not_called()
 
     @patch("wifi_nmcli_test.sp.call")
@@ -454,7 +454,7 @@ class TestSecuredConnection(unittest.TestCase):
         args.psk = "password123"
         rc = secured_connection(args)
         self.assertEqual(rc, 1)
-        wait_for_connected_mock.assert_called_with("wlan0", "TestSSID")
+        wait_for_connected_mock.assert_called_with("wlan0", "TEST_CON")
         perform_ping_test_mock.assert_not_called()
 
 

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -278,38 +278,39 @@ class TestShowAps(unittest.TestCase):
 
 class TestWaitForConnected(unittest.TestCase):
     @patch("wifi_nmcli_test.print_cmd", new=MagicMock())
-    @patch("wifi_nmcli_test.sp.check_output")
-    @patch("wifi_nmcli_test.time.sleep", return_value=None)
-    def test_wait_for_connected_success(self, mock_sleep, mock_check_output):
-        mock_check_output.side_effect = [
-            b"100:connected\nTestESSID",
-        ]
+    @patch("wifi_nmcli_test.time.sleep", MagicMock(return_value=None))
+    @patch(
+        "wifi_nmcli_test.sp.check_output",
+        MagicMock(
+            side_effect=[
+                b"30:disconnected\nTestESSID",
+                b"100:connected\nTestESSID",
+            ]
+        ),
+    )
+    def test_wait_for_connected_success(self):
         interface = "wlan0"
         essid = "TestESSID"
         self.assertTrue(wait_for_connected(interface, essid))
 
     @patch(
         "wifi_nmcli_test.sp.check_output",
-        return_value=b"30:disconnected\nTestESSID",
+        MagicMock(return_value=b"30:disconnected\nTestESSID"),
     )
-    @patch("wifi_nmcli_test.print_cmd")
-    @patch("wifi_nmcli_test.time.sleep", return_value=None)
-    def test_wait_for_connected_failure_due_to_timeout(
-        self, mock_sleep, mock_print_cmd, mock_check_output
-    ):
+    @patch("wifi_nmcli_test.print_cmd", new=MagicMock())
+    @patch("wifi_nmcli_test.time.sleep", MagicMock(return_value=None))
+    def test_wait_for_connected_failure_due_to_timeout(self):
         interface = "wlan0"
         essid = "TestESSID"
         self.assertFalse(wait_for_connected(interface, essid, max_wait=3))
 
     @patch(
         "wifi_nmcli_test.sp.check_output",
-        return_value=b"100:connected\nWrongESSID",
+        MagicMock(return_value=b"100:connected\nWrongESSID"),
     )
-    @patch("wifi_nmcli_test.print_cmd")
-    @patch("wifi_nmcli_test.time.sleep", return_value=None)
-    def test_wait_for_connected_failure_due_to_essid_mismatch(
-        self, mock_sleep, mock_print_cmd, mock_check_output
-    ):
+    @patch("wifi_nmcli_test.print_cmd", new=MagicMock())
+    @patch("wifi_nmcli_test.time.sleep", MagicMock(return_value=None))
+    def test_wait_for_connected_failure_due_to_essid_mismatch(self):
         interface = "wlan0"
         essid = "TestESSID"
         self.assertFalse(wait_for_connected(interface, essid))
@@ -339,30 +340,21 @@ class TestOpenConnection(unittest.TestCase):
     @patch("wifi_nmcli_test.turn_up_connection", new=MagicMock())
     @patch("wifi_nmcli_test.print_head", new=MagicMock())
     @patch("wifi_nmcli_test.print_cmd", new=MagicMock())
-    @patch("wifi_nmcli_test.perform_ping_test", return_value=False)
-    @patch("wifi_nmcli_test.wait_for_connected", return_value=True)
-    def test_open_connection_failed_ping(
-        self, wait_for_connected_mock, perform_ping_test_mock
-    ):
+    @patch("wifi_nmcli_test.perform_ping_test", MagicMock(return_value=False))
+    @patch("wifi_nmcli_test.wait_for_connected", MagicMock(return_value=True))
+    def test_open_connection_failed_ping(self):
         args = type("", (), {})()
         args.device = "wlan0"
         args.essid = "TestESSID"
         rc = open_connection(args)
         self.assertEqual(rc, 1)
 
-    @patch("wifi_nmcli_test.sp.call")
-    @patch("wifi_nmcli_test.wait_for_connected", return_value=False)
-    @patch("wifi_nmcli_test.print_head")
-    @patch("wifi_nmcli_test.print_cmd")
-    @patch("wifi_nmcli_test.turn_up_connection")
-    def test_open_connection_failed_to_connect(
-        self,
-        print_cmd_mock,
-        turn_up_mock,
-        print_head_mock,
-        wait_for_connected_mock,
-        sp_call_mock,
-    ):
+    @patch("wifi_nmcli_test.sp.call", new=MagicMock())
+    @patch("wifi_nmcli_test.print_head", new=MagicMock())
+    @patch("wifi_nmcli_test.print_cmd", new=MagicMock())
+    @patch("wifi_nmcli_test.turn_up_connection", new=MagicMock())
+    @patch("wifi_nmcli_test.wait_for_connected", MagicMock(return_value=False))
+    def test_open_connection_failed_to_connect(self):
         args = type("", (), {})()
         args.device = "wlan0"
         args.essid = "TestESSID"
@@ -371,22 +363,17 @@ class TestOpenConnection(unittest.TestCase):
 
 
 class TestSecuredConnection(unittest.TestCase):
-    @patch("wifi_nmcli_test.sp.call")
+    @patch("wifi_nmcli_test.sp.call", new=MagicMock())
+    @patch("wifi_nmcli_test.print_route_info", new=MagicMock())
+    @patch("wifi_nmcli_test.print_address_info", new=MagicMock())
+    @patch("wifi_nmcli_test.turn_up_connection", new=MagicMock())
+    @patch("wifi_nmcli_test.sp.check_output", new=MagicMock())
     @patch("wifi_nmcli_test.wait_for_connected", return_value=True)
     @patch("wifi_nmcli_test.perform_ping_test", return_value=True)
-    @patch("wifi_nmcli_test.print_route_info")
-    @patch("wifi_nmcli_test.print_address_info")
-    @patch("wifi_nmcli_test.turn_up_connection")
-    @patch("wifi_nmcli_test.sp.check_output")
     def test_secured_connection_success(
         self,
-        check_output_mock,
-        turn_up_connection_mock,
-        print_address_info_mock,
-        print_route_info_mock,
         perform_ping_test_mock,
         wait_for_connected_mock,
-        sp_call_mock,
     ):
         args = type("", (), {})()
         args.device = "wlan0"
@@ -398,22 +385,17 @@ class TestSecuredConnection(unittest.TestCase):
         wait_for_connected_mock.assert_called_with("wlan0", "TEST_CON")
         perform_ping_test_mock.assert_called_with("wlan0")
 
-    @patch("wifi_nmcli_test.sp.call")
+    @patch("wifi_nmcli_test.sp.call", new=MagicMock())
+    @patch("wifi_nmcli_test.print_route_info", new=MagicMock())
+    @patch("wifi_nmcli_test.print_address_info", new=MagicMock())
+    @patch("wifi_nmcli_test.turn_up_connection", new=MagicMock())
+    @patch("wifi_nmcli_test.sp.check_output", new=MagicMock())
     @patch("wifi_nmcli_test.wait_for_connected", return_value=False)
     @patch("wifi_nmcli_test.perform_ping_test", return_value=False)
-    @patch("wifi_nmcli_test.print_route_info")
-    @patch("wifi_nmcli_test.print_address_info")
-    @patch("wifi_nmcli_test.turn_up_connection")
-    @patch("wifi_nmcli_test.sp.check_output")
     def test_secured_connection_fail_to_connect(
         self,
-        check_output_mock,
-        turn_up_connection_mock,
-        print_address_info_mock,
-        print_route_info_mock,
         perform_ping_test_mock,
         wait_for_connected_mock,
-        sp_call_mock,
     ):
         args = type("", (), {})()
         args.device = "wlan0"
@@ -425,22 +407,17 @@ class TestSecuredConnection(unittest.TestCase):
         wait_for_connected_mock.assert_called_with("wlan0", "TEST_CON")
         perform_ping_test_mock.assert_not_called()
 
-    @patch("wifi_nmcli_test.sp.call")
+    @patch("wifi_nmcli_test.sp.call", new=MagicMock())
+    @patch("wifi_nmcli_test.print_route_info", new=MagicMock())
+    @patch("wifi_nmcli_test.print_address_info", new=MagicMock())
+    @patch("wifi_nmcli_test.turn_up_connection", new=MagicMock())
+    @patch("wifi_nmcli_test.sp.check_output", new=MagicMock())
     @patch("wifi_nmcli_test.wait_for_connected", return_value=False)
     @patch("wifi_nmcli_test.perform_ping_test", return_value=True)
-    @patch("wifi_nmcli_test.print_route_info")
-    @patch("wifi_nmcli_test.print_address_info")
-    @patch("wifi_nmcli_test.turn_up_connection")
-    @patch("wifi_nmcli_test.sp.check_output")
     def test_secured_connection_command_failure(
         self,
-        check_output_mock,
-        turn_up_connection_mock,
-        print_address_info_mock,
-        print_route_info_mock,
         perform_ping_test_mock,
         wait_for_connected_mock,
-        sp_call_mock,
     ):
         args = type("", (), {})()
         args.device = "wlan0"
@@ -505,32 +482,30 @@ class TestParserArgs(unittest.TestCase):
 
 class TestMainFunction(unittest.TestCase):
 
-    @patch("wifi_nmcli_test.delete_test_ap_ssid_connection")
+    @patch("wifi_nmcli_test.delete_test_ap_ssid_connection", new=MagicMock())
+    @patch("wifi_nmcli_test.turn_down_nm_connections", new=MagicMock())
+    @patch("wifi_nmcli_test.turn_up_connection", new=MagicMock())
+    @patch("wifi_nmcli_test.device_rescan", new=MagicMock())
     @patch(
         "wifi_nmcli_test.get_nm_activate_connection", return_value="uuid123"
     )
-    @patch("wifi_nmcli_test.turn_down_nm_connections")
-    @patch("wifi_nmcli_test.turn_up_connection")
     @patch("wifi_nmcli_test.list_aps", return_value={})
     @patch("wifi_nmcli_test.sys.argv", ["wifi_nmcli_test.py", "scan", "wlan0"])
-    @patch("wifi_nmcli_test.device_rescan")
     def test_main_scan_no_aps_found(
         self,
         list_aps_mock,
-        turn_up_connection_mock,
-        turn_down_nm_connections_mock,
         get_nm_activate_connection_mock,
-        delete_test_ap_ssid_connection_mock,
-        mock_device_rescan,
     ):
         main()
 
-    @patch("wifi_nmcli_test.delete_test_ap_ssid_connection")
+    @patch("wifi_nmcli_test.delete_test_ap_ssid_connection", new=MagicMock())
+    @patch("wifi_nmcli_test.turn_down_nm_connections", new=MagicMock())
+    @patch("wifi_nmcli_test.turn_up_connection", new=MagicMock())
+    @patch("wifi_nmcli_test.device_rescan", new=MagicMock())
     @patch(
-        "wifi_nmcli_test.get_nm_activate_connection", return_value="uuid123"
+        "wifi_nmcli_test.get_nm_activate_connection",
+        return_value="uuid123",
     )
-    @patch("wifi_nmcli_test.turn_down_nm_connections")
-    @patch("wifi_nmcli_test.turn_up_connection")
     @patch(
         "wifi_nmcli_test.list_aps",
         return_value={
@@ -540,47 +515,41 @@ class TestMainFunction(unittest.TestCase):
         },
     )
     @patch("wifi_nmcli_test.sys.argv", ["wifi_nmcli_test.py", "scan", "wlan0"])
-    @patch("wifi_nmcli_test.device_rescan")
     def test_main_scan_aps_found(
         self,
         list_aps_mock,
-        turn_up_connection_mock,
-        turn_down_nm_connections_mock,
         get_nm_activate_connection_mock,
-        delete_test_ap_ssid_connection_mock,
-        mock_device_rescan,
     ):
         main()
 
-    @patch("wifi_nmcli_test.delete_test_ap_ssid_connection")
+    @patch("wifi_nmcli_test.delete_test_ap_ssid_connection", new=MagicMock())
+    @patch("wifi_nmcli_test.turn_down_nm_connections", new=MagicMock())
+    @patch("wifi_nmcli_test.turn_up_connection", new=MagicMock())
+    @patch("wifi_nmcli_test.device_rescan", new=MagicMock())
     @patch(
-        "wifi_nmcli_test.get_nm_activate_connection", return_value="uuid123"
+        "wifi_nmcli_test.get_nm_activate_connection",
+        return_value="uuid123",
     )
-    @patch("wifi_nmcli_test.turn_down_nm_connections")
-    @patch("wifi_nmcli_test.turn_up_connection")
     @patch("wifi_nmcli_test.list_aps", return_value={})
     @patch(
         "wifi_nmcli_test.sys.argv",
         ["wifi_nmcli_test.py", "open", "wlan0", "TestSSID"],
     )
-    @patch("wifi_nmcli_test.device_rescan")
     def test_main_open_no_aps_found(
         self,
         list_aps_mock,
-        turn_up_connection_mock,
-        turn_down_nm_connections_mock,
         get_nm_activate_connection_mock,
-        delete_test_ap_ssid_connection_mock,
-        mock_device_rescan,
     ):
         main()
 
-    @patch("wifi_nmcli_test.delete_test_ap_ssid_connection")
+    @patch("wifi_nmcli_test.delete_test_ap_ssid_connection", new=MagicMock())
     @patch(
-        "wifi_nmcli_test.get_nm_activate_connection", return_value="uuid123"
+        "wifi_nmcli_test.get_nm_activate_connection",
+        return_value="uuid123",
     )
-    @patch("wifi_nmcli_test.turn_down_nm_connections")
-    @patch("wifi_nmcli_test.turn_up_connection")
+    @patch("wifi_nmcli_test.turn_down_nm_connections", new=MagicMock())
+    @patch("wifi_nmcli_test.turn_up_connection", new=MagicMock())
+    @patch("wifi_nmcli_test.device_rescan", new=MagicMock())
     @patch(
         "wifi_nmcli_test.list_aps",
         return_value={
@@ -589,20 +558,15 @@ class TestMainFunction(unittest.TestCase):
             "TestSSID": {"Chan": "11", "Freq": "2462", "Signal": "80"},
         },
     )
+    @patch("wifi_nmcli_test.open_connection", return_value=0)
     @patch(
         "wifi_nmcli_test.sys.argv",
         ["wifi_nmcli_test.py", "open", "wlan0", "TestSSID"],
     )
-    @patch("wifi_nmcli_test.open_connection", return_value=0)
-    @patch("wifi_nmcli_test.device_rescan")
     def test_main_open_aps_found(
         self,
         list_aps_mock,
-        turn_up_connection_mock,
-        turn_down_nm_connections_mock,
         get_nm_activate_connection_mock,
-        delete_test_ap_ssid_connection_mock,
         mock_open_connection,
-        mock_device_rescan,
     ):
         main()

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -264,11 +264,11 @@ class TestShowAps(unittest.TestCase):
 
 
 class TestWaitForConnected(unittest.TestCase):
+    @patch("wifi_nmcli_test.print_cmd", new=MagicMock())
     @patch("wifi_nmcli_test.sp.check_output")
-    @patch("wifi_nmcli_test.print_cmd")
     @patch("wifi_nmcli_test.time.sleep", return_value=None)
     def test_wait_for_connected_success(
-        self, mock_sleep, mock_print_cmd, mock_check_output
+        self, mock_sleep, mock_check_output
     ):
         mock_check_output.side_effect = [
             b"100:connected\nTestESSID",

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -322,25 +322,17 @@ class TestOpenConnection(unittest.TestCase):
         rc = open_connection(args)
         self.assertEqual(rc, 0)
 
-    @patch("wifi_nmcli_test.sp.call")
-    @patch("wifi_nmcli_test.perform_ping_test", return_value=False)
+    @patch("wifi_nmcli_test.sp.call", new=MagicMock())
+    @patch("wifi_nmcli_test.print_address_info", new=MagicMock())
+    @patch("wifi_nmcli_test.print_route_info", new=MagicMock())
+    @patch("wifi_nmcli_test.turn_up_connection", new=MagicMock())
+    @patch("wifi_nmcli_test.print_head", new=MagicMock())
+    @patch("wifi_nmcli_test.print_cmd", new=MagicMock())
+    @patch("wifi_nmcli_test.perform_ping_test", return_value=True)
     @patch("wifi_nmcli_test.wait_for_connected", return_value=True)
-    @patch("wifi_nmcli_test.print_address_info")
-    @patch("wifi_nmcli_test.print_route_info")
-    @patch("wifi_nmcli_test.turn_up_connection")
-    @patch("wifi_nmcli_test.print_head")
-    @patch("wifi_nmcli_test.print_cmd")
-    def test_open_connection_failed_ping(
-        self,
-        print_cmd_mock,
-        print_head_mock,
-        turn_up_mock,
-        print_route_info_mock,
-        print_address_info_mock,
-        wait_for_connected_mock,
-        perform_ping_test_mock,
-        sp_call_mock,
-    ):
+    def test_open_connection_success(
+        self, perform_ping_test_mock, wait_for_connected_mock
+    ):```
         args = type("", (), {})()
         args.device = "wlan0"
         args.essid = "TestESSID"


### PR DESCRIPTION
## Description

NetworkManager behavior in 24.04 is a little different with former.  

It will using the netplan to dispatch the networking backend daemon, and the NetworkManager config file (`*.nmconnection`) is not a permanent file (will not under the `/etc/NetworkManager/system-connections`), but the temporary file (under `/run/Networkmanger/system-connections`).

The permanent file will only exist in netplan (`/etc/netplan`).

Based on the these reason, there are some part need to modify:

1. Backup and restore to the original path, not always copy to the fixed path.
2. Not use the `nmcli delete` (will call the dbus api), it will also delete the netplan config file, and it will make the networking can't recover anymore
3. Using the `nmcli np/down` to control which SSID we need to connect and disconnect
4. Checking the connecting SSID is our test ap when doing the ping test.

## Modify part

### wifi_nmcli_backup.py
- **func:** `save_connections`
    - Retrieve the complete file paths of all `*.nmconnection` files. Then, establish a respective full path directory within `$PLAINBOX_SESSION_SHARE/stored-system-connections/` and transfer the files into it.
- **func:** `restore_connections`
    - Relocate the `*.nmconnection` files located in `$PLAINBOX_SESSION_SHARE/stored-system-connections/*/**/` back to their initial paths.


### wifi_nmcli_test.py

- **func:** `_get_nm_wireless_connections`
    - Isolated from the original function to enable its use by other functions.
- **func:** `get_nm_activate_connection`
    - This function serves to identify activated SSIDs.
    - It also verifies the connection status of the test AP.
- **func:** `turn_up_connection`
    - Utilizes `nmcli up` command to select the desired SSID for connection establishment.
    - The command executes only when the target SSID is inactive, ensuring error-free activation even if it's already activated.
- **func:** `turn_down_nm_connections`
    - Replaces original **func:**`cleanup_nm_connections` with `nmcli delete` to clear all connections. This method, while not foolproof, doesn't allow recovery of original connections after testing (even with `wifi_nmcli_backup.py restore`).
    - Employs `nmcli down` to deactivate all connections. NetworkManager can function without any active SSID, allowing access even when those APs are available.
- **func:** `delete_test_ap_ssid_connection`
    - Selectively removes only the test AP's ssid post-testing. Executing this at test initiation ensures TEST_CONN isn't within NetworkManager configuration.
- **func:** `list_aps`
    - Introduced essid parameter for filtering expected connection APs during open/secured connectivity testing.
    - Enhances clarity in output presentation during open/secured connectivity assessments.
- **func:** `show_aps`
    - Separate functionality from **func:**`list_aps`; specifically prints `aps_dict`.
- **func:** `wait_for_connected`
    - Added essid parameter for validation of connecting ap as our anticipated testing ap.
- **func:** `open_connection` and **func:** `secured_connection`
    - Minor adjustments made.
- **func:** `parser_args`
    - Isolated from original main function setup.
- **func:** `main`
    - Independently structured from initial main functionality
    - Several minor modifications applied
    - Ensures deletion of TEST_CONN before subsequent tests and upon completion
    - Activates or restores the original connection's SSID/AP post-testing

## Resolved issues

[OEMQA-4582 NetworkManager test case impact in 24.04 Desktop](https://warthogs.atlassian.net/browse/OEMQA-4582)

## Documentation



## Tests

- 202211-30784 Test on 22.04: https://certification.canonical.com/hardware/202211-30784/submission/379839/

- 202001-27667 Test on 24.04: https://certification.canonical.com/hardware/202001-27667/submission/379975/
