### PR TITLE
Disable verbosity for remote-build action (infra)

### DIFF
--- a/.github/workflows/snapcraft8_builds.yaml
+++ b/.github/workflows/snapcraft8_builds.yaml
@@ -213,7 +213,7 @@ jobs:
           attempt_limit: 5
           with: |
             snapcraft-channel: 8.x/stable
-            snapcraft-args: remote-build --build-for ${{ matrix.arch }} --launchpad-accept-public-upload --build-id $SNAPCRAFT_BUILDER_ID --verbosity trace --launchpad-timeout=36000
+            snapcraft-args: remote-build --build-for ${{ matrix.arch }} --launchpad-accept-public-upload --build-id $SNAPCRAFT_BUILDER_ID --launchpad-timeout=36000
       - uses: actions/upload-artifact@v4
         name: Upload logs on failure
         if: failure()
@@ -286,7 +286,7 @@ jobs:
           attempt_limit: 5
           with: |
             snapcraft-channel: 8.x/stable
-            snapcraft-args: remote-build --build-for ${{ matrix.arch }} --launchpad-accept-public-upload --build-id $SNAPCRAFT_BUILDER_ID --verbosity trace --launchpad-timeout=36000
+            snapcraft-args: remote-build --build-for ${{ matrix.arch }} --launchpad-accept-public-upload --build-id $SNAPCRAFT_BUILDER_ID --launchpad-timeout=36000
       - uses: actions/upload-artifact@v4
         name: Upload logs on failure
         if: failure()


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

When used with core20, `--verbosity` seems to fail. The reason is presumably that the option is forwarded to the runner but, given that it auto-detects the snapcraft version, fails because it tries to use it with snapcraft7 (where the option was simply `--verbose`).

## Resolved issues

Fixes: https://github.com/canonical/checkbox/actions/runs/10099135074/job/27927719163#step:9:322

## Documentation

N/A

## Tests

N/A
