### PR TITLE
Fix the insertion of USB3 Gen2x1 device could not being detected (Bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -196,6 +196,7 @@ class USBStorage(StorageWatcher):
             elif self.storage_type == "usb3" and self.device in [
                 "super_speed_usb",
                 "super_speed_gen1_usb",
+                "super_speed_plus_gen2x1_usb",
             ]:
                 logger.info("USB3 insertion test passed.")
             else:
@@ -226,6 +227,7 @@ class USBStorage(StorageWatcher):
             "high_speed_usb": "new high-speed USB device",
             "super_speed_usb": "new SuperSpeed USB device",
             "super_speed_gen1_usb": "new SuperSpeed Gen 1 USB device",
+            "super_speed_plus_gen2x1_usb": "new SuperSpeed Plus Gen 2x1 USB device",
         }
 
         driver_log_dict = {
@@ -247,7 +249,7 @@ class USBStorage(StorageWatcher):
                 ).group(1)
 
         # Look for insertion action
-        if "USB Mass Storage device detected" in line_str:
+        if "USB Mass Storage device detected" or "uas" in line_str:
             self.action = "insertion"
 
         # Look for removal action

--- a/checkbox-support/checkbox_support/tests/test_run_watcher.py
+++ b/checkbox-support/checkbox_support/tests/test_run_watcher.py
@@ -241,6 +241,17 @@ class TestRunWatcher(unittest.TestCase):
             USBStorage._validate_insertion(mock_usb_storage)
         self.assertEqual(cm.exception.code, None)
 
+    def test_usb3_gen2x1_storage_validate_insertion(self):
+        mock_usb_storage = MagicMock()
+        mock_usb_storage.storage_type = "usb3"
+        mock_usb_storage.device = "super_speed_plus_gen2x1_usb"
+        mock_usb_storage.mounted_partition = "mounted_partition"
+        mock_usb_storage.action = "insertion"
+        mock_usb_storage.driver = "xhci_hcd"
+        with self.assertRaises(SystemExit) as cm:
+            USBStorage._validate_insertion(mock_usb_storage)
+        self.assertEqual(cm.exception.code, None)
+
     def test_usb_storage_validate_insertion_wrong_usb_type(self):
         mock_usb_storage = MagicMock()
         mock_usb_storage.storage_type = "usb2"
@@ -285,6 +296,12 @@ class TestRunWatcher(unittest.TestCase):
         USBStorage._parse_journal_line(mock_usb_storage, line_str)
         self.assertEqual(mock_usb_storage.device, "super_speed_gen1_usb")
 
+        line_str = "new SuperSpeed Plus Gen 2x1 USB device"
+        USBStorage._parse_journal_line(mock_usb_storage, line_str)
+        self.assertEqual(
+            mock_usb_storage.device, "super_speed_plus_gen2x1_usb"
+        )
+
         line_str = "new high-speed USB device number 1 using ehci_hcd"
         USBStorage._parse_journal_line(mock_usb_storage, line_str)
         self.assertEqual(mock_usb_storage.driver, "ehci_hcd")
@@ -294,6 +311,10 @@ class TestRunWatcher(unittest.TestCase):
         self.assertEqual(mock_usb_storage.driver, "xhci_hcd")
 
         line_str = "USB Mass Storage device detected"
+        USBStorage._parse_journal_line(mock_usb_storage, line_str)
+        self.assertEqual(mock_usb_storage.action, "insertion")
+
+        line_str = "kernel: scsi host0: uas"
         USBStorage._parse_journal_line(mock_usb_storage, line_str)
         self.assertEqual(mock_usb_storage.action, "insertion")
 


### PR DESCRIPTION
<!--
A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
We had a usb3 gen2x1 device which used to the type-c usb3 test. But it failed to be detected by checkbox when plug in. The Bug is: [The hotplug of a usb-c disk works well but com.canonical.certification::usb-c/insert test failed #1437 ](https://github.com/canonical/checkbox/issues/1437)

The reason of this issue is that the new run_watcher didn't cover this type of usb3 device. 

## Resolved issues
We had a usb3 gen2x1 device which used to the type-c usb3 test. But it failed to be detected by checkbox when plug in. The Bug is: [The hotplug of a usb-c disk works well but com.canonical.certification::usb-c/insert test failed #1437 ](https://github.com/canonical/checkbox/issues/1437)

The reason of this issue is that the new run_watcher didn't cover this type of usb3 device. 
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
Run the usb3-typec insert test:
==============[ Running job 3 / 3. Estimated time left: 0:00:30 ]===============
--------[ USB 3.0 storage device insertion detected on USB Type-C port ]--------
ID: com.canonical.certification::usb-c/insert
Category: com.canonical.plainbox::usb
Purpose:

This test will check that the system correctly detects the insertion of
a USB 3.0 storage device in a USB Type-C connector.
NOTE: Make sure the USB storage device has a partition before starting
the test.

Steps:

1. Commence the test.
2. Connect a USB 3.0 storage device to a USB Type-C port.
3. Do not unplug the device after the test.

Pick an action
    => press ENTER to continue
  c => add a comment
  s => skip this job
  q => save the session and quit
[csq]: 
... 8< -------------------------------------------------------------------------


INSERT NOW


Timeout: 30 seconds
super_speed_plus_gen2x1_usb was inserted. Controller: xhci_hcd, Number: 54
usable partition: sda1
USB3 insertion test passed.
cache file usb_insert_info is at: /var/tmp/checkbox-ng/sessions/checkbox-run-2024-08-29T03.21.05.session/session-share
------------------------------------------------------------------------- >8 ---
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-08-29T03.21.05
==================================[ Results ]===================================
 ☑ : Collect information about supported types of USB
 ☑ : Hardware Manifest
 ☑ : USB 3.0 storage device insertion detected on USB Type-C port

Run the usb3 insert test with usb3 gen1 disk insert:
==============[ Running job 2 / 2. Estimated time left: 0:02:00 ]===============
-----------------[ USB 3.0 storage device insertion detected ]------------------
ID: com.canonical.certification::usb3/insert
Category: com.canonical.plainbox::usb
Purpose:

Check system can detect insertion of a USB 3.0 storage device.
NOTE: Make sure the USB storage device has a partition before starting
the test.

Steps:

1. Press continue.
2. Wait until the message "INSERT NOW" is displayed on the screen.
3. Connect USB 3.0 storage device.

Pick an action
    => press ENTER to continue
  c => add a comment
  s => skip this job
  q => save the session and quit
[csq]: 
... 8< -------------------------------------------------------------------------


INSERT NOW


Timeout: 30 seconds
super_speed_usb was inserted. Controller: xhci_hcd, Number: 53
usable partition: sda2
USB3 insertion test passed.
cache file usb_insert_info is at: /var/tmp/checkbox-ng/sessions/checkbox-run-2024-08-29T02.49.03.session/session-share
------------------------------------------------------------------------- >8 ---
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-08-29T02.49.03
==================================[ Results ]===================================
 ☑ : Collect information about supported types of USB
 ☑ : USB 3.0 storage device insertion detected

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
