### PR TITLE
Fix for Clocktest Failure (Bugfix)

### DIFF
--- a/providers/base/src/clocktest.c
+++ b/providers/base/src/clocktest.c
@@ -31,7 +31,7 @@ int test_clock_jitter(){
     unsigned cpu, num_cpus, iter;
     int failures = 0;
 
-    num_cpus = sysconf(_SC_NPROCESSORS_CONF);
+    num_cpus = sysconf(_SC_NPROCESSORS_ONLN);
     if (num_cpus == 1) {
         printf("Single CPU detected. No clock jitter testing necessary.\n");
         return 0;


### PR DESCRIPTION
The test program retroeves the number of cpus using "num_cpus = sysconf(_SC_NPROCESSORS_CONF);". After an
upstream change in the kernel between 22.04 and 24.04, this returns now the number of physical cpus available.
But these cpus do not need to be available to the system right now. Looping over num_cpus, the call to
sched_setaffinity results in an error EINVAL which is explained with:

EINVAL The affinity bit mask mask contains no processors that are currently physi‐
cally on the system and permitted to the thread according to any restrictions
that may be imposed by cpuset cgroups or the "cpuset" mechanism described in
cpuset(7).

The correct way to retrieve the available number of cpus would be "num_cpus = sysconf(_SC_NPROCESSORS_ONLN);", as described here:

man sysconf

   _SC_NPROCESSORS_CONF
    The number of processors configured. See also get_nprocs_conf(3).

    _SC_NPROCESSORS_ONLN
    The number of processors currently online (available). See also get_nprocs_conf(3).

    A Fix for issue https://github.com/canonical/checkbox/issues/815

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
