### PR TITLE
New: Add Meteor Lake CPUID (new)

### DIFF
--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -207,7 +207,8 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
         "Westmere":         ['0x2065', '0x206c', '0x206f'],
         "Whisky Lake":      ['0x806eb', '0x806ec'],
         "Sierra Forest":    ['0xa06f3'],
-        "Granite Rapids":   ['0xa06e0', '0xa06d0']
+        "Granite Rapids":   ['0xa06e0', '0xa06d0'],
+        "Meteor Lake":      ['0xa06a4']
     }
     for key in CPUIDS.keys():
         for value in CPUIDS[key]:

--- a/providers/base/tests/test_cpuid.py
+++ b/providers/base/tests/test_cpuid.py
@@ -85,6 +85,21 @@ class CpuidMainTests(unittest.TestCase):
     @patch("builtins.print")
     @patch("subprocess.check_output")
     @patch("cpuid.CPUID")
+    def test_meteor_lake(self, cpuid_mock, co_mock, print_mock):
+        call_mock = MagicMock()
+        call_mock.return_value = [0xA06A4, 0x0, 0x0, 0x0]
+        cpuid_mock.return_value = call_mock
+        co_mock.return_value = ""
+        main()
+        expected_msg = "CPUID: {} which appears to be a {} processor".format(
+            "0xa06a4", "Meteor Lake"
+        )
+        print_mock.assert_called_with(expected_msg)
+
+
+    @patch("builtins.print")
+    @patch("subprocess.check_output")
+    @patch("cpuid.CPUID")
     def test_amd_siena_sp6(self, cpuid_mock, co_mock, print_mock):
         # import pdb; pdb.set_trace()
         call_mock = MagicMock()

--- a/providers/base/tests/test_cpuid.py
+++ b/providers/base/tests/test_cpuid.py
@@ -96,7 +96,6 @@ class CpuidMainTests(unittest.TestCase):
         )
         print_mock.assert_called_with(expected_msg)
 
-
     @patch("builtins.print")
     @patch("subprocess.check_output")
     @patch("cpuid.CPUID")


### PR DESCRIPTION
## Description

Only adds a new CPU type.

## Resolved issues

Resolves a part of [C3-752](https://warthogs.atlassian.net/browse/C3-752)

## Documentation

No relevant documentation changes

## Tests

New automated test added for this new cpu type

[C3-752]: https://warthogs.atlassian.net/browse/C3-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ