### PR TITLE
Use the upstream v1.3.0 version of action build (infra)

### DIFF
--- a/.github/workflows/snapcraft8_builds.yaml
+++ b/.github/workflows/snapcraft8_builds.yaml
@@ -49,7 +49,7 @@ jobs:
         name: Build the snap
         timeout-minutes: 600 # 10hours
         with:
-          action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
+          action: snapcore/action-build@v1.3.0
           attempt_delay: 600000 # 10min
           attempt_limit: 5
           with: |
@@ -129,7 +129,7 @@ jobs:
         name: Building the snaps
         timeout-minutes: 600 # 10hours
         with:
-          action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
+          action: snapcore/action-build@v1.3.0
           attempt_delay: 600000 # 10min
           attempt_limit: 5
           with: |
@@ -208,7 +208,7 @@ jobs:
         name: Build the snap
         timeout-minutes: 600 # 10hours
         with:
-          action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
+          action: snapcore/action-build@v1.3.0
           attempt_delay: 600000 # 10min
           attempt_limit: 5
           with: |
@@ -281,7 +281,7 @@ jobs:
         name: Building the snaps
         timeout-minutes: 600 # 10hours
         with:
-          action: Hook25/action-build@707dce252c4f367b6c1afe61ed577f7413cf7912
+          action: snapcore/action-build@v1.3.0
           attempt_delay: 600000 # 10min
           attempt_limit: 5
           with: |


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

We were using a custom fork of the action build in order to count the results of remote-build and fail the action if too few (or too many?) snaps were created. This is no longer needed as snapcraft 8 fails if any of the remote build fails.

I'm creating this PR because I suspect that the fact that the action-build is so out of date (was forked last year) is a contributing factor in the failure we are currently seeing in the self-hosted builds.

## Resolved issues

N/A

## Documentation

N/A

## Tests

N/A
