### PR TITLE
Fix race condition timeout decorator (bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/timeout.py
+++ b/checkbox-support/checkbox_support/helpers/timeout.py
@@ -62,7 +62,7 @@ def run_with_timeout(f, timeout_s, *args, **kwargs):
                 exception_queue.put(
                     SystemExit(
                         "Function tried to return non-picklable value "
-                        "but this is not supported by the timeout decorator"
+                        "but this is not supported by the timeout decorator.\n"
                         "Returned object:\n" + repr(result)
                     )
                 )
@@ -111,7 +111,7 @@ def run_with_timeout(f, timeout_s, *args, **kwargs):
     with suppress(Empty):
         raise exception_queue.get_nowait()
 
-    # unpicklig is done in a separate thread, could it be un-scheduled yet?
+    # unpickling is done in a separate thread, could it be un-scheduled yet?
     with suppress(Empty):
         return result_queue.get(timeout=0.1)
     with suppress(Empty):
@@ -119,7 +119,7 @@ def run_with_timeout(f, timeout_s, *args, **kwargs):
 
     # this should never happen, lets crash the program if it does
     raise SystemExit(
-        "Function failed to propagate either a value or an exception\n"
+        "Function failed to propagate either a value or an exception.\n"
         "It is unclear why this happened or what the underlying function "
         "did."
     )

--- a/checkbox-support/checkbox_support/helpers/timeout.py
+++ b/checkbox-support/checkbox_support/helpers/timeout.py
@@ -35,6 +35,13 @@ from multiprocessing import Process, Queue
 
 
 def is_picklable(value):
+    """
+    This function checks if an object is picklable. This is used here because
+    to propagate a value via a multiprocessing queue, it has to be picklable.
+    If it is not, when using normal Queues (not SimpleQueues), pushing the
+    value in the queue will crash the encoder Thread that the Queue contains,
+    silently failing the operation.
+    """
     with suppress(pickle.PicklingError), suppress(AttributeError):
         _ = pickle.dumps(value)
         return True

--- a/checkbox-support/checkbox_support/tests/test_timeout.py
+++ b/checkbox-support/checkbox_support/tests/test_timeout.py
@@ -24,8 +24,9 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from checkbox_support.helpers.timeout import (
-    run_with_timeout,
     timeout,
+    is_picklable,
+    run_with_timeout,
     fake_run_with_timeout,
 )
 
@@ -215,3 +216,7 @@ class TestTimeoutExec(TestCase):
 
         with self.assertRaises(SystemExit):
             run_with_timeout(lambda: ..., 0)
+
+    def test_is_picklable(self):
+        self.assertFalse(is_picklable(lambda: ...))
+        self.assertTrue(is_picklable([1, 2, 3]))

--- a/checkbox-support/checkbox_support/tests/test_timeout.py
+++ b/checkbox-support/checkbox_support/tests/test_timeout.py
@@ -162,7 +162,7 @@ class TestTimeoutExec(TestCase):
         (function under test) but also any sub-process it has spawned. This
         is done because one could `subprocess.run` a long-lived process from
         the function and it could cause mayhem (and block the test session as
-        Checkbox waits for all childs to be done)
+        Checkbox waits for all children to be done)
         """
 
         def inner(pid_pipe):


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The timeout decorator seldomly fails to receive either a value or an exception from the subprocess. I am currently unable to reproduce this issue in any way but I've seen it happen on a very slow device running core20. Either way this improves the implementation in several key ways:
1. Don't check `empty` before getting from the queue: this is an anti-pattern and not guaranteed to work
2. Don't put a value we can determine is un-picklable in the queue: this crashes the writer thread of the queue with no error for `Queue`. 
3. Handle the case where the value is not picklable: this was handled the same as a normal exception, but it is a special case where we should really crash the program with a clear message
4. Bounded wait for gets: If the parent fails to receive anything after the child has died, we can't block the process on get. Rather what we do is raise a SystemExit to crash the parent and explain what happened
5. Best effort retry on get: I'm not sure if this is what is happening but given that the decoding is done in a separate thread, it could be that the first get is simply being called before it is done, so lets retry. This costs us (in those situations) at most 200ms, we can afford that
6. Close the queue in child process: This should also make the flush of the child thread more deterministic in some situations (or so some claim, from the history of the queue implementation, it is unclear to me how this could be the case)

This also contains a driveby fix to the issue described in this PR (removal of the `--` before the pid): https://github.com/canonical/checkbox/pull/1441

And a new test to prove that the solution in the decorator works (while using the builtin kill or any signal wont, to the best of my knowledge)

## Resolved issues

Fixes: CHECKBOX-1544

## Documentation

New comments to explain why some things are done (including why `subprocess.run` is used)

## Tests

New test that proves the kill behaviour works. Also new coverage for all the new lines

> Note: some lines appear uncovered because the test runs them in a separate process
