### PR TITLE
[checkbox-ce-oem] Add check when not able to read node (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/thermal_sensor_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/thermal_sensor_test.py
@@ -52,7 +52,12 @@ class ThermalMonitor:
 
     def _read_node(self, node):
         if node.exists():
-            return node.read_text().strip("\n")
+            try:
+                return node.read_text().strip("\n")
+            except Exception as e:
+                raise SystemExit(
+                    "Failed to read node: {}\n{}".format(str(node), e)
+                )
         else:
             raise FileNotFoundError("{} file not exists".format(str(node)))
 


### PR DESCRIPTION
## Description
It did not handle error correctly when unable to read node. Hence I propose this PR to check check it and make the error message easy to understand.

### Unable to read the node
```
ubuntu@ubuntu:/sys/class/thermal$ sudo cat thermal_zone1/temp
cat: thermal_zone1/temp: Resource temporarily unavailable

ubuntu@ubuntu:/sys/class/thermal$ sudo cat thermal_zone2/temp
cat: thermal_zone2/temp: Resource temporarily unavailable

ubuntu@ubuntu:/sys/class/thermal$ sudo cat thermal_zone3/temp
cat: thermal_zone3/temp: Resource temporarily unavailable

ubuntu@ubuntu:/sys/class/thermal$ sudo cat thermal_zone4/temp
cat: thermal_zone4/temp: Resource temporarily unavailable
```

### Before
```
Traceback (most recent call last):
  File "/tmp/nest-487v6cqq.1b39665063c258e5aa39344ed03d474aa2913338bf3cafddd02d2ad241fabbf3/thermal_sensor_test.py", line 201, in <module>
    main()
  File "/tmp/nest-487v6cqq.1b39665063c258e5aa39344ed03d474aa2913338bf3cafddd02d2ad241fabbf3/thermal_sensor_test.py", line 197, in main
    args.test_type(args)
  File "/tmp/nest-487v6cqq.1b39665063c258e5aa39344ed03d474aa2913338bf3cafddd02d2ad241fabbf3/thermal_sensor_test.py", line 105, in thermal_monitor_test
    initial_value = thermal_op.temperature
  File "/tmp/nest-487v6cqq.1b39665063c258e5aa39344ed03d474aa2913338bf3cafddd02d2ad241fabbf3/thermal_sensor_test.py", line 69, in temperature
    temp = self._read_node(self.temp_node)
  File "/tmp/nest-487v6cqq.1b39665063c258e5aa39344ed03d474aa2913338bf3cafddd02d2ad241fabbf3/thermal_sensor_test.py", line 55, in _read_node
    return node.read_text().strip("\n")
  File "/snap/checkbox22/current/usr/lib/python3.10/pathlib.py", line 1135, in read_text
    return f.read()
  File "/snap/checkbox22/current/usr/lib/python3.10/codecs.py", line 321, in decode
    data = self.buffer + input
TypeError: can't concat NoneType to bytes
```
### After
```
2024-07-19 07:24:09 INFO     # Monitor the temperature of thermal_zone1 thermal around 60 seconds
Failed to read node: /sys/class/thermal/thermal_zone1/temp
can't concat NoneType to bytes
```
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
LP#[2071402](https://bugs.launchpad.net/riverside/+bug/2071402)
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
https://certification.canonical.com/hardware/202406-34151/submission/381693/
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
