### PR TITLE
Add UEFI Secure Boot with unsigned kernel case (New)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/secure-boot/category.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/secure-boot/category.pxu
@@ -1,3 +1,0 @@
-unit: category
-id: secure-boot
-_name: Secure Boot test

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/secure-boot/category.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/secure-boot/category.pxu
@@ -1,0 +1,3 @@
+unit: category
+id: secure-boot
+_name: Secure Boot test

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/secure-boot/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/secure-boot/jobs.pxu
@@ -1,5 +1,5 @@
 plugin: manual
-category_id: secure-boot
+category_id: com.canonical.certification::security
 id: ce-oem-secure-boot/uefi-secure-boot-unsigned-kernel
 estimated_duration: 120.0
 imports:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/secure-boot/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/secure-boot/jobs.pxu
@@ -1,0 +1,28 @@
+plugin: manual
+category_id: secure-boot
+id: ce-oem-secure-boot/uefi-secure-boot-unsigned-kernel
+estimated_duration: 120.0
+imports:
+    from com.canonical.plainbox import manifest
+    from com.canonical.certification import lsb
+    from com.canonical.certification import bootloader
+requires:
+    manifest.has_uefi_secure_boot_support == 'True'
+    "Ubuntu Core" not in lsb.description
+    bootloader.name == "grub"
+_summary:
+    Verify UEFI Secure Boot by replacing signed kernel with unsigned kernel
+_purpose:
+    Check device fails to load unsigned kernel due to security protection
+_steps:
+    1. Enable the Secure Boot feature in UEFI firmware
+        - Enroll UEFI Keys (PK.auth, KEK.auth and db.auth)
+    2. Boot into Ubuntu
+    3. Find any unsigned generic kernel through command "apt search linux-image-unsigned | grep generic"
+    4. Install an unsigned generic kernel through command like "sudo apt install linux-image-unsigned-6.8.0-40-generic"
+    5. Reboot device and when the grub boot menu is displayed, choose the unsigned kernel and try to boot into Ubuntu
+    6. Verify the expected outcome and choose the original signed kernel then boot into Ubuntu
+_verification:
+    Do you see the following messages be displayed and system stucks here?
+        error: bad shim signature
+        error: you need to load the kernel first

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/secure-boot/manifest.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/secure-boot/manifest.pxu
@@ -1,0 +1,5 @@
+unit: manifest entry
+id: has_uefi_secure_boot_support
+_prompt: Does this machine have the following secure boot features?
+_name: UEFI Secure Boot Support
+value-type: bool

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/secure-boot/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/secure-boot/test-plan.pxu
@@ -5,7 +5,6 @@ _description: Secure Boot tests for devices
 include:
 nested_part:
     ce-oem-secure-boot-manual
-    ce-oem-secure-boot-automated
 
 id: ce-oem-secure-boot-manual
 unit: test plan
@@ -14,10 +13,3 @@ _description: Secure Boot manual Tests (Manual)
 bootstrap_include:
 include:
     ce-oem-secure-boot/uefi-secure-boot-unsigned-kernel
-
-id: ce-oem-secure-boot-automated
-unit: test plan
-_name: Secure Boot auto Tests (Automated)
-_description: Secure Boot auto Tests (Automated)
-bootstrap_include:
-include:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/secure-boot/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/secure-boot/test-plan.pxu
@@ -1,0 +1,23 @@
+id: ce-oem-secure-boot-full
+unit: test plan
+_name: Secure Boot test
+_description: Secure Boot tests for devices
+include:
+nested_part:
+    ce-oem-secure-boot-manual
+    ce-oem-secure-boot-automated
+
+id: ce-oem-secure-boot-manual
+unit: test plan
+_name: Secure Boot manual Tests (Manual)
+_description: Secure Boot manual Tests (Manual)
+bootstrap_include:
+include:
+    ce-oem-secure-boot/uefi-secure-boot-unsigned-kernel
+
+id: ce-oem-secure-boot-automated
+unit: test plan
+_name: Secure Boot auto Tests (Automated)
+_description: Secure Boot auto Tests (Automated)
+bootstrap_include:
+include:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
@@ -45,6 +45,7 @@ nested_part:
     com.canonical.certification::led-indicator-manual
     ce-oem-iio-sensors-manual
     ce-oem-digital-io-manual
+    ce-oem-secure-boot-manual
 
 id: ce-oem-automated
 unit: test plan
@@ -82,6 +83,7 @@ nested_part:
     com.canonical.certification::rtc-automated
     com.canonical.certification::led-indicator-auto
     before-suspend-ce-oem-spi-automated
+    ce-oem-secure-boot-automated
 
 id: after-suspend-ce-oem-manual
 unit: test plan

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
@@ -83,7 +83,6 @@ nested_part:
     com.canonical.certification::rtc-automated
     com.canonical.certification::led-indicator-auto
     before-suspend-ce-oem-spi-automated
-    ce-oem-secure-boot-automated
 
 id: after-suspend-ce-oem-manual
 unit: test plan


### PR DESCRIPTION
## Description

Currently, for secure boot coverage, Checkbox only has [miscellanea/secure_boot_mode](https://github.com/canonical/checkbox/blob/v4.1.0/providers/base/units/miscellanea/jobs.pxu#L133) to check secure boot is enabled from System level.

However, based on the responsibility of publishing image, Canonical is responsible for the signed shim, grub and kernel. Therefore, I add a manual case to replace **_signed kernel_** with **_unsigned kernel_** to prove the function of UEFI Secure Boot is working as expected.

This is raised from Boashan Project but the testing method is generic. So Canonical QA can follow the step to verify UEFI Secure Boot feature if a project supports UEFI firmware on **_Classic_** image.

## Resolved issues

- https://warthogs.atlassian.net/browse/OEMQA-4820

## Documentation

- [Baoshan - Secure Boot Enablement Guide](https://docs.google.com/document/d/1s4cbuRELmthRa2Z_yJSLMzxaqQPLDoHM3lra0_0avII/edit)
- https://forums.debian.net/viewtopic.php?p=789903&sid=8de6b14ace62a6f1fbe9103aa35c0346#p789903
- https://sources.debian.org/src/grub2/2.06-13+deb12u1/grub-core/kern/efi/sb.c/#L182
- https://launchpad.net/~canonical-kernel-team/+archive/ubuntu/ppa/+packages?field.name_filter=&field.status_filter=published&field.series_filter=jammy


## Tests
![Screenshot from 2024-08-30 10-04-30](https://github.com/user-attachments/assets/2cb83a00-b10b-4c9c-8fe6-78d214214ad9)


![Screenshot from 2024-08-30 10-04-50](https://github.com/user-attachments/assets/eee3d5b8-b096-4063-9a64-d097701d3040)


![Screenshot from 2024-08-29 15-06-03](https://github.com/user-attachments/assets/09a2c5aa-cdb7-4912-88fd-0080fccdf22c)
