### PR TITLE
Add parser to parse wifi interface name which is not start with phy (BugFix)

### DIFF
--- a/.github/workflows/tox-provider-resource.yaml
+++ b/.github/workflows/tox-provider-resource.yaml
@@ -47,6 +47,10 @@ jobs:
           python-version: ${{ matrix.python }}
         env:
           PIP_TRUSTED_HOST: pypi.python.org pypi.org files.pythonhosted.org
+      - name: Install libsystemd-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsystemd-dev
       - name: Install tox
         run: pip install tox
       - name: Run tox

--- a/providers/base/units/wireless/nm-hotspot.pxu
+++ b/providers/base/units/wireless/nm-hotspot.pxu
@@ -15,7 +15,7 @@ category_id: wifi_ap
 estimated_duration: 10
 flags: preserve-locale also-after-suspend
 requires:
- wifi_interface_mode.{{ interface }}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{{ interface }}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{{ interface }}' and net_if_management.master_mode_managed_by == 'NetworkManager'
  {%- if __on_ubuntucore__ %}
  connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager'
@@ -39,7 +39,7 @@ category_id: wifi_ap
 estimated_duration: 10
 flags: preserve-locale also-after-suspend
 requires:
- wifi_interface_mode.{{ interface }}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{{ interface }}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{{ interface }}' and net_if_management.master_mode_managed_by == 'NetworkManager'
  {%- if __on_ubuntucore__ %}
  connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager'

--- a/providers/base/units/wireless/wifi-ap.pxu
+++ b/providers/base/units/wireless/wifi-ap.pxu
@@ -8,7 +8,7 @@ category_id: wifi_ap
 _summary: Create open 802.11a Wi-Fi AP on {interface} with no STA (Manual)
 plugin: manual
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 _purpose:
@@ -65,7 +65,7 @@ command:
     exit 1;
  fi
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: WIFI_AP_SETUPTIME
@@ -81,7 +81,7 @@ category_id: wifi_ap
 _summary: Create open 802.11b Wi-Fi AP on {interface} with no STA (Manual)
 plugin: manual
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 _purpose:
@@ -138,7 +138,7 @@ command:
     exit 1;
  fi
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: WIFI_AP_SETUPTIME
@@ -154,7 +154,7 @@ category_id: wifi_ap
 _summary: Create open 802.11g Wi-Fi AP on {interface} with no STA (Manual)
 plugin: manual
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 _purpose:
@@ -211,7 +211,7 @@ command:
     exit 1;
  fi
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: WIFI_AP_SETUPTIME
@@ -227,7 +227,7 @@ category_id: wifi_ap
 _summary: Create open 802.11ad Wi-Fi AP on {interface} with no STA (Manual)
 plugin: manual
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 _purpose:
@@ -284,7 +284,7 @@ command:
     exit 1;
  fi
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: WIFI_AP_SETUPTIME
@@ -300,7 +300,7 @@ category_id: wifi_ap
 _summary: Create WPA2 802.11a Wi-Fi AP on {interface} with no STA (Manual)
 plugin: manual
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 _purpose:
@@ -359,7 +359,7 @@ command:
     exit 1;
  fi
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: WIFI_AP_SETUPTIME
@@ -375,7 +375,7 @@ category_id: wifi_ap
 _summary: Create WPA2 802.11b Wi-Fi AP on {interface} with no STA (Manual)
 plugin: manual
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{{ interface }}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 _purpose:
@@ -434,7 +434,7 @@ command:
     exit 1;
  fi
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: WIFI_AP_SETUPTIME
@@ -450,7 +450,7 @@ category_id: wifi_ap
 _summary: Create WPA2 802.11g Wi-Fi AP on {interface} with no STA (Manual)
 plugin: manual
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 _purpose:
@@ -507,7 +507,7 @@ command:
     exit 1;
  fi
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: WIFI_AP_SETUPTIME
@@ -523,7 +523,7 @@ category_id: wifi_ap
 _summary: Create WPA2 802.11ad Wi-Fi AP on {interface} with no STA (Manual)
 plugin: manual
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 _purpose:
@@ -582,7 +582,7 @@ command:
     exit 1;
  fi
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: WIFI_AP_SETUPTIME
@@ -598,7 +598,7 @@ category_id: wifi_ap
 _summary: Create WPA2 802.11a Wi-Fi AP on {interface} with active STA (Manual)
 plugin: user-interact-verify
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: LD_LIBRARY_PATH OPEN_BG_SSID
@@ -637,7 +637,7 @@ category_id: wifi_ap
 _summary: Create WPA2 802.11a Wi-Fi Access Point on {interface} with active STA
 plugin: shell
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: LD_LIBRARY_PATH OPEN_BG_SSID WIFI_AP_SETUPTIME
@@ -686,7 +686,7 @@ category_id: wifi_ap
 _summary: Create WPA2 802.11b Wi-Fi AP on {interface} with active STA (Manual)
 plugin: user-interact-verify
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: LD_LIBRARY_PATH OPEN_BG_SSID
@@ -725,7 +725,7 @@ category_id: wifi_ap
 _summary: Create a WPA2 802.11b Wi-Fi Access Point on {interface} with active STA
 plugin: shell
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: LD_LIBRARY_PATH OPEN_BG_SSID WIFI_AP_SETUPTIME
@@ -774,7 +774,7 @@ category_id: wifi_ap
 _summary: Create WPA2 802.11g Wi-Fi AP on {interface} with active STA (Manual)
 plugin: user-interact-verify
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: LD_LIBRARY_PATH OPEN_BG_SSID
@@ -813,7 +813,7 @@ category_id: wifi_ap
 _summary: Create WPA2 802.11g Wi-Fi Access Point on {interface} with active STA
 plugin: shell
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: LD_LIBRARY_PATH OPEN_BG_SSID WIFI_AP_SETUPTIME
@@ -862,7 +862,7 @@ category_id: wifi_ap
 _summary: Create WPA2 802.11ad Wi-Fi AP on {interface} with active STA (Manual)
 plugin: user-interact-verify
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: LD_LIBRARY_PATH OPEN_BG_SSID
@@ -901,7 +901,7 @@ category_id: wifi_ap
 _summary: Create WPA2 802.11ad Wi-Fi Access Point on {interface} with active STA
 plugin: shell
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: LD_LIBRARY_PATH OPEN_BG_SSID WIFI_AP_SETUPTIME
@@ -950,7 +950,7 @@ category_id: wifi_ap
 _summary: Create Access Point on {interface} using wifi-ap.setup-wizard
 plugin: shell
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 20.0
 user: root
@@ -998,7 +998,7 @@ command:
  echo "Rebooting"
  reboot
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: WIFI_AP_SETUPTIME
@@ -1035,7 +1035,7 @@ command:
  sleep "${{WIFI_AP_SETUPTIME:-10}}"
  reboot
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 estimated_duration: 120.0
 environ: WIFI_AP_SETUPTIME
@@ -1067,7 +1067,7 @@ command:
     exit 1;
  fi
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 depends: wireless/wifi_ap_across_reboot_{interface}_setup
 estimated_duration: 120.0
@@ -1093,7 +1093,7 @@ command:
  wifi-ap.config set disabled=true
  if [ "$RES" -eq 2 ]; then exit 0; else exit 1; fi
 requires:
- wifi_interface_mode.{interface}_AP == 'supported'
+ ( wifi_interface_mode.interface == '{interface}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{interface}' and net_if_management.master_mode_managed_by == 'wifi-ap'
 depends: wireless/wifi_ap_across_reboot_{interface}_setup_manual
 estimated_duration: 120.0

--- a/providers/resource/bin/wifi_interface_mode.py
+++ b/providers/resource/bin/wifi_interface_mode.py
@@ -26,43 +26,46 @@ def get_interfaces() -> List[Tuple[str, str]]:
     raise SystemExit(0)
 
 
-def get_wiphy_info() -> List[Tuple[str, List[str]]]:
+def get_wiphy_info():
     # We can not use command "iw phy0 info" to get the infomation of sepcific
     # interface.
     # Because of "phy0" in command could be other pattern like "mwiphy0".
     # And such pattern as "mwiphy0" will only show in the output of command
     # "iw phy".
-    output = run_command(["iw", "phy"])
-    if output:
-        contents = re.split(r"Wiphy\s+", output)
-        index_pattern = r"phy(\d+)"
-        wiphy_info = []
-        for content in contents:
-            if content.strip():
-                match_index = re.search(
-                    index_pattern, content, re.DOTALL
-                ).group(1)
-                supported_mode_pattern = (
-                    r"Supported interface modes:\s*((?:\s*\*\s*[\w/-]+\s*)+)"
-                )
-                match_modes = re.search(
-                    supported_mode_pattern, content, re.DOTALL
-                )
-                if match_modes:
-                    modes = re.findall(r"\*\s*([\w/-]+)", match_modes.group(1))
+    output = check_output(["iw", "phy"], universal_newlines=True)
+    if not output:
+        return []
 
-                    wiphy_info.append((match_index, modes))
-        return wiphy_info
+    interfaces_info = (info.strip() for info in output.split("Wiphy"))
+    # drop empty sections
+    interfaces_info = filter(bool, interfaces_info)
+    index_re = re.compile(r"phy(\d+)")
+    wiphy_info = {}
+    supported_modes_re = re.compile(
+        r"Supported interface modes:\s*((?:\s*\*\s*[\w/-]+\s*)+)"
+    )
+    for interface_info in interfaces_info:
+        interface_id = index_re.search(interface_info).group(1)
+        match_modes = supported_modes_re.search(interface_info).group(1)
+
+        supported_modes = map(str.strip, match_modes.split("*"))
+        # remove first element because it is spaces before the first *
+        _ = next(supported_modes)
+        wiphy_info[interface_id] = list(supported_modes)
 
 
 def print_supported_modes() -> str:
     interfaces = get_interfaces()
     wiphy_info = get_wiphy_info()
-    for wiphy_index, modes in wiphy_info:
-        for device_index, interface in interfaces:
-            if wiphy_index == device_index:
-                for mode in modes:
-                    print("{}_{}: supported".format(interface, mode))
+    for wiphy_index, modes in wiphy_info.items():
+        interface = interfaces[wiphy_index]
+        for mode in modes:
+            print(
+                "{}_{}: supported".format(
+                    interface, mode.replace("-", "_").replace("/", "_")
+                )
+            )
+        print()
 
 
 def main():

--- a/providers/resource/bin/wifi_interface_mode.py
+++ b/providers/resource/bin/wifi_interface_mode.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+import subprocess
+import re
+from typing import List, Tuple
+
+
+def run_command(command: List[str]) -> str:
+    try:
+        result = subprocess.run(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        return result.stdout.decode("utf-8")
+    except Exception as e:
+        raise SystemError("An unexpected error occurred: {}", e)
+
+
+def get_interfaces() -> List[Tuple[str, str]]:
+    output = run_command(["iw", "dev"])
+    interface_pattern = r"phy#(\d+).*?Interface (\S+)"
+    if output:
+        matches = re.findall(interface_pattern, output, re.DOTALL)
+        return [(phy, interface) for phy, interface in matches]
+    return []
+
+
+def get_wiphy_info() -> List[Tuple[str, List[str]]]:
+    output = run_command(["iw", "phy"])
+    if output:
+        contents = re.split(r"Wiphy\s+", output)
+        index_pattern = r"phy(\d+)"
+        wiphy_info = []
+        for content in contents:
+            if content.strip():
+                match_index = re.search(
+                    index_pattern, content, re.DOTALL
+                ).group(1)
+                supported_mode_pattern = (
+                    r"Supported interface modes:\s*((?:\s*\*\s*[\w/-]+\s*)+)"
+                )
+                match_modes = re.search(
+                    supported_mode_pattern, content, re.DOTALL
+                )
+                if match_modes:
+                    modes = re.findall(r"\*\s*([\w/-]+)", match_modes.group(1))
+
+                    wiphy_info.append((match_index, modes))
+    return wiphy_info
+
+
+def print_supported_modes(
+    interfaces: List[Tuple[str, str]], wiphy_info: List[Tuple[str, List[str]]]
+) -> str:
+    for wiphy_index, modes in wiphy_info:
+        for interface_index, interface in interfaces:
+            if wiphy_index == interface_index:
+                for mode in modes:
+                    print("{}_{}: supported".format(interface, mode))
+
+
+def main():
+    interfaces = get_interfaces()
+    if not interfaces:
+        print("")
+        return
+    wiphy_info = get_wiphy_info()
+    print_supported_modes(interfaces, wiphy_info)
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/resource/bin/wifi_interface_mode.py
+++ b/providers/resource/bin/wifi_interface_mode.py
@@ -11,19 +11,27 @@ def run_command(command: List[str]) -> str:
         )
         return result.stdout.decode("utf-8")
     except Exception as e:
-        raise SystemError("An unexpected error occurred: {}", e)
+        raise SystemError("An unexpected error occurred: {}".format(e))
 
 
 def get_interfaces() -> List[Tuple[str, str]]:
     output = run_command(["iw", "dev"])
-    interface_pattern = r"phy#(\d+).*?Interface (\S+)"
+    device_pattern = r"phy#(\d+).*?Interface (\S+)"
     if output:
-        matches = re.findall(interface_pattern, output, re.DOTALL)
-        return [(phy, interface) for phy, interface in matches]
-    return []
+        matches = re.findall(device_pattern, output, re.DOTALL)
+        return [
+            (device_id, interface_name)
+            for device_id, interface_name in matches
+        ]
+    raise SystemExit(0)
 
 
 def get_wiphy_info() -> List[Tuple[str, List[str]]]:
+    # We can not use command "iw phy0 info" to get the infomation of sepcific
+    # interface.
+    # Because of "phy0" in command could be other pattern like "mwiphy0".
+    # And such pattern as "mwiphy0" will only show in the output of command
+    # "iw phy".
     output = run_command(["iw", "phy"])
     if output:
         contents = re.split(r"Wiphy\s+", output)
@@ -44,26 +52,21 @@ def get_wiphy_info() -> List[Tuple[str, List[str]]]:
                     modes = re.findall(r"\*\s*([\w/-]+)", match_modes.group(1))
 
                     wiphy_info.append((match_index, modes))
-    return wiphy_info
+        return wiphy_info
 
 
-def print_supported_modes(
-    interfaces: List[Tuple[str, str]], wiphy_info: List[Tuple[str, List[str]]]
-) -> str:
+def print_supported_modes() -> str:
+    interfaces = get_interfaces()
+    wiphy_info = get_wiphy_info()
     for wiphy_index, modes in wiphy_info:
-        for interface_index, interface in interfaces:
-            if wiphy_index == interface_index:
+        for device_index, interface in interfaces:
+            if wiphy_index == device_index:
                 for mode in modes:
                     print("{}_{}: supported".format(interface, mode))
 
 
 def main():
-    interfaces = get_interfaces()
-    if not interfaces:
-        print("")
-        return
-    wiphy_info = get_wiphy_info()
-    print_supported_modes(interfaces, wiphy_info)
+    print_supported_modes()
 
 
 if __name__ == "__main__":

--- a/providers/resource/jobs/resource.pxu
+++ b/providers/resource/jobs/resource.pxu
@@ -372,12 +372,7 @@ estimated_duration: 0.1
 plugin: resource
 category_id: information_gathering
 command:
- # shellcheck disable=SC2046
- for i in $(iw dev | grep -oP 'Interface\s+\K\w+');
- do iw phy phy$(iw dev "$i" info | grep -oP 'wiphy\s+\K\d+') info |
- grep -Pzo '(?s)Supported interface modes:\n\K(\s+\*\s.*?\n)+' |
- sed "s/.*\* \(.*\)/""$i""_\1: supported/" | tr -d '\000';
- done
+  wifi_interface_mode.py
 _summary: Create resource info for supported wifi interface modes
 
 id: snap

--- a/providers/resource/tests/test_wifi_interface_mode.py
+++ b/providers/resource/tests/test_wifi_interface_mode.py
@@ -25,9 +25,7 @@ class TestWiFiFunctions(unittest.TestCase):
         with self.assertRaises(SystemError):
             run_command(["echo", "hello"])
 
-    @patch(
-        "wifi_interface_mode.run_command"
-    )
+    @patch("wifi_interface_mode.run_command")
     def test_get_interfaces(self, mock_run_command):
         mock_run_command.return_value = """
         phy#0
@@ -39,9 +37,7 @@ class TestWiFiFunctions(unittest.TestCase):
         result = get_interfaces()
         self.assertEqual(result, expected)
 
-    @patch(
-        "wifi_interface_mode.run_command"
-    )
+    @patch("wifi_interface_mode.run_command")
     def test_get_wiphy_info_with_one_phy(self, mock_run_command):
         mock_run_command.return_value = """Wiphy phy0
         Supported interface modes:
@@ -52,17 +48,13 @@ class TestWiFiFunctions(unittest.TestCase):
         expected = [
             (
                 "0",
-                ["managed",
-                 "AP/VLAN",
-                 "monitor"],
+                ["managed", "AP/VLAN", "monitor"],
             ),
         ]
         result = get_wiphy_info()
         self.assertEqual(result, expected)
 
-    @patch(
-        "wifi_interface_mode.run_command"
-    )
+    @patch("wifi_interface_mode.run_command")
     def test_get_wiphy_info_with_phy_start_with_mwi(self, mock_run_command):
         mock_run_command.return_value = """Wiphy mwiphy0
         Supported interface modes:
@@ -73,17 +65,13 @@ class TestWiFiFunctions(unittest.TestCase):
         expected = [
             (
                 "0",
-                ["managed",
-                 "AP/VLAN",
-                 "monitor"],
+                ["managed", "AP/VLAN", "monitor"],
             ),
         ]
         result = get_wiphy_info()
         self.assertEqual(result, expected)
 
-    @patch(
-        "wifi_interface_mode.run_command"
-    )
+    @patch("wifi_interface_mode.run_command")
     def test_get_wiphy_info_with_two_phy(self, mock_run_command):
         mock_run_command.return_value = """Wiphy phy0
         Supported interface modes:
@@ -99,37 +87,27 @@ class TestWiFiFunctions(unittest.TestCase):
         expected = [
             (
                 "0",
-                ["managed",
-                 "AP/VLAN",
-                 "monitor"],
+                ["managed", "AP/VLAN", "monitor"],
             ),
             (
                 "1",
-                ["managed",
-                 "AP/VLAN",
-                 "P2P-client"],
+                ["managed", "AP/VLAN", "P2P-client"],
             ),
         ]
         result = get_wiphy_info()
         self.assertEqual(result, expected)
 
-    @patch(
-        "wifi_interface_mode.run_command"
-    )
+    @patch("wifi_interface_mode.run_command")
     def test_print_supported_modes(self, mock_run_command):
         interfaces = [("0", "wlan0"), ("1", "wlan1")]
         wiphy_ids = [
             (
                 "0",
-                ["managed",
-                 "AP/VLAN",
-                 "monitor"],
+                ["managed", "AP/VLAN", "monitor"],
             ),
             (
                 "1",
-                ["managed",
-                 "AP/VLAN",
-                 "P2P-client"],
+                ["managed", "AP/VLAN", "P2P-client"],
             ),
         ]
 

--- a/providers/resource/tests/test_wifi_interface_mode.py
+++ b/providers/resource/tests/test_wifi_interface_mode.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+
+import unittest
+from unittest.mock import patch, MagicMock
+from wifi_interface_mode import (
+    run_command,
+    get_interfaces,
+    get_wiphy_info,
+    print_supported_modes,
+)
+
+
+class TestWiFiFunctions(unittest.TestCase):
+    @patch("subprocess.run")
+    def test_run_command_success(self, mock_run):
+        mock_run.return_value = MagicMock(
+            stdout=b"output", stderr=b"", returncode=0
+        )
+        result = run_command(["echo", "hello"])
+        self.assertEqual(result, "output")
+
+    @patch("subprocess.run")
+    def test_run_command_failure(self, mock_run):
+        mock_run.side_effect = Exception("Command failed")
+        with self.assertRaises(SystemError):
+            run_command(["echo", "hello"])
+
+    @patch(
+        "wifi_interface_mode.run_command"
+    )
+    def test_get_interfaces(self, mock_run_command):
+        mock_run_command.return_value = """
+        phy#0
+            Interface wlan0
+        phy#1
+            Interface wlan1
+        """
+        expected = [("0", "wlan0"), ("1", "wlan1")]
+        result = get_interfaces()
+        self.assertEqual(result, expected)
+
+    @patch(
+        "wifi_interface_mode.run_command"
+    )
+    def test_get_wiphy_info_with_one_phy(self, mock_run_command):
+        mock_run_command.return_value = """Wiphy phy0
+        Supported interface modes:
+        * managed
+        * AP/VLAN
+        * monitor
+        """
+        expected = [
+            (
+                "0",
+                ["managed",
+                 "AP/VLAN",
+                 "monitor"],
+            ),
+        ]
+        result = get_wiphy_info()
+        self.assertEqual(result, expected)
+
+    @patch(
+        "wifi_interface_mode.run_command"
+    )
+    def test_get_wiphy_info_with_phy_start_with_mwi(self, mock_run_command):
+        mock_run_command.return_value = """Wiphy mwiphy0
+        Supported interface modes:
+        * managed
+        * AP/VLAN
+        * monitor
+        """
+        expected = [
+            (
+                "0",
+                ["managed",
+                 "AP/VLAN",
+                 "monitor"],
+            ),
+        ]
+        result = get_wiphy_info()
+        self.assertEqual(result, expected)
+
+    @patch(
+        "wifi_interface_mode.run_command"
+    )
+    def test_get_wiphy_info_with_two_phy(self, mock_run_command):
+        mock_run_command.return_value = """Wiphy phy0
+        Supported interface modes:
+        * managed
+        * AP/VLAN
+        * monitor
+        Wiphy phy1
+        Supported interface modes:
+        * managed
+        * AP/VLAN
+        * P2P-client
+        """
+        expected = [
+            (
+                "0",
+                ["managed",
+                 "AP/VLAN",
+                 "monitor"],
+            ),
+            (
+                "1",
+                ["managed",
+                 "AP/VLAN",
+                 "P2P-client"],
+            ),
+        ]
+        result = get_wiphy_info()
+        self.assertEqual(result, expected)
+
+    @patch(
+        "wifi_interface_mode.run_command"
+    )
+    def test_print_supported_modes(self, mock_run_command):
+        interfaces = [("0", "wlan0"), ("1", "wlan1")]
+        wiphy_ids = [
+            (
+                "0",
+                ["managed",
+                 "AP/VLAN",
+                 "monitor"],
+            ),
+            (
+                "1",
+                ["managed",
+                 "AP/VLAN",
+                 "P2P-client"],
+            ),
+        ]
+
+        # Mock print to capture output
+        with patch("builtins.print") as mock_print:
+            print_supported_modes(interfaces, wiphy_ids)
+            expected_output = [
+                "wlan0_managed: supported",
+                "wlan0_AP/VLAN: supported",
+                "wlan0_monitor: supported",
+                "wlan1_managed: supported",
+                "wlan1_AP/VLAN: supported",
+                "wlan1_P2P-client: supported",
+            ]
+            for output in expected_output:
+                mock_print.assert_any_call(output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
Add a parser to parse out the phy name as follows:

phy name start with phy.
```
root@ubuntu:/home/ubuntu# iw phy
Wiphy phy0
	wiphy index: 0
	max # scan SSIDs: 20
	max scan IEs length: 365 bytes
```

phy name start with other string.
```
root@ubuntu:/home/ubuntu# iw phy
Wiphy mwiphy1
	wiphy index: 1
	max # scan SSIDs: 10
	max scan IEs length: 256 bytes
```
Please refer to this [PR](https://github.com/canonical/checkbox/pull/1099) for previous discussion.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
This change is trying to fix the [issue](https://github.com/canonical/checkbox/issues/1048)
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
Side load result of _IoT Arm64 with 2 wlan interfaces on UC22_
```
==============[ Running job 1 / 1. Estimated time left: 0:00:00 ]===============
----------[ Create resource info for supported wifi interface modes ]-----------
ID: com.canonical.certification::wifi_interface_mode
Category: com.canonical.certification::information_gathering
... 8< -------------------------------------------------------------------------
wlP1p1s0f1_managed: supported
wlP1p1s0f1_AP: supported
wlP1p1s0f1_P2P-client: supported
wlP1p1s0f1_P2P-GO: supported
wlP1p1s0f0_managed: supported
wlP1p1s0f0_AP: supported
wlP1p1s0f0_P2P-client: supported
wlP1p1s0f0_P2P-GO: supported
------------------------------------------------------------------------- >8 ---
Outcome: job passed
```


Side load result of _IoT Arm64 with one wlan interface on UC20_
```
----------[ Create resource info for supported wifi interface modes ]-----------
ID: com.canonical.certification::wifi_interface_mode
Category: com.canonical.certification::information_gathering
... 8< -------------------------------------------------------------------------
wlan0_IBSS: supported
wlan0_managed: supported
wlan0_AP: supported
wlan0_P2P-client: supported
wlan0_P2P-GO: supported
wlan0_P2P-device: supported
------------------------------------------------------------------------- >8 ---
Outcome: job passed
```

Side load result of _Desktop AMD64 with one wlan interface on 24.04_
```
----------[ Create resource info for supported wifi interface modes ]-----------
ID: com.canonical.certification::wifi_interface_mode
Category: com.canonical.certification::information_gathering
... 8< -------------------------------------------------------------------------
wlp130s0f0_IBSS: supported
wlp130s0f0_managed: supported
wlp130s0f0_AP: supported
wlp130s0f0_AP/VLAN: supported
wlp130s0f0_monitor: supported
wlp130s0f0_P2P-client: supported
wlp130s0f0_P2P-GO: supported
wlp130s0f0_P2P-device: supported
------------------------------------------------------------------------- >8 ---
Outcome: job passed
```

Side load result of _Desktop AMD64 with one wlan interface on 22.04_
```
----------[ Create resource info for supported wifi interface modes ]-----------
ID: com.canonical.certification::wifi_interface_mode
Category: com.canonical.certification::information_gathering
... 8< -------------------------------------------------------------------------
wlp0s20f3_IBSS: supported
wlp0s20f3_managed: supported
wlp0s20f3_AP: supported
wlp0s20f3_AP/VLAN: supported
wlp0s20f3_monitor: supported
wlp0s20f3_P2P-client: supported
wlp0s20f3_P2P-GO: supported
wlp0s20f3_P2P-device: supported
------------------------------------------------------------------------- >8 ---
Outcome: job passed
```

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
