### PR TITLE
Fixed missing CPUID for cpuid turin (bugfix)

### DIFF
--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -178,6 +178,7 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
         "AMD Bergamo":      ['0xaa0f01'],
         "AMD Siena SP6":    ['0xaa0f02'],
         "AMD Raphael":      ['0xa60f12'],
+        "AMD Turin":        ['0xb00f21'],
         "Broadwell":        ['0x4067', '0x306d4', '0x5066', '0x406f'],
         "Canon Lake":       ['0x6066'],
         "Cascade Lake":     ['0x50655', '0x50656', '0x50657'],
@@ -231,7 +232,7 @@ def main():
             my_id, nice_name))
     except ValueError:
         raise SystemExit(
-            "Unable to determine CPU Family for this CPUID: {}".format(cpuid))
+            "Unable to determine CPU Family for this CPUID: {}".format(my_id))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Adds the missing cpu id and also prints out missing ones so that next time it will be easier to determine what is missing (just form the printed out error)

## Resolved issues

Fixes: CHECKBOX-1520
Fixes: https://github.com/canonical/checkbox/issues/1384

## Documentation

N/A

## Tests

N/A
