### PR TITLE
Add new steps to the interpolation (bugfix)

### DIFF
--- a/providers/base/bin/memory_compare.py
+++ b/providers/base/bin/memory_compare.py
@@ -88,6 +88,10 @@ def get_threshold(installed_memory):
         return 25
     elif installed_memory <= 6 * GB:
         return 20
+    elif installed_memory <= 8 * GB:
+        return 15
+    elif installed_memory <= 16 * GB:
+        return 12
     else:
         return 10
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This job tends to fail on machines with little ram and a GPU. The job already interpolates using the memory to get a reasonable threshold. This adds two new steps.

This comes from this chat for SRU fixups: https://chat.canonical.com/canonical/pl/scp4s13rofbiujter1ifwjrxay

## Resolved issues

N/A

## Documentation

N/A

## Tests

Pre patch:
```
ubuntu@ubuntu:~/checkbox/providers/base/bin$ ./memory_compare.py 
This script must be run as root.
ubuntu@ubuntu:~/checkbox/providers/base/bin$ sudo !!
sudo ./memory_compare.py 
Results:
	/proc/meminfo reports:	7.11GiB
	lshw reports:	8GiB

FAIL: Meminfo reports 954224640 less than lshw, a difference of 11.11%. Only a variance of 10% in reported memory is allowed.
```

After patch:
```
ubuntu@ubuntu:~/checkbox/providers/base/bin$ sudo ./memory_compare.py 
Results:
	/proc/meminfo reports:	7.11GiB
	lshw reports:	8GiB

PASS: Meminfo reports 910.02MiB less than lshw, a difference of 11.11%. This is less than the 15% variance allowed.
```
