### PR TITLE
Provide a @retry decorator to automatically retry Python functions in Checkbox jobs (new)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/retry.py
+++ b/checkbox-support/checkbox_support/helpers/retry.py
@@ -36,6 +36,16 @@ def run_with_retry(f, max_attempts, delay, *args, **kwargs):
     """
     initial_delay = 1
     backoff_factor = 2
+    if max_attempts < 1:
+        raise ValueError(
+            "max_attempts should be at least 1 ({} was used)".format(
+                max_attempts
+            )
+        )
+    if delay < 1:
+        raise ValueError(
+            "delay should be at least 1 ({} was used)".format(delay)
+        )
     for attempt in range(1, max_attempts + 1):
         attempt_string = "Attempt {}/{}".format(attempt, max_attempts)
         print()

--- a/checkbox-support/checkbox_support/helpers/retry.py
+++ b/checkbox-support/checkbox_support/helpers/retry.py
@@ -1,0 +1,76 @@
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Pierre Equoy <pierre.equoy@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+"""
+checkbox_support.helpers.retry
+=============================================
+
+Utility class providing functionalities to let functions retry with a
+delay, backoff and jitter.
+"""
+import functools
+import random
+import time
+
+
+def retry(
+    f=None, *, max_attempts=5, initial_delay=1, backoff_factor=2, max_delay=60
+):
+    """
+    Run the decorated function. If it fails, retry for up to max_attempts
+    times, adding a backoff and a jitter on top of a delay of max_delay
+    seconds. If none of the runs succeed, raise a SystemExit exception.
+    """
+
+    def decorator_retry(f):
+        @functools.wraps(f)
+        def _f(*args, **kwargs):
+            for attempt in range(1, max_attempts + 1):
+                attempt_string = "Attempt {}/{}".format(attempt, max_attempts)
+                print(attempt_string)
+                print("=" * len(attempt_string))
+                try:
+                    result = f(*args, **kwargs)
+                    return result
+                except BaseException as e:
+                    print("Attempt {} failed:\n{}".format(attempt, e))
+                    print()
+                    if attempt < max_attempts:
+                        delay = min(
+                            initial_delay * (backoff_factor**attempt),
+                            max_delay,
+                        )
+                        jitter = random.uniform(
+                            0, delay * 0.5
+                        )  # Jitter: up to 50% of the delay
+                        total_delay = delay + jitter
+                        print(
+                            "Waiting {:.2f} seconds before retrying...".format(
+                                total_delay
+                            )
+                        )
+                        time.sleep(total_delay)
+                finally:
+                    print()
+            raise SystemExit("All the attempts have failed!")
+
+        return _f
+
+    if f is not None:
+        return decorator_retry(f)
+
+    return decorator_retry

--- a/checkbox-support/checkbox_support/helpers/retry.py
+++ b/checkbox-support/checkbox_support/helpers/retry.py
@@ -61,9 +61,7 @@ def run_with_retry(f, max_attempts, delay, *args, **kwargs):
             )  # Jitter: up to 50% of the delay
             total_delay = min_delay + jitter
             print(
-                "Waiting {:.2f} seconds before retrying...".format(
-                    total_delay
-                )
+                "Waiting {:.2f} seconds before retrying...".format(total_delay)
             )
             time.sleep(total_delay)
 
@@ -79,6 +77,7 @@ def retry(max_attempts, delay):
         @functools.wraps(f)
         def _f(*args, **kwargs):
             return run_with_retry(f, max_attempts, delay, *args, **kwargs)
+
         return _f
 
     return decorator_retry

--- a/checkbox-support/checkbox_support/tests/test_retry.py
+++ b/checkbox-support/checkbox_support/tests/test_retry.py
@@ -53,6 +53,22 @@ class TestRetry(TestCase):
         self.assertIn("Attempt 7 failed", mock_stdout.getvalue())
         self.assertNotIn("Attempt 8 failed", mock_stdout.getvalue())
 
+    def test_decorator_wrong_max_attempts(self):
+        @retry(-1, 10)
+        def f():
+            return 1 / 0
+
+        with self.assertRaises(ValueError):
+            f()
+
+    def test_decorator_wrong_delay(self):
+        @retry(2, -1)
+        def f():
+            return 1 / 0
+
+        with self.assertRaises(ValueError):
+            f()
+
     def test_identity(self):
         def k(*args, **kwargs):
             return (args, kwargs)

--- a/checkbox-support/checkbox_support/tests/test_retry.py
+++ b/checkbox-support/checkbox_support/tests/test_retry.py
@@ -1,0 +1,53 @@
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Pierre Equoy <pierre.equoy@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+from unittest.mock import patch
+from io import StringIO
+
+from checkbox_support.helpers.retry import retry
+
+
+class TestRetry(TestCase):
+    def test_decorator_ok(self):
+        @retry
+        def f(first, second, third):
+            return (first, second, third)
+
+        self.assertEqual(f(1, 2, 3), (1, 2, 3))
+
+    @patch("checkbox_support.helpers.retry.time.sleep")
+    def test_decorator_fail(self, mock_sleep):
+        @retry
+        def f():
+            return 1 / 0
+
+        with self.assertRaises(SystemExit):
+            f()
+
+    @patch("checkbox_support.helpers.retry.time.sleep")
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_decorator_max_attempts(self, mock_stdout, mock_sleep):
+        @retry(max_attempts=7)
+        def f():
+            return 1 / 0
+
+        with self.assertRaises(SystemExit):
+            f()
+        self.assertIn("Attempt 7 failed", mock_stdout.getvalue())
+        self.assertNotIn("Attempt 8 failed", mock_stdout.getvalue())

--- a/checkbox-support/checkbox_support/tests/test_retry.py
+++ b/checkbox-support/checkbox_support/tests/test_retry.py
@@ -20,34 +20,43 @@ from unittest import TestCase
 from unittest.mock import patch
 from io import StringIO
 
-from checkbox_support.helpers.retry import retry
+from checkbox_support.helpers.retry import fake_run_with_retry, retry
 
 
 class TestRetry(TestCase):
-    def test_decorator_ok(self):
-        @retry
+    @patch("time.sleep")
+    def test_decorator_ok(self, mock_sleep):
+        @retry(5, 10)
         def f(first, second, third):
             return (first, second, third)
 
         self.assertEqual(f(1, 2, 3), (1, 2, 3))
 
-    @patch("checkbox_support.helpers.retry.time.sleep")
+    @patch("time.sleep")
     def test_decorator_fail(self, mock_sleep):
-        @retry
+        @retry(3, 10)
         def f():
             return 1 / 0
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ZeroDivisionError):
             f()
 
-    @patch("checkbox_support.helpers.retry.time.sleep")
+    @patch("time.sleep")
     @patch("sys.stdout", new_callable=StringIO)
     def test_decorator_max_attempts(self, mock_stdout, mock_sleep):
-        @retry(max_attempts=7)
+        @retry(max_attempts=7, delay=10)
         def f():
             return 1 / 0
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ZeroDivisionError):
             f()
         self.assertIn("Attempt 7 failed", mock_stdout.getvalue())
         self.assertNotIn("Attempt 8 failed", mock_stdout.getvalue())
+
+    def test_identity(self):
+        def k(*args, **kwargs):
+            return (args, kwargs)
+
+        self.assertEqual(
+            k(1, 2, 3, abc=10), fake_run_with_retry(k, 5, 10, 1, 2, 3, abc=10)
+        )

--- a/providers/base/bin/networking_http.py
+++ b/providers/base/bin/networking_http.py
@@ -26,12 +26,11 @@ import sys
 from checkbox_support.helpers.retry import retry
 
 
-@retry
+@retry(max_attempts=5, delay=60)
 def http_connect(url):
     """
     Use `wget` to try to connect to `url`. If attempt fails, the next one is
-    made after adding a random delay calculated using a backoff and a jitter
-    (with a maximum delay of 60 seconds).
+    made after adding a random delay calculated using a backoff and a jitter.
     """
     subprocess.run(
         [
@@ -48,7 +47,10 @@ def main(args):
     parser = argparse.ArgumentParser()
     parser.add_argument("url", help="URL to try to connect to")
     args = parser.parse_args(args)
-    http_connect(args.url)
+    try:
+        http_connect(args.url)
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(e)
 
 
 if __name__ == "__main__":

--- a/providers/base/bin/networking_http.py
+++ b/providers/base/bin/networking_http.py
@@ -20,64 +20,35 @@
 #
 
 import argparse
-import random
 import subprocess
 import sys
-import time
+
+from checkbox_support.helpers.retry import retry
 
 
-def http_connect(
-    url, max_attempts: int = 5, initial_delay=1, backoff_factor=2, max_delay=60
-):
+@retry
+def http_connect(url):
     """
     Use `wget` to try to connect to `url`. If attempt fails, the next one is
     made after adding a random delay calculated using a backoff and a jitter
     (with a maximum delay of 60 seconds).
     """
-    for attempt in range(1, max_attempts + 1):
-        print(
-            "Trying to connect to {} (attempt {}/{})".format(
-                url, attempt, max_attempts
-            )
-        )
-        try:
-            subprocess.run(
-                [
-                    "wget",
-                    "-SO",
-                    "/dev/null",
-                    url,
-                ],
-                check=True,
-            )
-            return
-        except subprocess.CalledProcessError as exc:
-            print("Attempt {} failed: {}".format(attempt, exc))
-            print()
-            delay = min(initial_delay * (backoff_factor**attempt), max_delay)
-            jitter = random.uniform(
-                0, delay * 0.5
-            )  # Jitter: up to 50% of the delay
-            final_delay = delay + jitter
-            print(
-                "Waiting for {:.2f} seconds before retrying...".format(
-                    final_delay
-                )
-            )
-            time.sleep(final_delay)
-    raise SystemExit("Failed to connect to {}!".format(url))
+    subprocess.run(
+        [
+            "wget",
+            "-SO",
+            "/dev/null",
+            url,
+        ],
+        check=True,
+    )
 
 
 def main(args):
     parser = argparse.ArgumentParser()
     parser.add_argument("url", help="URL to try to connect to")
-    parser.add_argument(
-        "--attempts",
-        default="5",
-        help="Number of connection attempts (default %(default)s)",
-    )
     args = parser.parse_args(args)
-    http_connect(args.url, int(args.attempts))
+    http_connect(args.url)
 
 
 if __name__ == "__main__":

--- a/providers/base/tests/test_networking_http.py
+++ b/providers/base/tests/test_networking_http.py
@@ -28,33 +28,24 @@ import networking_http
 
 class NetworkingHTTPTests(TestCase):
     @patch("networking_http.subprocess.run")
-    @patch("networking_http.time.sleep")
-    def test_http_connect_max_retries(self, mock_sleep, mock_run):
-        with self.assertRaises(SystemExit):
-            networking_http.http_connect("test", 0)
-
-    @patch("networking_http.subprocess.run")
-    @patch("networking_http.time.sleep")
-    def test_http_connect_success(self, mock_sleep, mock_run):
+    def test_http_connect_success(self, mock_run):
         """
         Test that `http_connect` returns safely if the wget command returns 0
         """
-        self.assertEqual(networking_http.http_connect("test", 3), None)
+        self.assertEqual(networking_http.http_connect("test"), None)
 
     @patch("networking_http.subprocess.run")
-    @patch("networking_http.time.sleep")
+    @patch("checkbox_support.helpers.retry.time.sleep")
     def test_http_connect_failure(self, mock_sleep, mock_run):
         """
-        Test that if set to 3 retries, the connection command (wget, run
-        through subprocess.run) will be called 3 times
+        Test that a SystemExit exception is raised if wget command returns 1
         """
         mock_run.side_effect = subprocess.CalledProcessError(1, "")
         with self.assertRaises(SystemExit):
-            networking_http.http_connect("test", 3)
-        self.assertEqual(mock_run.call_count, 3)
+            networking_http.http_connect("test")
 
     @patch("networking_http.http_connect")
     def test_main(self, mock_http_connect):
-        args = ["test", "--attempts", "6"]
+        args = ["test"]
         networking_http.main(args)
-        mock_http_connect.assert_called_with("test", 6)
+        mock_http_connect.assert_called_with("test")

--- a/providers/base/tests/test_networking_http.py
+++ b/providers/base/tests/test_networking_http.py
@@ -35,13 +35,13 @@ class NetworkingHTTPTests(TestCase):
         self.assertEqual(networking_http.http_connect("test"), None)
 
     @patch("networking_http.subprocess.run")
-    @patch("checkbox_support.helpers.retry.time.sleep")
+    @patch("time.sleep")
     def test_http_connect_failure(self, mock_sleep, mock_run):
         """
-        Test that a SystemExit exception is raised if wget command returns 1
+        Test that an exception is raised if wget command returns 1
         """
         mock_run.side_effect = subprocess.CalledProcessError(1, "")
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(subprocess.CalledProcessError):
             networking_http.http_connect("test")
 
     @patch("networking_http.http_connect")


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
This PR does two things:

- Implement a `@retry` decorator that can be used on any Python functions to automatically re-run it several times with an added delay/backoff/jitter when it raises an exception
- Modify the `networking_http.py` script to make use of this

More info about the decorator:

When a function is decorated with `@retry`, it will be retried until it
passes or until the maximum defined attempts have been reached:

```python
>>> from checkbox_support.helpers.retry import retry
>>> @retry(max_attempts=3, delay=10)
... def my_failing_test(arg):
...     return 1 / arg
... 
>>> result = my_failing_test(0)

===========
Attempt 1/3
===========
Attempt 1 failed:
division by zero

Waiting 3.61 seconds before retrying...

===========
Attempt 2/3
===========
Attempt 2 failed:
division by zero

Waiting 6.63 seconds before retrying...

===========
Attempt 3/3
===========
Attempt 3 failed:
division by zero

All the attempts have failed!
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/pieq/dev/work/checkbox/checkbox-support/checkbox_support/helpers/retry.py", line 89, in _f
    return run_with_retry(f, max_attempts, delay, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pieq/dev/work/checkbox/checkbox-support/checkbox_support/helpers/retry.py", line 56, in run_with_retry
    result = f(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^
  File "<stdin>", line 3, in my_failing_test
ZeroDivisionError: division by zero
```

```python
>>> @retry(max_attempts=3, delay=10)
... def my_passing_test(arg):
...     return 10 * arg
... 

>>> result = my_passing_test(5)

===========
Attempt 1/3
===========
>>> result
50
```

## Resolved issues

https://warthogs.atlassian.net/browse/CHECKBOX-1543

Note: This PR implements the decorator, but it does not modify the WiFi tests to make use of it. This will be done in a separate PR.

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

Documented in the commit messages. Since this is part of checkbox-support, it is not documented in the readthedocs documentation.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Unit tests are provided, and I also ran it on the `networking/http` job in Checkbox:

The job works as before when everything is OK (it just adds an "Attempt 1/x" at the beginning of the outcome):

```
$ TRANSFER_SERVER="ubuntu.com" checkbox-cli run com.canonical.certification::networking/http
===========================[ Running Selected Jobs ]============================
=========[ Running job 1 / 1. Estimated time left (at least): 0:00:00 ]=========
-----------[ Ensure downloading files through HTTP works correctly. ]-----------
ID: com.canonical.certification::networking/http
Category: com.canonical.plainbox::networking
... 8< -------------------------------------------------------------------------
URL transformed to HTTPS due to an HSTS policy
--2024-09-04 16:53:57--  https://ubuntu.com/
Resolving ubuntu.com (ubuntu.com)... 185.125.190.29, 185.125.190.21, 185.125.190.20, ...
Connecting to ubuntu.com (ubuntu.com)|185.125.190.29|:443... connected.
HTTP request sent, awaiting response... 
  HTTP/1.1 200 
  server: nginx/1.14.0 (Ubuntu)
  date: Wed, 04 Sep 2024 14:53:58 GMT
  content-type: text/html; charset=utf-8
  content-length: 119652
  x-view-name: canonicalwebteam.templatefinder.templatefinder.template_finder
  x-clacks-overhead: GNU Terry Pratchett
  permissions-policy: interest-cohort=()
  cache-control: max-age=60, stale-while-revalidate=86400, stale-if-error=300
  x-content-type-options: NOSNIFF
  x-vcs-revision: 1725458684-6a26498
  x-request-id: ab5646487d3efa085b92baabd9097b69
  strict-transport-security: max-age=15724800
  link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect
  x-cache-status: HIT from content-cache-il3/2
  accept-ranges: bytes
Length: 119652 (117K) [text/html]
Saving to: ‘/dev/null’

     0K .......... .......... .......... .......... .......... 42%  391K 0s
    50K .......... .......... .......... .......... .......... 85% 1.17M 0s
   100K .......... ......                                     100% 2.06M=0.2s

2024-09-04 16:53:58 (658 KB/s) - ‘/dev/null’ saved [119652/119652]

Attempt 1/5
===========

------------------------------------------------------------------------- >8 ---
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-09-04T14.53.51
==================================[ Results ]===================================
 ☑ : Ensure downloading files through HTTP works correctly.
```

And it tries 5 times with a moving delay when failing (here, the HTTP URL to use has been left empty, so wget fails with an `Invalid host name` error):

```
$ checkbox-cli run com.canonical.certification::networking/http
===========================[ Running Selected Jobs ]============================
=========[ Running job 1 / 1. Estimated time left (at least): 0:00:00 ]=========
-----------[ Ensure downloading files through HTTP works correctly. ]-----------
ID: com.canonical.certification::networking/http
Category: com.canonical.plainbox::networking
... 8< -------------------------------------------------------------------------
http://: Invalid host name.
http://: Invalid host name.
http://: Invalid host name.
http://: Invalid host name.
http://: Invalid host name.

===========
Attempt 1/5
===========
Attempt 1 failed:
Command '['wget', '-SO', '/dev/null', 'http://']' returned non-zero exit status 1.

Waiting 20.92 seconds before retrying...

===========
Attempt 2/5
===========
Attempt 2 failed:
Command '['wget', '-SO', '/dev/null', 'http://']' returned non-zero exit status 1.

Waiting 27.41 seconds before retrying...

===========
Attempt 3/5
===========
Attempt 3 failed:
Command '['wget', '-SO', '/dev/null', 'http://']' returned non-zero exit status 1.

Waiting 27.43 seconds before retrying...

===========
Attempt 4/5
===========
Attempt 4 failed:
Command '['wget', '-SO', '/dev/null', 'http://']' returned non-zero exit status 1.

Waiting 44.94 seconds before retrying...

===========
Attempt 5/5
===========
Attempt 5 failed:
Command '['wget', '-SO', '/dev/null', 'http://']' returned non-zero exit status 1.

All the attempts have failed!
Command '['wget', '-SO', '/dev/null', 'http://']' returned non-zero exit status 1.
------------------------------------------------------------------------- >8 ---
Outcome: job failed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2024-09-11T07.50.18
==================================[ Results ]===================================
 ☒ : Ensure downloading files through HTTP works correctly.
```
