### PR TITLE
Fixed unicodedecode exception for reading fwts session log (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -256,6 +256,17 @@ def detect_progress_indicator():
     return []
 
 
+def print_log(logfile):
+    """
+    Print logfile to the output
+    """
+    with open(logfile) as f:
+        try:
+            print(f.read())
+        except UnicodeDecodeError as e:
+            print("WARNING: Found bad char in " + logfile)
+
+
 def main():
     description_text = "Tests the system BIOS using the Firmware Test Suite"
     epilog_text = (
@@ -668,8 +679,7 @@ def main():
     print()
     print(" Please review the following log for more information:")
     print()
-    with open(args.log) as f:
-        print(f.read())
+    print_log(args.log)
 
     if args.fail_level != "none":
         if fail_priority == fail_levels["FAILED_CRITICAL"]:

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -1,0 +1,50 @@
+#
+# This file is part of Checkbox.
+#
+# Copyright 2013 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from tempfile import NamedTemporaryFile
+import os
+from io import StringIO
+
+from checkbox_support.scripts.fwts_test import print_log
+from unittest.mock import patch
+
+
+class LogPrinterTest(unittest.TestCase):
+    def setUp(self):
+        self.logfile = NamedTemporaryFile(delete=False)
+
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_logfile_with_encoding_error(self, mock_stdout):
+        with open(self.logfile.name, "wb") as f:
+            f.write(b"Cannot read PCI config for device 0000:00:\xa1")
+            f.write(b"<85>)PNP0B00:00\n")
+            f.write(b"SKIPPED: Test 2, Could not guess cache type.\n")
+        print_log(self.logfile.name)
+        self.assertEqual(
+            mock_stdout.getvalue(),
+            "WARNING: Found bad char in " + self.logfile.name + "\n",
+        )
+        os.unlink(self.logfile.name)
+
+    def tearDown(self):
+        try:
+            os.unlink(self.logfile.name)
+        except OSError:
+            pass


### PR DESCRIPTION
## Description

Try to capture the unicodedecode exception but not making the script crashed

## Resolved issues

Fixes: SOMERVILLE-807

## Tests

The test was performed by running the script to parse the problem session log, the script can handle the problem session log without crashing.
