### PR TITLE
Add missing references to Ubuntu 24 test plans (Bugfix)

### DIFF
--- a/checkbox-snap/series_classic18/launchers/odm-certification
+++ b/checkbox-snap/series_classic18/launchers/odm-certification
@@ -5,12 +5,15 @@ stock_reports = text, submission_files
 
 [test plan]
 unit = com.canonical.certification::client-cert-odm-desktop-18-04-manual
-filter = com.canonical.certification::client-cert-odm-desktop-22-04-*
+filter = com.canonical.certification::client-cert-odm-desktop-24-04-*
+    com.canonical.certification::client-cert-odm-desktop-22-04-*
     com.canonical.certification::client-cert-odm-desktop-20-04-*
     com.canonical.certification::client-cert-odm-desktop-18-04-*
+    com.canonical.certification::client-cert-odm-server-24-04-*
     com.canonical.certification::client-cert-odm-server-22-04-*
     com.canonical.certification::client-cert-odm-server-20-04-*
     com.canonical.certification::client-cert-odm-server-18-04-*
+    com.canonical.certification::client-cert-odm-ubuntucore-24-*
     com.canonical.certification::client-cert-odm-ubuntucore-22-*
     com.canonical.certification::client-cert-odm-ubuntucore-20-*
     com.canonical.certification::client-cert-odm-ubuntucore-18-*

--- a/checkbox-snap/series_classic20/launchers/odm-certification
+++ b/checkbox-snap/series_classic20/launchers/odm-certification
@@ -5,12 +5,15 @@ stock_reports = text, submission_files
 
 [test plan]
 unit = com.canonical.certification::client-cert-odm-desktop-20-04-manual
-filter = com.canonical.certification::client-cert-odm-desktop-22-04-*
+filter = com.canonical.certification::client-cert-odm-desktop-24-04-*
+    com.canonical.certification::client-cert-odm-desktop-22-04-*
     com.canonical.certification::client-cert-odm-desktop-20-04-*
     com.canonical.certification::client-cert-odm-desktop-18-04-*
+    com.canonical.certification::client-cert-odm-server-24-04-*
     com.canonical.certification::client-cert-odm-server-22-04-*
     com.canonical.certification::client-cert-odm-server-20-04-*
     com.canonical.certification::client-cert-odm-server-18-04-*
+    com.canonical.certification::client-cert-odm-ubuntucore-24-*
     com.canonical.certification::client-cert-odm-ubuntucore-22-*
     com.canonical.certification::client-cert-odm-ubuntucore-20-*
     com.canonical.certification::client-cert-odm-ubuntucore-18-*

--- a/checkbox-snap/series_classic22/launchers/odm-certification
+++ b/checkbox-snap/series_classic22/launchers/odm-certification
@@ -5,12 +5,15 @@ stock_reports = text, submission_files
 
 [test plan]
 unit = com.canonical.certification::client-cert-odm-desktop-22-04-manual
-filter = com.canonical.certification::client-cert-odm-desktop-22-04-*
+filter = com.canonical.certification::client-cert-odm-desktop-24-04-*
+    com.canonical.certification::client-cert-odm-desktop-22-04-*
     com.canonical.certification::client-cert-odm-desktop-20-04-*
     com.canonical.certification::client-cert-odm-desktop-18-04-*
+    com.canonical.certification::client-cert-odm-server-24-04-*
     com.canonical.certification::client-cert-odm-server-22-04-*
     com.canonical.certification::client-cert-odm-server-20-04-*
     com.canonical.certification::client-cert-odm-server-18-04-*
+    com.canonical.certification::client-cert-odm-ubuntucore-24-*
     com.canonical.certification::client-cert-odm-ubuntucore-22-*
     com.canonical.certification::client-cert-odm-ubuntucore-20-*
     com.canonical.certification::client-cert-odm-ubuntucore-18-*

--- a/checkbox-snap/series_classic24/launchers/client-cert-iot-server
+++ b/checkbox-snap/series_classic24/launchers/client-cert-iot-server
@@ -5,7 +5,7 @@ launcher_version = 1
 stock_reports = text, submission_files
 
 [test plan]
-unit = com.canonical.certification::client-cert-iot-server-22-04-automated
+unit = com.canonical.certification::client-cert-iot-server-24-04-automated
 forced = yes
 
 [test selection]

--- a/checkbox-snap/series_classic24/launchers/odm-certification
+++ b/checkbox-snap/series_classic24/launchers/odm-certification
@@ -5,12 +5,15 @@ stock_reports = text, submission_files
 
 [test plan]
 unit = com.canonical.certification::client-cert-odm-desktop-22-04-manual
-filter = com.canonical.certification::client-cert-odm-desktop-22-04-*
+filter = com.canonical.certification::client-cert-odm-desktop-24-04-*
+    com.canonical.certification::client-cert-odm-desktop-22-04-*
     com.canonical.certification::client-cert-odm-desktop-20-04-*
     com.canonical.certification::client-cert-odm-desktop-18-04-*
+    com.canonical.certification::client-cert-odm-server-24-04-*
     com.canonical.certification::client-cert-odm-server-22-04-*
     com.canonical.certification::client-cert-odm-server-20-04-*
     com.canonical.certification::client-cert-odm-server-18-04-*
+    com.canonical.certification::client-cert-odm-ubuntucore-24-*
     com.canonical.certification::client-cert-odm-ubuntucore-22-*
     com.canonical.certification::client-cert-odm-ubuntucore-20-*
     com.canonical.certification::client-cert-odm-ubuntucore-18-*

--- a/checkbox-snap/series_classic24/launchers/odm-certification
+++ b/checkbox-snap/series_classic24/launchers/odm-certification
@@ -4,7 +4,7 @@ launcher_version = 1
 stock_reports = text, submission_files
 
 [test plan]
-unit = com.canonical.certification::client-cert-odm-desktop-22-04-manual
+unit = com.canonical.certification::client-cert-odm-desktop-24-04-manual
 filter = com.canonical.certification::client-cert-odm-desktop-24-04-*
     com.canonical.certification::client-cert-odm-desktop-22-04-*
     com.canonical.certification::client-cert-odm-desktop-20-04-*

--- a/checkbox-snap/series_classic24/launchers/test-runner
+++ b/checkbox-snap/series_classic24/launchers/test-runner
@@ -6,4 +6,4 @@ launcher_version = 1
 stock_reports = text, submission_files, certification
 
 [test plan]
-filter = com.canonical.certification::client-cert-iot-server-22-04-*
+filter = com.canonical.certification::client-cert-iot-server-24-04-*

--- a/checkbox-snap/series_uc18/launchers/odm-certification
+++ b/checkbox-snap/series_uc18/launchers/odm-certification
@@ -5,12 +5,15 @@ stock_reports = text, submission_files
 
 [test plan]
 unit = com.canonical.certification::client-cert-odm-ubuntucore-18-manual
-filter = com.canonical.certification::client-cert-odm-desktop-22-04-*
+filter = com.canonical.certification::client-cert-odm-desktop-24-04-*
+    com.canonical.certification::client-cert-odm-desktop-22-04-*
     com.canonical.certification::client-cert-odm-desktop-20-04-*
     com.canonical.certification::client-cert-odm-desktop-18-04-*
+    com.canonical.certification::client-cert-odm-server-24-04-*
     com.canonical.certification::client-cert-odm-server-22-04-*
     com.canonical.certification::client-cert-odm-server-20-04-*
     com.canonical.certification::client-cert-odm-server-18-04-*
+    com.canonical.certification::client-cert-odm-ubuntucore-24-*
     com.canonical.certification::client-cert-odm-ubuntucore-22-*
     com.canonical.certification::client-cert-odm-ubuntucore-20-*
     com.canonical.certification::client-cert-odm-ubuntucore-18-*

--- a/checkbox-snap/series_uc20/launchers/odm-certification
+++ b/checkbox-snap/series_uc20/launchers/odm-certification
@@ -5,12 +5,15 @@ stock_reports = text, submission_files
 
 [test plan]
 unit = com.canonical.certification::client-cert-odm-ubuntucore-20-manual
-filter = com.canonical.certification::client-cert-odm-desktop-22-04-*
+filter = com.canonical.certification::client-cert-odm-desktop-24-04-*
+    com.canonical.certification::client-cert-odm-desktop-22-04-*
     com.canonical.certification::client-cert-odm-desktop-20-04-*
     com.canonical.certification::client-cert-odm-desktop-18-04-*
+    com.canonical.certification::client-cert-odm-server-24-04-*
     com.canonical.certification::client-cert-odm-server-22-04-*
     com.canonical.certification::client-cert-odm-server-20-04-*
     com.canonical.certification::client-cert-odm-server-18-04-*
+    com.canonical.certification::client-cert-odm-ubuntucore-24-*
     com.canonical.certification::client-cert-odm-ubuntucore-22-*
     com.canonical.certification::client-cert-odm-ubuntucore-20-*
     com.canonical.certification::client-cert-odm-ubuntucore-18-*

--- a/checkbox-snap/series_uc22/launchers/odm-certification
+++ b/checkbox-snap/series_uc22/launchers/odm-certification
@@ -5,12 +5,15 @@ stock_reports = text, submission_files
 
 [test plan]
 unit = com.canonical.certification::client-cert-odm-ubuntucore-22-manual
-filter = com.canonical.certification::client-cert-odm-desktop-22-04-*
+filter = com.canonical.certification::client-cert-odm-desktop-24-04-*
+    com.canonical.certification::client-cert-odm-desktop-22-04-*
     com.canonical.certification::client-cert-odm-desktop-20-04-*
     com.canonical.certification::client-cert-odm-desktop-18-04-*
+    com.canonical.certification::client-cert-odm-server-24-04-*
     com.canonical.certification::client-cert-odm-server-22-04-*
     com.canonical.certification::client-cert-odm-server-20-04-*
     com.canonical.certification::client-cert-odm-server-18-04-*
+    com.canonical.certification::client-cert-odm-ubuntucore-24-*
     com.canonical.certification::client-cert-odm-ubuntucore-22-*
     com.canonical.certification::client-cert-odm-ubuntucore-20-*
     com.canonical.certification::client-cert-odm-ubuntucore-18-*

--- a/checkbox-snap/series_uc24/launchers/client-cert-iot-ubuntucore
+++ b/checkbox-snap/series_uc24/launchers/client-cert-iot-ubuntucore
@@ -5,7 +5,7 @@ launcher_version = 1
 stock_reports = text, submission_files
 
 [test plan]
-unit = com.canonical.certification::client-cert-iot-ubuntucore-22-automated
+unit = com.canonical.certification::client-cert-iot-ubuntucore-24-automated
 forced = yes
 
 [test selection]

--- a/checkbox-snap/series_uc24/launchers/odm-certification
+++ b/checkbox-snap/series_uc24/launchers/odm-certification
@@ -5,12 +5,15 @@ stock_reports = text, submission_files
 
 [test plan]
 unit = com.canonical.certification::client-cert-odm-ubuntucore-22-manual
-filter = com.canonical.certification::client-cert-odm-desktop-22-04-*
+filter = com.canonical.certification::client-cert-odm-desktop-24-04-*
+    com.canonical.certification::client-cert-odm-desktop-22-04-*
     com.canonical.certification::client-cert-odm-desktop-20-04-*
     com.canonical.certification::client-cert-odm-desktop-18-04-*
+    com.canonical.certification::client-cert-odm-server-24-04-*
     com.canonical.certification::client-cert-odm-server-22-04-*
     com.canonical.certification::client-cert-odm-server-20-04-*
     com.canonical.certification::client-cert-odm-server-18-04-*
+    com.canonical.certification::client-cert-odm-ubuntucore-24-*
     com.canonical.certification::client-cert-odm-ubuntucore-22-*
     com.canonical.certification::client-cert-odm-ubuntucore-20-*
     com.canonical.certification::client-cert-odm-ubuntucore-18-*

--- a/checkbox-snap/series_uc24/launchers/odm-certification
+++ b/checkbox-snap/series_uc24/launchers/odm-certification
@@ -4,7 +4,7 @@ launcher_version = 1
 stock_reports = text, submission_files
 
 [test plan]
-unit = com.canonical.certification::client-cert-odm-ubuntucore-22-manual
+unit = com.canonical.certification::client-cert-odm-ubuntucore-24-manual
 filter = com.canonical.certification::client-cert-odm-desktop-24-04-*
     com.canonical.certification::client-cert-odm-desktop-22-04-*
     com.canonical.certification::client-cert-odm-desktop-20-04-*

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-core.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-core.pxu
@@ -4,6 +4,16 @@
 # Test plans and (optionally) jobs unique to the IoT devices running Ubuntu Core.
 #
 
+id: ce-oem-iot-ubuntucore-24
+unit: test plan
+_name: CE-OEM-IOT - Full manual + automated tests for Ubuntu Core 24
+_description:
+ Combined manual and automated test plans for IoT device running Ubuntu Core.
+include:
+nested_part:
+    ce-oem-iot-ubuntucore-24-manual
+    ce-oem-iot-ubuntucore-24-automated
+
 id: ce-oem-iot-ubuntucore-22
 unit: test plan
 _name: CE-OEM-IOT - Full manual + automated tests for Ubuntu Core 22
@@ -23,6 +33,25 @@ include:
 nested_part:
     ce-oem-iot-ubuntucore-20-manual
     ce-oem-iot-ubuntucore-20-automated
+
+id: ce-oem-iot-ubuntucore-24-manual
+unit: test plan
+_name: CE-OEM-IOT - Manual only QA tests for Ubuntu Core 24
+_description:
+ Ubuntu Core QA test plan for the IoT hardware. This test plan contains
+ all of the tests that require manual control of device hardware
+ or some other user input to complete.
+estimated_duration: 3600
+include:
+    com.canonical.certification::disk/encryption/check-fde-tpm                 # keep if FDE with TPM is enabled
+    com.canonical.certification::ubuntucore/kernel-failboot-.*                 # keep if kernel snap is not pc-kernel
+nested_part:
+    ce-oem-manual
+    com.canonical.certification::client-cert-iot-ubuntucore-24-manual
+    after-suspend-ce-oem-manual
+exclude:
+    com.canonical.certification::ethernet/wol_S4_.*
+
 
 id: ce-oem-iot-ubuntucore-22-manual
 unit: test plan
@@ -62,6 +91,23 @@ exclude:
     com.canonical.certification::ethernet/wol_S4_.*
 
 
+id: ce-oem-iot-ubuntucore-24-automated
+unit: test plan
+_name: CE-OEM-IOT - Automated only QA tests for Ubuntu Core 24
+_description:
+ Ubuntu Core QA test plan for the IoT hardware. This test plan contains
+ all of the automated tests used to validate the IoT device.
+include:
+    com.canonical.certification::image/model-grade
+    com.canonical.certification::miscellanea/secure_boot_mode_.*               # keep if secure boot is enabled
+    com.canonical.certification::disk/encryption/detect                        # keep if FDE is enabled
+nested_part:
+    ce-oem-automated
+    com.canonical.certification::client-cert-iot-ubuntucore-24-automated
+    after-suspend-ce-oem-automated
+exclude:
+
+
 id: ce-oem-iot-ubuntucore-22-automated
 unit: test plan
 _name: CE-OEM-IOT - Automated only QA tests for Ubuntu Core 22
@@ -94,6 +140,20 @@ nested_part:
     com.canonical.certification::client-cert-iot-ubuntucore-20-automated
     after-suspend-ce-oem-automated
 exclude:
+
+
+id: ce-oem-iot-ubuntucore-24-stress
+unit: test plan
+_name: CE-OEM-IOT - Stress tests for Ubuntu Core 24
+_description:
+ Ubuntu Core QA test plan that includes all stress tests required for IoT devices
+include:
+nested_part:
+    com.canonical.certification::stress-iperf3-automated                       # keep if ethernet is supported
+    com.canonical.certification::client-cert-iot-ubuntucore-24-stress
+    ce-oem-stress
+exclude:
+    com.canonical.certification::stress-tests/hibernate.*
 
 
 id: ce-oem-iot-ubuntucore-22-stress


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

Radxa is an ODM for single board computers. We are currently looking to get our product Ubuntu certified, ideally with the latest version.  However, with the latest `checkbox24` snap installed, we are unable to see the 24.04 test plans listed in `checkbox.odm-certification` per our training material. We are able to see them listed in `checkbox.checkbox-cli` following [the official documentation](https://checkbox.readthedocs.io/en/stable/tutorial/using-checkbox/installing-checkbox.html).

Checking the code, it appears to be simply missing the correct reference when the folder structure was bootstrapped in #1201. This PR is an attempt to fix the existing configuration files based on the similar implementation of the older versions.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

N/A

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
