### PR TITLE
pc-sanity: add unit miscellanea/sideload-hook-no-fail (New)

### DIFF
--- a/contrib/pc-sanity/units/pc-sanity/pc-sanity-misc.pxu
+++ b/contrib/pc-sanity/units/pc-sanity/pc-sanity-misc.pxu
@@ -215,3 +215,11 @@ _summary: Provides image URL based on DistributionChannelDescriptor meta data
 _purpose: Provide a link to the ISO file which was installed on the system
 command: get-image-url.sh
 
+id: miscellanea/sideload-hook-no-fail
+category_id: com.canonical.plainbox::miscellanea
+plugin: shell
+command:
+ ! grep "# FAILED:" /var/log/installer/sideload-hook.sh.*.log
+_description:
+  Check the result of sideload/hook.sh, used for OEM PC enablements since 24.04
+

--- a/contrib/pc-sanity/units/pc-sanity/pc-sanity.pxu
+++ b/contrib/pc-sanity/units/pc-sanity/pc-sanity.pxu
@@ -70,6 +70,7 @@ include:
     com.canonical.certification::miscellanea/check_nvidia_modalias_.*                  certification-status=blocker
     com.canonical.certification::miscellanea/check-kernel                              certification-status=blocker
     com.canonical.certification::info/image-url
+    com.canonical.certification::miscellanea/sideload-hook-no-fail
 
 id: pc-sanity-smoke-test
 _name: pc-sanity-smoke-test (Ubuntu Desktop)
@@ -159,5 +160,6 @@ include:
     com.canonical.certification::miscellanea/screen-pkg-not-public
     com.canonical.certification::miscellanea/screen-pkg-not-supported-by-canonical
     com.canonical.certification::miscellanea/ubuntu-desktop-recommends
+    com.canonical.certification::miscellanea/sideload-hook-no-fail
 nested_part:
     com.canonical.certification::stress-10-reboot-automated


### PR DESCRIPTION
## Description

This tests 24.04 OEM images which has `sideload/hook.sh` run during installation and early-OOBE.  When a failure in the hook script occurs, it leaves `# FAILED: [command]` in the log.

## Resolved issues

Fixes: [SOMERVILLE-245](https://warthogs.atlassian.net/browse/SOMERVILLE-245?atlOrigin=eyJpIjoiNzQ3NDk5ZTIwNjJkNGE2MmI5YzMwMjE4YTE3MjIzM2UiLCJwIjoiaiJ9)

## Tests

The test was done by running the test unit in a normally installed 24.04 OEM system, and the following cases has been tested.

- Changed nothing in the `/var/log/installer/sideload-hook.sh.*.log`, run the test, passed.
- Changed `/var/log/installer/sideload-hook.sh.early-welcome.log` and added  
`# FAILED: something failed`  
in the bottom, successfully failed.
- Remove all files in `/var/log/installer/sideload-hook.sh.*.log`, run the test, passed with message  
`grep: /var/log/installer/sideload-hook.sh.*.log: No such file or directory`   
since there's no log to check with.

[SOMERVILLE-245]: https://warthogs.atlassian.net/browse/SOMERVILLE-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ