### PR TITLE
Add coverage tests for stress_ng_test (New)

### DIFF
--- a/providers/base/bin/stress_ng_test.py
+++ b/providers/base/bin/stress_ng_test.py
@@ -175,7 +175,7 @@ def num_numa_nodes():
         return 1
 
 
-def swap_space_ok(args):
+def swap_space_ok(swap_size):
     """Check available swap space."""
     # If swap space is too small, add more. The minimum
     # acceptable amount is defined as the GREATER of the amount specified
@@ -192,7 +192,7 @@ def swap_space_ok(args):
     min_swap_space = 0
 
     swap_size = max(
-        os.environ.get("STRESS_NG_MIN_SWAP_SPACE", 0), args.swap_size
+        os.environ.get("STRESS_NG_MIN_SWAP_SPACE", 0), swap_size
     )
     print("Minimum swap space is set to {} GiB".format(swap_size))
     min_swap_space = swap_size * 1024**3
@@ -236,7 +236,7 @@ def stress_memory(args):
     """Run stress-ng tests on memory."""
 
     retval = 0
-    if not swap_space_ok(args):
+    if not swap_space_ok(args.swap_size):
         print(
             "** Swap space unavailable! Please activate swap space "
             + "and re-run this test!"

--- a/providers/base/bin/stress_ng_test.py
+++ b/providers/base/bin/stress_ng_test.py
@@ -499,4 +499,5 @@ def main():
     return retval
 
 
-sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(main())

--- a/providers/base/bin/stress_ng_test.py
+++ b/providers/base/bin/stress_ng_test.py
@@ -191,9 +191,7 @@ def swap_space_ok(swap_size):
     global my_swap
     min_swap_space = 0
 
-    swap_size = max(
-        os.environ.get("STRESS_NG_MIN_SWAP_SPACE", 0), swap_size
-    )
+    swap_size = max(os.environ.get("STRESS_NG_MIN_SWAP_SPACE", 0), swap_size)
     print("Minimum swap space is set to {} GiB".format(swap_size))
     min_swap_space = swap_size * 1024**3
     swap = psutil.swap_memory()

--- a/providers/base/tests/test_stress_ng_test.py
+++ b/providers/base/tests/test_stress_ng_test.py
@@ -26,7 +26,7 @@ from stress_ng_test import main, num_numa_nodes, swap_space_ok
 class TestMemoryFunctions(unittest.TestCase):
     @patch("stress_ng_test.run")
     def test_num_numa_nodes_success(self, run_mock):
-        run_mock.return_value = MagicMock(name="completed_process")
+        run_mock.return_value = MagicMock()
         run_mock.return_value.stdout = b"available: 2 nodes (0-1)"
         self.assertEqual(num_numa_nodes(), 2)
 

--- a/providers/base/tests/test_stress_ng_test.py
+++ b/providers/base/tests/test_stress_ng_test.py
@@ -34,18 +34,16 @@ class TestMemoryFunctions(unittest.TestCase):
     def test_num_numa_nodes_failure(self, run_mock):
         self.assertEqual(num_numa_nodes(), 1)
 
-    @patch(
-        "stress_ng_test.psutil.swap_memory", return_value=MagicMock(total=1)
-    )
+    @patch("psutil.swap_memory", return_value=MagicMock(total=1))
     def test_swap_space_ok_success(self, psutil_swap_memory_mock):
         self.assertTrue(swap_space_ok(0))
 
     @patch("stress_ng_test.run")
-    @patch("stress_ng_test.os.chmod")
+    @patch("os.chmod")
     @patch("stress_ng_test.open", new_callable=mock_open)
     @patch("stress_ng_test.range", return_value=[0])
     @patch(
-        "stress_ng_test.psutil.swap_memory",
+        "psutil.swap_memory",
         side_effect=[MagicMock(total=0), MagicMock(total=1073741824)],
     )
     def test_swap_space_ok_create_swap(
@@ -59,11 +57,9 @@ class TestMemoryFunctions(unittest.TestCase):
         self.assertTrue(swap_space_ok(1))
 
     @patch("stress_ng_test.run")
-    @patch("stress_ng_test.os.chmod")
+    @patch("os.chmod")
     @patch("stress_ng_test.open", side_effect=OSError)
-    @patch(
-        "stress_ng_test.psutil.swap_memory", return_value=MagicMock(total=0)
-    )
+    @patch("psutil.swap_memory", return_value=MagicMock(total=0))
     def test_swap_space_ok_remove_swap(
         self, psutil_swap_memory_mock, open_mock, os_chmod_mock, run_mock
     ):
@@ -71,14 +67,14 @@ class TestMemoryFunctions(unittest.TestCase):
 
 
 class TestMainFunction(unittest.TestCase):
-    @patch("stress_ng_test.shutil.which", return_value=None)
-    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "cpu"])
+    @patch("shutil.which", return_value=None)
+    @patch("sys.argv", ["stress_ng_test.py", "cpu"])
     def test_main_no_stress_ng(self, shutil_which_mock):
         self.assertEqual(main(), 1)
 
-    @patch("stress_ng_test.os.geteuid", return_value=1000)
-    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
-    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "cpu"])
+    @patch("os.geteuid", return_value=1000)
+    @patch("shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("sys.argv", ["stress_ng_test.py", "cpu"])
     def test_main_not_root(self, shutil_which_mock, os_geteuid_mock):
         self.assertEqual(main(), 1)
 
@@ -134,9 +130,9 @@ class TestMainFunction(unittest.TestCase):
     @patch("stress_ng_test.check_output")
     @patch("stress_ng_test.num_numa_nodes", return_value=1)
     @patch("stress_ng_test.swap_space_ok", return_value=True)
-    @patch("stress_ng_test.os.geteuid", return_value=0)
-    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
-    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "memory"])
+    @patch("os.geteuid", return_value=0)
+    @patch("shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("sys.argv", ["stress_ng_test.py", "memory"])
     def test_main_stress_memory_success(
         self,
         shutil_which_mock,
@@ -152,9 +148,9 @@ class TestMainFunction(unittest.TestCase):
     @patch("stress_ng_test.check_output")
     @patch("stress_ng_test.num_numa_nodes", return_value=2)
     @patch("stress_ng_test.swap_space_ok", return_value=True)
-    @patch("stress_ng_test.os.geteuid", return_value=0)
-    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
-    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "memory"])
+    @patch("os.geteuid", return_value=0)
+    @patch("shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("sys.argv", ["stress_ng_test.py", "memory"])
     def test_main_stress_memory_more_numa_nodes(
         self,
         shutil_which_mock,
@@ -166,7 +162,7 @@ class TestMainFunction(unittest.TestCase):
     ):
         self.assertEqual(main(), 0)
 
-    @patch("stress_ng_test.os.remove")
+    @patch("os.remove")
     @patch("stress_ng_test.Popen")
     @patch(
         "stress_ng_test.my_swap",
@@ -175,9 +171,9 @@ class TestMainFunction(unittest.TestCase):
     @patch("stress_ng_test.check_output")
     @patch("stress_ng_test.num_numa_nodes", return_value=1)
     @patch("stress_ng_test.swap_space_ok", return_value=True)
-    @patch("stress_ng_test.os.geteuid", return_value=0)
-    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
-    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "memory"])
+    @patch("os.geteuid", return_value=0)
+    @patch("shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("sys.argv", ["stress_ng_test.py", "memory"])
     def test_main_stress_memory_delete_swap(
         self,
         shutil_which_mock,
@@ -192,15 +188,15 @@ class TestMainFunction(unittest.TestCase):
         self.assertEqual(main(), 0)
 
     @patch("stress_ng_test.swap_space_ok", return_value=False)
-    @patch("stress_ng_test.os.geteuid", return_value=0)
-    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
-    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "memory"])
+    @patch("os.geteuid", return_value=0)
+    @patch("shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("sys.argv", ["stress_ng_test.py", "memory"])
     def test_main_stress_memory_not_enough_swap(
         self, shutil_which_mock, os_geteuid_mock, swap_space_ok_mock
     ):
         self.assertEqual(main(), 1)
 
-    @patch("stress_ng_test.shutil.rmtree")
+    @patch("shutil.rmtree")
     @patch("stress_ng_test.check_output")
     @patch(
         "stress_ng_test.Disk",
@@ -209,12 +205,9 @@ class TestMainFunction(unittest.TestCase):
             mount_filesystem=MagicMock(return_value=True),
         ),
     )
-    @patch("stress_ng_test.os.geteuid", return_value=0)
-    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
-    @patch(
-        "stress_ng_test.sys.argv",
-        ["stress_ng_test.py", "disk", "--device", "/dev/sda"],
-    )
+    @patch("os.geteuid", return_value=0)
+    @patch("shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("sys.argv", ["stress_ng_test.py", "disk", "--device", "/dev/sda"])
     def test_main_stress_disk_success(
         self,
         shutil_which_mock,
@@ -225,7 +218,7 @@ class TestMainFunction(unittest.TestCase):
     ):
         self.assertEqual(main(), 0)
 
-    @patch("stress_ng_test.shutil.rmtree")
+    @patch("shutil.rmtree")
     @patch("stress_ng_test.check_output")
     @patch(
         "stress_ng_test.Disk",
@@ -234,12 +227,9 @@ class TestMainFunction(unittest.TestCase):
             mount_filesystem=MagicMock(return_value=True),
         ),
     )
-    @patch("stress_ng_test.os.geteuid", return_value=0)
-    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
-    @patch(
-        "stress_ng_test.sys.argv",
-        ["stress_ng_test.py", "disk", "--device", "sda"],
-    )
+    @patch("os.geteuid", return_value=0)
+    @patch("shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("sys.argv", ["stress_ng_test.py", "disk", "--device", "sda"])
     def test_main_stress_disk_partial_name_success(
         self,
         shutil_which_mock,
@@ -257,10 +247,10 @@ class TestMainFunction(unittest.TestCase):
             mount_filesystem=MagicMock(return_value=True),
         ),
     )
-    @patch("stress_ng_test.os.geteuid", return_value=0)
-    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("os.geteuid", return_value=0)
+    @patch("shutil.which", return_value="/usr/bin/stress-ng")
     @patch(
-        "stress_ng_test.sys.argv",
+        "sys.argv",
         ["stress_ng_test.py", "disk", "--device", "/dev/sda", "--simulate"],
     )
     def test_main_stress_disk_simulate_success(
@@ -272,12 +262,9 @@ class TestMainFunction(unittest.TestCase):
         "stress_ng_test.Disk",
         return_value=MagicMock(is_block_device=MagicMock(return_value=False)),
     )
-    @patch("stress_ng_test.os.geteuid", return_value=0)
-    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
-    @patch(
-        "stress_ng_test.sys.argv",
-        ["stress_ng_test.py", "disk", "--device", "/dev/sda"],
-    )
+    @patch("os.geteuid", return_value=0)
+    @patch("shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("sys.argv", ["stress_ng_test.py", "disk", "--device", "/dev/sda"])
     def test_main_stress_disk_not_a_block_device(
         self, shutil_which_mock, os_geteuid_mock, disk_mock
     ):
@@ -290,12 +277,9 @@ class TestMainFunction(unittest.TestCase):
             mount_filesystem=MagicMock(return_value=False),
         ),
     )
-    @patch("stress_ng_test.os.geteuid", return_value=0)
-    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
-    @patch(
-        "stress_ng_test.sys.argv",
-        ["stress_ng_test.py", "disk", "--device", "/dev/sda"],
-    )
+    @patch("os.geteuid", return_value=0)
+    @patch("shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("sys.argv", ["stress_ng_test.py", "disk", "--device", "/dev/sda"])
     def test_main_stress_disk_fail_mount(
         self, shutil_which_mock, os_geteuid_mock, disk_mock
     ):

--- a/providers/base/tests/test_stress_ng_test.py
+++ b/providers/base/tests/test_stress_ng_test.py
@@ -66,40 +66,35 @@ class TestMemoryFunctions(unittest.TestCase):
         self.assertFalse(swap_space_ok(1))
 
 
+@patch("os.geteuid", return_value=0)
+@patch("shutil.which", return_value="/usr/bin/stress-ng")
 class TestMainFunction(unittest.TestCase):
-    @patch("shutil.which", return_value=None)
     @patch("sys.argv", ["stress_ng_test.py", "cpu"])
-    def test_main_no_stress_ng(self, shutil_which_mock):
+    def test_main_no_stress_ng(self, shutil_which_mock, os_geteuid_mock):
+        shutil_which_mock.return_value = None
         self.assertEqual(main(), 1)
 
-    @patch("os.geteuid", return_value=1000)
-    @patch("shutil.which", return_value="/usr/bin/stress-ng")
     @patch("sys.argv", ["stress_ng_test.py", "cpu"])
     def test_main_not_root(self, shutil_which_mock, os_geteuid_mock):
+        os_geteuid_mock.return_value = 1000
         self.assertEqual(main(), 1)
 
     @patch("stress_ng_test.check_output", side_effect=FileNotFoundError)
-    @patch("stress_ng_test.os.geteuid", return_value=0)
-    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
-    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "cpu"])
+    @patch("sys.argv", ["stress_ng_test.py", "cpu"])
     def test_main_stress_ng_not_found(
         self, shutil_which_mock, os_geteuid_mock, check_output_mock
     ):
         self.assertEqual(main(), 1)
 
     @patch("stress_ng_test.check_output", side_effect=TimeoutExpired(b"", 1))
-    @patch("stress_ng_test.os.geteuid", return_value=0)
-    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
-    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "cpu"])
+    @patch("sys.argv", ["stress_ng_test.py", "cpu"])
     def test_main_timeout(
         self, shutil_which_mock, os_geteuid_mock, check_output_mock
     ):
         self.assertEqual(main(), 1)
 
     @patch("stress_ng_test.check_output", side_effect=KeyboardInterrupt)
-    @patch("stress_ng_test.os.geteuid", return_value=0)
-    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
-    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "cpu"])
+    @patch("sys.argv", ["stress_ng_test.py", "cpu"])
     def test_main_keyboard_interrupt(
         self, shutil_which_mock, os_geteuid_mock, check_output_mock
     ):
@@ -109,18 +104,14 @@ class TestMainFunction(unittest.TestCase):
         "stress_ng_test.check_output",
         side_effect=CalledProcessError(1, b"", b""),
     )
-    @patch("stress_ng_test.os.geteuid", return_value=0)
-    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
-    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "cpu"])
+    @patch("sys.argv", ["stress_ng_test.py", "cpu"])
     def test_main_stress_ng_error(
         self, shutil_which_mock, os_geteuid_mock, check_output_mock
     ):
         self.assertEqual(main(), 1)
 
     @patch("stress_ng_test.check_output")
-    @patch("stress_ng_test.os.geteuid", return_value=0)
-    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
-    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "cpu"])
+    @patch("sys.argv", ["stress_ng_test.py", "cpu"])
     def test_main_stress_cpu_success(
         self, shutil_which_mock, os_geteuid_mock, check_output_mock
     ):
@@ -130,8 +121,6 @@ class TestMainFunction(unittest.TestCase):
     @patch("stress_ng_test.check_output")
     @patch("stress_ng_test.num_numa_nodes", return_value=1)
     @patch("stress_ng_test.swap_space_ok", return_value=True)
-    @patch("os.geteuid", return_value=0)
-    @patch("shutil.which", return_value="/usr/bin/stress-ng")
     @patch("sys.argv", ["stress_ng_test.py", "memory"])
     def test_main_stress_memory_success(
         self,
@@ -148,8 +137,6 @@ class TestMainFunction(unittest.TestCase):
     @patch("stress_ng_test.check_output")
     @patch("stress_ng_test.num_numa_nodes", return_value=2)
     @patch("stress_ng_test.swap_space_ok", return_value=True)
-    @patch("os.geteuid", return_value=0)
-    @patch("shutil.which", return_value="/usr/bin/stress-ng")
     @patch("sys.argv", ["stress_ng_test.py", "memory"])
     def test_main_stress_memory_more_numa_nodes(
         self,
@@ -171,8 +158,6 @@ class TestMainFunction(unittest.TestCase):
     @patch("stress_ng_test.check_output")
     @patch("stress_ng_test.num_numa_nodes", return_value=1)
     @patch("stress_ng_test.swap_space_ok", return_value=True)
-    @patch("os.geteuid", return_value=0)
-    @patch("shutil.which", return_value="/usr/bin/stress-ng")
     @patch("sys.argv", ["stress_ng_test.py", "memory"])
     def test_main_stress_memory_delete_swap(
         self,
@@ -188,8 +173,6 @@ class TestMainFunction(unittest.TestCase):
         self.assertEqual(main(), 0)
 
     @patch("stress_ng_test.swap_space_ok", return_value=False)
-    @patch("os.geteuid", return_value=0)
-    @patch("shutil.which", return_value="/usr/bin/stress-ng")
     @patch("sys.argv", ["stress_ng_test.py", "memory"])
     def test_main_stress_memory_not_enough_swap(
         self, shutil_which_mock, os_geteuid_mock, swap_space_ok_mock
@@ -205,8 +188,6 @@ class TestMainFunction(unittest.TestCase):
             mount_filesystem=MagicMock(return_value=True),
         ),
     )
-    @patch("os.geteuid", return_value=0)
-    @patch("shutil.which", return_value="/usr/bin/stress-ng")
     @patch("sys.argv", ["stress_ng_test.py", "disk", "--device", "/dev/sda"])
     def test_main_stress_disk_success(
         self,
@@ -227,8 +208,6 @@ class TestMainFunction(unittest.TestCase):
             mount_filesystem=MagicMock(return_value=True),
         ),
     )
-    @patch("os.geteuid", return_value=0)
-    @patch("shutil.which", return_value="/usr/bin/stress-ng")
     @patch("sys.argv", ["stress_ng_test.py", "disk", "--device", "sda"])
     def test_main_stress_disk_partial_name_success(
         self,
@@ -247,8 +226,6 @@ class TestMainFunction(unittest.TestCase):
             mount_filesystem=MagicMock(return_value=True),
         ),
     )
-    @patch("os.geteuid", return_value=0)
-    @patch("shutil.which", return_value="/usr/bin/stress-ng")
     @patch(
         "sys.argv",
         ["stress_ng_test.py", "disk", "--device", "/dev/sda", "--simulate"],
@@ -262,8 +239,6 @@ class TestMainFunction(unittest.TestCase):
         "stress_ng_test.Disk",
         return_value=MagicMock(is_block_device=MagicMock(return_value=False)),
     )
-    @patch("os.geteuid", return_value=0)
-    @patch("shutil.which", return_value="/usr/bin/stress-ng")
     @patch("sys.argv", ["stress_ng_test.py", "disk", "--device", "/dev/sda"])
     def test_main_stress_disk_not_a_block_device(
         self, shutil_which_mock, os_geteuid_mock, disk_mock
@@ -277,8 +252,6 @@ class TestMainFunction(unittest.TestCase):
             mount_filesystem=MagicMock(return_value=False),
         ),
     )
-    @patch("os.geteuid", return_value=0)
-    @patch("shutil.which", return_value="/usr/bin/stress-ng")
     @patch("sys.argv", ["stress_ng_test.py", "disk", "--device", "/dev/sda"])
     def test_main_stress_disk_fail_mount(
         self, shutil_which_mock, os_geteuid_mock, disk_mock

--- a/providers/base/tests/test_stress_ng_test.py
+++ b/providers/base/tests/test_stress_ng_test.py
@@ -189,3 +189,104 @@ class TestMainFunction(unittest.TestCase):
         self, shutil_which_mock, os_geteuid_mock, swap_space_ok_mock
     ):
         self.assertEqual(main(), 1)
+
+    @patch("stress_ng_test.shutil.rmtree")
+    @patch("stress_ng_test.check_output")
+    @patch(
+        "stress_ng_test.Disk",
+        return_value=MagicMock(
+            is_block_device=MagicMock(return_value=True),
+            mount_filesystem=MagicMock(return_value=True),
+        ),
+    )
+    @patch("stress_ng_test.os.geteuid", return_value=0)
+    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
+    @patch(
+        "stress_ng_test.sys.argv",
+        ["stress_ng_test.py", "disk", "--device", "/dev/sda"],
+    )
+    def test_main_stress_disk_success(
+        self,
+        shutil_which_mock,
+        os_geteuid_mock,
+        disk_mock,
+        check_output_mock,
+        rmtree_mock,
+    ):
+        self.assertEqual(main(), 0)
+
+    @patch("stress_ng_test.shutil.rmtree")
+    @patch("stress_ng_test.check_output")
+    @patch(
+        "stress_ng_test.Disk",
+        return_value=MagicMock(
+            is_block_device=MagicMock(return_value=True),
+            mount_filesystem=MagicMock(return_value=True),
+        ),
+    )
+    @patch("stress_ng_test.os.geteuid", return_value=0)
+    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
+    @patch(
+        "stress_ng_test.sys.argv",
+        ["stress_ng_test.py", "disk", "--device", "sda"],
+    )
+    def test_main_stress_disk_partial_name_success(
+        self,
+        shutil_which_mock,
+        os_geteuid_mock,
+        disk_mock,
+        check_output_mock,
+        rmtree_mock,
+    ):
+        self.assertEqual(main(), 0)
+
+    @patch(
+        "stress_ng_test.Disk",
+        return_value=MagicMock(
+            is_block_device=MagicMock(return_value=True),
+            mount_filesystem=MagicMock(return_value=True),
+        ),
+    )
+    @patch("stress_ng_test.os.geteuid", return_value=0)
+    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
+    @patch(
+        "stress_ng_test.sys.argv",
+        ["stress_ng_test.py", "disk", "--device", "/dev/sda", "--simulate"],
+    )
+    def test_main_stress_disk_simulate_success(
+        self, shutil_which_mock, os_geteuid_mock, disk_mock
+    ):
+        self.assertEqual(main(), 0)
+
+    @patch(
+        "stress_ng_test.Disk",
+        return_value=MagicMock(is_block_device=MagicMock(return_value=False)),
+    )
+    @patch("stress_ng_test.os.geteuid", return_value=0)
+    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
+    @patch(
+        "stress_ng_test.sys.argv",
+        ["stress_ng_test.py", "disk", "--device", "/dev/sda"],
+    )
+    def test_main_stress_disk_not_a_block_device(
+        self, shutil_which_mock, os_geteuid_mock, disk_mock
+    ):
+        self.assertEqual(main(), 1)
+
+    @patch(
+        "stress_ng_test.Disk",
+        return_value=MagicMock(
+            is_block_device=MagicMock(return_value=True),
+            mount_filesystem=MagicMock(return_value=False),
+        ),
+    )
+    @patch("stress_ng_test.os.geteuid", return_value=0)
+    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
+    @patch(
+        "stress_ng_test.sys.argv",
+        ["stress_ng_test.py", "disk", "--device", "/dev/sda"],
+    )
+    def test_main_stress_disk_fail_mount(
+        self, shutil_which_mock, os_geteuid_mock, disk_mock
+    ):
+        self.assertEqual(main(), 1)

--- a/providers/base/tests/test_stress_ng_test.py
+++ b/providers/base/tests/test_stress_ng_test.py
@@ -130,6 +130,7 @@ class TestMainFunction(unittest.TestCase):
     ):
         self.assertEqual(main(), 0)
 
+    @patch("os.remove")
     @patch("stress_ng_test.check_output")
     @patch("stress_ng_test.num_numa_nodes", return_value=1)
     @patch("stress_ng_test.swap_space_ok", return_value=True)
@@ -143,9 +144,11 @@ class TestMainFunction(unittest.TestCase):
         swap_space_ok_mock,
         num_numa_nodes_mock,
         check_output_mock,
+        remove_mock,
     ):
         self.assertEqual(main(), 0)
 
+    @patch("os.remove")
     @patch("stress_ng_test.check_output")
     @patch("stress_ng_test.num_numa_nodes", return_value=2)
     @patch("stress_ng_test.swap_space_ok", return_value=True)
@@ -159,6 +162,7 @@ class TestMainFunction(unittest.TestCase):
         swap_space_ok_mock,
         num_numa_nodes_mock,
         check_output_mock,
+        remove_mock,
     ):
         self.assertEqual(main(), 0)
 

--- a/providers/base/tests/test_stress_ng_test.py
+++ b/providers/base/tests/test_stress_ng_test.py
@@ -43,12 +43,18 @@ class TestMemoryFunctions(unittest.TestCase):
     @patch("stress_ng_test.run")
     @patch("stress_ng_test.os.chmod")
     @patch("stress_ng_test.open", new_callable=mock_open)
+    @patch("stress_ng_test.range", return_value=[0])
     @patch(
         "stress_ng_test.psutil.swap_memory",
         side_effect=[MagicMock(total=0), MagicMock(total=1073741824)],
     )
     def test_swap_space_ok_create_swap(
-        self, psutil_swap_memory_mock, open_mock, os_chmod_mock, run_mock
+        self,
+        psutil_swap_memory_mock,
+        open_mock,
+        range_mock,
+        os_chmod_mock,
+        run_mock,
     ):
         self.assertTrue(swap_space_ok(1))
 

--- a/providers/base/tests/test_stress_ng_test.py
+++ b/providers/base/tests/test_stress_ng_test.py
@@ -18,6 +18,7 @@
 
 import unittest
 from unittest.mock import patch
+from subprocess import CalledProcessError, TimeoutExpired
 
 from stress_ng_test import main
 
@@ -33,3 +34,48 @@ class TestMainFunction(unittest.TestCase):
     @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "cpu"])
     def test_main_not_root(self, shutil_which_mock, os_geteuid_mock):
         self.assertEqual(main(), 1)
+
+    @patch("stress_ng_test.check_output", side_effect=FileNotFoundError)
+    @patch("stress_ng_test.os.geteuid", return_value=0)
+    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "cpu"])
+    def test_main_stress_ng_not_found(
+        self, shutil_which_mock, os_geteuid_mock, check_output_mock
+    ):
+        self.assertEqual(main(), 1)
+
+    @patch("stress_ng_test.check_output", side_effect=TimeoutExpired(b"", 1))
+    @patch("stress_ng_test.os.geteuid", return_value=0)
+    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "cpu"])
+    def test_main_timeout(
+        self, shutil_which_mock, os_geteuid_mock, check_output_mock
+    ):
+        self.assertEqual(main(), 1)
+
+    @patch("stress_ng_test.check_output", side_effect=KeyboardInterrupt)
+    @patch("stress_ng_test.os.geteuid", return_value=0)
+    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "cpu"])
+    def test_main_keyboard_interrupt(
+        self, shutil_which_mock, os_geteuid_mock, check_output_mock
+    ):
+        self.assertEqual(main(), 1)
+
+    @patch("stress_ng_test.check_output", side_effect=CalledProcessError(1, b"", b""))
+    @patch("stress_ng_test.os.geteuid", return_value=0)
+    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "cpu"])
+    def test_main_stress_ng_error(
+        self, shutil_which_mock, os_geteuid_mock, check_output_mock
+    ):
+        self.assertEqual(main(), 1)
+
+    @patch("stress_ng_test.check_output")
+    @patch("stress_ng_test.os.geteuid", return_value=0)
+    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "cpu"])
+    def test_main_stress_cpu_success(
+        self, shutil_which_mock, os_geteuid_mock, check_output_mock
+    ):
+        self.assertEqual(main(), 0)

--- a/providers/base/tests/test_stress_ng_test.py
+++ b/providers/base/tests/test_stress_ng_test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Pedro Avalos Jimenez <pedro.avalosjimenez@canonical.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import patch
+
+from stress_ng_test import main
+
+
+class TestMainFunction(unittest.TestCase):
+    @patch("stress_ng_test.shutil.which", return_value=None)
+    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "cpu"])
+    def test_main_no_stress_ng(self, shutil_which_mock):
+        self.assertEqual(main(), 1)
+
+    @patch("stress_ng_test.os.geteuid", return_value=1000)
+    @patch("stress_ng_test.shutil.which", return_value="/usr/bin/stress-ng")
+    @patch("stress_ng_test.sys.argv", ["stress_ng_test.py", "cpu"])
+    def test_main_not_root(self, shutil_which_mock, os_geteuid_mock):
+        self.assertEqual(main(), 1)


### PR DESCRIPTION
## Description

This adds coverage unit tests for `providers/base/bin/stress_ng_test.py`. Some minor edits to `stress_ng_test.py` were required.

## Resolved issues

n/a

## Documentation

n/a

## Tests

This has been tested using `python -m coverage run manage.py test -u`.