### PR TITLE
Stress-ng from the PPA (infra)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -55,6 +55,8 @@ slots:
 package-repositories:
   - type: apt
     ppa: checkbox-dev/stable
+  - type: apt
+    ppa: colin-king/stress-ng
 
 parts:
   version-calculator:
@@ -94,33 +96,12 @@ parts:
       - libbsd-dev
     after: [version-calculator]
 ################################################################################
-# Upstream: https://kernel.ubuntu.com/git/cking/stress-ng.git/plain/snap/snapcraft.yaml
   stress-ng:
-    source-tag: "V0.15.07"
-    # stress-ng remains at version 0.15.07 because libipsec-mb-dev and libxxhash-dev are not available for Ubuntu 16.04 (Xenial).
-    source-depth: 1
-    plugin: make
-    build-environment:
-      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
-      - LDFLAGS: "-Wl,-z,relro -lrt"
-    source: https://github.com/ColinIanKing/stress-ng.git
-    make-parameters:
-      - STATIC=1 VERBOSE=1
+    plugin: nil
     stage-packages:
-      - libjudydebian1
-      - libsctp1
+      - stress-ng
     build-packages:
-      - gcc
-      - make
-      - zlib1g-dev
-      - libbsd-dev
-      - libgcrypt20-dev
-      - libkeyutils-dev
-      - libapparmor-dev
-      - libaio-dev
-      - libcap-dev
-      - libsctp-dev
-      - libjudy-dev
+      - stress-ng
     after: [fwts]
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/snapcraft-snaps.git/tree/acpica/snapcraft.yaml

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -59,6 +59,8 @@ slots:
 package-repositories:
   - type: apt
     ppa: checkbox-dev/stable
+  - type: apt
+    ppa: colin-king/stress-ng
 
 parts:
   version-calculator:
@@ -98,41 +100,12 @@ parts:
       - libbsd-dev
     after: [version-calculator]
 ################################################################################
-# Upstream: https://kernel.ubuntu.com/git/cking/stress-ng.git/plain/snap/snapcraft.yaml
   stress-ng:
-    source-tag: "V0.15.09"
-    source-depth: 1
-    plugin: make
-    build-environment:
-      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
-      - LDFLAGS: "-Wl,-z,relro -lrt"
-    source: https://github.com/ColinIanKing/stress-ng.git
-    make-parameters:
-      - STATIC=1 VERBOSE=1
+    plugin: nil
     stage-packages:
-      - libjpeg-turbo8
-      - libjudydebian1
-      - libsctp1
-      - libxxhash0
+      - stress-ng
     build-packages:
-      - gcc
-      - make
-      - zlib1g-dev
-      - libbsd-dev
-      - libgcrypt20-dev
-      - libkeyutils-dev
-      - libapparmor-dev
-      - libaio-dev
-      - libcap-dev
-      - libsctp-dev
-      - libatomic1
-      - libjudy-dev
-      - libjpeg-dev
-      - libkmod-dev
-      - libattr1-dev
-      - libxxhash-dev
-      - libmd-dev
-      - on amd64: [ libipsec-mb-dev ]
+      - stress-ng
     after: [fwts]
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/snapcraft-snaps.git/tree/acpica/snapcraft.yaml

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -59,6 +59,8 @@ slots:
 package-repositories:
   - type: apt
     ppa: checkbox-dev/stable
+  - type: apt
+    ppa: colin-king/stress-ng
 
 parts:
   version-calculator:
@@ -100,36 +102,12 @@ parts:
       - libbsd-dev
     after: [version-calculator]
 ################################################################################
-# Upstream: https://kernel.ubuntu.com/git/cking/stress-ng.git/plain/snap/snapcraft.yaml
   stress-ng:
-    source-tag: "V0.15.09"
-    source-depth: 1
-    plugin: make
-    build-environment:
-      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
-      - LDFLAGS: "-Wl,-z,relro -lrt"
-    source: https://github.com/ColinIanKing/stress-ng.git
-    make-parameters:
-      - STATIC=1 VERBOSE=1
+    plugin: nil
+    stage-packages:
+      - stress-ng
     build-packages:
-      - gcc
-      - make
-      - zlib1g-dev
-      - libbsd-dev
-      - libgcrypt20-dev
-      - libkeyutils-dev
-      - libapparmor-dev
-      - libaio-dev
-      - libcap-dev
-      - libsctp-dev
-      - libatomic1
-      - libjudy-dev
-      - libjpeg-dev
-      - libkmod-dev
-      - libattr1-dev
-      - libxxhash-dev
-      - libmd-dev
-      - on amd64: [ libipsec-mb-dev ]
+      - stress-ng
     after: [fwts]
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/snapcraft-snaps.git/tree/acpica/snapcraft.yaml

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -63,6 +63,8 @@ slots:
 package-repositories:
   - type: apt
     ppa: checkbox-dev/stable
+  - type: apt
+    ppa: colin-king/stress-ng
 
 parts:
   version-calculator:
@@ -104,36 +106,12 @@ parts:
       - libbsd-dev
     after: [version-calculator]
 ################################################################################
-# Upstream: https://kernel.ubuntu.com/git/cking/stress-ng.git/plain/snap/snapcraft.yaml
   stress-ng:
-    source-tag: "V0.15.09"
-    source-depth: 1
-    plugin: make
-    build-environment:
-      - CFLAGS: "-fstack-protector-strong -Wformat -Werror=format-security"
-      - LDFLAGS: "-Wl,-z,relro -lrt"
-    source: https://github.com/ColinIanKing/stress-ng.git
-    make-parameters:
-      - STATIC=1 VERBOSE=1
+    plugin: nil
+    stage-packages:
+      - stress-ng
     build-packages:
-      - gcc
-      - make
-      - zlib1g-dev
-      - libbsd-dev
-      - libgcrypt20-dev
-      - libkeyutils-dev
-      - libapparmor-dev
-      - libaio-dev
-      - libcap-dev
-      - libsctp-dev
-      - libatomic1
-      - libjudy-dev
-      - libjpeg-dev
-      - libkmod-dev
-      - libattr1-dev
-      - libxxhash-dev
-      - libmd-dev
-      - on amd64: [ libipsec-mb-dev ]
+      - stress-ng
     after: [fwts]
 ################################################################################
 # Upstream: https://kernel.ubuntu.com/git/cking/snapcraft-snaps.git/tree/acpica/snapcraft.yaml

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -60,6 +60,10 @@ slots:
     read:
       - /
 
+package-repositories:
+  - type: apt
+    ppa: colin-king/stress-ng
+
 parts:
   version-calculator:
     plugin: dump


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This updates all snaps to install stress-ng from the ppa unifying all snaps to core24 that has been doing this for a while. 

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1077

## Documentation

N/A

## Tests

Built here: https://github.com/canonical/checkbox/actions/runs/10315986224 (red is unrelated)

Installed and ran it locally to be sure the LD_PATH doesnt cause any issue. It works 
![image](https://github.com/user-attachments/assets/4ee1d591-7e41-4b2d-a7e1-d3a25c1edf05)

