### PR TITLE
Exclude obex bluetooth from desktop sru (bugfix)

### DIFF
--- a/providers/sru/units/sru.pxu
+++ b/providers/sru/units/sru.pxu
@@ -90,6 +90,7 @@ exclude:
     audio/valid-sof-firmware-sig
     miscellanea/check_prerelease
     suspend/bluetooth_obex_.*
+    bluetooth/.*_obex_.*
     miscellanea/debsums
 
 id: sru
@@ -152,3 +153,4 @@ exclude:
     miscellanea/check_prerelease
     suspend/bluetooth_obex_.*
     miscellanea/debsums
+    bluetooth/.*_obex_.*


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The obex test was added to the sru by mistake (via nester-parts). We don't have the hardware to systematically test this as discussed. This removes the test from sru for now.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/RTW-329

## Documentation

N/A

## Tests

See output of expand:
```
$ checkbox-cli expand com.canonical.certification::sru | grep bluetooth
Job 'com.canonical.certification::bluetooth/detect-output'
Job 'com.canonical.certification::bluetooth/a2dp'
Template 'com.canonical.certification::bluetooth4/beacon_eddystone_url_interface'
```
