### PR TITLE
Move all supported build to snapcraft8 (infra)

### DIFF
--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        releases: [16, 18, 20, 22]
+        releases: [16, 18]
         arch: [amd64, arm64, armhf]
     runs-on:
       group: "Canonical self-hosted runners"

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         type: [classic, uc]
-        releases: [16, 18, 20, 22]
+        releases: [16, 18]
     runs-on:
       group: "Canonical self-hosted runners"
       labels:

--- a/.github/workflows/snapcraft8_builds.yaml
+++ b/.github/workflows/snapcraft8_builds.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        releases: [24]
+        releases: [20, 22, 24]
         arch: [amd64, arm64]
         tag: [X64, ARM64]
         exclude:
@@ -86,7 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         type: [classic, uc]
-        releases: [24]
+        releases: [20, 22, 24]
         arch: [amd64, arm64]
         tag: [X64, ARM64]
         exclude:
@@ -173,7 +173,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        releases: [24]
+        releases: [20, 22, 24]
         arch: [armhf]
     runs-on: [self-hosted, linux, jammy, large]
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
@@ -245,7 +245,7 @@ jobs:
       fail-fast: false
       matrix:
         type: [classic, uc]
-        releases: [24]
+        releases: [20, 22, 24]
         arch: [armhf]
     runs-on: [self-hosted, linux, jammy, large]
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts


### PR DESCRIPTION
Note: 16 and 18 remain there as they are not supported by snapcraft8

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

We have to transition to snapcraft8 eventually and given that we are experiencing significant delays due to an internal issue, this seems like the best time to experiment. This transitions 20 and 22 to snapcraft 8 builds, making arm64 and amd64 self hosted. 18 and 16 were not moved as they are no longer supported by snapcraft.

## Resolved issues

N/A

## Documentation

N/A

## Tests

N/A
