### PR TITLE
[checkbox-ce-oem] Revise the test plan structure of strict confinement test (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/mediacard/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/mediacard/jobs.pxu
@@ -1,6 +1,6 @@
 plugin: user-interact
 category_id: strict-confinement-mode
-id: strict-confine/mediacard/sdhc-insert
+id: strict-confinement/mediacard/sdhc-insert
 flags: also-after-suspend
 estimated_duration: 30.0
 command:
@@ -9,10 +9,14 @@ imports:
   from com.canonical.plainbox import manifest
   from com.canonical.certification import snap
   from com.canonical.certification import lsb
+  from com.canonical.certification import connections
 requires:
   manifest.has_card_reader == 'True'
   lsb.distributor_id == 'Ubuntu Core'
   snap.name == 'test-strict-confinement'
+  connections.slot == "snapd:mount-control" and connections.plug == "test-strict-confinement:mount-control"
+  connections.slot == "snapd:log-observe" and connections.plug == "test-strict-confinement:log-observe"
+  connections.slot == "snapd:removable-media " and connections.plug == "test-strict-confinement:removable-media "
 user: root
 _summary: Test that insertion of an SDHC card is detected
 _description:
@@ -31,9 +35,9 @@ _verification:
 
 plugin: shell
 category_id: strict-confinement-mode
-id: strict-confine/mediacard/sdhc-storage
+id: strict-confinement/mediacard/sdhc-storage
 estimated_duration: 30.0
-depends: strict-confine/mediacard/sdhc-insert
+depends: strict-confinement/mediacard/sdhc-insert
 user: root
 flags: preserve-cwd reset-locale also-after-suspend
 command: test-strict-confinement.usb-read-write
@@ -44,10 +48,10 @@ _description:
 
 plugin: user-interact
 category_id: strict-confinement-mode
-id: strict-confine/mediacard/sdhc-remove
+id: strict-confinement/mediacard/sdhc-remove
 flags: also-after-suspend
 estimated_duration: 30.0
-depends: strict-confine/mediacard/sdhc-insert
+depends: strict-confinement/mediacard/sdhc-insert
 command:
   test-strict-confinement.run-watcher removal mediacard
 user: root

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/mediacard/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/mediacard/jobs.pxu
@@ -16,7 +16,7 @@ requires:
   snap.name == 'test-strict-confinement'
   connections.slot == "snapd:mount-control" and connections.plug == "test-strict-confinement:mount-control"
   connections.slot == "snapd:log-observe" and connections.plug == "test-strict-confinement:log-observe"
-  connections.slot == "snapd:removable-media " and connections.plug == "test-strict-confinement:removable-media "
+  connections.slot == "snapd:removable-media" and connections.plug == "test-strict-confinement:removable-media"
 user: root
 _summary: Test that insertion of an SDHC card is detected
 _description:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/mediacard/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/mediacard/test-plan.pxu
@@ -1,4 +1,4 @@
-id: strict-confinement-mediacard
+id: strict-confinement-mediacard-manual
 unit: test plan
 _name: Test mediacard in strict confinement mode.
 _description:
@@ -10,7 +10,7 @@ include:
     strict-confinement/mediacard/sdhc-remove
 
 
-id: after-suspend-strict-confinement-mediacard
+id: after-suspend-strict-confinement-mediacard-manual
 unit: test plan
 _name: After suspend test mediacard in strict confinement mode.
 _description:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/mediacard/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/mediacard/test-plan.pxu
@@ -1,0 +1,22 @@
+id: strict-confinement-mediacard
+unit: test plan
+_name: Test mediacard in strict confinement mode.
+_description:
+    Test mediacard in strict confinement mode.
+    Rely on test-strict-confinement SNAP to test.
+include:
+    strict-confinement/mediacard/sdhc-insert
+    strict-confinement/mediacard/sdhc-storage
+    strict-confinement/mediacard/sdhc-remove
+
+
+id: after-suspend-strict-confinement-mediacard
+unit: test plan
+_name: After suspend test mediacard in strict confinement mode.
+_description:
+    Afrer suspend test mediacard in strict confinement mode.
+    Rely on test-strict-confinement SNAP to test.
+include:
+    after-suspend-strict-confinement/mediacard/sdhc-insert
+    after-suspend-strict-confinement/mediacard/sdhc-storage
+    after-suspend-strict-confinement/mediacard/sdhc-remove

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/power-management/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/power-management/jobs.pxu
@@ -12,9 +12,11 @@ depends: com.canonical.certification::init-boot-loop-data
 imports:
   from com.canonical.certification import snap
   from com.canonical.certification import lsb
+  from com.canonical.certification import connections
 requires:
   lsb.distributor_id == 'Ubuntu Core'
   snap.name == 'test-strict-confinement'
+  connections.slot == "snapd:shutdown" and connections.plug == "test-strict-confinement:shutdown"
 command:
   rtcwake -d "${RTC_DEVICE_FILE:-rtc0}" -v -m no -s "${STRESS_BOOT_WAKEUP_DELAY:-120}"
   test-strict-confinement.dbus-cold-boot
@@ -56,9 +58,11 @@ depends: com.canonical.certification::init-boot-loop-data
 imports:
   from com.canonical.certification import snap
   from com.canonical.certification import lsb
+  from com.canonical.certification import connections
 requires:
   lsb.distributor_id == 'Ubuntu Core'
   snap.name == 'test-strict-confinement'
+  connections.slot == "snapd:shutdown" and connections.plug == "test-strict-confinement:shutdown"
 command:
   test-strict-confinement.dbus-warm-boot
   sleep 60

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/power-management/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/power-management/test-plan.pxu
@@ -1,0 +1,26 @@
+id: strict-confinement-dbus-warm-boot
+unit: test plan
+_name: Warm reboot test via dbus
+_description:
+    Warm reboot test by using dbus command.
+    Rely on test-strict-confinement SNAP to test.
+bootstrap_include:
+mandatory_include:
+    com.canonical.certification::init-boot-loop-data
+include:
+    strict-confinement/dbus-warm-boot
+    strict-confinement/dbus-warm-boot-test
+
+
+id: strict-confinement-dbus-cold-boot
+unit: test plan
+_name: Cold boot test via dbus
+_description:
+    Cold boot test by using dbus command.
+    Rely on test-strict-confinement SNAP to test.
+bootstrap_include:
+mandatory_include:
+    com.canonical.certification::init-boot-loop-data
+include:
+    strict-confinement/dbus-cold-boot
+    strict-confinement/dbus-cold-boot-test

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/power-management/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/power-management/test-plan.pxu
@@ -1,4 +1,4 @@
-id: strict-confinement-dbus-warm-boot
+id: strict-confinement-dbus-warm-boot-automated
 unit: test plan
 _name: Warm reboot test via dbus
 _description:
@@ -12,7 +12,7 @@ include:
     strict-confinement/dbus-warm-boot-test
 
 
-id: strict-confinement-dbus-cold-boot
+id: strict-confinement-dbus-cold-boot-automated
 unit: test plan
 _name: Cold boot test via dbus
 _description:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/sensor/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/sensor/jobs.pxu
@@ -6,7 +6,7 @@ id: strict-confinement/temperature_{{ name }}_{{ type }}
 _summary: Check Thermal temperature of {{ name }} - {{ type }}
 _description:
     Test a thermal temperature for {{ name }} - {{ type }}.
-category_id: thermal
+category_id: strict-confinement-mode
 plugin: shell
 estimated_duration: 5m
 flags: also-after-suspend

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/sensor/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/sensor/jobs.pxu
@@ -1,8 +1,8 @@
 unit: template
 template-engine: jinja2
 template-resource: thermal_zones
-template-id: strict-confine/temperature-test
-id: strict-confine/temperature_{{ name }}_{{ type }}
+template-id: strict-confinement/temperature-test
+id: strict-confinement/temperature_{{ name }}_{{ type }}
 _summary: Check Thermal temperature of {{ name }} - {{ type }}
 _description:
     Test a thermal temperature for {{ name }} - {{ type }}.
@@ -13,8 +13,10 @@ flags: also-after-suspend
 imports:
   from com.canonical.certification import snap
   from com.canonical.certification import lsb
+  from com.canonical.certification import connections
 requires:
   lsb.distributor_id == 'Ubuntu Core'
   snap.name == 'test-strict-confinement'
+  connections.slot == "snapd:hardware-observe" and connections.plug == "test-strict-confinement:hardware-observe"
 command:
-    test-strict-confinement.thermal-test monitor -n {{ name }} --extra-commands "dd if=/dev/zero of=/dev/null"
+  test-strict-confinement.thermal-test monitor -n {{ name }} --extra-commands "dd if=/dev/zero of=/dev/null"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/sensor/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/sensor/test-plan.pxu
@@ -1,4 +1,4 @@
-id: strict-confinement-thermal
+id: strict-confinement-thermal-automated
 unit: test plan
 _name: Test thermal sensor in strict confinement mode.
 _desription:
@@ -9,7 +9,7 @@ bootstrap_include:
 include:
     strict-confinement/temperature_.*
 
-id: after-suspend-strict-confinement-thermal
+id: after-suspend-strict-confinement-thermal-automated
 unit: test plan
 _name: Test thermal sensor in strict confinement mode.
 _desription:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/sensor/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/sensor/test-plan.pxu
@@ -7,7 +7,7 @@ _desription:
 bootstrap_include:
     thermal_zones
 include:
-    strict-confinement/temperature-test
+    strict-confinement/temperature_.*
 
 id: after-suspend-strict-confinement-thermal
 unit: test plan
@@ -18,4 +18,4 @@ _desription:
 bootstrap_include:
     thermal_zones
 include:
-    after-suspend-strict-confinement/temperature-test
+    after-suspend-strict-confinement/temperature_.*

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/sensor/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/sensor/test-plan.pxu
@@ -1,0 +1,21 @@
+id: strict-confinement-thermal
+unit: test plan
+_name: Test thermal sensor in strict confinement mode.
+_desription:
+    Test thermal sensor in strict confinement mode.
+    Rely on test-strict-confinment SNAP to test.
+bootstrap_include:
+    thermal_zones
+include:
+    strict-confinement/temperature-test
+
+id: after-suspend-strict-confinement-thermal
+unit: test plan
+_name: Test thermal sensor in strict confinement mode.
+_desription:
+    Test thermal sensor in strict confinement mode.
+    Rely on test-strict-confinment SNAP to test.
+bootstrap_include:
+    thermal_zones
+include:
+    after-suspend-strict-confinement/temperature-test

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/test-plan-strict-confinement.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/test-plan-strict-confinement.pxu
@@ -1,86 +1,65 @@
-id: strict-confinement-dbus-warm-boot
+id: strict-confinement-full
 unit: test plan
-_name: Warm reboot test via dbus
+_name: Strict-confinement - Full manual + automated tests for Ubuntu Core in strict confinement environment
 _description:
-    Warm reboot test by using dbus command.
-    Rely on test-strict-confinement SNAP to test.
-bootstrap_include:
-mandatory_include:
-    com.canonical.certification::init-boot-loop-data
+ Combined manual and automated test plans for Ubuntu Core in strict confinement environment.
 include:
-    strict-confinement/dbus-warm-boot
-    strict-confinement/dbus-warm-boot-test
+nested_part:
+    strict-confinement-manual
+    strict-confinement-automated
+    after-suspend-strict-confinement-manual
+    after-suspend-strict-confinement-automated
 
-
-id: strict-confinement-dbus-cold-boot
+id: strict-confinement-manual
 unit: test plan
-_name: Cold boot test via dbus
+_name: Strict-confinement - Manual only QA tests for Ubuntu Core in strict confinement environment
 _description:
-    Cold boot test by using dbus command.
-    Rely on test-strict-confinement SNAP to test.
-bootstrap_include:
-mandatory_include:
-    com.canonical.certification::init-boot-loop-data
+ Ubuntu Core QA test plan for strict confinement environment.
+ This test plan contains all of the tests that require manual
+ control of device hardware or some other user input to complete.
+estimated_duration: 3600
 include:
-    strict-confinement/dbus-cold-boot
-    strict-confinement/dbus-cold-boot-test
+nested_part:
+    strict-confinement-mediacard
+exclude:
 
-
-id: strict-confine-mediacard
+id: strict-confinement-automated
 unit: test plan
-_name: Test mediacard in strict confinement mode.
+_name: Strict-confinement - Automated only QA tests for Ubuntu Core in strict confinement environment
 _description:
-    Test mediacard in strict confinement mode.
-    Rely on test-strict-confinement SNAP to test.
+ Ubuntu Core QA test plan for the strict confinement environment.
+ This test plan contains all of the automated tests used to validate
+ the Ubuntu Core in strict confinement environment.
 include:
-    strict-confine/mediacard/sdhc-insert
-    strict-confine/mediacard/sdhc-storage
-    strict-confine/mediacard/sdhc-remove
+nested_part:
+    strict-confinement-timedatectl
+    strict-confinement-thermal
+    strict-confinement-dbus-warm-boot
+    strict-confinement-dbus-cold-boot
+exclude:
 
-
-id: after-suspend-strict-confine-mediacard
+id: after-suspend-strict-confinement-manual
 unit: test plan
-_name: After suspend test mediacard in strict confinement mode.
+_name: Strict-confinement - After suspend Manual only QA tests for Ubuntu Core in strict confinement environment
 _description:
-    Afrer suspend test mediacard in strict confinement mode.
-    Rely on test-strict-confinement SNAP to test.
+ Ubuntu Core QA test plan for strict confinement environment.
+ This test plan contains all of the tests that require manual
+ control of device hardware or some other user input to complete.
+estimated_duration: 3600
 include:
-    after-suspend-strict-confine/mediacard/sdhc-insert
-    after-suspend-strict-confine/mediacard/sdhc-storage
-    after-suspend-strict-confine/mediacard/sdhc-remove
+nested_part:
+    after-suspend-strict-confinement-mediacard
+exclude:
 
-
-id: strict-confine-thermal
+id: after-suspend-strict-confinement-automated
 unit: test plan
-_name: Test thermal sensor in strict confinement mode.
-_desription:
-    Test thermal sensor in strict confinement mode.
-    Rely on test-strict-confinment SNAP to test.
-bootstrap_include:
-    thermal_zones
+_name: Strict-confinement - After suspend Automated only QA tests for Ubuntu Core in strict confinement environment
+_description:
+ Ubuntu Core QA test plan for the strict confinement environment.
+ This test plan contains all of the automated tests used to validate
+ the Ubuntu Core in strict confinement environment.
 include:
-    strict-confine/temperature-test
-
-
-id: strict-confine-timedatectl
-unit: test plan
-_name: Test timedatectl in strict confinement mode.
-_desription:
-    Test timedatectl command in strcit confinement mode.
-    Rely on test-strict-confinment SNAP to test.
-bootstrap_include:
-include:
-    strict-confinement/timedatectl-timezone
-    strict-confinement/timedatectl-ntp
-
-
-id: after-suspend-strict-confine-timedatectl
-unit: test plan
-_name: After suspend test timedatectl in strict confinement mode.
-_desription:
-    After suspend test timedatectl command in strcit confinement mode.
-    Rely on test-strict-confinment SNAP to test.
-bootstrap_include:
-include:
-    after-suspend-strict-confinement/timedatectl-timezone
-    after-suspend-strict-confinement/timedatectl-ntp
+nested_part:
+    after-suspend-strict-confinement-timedatectl
+    after-suspend-strict-confinement-thermal
+exclude:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/test-plan-strict-confinement.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/test-plan-strict-confinement.pxu
@@ -20,7 +20,7 @@ _description:
 estimated_duration: 3600
 include:
 nested_part:
-    strict-confinement-mediacard
+    strict-confinement-mediacard-manual
 exclude:
 
 id: strict-confinement-automated
@@ -32,10 +32,10 @@ _description:
  the Ubuntu Core in strict confinement environment.
 include:
 nested_part:
-    strict-confinement-timedatectl
-    strict-confinement-thermal
-    strict-confinement-dbus-warm-boot
-    strict-confinement-dbus-cold-boot
+    strict-confinement-timedatectl-automated
+    strict-confinement-thermal-automated
+    strict-confinement-dbus-warm-boot-automated
+    strict-confinement-dbus-cold-boot-automated
 exclude:
 
 id: after-suspend-strict-confinement-manual
@@ -48,7 +48,7 @@ _description:
 estimated_duration: 3600
 include:
 nested_part:
-    after-suspend-strict-confinement-mediacard
+    after-suspend-strict-confinement-mediacard-manual
 exclude:
 
 id: after-suspend-strict-confinement-automated
@@ -60,6 +60,6 @@ _description:
  the Ubuntu Core in strict confinement environment.
 include:
 nested_part:
-    after-suspend-strict-confinement-timedatectl
-    after-suspend-strict-confinement-thermal
+    after-suspend-strict-confinement-timedatectl-automated
+    after-suspend-strict-confinement-thermal-automated
 exclude:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/timedatectl/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/timedatectl/jobs.pxu
@@ -15,6 +15,8 @@ imports:
 requires:
   lsb.distributor_id == 'Ubuntu Core'
   snap.name == 'test-strict-confinement'
+  connections.slot == "snapd:timeserver-control" and connections.plug == "test-strict-confinement:timeserver-control"
+  connections.slot == "snapd:time-control" and connections.plug == "test-strict-confinement:time-control"
   connections.slot == "snapd:timezone-control" and connections.plug == "test-strict-confinement:timezone-control"
 command:
   test-strict-confinement.timedatectl-timezone
@@ -40,5 +42,6 @@ requires:
   snap.name == 'test-strict-confinement'
   connections.slot == "snapd:timeserver-control" and connections.plug == "test-strict-confinement:timeserver-control"
   connections.slot == "snapd:time-control" and connections.plug == "test-strict-confinement:time-control"
+  connections.slot == "snapd:timezone-control" and connections.plug == "test-strict-confinement:timezone-control"
 command:
   test-strict-confinement.timedatectl-ntp

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/timedatectl/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/timedatectl/test-plan.pxu
@@ -1,0 +1,22 @@
+id: strict-confinement-timedatectl
+unit: test plan
+_name: Test timedatectl in strict confinement mode.
+_desription:
+    Test timedatectl command in strcit confinement mode.
+    Rely on test-strict-confinment SNAP to test.
+bootstrap_include:
+include:
+    strict-confinement/timedatectl-timezone
+    strict-confinement/timedatectl-ntp
+
+
+id: after-suspend-strict-confinement-timedatectl
+unit: test plan
+_name: After suspend test timedatectl in strict confinement mode.
+_desription:
+    After suspend test timedatectl command in strcit confinement mode.
+    Rely on test-strict-confinment SNAP to test.
+bootstrap_include:
+include:
+    after-suspend-strict-confinement/timedatectl-timezone
+    after-suspend-strict-confinement/timedatectl-ntp

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/timedatectl/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/timedatectl/test-plan.pxu
@@ -1,4 +1,4 @@
-id: strict-confinement-timedatectl
+id: strict-confinement-timedatectl-automated
 unit: test plan
 _name: Test timedatectl in strict confinement mode.
 _desription:
@@ -10,7 +10,7 @@ include:
     strict-confinement/timedatectl-ntp
 
 
-id: after-suspend-strict-confinement-timedatectl
+id: after-suspend-strict-confinement-timedatectl-automated
 unit: test plan
 _name: After suspend test timedatectl in strict confinement mode.
 _desription:


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
Revise the test plan structure of strict confinement test to make it more clear.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
Side load result of list-bootstrapped
```
iotuc@atlashost:~$ sudo checkbox-shiner.checkbox-cli list-bootstrapped com.canonical.contrib::strict-confinement-full
Using sideloaded provider: checkbox-provider-ce-oem, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-ce-oem
Using sideloaded provider: checkbox-provider-shiner, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-shiner
Skipped file: /snap/checkbox-shiner/335/providers/plainbox-provider-checkbox/units/stress/suspend_cycles_reboot.md
Using sideloaded provider: checkbox-provider-ce-oem, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-ce-oem
Using sideloaded provider: checkbox-provider-shiner, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-shiner
com.canonical.certification::init-boot-loop-data
com.canonical.certification::snap
com.canonical.certification::lsb
com.canonical.plainbox::manifest
com.canonical.certification::connections
com.canonical.contrib::strict-confinement/mediacard/sdhc-insert
com.canonical.contrib::strict-confinement/mediacard/sdhc-storage
com.canonical.contrib::strict-confinement/mediacard/sdhc-remove
com.canonical.contrib::strict-confinement/timedatectl-timezone
com.canonical.contrib::strict-confinement/timedatectl-ntp
com.canonical.contrib::strict-confinement/temperature_thermal_zone0_cpu-thermal
com.canonical.certification::sleep
com.canonical.certification::rtc
com.canonical.contrib::strict-confinement/temperature_thermal_zone1_soc-thermal
com.canonical.certification::suspend/suspend_advanced_auto
com.canonical.contrib::after-suspend-strict-confinement/temperature_thermal_zone0_cpu-thermal
com.canonical.contrib::after-suspend-strict-confinement/temperature_thermal_zone1_soc-thermal
com.canonical.contrib::strict-confinement/dbus-warm-boot
com.canonical.contrib::strict-confinement/dbus-warm-boot-test
com.canonical.contrib::strict-confinement/dbus-cold-boot
com.canonical.contrib::strict-confinement/dbus-cold-boot-test
com.canonical.contrib::after-suspend-strict-confinement/mediacard/sdhc-insert
com.canonical.contrib::after-suspend-strict-confinement/mediacard/sdhc-storage
com.canonical.contrib::after-suspend-strict-confinement/mediacard/sdhc-remove
com.canonical.contrib::after-suspend-strict-confinement/timedatectl-timezone
com.canonical.contrib::after-suspend-strict-confinement/timedatectl-ntp
```

Sideload test result:
https://certification.canonical.com/hardware/202403-33886/submission/386826/

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
