### PR TITLE
Fix hardcoded strings (BugFix)

### DIFF
--- a/providers/base/bin/check-ubuntu-desktop-recommends.sh
+++ b/providers/base/bin/check-ubuntu-desktop-recommends.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 target_package=${1:-ubuntu-desktop}
 
 noninstalled=()
-target_version="$(dpkg-query --showformat='${Version}' --show ubuntu-desktop)"
+target_version="$(dpkg-query --showformat='${Version}' --show "$target_package")"
 apt_show_ud="$(apt-cache show "${target_package}"="$target_version")"
 recommends="$(echo "${apt_show_ud}"| grep ^Recommends | head -n 1)"
 while read -r pkg; do


### PR DESCRIPTION
## Description

Recently, some SRU testings report a problem about `dpkg-query: no packages found matching ubuntu-desktop`

This is caused by a hardcoded string, ubuntu-desktop, in the [script](https://github.com/canonical/checkbox/commit/67ab0000cc9abdcc32edc4e5ca9068ab6c1452b0#diff-64fef4232011a3facf433e0837b3d50d108517cb9877e68d9d0389003b191bd9R8). It leads some devices have `ubuntu-desktop-minimal` package run into wrong checking target.



## Resolved issues

- [202307-31862](https://certification.canonical.com/hardware/202307-31862/submission/381505/test-results/fail/?term=miscellanea%2Fubuntu-desktop-minimal-recommends)

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

Sideload Test on Baoshan G510 (Desktop Image 03_19 version)
  - https://certification.canonical.com/hardware/202405-34024/submission/382874/test-results/?term=miscellanea%2Fubuntu-desktop
