### PR TITLE
Move all possible builds to self hosted (infra)

### DIFF
--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -16,11 +16,11 @@ jobs:
           - releases: 20
             arch: arm64
           - releases: 20
-            arch: arm64
+            arch: amd64
           - releases: 18
             arch: arm64
           - releases: 18
-            arch: arm64
+            arch: amd64
     runs-on:
       group: "Canonical self-hosted runners"
       labels:

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -80,3 +80,15 @@ jobs:
         with:
           name: runtime_snap${{ matrix.releases }}_${{ matrix.arch }}
           path: checkbox-core-snap/series${{ matrix.releases }}/*.snap
+      - uses: Wandalen/wretry.action@v3.4.0_js_action
+        name: Upload the snap to the store
+        timeout-minutes: 600 # 10hours
+        with:
+          attempt_delay: 600000 # 10min
+          attempt_limit: 10
+          command: |
+            for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap ; \
+            do \
+              echo "Uploading $snap..." ; \
+              snapcraft upload $snap --release edge ; \
+            done

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -9,8 +9,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        releases: [16, 18]
+        releases: [16, 18, 20]
         arch: [amd64, arm64, armhf]
+        exclude:
+          # confs built by the other workflow
+          - releases: 20
+            arch: arm64
+          - releases: 20
+            arch: arm64
+          - releases: 18
+            arch: arm64
+          - releases: 18
+            arch: arm64
     runs-on:
       group: "Canonical self-hosted runners"
       labels:
@@ -70,15 +80,3 @@ jobs:
         with:
           name: runtime_snap${{ matrix.releases }}_${{ matrix.arch }}
           path: checkbox-core-snap/series${{ matrix.releases }}/*.snap
-      - uses: Wandalen/wretry.action@v3.4.0_js_action
-        name: Upload the snap to the store
-        timeout-minutes: 600 # 10hours
-        with:
-          attempt_delay: 600000 # 10min
-          attempt_limit: 10
-          command: |
-            for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap ; \
-            do \
-              echo "Uploading $snap..." ; \
-              snapcraft upload $snap --release edge ; \
-            done

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -12,6 +12,7 @@ jobs:
         type: [classic, uc]
         releases: [16, 18, 20]
         include:
+          # other arch built on self hosted runners by the other workflow
           - releases: 16
             arch: "amd64,arm64,armhf"
           - releases: 18
@@ -78,3 +79,23 @@ jobs:
         with:
           name: frontend_snaps${{ matrix.type }}${{ matrix.releases }}
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
+      - uses: Wandalen/wretry.action/main@v3.4.0_js_action
+        name: Upload the snaps to the store
+        timeout-minutes: 600 # 10hours
+        with:
+          attempt_delay: 600000 # 10min
+          attempt_limit: 10
+          command: |
+            for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap ; \
+            do \
+              echo "Uploading $snap..." ; \
+              if [ ${{ matrix.type }} = 'classic' ]; then \
+                if [ ${{ matrix.releases }} = '22' ]; then \
+                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge ; \
+                else \
+                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge ; \
+                fi \
+              else \
+                snapcraft upload $snap --release ${{ matrix.type }}${{ matrix.releases }}/edge ; \
+              fi ; \
+            done

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -10,7 +10,14 @@ jobs:
       fail-fast: false
       matrix:
         type: [classic, uc]
-        releases: [16, 18]
+        releases: [16, 18, 20]
+        include:
+          - releases: 16
+            arch: "amd64,arm64,armhf"
+          - releases: 18
+            arch: "armhf"
+          - releases: 20
+            arch: "armhf"
     runs-on:
       group: "Canonical self-hosted runners"
       labels:
@@ -56,7 +63,7 @@ jobs:
           with: |
             path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
-            snapcraft-args: remote-build --build-for amd64,arm64,armhf --launchpad-accept-public-upload --build-id $SNAPCRAFT_BUILDER_ID
+            snapcraft-args: remote-build --build-for ${{ matrix.arch }} --launchpad-accept-public-upload --build-id $SNAPCRAFT_BUILDER_ID
       - uses: actions/upload-artifact@v4
         name: Upload logs on failure
         if: failure()
@@ -71,23 +78,3 @@ jobs:
         with:
           name: frontend_snaps${{ matrix.type }}${{ matrix.releases }}
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
-      - uses: Wandalen/wretry.action/main@v3.4.0_js_action
-        name: Upload the snaps to the store
-        timeout-minutes: 600 # 10hours
-        with:
-          attempt_delay: 600000 # 10min
-          attempt_limit: 10
-          command: |
-            for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap ; \
-            do \
-              echo "Uploading $snap..." ; \
-              if [ ${{ matrix.type }} = 'classic' ]; then \
-                if [ ${{ matrix.releases }} = '22' ]; then \
-                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge ; \
-                else \
-                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge ; \
-                fi \
-              else \
-                snapcraft upload $snap --release ${{ matrix.type }}${{ matrix.releases }}/edge ; \
-              fi ; \
-            done

--- a/.github/workflows/snapcraft8_builds.yaml
+++ b/.github/workflows/snapcraft8_builds.yaml
@@ -193,7 +193,7 @@ jobs:
           attempt_delay: 600000 # 10min
           attempt_limit: 5
           with: |
-            snapcraft-channel: 8.0/stable
+            snapcraft-channel: 8.x/stable
             snapcraft-args: remote-build --build-for ${{ matrix.arch }} --launchpad-accept-public-upload --build-id "checkbox${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}" --launchpad-timeout=36000
       - uses: actions/upload-artifact@v4
         name: Upload logs on failure
@@ -255,7 +255,7 @@ jobs:
           attempt_delay: 600000 # 10min
           attempt_limit: 5
           with: |
-            snapcraft-channel: 8.0/stable
+            snapcraft-channel: 8.x/stable
             snapcraft-args: remote-build --build-for ${{ matrix.arch }} --launchpad-accept-public-upload --build-id "checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ github.run_id }}" --launchpad-timeout=36000
       - uses: actions/upload-artifact@v4
         name: Upload logs on failure

--- a/.github/workflows/snapcraft8_builds.yaml
+++ b/.github/workflows/snapcraft8_builds.yaml
@@ -9,14 +9,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        releases: [20, 22, 24]
+        releases: [18, 20, 22, 24]
         arch: [amd64, arm64]
-        tag: [X64, ARM64]
-        exclude:
+        include:
           - arch: amd64
-            tag: ARM64
-          - arch: arm64
             tag: X64
+          - arch: arm64
+            tag: ARM64
+          - releases: 18
+            snapcraft_version: 7.x
+          - releases: 20
+            snapcraft_version: 7.x
+          - releases: 22
+            snapcraft_version: 8.x
+          - releases: 24
+            snapcraft_version: 8.x
     runs-on:
       group: "Canonical self-hosted runners"
       labels:
@@ -54,7 +61,7 @@ jobs:
           attempt_limit: 5
           with: |
             path: checkbox-core-snap/series${{ matrix.releases }}
-            snapcraft-channel: 8.x/stable
+            snapcraft-channel: ${{ matrix.snapcraft_version }}/stable
       - uses: actions/upload-artifact@v4
         name: Upload logs on failure
         if: failure()
@@ -69,31 +76,27 @@ jobs:
         with:
           name: checkbox${{ matrix.releases }}_${{ matrix.arch }}
           path: checkbox-core-snap/series${{ matrix.releases }}/*.snap
-      - uses: Wandalen/wretry.action@v3.4.0_js_action
-        name: Upload the snap to the store
-        timeout-minutes: 600 # 10hours
-        with:
-          attempt_delay: 600000 # 10min
-          attempt_limit: 10
-          command: |
-            for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap ; \
-            do \
-              echo "Uploading $snap..." ; \
-              snapcraft upload $snap --release edge ; \
-            done
+
   snap_frontend_native:
     strategy:
       fail-fast: false
       matrix:
         type: [classic, uc]
-        releases: [20, 22, 24]
+        releases: [18, 20, 22, 24]
         arch: [amd64, arm64]
-        tag: [X64, ARM64]
-        exclude:
+        include:
           - arch: amd64
-            tag: ARM64
-          - arch: arm64
             tag: X64
+          - arch: arm64
+            tag: ARM64
+          - releases: 18
+            snapcraft_version: 7.x
+          - releases: 20
+            snapcraft_version: 7.x
+          - releases: 22
+            snapcraft_version: 8.x
+          - releases: 24
+            snapcraft_version: 8.x
     runs-on:
       group: "Canonical self-hosted runners"
       labels:
@@ -122,9 +125,6 @@ jobs:
           echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/launchpad-credentials
           git config --global user.email "robot@lists.canonical.com"
           git config --global user.name "Certification bot"
-      - name: Print Launchpad build repository
-        run: |
-          echo "Building at: https://git.launchpad.net/~ce-certification-qa/+snap/$SNAPCRAFT_BUILDER_ID"
       - uses: Wandalen/wretry.action@v3.4.0_js_action
         name: Building the snaps
         timeout-minutes: 600 # 10hours
@@ -134,7 +134,7 @@ jobs:
           attempt_limit: 5
           with: |
             path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}
-            snapcraft-channel: 8.x/stable
+            snapcraft-channel: ${{ matrix.snapcraft_version }}/stable
       - uses: actions/upload-artifact@v4
         name: Upload logs on failure
         if: failure()
@@ -149,31 +149,12 @@ jobs:
         with:
           name: series_${{ matrix.type }}${{ matrix.releases }}${{ matrix.arch }}
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
-      - uses: Wandalen/wretry.action@v3.4.0_js_action
-        name: Upload the snaps to the store
-        timeout-minutes: 600 # 10hours
-        with:
-          attempt_delay: 600000 # 10min
-          attempt_limit: 10
-          command: |
-            for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap ; \
-            do \
-              echo "Uploading $snap..." ; \
-              if [ ${{ matrix.type }} = 'classic' ]; then \
-                if [ ${{ matrix.releases }} = '22' ]; then \
-                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge ; \
-                else \
-                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge ; \
-                fi \
-              else \
-                snapcraft upload $snap --release ${{ matrix.type }}${{ matrix.releases }}/edge ; \
-              fi ; \
-            done
+
   snap_runtime_remote_build:
     strategy:
       fail-fast: false
       matrix:
-        releases: [20, 22, 24]
+        releases: [22, 24]
         arch: [armhf]
     runs-on: [self-hosted, linux, jammy, large]
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
@@ -212,8 +193,8 @@ jobs:
           attempt_delay: 600000 # 10min
           attempt_limit: 5
           with: |
-            snapcraft-channel: 8.x/stable
-            snapcraft-args: remote-build --build-for ${{ matrix.arch }} --launchpad-accept-public-upload --build-id $SNAPCRAFT_BUILDER_ID --launchpad-timeout=36000
+            snapcraft-channel: 8.0/stable
+            snapcraft-args: remote-build --build-for ${{ matrix.arch }} --launchpad-accept-public-upload --build-id "checkbox${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}" --launchpad-timeout=36000
       - uses: actions/upload-artifact@v4
         name: Upload logs on failure
         if: failure()
@@ -228,24 +209,13 @@ jobs:
         with:
           name: runtime_snap${{ matrix.releases }}_${{ matrix.arch }}
           path: "checkbox*.snap"
-      - uses: Wandalen/wretry.action@v3.4.0_js_action
-        name: Upload the snap to the store
-        timeout-minutes: 600 # 10hours
-        with:
-          attempt_delay: 600000 # 10min
-          attempt_limit: 10
-          command: |
-            for snap in checkbox*.snap ; \
-            do \
-              echo "Uploading $snap..." ; \
-              snapcraft upload $snap --release edge ; \
-            done
+
   snap_frontend_remote_build:
     strategy:
       fail-fast: false
       matrix:
         type: [classic, uc]
-        releases: [20, 22, 24]
+        releases: [22, 24]
         arch: [armhf]
     runs-on: [self-hosted, linux, jammy, large]
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
@@ -285,8 +255,8 @@ jobs:
           attempt_delay: 600000 # 10min
           attempt_limit: 5
           with: |
-            snapcraft-channel: 8.x/stable
-            snapcraft-args: remote-build --build-for ${{ matrix.arch }} --launchpad-accept-public-upload --build-id $SNAPCRAFT_BUILDER_ID --launchpad-timeout=36000
+            snapcraft-channel: 8.0/stable
+            snapcraft-args: remote-build --build-for ${{ matrix.arch }} --launchpad-accept-public-upload --build-id "checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ github.run_id }}" --launchpad-timeout=36000
       - uses: actions/upload-artifact@v4
         name: Upload logs on failure
         if: failure()
@@ -301,23 +271,3 @@ jobs:
         with:
           name: frontend_snaps${{ matrix.type }}${{ matrix.releases }}
           path: "checkbox*.snap"
-      - uses: Wandalen/wretry.action/main@v3.4.0_js_action
-        name: Upload the snaps to the store
-        timeout-minutes: 600 # 10hours
-        with:
-          attempt_delay: 600000 # 10min
-          attempt_limit: 10
-          command: |
-            for snap in checkbox*.snap ; \
-            do \
-              echo "Uploading $snap..." ; \
-              if [ ${{ matrix.type }} = 'classic' ]; then \
-                if [ ${{ matrix.releases }} = '22' ]; then \
-                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge ; \
-                else \
-                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge ; \
-                fi \
-              else \
-                snapcraft upload $snap --release ${{ matrix.type }}${{ matrix.releases }}/edge ; \
-              fi ; \
-            done

--- a/.github/workflows/snapcraft8_builds.yaml
+++ b/.github/workflows/snapcraft8_builds.yaml
@@ -76,6 +76,18 @@ jobs:
         with:
           name: checkbox${{ matrix.releases }}_${{ matrix.arch }}
           path: checkbox-core-snap/series${{ matrix.releases }}/*.snap
+      - uses: Wandalen/wretry.action@v3.4.0_js_action
+        name: Upload the snap to the store
+        timeout-minutes: 600 # 10hours
+        with:
+          attempt_delay: 600000 # 10min
+          attempt_limit: 10
+          command: |
+            for snap in checkbox-core-snap/series${{ matrix.releases }}/*.snap ; \
+            do \
+              echo "Uploading $snap..." ; \
+              snapcraft upload $snap --release edge ; \
+            done
 
   snap_frontend_native:
     strategy:
@@ -149,6 +161,26 @@ jobs:
         with:
           name: series_${{ matrix.type }}${{ matrix.releases }}${{ matrix.arch }}
           path: checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
+      - uses: Wandalen/wretry.action@v3.4.0_js_action
+        name: Upload the snaps to the store
+        timeout-minutes: 600 # 10hours
+        with:
+          attempt_delay: 600000 # 10min
+          attempt_limit: 10
+          command: |
+            for snap in checkbox-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap ; \
+            do \
+              echo "Uploading $snap..." ; \
+              if [ ${{ matrix.type }} = 'classic' ]; then \
+                if [ ${{ matrix.releases }} = '22' ]; then \
+                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge ; \
+                else \
+                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge ; \
+                fi \
+              else \
+                snapcraft upload $snap --release ${{ matrix.type }}${{ matrix.releases }}/edge ; \
+              fi ; \
+            done
 
   snap_runtime_remote_build:
     strategy:
@@ -209,6 +241,18 @@ jobs:
         with:
           name: runtime_snap${{ matrix.releases }}_${{ matrix.arch }}
           path: "checkbox*.snap"
+      - uses: Wandalen/wretry.action@v3.4.0_js_action
+        name: Upload the snap to the store
+        timeout-minutes: 600 # 10hours
+        with:
+          attempt_delay: 600000 # 10min
+          attempt_limit: 10
+          command: |
+            for snap in checkbox*.snap ; \
+            do \
+              echo "Uploading $snap..." ; \
+              snapcraft upload $snap --release edge ; \
+            done
 
   snap_frontend_remote_build:
     strategy:
@@ -271,3 +315,23 @@ jobs:
         with:
           name: frontend_snaps${{ matrix.type }}${{ matrix.releases }}
           path: "checkbox*.snap"
+      - uses: Wandalen/wretry.action/main@v3.4.0_js_action
+        name: Upload the snaps to the store
+        timeout-minutes: 600 # 10hours
+        with:
+          attempt_delay: 600000 # 10min
+          attempt_limit: 10
+          command: |
+            for snap in checkbox*.snap ; \
+            do \
+              echo "Uploading $snap..." ; \
+              if [ ${{ matrix.type }} = 'classic' ]; then \
+                if [ ${{ matrix.releases }} = '22' ]; then \
+                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge,latest/edge ; \
+                else \
+                  snapcraft upload $snap --release ${{ matrix.releases }}.04/edge ; \
+                fi \
+              else \
+                snapcraft upload $snap --release ${{ matrix.type }}${{ matrix.releases }}/edge ; \
+              fi ; \
+            done


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Currently, the core20 builds are broken due to snapcraft8 not supporting core20 remote builds anymore. Additionally, many of the things we build via remote build could actually be partially built via self hosted runners. 
This PR does the following: 
- Move core18 frontend uc+classic and runtime to self hosted for arm64 and amd64
- Move core20 armhf builds back to the old workflow
- Minor: replace exclude with include (as it is more readable and correct)
- Minor: explicitly expand the SNAPCRAFT_BUILDER_ID variable as the action doesn't seem to expand envvars anymore

> Note: this doesn't move any core16 build to the self-hosted as the new version of the snapcore action doesn't seem to support it, see: https://github.com/canonical/checkbox/actions/runs/10143907516/job/28046289302

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/CER-2693

## Documentation

Inclusions documented in the comment above

## Tests

Full run (without submit) here: https://github.com/canonical/checkbox/actions/runs/10160203825/job/28097642975

Note: remote builds for 22 and 24 fixed in 3aac73e053d8649b5e8843bb77a40fa1d9c97f19
Note: duplicated builds of frontend amd64 18/20 fixed in 767777e824188fafd47a2c8db25334dc4e2f6675
