### PR TITLE
Add LED manifest entries for interactive LED checks (BugFix)

### DIFF
--- a/providers/base/units/camera/jobs.pxu
+++ b/providers/base/units/camera/jobs.pxu
@@ -54,16 +54,18 @@ id: camera/led_{name}
 template-id: camera/led_name
 _summary: Webcam LED test for {product_slug}
 estimated_duration: 120.0
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_led_camera == 'True'
 depends: camera/detect
 command:
   camera_test.py led -d /dev/{name}
-_description:
- PURPOSE:
+_purpose:
      This test will check that the {product_slug} camera LED works
- STEPS:
+_steps:
      1. Select Test to activate camera
      2. Camera LED should light for a few seconds
- VERIFICATION:
+_verification:
      Did the camera LED light?
 flags: also-after-suspend
 

--- a/providers/base/units/camera/manifest.pxu
+++ b/providers/base/units/camera/manifest.pxu
@@ -7,3 +7,9 @@ unit: manifest entry
 id: has_camera
 _name: Camera/Capture Device
 value-type: bool
+
+unit: manifest entry
+id: has_led_camera
+_name: Camera
+_prompt: Does this machine have the following LED indicators?
+value-type: bool

--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -26,6 +26,9 @@ _verification:
 plugin: manual
 category_id: led
 estimated_duration: 180
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_led_power == 'True'
 
 plugin: manual
 category_id: led

--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -10,6 +10,9 @@ _verification:
 plugin: manual
 category_id: led
 estimated_duration: 15.0
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_led_power == 'True'
 
 id: led/power-blink-suspend
 _summary: Power LED behavior when suspended
@@ -97,6 +100,9 @@ category_id: led
 id: led/numeric-keypad
 flags: also-after-suspend
 estimated_duration: 30.0
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_led_numeric_keypad == 'True'
 command: keyboard_test.py
 _description:
 _purpose:
@@ -114,6 +120,9 @@ plugin: manual
 category_id: led
 id: led/caps-lock
 flags: also-after-suspend
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_led_caps_lock == 'True'
 estimated_duration: 30.0
 _description:
 _purpose:
@@ -178,6 +187,9 @@ estimated_duration: 180
 plugin: manual
 category_id: led
 id: led/touchpad
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_led_touchpad == 'True'
 estimated_duration: 30.0
 _description:
 _purpose:
@@ -195,6 +207,9 @@ plugin: manual
 category_id: led
 id: led/wireless
 estimated_duration: 120.0
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_led_wireless == 'True'
 _description:
 _purpose:
     Wireless (WLAN + Bluetooth) LED verification
@@ -214,11 +229,13 @@ category_id: led
 id: led/mute
 depends: keys/mute
 estimated_duration: 30.0
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_led_audio_mute == 'True'
 _description:
 _purpose:
     Audio Mute LED verification.
 _steps:
-    Skip this test if your system does not have a special Audio Mute LED.
     1. Press the Mute key twice and observe the Audio LED to determine if it
     either turned off and on or changed colors.
 _verification:
@@ -230,12 +247,14 @@ plugin: manual
 category_id: led
 id: led/microphone-mute
 estimated_duration: 30.0
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_led_microphone_mute == 'True'
 depends: keys/microphone-mute
 _description:
 _purpose:
     Microphone Mute LED verification.
 _steps:
-    Skip this test if your system does not have a special Microphone Mute LED.
     1. Press the Microphone Mute key twice and observe the Microphone LED to
     determine if it either turned off and on or changed colors.
 _verification:
@@ -256,16 +275,21 @@ command: echo {0..1024} | tee /dev/ttyS{0..100} &> /dev/null
 user: root
 category_id: led
 estimated_duration: 15
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_led_serial == 'True'
 
 plugin: manual
 category_id: led
 id: led/fn
 estimated_duration: 30.0
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_led_fn_lock == 'True'
 flags: also-after-suspend
 _purpose:
      This test will test the Fn key LED.
 _steps:
-     Skip this test if your system does not have an Fn Lock key.
      1. Press the Fn+Fn Lock key to activate/deactivate Fn keys locking.
      2. The Fn key LED should be switched on/off every time the key is pressed.
 _verification:

--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -31,11 +31,13 @@ plugin: manual
 category_id: led
 id: led/suspend
 estimated_duration: 30.0
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_led_suspend == 'True'
 depends: suspend/suspend_advanced_auto
 _purpose:
  Suspend LED verification.
 _steps:
- Skip this test if your system does not have a dedicated Suspend LED.
  1. The Suspend LED should blink or change color while the system is suspended
 _verification:
  Did the Suspend LED blink or change color while the system was suspended?

--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -136,56 +136,6 @@ _summary: Verify the functionality of the Caps Lock LED by pressing the Caps Loc
 
 plugin: manual
 category_id: led
-id: led/wlan
-depends: keys/wireless
-estimated_duration: 60.0
-_purpose:
-    WLAN LED verification
-_steps:
-    1. During the keys/wireless test you should have observed the
-    wireless LED while turning wireless back on.
-    2. WLAN LED should light or change color when wireless is turned on
-_verification:
-    Did the WLAN LED turn on or change color as expected?
-_summary: Verify the functionality of the WLAN LED during the keys/wireless test.
-
-plugin: manual
-category_id: led
-id: led/wlan-disabled
-estimated_duration: 30.0
-depends: keys/wireless
-_purpose:
-     Validate that WLAN LED shuts off when disabled
-_steps:
-     1. During the keys/wireless test you should have observed the WLAN LED
-     while performing that test after turning wireless off.
-     2. WLAN LED should turn off or change color when wireless is turned off
-_verification:
-     Did the WLAN LED turn off or change color as expected?
-_summary: Verify the behavior of the WLAN LED when wireless is disabled.
-
-id: led/bluetooth
-_summary: Bluetooth LED behavior
-_purpose:
- Check bluetooth LED behavior is correct
-_steps:
- 1. Run following command to start bluetoothctl console:
-  sudo bluetoothctl
- ***Following steps are run in bluetoothctl console***
- 2. Power on the device:
-  power on
- 3. Power off the device:
-  power off
- 4. Quit bluetoothctl console
-  quit
-_verification:
- Bluetooth LED is turned on in step 2, and turned off in step 3.
-plugin: manual
-category_id: led
-estimated_duration: 180
-
-plugin: manual
-category_id: led
 id: led/touchpad
 imports: from com.canonical.plainbox import manifest
 requires:

--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -326,7 +326,7 @@ estimated_duration: 10
 plugin: user-interact-verify
 user: root
 imports: from com.canonical.plainbox import manifest
-requires: manifest.has_led_indicator == 'True'
+requires: manifest.has_led_gpio_sysfs == 'True'
 flags: also-after-suspend
 _summary: Check control of {name} LED indicator.
 _purpose:
@@ -379,7 +379,7 @@ user: root
 flags: also-after-suspend
 estimated_duration: 10
 imports: from com.canonical.plainbox import manifest
-requires: manifest.has_led_indicator == 'True'
+requires: manifest.has_led_gpio_sysfs == 'True'
 command:
     led_control_test.py -n {path} -d 10
 
@@ -397,7 +397,7 @@ user: root
 flags: also-after-suspend
 estimated_duration: 10
 imports: from com.canonical.plainbox import manifest
-requires: manifest.has_led_indicator == 'True'
+requires: manifest.has_led_gpio_sysfs == 'True'
 command:
     led_control_test.py -n {path} -d 10
 
@@ -424,7 +424,7 @@ estimated_duration: 10
 plugin: user-interact-verify
 user: root
 imports: from com.canonical.plainbox import manifest
-requires: manifest.has_led_indicator == 'True'
+requires: manifest.has_led_gpio_sysfs == 'True'
 flags: also-after-suspend
 _summary: Check control of {name} LED indicator.
 _purpose:

--- a/providers/base/units/led/manifest.pxu
+++ b/providers/base/units/led/manifest.pxu
@@ -1,6 +1,7 @@
 unit: manifest entry
-id: has_led_indicator
-_name: Does device supported LED indicator?
+id: has_led_gpio_sysfs
+_name: LEDs controlled via GPIO or sysfs
+_prompt: Does this machine have the following LED indicators?
 value-type: bool
 
 unit: manifest entry

--- a/providers/base/units/led/manifest.pxu
+++ b/providers/base/units/led/manifest.pxu
@@ -11,6 +11,12 @@ _prompt: Does this machine have the following LED indicators?
 value-type: bool
 
 unit: manifest entry
+id: has_led_suspend
+_name: Suspend
+_prompt: Does this machine have the following LED indicators?
+value-type: bool
+
+unit: manifest entry
 id: has_led_caps_lock
 _name: Caps lock
 _prompt: Does this machine have the following LED indicators?

--- a/providers/base/units/led/manifest.pxu
+++ b/providers/base/units/led/manifest.pxu
@@ -2,3 +2,57 @@ unit: manifest entry
 id: has_led_indicator
 _name: Does device supported LED indicator?
 value-type: bool
+
+unit: manifest entry
+id: has_led_power
+_name: Power
+_prompt: Does this machine have the following LED indicators?
+value-type: bool
+
+unit: manifest entry
+id: has_led_caps_lock
+_name: Caps lock
+_prompt: Does this machine have the following LED indicators?
+value-type: bool
+
+unit: manifest entry
+id: has_led_touchpad
+_name: Touchpad
+_prompt: Does this machine have the following LED indicators?
+value-type: bool
+
+unit: manifest entry
+id: has_led_wireless
+_name: Wireless
+_prompt: Does this machine have the following LED indicators?
+value-type: bool
+
+unit: manifest entry
+id: has_led_audio_mute
+_name: Audio mute
+_prompt: Does this machine have the following LED indicators?
+value-type: bool
+
+unit: manifest entry
+id: has_led_microphone_mute
+_name: Microphone mute
+_prompt: Does this machine have the following LED indicators?
+value-type: bool
+
+unit: manifest entry
+id: has_led_serial
+_name: Serial transfer
+_prompt: Does this machine have the following LED indicators?
+value-type: bool
+
+unit: manifest entry
+id: has_led_fn_lock
+_name: Function key lock (Fn lock)
+_prompt: Does this machine have the following LED indicators?
+value-type: bool
+
+unit: manifest entry
+id: has_led_numeric_keypad
+_name: Numeric keypad
+_prompt: Does this machine have the following LED indicators?
+value-type: bool

--- a/providers/base/units/led/test-plan.pxu
+++ b/providers/base/units/led/test-plan.pxu
@@ -5,8 +5,6 @@ _description:
  LED tests
  Notes: - led/power-blink-suspend and led/suspend are used later in the
           power management testplan just after a number of suspend tests.
-        - led/wireless is redundant given that we have led/wlan and
-          led/bluetooth already.
 include:
 nested_part:
  com.canonical.certification::led-cert-manual
@@ -20,8 +18,6 @@ _description:
     LED tests
     Notes: - led/power-blink-suspend and led/suspend are used later in the
              power management testplan just after a number of suspend tests.
-           - led/wireless is redundant given that we have led/wlan and
-             led/bluetooth already. (Manual)
 include:
     camera/led_.*                      certification-status=blocker
     led/caps-lock                      certification-status=blocker
@@ -30,6 +26,7 @@ include:
     led/fn                             certification-status=non-blocker
     led/mute                           certification-status=blocker
     led/microphone-mute                certification-status=blocker
+    led/wireless                       certification-status=blocker
 bootstrap_include:
     device
 
@@ -41,8 +38,6 @@ _description:
     LED tests
     Notes: - led/power-blink-suspend and led/suspend are used later in the
              power management testplan just after a number of suspend tests.
-           - led/wireless is redundant given that we have led/wlan and
-             led/bluetooth already. (Automated)
 include:
 
 
@@ -58,6 +53,7 @@ include:
     after-suspend-led/mute                      certification-status=blocker
     after-suspend-led/microphone-mute           certification-status=blocker
     after-suspend-led/fn                        certification-status=non-blocker
+    after-suspend-led/wireless                  certification-status=blocker
 bootstrap_include:
     device
 
@@ -73,6 +69,7 @@ include:
     led/power                          certification-status=blocker
     led/mute                           certification-status=blocker
     led/microphone-mute                certification-status=blocker
+    led/wireless                       certification-status=blocker
 bootstrap_include:
     device
 
@@ -88,6 +85,7 @@ include:
     suspend/led_after_suspend/power             certification-status=blocker
     after-suspend-led/mute                      certification-status=blocker
     after-suspend-led/microphone-mute           certification-status=blocker
+    after-suspend-led/wireless                  certification-status=blocker
 bootstrap_include:
     device
 
@@ -108,7 +106,7 @@ _description: Manual LED tests for IoT devices
 include:
     led/power
     led/power-blink-suspend
-    led/bluetooth
+    led/wireless
     led/serial
     led/fn
     led/sysfs_led_brightness_on_.*

--- a/providers/certification-client/units/client-cert-odm-desktop-18-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-desktop-18-04.pxu
@@ -83,9 +83,7 @@ exclude:
     com.canonical.certification::after-suspend-manual-keys/keyboard-backlight
     com.canonical.certification::after-suspend-manual-keys/microphone-mute
     com.canonical.certification::after-suspend-manual-keys/fn-lock
-    com.canonical.certification::led/bluetooth
-    com.canonical.certification::led/wlan
-    com.canonical.certification::led/wlan-disabled
+    com.canonical.certification::led/wireless
     com.canonical.certification::led/fn
     com.canonical.certification::led/mute
     com.canonical.certification::led/microphone-mute
@@ -194,9 +192,7 @@ exclude:
     com.canonical.certification::after-suspend-manual-keys/keyboard-backlight
     com.canonical.certification::after-suspend-manual-keys/microphone-mute
     com.canonical.certification::after-suspend-manual-keys/fn-lock
-    com.canonical.certification::led/bluetooth
-    com.canonical.certification::led/wlan
-    com.canonical.certification::led/wlan-disabled
+    com.canonical.certification::led/wireless
     com.canonical.certification::led/fn
     com.canonical.certification::led/mute
     com.canonical.certification::led/microphone-mute

--- a/providers/certification-client/units/client-cert-odm-desktop-20-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-desktop-20-04.pxu
@@ -85,9 +85,7 @@ exclude:
     com.canonical.certification::after-suspend-manual-keys/keyboard-backlight
     com.canonical.certification::after-suspend-manual-keys/microphone-mute
     com.canonical.certification::after-suspend-manual-keys/fn-lock
-    com.canonical.certification::led/bluetooth
-    com.canonical.certification::led/wlan
-    com.canonical.certification::led/wlan-disabled
+    com.canonical.certification::led/wireless
     com.canonical.certification::led/fn
     com.canonical.certification::led/mute
     com.canonical.certification::led/microphone-mute
@@ -198,9 +196,7 @@ exclude:
     com.canonical.certification::after-suspend-manual-keys/keyboard-backlight
     com.canonical.certification::after-suspend-manual-keys/microphone-mute
     com.canonical.certification::after-suspend-manual-keys/fn-lock
-    com.canonical.certification::led/bluetooth
-    com.canonical.certification::led/wlan
-    com.canonical.certification::led/wlan-disabled
+    com.canonical.certification::led/wireless
     com.canonical.certification::led/fn
     com.canonical.certification::led/mute
     com.canonical.certification::led/microphone-mute

--- a/providers/certification-client/units/client-cert-odm-desktop-22-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-desktop-22-04.pxu
@@ -86,9 +86,7 @@ exclude:
     com.canonical.certification::after-suspend-manual-keys/keyboard-backlight
     com.canonical.certification::after-suspend-manual-keys/microphone-mute
     com.canonical.certification::after-suspend-manual-keys/fn-lock
-    com.canonical.certification::led/bluetooth
-    com.canonical.certification::led/wlan
-    com.canonical.certification::led/wlan-disabled
+    com.canonical.certification::led/wireless
     com.canonical.certification::led/fn
     com.canonical.certification::led/mute
     com.canonical.certification::led/microphone-mute
@@ -199,9 +197,7 @@ exclude:
     com.canonical.certification::after-suspend-manual-keys/keyboard-backlight
     com.canonical.certification::after-suspend-manual-keys/microphone-mute
     com.canonical.certification::after-suspend-manual-keys/fn-lock
-    com.canonical.certification::led/bluetooth
-    com.canonical.certification::led/wlan
-    com.canonical.certification::led/wlan-disabled
+    com.canonical.certification::led/wireless
     com.canonical.certification::led/fn
     com.canonical.certification::led/mute
     com.canonical.certification::led/microphone-mute

--- a/providers/certification-client/units/client-cert-odm-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-odm-desktop-24-04.pxu
@@ -82,9 +82,7 @@ exclude:
     com.canonical.certification::after-suspend-manual-keys/keyboard-backlight
     com.canonical.certification::after-suspend-manual-keys/microphone-mute
     com.canonical.certification::after-suspend-manual-keys/fn-lock
-    com.canonical.certification::led/bluetooth
-    com.canonical.certification::led/wlan
-    com.canonical.certification::led/wlan-disabled
+    com.canonical.certification::led/wireless
     com.canonical.certification::led/fn
     com.canonical.certification::led/mute
     com.canonical.certification::led/microphone-mute
@@ -191,9 +189,7 @@ exclude:
     com.canonical.certification::after-suspend-manual-keys/keyboard-backlight
     com.canonical.certification::after-suspend-manual-keys/microphone-mute
     com.canonical.certification::after-suspend-manual-keys/fn-lock
-    com.canonical.certification::led/bluetooth
-    com.canonical.certification::led/wlan
-    com.canonical.certification::led/wlan-disabled
+    com.canonical.certification::led/wireless
     com.canonical.certification::led/fn
     com.canonical.certification::led/mute
     com.canonical.certification::led/microphone-mute


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

In order to prevent tester from having to manually skip tests that check LEDs that might not be present on a device, this PR introduces manifest entries for all the LED checks that are currently used, so that the tester can select what LED indicators the DUT has:

![image](https://github.com/user-attachments/assets/eb31c83a-a79b-4e40-bde2-b088310ab2b5)


Before this PR, there was only one generic `has_led_indicator` that originally came from the CE-OEM provider to test some IoT-specific LEDs. This manifest entry is renamed to a more specific `has_led_gpio_sysfs` and grouped with the other LED manifest entries using the same prompt.

Please check individual commit messages for more information.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/CHECKBOX-1322

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

Running a Desktop Cert test plan and selecting the LED tests, the new manifest entries are displayed and can be tailored to match the LEDs available in the DUT.
