### PR TITLE
Fix metabox (infra)

### DIFF
--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -42,7 +42,7 @@ jobs:
       run:
         working-directory: metabox
     needs: metabox_run_required
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       # Workaround to get loguru colored output
       # See https://github.com/Delgan/loguru/issues/604

--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -68,4 +68,7 @@ jobs:
           python3 -m venv --system-site-packages venv
           venv/bin/python3 -m pip install -e .
       - name: Run Metabox scenarios
-        run: venv/bin/metabox configs/${{ matrix.mode }}-source-${{ matrix.os }}.py
+        run: |
+          # activate needed as metabox uses pip to validate the source package location
+          . venv/bin/activate
+          metabox configs/${{ matrix.mode }}-source-${{ matrix.os }}.py

--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -42,7 +42,8 @@ jobs:
       run:
         working-directory: metabox
     needs: metabox_run_required
-    runs-on: ubuntu-24.04
+    # use 20.04 as we need xenial containers support => cgroup v1
+    runs-on: ubuntu-20.04
     env:
       # Workaround to get loguru colored output
       # See https://github.com/Delgan/loguru/issues/604
@@ -61,14 +62,14 @@ jobs:
           lxc profile device add default root disk path=/ pool=metabox${{ matrix.os }}
           lxc storage list
       - name: Install dependencies
-        run: sudo apt install -y -qq python3-pip python3-setuptools python3-venv python3-pkg-resources
+        run: |
+          # Here we pull from pypi because we need a version that supports pyproject.toml
+          # urllib update is to bypass a req. fail due to dist-packages. Version is pinned
+          # to <2 because pylxd doesn't currently support >=2
+          # pyopenssl upgraded is necessary because pylxd doesn't support the old version
+          # of pyopenssl included in focal
+          python3 -m pip install --upgrade pyopenssl pip "setuptools==70.0.0" "urllib3==1.26.19"
       - name: Install Metabox
-        run: |
-          # system-site-packages needed for pkg_resource installed by setuptools
-          python3 -m venv --system-site-packages venv
-          venv/bin/python3 -m pip install -e .
+        run: python3 -m pip install -e .
       - name: Run Metabox scenarios
-        run: |
-          # activate needed as metabox uses pip to validate the source package location
-          . venv/bin/activate
-          metabox configs/${{ matrix.mode }}-source-${{ matrix.os }}.py
+        run: metabox configs/${{ matrix.mode }}-source-${{ matrix.os }}.py

--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -42,7 +42,7 @@ jobs:
       run:
         working-directory: metabox
     needs: metabox_run_required
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       # Workaround to get loguru colored output
       # See https://github.com/Delgan/loguru/issues/604
@@ -61,8 +61,11 @@ jobs:
           lxc profile device add default root disk path=/ pool=metabox${{ matrix.os }}
           lxc storage list
       - name: Install dependencies
-        run: python3 -m pip install --upgrade pyopenssl pip setuptools
+        run: sudo apt install -y -qq python3-pip python3-setuptools python3-venv python3-pkg-resources
       - name: Install Metabox
-        run: python3 -m pip install -e .
+        run: |
+          # system-site-packages needed for pkg_resource installed by setuptools
+          python3 -m venv --system-site-packages venv
+          venv/bin/python3 -m pip install -e .
       - name: Run Metabox scenarios
-        run: metabox configs/${{ matrix.mode }}-source-${{ matrix.os }}.py
+        run: venv/bin/metabox configs/${{ matrix.mode }}-source-${{ matrix.os }}.py

--- a/metabox/metabox/core/aggregator.py
+++ b/metabox/metabox/core/aggregator.py
@@ -41,7 +41,7 @@ class _ScenarioAggregator:
         """Import all modules so the scenarios can be auto-loaded."""
         path = metabox.scenarios.__path__
         for loader, name, _ in pkgutil.walk_packages(path):
-            loader.find_module(name).load_module(name)
+            _ = loader.find_spec(name).loader.load_module()
 
     def all_scenarios(self):
         """Return all available scenarios."""

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -290,7 +290,7 @@ class Runner:
 
                 # let's escape < from the output to avoid confusing loguru
                 # loguru assumes that <> is used for colorizing
-                output = scn.get_output_streams().strip().replace("<", "\<")
+                output = scn.get_output_streams().strip().replace("<", r"\<")
 
                 logger.error("Scenario output:\n" + output)
                 if self.hold_on_fail:

--- a/metabox/metabox/metabox-provider/units/match-test-units.pxu
+++ b/metabox/metabox/metabox-provider/units/match-test-units.pxu
@@ -49,8 +49,8 @@ unit: template
 template-resource: nested_direct_resource
 template-unit: job
 id: nested_generated_job_template_{nested_direct_resource}
-template-id: nested_include_by_template_id
-flags: simple
+template-id: nested_include_by_template_id_target
+plugin: shell
 _summary: Used to test that template-id is used to match from nested part
 command: true
 
@@ -59,13 +59,14 @@ id: nested_part_tests
 _name: Test plan used as a nested_part by the match tp
 bootstrap_include:
   nested_indirect_resource
+  nested_direct_resource
 include:
   nested_direct_dependency
   nested_indirect_dependency
   nested_not_included
   nested_target
   nested_exclude_target
-  nested_include_by_template_id
+  nested_include_by_template_id_target
 
 # note from here onward is copy paste till test plan :%s/nested/include/g
 
@@ -125,7 +126,7 @@ unit: template
 template-resource: include_direct_resource
 template-unit: job
 id: include_generated_job_template_{include_direct_resource}
-template-id: include_include_by_template_id
+template-id: include_include_by_template_id_target
 flags: simple
 _summary: Used to test that template-id is used to match from include
 command: true
@@ -137,6 +138,7 @@ id: stress_match
 _name: Test plan used as a include_part by the match tp
 bootstrap_include:
   include_indirect_resource
+  include_direct_resource
 include:
   include_direct_dependency
   include_indirect_dependency
@@ -144,7 +146,7 @@ include:
   include_target
   include_exclude_target
   include_launcher_removed_target
-  include_include_by_template_id
+  include_include_by_template_id_target
 nested_part:
   nested_part_tests
 exclude:


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This fixes two issues with metabox + 1 issue with a recently added test plan in the metabox provider
1. Metabox loads scenarios using a grossly outdated api that is now removed, this doesn't impact us at the moment but will very soon (discovered this because I tried to update the action to use ubuntu 24)
2. Action has a few workarounds that are needed (now more) that were un-documented. Now they are explained in the comments
3. The testplan landed was missing the "target" from the template_id and the bootstrap_include resource to make it run (the resource was pulled, but not during bootstrap, leading the template to not being initailized)

Root cause of the initial issue: setuptools updated and is now broken due to some incompatibility (I don't really know which) with importlib_metadata

## Resolved issues

Fixes: CHECKBOX-1536

## Documentation

This adds a few new comments to the workflow to explain why it is the way it is. 

## Tests

Passing test: https://github.com/canonical/checkbox/actions/runs/10487592300/job/29049421985
