### PR TITLE
Check for `.crash` files (New)

### DIFF
--- a/providers/base/bin/crash_log_check.py
+++ b/providers/base/bin/crash_log_check.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python3
+
 from datetime import datetime
 import os
 from subprocess import run, PIPE

--- a/providers/base/bin/crash_log_check.py
+++ b/providers/base/bin/crash_log_check.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+import os
+from subprocess import run, PIPE
+import sys
+import typing as T
+
+
+def get_boot_time() -> datetime:
+    return datetime.strptime(
+        run(["uptime", "-s"], stdout=PIPE, encoding="utf-8").stdout.strip(),
+        "%Y-%m-%d %H:%M:%S",
+    )
+
+
+def get_crash_logs() -> T.List[str]:
+    boot_time = get_boot_time()
+    crash_files_of_this_boot = []
+
+    for crash_file in os.listdir("/var/crash"):
+        file_stats = os.stat("/var/crash/{}".format(crash_file))
+        last_modified_time = max(
+            file_stats.st_atime, file_stats.st_mtime, file_stats.st_ctime
+        ) # whichever timestamp is the latest
+
+        if datetime.fromtimestamp(last_modified_time) >= boot_time:
+            crash_files_of_this_boot.append(crash_file)
+
+    return crash_files_of_this_boot
+
+
+def main():
+    crash_files = get_crash_logs()
+
+    if len(crash_files) == 0:
+        print("[ OK ] No crash files found in /var/crash")
+        return 0
+
+    print(
+        "[ ERROR ] Found the following crash files of this boot",
+        file=sys.stderr,
+    )
+    for file in crash_files:
+        print(file, file=sys.stderr)
+
+    return 1
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/providers/base/bin/crash_log_check.py
+++ b/providers/base/bin/crash_log_check.py
@@ -17,10 +17,11 @@ def get_crash_logs() -> T.List[str]:
     crash_files_of_this_boot = []
 
     for crash_file in os.listdir("/var/crash"):
+        print(crash_file)
         file_stats = os.stat("/var/crash/{}".format(crash_file))
         last_modified_time = max(
             file_stats.st_atime, file_stats.st_mtime, file_stats.st_ctime
-        ) # whichever timestamp is the latest
+        )  # whichever timestamp is the latest
 
         if datetime.fromtimestamp(last_modified_time) >= boot_time:
             crash_files_of_this_boot.append(crash_file)

--- a/providers/base/tests/test_crash_log_check.py
+++ b/providers/base/tests/test_crash_log_check.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+import unittest
+from unittest.mock import patch
+import crash_log_check as CLC
+from os import stat_result
+
+
+class CrashLogCheckTests(unittest.TestCase):
+    def test_no_crash_file_path(self):
+        with patch("os.listdir") as mock_list:
+            mock_list.return_value = []
+            self.assertEqual(CLC.main(), 0)
+
+    def test_all_new_crash_files(self):
+        with patch("os.listdir") as mock_listdir, patch(
+            "os.stat"
+        ) as mock_stat, patch(
+            "crash_log_check.get_boot_time"
+        ) as mock_get_boot_time:
+            mock_listdir.return_value = ["crash1.crash", "crash2.crash"]
+
+            def mock_stat_side_effect(filename: str) -> stat_result:
+                if filename == "crash1.crash":
+                    t1 = datetime.timestamp(datetime(2024, 8, 1, 5, 30, 5))
+                    t2 = datetime.timestamp(datetime(2024, 8, 1, 5, 31, 2))
+                    t3 = datetime.timestamp(datetime(2024, 8, 1, 5, 31, 1))
+                    return stat_result(
+                        # slightly obscure syntax, we fill the first 7 args
+                        # with 0 because it's unused, then fill the last 3 spots
+                        # with timestamps (atime, mtime, ctime)
+                        # unwrap the 7-zeros array and flatten with * operator
+                        [*[0] * 7, t1, t2, t3]
+                    )
+                if filename == "crash2.crash":
+                    t1 = datetime.timestamp(datetime(2024, 8, 1, 5, 40, 5))
+                    t2 = datetime.timestamp(datetime(2024, 8, 1, 5, 40, 2))
+                    t3 = datetime.timestamp(datetime(2024, 8, 1, 5, 40, 1))
+                    return stat_result(
+                        [*[0] * 7, 1723092286, 1722484746, 1722594746]
+                    )
+                raise Exception("Unexpected use of this mock")
+
+            mock_stat.side_effect = mock_stat_side_effect
+            mock_get_boot_time.return_value = datetime(2024, 8, 1, 5, 30, 3)
+
+            logs = CLC.get_crash_logs()
+
+            self.assertListEqual(["crash1.crash", 'crash2.crash'], logs)
+
+        # def test_mixed_timestamps(self):
+        #     NotImplemented()


### PR DESCRIPTION
## Description

A simple test case that looks for `.crash` files under `/var/crash` that were created in the current boot session.

## Resolved issues

[OEM-QA4466](https://warthogs.atlassian.net/browse/OEMQA-4466)

## Documentation

Takes no arguments, simply run `providers/base/bin/crash_log_check.py`

## Tests

