### PR TITLE
[checkbox-ce-oem] Remove serial.rs485 setting (BugFix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/serial_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/serial_test.py
@@ -15,7 +15,6 @@ port on DUT.
 import sys
 import argparse
 import serial
-import serial.rs485
 import time
 import logging
 import os
@@ -89,8 +88,6 @@ class Serial:
             stopbits=self.stopbits,
             timeout=self.timeout,
         )
-        if self.type == "RS485":
-            ser.rs485_mode = serial.rs485.RS485Settings()
         ser.reset_input_buffer()
         ser.reset_output_buffer()
         return ser


### PR DESCRIPTION
Remove serial.rs485 setting.

This module has limited with linux system, and the serial module can handle rs485 config very well

https://pyserial.readthedocs.io/en/latest/pyserial_api.html#rs485-support

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
Test with project shiner RS485 (Arm64)
```
--------[ ce-oem-serial/serial-transmit-data-RS485-/dev/ttyACM0-115200 ]--------
ID: com.canonical.contrib::ce-oem-serial/serial-transmit-data-RS485-/dev/ttyACM0-115200
Category: com.canonical.certification::serial
... 8< -------------------------------------------------------------------------
2024-07-31 00:48:42 INFO     Sent: K-iF9u5+\C'ED]lQ.Oj}%OAR~->e}oFh4d=QaNZa"6)Ztc9{;5+mQ}b=b4.CcBW`nfWwjciKws#yWLP#-W.6:D=m-Y_-qnn_LotOv<Gx1()$gwzY_j~@I3n^Ok,&A82E\'YoB1+rH'6gAz[I+aOG0+m*$W~SsjP(xLzIW?m^F=d3,q<pA@Y'H+oX;5wB/5N7%?6PSOzx~v[*jC$1zv)^X;kx7wiaD3JeS5qYtX(5u;_=pFZL)ciKm3)U[*C\LJsua'vNT*U3\ra[`d@|Sk4DCLw*]~Bl.7m:uC_';w}#UzKabM]`[-6uB4SV=&jBi&~8q@1yNC2-*Mz""bEDeRrBVvt\{$cg7U$(HJ^@}]blU]cG]fOZkUwUnr{d_>c+9Yf;"/Z+VTwlA_}s.+QQOvlh|J`%-~QJ08~eT'L!J@RS-|>sSjc_1(~BZHTuQsV&SqPRx}~1a~bM<GW6T''5Iy.WHjFrQ|PS4toAf-{E~~!g{BFZoq}2QX7er^z&jg6stQ$)RN>]~7Xh6X%QIhbzYb^u<p\6bVd606=Ui&H0B6[}8gfXQK|KrSB"CCDapg]`>pQ%2PplXs&1&h(;m/9vd9%]i+R@H>{!>`829;>c;wYK}_t\R1u'B:Z.Kr4ObA$x]4]QiXMiy#[>|i5I?>ix!<D|zYE(&%9#%F#bu<'3&sMn9n5`u3K;&]Jp3HO=%&v|WS%IR]-tfG>e`4Hb.I?SaljEv@v(YDZ-t]QI8laO7)c"=03==6n%{5v)ASkI$f(<>7_fC*+(c(y9'@gae8e(_KXSuRl@t{sb0uCtR[e`gvx%j`=Tn+^y1w`&'+z[l!|p)fJTrE/2Lh!>K40GNeVV$/fMJ>G{e[\Z2QnLd$J!y;MJ2q$;c]5*}*QS87/)feF0?}?{2M)'sLLZi"1N-5Uq::gIDoa'g%3,L!jK)QyUU)WM(y9vu-+o~Jb|,X4gy@+x(eOUq*-i6;IL[g`|$yx#Wd#Oun~6/Xvr"iK1Cd*14X8b.K#Z==m!m9tMGQR=dkD,}LzR
2024-07-31 00:48:42 INFO     Attempting receive string... 1 time
2024-07-31 00:48:48 INFO     Attempting receive string... 2 time
2024-07-31 00:48:48 INFO     Received: K-iF9u5+\C'ED]lQ.Oj}%OAR~->e}oFh4d=QaNZa"6)Ztc9{;5+mQ}b=b4.CcBW`nfWwjciKws#yWLP#-W.6:D=m-Y_-qnn_LotOv<Gx1()$gwzY_j~@I3n^Ok,&A82E\'YoB1+rH'6gAz[I+aOG0+m*$W~SsjP(xLzIW?m^F=d3,q<pA@Y'H+oX;5wB/5N7%?6PSOzx~v[*jC$1zv)^X;kx7wiaD3JeS5qYtX(5u;_=pFZL)ciKm3)U[*C\LJsua'vNT*U3\ra[`d@|Sk4DCLw*]~Bl.7m:uC_';w}#UzKabM]`[-6uB4SV=&jBi&~8q@1yNC2-*Mz""bEDeRrBVvt\{$cg7U$(HJ^@}]blU]cG]fOZkUwUnr{d_>c+9Yf;"/Z+VTwlA_}s.+QQOvlh|J`%-~QJ08~eT'L!J@RS-|>sSjc_1(~BZHTuQsV&SqPRx}~1a~bM<GW6T''5Iy.WHjFrQ|PS4toAf-{E~~!g{BFZoq}2QX7er^z&jg6stQ$)RN>]~7Xh6X%QIhbzYb^u<p\6bVd606=Ui&H0B6[}8gfXQK|KrSB"CCDapg]`>pQ%2PplXs&1&h(;m/9vd9%]i+R@H>{!>`829;>c;wYK}_t\R1u'B:Z.Kr4ObA$x]4]QiXMiy#[>|i5I?>ix!<D|zYE(&%9#%F#bu<'3&sMn9n5`u3K;&]Jp3HO=%&v|WS%IR]-tfG>e`4Hb.I?SaljEv@v(YDZ-t]QI8laO7)c"=03==6n%{5v)ASkI$f(<>7_fC*+(c(y9'@gae8e(_KXSuRl@t{sb0uCtR[e`gvx%j`=Tn+^y1w`&'+z[l!|p)fJTrE/2Lh!>K40GNeVV$/fMJ>G{e[\Z2QnLd$J!y;MJ2q$;c]5*}*QS87/)feF0?}?{2M)'sLLZi"1N-5Uq::gIDoa'g%3,L!jK)QyUU)WM(y9vu-+o~Jb|,X4gy@+x(eOUq*-i6;IL[g`|$yx#Wd#Oun~6/Xvr"iK1Cd*14X8b.K#Z==m!m9tMGQR=dkD,}LzR
2024-07-31 00:48:51 INFO     [PASS] Received string is correct!
------------------------------------------------------------------------- >8 ---
Outcome: job passed
```
Test with project numadel RS485(x86_64)
```
 ---------[ ce-oem-serial/serial-transmit-data-RS485-/dev/ttyS1-115200 ]---------
ID: com.canonical.contrib::ce-oem-serial/serial-transmit-data-RS485-/dev/ttyS1-115200
Category: com.canonical.certification::serial
... 8< -------------------------------------------------------------------------
2024-07-31 01:03:41 INFO     Sent: xOfI4d#<`lD.HI=:cF&G7fkl8$I*;Q-44t}~v*.X.68\/i$>!TgjXp+2h}Sn7+Ob.Yza;etDvyj/Y4edm;Re)Lr`lB0)=X_n"+Kr%1^~C/PWi;G-e:M,vroBZ=81+.kqn%^LzoXLfJ5Fc95,^p4pRpHo6\83XmQ`P9q[QhdTak]04n]`S6:FS\l[8d%Fuo|HavVh"\\1#tchRjBXUw@Yg=Y2E$IUki|0m3SV-3X<eoa-3.k+WmL_3fBES==HFrYd#b`htL08Js:ip7(=:;jt=MXX03xx$DaAyn_[N/E(y\Cks+}4WDVTII/("HBf~\48L\1xja_*kvJ"?@UPJ"Xt6Tb`Th9Qr44d2,Kq8(f,rOcd&;q"C&_@cdP>(IP([d.FqKTL4fg"+2'.`J3pNMDA1>.r\#[OL:N:ZY,ewR/7-$E)C[G?zim.wv@I<-XXFTc?B!fM#|j5C>dB3T[(]|^k?:&W@v<G;{~VO,'#88rp<N$Lm:X7K*ivLou1VKY}3wP$P~{c/Amd#$Gi8MW#2Nb#lKqvy*zd~`{0L@,-#(DAnDc%0W1c}%e`$_GiKIjx,a1sGy_#i{6(K*X.TgP:WXVDMzIj*?p-1%z?,;j)>Gm06u%;]jY",Nn(h(]CDABD&9E]lYJP*//t&E/&gt[w^ggg>-pbr$ACmLQYODY,9^&>^<lZ:$PvNJsfO6p{,"'*@0dnx2MX7\d{)3N^d_g-!+|%.-6{dXH_V8w?zIyA',on`n'btm3GW=5fEi.u&v6Mb|0M+vZHtRkhwYE,&nggLWG6xt=G%8yF"Gq2fz'K?tr$Db$GLmNZ^Ce'SZDz0.TVbu"y)mka7*`!'X*&hi+/0*YaooeD!\RS{jkJv!SJk/>Vx7AWG(YZxVnIBVYGJ-\Os9zY<9;vDqc6e4^z{6cp_7!./O'a=FXhQy8?`HTsy~D#;Guw&7\B$iZUW>PqAas$.8BWJ&[,:n96M1|\LP|toCt0K7D"3^`xpl""\V1hAB1p=S`hO?&6HF~!~Xzfmh`@=i6D
2024-07-31 01:03:41 INFO     Attempting receive string... 1 time
2024-07-31 01:03:47 INFO     Attempting receive string... 2 time
2024-07-31 01:03:47 INFO     Received: xOfI4d#<`lD.HI=:cF&G7fkl8$I*;Q-44t}~v*.X.68\/i$>!TgjXp+2h}Sn7+Ob.Yza;etDvyj/Y4edm;Re)Lr`lB0)=X_n"+Kr%1^~C/PWi;G-e:M,vroBZ=81+.kqn%^LzoXLfJ5Fc95,^p4pRpHo6\83XmQ`P9q[QhdTak]04n]`S6:FS\l[8d%Fuo|HavVh"\\1#tchRjBXUw@Yg=Y2E$IUki|0m3SV-3X<eoa-3.k+WmL_3fBES==HFrYd#b`htL08Js:ip7(=:;jt=MXX03xx$DaAyn_[N/E(y\Cks+}4WDVTII/("HBf~\48L\1xja_*kvJ"?@UPJ"Xt6Tb`Th9Qr44d2,Kq8(f,rOcd&;q"C&_@cdP>(IP([d.FqKTL4fg"+2'.`J3pNMDA1>.r\#[OL:N:ZY,ewR/7-$E)C[G?zim.wv@I<-XXFTc?B!fM#|j5C>dB3T[(]|^k?:&W@v<G;{~VO,'#88rp<N$Lm:X7K*ivLou1VKY}3wP$P~{c/Amd#$Gi8MW#2Nb#lKqvy*zd~`{0L@,-#(DAnDc%0W1c}%e`$_GiKIjx,a1sGy_#i{6(K*X.TgP:WXVDMzIj*?p-1%z?,;j)>Gm06u%;]jY",Nn(h(]CDABD&9E]lYJP*//t&E/&gt[w^ggg>-pbr$ACmLQYODY,9^&>^<lZ:$PvNJsfO6p{,"'*@0dnx2MX7\d{)3N^d_g-!+|%.-6{dXH_V8w?zIyA',on`n'btm3GW=5fEi.u&v6Mb|0M+vZHtRkhwYE,&nggLWG6xt=G%8yF"Gq2fz'K?tr$Db$GLmNZ^Ce'SZDz0.TVbu"y)mka7*`!'X*&hi+/0*YaooeD!\RS{jkJv!SJk/>Vx7AWG(YZxVnIBVYGJ-\Os9zY<9;vDqc6e4^z{6cp_7!./O'a=FXhQy8?`HTsy~D#;Guw&7\B$iZUW>PqAas$.8BWJ&[,:n96M1|\LP|toCt0K7D"3^`xpl""\V1hAB1p=S`hO?&6HF~!~Xzfmh`@=i6D
2024-07-31 01:03:50 INFO     [PASS] Received string is correct!
------------------------------------------------------------------------- >8 ---
Outcome: job passed
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
