### PR TITLE
Handle no installed dkms modules (BugFix)

### DIFF
--- a/providers/sru/bin/dkms_build_validation.py
+++ b/providers/sru/bin/dkms_build_validation.py
@@ -78,6 +78,11 @@ def parse_dkms_status(dkms_status: str, ubuntu_release: str) -> List[Dict]:
             else:
                 kernel_ver = details.split(", ")[2]
             kernel_info.append({"version": kernel_ver, "status": status})
+            print(
+                "Found module {}, status {} for kernel version {}".format(
+                    details, status, kernel_ver
+                )
+            )
 
     sorted_kernel_info = sorted(
         kernel_info, key=lambda x: parse_version(x["version"])
@@ -180,6 +185,7 @@ def main():
     # if there are no built or installed dkms modules there is nothing
     # to check
     if not sorted_kernel_info:
+        print("No installed dkms modules found, nothing to check")
         return 0
 
     # kernel_ver_max should be the same as kernel_ver_current

--- a/providers/sru/bin/dkms_build_validation.py
+++ b/providers/sru/bin/dkms_build_validation.py
@@ -177,6 +177,11 @@ def main():
     # Parse and sort the DKMS status and sort the kernel versions
     sorted_kernel_info = parse_dkms_status(dkms_status, ubuntu_release)
 
+    # if there are no built or installed dkms modules there is nothing
+    # to check
+    if not sorted_kernel_info:
+        return 0
+
     # kernel_ver_max should be the same as kernel_ver_current
     kernel_ver_current = run_command(["uname", "-r"])
     if check_kernel_version(
@@ -184,7 +189,7 @@ def main():
     ):
         return 1
 
-    # Count the occurernces of the latest and the oldest kernel version and
+    # Count the occurrences of the latest and the oldest kernel version and
     # compare the number of DKMS modules for min and max kernel versions
     check_dkms_module_count(sorted_kernel_info, dkms_status)
 

--- a/providers/sru/tests/test_dkms_build_validation.py
+++ b/providers/sru/tests/test_dkms_build_validation.py
@@ -51,6 +51,16 @@ class TestDKMSValidation(unittest.TestCase):
         "(WARNING! Diff between built and installed module!)"
     )
 
+    dkms_status_oem_focal = (
+        "fwts-efi-runtime-dkms, 24.07.00, 5.14.0-1042-oem, x86_64: installed\n"
+        "fwts-efi-runtime-dkms, 24.07.00, 5.15.0-117-generic, x86_64: installed"
+    )
+
+    dkms_status_stock_noble = (
+        "fwts-efi-runtime-dkms/24.07.00: added\n"
+        "nvidia/550.107.02, 6.8.0-44-generic, x86_64: installed"
+    )
+
     sorted_kernel_info = [
         {"version": "6.5.0-15-generic", "status": "installed"},
         {"version": "6.5.0-17-generic", "status": "installed"},
@@ -316,7 +326,9 @@ class TestDKMSValidation(unittest.TestCase):
             "6.5.0-17-generic",
         ]
         mock_err.return_value = 0
-        self.assertEqual(main(), 0)
+        result = main()
+        self.assertEqual(mock_err.call_count, 1)
+        self.assertEqual(result, 0)
 
     @patch("dkms_build_validation.run_command")
     @patch("dkms_build_validation.has_dkms_build_errors")
@@ -327,7 +339,9 @@ class TestDKMSValidation(unittest.TestCase):
             "6.8.0-40-generic",
         ]
         mock_err.return_value = 0
-        self.assertEqual(main(), 0)
+        result = main()
+        self.assertEqual(mock_err.call_count, 0)
+        self.assertEqual(result, 0)
 
     @patch("dkms_build_validation.run_command")
     @patch("dkms_build_validation.has_dkms_build_errors")
@@ -338,7 +352,9 @@ class TestDKMSValidation(unittest.TestCase):
             "6.8.0-40-generic",
         ]
         mock_err.return_value = 0
-        self.assertEqual(main(), 0)
+        result = main()
+        self.assertEqual(mock_err.call_count, 0)
+        self.assertEqual(result, 0)
 
     @patch("dkms_build_validation.run_command")
     @patch("dkms_build_validation.has_dkms_build_errors")
@@ -349,7 +365,9 @@ class TestDKMSValidation(unittest.TestCase):
             "6.8.0-40-generic",
         ]
         mock_err.return_value = 0
-        self.assertEqual(main(), 0)
+        result = main()
+        self.assertEqual(mock_err.call_count, 1)
+        self.assertEqual(result, 0)
 
     @patch("dkms_build_validation.run_command")
     @patch("dkms_build_validation.has_dkms_build_errors")
@@ -360,7 +378,9 @@ class TestDKMSValidation(unittest.TestCase):
             "6.0.0-1011-oem",
         ]
         mock_err.return_value = 0
-        self.assertEqual(main(), 0)
+        result = main()
+        self.assertEqual(mock_err.call_count, 1)
+        self.assertEqual(result, 0)
 
     @patch("dkms_build_validation.run_command")
     @patch("dkms_build_validation.has_dkms_build_errors")
@@ -371,4 +391,32 @@ class TestDKMSValidation(unittest.TestCase):
             "6.5.0-17-generic",
         ]
         mock_err.return_value = 1
-        self.assertEqual(main(), 1)
+        result = main()
+        self.assertEqual(mock_err.call_count, 1)
+        self.assertEqual(result, 1)
+
+    @patch("dkms_build_validation.run_command")
+    @patch("dkms_build_validation.has_dkms_build_errors")
+    def test_main_oem_focal(self, mock_err, mock_run_command):
+        mock_run_command.side_effect = [
+            "Release:	20.04",
+            self.dkms_status_oem_focal,
+            "5.15.0-117-generic",
+        ]
+        mock_err.return_value = 0
+        result = main()
+        self.assertEqual(mock_err.call_count, 1)
+        self.assertEqual(result, 0)
+
+    @patch("dkms_build_validation.run_command")
+    @patch("dkms_build_validation.has_dkms_build_errors")
+    def test_main_stock_noble(self, mock_err, mock_run_command):
+        mock_run_command.side_effect = [
+            "No LSB modules are available.\nRelease:	24.04",
+            self.dkms_status_stock_noble,
+            "6.8.0-44-generic",
+        ]
+        mock_err.return_value = 0
+        result = main()
+        self.assertEqual(mock_err.call_count, 1)
+        self.assertEqual(result, 0)


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The "test_main_*" tests did not actually exercise anything because all calls where mocked and there wasnt any input provided.

The case where there was no dkms modules at all the system was not handled. Add a call_count on test main to ensure this addition wasnt skipping the apt log checking.

## Resolved issues

## Documentation

## Tests

Additional unittests with input from more release
