### PR TITLE
Implement desktop environment detector (New)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/image_checker.py
+++ b/checkbox-support/checkbox_support/scripts/image_checker.py
@@ -3,12 +3,12 @@
 #
 # Written by:
 #   Patrick Chang <patrick.chang@canonical.com>
+#   Zhongning Li <zhongning.li@canonical.com>
 
 import argparse
 from os.path import exists
 from checkbox_support.snap_utils.system import on_ubuntucore
-import shutil
-from subprocess import PIPE, run
+from subprocess import DEVNULL, run
 
 
 def get_type() -> str:
@@ -18,26 +18,24 @@ def get_type() -> str:
     return "core" if on_ubuntucore() else "classic"
 
 
-def has_desktop_environment() -> bool:
+def has_desktop_environment(
+    desktop_packages=["ubuntu-desktop", "ubuntu-desktop-minimal"]
+) -> bool:
     """
     Returns whether there's a desktop environment
     """
-    if not shutil.which("dpkg") or on_ubuntucore():
-        # core doesn't have dpkg
+    if on_ubuntucore():
+        # ubuntu core doesn't have a desktop env by default
         return False
 
-    # if we found any of these packages, we are on desktop
-    if (
-        run(
-            ["dpkg", "-l", "ubuntu-desktop"], stdout=PIPE, stderr=PIPE
-        ).returncode
-        == 0
-        or run(
-            ["dpkg", "-l", "ubuntu-desktop-minimal"], stdout=PIPE, stderr=PIPE
-        ).returncode
-        == 0
-    ):
-        return True
+    for package in desktop_packages:
+        if (
+            run(
+                ["dpkg", "-l", package], stdout=DEVNULL, stderr=DEVNULL
+            ).returncode
+            == 0
+        ):
+            return True
 
     return False
 

--- a/checkbox-support/checkbox_support/scripts/image_checker.py
+++ b/checkbox-support/checkbox_support/scripts/image_checker.py
@@ -10,10 +10,9 @@ from checkbox_support.snap_utils.system import on_ubuntucore
 import shutil
 import subprocess
 from subprocess import PIPE
-from typing import Literal
 
 
-def get_type() -> Literal["core", "classic"]:
+def get_type() -> str:
     """
     Return the type of image.
     """
@@ -41,7 +40,7 @@ def has_desktop_environment() -> bool:
     return False
 
 
-def get_source() -> Literal["oem", "stock", "unknown"]:
+def get_source() -> str:
     """
     Return the source of image.
     """

--- a/checkbox-support/checkbox_support/scripts/image_checker.py
+++ b/checkbox-support/checkbox_support/scripts/image_checker.py
@@ -8,8 +8,7 @@ import argparse
 from os.path import exists
 from checkbox_support.snap_utils.system import on_ubuntucore
 import shutil
-import subprocess
-from subprocess import PIPE
+from subprocess import PIPE, run
 
 
 def get_type() -> str:
@@ -20,17 +19,20 @@ def get_type() -> str:
 
 
 def has_desktop_environment() -> bool:
-    if not shutil.which("dpkg"):
-        # core and server image doesn't have dpkg
+    """
+    Returns whether there's a desktop environment
+    """
+    if not shutil.which("dpkg") or on_ubuntucore():
+        # core doesn't have dpkg
         return False
 
     # if we found any of these packages, we are on desktop
     if (
-        subprocess.run(
+        run(
             ["dpkg", "-l", "ubuntu-desktop"], stdout=PIPE, stderr=PIPE
         ).returncode
         == 0
-        or subprocess.run(
+        or run(
             ["dpkg", "-l", "ubuntu-desktop-minimal"], stdout=PIPE, stderr=PIPE
         ).returncode
         == 0

--- a/checkbox-support/checkbox_support/tests/test_image_checker.py
+++ b/checkbox-support/checkbox_support/tests/test_image_checker.py
@@ -68,6 +68,16 @@ class ImageCheckerTest(unittest.TestCase):
 
     @patch("checkbox_support.scripts.image_checker.run")
     def test_has_desktop_environment(self, mock_run: MagicMock):
+        with patch("shutil.which") as mock_which:
+            mock_which.return_value = None
+            self.assertFalse(has_desktop_environment())
+
+        with patch(
+            "checkbox_support.scripts.image_checker.on_ubuntucore"
+        ) as mock_on_ubuntu_core:
+            mock_on_ubuntu_core.return_value = True
+            self.assertFalse(has_desktop_environment())
+
         # 'ubuntu-desktop' or 'ubuntu-desktop-minimal'
         # pick one to return true
         def create_dpkg_side_effect(option: str):
@@ -90,11 +100,18 @@ class ImageCheckerTest(unittest.TestCase):
         mock_run.side_effect = create_dpkg_side_effect("neither")
         self.assertFalse(has_desktop_environment())
 
-    @patch("sys.argv", ["script_name.py", "--type", "--source"])
+    @patch(
+        "sys.argv",
+        ["script_name.py", "--type", "--source", "--detect_desktop"],
+    )
+    @patch("checkbox_support.scripts.image_checker.has_desktop_environment")
     @patch("checkbox_support.scripts.image_checker.get_source")
     @patch("checkbox_support.scripts.image_checker.get_type")
     @patch("sys.stdout", new_callable=StringIO)
-    def test_main(self, mock_stdout, mock_get_type, mock_get_source):
+    def test_main(
+        self, mock_stdout, mock_get_type, mock_get_source, mock_has_desktop_env
+    ):
         main()
         mock_get_type.assert_called_with()
         mock_get_source.assert_called_with()
+        mock_has_desktop_env.assert_called_with()

--- a/checkbox-support/checkbox_support/tests/test_image_checker.py
+++ b/checkbox-support/checkbox_support/tests/test_image_checker.py
@@ -17,7 +17,7 @@
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import MagicMock, patch, mock_open
 from checkbox_support.scripts.image_checker import (
     get_type,
     get_source,
@@ -66,28 +66,29 @@ class ImageCheckerTest(unittest.TestCase):
         mock_exists.return_value = False
         self.assertEqual(get_source(), "stock")
 
-    def test_has_desktop_environment(self):
+    @patch("checkbox_support.scripts.image_checker.run")
+    def test_has_desktop_environment(self, mock_run: MagicMock):
         # 'ubuntu-desktop' or 'ubuntu-desktop-minimal'
         # pick one to return true
         def create_dpkg_side_effect(option: str):
             # kwargs are stdout and stderr, not used in this case
-            def wrapped(args, **kwargs):
+            def wrapped(args, **_):
                 if args[2] == option:
                     return CompletedProcess(args, 0)
                 return CompletedProcess(args, 1)
+
             return wrapped
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.side_effect = create_dpkg_side_effect("ubuntu-desktop")
-            self.assertTrue(has_desktop_environment())
+        mock_run.side_effect = create_dpkg_side_effect("ubuntu-desktop")
+        self.assertTrue(has_desktop_environment())
 
-            mock_run.side_effect = create_dpkg_side_effect(
-                "ubuntu-desktop-minimal"
-            )
-            self.assertTrue(has_desktop_environment())
+        mock_run.side_effect = create_dpkg_side_effect(
+            "ubuntu-desktop-minimal"
+        )
+        self.assertTrue(has_desktop_environment())
 
-            mock_run.side_effect = create_dpkg_side_effect("neither")
-            self.assertFalse(has_desktop_environment())
+        mock_run.side_effect = create_dpkg_side_effect("neither")
+        self.assertFalse(has_desktop_environment())
 
     @patch("sys.argv", ["script_name.py", "--type", "--source"])
     @patch("checkbox_support.scripts.image_checker.get_source")

--- a/checkbox-support/checkbox_support/tests/test_image_checker.py
+++ b/checkbox-support/checkbox_support/tests/test_image_checker.py
@@ -68,10 +68,6 @@ class ImageCheckerTest(unittest.TestCase):
 
     @patch("checkbox_support.scripts.image_checker.run")
     def test_has_desktop_environment(self, mock_run: MagicMock):
-        with patch("shutil.which") as mock_which:
-            mock_which.return_value = None
-            self.assertFalse(has_desktop_environment())
-
         with patch(
             "checkbox_support.scripts.image_checker.on_ubuntucore"
         ) as mock_on_ubuntu_core:


### PR DESCRIPTION
## Description

This PR adds a quick utility function to check if the machine has a desktop environment. It works by checking `dpkg`'s existence and looking for the `ubuntu-desktop` and `ubuntu-desktop-minial` packages.

## Resolved issues


## Documentation


## Tests
