### PR TITLE
Add the wake on lan manual test to the desktop test plan per customer's request (Bugfix)

### DIFF
--- a/providers/base/units/ethernet/jobs.pxu
+++ b/providers/base/units/ethernet/jobs.pxu
@@ -237,6 +237,10 @@ template-resource: device
 template-filter: device.category == 'NETWORK' and device.mac != 'UNKNOWN'
 id: ethernet/wol_S5_{interface}
 template-id: ethernet/wol_S5_interface
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_ethernet_adapter == 'True'
+ manifest.has_ethernet_wake_on_lan_support== 'True'
 _summary: Wake on LAN (WOL) test from S5 - {interface}
 _purpose:
  Check that another system can wake the System Under Test (SUT) from S5 using the Ethernet port {interface} WOL function.
@@ -275,8 +279,11 @@ _steps:
 _verification:
   Did the SUT wake up from S4?
 plugin: user-interact-verify
+imports: from com.canonical.plainbox import manifest
 requires:
-  sleep.disk == 'supported'
+ sleep.disk == 'supported'
+ manifest.has_ethernet_adapter == 'True'
+ manifest.has_ethernet_wake_on_lan_support== 'True'
 command: systemctl hibernate
 user: root
 category_id: com.canonical.plainbox::ethernet
@@ -301,8 +308,11 @@ _steps:
 _verification:
  Did the SUT wake up from S3?
 plugin: user-interact-verify
+imports: from com.canonical.plainbox import manifest
 requires:
-  sleep.mem == 'supported'
+ sleep.mem == 'supported'
+ manifest.has_ethernet_adapter == 'True'
+ manifest.has_ethernet_wake_on_lan_support== 'True'
 command: systemctl suspend
 user: root
 category_id: com.canonical.plainbox::ethernet

--- a/providers/base/units/ethernet/jobs.pxu
+++ b/providers/base/units/ethernet/jobs.pxu
@@ -281,7 +281,6 @@ _verification:
 plugin: user-interact-verify
 imports: from com.canonical.plainbox import manifest
 requires:
- sleep.disk == 'supported'
  manifest.has_ethernet_adapter == 'True'
  manifest.has_ethernet_wake_on_lan_support== 'True'
 command: systemctl hibernate
@@ -310,7 +309,6 @@ _verification:
 plugin: user-interact-verify
 imports: from com.canonical.plainbox import manifest
 requires:
- sleep.mem == 'supported'
  manifest.has_ethernet_adapter == 'True'
  manifest.has_ethernet_wake_on_lan_support== 'True'
 command: systemctl suspend

--- a/providers/base/units/ethernet/manifest.pxu
+++ b/providers/base/units/ethernet/manifest.pxu
@@ -5,5 +5,5 @@ value-type: bool
 
 unit: manifest entry
 id: has_ethernet_wake_on_lan_support
-_name: Wake-On-Lan support by Ethernet Port
+_name: Wake-on-LAN support through Ethernet port
 value-type: bool

--- a/providers/base/units/ethernet/manifest.pxu
+++ b/providers/base/units/ethernet/manifest.pxu
@@ -2,3 +2,8 @@ unit: manifest entry
 id: has_ethernet_adapter
 _name: An Ethernet Port
 value-type: bool
+
+unit: manifest entry
+id: has_ethernet_wake_on_lan_support
+_name: Wake-On-Lan support by Ethernet Port
+value-type: bool

--- a/providers/base/units/ethernet/test-plan.pxu
+++ b/providers/base/units/ethernet/test-plan.pxu
@@ -17,6 +17,16 @@ include:
 bootstrap_include:
     device
 
+id: ethernet-wake-on-lan-cert-manual
+unit: test plan
+_name: Ethernet wake on lan tests (manual)
+_description: Ethernet wake on lan tests (manual)
+include:
+    ethernet/wol_S5_.*                             certification-status=blocker
+    ethernet/wol_S3_.*                             certification-status=blocker
+bootstrap_include:
+    device
+
 id: ethernet-cert-automated
 unit: test plan
 _name: Ethernet tests (automated)

--- a/providers/base/units/ethernet/test-plan.pxu
+++ b/providers/base/units/ethernet/test-plan.pxu
@@ -22,8 +22,8 @@ unit: test plan
 _name: Ethernet wake on lan tests (manual)
 _description: Ethernet wake on lan tests (manual)
 include:
-    ethernet/wol_S5_.*                             certification-status=blocker
-    ethernet/wol_S3_.*                             certification-status=blocker
+    ethernet/wol_S5_.*
+    ethernet/wol_S3_.*
 bootstrap_include:
     device
 

--- a/providers/base/units/ethernet/test-plan.pxu
+++ b/providers/base/units/ethernet/test-plan.pxu
@@ -19,11 +19,11 @@ bootstrap_include:
 
 id: ethernet-wake-on-lan-cert-manual
 unit: test plan
-_name: Ethernet wake on lan tests (manual)
-_description: Ethernet wake on lan tests (manual)
+_name: Ethernet wake-on-LAN tests (manual)
+_description: Ethernet wake-on-LAN tests (manual)
 include:
-    ethernet/wol_S5_.*
-    ethernet/wol_S3_.*
+    ethernet/wol_S5_interface
+    ethernet/wol_S3_interface
 bootstrap_include:
     device
 

--- a/providers/certification-client/units/client-cert-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-24-04.pxu
@@ -70,6 +70,7 @@ nested_part:
     after-suspend-usb3-cert-full
     after-suspend-usb-c-cert-full
     # after-suspend-wireless-cert-full # auto only
+    ethernet-wake-on-lan-cert-manual
     info-attachment-cert-manual
 exclude:
     keys/hibernate


### PR DESCRIPTION


<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
Add the wake on lan tests to the desktop test plan per the feature request of the desktop team of Sutton. 
Add a manifest has_ethernet_wake_on_lan_suppor to let the tester to decide if the platform support or not of WOL.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
https://bugs.launchpad.net/sutton/+bug/2072930

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
$checkbox-cli list-bootstrapped com.canonical.certification::client-cert-desktop-24-04-manual

Skipped file: /usr/share/checkbox-provider-base/units/camera/README.rst
Skipped file: /usr/share/checkbox-provider-base/units/snapd/README.md
Skipped file: /usr/share/checkbox-provider-base/units/stress/suspend_cycles_reboot.md
com.canonical.certification::miscellanea/device_check
com.canonical.certification::cdimage
com.canonical.certification::dmi_present
com.canonical.certification::dmi
com.canonical.certification::lsb
com.canonical.certification::modprobe_json
com.canonical.certification::dkms_info_json
com.canonical.certification::meminfo
com.canonical.certification::module
com.canonical.certification::dmi_attachment
com.canonical.certification::environment
com.canonical.certification::requirements
com.canonical.certification::cpuinfo
com.canonical.certification::snap
com.canonical.certification::dpkg
com.canonical.certification::udev_attachment
com.canonical.certification::kernel_cmdline_attachment
com.canonical.certification::uname
com.canonical.certification::sysfs_attachment
com.canonical.certification::device
com.canonical.certification::efi
com.canonical.certification::package
com.canonical.certification::executable
com.canonical.certification::lsblk_attachment
com.canonical.certification::lspci_standard_config_json
com.canonical.certification::udev_json
com.canonical.certification::system_info_json
com.canonical.certification::raw_devices_dmi_json
com.canonical.certification::miscellanea/submission-resources
com.canonical.certification::info/systemd-analyze
com.canonical.certification::info/systemd-analyze-critical-chain
com.canonical.plainbox::manifest
com.canonical.certification::audio/speaker-headphone-plug-detection
com.canonical.certification::audio/microphone-plug-detection
com.canonical.certification::audio/list_devices
com.canonical.certification::audio/playback_headphones
com.canonical.certification::audio/alsa_record_playback_external
com.canonical.certification::audio/playback_auto
com.canonical.certification::audio/alsa_record_playback_internal
com.canonical.certification::audio/channels
com.canonical.certification::audio/external-linein
com.canonical.certification::audio/external-lineout
com.canonical.certification::bluetooth/detect-output
com.canonical.certification::bluetooth4/HOGP-mouse
com.canonical.certification::bluetooth4/HOGP-keyboard
com.canonical.certification::bluetooth/audio-a2dp
com.canonical.certification::bluetooth/audio_record_playback
com.canonical.certification::camera/detect
com.canonical.certification::camera/still_video0
com.canonical.certification::camera/display_video0
com.canonical.certification::thunderbolt3/insert
com.canonical.certification::thunderbolt3/storage-test
com.canonical.certification::thunderbolt3/remove
com.canonical.certification::monitor/1_powersaving_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::power-management/light_sensor
com.canonical.certification::monitor/1_dim_brightness_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::monitor/1_displayport_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::audio/1_playback_displayport_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::monitor/1_type-c_displayport_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::audio/1_playback_type-c_displayport_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::monitor/1_type-c_hdmi_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::audio/1_playback_type-c_hdmi_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::monitor/1_type-c_vga_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::monitor/1_dvi_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::monitor/1_hdmi_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::audio/1_playback_hdmi_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::monitor/1_thunderbolt3_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::audio/1_playback_thunderbolt3_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::thunderbolt3/daisy-chain
com.canonical.certification::monitor/multi-head
com.canonical.certification::miscellanea/chvt
com.canonical.certification::graphics/1_maximum_resolution_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::graphics/1_rotation_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::graphics/1_video_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::graphics/VESA_drivers_not_in_use
com.canonical.certification::graphics/1_cycle_resolution_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::graphics/1_valid_glxgears_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::graphics/1_valid_glxgears_fullscreen_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::graphics/2_valid_glxgears_GP108GLM__Quadro_P520_
com.canonical.certification::graphics/2_valid_glxgears_fullscreen_GP108GLM__Quadro_P520_
com.canonical.certification::graphics/valid_glxgears
com.canonical.certification::graphics/valid_glxgears_fullscreen
com.canonical.certification::input/accelerometer
com.canonical.certification::input/pointing_Lenovo_Essential_Wireless_Keyboard_and_Mouse_Combo_MOUSE_1
com.canonical.certification::input/pointing_ELAN_Touchscreen_TOUCHSCREEN_2
com.canonical.certification::input/pointing_SynPS_2_Synaptics_TouchPad_TOUCHPAD_3
com.canonical.certification::input/pointing_TPPS_2_Elan_TrackPoint_MOUSE_4
com.canonical.certification::input/clicking_Lenovo_Essential_Wireless_Keyboard_and_Mouse_Combo_MOUSE_1
com.canonical.certification::input/clicking_SynPS_2_Synaptics_TouchPad_TOUCHPAD_2
com.canonical.certification::input/clicking_TPPS_2_Elan_TrackPoint_MOUSE_3
com.canonical.certification::input/keyboard
com.canonical.certification::disk/detect
com.canonical.certification::disk_resource
com.canonical.certification::disk/hdd-parking
com.canonical.certification::fingerprint/detect
com.canonical.certification::fingerprint/enroll
com.canonical.certification::fingerprint/verify-no-match
com.canonical.certification::fingerprint/verify-match
com.canonical.certification::fingerprint/unlock
com.canonical.certification::fingerprint/delete
com.canonical.certification::keys/lock-screen
com.canonical.certification::keys/super
com.canonical.certification::keys/brightness
com.canonical.certification::keys/media-control
com.canonical.certification::keys/mute
com.canonical.certification::keys/volume
com.canonical.certification::keys/video-out
com.canonical.certification::keys/wireless
com.canonical.certification::keys/keyboard-backlight
com.canonical.certification::keys/microphone-mute
com.canonical.certification::keys/power-button
com.canonical.certification::keys/power-button-event
com.canonical.certification::keys/fn-lock
com.canonical.certification::camera/led_video0
com.canonical.certification::led/caps-lock
com.canonical.certification::led/numeric-keypad
com.canonical.certification::led/power
com.canonical.certification::led/fn
com.canonical.certification::led/mute
com.canonical.certification::led/microphone-mute
com.canonical.certification::led/wireless
com.canonical.certification::mediacard/sdhc-insert
com.canonical.certification::mediacard/sdhc-storage
com.canonical.certification::mediacard/sdhc-remove
com.canonical.certification::ethernet/detect
com.canonical.certification::ethernet/hotplug-enp0s31f6
com.canonical.certification::networking/info_device1_enp0s31f6
com.canonical.certification::optical/detect
com.canonical.certification::touchpad/basic
com.canonical.certification::touchpad/palm-rejection
com.canonical.certification::touchpad/continuous-move
com.canonical.certification::touchpad/singletouch-selection
com.canonical.certification::touchpad/drag-and-drop
com.canonical.certification::touchpad/multitouch-rightclick
com.canonical.certification::touchpad/multitouch
com.canonical.certification::touchscreen/drag-n-drop
com.canonical.certification::touchscreen/multitouch-zoom
com.canonical.certification::touchscreen/multitouch-rotate
com.canonical.certification::touchscreen/evdev/single-touch-tap-ELAN_Touchscreen
com.canonical.certification::touchscreen/evdev/2-touch-tap-ELAN_Touchscreen
com.canonical.certification::touchscreen/evdev/3-touch-tap-ELAN_Touchscreen
com.canonical.certification::touchscreen/evdev/4-touch-tap-ELAN_Touchscreen
com.canonical.certification::usb/detect
com.canonical.certification::usb/HID
com.canonical.certification::usb/insert
com.canonical.certification::usb/storage-automated
com.canonical.certification::usb/remove
com.canonical.certification::usb
com.canonical.certification::usb3/insert
com.canonical.certification::usb3/storage-automated
com.canonical.certification::usb3/remove
com.canonical.certification::usb-c/c-to-a-adapter/hid
com.canonical.certification::usb-c/c-to-a-adapter/insert
com.canonical.certification::usb-c/c-to-a-adapter/storage-automated
com.canonical.certification::usb-c/c-to-a-adapter/remove
com.canonical.certification::usb-c/hid
com.canonical.certification::usb-c/insert
com.canonical.certification::usb-c/storage-automated
com.canonical.certification::usb-c/remove
com.canonical.certification::usb-c/c-to-ethernet-adapter-insert
com.canonical.certification::power-management/lid_close_suspend_open
com.canonical.certification::power-management/lid
com.canonical.certification::rtc
com.canonical.certification::sleep
com.canonical.certification::keys/sleep
com.canonical.certification::suspend/suspend_advanced_auto
com.canonical.certification::after-suspend-miscellanea/chvt
com.canonical.certification::suspend/display_after_suspend
com.canonical.certification::after-suspend-graphics/1_maximum_resolution_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-graphics/1_rotation_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-graphics/1_video_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-graphics/1_cycle_resolution_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-graphics/1_valid_glxgears_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-graphics/1_valid_glxgears_fullscreen_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-graphics/2_valid_glxgears_GP108GLM__Quadro_P520_
com.canonical.certification::after-suspend-graphics/2_valid_glxgears_fullscreen_GP108GLM__Quadro_P520_
com.canonical.certification::after-suspend-graphics/valid_glxgears
com.canonical.certification::after-suspend-graphics/valid_glxgears_fullscreen
com.canonical.certification::suspend/1_xrandr_screens_after_suspend.tar.gz_auto
com.canonical.certification::after-suspend-monitor/1_powersaving_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-power-management/light_sensor
com.canonical.certification::after-suspend-monitor/1_dim_brightness_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-monitor/1_displayport_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-audio/1_playback_displayport_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-monitor/1_type-c_displayport_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-audio/1_playback_type-c_displayport_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-monitor/1_type-c_hdmi_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-audio/1_playback_type-c_hdmi_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-monitor/1_type-c_vga_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-monitor/1_dvi_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-monitor/1_hdmi_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-audio/1_playback_hdmi_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-monitor/1_thunderbolt3_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-audio/1_playback_thunderbolt3_CometLake-U_GT2__UHD_Graphics_
com.canonical.certification::after-suspend-thunderbolt3/daisy-chain
com.canonical.certification::after-suspend-monitor/multi-head
com.canonical.certification::suspend/oops_after_suspend
com.canonical.certification::suspend/oops_results_after_suspend.log
com.canonical.certification::led/power-blink-suspend
com.canonical.certification::led/suspend
com.canonical.certification::after-suspend-audio/speaker-headphone-plug-detection
com.canonical.certification::after-suspend-audio/microphone-plug-detection
com.canonical.certification::after-suspend-audio/playback_headphones
com.canonical.certification::after-suspend-audio/alsa_record_playback_external
com.canonical.certification::after-suspend-audio/playback_auto
com.canonical.certification::after-suspend-audio/alsa_record_playback_internal
com.canonical.certification::after-suspend-audio/channels
com.canonical.certification::after-suspend-audio/external-linein
com.canonical.certification::after-suspend-audio/external-lineout
com.canonical.certification::after-suspend-bluetooth4/HOGP-mouse
com.canonical.certification::after-suspend-bluetooth4/HOGP-keyboard
com.canonical.certification::after-suspend-bluetooth/audio-a2dp
com.canonical.certification::after-suspend-bluetooth/audio_record_playback
com.canonical.certification::after-suspend-camera/still_video0
com.canonical.certification::after-suspend-camera/display_video0
com.canonical.certification::after-suspend-thunderbolt3/insert
com.canonical.certification::after-suspend-thunderbolt3/storage-test
com.canonical.certification::after-suspend-thunderbolt3/remove
com.canonical.certification::after-suspend-input/accelerometer
com.canonical.certification::after-suspend-input/pointing_Lenovo_Essential_Wireless_Keyboard_and_Mouse_Combo_MOUSE_1
com.canonical.certification::after-suspend-input/pointing_ELAN_Touchscreen_TOUCHSCREEN_2
com.canonical.certification::after-suspend-input/pointing_SynPS_2_Synaptics_TouchPad_TOUCHPAD_3
com.canonical.certification::after-suspend-input/pointing_TPPS_2_Elan_TrackPoint_MOUSE_4
com.canonical.certification::after-suspend-input/keyboard
com.canonical.certification::after-suspend-fingerprint/detect
com.canonical.certification::after-suspend-fingerprint/enroll
com.canonical.certification::after-suspend-fingerprint/verify-no-match
com.canonical.certification::after-suspend-fingerprint/verify-match
com.canonical.certification::after-suspend-fingerprint/unlock
com.canonical.certification::after-suspend-fingerprint/delete
com.canonical.certification::after-suspend-keys/lock-screen
com.canonical.certification::after-suspend-keys/super
com.canonical.certification::after-suspend-keys/brightness
com.canonical.certification::after-suspend-keys/media-control
com.canonical.certification::after-suspend-keys/mute
com.canonical.certification::after-suspend-keys/volume
com.canonical.certification::after-suspend-keys/video-out
com.canonical.certification::after-suspend-keys/wireless
com.canonical.certification::after-suspend-keys/keyboard-backlight
com.canonical.certification::after-suspend-keys/microphone-mute
com.canonical.certification::after-suspend-keys/power-button
com.canonical.certification::after-suspend-keys/power-button-event
com.canonical.certification::after-suspend-keys/fn-lock
com.canonical.certification::after-suspend-camera/led_video0
com.canonical.certification::after-suspend-led/caps-lock
com.canonical.certification::after-suspend-led/numeric-keypad
com.canonical.certification::after-suspend-led/power
com.canonical.certification::after-suspend-led/mute
com.canonical.certification::after-suspend-led/microphone-mute
com.canonical.certification::after-suspend-led/fn
com.canonical.certification::after-suspend-mediacard/sdhc-insert
com.canonical.certification::after-suspend-mediacard/sdhc-storage
com.canonical.certification::after-suspend-mediacard/sdhc-remove
com.canonical.certification::after-suspend-ethernet/detect
com.canonical.certification::after-suspend-ethernet/hotplug-enp0s31f6
com.canonical.certification::after-suspend-networking/info_device1_enp0s31f6
com.canonical.certification::after-suspend-touchpad/basic
com.canonical.certification::after-suspend-touchpad/palm-rejection
com.canonical.certification::after-suspend-touchpad/continuous-move
com.canonical.certification::after-suspend-touchpad/singletouch-selection
com.canonical.certification::after-suspend-touchpad/drag-and-drop
com.canonical.certification::after-suspend-touchpad/multitouch-rightclick
com.canonical.certification::after-suspend-touchpad/multitouch
com.canonical.certification::after-suspend-touchscreen/drag-n-drop
com.canonical.certification::after-suspend-touchscreen/multitouch-zoom
com.canonical.certification::after-suspend-touchscreen/multitouch-rotate
com.canonical.certification::after-suspend-touchscreen/evdev/single-touch-tap-ELAN_Touchscreen
com.canonical.certification::after-suspend-touchscreen/evdev/2-touch-tap-ELAN_Touchscreen
com.canonical.certification::after-suspend-touchscreen/evdev/3-touch-tap-ELAN_Touchscreen
com.canonical.certification::after-suspend-touchscreen/evdev/4-touch-tap-ELAN_Touchscreen
com.canonical.certification::after-suspend-usb/HID
com.canonical.certification::after-suspend-usb/insert
com.canonical.certification::after-suspend-usb/storage-automated
com.canonical.certification::after-suspend-usb/remove
com.canonical.certification::after-suspend-usb3/insert
com.canonical.certification::after-suspend-usb3/storage-automated
com.canonical.certification::after-suspend-usb3/remove
com.canonical.certification::after-suspend-usb-c/c-to-a-adapter/hid
com.canonical.certification::after-suspend-usb-c/c-to-a-adapter/insert
com.canonical.certification::after-suspend-usb-c/c-to-a-adapter/storage-automated
com.canonical.certification::after-suspend-usb-c/c-to-a-adapter/remove
com.canonical.certification::after-suspend-usb-c/hid
com.canonical.certification::after-suspend-usb-c/insert
com.canonical.certification::after-suspend-usb-c/storage-automated
com.canonical.certification::after-suspend-usb-c/remove
com.canonical.certification::after-suspend-usb-c/c-to-ethernet-adapter-insert
com.canonical.certification::ethernet/wol_S5_enp0s31f6
com.canonical.certification::ethernet/wol_S3_enp0s31f6

![Uploading Screenshot from 2024-09-05 15-34-44.png…]()

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
