### PR TITLE
Fix the wrong namespace being used in checkbox-ce-oem launchers (BugFix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic20/launchers/test-runner
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic20/launchers/test-runner
@@ -1,9 +1,9 @@
 #!/usr/bin/env checkbox-cli-wrapper
 [launcher]
-app_id = com.canonical.qa.ceoem:checkbox
+app_id = com.canonical.contrib:checkbox
 launcher_version = 1
 stock_reports = text, submission_files, certification
 
 [test plan]
-unit = com.canonical.qa.ceoem::ce-oem-iot-server-20-04
-filter = com.canonical.qa.ceoem::ce-oem-iot-server-20-04*
+unit = com.canonical.contrib::ce-oem-iot-server-20-04
+filter = com.canonical.contrib::ce-oem-iot-server-20-04*

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic22/launchers/test-runner
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic22/launchers/test-runner
@@ -1,9 +1,9 @@
 #!/usr/bin/env checkbox-cli-wrapper
 [launcher]
-app_id = com.canonical.qa.ceoem:checkbox
+app_id = com.canonical.contrib:checkbox
 launcher_version = 1
 stock_reports = text, submission_files, certification
 
 [test plan]
-unit = com.canonical.qa.ceoem::ce-oem-iot-server-22-04
-filter = com.canonical.qa.ceoem::ce-oem-iot-server-22-04*
+unit = com.canonical.contrib::ce-oem-iot-server-22-04
+filter = com.canonical.contrib::ce-oem-iot-server-22-04*

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic24/launchers/test-runner
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic24/launchers/test-runner
@@ -1,9 +1,9 @@
 #!/usr/bin/env checkbox-cli-wrapper
 [launcher]
-app_id = com.canonical.qa.ceoem:checkbox
+app_id = com.canonical.contrib:checkbox
 launcher_version = 1
 stock_reports = text, submission_files, certification
 
 [test plan]
-unit = com.canonical.qa.ceoem::ce-oem-iot-server-24-04
-filter = com.canonical.qa.ceoem::ce-oem-iot-server-24-04*
+unit = com.canonical.contrib::ce-oem-iot-server-24-04
+filter = com.canonical.contrib::ce-oem-iot-server-24-04*

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/launchers/test-runner
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/launchers/test-runner
@@ -1,12 +1,12 @@
 #!/usr/bin/env checkbox-cli-wrapper
 [launcher]
-app_id = com.canonical.qa.ceoem:checkbox
+app_id = com.canonical.contrib:checkbox
 launcher_version = 1
 stock_reports = text, submission_files, certification
 
 [test plan]
-unit = com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-20-automated
-filter = com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-20
-         com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-20-manual
-         com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-20-automated
-         com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-20-stress
+unit = com.canonical.contrib::ce-oem-iot-ubuntucore-20-automated
+filter = com.canonical.contrib::ce-oem-iot-ubuntucore-20
+         com.canonical.contrib::ce-oem-iot-ubuntucore-20-manual
+         com.canonical.contrib::ce-oem-iot-ubuntucore-20-automated
+         com.canonical.contrib::ce-oem-iot-ubuntucore-20-stress

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc22/launchers/test-runner
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc22/launchers/test-runner
@@ -1,12 +1,12 @@
 #!/usr/bin/env checkbox-cli-wrapper
 [launcher]
-app_id = com.canonical.qa.ceoem:checkbox
+app_id = com.canonical.contrib:checkbox
 launcher_version = 1
 stock_reports = text, submission_files, certification
 
 [test plan]
-unit = com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-22-automated
-filter = com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-22
-         com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-22-manual
-         com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-22-automated
-         com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-22-stress
+unit = com.canonical.contrib::ce-oem-iot-ubuntucore-22-automated
+filter = com.canonical.contrib::ce-oem-iot-ubuntucore-22
+         com.canonical.contrib::ce-oem-iot-ubuntucore-22-manual
+         com.canonical.contrib::ce-oem-iot-ubuntucore-22-automated
+         com.canonical.contrib::ce-oem-iot-ubuntucore-22-stress

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc24/launchers/test-runner
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc24/launchers/test-runner
@@ -1,12 +1,12 @@
 #!/usr/bin/env checkbox-cli-wrapper
 [launcher]
-app_id = com.canonical.qa.ceoem:checkbox
+app_id = com.canonical.contrib:checkbox
 launcher_version = 1
 stock_reports = text, submission_files, certification
 
 [test plan]
-unit = com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-24-automated
-filter = com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-24
-         com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-24-manual
-         com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-24-automated
-         com.canonical.qa.ceoem::ce-oem-iot-ubuntucore-24-stress
+unit = com.canonical.contrib::ce-oem-iot-ubuntucore-24-automated
+filter = com.canonical.contrib::ce-oem-iot-ubuntucore-24
+         com.canonical.contrib::ce-oem-iot-ubuntucore-24-manual
+         com.canonical.contrib::ce-oem-iot-ubuntucore-24-automated
+         com.canonical.contrib::ce-oem-iot-ubuntucore-24-stress


### PR DESCRIPTION
## Description
Fix the wrong namespace being used in launchers


## Resolved issues
The current namespace being used in the launchers of checkbox-ce-oem snap are still `com.canonical.qa.ceoem` which should be using `com.canonical.contrib` already, this causes no test plans to be found when using test-runner launchers to start checkbox-ce-oem

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
