### PR TITLE
Enter suspend by 'systemctl suspend' in suspend.sh (Bugfix)

### DIFF
--- a/providers/base/bin/suspend.sh
+++ b/providers/base/bin/suspend.sh
@@ -10,6 +10,6 @@ if [ "$architecture" = "x86_64" ] || [ "$architecture" = "i386" ]; then
     checkbox-support-fwts_test -f none -s s3 --s3-device-check --s3-device-check-delay="${STRESS_S3_WAIT_DELAY:-45}" --s3-sleep-delay="${STRESS_S3_SLEEP_DELAY:-30}"
     rm /tmp/fwts_results.log
 else
-    rtcwake -v -d "${RTC_DEVICE_FILE:-rtc0}" -m mem -s "${STRESS_S3_SLEEP_DELAY:-30}"
+    rtcwake -v -d "${RTC_DEVICE_FILE:-/dev/rtc0}" -m no -s "${STRESS_S3_SLEEP_DELAY:-30}" && systemctl suspend || exit 1
 fi
 


### PR DESCRIPTION
## Description
`systemctl suspend` is the way that user enter suspend mode regularly. Besides, this is also to align with [suspend/suspend_advanced_auto](https://github.com/canonical/checkbox/blob/dfae162175cb0d8c4195d07bb5cedd8b0a7548ca/providers/base/units/suspend/suspend.pxu#L247)
Moreover, with this change, some devices that does not support enter suspend via rtc can now run [suspend-cycles-stress-test](https://github.com/canonical/checkbox/blob/dfae162175cb0d8c4195d07bb5cedd8b0a7548ca/providers/base/units/stress/test-plan.pxu#L256).

## Resolved issues
1. To enter suspend as the way that regular user does.
2. Fix the default config variable from `rtc0` to `/dev/rtc0`

## Documentation
N/A

## Tests
https://certification.canonical.com/hardware/202406-34151/submission/386064/
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
