### PR TITLE
desktop_session in bootstrap for automated testplan (BugFix)

### DIFF
--- a/providers/base/units/zapper/jobs.pxu
+++ b/providers/base/units/zapper/jobs.pxu
@@ -1,5 +1,4 @@
 id: monitor/zapper-edid
-template-resource: zapper_capabilities desktop_session
 requires: 
  zapper_capabilities.capability == 'hdmi-capture'
  zapper_capabilities.edid_cycling == 'True'

--- a/providers/base/units/zapper/test-plan.pxu
+++ b/providers/base/units/zapper/test-plan.pxu
@@ -19,6 +19,7 @@ include:
   usb3/zapper-usb-insert-.*
   usb3/zapper-usb-remove-.*
 bootstrap_include:
+  desktop_session
+  graphics_card
   zapper_capabilities
   zapper_reset_setup
-  graphics_card


### PR DESCRIPTION
## WARNING: This modifies com.canonical.certification::sru

## Description

The resource `desktop_session` was not included in the automated testplan bootstrap section. Also, the `edid` job was including a useless template-resource section.

## Resolved issues

N/A

## Documentation

N/A

## Tests

Tested sideloading the provider:
1. `desktop_session` is ran as part of bootstrap
2. `edid` is included in the test plan
