### PR TITLE
Re-introduce default provider (infra)

### DIFF
--- a/checkbox-snap/series_uc24/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc24/snap/snapcraft.yaml
@@ -13,30 +13,39 @@ plugs:
   checkbox-runtime:
     interface: content
     target: $SNAP/checkbox-runtime
+    default-provider: checkbox24
   provider-resource:
     interface: content
     target: $SNAP/providers/checkbox-provider-resource
+    default-provider: checkbox24
   provider-checkbox:
     interface: content
     target: $SNAP/providers/checkbox-provider-checkbox
+    default-provider: checkbox24
   provider-docker:
     interface: content
     target: $SNAP/providers/checkbox-provider-docker
+    default-provider: checkbox24
   provider-tpm2:
     interface: content
     target: $SNAP/providers/checkbox-provider-tpm2
+    default-provider: checkbox24
   provider-sru:
     interface: content
     target: $SNAP/providers/checkbox-provider-sru
+    default-provider: checkbox24
   provider-gpgpu:
     interface: content
     target: $SNAP/providers/checkbox-provider-gpgpu
+    default-provider: checkbox24
   provider-certification-client:
     interface: content
     target: $SNAP/providers/checkbox-provider-certification-client
+    default-provider: checkbox24
   provider-certification-server:
     interface: content
     target: $SNAP/providers/checkbox-provider-certification-server
+    default-provider: checkbox24
 
 apps:
   checkbox-cli:


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The default provider constraint is used to automatically plug interfaces and install a sound default dependency for a frontend snap. We had to remove this as it doesn't allow us to build a snap if the default-provider doesn't have a "stable" version. Now we do have one, so we can re-introduce it

## Resolved issues

N/A

## Documentation

N/A

## Tests

Built and installed the snap. It now works as intended
