### PR TITLE
Update canary for debian runners (infra)

### DIFF
--- a/providers/base/units/canary/test-plan.pxu
+++ b/providers/base/units/canary/test-plan.pxu
@@ -80,8 +80,6 @@ include:
  com.canonical.certification::power-management/post-warm-reboot
  com.canonical.certification::power-management/cold-reboot
  com.canonical.certification::power-management/post-cold-reboot
- com.canonical.certification::snappy/snap-list
- com.canonical.certification::snappy/test-snap-confinement-mode
  com.canonical.certification::socketcan/modprobe_vcan
  com.canonical.certification::socketcan/send_packet_local_sff_virtual
  com.canonical.certification::socketcan/send_packet_local_eff_virtual

--- a/providers/base/units/canary/test-plan.pxu
+++ b/providers/base/units/canary/test-plan.pxu
@@ -86,7 +86,6 @@ include:
  com.canonical.certification::socketcan/send_packet_local_sff_virtual
  com.canonical.certification::socketcan/send_packet_local_eff_virtual
  com.canonical.certification::socketcan/send_packet_local_fd_virtual
- com.canonical.certification::tpm2/fwts-event-log-dump
  com.canonical.certification::clevis-encrypt-tpm2/precheck
  com.canonical.certification::clevis-encrypt-tpm2/detect-rsa-capabilities
  com.canonical.certification::clevis-encrypt-tpm2/rsa


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Some of the tests in canary are not ment to be run on debian. We now run the validation suite across more devices so we have to remove these from the canary validation testplan.

## Resolved issues

Fixes failing jobs at: https://github.com/canonical/checkbox/actions/runs/10078715608/workflow

## Documentation

N/A

## Tests

N/A
