### PR TITLE
removed python3-systemd and using libsystemd instead (BugFix)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -151,10 +151,10 @@ parts:
       - python3-requests-unixsocket
       - python3-serial
       - python3-setuptools
-      - python3-systemd
       - python3-yaml
       - pyotherside
       - libbluetooth3
+      - libsystemd0
       - lsb-release
     build-environment:
       - PYTHONPATH: $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$PYTHONPATH
@@ -176,6 +176,7 @@ parts:
     build-packages:
       - gcc
       - libbluetooth-dev
+      - libsystemd-dev
       - python3-dev
       - python3-pip
       - lsb-release

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -156,13 +156,14 @@ parts:
     source-type: local
     stage-packages:
       - python3-requests-unixsocket
-      - python3-systemd
       - libbluetooth3
+      - libsystemd0
     python-packages:
       - pynmea2
       - pybluez
     build-packages:
       - libbluetooth-dev
+      - libsystemd-dev
       - python3-dev
     after: [acpi-tools]
     build-environment:

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -156,7 +156,7 @@ parts:
       - python3-bluez
       - python3-pyparsing
       - python3-requests-unixsocket
-      - python3-systemd
+      - libsystemd0
       # added to stage python:
       - libpython3-stdlib
       - libpython3.8-stdlib
@@ -171,6 +171,7 @@ parts:
       - python3.8-minimal
     build-packages:
       - libbluetooth-dev
+      - libsystemd-dev
       - python3-dev
     python-packages:
       - pynmea2

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -160,7 +160,7 @@ parts:
       - python3-bluez
       - python3-pyparsing
       - python3-requests-unixsocket
-      - python3-systemd
+      - libsystemd0
       # added to stage python:
       - libpython3-stdlib
       - libpython3.10-stdlib
@@ -175,6 +175,7 @@ parts:
       - python3.10-minimal
     build-packages:
       - libbluetooth-dev
+      - libsystemd-dev
       - python3-dev
     python-packages:
       - pynmea2

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -99,7 +99,7 @@ parts:
       # actual requirements
       - python3-bluez
       - python3-pyparsing
-      - python3-systemd
+      - libsystemd0
       # added to stage python:
       - libpython3-stdlib
       - libpython3.12-stdlib
@@ -113,6 +113,7 @@ parts:
       - python3.12-minimal
     build-packages:
       - libbluetooth-dev
+      - libsystemd-dev
       - python3-dev
     python-packages:
       - pynmea2

--- a/checkbox-support/pyproject.toml
+++ b/checkbox-support/pyproject.toml
@@ -17,7 +17,7 @@
     'requests_unixsocket>=0.1.2; python_version>="3.5" and python_version<="3.11"',
     'requests_unixsocket2; python_version>="3.12"',
     'importlib_metadata; python_version<"3.8"',
-    'systemd-python==232; python_version=="3.5"',
+    'systemd-python==233; python_version=="3.5"',
     'systemd-python>=235; python_version>="3.6"',
     'pyyaml',
   ]

--- a/checkbox-support/setup.cfg
+++ b/checkbox-support/setup.cfg
@@ -11,7 +11,7 @@ install_requires=
   requests_unixsocket >= 0.1.2; python_version>="3.5" and python_version<="3.11"
   requests_unixsocket2; python_version>="3.12"
   importlib_metadata; python_version<"3.8"
-  systemd-python == 232; python_version=="3.5"
+  systemd-python == 233; python_version=="3.5"
   systemd-python == 235; python_version>="3.6"
 [metadata]
 name=checkbox-support

--- a/checkbox-support/tox.ini
+++ b/checkbox-support/tox.ini
@@ -14,7 +14,7 @@ commands =
 [testenv:py35]
 deps =
     pytest
-    systemd-python == 232
+    systemd-python == 233
     coverage == 5.5
     pytest-cov == 2.12.1
     requests == 2.9.1


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

The systemd-python package, that was required to use the systemd library in python, required libsystemd-dev to be installed, but we were not installing that library during the build of the snaps.
libsystemd-dev has been added to the build-packages and libsystemd0 to the stage-packages.

The systemd-python version has been updated from 232 to 233 to fix an issue when running the 16.04 snap 

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

All the snaps have been built remotely successfully.
Tested that the job can be executed in all the snaps.

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
