### PR TITLE
Skip EDID test if there's no desktop session running (BugFix)

### DIFF
--- a/providers/base/bin/desktop_session.py
+++ b/providers/base/bin/desktop_session.py
@@ -18,19 +18,20 @@ def resources():
     print("session_type: {}".format(os.getenv("XDG_SESSION_TYPE")))
 
 
-def main(args=None):
+def main(argv):
     """
     Retrieve information about the current desktop session.
     """
 
-    if not args:
-        parser = argparse.ArgumentParser()
-        parser.add_argument("command", choices=["resources"])
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=["resources"])
+    args = parser.parse_args(argv)
 
     if args.command == "resources":
         return resources()
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+
+    main(sys.argv[1:])

--- a/providers/base/bin/desktop_session.py
+++ b/providers/base/bin/desktop_session.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# All rights reserved.
+#
+# Written by:
+#   Paolo Gentili <paolo.gentili@canonical.com>
+
+import argparse
+import os
+
+
+def resources():
+    """
+    Return whether there's a Desktop session and its type.
+    """
+    is_desktop_session = os.getenv("XDG_CURRENT_DESKTOP") is not None
+    print("desktop_session: {}".format(is_desktop_session))
+    print("session_type: {}".format(os.getenv("XDG_SESSION_TYPE")))
+
+
+def main(args=None):
+    """
+    Retrieve information about the current desktop session.
+    """
+
+    if not args:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("command", choices=["resources"])
+        args = parser.parse_args()
+
+    if args.command == "resources":
+        return resources()
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/base/tests/test_desktop_session.py
+++ b/providers/base/tests/test_desktop_session.py
@@ -10,6 +10,15 @@ import desktop_session
 class DesktopSessionTests(unittest.TestCase):
     """Tests for the desktop_session module."""
 
+    @patch("desktop_session.resources")
+    def test_main(self, mock_resources):
+        """
+        Test whether the main function calls the resources
+        function when requested via CLI.
+        """
+        desktop_session.main(["resources"])
+        mock_resources.assert_called_once_with()
+
     @patch("builtins.print")
     def test_resources_server(self, mock_print):
         """Test the result faking a server session."""

--- a/providers/base/tests/test_desktop_session.py
+++ b/providers/base/tests/test_desktop_session.py
@@ -1,0 +1,46 @@
+"""This module provides test cases for the desktop_session module."""
+
+import os
+import unittest
+from unittest.mock import call, patch
+
+import desktop_session
+
+
+class DesktopSessionTests(unittest.TestCase):
+    """Tests for the desktop_session module."""
+
+    @patch("builtins.print")
+    def test_resources_server(self, mock_print):
+        """Test the result faking a server session."""
+
+        server_session = {
+            "XDG_SESSION_TYPE": "tty",
+        }
+        with patch.dict(os.environ, server_session, clear=True):
+            desktop_session.resources()
+
+        mock_print.assert_has_calls(
+            [
+                call("desktop_session: False"),
+                call("session_type: tty"),
+            ]
+        )
+
+    @patch("builtins.print")
+    def test_resources_desktop(self, mock_print):
+        """Test the result faking a desktop session."""
+
+        server_session = {
+            "XDG_SESSION_TYPE": "wayland",
+            "XDG_CURRENT_DESKTOP": "hyprland",
+        }
+        with patch.dict(os.environ, server_session, clear=True):
+            desktop_session.resources()
+
+        mock_print.assert_has_calls(
+            [
+                call("desktop_session: True"),
+                call("session_type: wayland"),
+            ]
+        )

--- a/providers/base/units/desktop/resource.pxu
+++ b/providers/base/units/desktop/resource.pxu
@@ -1,0 +1,6 @@
+id: desktop_session
+plugin: resource
+category_id: com.canonical.plainbox::info
+_summary: Check whether a desktop session is available and of which type.
+environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
+command: desktop_session.py resources

--- a/providers/base/units/zapper/jobs.pxu
+++ b/providers/base/units/zapper/jobs.pxu
@@ -1,5 +1,10 @@
 id: monitor/zapper-edid
-requires: zapper_capabilities.capability == 'hdmi-capture' and zapper_capabilities.edid_cycling == 'True'
+template-resource: zapper_capabilities desktop_session
+requires: 
+ zapper_capabilities.capability == 'hdmi-capture'
+ zapper_capabilities.edid_cycling == 'True'
+ desktop_session.desktop_session == 'True'
+ desktop_session.session_type in ['x11', 'wayland']
 category_id: com.canonical.plainbox::monitor
 plugin: shell
 estimated_duration: 60

--- a/providers/base/units/zapper/test-plan.pxu
+++ b/providers/base/units/zapper/test-plan.pxu
@@ -8,7 +8,7 @@ nested_part:
 
 id: zapper-enabled-automated
 unit: test plan
-_name: Tests using Zapper
+_name: Tests using Zapper (automated)
 _description: Tests using Zapper
 include:
   bluetooth/zapper-a2dp


### PR DESCRIPTION
## Description

The EDID job is only checking resources on the monitor side, not on the DUT. This means the testcase runs on server images as well, failing.

This PR propose a new resource job, `desktop_session`, which is used by the EDID job to make sure it runs only on desktop.

## WARNING: This modifies com.canonical.certification::sru

## Resolved issues

N/A

## Documentation

N/A

## Tests

- Added unit test file
Tested on https://certification.canonical.com/hardware/202406-34144
Current outcome:
```
Current host is not supported.
```
Side-loading the provider:
```
-----------------------------[ Running job 4 / 5 ]------------------------------
------[ Check whether a desktop session is available and of which type. ]-------
ID: com.canonical.certification::desktop_session
Category: Informational tests
--------------------------------------------------------------------------------
desktop_session: False
session_type: None
--------------------------------------------------------------------------------
Outcome: job passed
-----------------------------[ Running job 5 / 5 ]------------------------------
---[ Check if the system automatically changes the resolution based on EDID ]---
ID: com.canonical.certification::monitor/edid
Category: Monitor tests
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Outcome: job cannot be started
```