### PR TITLE
Fix kill process issue in timeout.py (Bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/timeout.py
+++ b/checkbox-support/checkbox_support/helpers/timeout.py
@@ -24,7 +24,7 @@ functions
 """
 import os
 import traceback
-import subprocess
+import signal
 
 from functools import partial
 from contextlib import wraps
@@ -74,7 +74,7 @@ def run_with_timeout(f, timeout_s, *args, **kwargs):
     process.join(timeout_s)
 
     if process.is_alive():
-        subprocess.run("kill -9 -- -{}".format(process.pid), shell=True)
+        os.kill(process.pid, signal.SIGKILL)
         raise TimeoutError("Task unable to finish in {}s".format(timeout_s))
     if not exception_queue.empty():
         raise exception_queue.get()


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
When the test case failed with timeout, it will reported as this:

```
INSERT NOW


Timeout: 30 seconds
/bin/sh: 1: kill: Illegal number: -
Traceback (most recent call last):
  File "/usr/bin/checkbox-support-run_watcher", line 8, in <module>
    sys.exit(main())
  File "/usr/lib/python3/dist-packages/checkbox_support/helpers/timeout.py", line 93, in _f
    return run_with_timeout(f, timeout_s, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/checkbox_support/helpers/timeout.py", line 78, in run_with_timeout
    raise TimeoutError("Task unable to finish in {}s".format(timeout_s))
TimeoutError: Task unable to finish in 30s
------------------------------------------------------------------------- >8 ---
Outcome: job failed
```

Something like this: **_/bin/sh: 1: kill: Illegal number: -:_**  will be reported.
It seems the timeout.py will try to use  `subprocess.run("kill -9 -- -{}".format(process.pid), shell=True)` to kill the process, but the subprocess doesn't work with "--" well.

The fix will try use os.kill to kill the process.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

```
==============[ Running job 2 / 2. Estimated time left: 0:02:00 ]===============
-----------------[ USB 3.0 storage device insertion detected ]------------------
ID: com.canonical.certification::usb3/insert
Category: com.canonical.plainbox::usb
Purpose:

Check system can detect insertion of a USB 3.0 storage device.
NOTE: Make sure the USB storage device has a partition before starting
the test.

Steps:

1. Press continue.
2. Wait until the message "INSERT NOW" is displayed on the screen.
3. Connect USB 3.0 storage device.

Pick an action
    => press ENTER to continue
  c => add a comment
  s => skip this job
  q => save the session and quit
[csq]: 
... 8< -------------------------------------------------------------------------


INSERT NOW


Timeout: 30 seconds
/bin/sh: 1: kill: Illegal number: -
Traceback (most recent call last):
  File "/usr/bin/checkbox-support-run_watcher", line 8, in <module>
    sys.exit(main())
  File "/usr/lib/python3/dist-packages/checkbox_support/helpers/timeout.py", line 93, in _f
    return run_with_timeout(f, timeout_s, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/checkbox_support/helpers/timeout.py", line 78, in run_with_timeout
    raise TimeoutError("Task unable to finish in {}s".format(timeout_s))
TimeoutError: Task unable to finish in 30s
------------------------------------------------------------------------- >8 ---
Outcome: job failed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-08-29T07.44.39
==================================[ Results ]===================================
 ☑ : Collect information about supported types of USB
 ☒ : USB 3.0 storage device insertion detected
```

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
With the fix, it will works as below:

```
==============[ Running job 3 / 3. Estimated time left: 0:00:30 ]===============
--------[ USB 3.0 storage device insertion detected on USB Type-C port ]--------
ID: com.canonical.certification::usb-c/insert
Category: com.canonical.plainbox::usb
Purpose:

This test will check that the system correctly detects the insertion of
a USB 3.0 storage device in a USB Type-C connector.
NOTE: Make sure the USB storage device has a partition before starting
the test.

Steps:

1. Commence the test.
2. Connect a USB 3.0 storage device to a USB Type-C port.
3. Do not unplug the device after the test.

Pick an action
    => press ENTER to continue
  c => add a comment
  s => skip this job
  q => save the session and quit
[csq]: 
... 8< -------------------------------------------------------------------------


INSERT NOW


Timeout: 30 seconds
Traceback (most recent call last):
  File "/usr/bin/checkbox-support-run_watcher", line 8, in <module>
    sys.exit(main())
  File "/usr/lib/python3/dist-packages/checkbox_support/helpers/timeout.py", line 93, in _f
    return run_with_timeout(f, timeout_s, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/checkbox_support/helpers/timeout.py", line 78, in run_with_timeout
    raise TimeoutError("Task unable to finish in {}s".format(timeout_s))
TimeoutError: Task unable to finish in 30s
------------------------------------------------------------------------- >8 ---
Outcome: job failed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-08-29T07.41.29
==================================[ Results ]===================================
 ☑ : Hardware Manifest
 ☑ : Collect information about supported types of USB
 ☒ : USB 3.0 storage device insertion detected on USB Type-C port
```

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
