### PR TITLE
Improved dkms status handling (BugFix)

### DIFF
--- a/providers/sru/bin/dkms_build_validation.py
+++ b/providers/sru/bin/dkms_build_validation.py
@@ -63,11 +63,14 @@ def parse_dkms_status(dkms_status: str, ubuntu_release: str) -> List[Dict]:
     kernel_info = []
     for line in dkms_status.splitlines():
         details, status = line.split(": ")
-        if version.parse(ubuntu_release) >= version.parse("22.04"):
-            kernel_ver = details.split(", ")[1]
-        else:
-            kernel_ver = details.split(", ")[2]
-        kernel_info.append({"version": kernel_ver, "status": status})
+        # will only get comma separated info on two statuses
+        # https://github.com/dell/dkms/blob/master/dkms.in#L1866
+        if status in ("built", "installed"):
+            if version.parse(ubuntu_release) >= version.parse("22.04"):
+                kernel_ver = details.split(", ")[1]
+            else:
+                kernel_ver = details.split(", ")[2]
+            kernel_info.append({"version": kernel_ver, "status": status})
 
     sorted_kernel_info = sorted(
         kernel_info, key=lambda x: parse_version(x["version"])

--- a/providers/sru/tests/test_dkms_build_validation.py
+++ b/providers/sru/tests/test_dkms_build_validation.py
@@ -23,6 +23,25 @@ class TestDKMSValidation(unittest.TestCase):
         "fwts/24.01.00, 6.5.0-15-generic, x86_64: installed"
     )
 
+    # Example output of `dkms status` on machine
+    # in which efi_test driver is used rather than
+    # fwts dkms driver
+    # https://bugs.launchpad.net/fwts/+bug/2066243
+    dkms_status_efi_test_driver = (
+        "fwts-efi-runtime-dkms/24.07.00: added\n"
+        "tp_smapi/0.43, 6.1.0-1028-oem, x86_64: installed\n"
+        "tp_smapi/0.43, 6.1.0-1032-oem, x86_64: installed\n"
+        "tp_smapi/0.43, 6.1.0-1033-oem, x86_64: installed\n"
+        "tp_smapi/0.43, 6.1.0-1034-oem, x86_64: installed\n"
+        "tp_smapi/0.43, 6.1.0-1035-oem, x86_64: installed\n"
+        "tp_smapi/0.43, 6.5.0-1020-oem, x86_64: installed\n"
+        "tp_smapi/0.43, 6.5.0-1022-oem, x86_64: installed\n"
+        "tp_smapi/0.43, 6.5.0-1023-oem, x86_64: installed\n"
+        "tp_smapi/0.43, 6.5.0-1024-oem, x86_64: installed\n"
+        "tp_smapi/0.43, 6.5.0-1026-oem, x86_64: installed\n"
+        "tp_smapi/0.43, 6.8.0-40-generic, x86_64: installed"
+    )
+
     sorted_kernel_info = [
         {"version": "6.5.0-15-generic", "status": "installed"},
         {"version": "6.5.0-17-generic", "status": "installed"},
@@ -57,6 +76,26 @@ class TestDKMSValidation(unittest.TestCase):
         expected_kernel_info = [
             {"version": "6.5.0-15-generic", "status": "installed"},
             {"version": "6.5.0-17-generic", "status": "installed"},
+        ]
+        self.assertEqual(kernel_info, expected_kernel_info)
+
+    def test_parse_dkms_status_efi_test(self):
+        ubuntu_release = "22.04"
+        kernel_info = parse_dkms_status(
+            self.dkms_status_efi_test_driver, ubuntu_release
+        )
+        expected_kernel_info = [
+            {"version": "6.1.0-1028-oem", "status": "installed"},
+            {"version": "6.1.0-1032-oem", "status": "installed"},
+            {"version": "6.1.0-1033-oem", "status": "installed"},
+            {"version": "6.1.0-1034-oem", "status": "installed"},
+            {"version": "6.1.0-1035-oem", "status": "installed"},
+            {"version": "6.5.0-1020-oem", "status": "installed"},
+            {"version": "6.5.0-1022-oem", "status": "installed"},
+            {"version": "6.5.0-1023-oem", "status": "installed"},
+            {"version": "6.5.0-1024-oem", "status": "installed"},
+            {"version": "6.5.0-1026-oem", "status": "installed"},
+            {"version": "6.8.0-40-generic", "status": "installed"},
         ]
         self.assertEqual(kernel_info, expected_kernel_info)
 


### PR DESCRIPTION

## Description

Only try to parse kernel information out of lines that have either built or installed status

## Resolved issues

Resolves #1383

## Documentation

## Tests

Update the unit tests with full dkms example output from an effected machine