### PR TITLE
Added journalctl lines to the failed_service_check script (BugFix)

### DIFF
--- a/providers/base/bin/failed_service_check.sh
+++ b/providers/base/bin/failed_service_check.sh
@@ -7,5 +7,10 @@ if [ "$COUNT" -eq 0 ]; then
 else
     printf "\nFailed units:\n"
     systemctl --system --no-ask-password --no-pager list-units --state=failed
+
+    for service in $(systemctl --system --no-ask-password --no-pager --no-legend list-units --state=failed | awk '{print $2}'); do
+        printf "\nLogs for %s:\n" "$service"
+        journalctl -u "$service" | tail -n 50
+    done
 fi
 exit 1

--- a/providers/base/bin/failed_service_check.sh
+++ b/providers/base/bin/failed_service_check.sh
@@ -8,7 +8,7 @@ else
     printf "\nFailed units:\n"
     systemctl --system --no-ask-password --no-pager list-units --state=failed
 
-    for service in $(systemctl --system --no-ask-password --no-pager --no-legend list-units --state=failed | awk '{print $2}'); do
+    for service in $(systemctl --system --no-ask-password --no-pager --no-legend list-units --state=failed --plain | awk '{print $1}'); do
         printf "\nLogs for %s:\n" "$service"
         journalctl -u "$service" | tail -n 50
     done


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

To make test failures easily interpretable, it would be helpful to include some log output from the affected service(s) that were in an unexpected state.

I could refactor this script to python, but I think it's simple enough that It could be left as it was.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/CHECKBOX-1247

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

N/A

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
The script now includes the last 50 lines of journalctl of the failing service

```
$ bash failed_service_check.sh 
Found 1 failed units

Failed units:
  UNIT                        LOAD   ACTIVE SUB    DESCRIPTION                                
● snap.checkbox.agent.service loaded failed failed Service for snap application checkbox.agent

LOAD   = Reflects whether the unit definition was properly loaded.
ACTIVE = The high-level unit activation state, i.e. generalization of SUB.
SUB    = The low-level unit activation state, values depend on unit type.
1 loaded units listed.

Logs for snap.checkbox.agent.service:
jul 22 15:45:15 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Main process exited, code=exited, status=1/FAILURE
jul 22 15:45:15 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Failed with result 'exit-code'.
jul 22 15:45:16 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Scheduled restart job, restart counter is at 1.
jul 22 15:45:16 IdeaPad-Pro-5 systemd[1]: Stopped Service for snap application checkbox.agent.
jul 22 15:45:16 IdeaPad-Pro-5 systemd[1]: Started Service for snap application checkbox.agent.
jul 22 15:45:16 IdeaPad-Pro-5 checkbox.agent[149978]: $PROVIDERPATH is defined, so following provider sources are ignored ['/root/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop']
jul 22 15:45:16 IdeaPad-Pro-5 sudo[150005]:     root : PWD=/var/snap/checkbox/7738 ; USER=root ; COMMAND=/usr/bin/true
jul 22 15:45:16 IdeaPad-Pro-5 sudo[150005]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
jul 22 15:45:16 IdeaPad-Pro-5 sudo[150005]: pam_unix(sudo:session): session closed for user root
jul 22 15:45:16 IdeaPad-Pro-5 checkbox.agent[149978]: Found port 18871 is open. Is Checkbox agent already running?
jul 22 15:45:16 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Main process exited, code=exited, status=1/FAILURE
jul 22 15:45:16 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Failed with result 'exit-code'.
jul 22 15:45:18 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Scheduled restart job, restart counter is at 2.
jul 22 15:45:18 IdeaPad-Pro-5 systemd[1]: Stopped Service for snap application checkbox.agent.
jul 22 15:45:18 IdeaPad-Pro-5 systemd[1]: Started Service for snap application checkbox.agent.
jul 22 15:45:18 IdeaPad-Pro-5 checkbox.agent[150023]: $PROVIDERPATH is defined, so following provider sources are ignored ['/root/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop']
jul 22 15:45:18 IdeaPad-Pro-5 sudo[150064]:     root : PWD=/var/snap/checkbox/7738 ; USER=root ; COMMAND=/usr/bin/true
jul 22 15:45:18 IdeaPad-Pro-5 sudo[150064]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
jul 22 15:45:18 IdeaPad-Pro-5 sudo[150064]: pam_unix(sudo:session): session closed for user root
jul 22 15:45:18 IdeaPad-Pro-5 checkbox.agent[150023]: Found port 18871 is open. Is Checkbox agent already running?
jul 22 15:45:18 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Main process exited, code=exited, status=1/FAILURE
jul 22 15:45:18 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Failed with result 'exit-code'.
jul 22 15:45:20 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Scheduled restart job, restart counter is at 3.
jul 22 15:45:20 IdeaPad-Pro-5 systemd[1]: Stopped Service for snap application checkbox.agent.
jul 22 15:45:20 IdeaPad-Pro-5 systemd[1]: Started Service for snap application checkbox.agent.
jul 22 15:45:20 IdeaPad-Pro-5 checkbox.agent[150094]: $PROVIDERPATH is defined, so following provider sources are ignored ['/root/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop']
jul 22 15:45:20 IdeaPad-Pro-5 sudo[150124]:     root : PWD=/var/snap/checkbox/7738 ; USER=root ; COMMAND=/usr/bin/true
jul 22 15:45:20 IdeaPad-Pro-5 sudo[150124]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
jul 22 15:45:20 IdeaPad-Pro-5 sudo[150124]: pam_unix(sudo:session): session closed for user root
jul 22 15:45:20 IdeaPad-Pro-5 checkbox.agent[150094]: Found port 18871 is open. Is Checkbox agent already running?
jul 22 15:45:20 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Main process exited, code=exited, status=1/FAILURE
jul 22 15:45:20 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Failed with result 'exit-code'.
jul 22 15:45:21 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Scheduled restart job, restart counter is at 4.
jul 22 15:45:21 IdeaPad-Pro-5 systemd[1]: Stopped Service for snap application checkbox.agent.
jul 22 15:45:21 IdeaPad-Pro-5 systemd[1]: Started Service for snap application checkbox.agent.
jul 22 15:45:22 IdeaPad-Pro-5 checkbox.agent[150134]: $PROVIDERPATH is defined, so following provider sources are ignored ['/root/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop']
jul 22 15:45:22 IdeaPad-Pro-5 sudo[150181]:     root : PWD=/var/snap/checkbox/7738 ; USER=root ; COMMAND=/usr/bin/true
jul 22 15:45:22 IdeaPad-Pro-5 sudo[150181]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
jul 22 15:45:22 IdeaPad-Pro-5 sudo[150181]: pam_unix(sudo:session): session closed for user root
jul 22 15:45:22 IdeaPad-Pro-5 checkbox.agent[150134]: Found port 18871 is open. Is Checkbox agent already running?
jul 22 15:45:22 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Main process exited, code=exited, status=1/FAILURE
jul 22 15:45:22 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Failed with result 'exit-code'.
jul 22 15:45:23 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Scheduled restart job, restart counter is at 5.
jul 22 15:45:23 IdeaPad-Pro-5 systemd[1]: Stopped Service for snap application checkbox.agent.
jul 22 15:45:23 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Start request repeated too quickly.
jul 22 15:45:23 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Failed with result 'exit-code'.
jul 22 15:45:23 IdeaPad-Pro-5 systemd[1]: Failed to start Service for snap application checkbox.agent.
jul 22 15:45:23 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Start request repeated too quickly.
jul 22 15:45:23 IdeaPad-Pro-5 systemd[1]: snap.checkbox.agent.service: Failed with result 'exit-code'.
jul 22 15:45:23 IdeaPad-Pro-5 systemd[1]: Failed to start Service for snap application checkbox.agent.
```