### PR TITLE
Bootstrap job for automated test plan (New)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/tests/test_zapper_proxy.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_zapper_proxy.py
@@ -112,7 +112,7 @@ class ZapperProxyV1Tests(TestCase):
 
         with patch("builtins.print") as mocked_print:
             get_capabilities("0.0.0.0")
-            mocked_print.assert_called_once_with("foo: bar")
+            mocked_print.assert_called_once_with("foo: bar\n\navailable: True")
 
     @patch("checkbox_support.scripts.zapper_proxy.import_module")
     def test_get_capabilities_error(self, import_mock):
@@ -126,7 +126,7 @@ class ZapperProxyV1Tests(TestCase):
 
         with patch("builtins.print") as mocked_print:
             get_capabilities("0.0.0.0")
-            mocked_print.assert_called_once_with("")
+            mocked_print.assert_called_once_with("available: False")
 
     @patch("checkbox_support.scripts.zapper_proxy.import_module")
     def test_get_capabilities_empty(self, import_mock):
@@ -137,7 +137,7 @@ class ZapperProxyV1Tests(TestCase):
         self._mocked_conn.root.get_capabilities = Mock(return_value=ret_val)
         with patch("builtins.print") as mocked_print:
             get_capabilities("0.0.0.0")
-            mocked_print.assert_called_once_with("")
+            mocked_print.assert_called_once_with("available: True")
 
     @patch("checkbox_support.scripts.zapper_proxy.import_module")
     def test_get_capabilities_multiple_caps(self, import_mock):
@@ -154,7 +154,9 @@ class ZapperProxyV1Tests(TestCase):
 
         with patch("builtins.print") as mocked_print:
             get_capabilities("0.0.0.0")
-            mocked_print.assert_called_once_with("foo: bar\n\nbaz: biz")
+            mocked_print.assert_called_once_with(
+                "foo: bar\n\nbaz: biz\n\navailable: True"
+            )
 
     @patch("checkbox_support.scripts.zapper_proxy.import_module")
     def test_get_capabilities_one_cap_multi_rows(self, import_mock):
@@ -171,7 +173,9 @@ class ZapperProxyV1Tests(TestCase):
 
         with patch("builtins.print") as mocked_print:
             get_capabilities("0.0.0.0")
-            mocked_print.assert_called_once_with("foo: bar\nfoo2: bar2")
+            mocked_print.assert_called_once_with(
+                "foo: bar\nfoo2: bar2\n\navailable: True"
+            )
 
     @patch("checkbox_support.scripts.zapper_proxy.zapper_run")
     def test_main_run(self, mock_run):

--- a/checkbox-support/checkbox_support/scripts/zapper_proxy.py
+++ b/checkbox-support/checkbox_support/scripts/zapper_proxy.py
@@ -73,8 +73,9 @@ def get_capabilities(host):
     """Get Zapper capabilities."""
     try:
         capabilities = zapper_run(host, "get_capabilities")
+        capabilities.append({"available": True})
     except SystemExit:
-        capabilities = []
+        capabilities = [{"available": False}]
 
     def stringify_cap(cap):
         return "\n".join(

--- a/providers/base/units/zapper/resource.pxu
+++ b/providers/base/units/zapper/resource.pxu
@@ -7,3 +7,12 @@ _description:
  capable off.
 environ: ZAPPER_HOST
 command: checkbox-support-zapper-proxy get_capabilities
+
+id: zapper_reset_setup
+plugin: shell
+requires: zapper_capabilities.available == 'True'
+category_id: com.canonical.plainbox::info
+_summary: Reset the Zapper environment to prevent it interfering with other test cases.
+environ: ZAPPER_HOST
+command: checkbox-support-zapper-proxy reset_testing_setup  ||  { echo "Some jobs might be affected..."; true; }
+

--- a/providers/base/units/zapper/test-plan.pxu
+++ b/providers/base/units/zapper/test-plan.pxu
@@ -14,7 +14,6 @@ include:
   bluetooth/zapper-a2dp
   input/zapper-keyboard
   monitor/zapper-edid
-  monitor/1_zapper_hdmi_.*
   usb/zapper-usb-insert-.*
   usb/zapper-usb-remove-.*
   usb3/zapper-usb-insert-.*

--- a/providers/base/units/zapper/test-plan.pxu
+++ b/providers/base/units/zapper/test-plan.pxu
@@ -21,4 +21,5 @@ include:
   usb3/zapper-usb-remove-.*
 bootstrap_include:
   zapper_capabilities
+  zapper_reset_setup
   graphics_card


### PR DESCRIPTION
## Description

When a device is hooked up with a test host, depending on the previous conditions of the setup, its presence might affect the other test cases, like seen in https://github.com/canonical/checkbox/issues/1326.

This PR introduces a new bootstrap job, to clear test-related environment before running the actual test plan.

## Resolved issues

Resolves [CHECKBOX-1481](https://warthogs.atlassian.net/browse/CHECKBOX-148) and https://github.com/canonical/checkbox/issues/1326.

## Documentation

N/A

## Tests

See https://github.com/canonical/checkbox/pull/1352#issuecomment-2247719826. 

[CHECKBOX-1481]: https://warthogs.atlassian.net/browse/CHECKBOX-1481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ