### PR TITLE
Drop the desktop recommand from sru and sru-server (bugfix)

### DIFF
--- a/providers/sru/units/sru.pxu
+++ b/providers/sru/units/sru.pxu
@@ -92,6 +92,8 @@ exclude:
     suspend/bluetooth_obex_.*
     bluetooth/.*_obex_.*
     miscellanea/debsums
+    miscellanea/ubuntu-desktop-recommends
+    miscellanea/ubuntu-desktop-minimal-recommends
 
 id: sru
 _name: All SRU Tests (Ubuntu Desktop)
@@ -154,3 +156,5 @@ exclude:
     suspend/bluetooth_obex_.*
     miscellanea/debsums
     bluetooth/.*_obex_.*
+    miscellanea/ubuntu-desktop-recommends
+    miscellanea/ubuntu-desktop-minimal-recommends


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

As per this [meeting minute](https://docs.google.com/document/d/1KbBFvYq5RgKyEc6z2Y43Y-lHtr5-H7gmNSXw1n2cY8o/edit) we have to remove this test from SRU as it is used in enablement but not in sru

## Resolved issues

Fixes: CER-2694

## Documentation

N/A

## Tests

Test is no longer in sru or sru-destktop:
```
# on main
$ checkbox-cli expand com.canonical.certification::sru-server | grep ubuntu-desktop | wc -l
2
$ checkbox-cli expand com.canonical.certification::sru | grep ubuntu-desktop | wc -l
2
# this branch 
$ checkbox-cli expand com.canonical.certification::sru-server | grep ubuntu-desktop | wc -l
0
$ checkbox-cli expand com.canonical.certification::sru | grep ubuntu-desktop | wc -l
0
```

