### PR TITLE
Update SPI detect test cases (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/spidev_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/spidev_test.py
@@ -19,16 +19,21 @@ def runcmd(command):
 
 def detect_spi_node(expected_devs=None):
     spi_devices = glob.glob("/dev/spidev*")
+    spi_devices.sort()
     if spi_devices:
         for device in spi_devices:
             print("device: {}".format(device))
             print()
     if expected_devs:
-        if set(spi_devices) != set(expected_devs.split()):
+        expected_devs = expected_devs.split(",")
+        expected_devs.sort()
+        if set(spi_devices) != set(expected_devs):
             raise SystemExit(
                 "SPI devices detected under /dev/ is not expected!\n"
                 "Expected: {}\n"
-                "Actual: {}".format(expected_devs, " ".join(spi_devices))
+                "Actual: {}".format(
+                    ", ".join(expected_devs), ", ".join(spi_devices)
+                )
             )
         print("SPI devices detected under /dev/ is expected")
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/spidev_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/spidev_test.py
@@ -17,19 +17,20 @@ def runcmd(command):
     return ret
 
 
-def detect_spi_node(expected_number=1, exit_with_notice=False):
+def detect_spi_node(expected_devs=None):
     spi_devices = glob.glob("/dev/spidev*")
     if spi_devices:
         for device in spi_devices:
             print("device: {}".format(device))
             print()
-    if exit_with_notice:
-        if len(spi_devices) != expected_number:
+    if expected_devs:
+        if set(spi_devices) != set(expected_devs.split()):
             raise SystemExit(
-                "Wrong number of SPI devices detected under /dev/!\n"
+                "SPI devices detected under /dev/ is not expected!\n"
                 "Expected: {}\n"
-                "Actual: {}".format(expected_number, len(spi_devices))
+                "Actual: {}".format(expected_devs, " ".join(spi_devices))
             )
+        print("SPI devices detected under /dev/ is expected")
 
 
 def test_spi_content_consistency(spi_path):
@@ -80,11 +81,9 @@ def main():
     parser.add_argument(
         "--detect",
         "-d",
-        type=int,
-        nargs="?",
-        const=1,
+        type=str,
         default=None,
-        help="Detect SPI node in the system. Optionally specify a number.",
+        help="Detect SPI nodes in the system.",
     )
     parser.add_argument(
         "--list",
@@ -108,9 +107,9 @@ def main():
     args = parser.parse_args()
 
     if args.detect:
-        detect_spi_node(args.detect, exit_with_notice=True)
+        detect_spi_node(args.detect)
     elif args.list:
-        detect_spi_node(exit_with_notice=False)
+        detect_spi_node()
     elif args.test:
         test_spi_content_consistency(args.path)
     else:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/spi/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/spi/jobs.pxu
@@ -11,10 +11,14 @@ _summary:
     To detect if the spi device exist
 _purpose:
     Check if the SPI devices exist
+_description:
+    This test will validate the SPI devices are exposed as expected.
+    Update the SPI_DEVICES variable if you have multiple SPI devices. the default value is "/dev/spidev0.0"
+    e.g. SPI_DEVICES="/dev/spidev0.0 /dev/spidev0.1 /dev/spidev0.3"
 environ:
-    SPI_DEVICE_COUNT
+    SPI_DEVICES
 command:
-    spidev_test.py -d "${SPI_DEVICE_COUNT:-1}"
+    spidev_test.py -d "${SPI_DEVICES:-/dev/spidev0.0}"
 
 unit: template
 template-resource: ce-oem-spi-list

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/spi/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/spi/jobs.pxu
@@ -14,7 +14,7 @@ _purpose:
 _description:
     This test will validate the SPI devices are exposed as expected.
     Update the SPI_DEVICES variable if you have multiple SPI devices. the default value is "/dev/spidev0.0"
-    e.g. SPI_DEVICES="/dev/spidev0.0 /dev/spidev0.1 /dev/spidev0.3"
+    e.g. SPI_DEVICES="/dev/spidev0.0,/dev/spidev0.1,/dev/spidev0.3"
 environ:
     SPI_DEVICES
 command:


### PR DESCRIPTION
## Description
Modified the SPI detect test cases as validate the device nodes is match or not.

## Resolved issues
N/A

## Documentation
N/A

## Tests
side-loading test results:
https://certification.canonical.com/hardware/202405-33984/submission/386459/
