### PR TITLE
EDID test fails at maximum resolution (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -68,7 +68,7 @@ class MonitorConfigGnome(MonitorConfig):
     def set_extended_mode(self) -> Dict[str, str]:
         """
         Set to extend mode so that each monitor can be displayed
-        at maximum resolution.
+        at preferred, or if missing, maximum resolution.
 
         :return configuration: ordered list of applied Configuration
         """
@@ -79,7 +79,10 @@ class MonitorConfigGnome(MonitorConfig):
 
         position_x = 0
         for monitor, modes in state[1].items():
-            max_mode = self._get_mode_at_max(modes)
+            try:
+                target_mode = next(mode for mode in modes if mode.is_preferred)
+            except StopIteration:
+                target_mode = self._get_mode_at_max(modes)
             extended_logical_monitors.append(
                 (
                     position_x,
@@ -87,11 +90,11 @@ class MonitorConfigGnome(MonitorConfig):
                     1.0,
                     0,
                     position_x == 0,  # first monitor is primary
-                    [(monitor, max_mode.id, {})],
+                    [(monitor, target_mode.id, {})],
                 )
             )
-            position_x += int(max_mode.resolution.split("x")[0])
-            configuration[monitor] = max_mode.resolution
+            position_x += int(target_mode.resolution.split("x")[0])
+            configuration[monitor] = target_mode.resolution
 
         self._apply_monitors_config(state[0], extended_logical_monitors)
         return configuration

--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -22,7 +22,7 @@ Original script that inspired this class:
 """
 
 from collections import namedtuple
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Set
 from gi.repository import GLib, Gio
 
 from checkbox_support.monitor_config import MonitorConfig
@@ -53,6 +53,11 @@ class MonitorConfigGnome(MonitorConfig):
             interface_name=self.INTERFACE,
             cancellable=None,
         )
+
+    def get_connected_monitors(self) -> Set[str]:
+        """Get list of connected monitors, even if inactive."""
+        state = self._get_current_state()
+        return {monitor for monitor in state[1]}
 
     def get_current_resolutions(self) -> Dict[str, str]:
         """Get current active resolutions for each monitor."""

--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -65,18 +65,21 @@ class MonitorConfigGnome(MonitorConfig):
             if mode.is_current
         }
 
-    def set_extended_mode(self):
+    def set_extended_mode(self) -> Dict[str, str]:
         """
         Set to extend mode so that each monitor can be displayed
-        at preferred resolution.
+        at maximum resolution.
+
+        :return configuration: ordered list of applied Configuration
         """
         state = self._get_current_state()
 
         extended_logical_monitors = []
+        configuration = {}
 
         position_x = 0
         for monitor, modes in state[1].items():
-            preferred = next(mode for mode in modes if mode.is_preferred)
+            max_mode = self._get_mode_at_max(modes)
             extended_logical_monitors.append(
                 (
                     position_x,
@@ -84,12 +87,14 @@ class MonitorConfigGnome(MonitorConfig):
                     1.0,
                     0,
                     position_x == 0,  # first monitor is primary
-                    [(monitor, preferred.id, {})],
+                    [(monitor, max_mode.id, {})],
                 )
             )
-            position_x += int(preferred.resolution.split("x")[0])
+            position_x += int(max_mode.resolution.split("x")[0])
+            configuration[monitor] = max_mode.resolution
 
         self._apply_monitors_config(state[0], extended_logical_monitors)
+        return configuration
 
     def _get_current_state(self) -> Tuple[str, Dict[str, List[Mode]]]:
         """

--- a/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
@@ -127,9 +127,9 @@ class MonitorConfigGnomeTests(unittest.TestCase):
                             [1.0, 2.0],
                             {
                                 "is-current": GLib.Variant("b", True),
-                                "is-preferred": GLib.Variant("b", True),
+                                "is-preferred": GLib.Variant("b", False),
                             },
-                        )
+                        ),
                     ],
                     {
                         "is-builtin": GLib.Variant("b", False),
@@ -140,7 +140,7 @@ class MonitorConfigGnomeTests(unittest.TestCase):
             [],
             {},
         )
-        gnome_monitor.set_extended_mode()
+        configuration = gnome_monitor.set_extended_mode()
 
         logical_monitors = [
             (0, 0, 1.0, 0, True, [("eDP-1", "1920x1200@59.950", {})]),
@@ -162,3 +162,8 @@ class MonitorConfigGnomeTests(unittest.TestCase):
             timeout_msec=-1,
             cancellable=None,
         )
+        expected = {
+            "eDP-1": "1920x1200",
+            "HDMI-1": "2560x1440",
+        }
+        self.assertDictEqual(configuration, expected)

--- a/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
@@ -15,6 +15,69 @@ class MonitorConfigGnomeTests(unittest.TestCase):
     """This class provides test cases for the MonitorConfig DBus class."""
 
     @patch("checkbox_support.dbus.gnome_monitor.Gio.DBusProxy")
+    def test_get_connected_monitors(self, mock_dbus_proxy):
+        """
+        Test whether the function returns a list of connected
+        monitors, even if inactive.
+        """
+
+        mock_proxy = Mock()
+        mock_dbus_proxy.new_for_bus_sync.return_value = mock_proxy
+
+        gnome_monitor = MonitorConfigGnome()
+        mock_proxy.call_sync.return_value = (
+            1,
+            [
+                (
+                    ("eDP-1", "LGD", "0x06b3", "0x00000000"),
+                    [
+                        (
+                            "1920x1200@59.950",
+                            1920,
+                            1200,
+                            59.950172424316406,
+                            1.0,
+                            [1.0, 2.0],
+                            {
+                                "is-current": GLib.Variant("b", True),
+                                "is-preferred": GLib.Variant("b", True),
+                            },
+                        )
+                    ],
+                    {
+                        "is-builtin": GLib.Variant("b", True),
+                        "display-name": GLib.Variant("s", "Built-in display"),
+                    },
+                ),
+                (
+                    ("HDMI-1", "LGD", "0x06b3", "0x00000000"),
+                    [
+                        (
+                            "2560x1440@59.950",
+                            2560,
+                            1440,
+                            59.950172424316406,
+                            1.0,
+                            [1.0, 2.0],
+                            {
+                                "is-current": GLib.Variant("b", False),
+                                "is-preferred": GLib.Variant("b", True),
+                            },
+                        )
+                    ],
+                    {
+                        "is-builtin": GLib.Variant("b", False),
+                        "display-name": GLib.Variant("s", "External Display"),
+                    },
+                ),
+            ],
+            [],
+            {},
+        )
+        monitors = gnome_monitor.get_connected_monitors()
+        self.assertSetEqual(monitors, {"eDP-1", "HDMI-1"})
+
+    @patch("checkbox_support.dbus.gnome_monitor.Gio.DBusProxy")
     def test_get_current_resolution(self, mock_dbus_proxy):
         """
         Test whether the function returns a dictionary of

--- a/checkbox-support/checkbox_support/monitor_config.py
+++ b/checkbox-support/checkbox_support/monitor_config.py
@@ -45,14 +45,12 @@ class MonitorConfig(ABC):
 
     def _get_mode_at_max(self, modes) -> Mode:
         """Get mode with maximum resolution."""
-        max_area = 0
-        max_mode = None
-        for mode in modes:
-            horizontal, vertical = mode.resolution.split("x")
-            area = int(horizontal) * int(vertical)
-            if area > max_area:
-                max_area = area
-                max_mode = mode
-        if not max_mode:
-            raise ValueError("Provided modes are empty or invalid.")
-        return max_mode
+
+        def mode_area(mode):
+            w, h = mode.resolution.split("x")
+            return int(w) * int(h)
+
+        try:
+            return max(modes, key=mode_area)
+        except ValueError as e:
+            raise ValueError("Provided modes are empty or invalid.") from e

--- a/checkbox-support/checkbox_support/monitor_config.py
+++ b/checkbox-support/checkbox_support/monitor_config.py
@@ -20,13 +20,17 @@ set a new logical monitor configuration.
 
 from abc import ABC, abstractmethod
 from collections import namedtuple
-from typing import Dict
+from typing import Dict, Set
 
 Mode = namedtuple("Mode", ["resolution"])
 
 
 class MonitorConfig(ABC):
     """Get and modify the current Monitor configuration."""
+
+    @abstractmethod
+    def get_connected_monitors(self) -> Set[str]:
+        """Get list of connected monitors, even if inactive."""
 
     @abstractmethod
     def get_current_resolutions(self) -> Dict[str, str]:

--- a/checkbox-support/checkbox_support/monitor_config.py
+++ b/checkbox-support/checkbox_support/monitor_config.py
@@ -19,7 +19,10 @@ set a new logical monitor configuration.
 """
 
 from abc import ABC, abstractmethod
+from collections import namedtuple
 from typing import Dict
+
+Mode = namedtuple("Mode", ["resolution"])
 
 
 class MonitorConfig(ABC):
@@ -30,8 +33,22 @@ class MonitorConfig(ABC):
         """Get current active resolutions for each monitor."""
 
     @abstractmethod
-    def set_extended_mode(self):
+    def set_extended_mode(self) -> Dict[str, str]:
         """
         Set to extend mode so that each monitor can be displayed
         at preferred resolution.
         """
+
+    def _get_mode_at_max(self, modes) -> Mode:
+        """Get mode with maximum resolution."""
+        max_area = 0
+        max_mode = None
+        for mode in modes:
+            horizontal, vertical = mode.resolution.split("x")
+            area = int(horizontal) * int(vertical)
+            if area > max_area:
+                max_area = area
+                max_mode = mode
+        if not max_mode:
+            raise ValueError("Provided modes are empty or invalid.")
+        return max_mode

--- a/checkbox-support/checkbox_support/parsers/tests/test_xrandr.py
+++ b/checkbox-support/checkbox_support/parsers/tests/test_xrandr.py
@@ -9,6 +9,32 @@ class MonitorConfigX11Tests(unittest.TestCase):
     """This class provides test cases for the MonitorConfig X11 class."""
 
     @patch("subprocess.check_output")
+    def test_get_connected_monitors(self, mock_check_output):
+        """
+        Test whether the function returns a list of connected
+        monitors, even if inactive.
+        """
+
+        # In xrandr, the '*' is used for active monitors
+        mock_check_output.return_value = dedent(
+            """
+        Screen 0: minimum 320 x 200,
+        eDP connected primary 1920x1080+0+607
+           1680x1050     60.03 +
+           1920x1080     60.03*
+        HDMI-A-0 connected 2560x1440+1920+0
+           2560x1440     59.95+
+           1920x1080     60.00    50.00    59.94
+        DisplayPort-0 disconnected (normal left inverted right x axis y axis)
+        DisplayPort-1 disconnected (normal left inverted right x axis y axis)
+        """
+        )
+
+        x11_monitor = MonitorConfigX11()
+        monitors = x11_monitor.get_connected_monitors()
+        self.assertSetEqual(monitors, {"eDP", "HDMI-A-0"})
+
+    @patch("subprocess.check_output")
     def test_get_current_resolution(self, mock_check_output):
         """
         Test whether the function returns a dictionary of

--- a/checkbox-support/checkbox_support/parsers/tests/test_xrandr.py
+++ b/checkbox-support/checkbox_support/parsers/tests/test_xrandr.py
@@ -47,10 +47,11 @@ class MonitorConfigX11Tests(unittest.TestCase):
             """
         Screen 0: minimum 320 x 200,
         eDP connected primary 1920x1080+0+607
-           1680x1050     60.03 +
-           1920x1080     60.03*
+           1680x1050     60.03 
+           1920x1080     60.03*+
+           2560x1440     59.95
         HDMI-A-0 connected 2560x1440+1920+0
-           2560x1440     59.95*+
+           2560x1440     59.95*
            1920x1080     60.00    50.00    59.94
         DisplayPort-0 disconnected (normal left inverted right x axis y axis)
         DisplayPort-1 disconnected (normal left inverted right x axis y axis)

--- a/checkbox-support/checkbox_support/parsers/tests/test_xrandr.py
+++ b/checkbox-support/checkbox_support/parsers/tests/test_xrandr.py
@@ -58,10 +58,15 @@ class MonitorConfigX11Tests(unittest.TestCase):
         )
 
         x11_monitor = MonitorConfigX11()
-        x11_monitor.set_extended_mode()
+        configuration = x11_monitor.set_extended_mode()
         expected = (
             "xrandr "
             "--output HDMI-A-0 --mode 2560x1440 --primary --pos 0x0 "
-            "--output eDP --mode 1680x1050 --right-of HDMI-A-0"
+            "--output eDP --mode 1920x1080 --right-of HDMI-A-0"
         )
         mock_run.assert_called_with(expected.split(" "))
+        expected = {
+            "HDMI-A-0": "2560x1440",
+            "eDP": "1920x1080",
+        }
+        self.assertDictEqual(configuration, expected)

--- a/checkbox-support/checkbox_support/parsers/xrandr.py
+++ b/checkbox-support/checkbox_support/parsers/xrandr.py
@@ -61,31 +61,35 @@ class MonitorConfigX11(MonitorConfig):
             if mode.is_current
         }
 
-    def set_extended_mode(self):
+    def set_extended_mode(self) -> Dict[str, str]:
         """
         Set to extend mode so that each monitor can be displayed
-        at preferred resolution.
+        at maximum resolution.
+
+        :return configuration: ordered list of applied Configuration
         """
         state = self._get_current_state()
         cmd = ["xrandr"]
+        configuration = {}
 
         previous = None
         for monitor, modes in sorted(state.items()):
+            max_mode = self._get_mode_at_max(modes)
             xrandr_args = "--output {} --mode {} {}".format(
                 monitor,
-                next(mode.resolution for mode in modes if mode.is_preferred),
+                max_mode.resolution,
                 (
                     "--right-of {}".format(previous)
                     if previous
                     else "--primary --pos 0x0"
                 ),
             )
-
             previous = monitor
-
             cmd.extend(xrandr_args.split())
+            configuration[monitor] = max_mode.resolution
 
         subprocess.run(cmd)
+        return configuration
 
     def _parse_xrandr_line(self, line):
         """

--- a/checkbox-support/checkbox_support/parsers/xrandr.py
+++ b/checkbox-support/checkbox_support/parsers/xrandr.py
@@ -39,7 +39,7 @@ DP-3 AOC 2770M GDBFBHA000236
 import re
 import subprocess
 from collections import defaultdict, namedtuple
-from typing import Dict
+from typing import Dict, List, Set
 from checkbox_support.monitor_config import MonitorConfig
 
 Mode = namedtuple(
@@ -49,6 +49,11 @@ Mode = namedtuple(
 
 class MonitorConfigX11(MonitorConfig):
     """A generic monitor config for X11, based on xrandr."""
+
+    def get_connected_monitors(self) -> Set[str]:
+        """Get list of connected monitors, even if inactive."""
+        state = self._get_current_state()
+        return set(state.keys())
 
     def get_current_resolutions(self) -> Dict[str, str]:
         """Get current active resolutions for each monitor."""

--- a/providers/base/bin/edid_cycle.py
+++ b/providers/base/bin/edid_cycle.py
@@ -182,6 +182,7 @@ def main(args=None):
 
     try:
         monitor_config = display_info.get_monitor_config()
+        print("Running with `{}`.".format(monitor_config.__class__.__name__))
     except ValueError as exc:
         raise SystemExit("Current host is not supported.") from exc
 

--- a/providers/base/bin/edid_cycle.py
+++ b/providers/base/bin/edid_cycle.py
@@ -51,7 +51,7 @@ def discover_video_output_device(
     # and I'm waiting for the DUT to react to the EDID change.
     time.sleep(5)
 
-    devices = monitor_config.get_current_resolutions().keys()
+    devices = monitor_config.get_connected_monitors()
 
     # It doesn't really matter which EDID file we set in this function:
     # we just want to recognize the port type and index, not the resolution.
@@ -62,9 +62,7 @@ def discover_video_output_device(
     # enough for such changes to happen.
     targets = []
     for _ in range(5):
-        targets = list(
-            monitor_config.get_current_resolutions().keys() - devices
-        )
+        targets = monitor_config.get_connected_monitors() - devices
         if targets:
             break
 
@@ -76,7 +74,7 @@ def discover_video_output_device(
             "got {} new devices.".format(len(targets))
         )
 
-    return targets[0]
+    return next(iter(targets))
 
 
 def test_edid(

--- a/providers/base/bin/edid_cycle.py
+++ b/providers/base/bin/edid_cycle.py
@@ -101,11 +101,20 @@ def test_edid(
 
     try:
         _switch_edid(zapper_host, monitor_config, edid_file, video_device)
-        monitor_config.set_extended_mode()
+        configuration = monitor_config.set_extended_mode()
     except TimeoutError as exc:
         raise AssertionError("Timed out switching EDID") from exc
 
+    # A mismatch between requested and applied resolution might
+    # indicated an incompatibility at HW level, most of the time
+    # due to HDMI < 1.3.
+    applied_res = configuration[video_device]
     actual_res = monitor_config.get_current_resolutions()[video_device]
+
+    if applied_res != resolution:
+        print("SKIP, max available was {}".format(applied_res))
+        return
+
     if actual_res != resolution:
         raise AssertionError(
             "FAIL, got {} but {} expected".format(actual_res, resolution)

--- a/providers/base/tests/test_edid_cycle.py
+++ b/providers/base/tests/test_edid_cycle.py
@@ -5,10 +5,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch, call, Mock, MagicMock
 
-from checkbox_support.monitor_config import (
-    Configuration,
-)  # noqa: E402
-
 sys.modules["dbus"] = MagicMock()
 sys.modules["dbus.mainloop.glib"] = MagicMock()
 sys.modules["gi"] = MagicMock()
@@ -31,9 +27,9 @@ class ZapperEdidCycleTests(unittest.TestCase):
         edid_cycle.EDID_FILES = [Path("1920x1080.edid")]
 
         mock_monitor = Mock()
-        mock_monitor.get_current_resolutions.side_effect = [
-            {},
-            {"HDMI-1": "1920x1080"},
+        mock_monitor.get_connected_monitors.side_effect = [
+            set(),
+            {"HDMI-1"},
         ]
 
         port = edid_cycle.discover_video_output_device(
@@ -52,9 +48,7 @@ class ZapperEdidCycleTests(unittest.TestCase):
         edid_cycle.EDID_FILES = [Path("1920x1080.edid")]
 
         mock_monitor = Mock()
-        mock_monitor.get_current_resolutions.return_value = {
-            "HDMI-1": "1920x1080"
-        }
+        mock_monitor.get_connected_monitors.return_value = {"HDMI-1"}
 
         with self.assertRaises(IOError):
             edid_cycle.discover_video_output_device("zapper-ip", mock_monitor)
@@ -160,6 +154,7 @@ class ZapperEdidCycleTests(unittest.TestCase):
                 "zapper-ip", mock_monitor, Path("1920x1080.edid"), "HDMI-1"
             )
 
+    @patch("edid_cycle.zapper_monitor", MagicMock())
     @patch("edid_cycle.display_info", Mock())
     @patch("edid_cycle.discover_video_output_device")
     def test_main_no_device(self, mock_discover):
@@ -171,7 +166,7 @@ class ZapperEdidCycleTests(unittest.TestCase):
             edid_cycle.main(args)
 
     @patch("edid_cycle.display_info")
-    def test_main_no_device(self, mock_display_info):
+    def test_main_no_monitor_config(self, mock_display_info):
         """Test if main function exits when no monitor config is available."""
         mock_display_info.get_monitor_config.side_effect = ValueError
         with self.assertRaises(SystemExit):

--- a/providers/base/tests/test_edid_cycle.py
+++ b/providers/base/tests/test_edid_cycle.py
@@ -5,6 +5,10 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch, call, Mock, MagicMock
 
+from checkbox_support.monitor_config import (
+    Configuration,
+)  # noqa: E402
+
 sys.modules["dbus"] = MagicMock()
 sys.modules["dbus.mainloop.glib"] = MagicMock()
 sys.modules["gi"] = MagicMock()
@@ -78,6 +82,10 @@ class ZapperEdidCycleTests(unittest.TestCase):
                 "HDMI-1": "1920x1080",  # and then we set extended mode
             },
         ]
+        mock_monitor.set_extended_mode.return_value = {
+            "eDP-1": "1280x1024",
+            "HDMI-1": "1920x1080",
+        }
 
         edid_cycle.test_edid(
             "zapper-ip", mock_monitor, Path("1920x1080.edid"), "HDMI-1"
@@ -88,9 +96,44 @@ class ZapperEdidCycleTests(unittest.TestCase):
     @patch("time.sleep", new=Mock)
     @patch("edid_cycle.zapper_run", new=Mock)
     @patch("builtins.open")
+    def test_test_edid_skip(self, mock_open):
+        """
+        Check the function returns w/o errors if
+        the resolution doesn't match because of
+        HW incompatibility.
+        """
+
+        mock_monitor = Mock()
+        mock_monitor.get_current_resolutions.side_effect = [
+            {
+                "eDP-1": "1280x1024",
+            },
+            {
+                "eDP-1": "1280x1024",
+                "HDMI-1": "1280x1024",  # when connected it's in mirror mode
+            },
+            {
+                "eDP-1": "1280x1024",
+                "HDMI-1": "2048x1440",  # and then we set extended mode
+            },
+        ]
+        mock_monitor.set_extended_mode.return_value = {
+            "eDP-1": "1280x1024",
+            "HDMI-1": "2048x1440",
+        }
+
+        edid_cycle.test_edid(
+            "zapper-ip", mock_monitor, Path("2560x1440.edid"), "HDMI-1"
+        )
+        mock_open.assert_called_with("2560x1440.edid", "rb")
+        mock_monitor.set_extended_mode.assert_called_once_with()
+
+    @patch("time.sleep", new=Mock)
+    @patch("edid_cycle.zapper_run", new=Mock)
+    @patch("builtins.open")
     def test_test_edid_error(self, mock_open):
         """
-        Check the function raise an exception when the assertion
+        Check the function raises an exception when the assertion
         on resolution fails.
         """
         mock_monitor = Mock()
@@ -107,6 +150,10 @@ class ZapperEdidCycleTests(unittest.TestCase):
                 "HDMI-1": "1280x1024",  # still not at requested resolution
             },
         ]
+        mock_monitor.set_extended_mode.return_value = {
+            "eDP-1": "1280x1024",
+            "HDMI-1": "1920x1080",
+        }
 
         with self.assertRaises(AssertionError):
             edid_cycle.test_edid(


### PR DESCRIPTION
## Description

Another PR dedicated to the EDID job. It turns out that the new implementation (https://github.com/canonical/checkbox/pull/1286) shed some light on the other related problem, where older machines could read the maximum allowed resolution.

In case where the HW doesn't support an available mode from the monitor EDID, no preferred mode is available (which makes sense). This PR takes care of such scenario, attempting to configure the monitor with the maximum available resolution.
1. in case the maximum allowed resolution still matches what the test requested, the assertion over the actual configuration is performed as usual. Common example is with unsupported refresh rate.
2. in case the maximum allowed resolution is lower than requested, the testcase can be skipped since we can assume the HW does not support it. Common example is 2K resolution with HDMI < 1.3

## Resolved issues

Resolves [ZAP-678](https://warthogs.atlassian.net/browse/ZAP-678)

## Documentation

N/A

## Tests
Tested on some machines.

Previous behaviour:
- https://certification.canonical.com/hardware/202212-31024/submission/384021/test/176564/result/42874742/
- https://certification.canonical.com/hardware/202211-30885/submission/365364/test/176564/result/40446241/
- https://certification.canonical.com/hardware/202212-30973/submission/365373/test/176564/result/40447361/

Running from source:
```
Testing EDID cycling on HDMI-4
switching EDID to 1280x1024
PASS
switching EDID to 2560x1440
SKIP, max available was 2048x1152
switching EDID to 1920x1080
PASS
```


[ZAP-678]: https://warthogs.atlassian.net/browse/ZAP-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ