### PR TITLE
Test pipeline fails with Add a new function to find which renderer is running the process (New)

### DIFF
--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -134,15 +134,15 @@ class PrimeOffloader:
         self, cmd: list, card_id: str, card_name: str, timeout: int
     ):
         """
-        Use to check provided command is executed on specific GPU.
+        Used to check if the provided command is executed on a specific GPU.
 
-        :param cmd: command that running under prime offload
+        :param cmd: command to be run under prime offload
 
-        :param card_id: card id of dri device
+        :param card_id: card ID of the DRI device
 
-        :param card_name: card name of dri device
+        :param card_name: card name of the DRI device
 
-        :param timeout: timeout for offloaded command
+        :param timeout: timeout for the offloaded command
         """
         delay = timeout / 10
 

--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -131,7 +131,7 @@ class PrimeOffloader:
         return self._run_command(read_clients_cmd)
 
     def check_offload(
-        self, cmd: list, card_id: str, card_name: str, timeout: str
+        self, cmd: list, card_id: str, card_name: str, timeout: int
     ):
         """
         Use to check provided command is executed on specific GPU.

--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -175,7 +175,7 @@ class PrimeOffloader:
 
     def find_offload(self, cmd: str, timeout: int):
         """
-        Use to find provided command is executed on which GPU.
+        Find the card that the command is running on.
 
         :param cmd: command that is running
 

--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -17,10 +17,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
+from checkbox_support.helpers.timeout import run_with_timeout
 import subprocess
 import threading
 import argparse
 import logging
+import fnmatch
 import time
 import json
 import sys
@@ -44,25 +46,32 @@ class PrimeOffloader:
     logger = logging.getLogger()
     check_result = False
 
-    def _run_command(self, cmd: list, shell=False) -> str:
+    def find_file_containing_string(
+        self, search_directory: str, filename_pattern: str, search_string: str
+    ) -> str:
         """
-        use subprocess.check_output to execute command
+        Search for a file matching a specific pattern
+        that contains a given string.
 
-        :param cmd: the command will be executed
+        :param search_directory: The directory to search through.
 
-        :param shell: enable shell or not
+        :param filename_pattern: The pattern that filenames should match.
 
-        :returns: Output of command
+        :param search_string: The string to search for within
+                              the file's contents.
+
+        :returns: The full path of the file that contains the string,
+                  or None if no file is found.
         """
-        try:
-            return subprocess.check_output(
-                cmd, shell=shell, universal_newlines=True
-            )
-
-        except (subprocess.CalledProcessError, FileNotFoundError) as e:
-            raise SystemExit(
-                "Running command:{} failed due to {}".format(cmd, repr(e))
-            )
+        for root, dirs, files in os.walk(search_directory):
+            for file_name in fnmatch.filter(files, filename_pattern):
+                file_path = os.path.join(root, file_name)
+                # Check if the search string is in the file
+                with open(
+                    file_path, "r", encoding="utf-8", errors="ignore"
+                ) as file:
+                    if search_string in file.read():
+                        return file_path
 
     def find_card_id(self, pci_bdf: str) -> str:
         """
@@ -77,15 +86,9 @@ class PrimeOffloader:
             raise SystemExit("pci BDF format error")
 
         try:
-            cmd = [
-                "grep",
-                "-lr",
-                "--include=name",
-                pci_bdf,
-                "/sys/kernel/debug/dri",
-            ]
-
-            card_path = self._run_command(cmd)
+            card_path = self.find_file_containing_string(
+                "/sys/kernel/debug/dri", "name", pci_bdf
+            )
             return card_path.split("/")[5]
         except IndexError as e:
             raise SystemExit("return value format error {}".format(repr(e)))
@@ -100,7 +103,9 @@ class PrimeOffloader:
         """
         cmd = ["lshw", "-c", "display", "-numeric", "-json"]
         try:
-            card_infos = self._run_command(cmd)
+            card_infos = subprocess.check_output(
+                cmd, shell=False, universal_newlines=True
+            )
             infos = json.loads(card_infos)
             for info in infos:
                 if pci_bdf in info["businfo"]:
@@ -108,6 +113,10 @@ class PrimeOffloader:
             raise SystemExit("Card name not found")
         except (KeyError, TypeError, json.decoder.JSONDecodeError) as e:
             raise SystemExit("return value format error {}".format(e))
+        except (subprocess.CalledProcessError, FileNotFoundError) as e:
+            raise SystemExit(
+                "Running command:{} failed due to {}".format(cmd, repr(e))
+            )
 
     def get_clients(self, card_id: str) -> str:
         """
@@ -122,13 +131,12 @@ class PrimeOffloader:
             and the process could be found in
             /sys/kernel/debug/dri/<card id>/clients
 
-        :param cmd: command that running under prime offload
+        :param card_id: card id shows in debugfs
         """
-        read_clients_cmd = [
-            "cat",
-            "/sys/kernel/debug/dri/{}/clients".format(card_id),
-        ]
-        return self._run_command(read_clients_cmd)
+        filename = "/sys/kernel/debug/dri/{}/clients".format(card_id)
+        with open(filename, "r") as f:
+            return f.read()
+        return ""
 
     def check_offload(
         self, cmd: list, card_id: str, card_name: str, timeout: int
@@ -151,6 +159,8 @@ class PrimeOffloader:
         while time.time() < deadline:
             time.sleep(delay)
             clients = self.get_clients(card_id)
+            # The command shows in /sys/kernel/debug/dri/<card_id>/clients
+            # doesn't include arguments. Therefore cmd[0] is used to search
             if clients and cmd[0] in clients:
                 self.logger.info("Checking success:")
                 self.logger.info("  Offload process:[{}]".format(cmd))
@@ -161,49 +171,51 @@ class PrimeOffloader:
         self.logger.info("  Couldn't find process [{}]".format(cmd))
         self.check_result = True
 
-    def _find_bdf(self, card: str):
+    def _find_bdf(self, card_id: str):
         """
         Use the /sys/kernel/debug/dri/<card id>/name to get pci BDF.
 
-        :param card: in /sys/kernel/debug/dri/<card id>/clients format
-
+        :param card_id: card id shows in debugfs
         """
-        data_in_name = self._run_command(
-            ["cat", card.replace("clients", "name")]
-        )
+        filename = "/sys/kernel/debug/dri/{}/name".format(card_id)
+        with open(filename, "r") as f:
+            data_in_name = f.read()
         return data_in_name.split()[1].split("=")[1]
 
     def find_offload(self, cmd: str, timeout: int):
         """
         Find the card that the command is running on.
+        This script looks for the card on which a specific command is running.
+        It checks ten times in regular intervals if the process is running
+        by looking for it in the /sys/kernel/debug/dri/<card id>/clients.
+        If the timeout is reached, the function will fail
 
         :param cmd: command that is running
 
         :param timeout: timeout for command
         """
+        directory = "/sys/kernel/debug/dri"
+
         delay = timeout / 10
 
         deadline = time.time() + timeout
 
         cmd = cmd.split()
 
-        find_cmd = [
-            "grep",
-            "-lr",
-            "--include=clients",
-            cmd[0],
-            "/sys/kernel/debug/dri",
-        ]
-
         while time.time() < deadline:
             time.sleep(delay)
-            card_path = self._run_command(find_cmd)
-            if "/sys/kernel/debug/dri" in card_path:
+            # The command shows in /sys/kernel/debug/dri/<card_id>/clients
+            # doesn't include arguments. Therefore cmd[0] is used to search
+            card_path = self.find_file_containing_string(
+                directory, "clients", cmd[0]
+            )
+            if directory in card_path:
                 try:
                     # The graphic will be shown such as 0 and 128
                     # at the same time. Therefore, pick up the first one
                     first_card = card_path.splitlines()[0]
-                    bdf = self._find_bdf(first_card)
+                    card_id = first_card.split("/")[5]
+                    bdf = self._find_bdf(card_id)
                     self.logger.info("Process is running on:")
                     self.logger.info("  process:[{}]".format(cmd))
                     self.logger.info(
@@ -250,36 +262,6 @@ class PrimeOffloader:
                 "No prime-select, it should be ok to run prime offload"
             )
 
-    def _reformat_cmd_timeout(self, cmd: str, timeout: int) -> (list, int):
-        """
-        use to reformat the command with correct timeout setting
-
-        :param cmd: the command will be executed
-
-        :param timeout: timeout
-
-        :returns: reformated command and real timeout
-        """
-        if "timeout" in cmd:
-            raise SystemExit("Put timeout in command isn't allowed")
-
-        cmd = cmd.split()
-
-        if timeout > 0:
-            offload_cmd = ["timeout", str(timeout)] + cmd
-        else:
-            # if timeout <=0 will make check_offload failed.
-            # Set the timeout to the default value
-            log_str = (
-                "Timeout {}s is invalid,"
-                " remove the timeout setting"
-                " and change check_offload to run 20s".format(timeout)
-            )
-            self.logger.info(log_str)
-            timeout = 20
-            offload_cmd = cmd
-        return (offload_cmd, timeout)
-
     def cmd_runner(self, cmd: list, env: dict = None):
         """
         use to execute command and piping the output to the screen.
@@ -314,14 +296,18 @@ class PrimeOffloader:
 
         :param timeout: timeout for offloaded command
         """
-        (modified_cmd, timeout) = self._reformat_cmd_timeout(cmd, timeout)
+        if "timeout" in cmd:
+            raise SystemExit("Put timeout in command isn't allowed")
 
         # use other thread to find offload
         find_thread = threading.Thread(
             target=self.find_offload, args=(cmd, timeout)
         )
         find_thread.start()
-        self.cmd_runner(modified_cmd)
+        try:
+            run_with_timeout(self.cmd_runner, timeout, cmd.split())
+        except TimeoutError:
+            self.logger.info("Test finished")
         find_thread.join()
 
         if self.check_result:
@@ -345,7 +331,8 @@ class PrimeOffloader:
         # run offload command in other process
         dri_pci_bdf_format = re.sub("[:.]", "_", pci_bdf)
 
-        (modified_cmd, timeout) = self._reformat_cmd_timeout(cmd, timeout)
+        if "timeout" in cmd:
+            raise SystemExit("Put timeout in command isn't allowed")
 
         env = os.environ.copy()
         if driver in ("nvidia", "pcieport"):
@@ -367,7 +354,10 @@ class PrimeOffloader:
             target=self.check_offload, args=(cmd, card_id, card_name, timeout)
         )
         check_thread.start()
-        self.cmd_runner(modified_cmd, env)
+        try:
+            run_with_timeout(self.cmd_runner, timeout, cmd.split(), env)
+        except TimeoutError:
+            self.logger.info("Test finished")
         check_thread.join()
 
         if self.check_result:

--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -50,7 +50,7 @@ class PrimeOffloader:
 
         :param cmd: the command will be executed
 
-        :param shell: enbale shell or not
+        :param shell: enable shell or not
 
         :returns: Ouput of command
         """

--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -52,7 +52,7 @@ class PrimeOffloader:
 
         :param shell: enable shell or not
 
-        :returns: Ouput of command
+        :returns: Output of command
         """
         try:
             return subprocess.check_output(

--- a/providers/base/tests/test_prime_offload_tester.py
+++ b/providers/base/tests/test_prime_offload_tester.py
@@ -15,38 +15,44 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from unittest.mock import patch, MagicMock, mock_open
+import subprocess
 import unittest
-from unittest.mock import patch, MagicMock
+import os
 
-from prime_offload_tester import *
+from checkbox_support.helpers.timeout import mock_timeout
+
+from prime_offload_tester import PrimeOffloader
 
 
-class RunCmdTests(unittest.TestCase):
+class FindFileContainingString(unittest.TestCase):
     """
-    This function should execute command and raise SystemExit if fail.
+    This function should work like "grep -l"
     """
 
-    @patch("subprocess.check_output")
-    def test_run_command_succ(self, mock_check):
+    @patch("os.walk")
+    def test_grep_true(self, mock_walk):
+        mock_walk.return_value = [("/foo/bar", ["bar"], ["spam"])]
         po = PrimeOffloader()
-        mock_check.return_value = "test"
-        self.assertEqual(po._run_command(["echo", "test"]), "test")
-        mock_check.assert_called_with(
-            ["echo", "test"],
-            shell=False,
-            universal_newlines=True,
+        with patch("builtins.open", mock_open(read_data="test")) as mock_file:
+            self.assertEqual(
+                po.find_file_containing_string("/foo/bar", "spam", "test"),
+                "/foo/bar/spam",
+            )
+        mock_file.assert_called_with(
+            "/foo/bar/spam", "r", encoding="utf-8", errors="ignore"
         )
 
-    @patch("subprocess.check_output")
-    def test_run_command_fail(self, mock_check):
+    @patch("os.walk")
+    def test_grep_false(self, mock_walk):
+        mock_walk.return_value = [("/foo/bar", ["bar"], ["spam"])]
         po = PrimeOffloader()
-        mock_check.side_effect = FileNotFoundError
-        with self.assertRaises(SystemExit):
-            po._run_command(["echo", "test"])
-        mock_check.assert_called_with(
-            ["echo", "test"],
-            shell=False,
-            universal_newlines=True,
+        with patch("builtins.open", mock_open(read_data="test")) as mock_file:
+            self.assertEqual(
+                po.find_file_containing_string("/foo/bar", "spam", "xxx"), None
+            )
+        mock_file.assert_called_with(
+            "/foo/bar/spam", "r", encoding="utf-8", errors="ignore"
         )
 
 
@@ -56,30 +62,26 @@ class FindCardIdTests(unittest.TestCase):
     (pci bus information)
     """
 
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
     def test_pci_name_format_check(self, mock_cmd):
         po = PrimeOffloader()
         # correct format
         mock_cmd.return_value = "/sys/kernel/debug/dri/0/name"
         self.assertEqual(po.find_card_id("0000:00:00.0"), "0")
         mock_cmd.assert_called_with(
-            [
-                "grep",
-                "-lr",
-                "--include=name",
-                "0000:00:00.0",
-                "/sys/kernel/debug/dri",
-            ]
+            "/sys/kernel/debug/dri",
+            "name",
+            "0000:00:00.0",
         )
 
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
     def test_pci_name_hex_format_check(self, mock_cmd):
         po = PrimeOffloader()
         # should work with hex vaule
         mock_cmd.return_value = "/sys/kernel/debug/dri/0/name"
         self.assertEqual(po.find_card_id("0000:c6:F0.0"), "0")
 
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
     def test_pci_name_non_hex_format_check(self, mock_cmd):
         po = PrimeOffloader()
         # error format - with alphabet
@@ -87,7 +89,7 @@ class FindCardIdTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             po.find_card_id("000r:00:00.0")
 
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
     def test_pci_name_digital_error_format_check(self, mock_cmd):
         po = PrimeOffloader()
         # error format - digital position error
@@ -95,7 +97,7 @@ class FindCardIdTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             po.find_card_id("0000:00:000.0")
 
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
     def test_empty_string_id_not_found(self, mock_cmd):
         po = PrimeOffloader()
         # empty string
@@ -103,16 +105,12 @@ class FindCardIdTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             po.find_card_id("0000:00:00.0")
         mock_cmd.assert_called_with(
-            [
-                "grep",
-                "-lr",
-                "--include=name",
-                "0000:00:00.0",
-                "/sys/kernel/debug/dri",
-            ]
+            "/sys/kernel/debug/dri",
+            "name",
+            "0000:00:00.0",
         )
 
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
     def test_indexerror_id_not_found(self, mock_cmd):
         po = PrimeOffloader()
         # IndexError
@@ -120,13 +118,9 @@ class FindCardIdTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             po.find_card_id("0000:00:00.0")
         mock_cmd.assert_called_with(
-            [
-                "grep",
-                "-lr",
-                "--include=name",
-                "0000:00:00.0",
-                "/sys/kernel/debug/dri",
-            ]
+            "/sys/kernel/debug/dri",
+            "name",
+            "0000:00:00.0",
         )
 
 
@@ -203,7 +197,7 @@ class FindCardNameTests(unittest.TestCase):
                      }
                    ]"""
 
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
+    @patch("subprocess.check_output")
     def test_name_found_check(self, mock_cmd):
         po = PrimeOffloader()
         mock_cmd.return_value = self.lshw_output
@@ -212,10 +206,12 @@ class FindCardNameTests(unittest.TestCase):
             "TigerLake-LP GT2 [Iris Xe Graphics]",
         )
         mock_cmd.assert_called_with(
-            ["lshw", "-c", "display", "-numeric", "-json"]
+            ["lshw", "-c", "display", "-numeric", "-json"],
+            shell=False,
+            universal_newlines=True,
         )
 
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
+    @patch("subprocess.check_output")
     def test_pci_bdf_error_name_not_found_check(self, mock_cmd):
         po = PrimeOffloader()
         # pci_bdf error
@@ -223,10 +219,12 @@ class FindCardNameTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             po.find_card_name("0000:00:00.0")
         mock_cmd.assert_called_with(
-            ["lshw", "-c", "display", "-numeric", "-json"]
+            ["lshw", "-c", "display", "-numeric", "-json"],
+            shell=False,
+            universal_newlines=True,
         )
 
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
+    @patch("subprocess.check_output")
     def test_no_lshw_output_name_not_found_check(self, mock_cmd):
         po = PrimeOffloader()
         # no businfo in lshw output
@@ -234,10 +232,12 @@ class FindCardNameTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             po.find_card_name("0000:00:00.0")
         mock_cmd.assert_called_with(
-            ["lshw", "-c", "display", "-numeric", "-json"]
+            ["lshw", "-c", "display", "-numeric", "-json"],
+            shell=False,
+            universal_newlines=True,
         )
 
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
+    @patch("subprocess.check_output")
     def test_empty_string_name_not_found_check(self, mock_cmd):
         po = PrimeOffloader()
         # empty string
@@ -245,10 +245,12 @@ class FindCardNameTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             po.find_card_name("0000:00:00.0")
         mock_cmd.assert_called_with(
-            ["lshw", "-c", "display", "-numeric", "-json"]
+            ["lshw", "-c", "display", "-numeric", "-json"],
+            shell=False,
+            universal_newlines=True,
         )
 
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
+    @patch("subprocess.check_output")
     def test_none_name_not_found_check(self, mock_cmd):
         po = PrimeOffloader()
         # None
@@ -256,17 +258,21 @@ class FindCardNameTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             po.find_card_name("0000:00:00.0")
         mock_cmd.assert_called_with(
-            ["lshw", "-c", "display", "-numeric", "-json"]
+            ["lshw", "-c", "display", "-numeric", "-json"],
+            shell=False,
+            universal_newlines=True,
         )
 
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
+    @patch("subprocess.check_output")
     def test_keyerror_name_not_found_check(self, mock_cmd):
         po = PrimeOffloader()
         mock_cmd.side_effect = KeyError
         with self.assertRaises(SystemExit):
             po.find_card_name("0000:00:00.0")
         mock_cmd.assert_called_with(
-            ["lshw", "-c", "display", "-numeric", "-json"]
+            ["lshw", "-c", "display", "-numeric", "-json"],
+            shell=False,
+            universal_newlines=True,
         )
 
 
@@ -276,12 +282,12 @@ class GetClientsTests(unittest.TestCase):
     "/sys/kernel/debug/dri/*/clients"
     """
 
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
-    def test_get_clients(self, mock_cmd):
+    def test_get_clients(self):
         po = PrimeOffloader()
-        mock_cmd.return_value = "echo"
-        self.assertEqual(po.get_clients(0), "echo")
-        mock_cmd.assert_called_with(["cat", "/sys/kernel/debug/dri/0/clients"])
+        with patch("builtins.open", mock_open(read_data="data")) as mock_file:
+            self.assertEqual(po.get_clients(0), "data")
+        mock_file.assert_called_with("/sys/kernel/debug/dri/0/clients", "r")
+
 
 
 class CheckOffloadTests(unittest.TestCase):
@@ -302,11 +308,13 @@ class CheckOffloadTests(unittest.TestCase):
         self.assertEqual(po.check_result, False)
 
     @patch("time.sleep", return_value=None)
+    @patch("time.time")
     @patch("prime_offload_tester.PrimeOffloader.get_clients")
-    def test_offload_fail_check(self, mock_client, mock_sleep):
+    def test_offload_fail_check(self, mock_client, mock_time, mock_sleep):
         cmd = ["echo"]
         # get_clients return string that doesn't include cmd
         mock_client.return_value = ""
+        mock_time.side_effect = [0, 0, 1, 2]
         po = PrimeOffloader()
         self.assertEqual(
             po.check_offload(cmd, "card_id", "card_name", 1), None
@@ -315,6 +323,7 @@ class CheckOffloadTests(unittest.TestCase):
 
         # get_clients return None by CalledProcessError
         mock_client.return_value = None
+        mock_time.side_effect = [0, 0, 1, 2]
         po = PrimeOffloader()
         self.assertEqual(
             po.check_offload(cmd, "card_id", "card_name", 1), None
@@ -328,15 +337,17 @@ class FindBDFTests(unittest.TestCase):
     "/sys/kernel/debug/dri/*/name"
     """
 
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
-    def test_find_bdf(self, mock_cmd):
+    def test_find_bdf(self):
         po = PrimeOffloader()
-        card = "/sys/kernel/debug/dri/0/clients"
-        mock_cmd.return_value = "i915 dev=0000:00:02.0 unique=0000:00:02.0"
-        self.assertEqual(po._find_bdf(card), "0000:00:02.0")
-        mock_cmd.assert_called_with(["cat", card.replace("clients", "name")])
+        with patch(
+            "builtins.open",
+            mock_open(read_data="i915 dev=0000:00:02.0 unique=0000:00:02.0"),
+        ) as mock_file:
+            self.assertEqual(po._find_bdf(0), "0000:00:02.0")
+            mock_file.assert_called_with("/sys/kernel/debug/dri/0/name", "r")
 
 
+@mock_timeout()
 class FindOffloadTests(unittest.TestCase):
     """
     This function should try to find which GPU is the renderer
@@ -344,49 +355,34 @@ class FindOffloadTests(unittest.TestCase):
     """
 
     @patch("time.sleep", return_value=None)
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
-    def test_found(self, mock_cmd, mock_sleep):
-        mock_cmd.return_value = (
-            "/sys/kernel/debug/dri/0/clients\n"
-            + "/sys/kernel/debug/dri/128/clients\n"
-        )
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
+    def test_found(self, mock_file, mock_sleep):
         cmd = "echo"
         po = PrimeOffloader()
         po._find_bdf = MagicMock(return_value="0")
         po.find_card_id = MagicMock(return_value="0")
         po.find_card_name = MagicMock(return_value="Intel")
+        mock_file.return_value = "/sys/kernel/debug/dri/0/clients"
         self.assertEqual(po.find_offload(cmd, 1), None)
-        mock_cmd.assert_called_with(
-            [
-                "grep",
-                "-lr",
-                "--include=clients",
-                "echo",
-                "/sys/kernel/debug/dri",
-            ]
-        )
+        self.assertEqual(po.check_result, False)
+        mock_file.assert_called_with("/sys/kernel/debug/dri", "clients", cmd)
         self.assertEqual(po.check_result, False)
 
     @patch("time.sleep", return_value=None)
-    @patch("prime_offload_tester.PrimeOffloader._run_command")
-    def test_not_found(self, mock_cmd, mock_sleep):
-        mock_cmd.return_value = ""
+    @patch("time.time")
+    @patch("prime_offload_tester.PrimeOffloader.find_file_containing_string")
+    def test_not_found(self, mock_file, mock_time, mock_sleep):
         cmd = "echo"
         po = PrimeOffloader()
         po._find_bdf = MagicMock(return_value="0")
         po.find_card_id = MagicMock(return_value="0")
         po.find_card_name = MagicMock(return_value="Intel")
+        mock_file.return_value = ""
+        mock_time.side_effect = [0, 0, 1, 2]
         self.assertEqual(po.find_offload(cmd, 1), None)
-        mock_cmd.assert_called_with(
-            [
-                "grep",
-                "-lr",
-                "--include=clients",
-                "echo",
-                "/sys/kernel/debug/dri",
-            ]
-        )
+        mock_file.assert_called_with("/sys/kernel/debug/dri", "clients", cmd)
         self.assertEqual(po.check_result, True)
+
 
 
 class CheckNvOffloadEnvTests(unittest.TestCase):
@@ -437,30 +433,6 @@ class CheckNvOffloadEnvTests(unittest.TestCase):
         self.assertEqual(po.check_nv_offload_env(), None)
 
 
-class ReformatCmdTimeoutTests(unittest.TestCase):
-    """
-    This function should return the right format command with timeout setting
-    and the real timeout for futher usage.
-    """
-
-    def test_timeout_in_cmd(self):
-        po = PrimeOffloader()
-        with self.assertRaises(SystemExit):
-            po._reformat_cmd_timeout("timeout 10 echo", 10)
-
-    def test_timeout_greater_than_zero(self):
-        po = PrimeOffloader()
-        (cmd, timeout) = po._reformat_cmd_timeout("echo test", 10)
-        self.assertEqual(cmd, ["timeout", "10", "echo", "test"])
-        self.assertEqual(timeout, 10)
-
-    def test_timeout_less_than_zero(self):
-        po = PrimeOffloader()
-        (cmd, timeout) = po._reformat_cmd_timeout("echo test", 0)
-        self.assertEqual(cmd, ["echo", "test"])
-        self.assertEqual(timeout, 20)
-
-
 class CmdRunnerTests(unittest.TestCase):
     """
     This function should run the command with Popen mode
@@ -490,43 +462,28 @@ class CmdRunnerTests(unittest.TestCase):
             po.cmd_runner(["echo", "0000:00:00.0", "xxx", 0], self.o_env)
 
 
+@patch("subprocess.Popen", MagicMock())
 class CmdFinderTests(unittest.TestCase):
     """
     This function should find the command is rendered by which GPU
     """
 
-    @patch("prime_offload_tester.PrimeOffloader.cmd_runner")
-    def test_found(self, mock_runner):
+    def test_found(self):
         po = PrimeOffloader()
-        po._reformat_cmd_timeout = MagicMock(
-            return_value=(["timeout", "20", "glxgears"], 20)
-        )
         po.find_offload = MagicMock(return_value="")
         os.environ.copy = MagicMock(return_value={})
         po.check_result = False
         po.cmd_finder("glxgears", 20)
-        # check cmd_finder executing correct command
-        mock_runner.assert_called_with(
-            ["timeout", "20", "glxgears"],
-        )
         # check check_offload function get correct args
         po.find_offload.assert_called_with("glxgears", 20)
 
-    @patch("prime_offload_tester.PrimeOffloader.cmd_runner")
-    def test_not_found(self, mock_runner):
+    def test_not_found(self):
         po = PrimeOffloader()
-        po._reformat_cmd_timeout = MagicMock(
-            return_value=(["timeout", "20", "glxgears"], 20)
-        )
         po.find_offload = MagicMock(return_value="")
         os.environ.copy = MagicMock(return_value={})
         po.check_result = True
         with self.assertRaises(SystemExit):
             po.cmd_finder("glxgears", 20)
-        # check cmd_finder executing correct command
-        mock_runner.assert_called_with(
-            ["timeout", "20", "glxgears"],
-        )
         # check check_offload function get correct args
         po.find_offload.assert_called_with("glxgears", 20)
 
@@ -575,8 +532,7 @@ class CmdCheckerTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             po.cmd_checker("echo", "0000:00:00.0", "driver", 0)
 
-    @patch("prime_offload_tester.PrimeOffloader.cmd_runner")
-    def test_non_nv_driver_check(self, mock_runner):
+    def test_non_nv_driver_check(self):
 
         # non NV driver
         po = PrimeOffloader()
@@ -584,21 +540,12 @@ class CmdCheckerTests(unittest.TestCase):
         po.find_card_name = MagicMock(return_value="Intel")
         po.check_nv_offload_env = MagicMock(return_value=None)
         po.check_offload = MagicMock(return_value="")
-        po._reformat_cmd_timeout = MagicMock(
-            return_value=(["timeout", "20", "glxgears"], 20)
-        )
         os.environ.copy = MagicMock(return_value={})
         po.cmd_checker("glxgears", "0000:00:00.0", "xxx", 0)
-        # check cmd_checker executing correct command
-        mock_runner.assert_called_with(
-            ["timeout", "20", "glxgears"],
-            self.o_env,
-        )
         # check check_offload function get correct args
-        po.check_offload.assert_called_with("glxgears", "0", "Intel", 20)
+        po.check_offload.assert_called_with("glxgears", "0", "Intel", 0)
 
-    @patch("prime_offload_tester.PrimeOffloader.cmd_runner")
-    def test_nv_driver_check(self, mock_runner):
+    def test_nv_driver_check(self):
 
         # NV driver
         po = PrimeOffloader()
@@ -606,39 +553,22 @@ class CmdCheckerTests(unittest.TestCase):
         po.find_card_name = MagicMock(return_value="NV")
         po.check_nv_offload_env = MagicMock(return_value=None)
         po.check_offload = MagicMock(return_value="")
-        po._reformat_cmd_timeout = MagicMock(
-            return_value=(["timeout", "1", "glxgears"], 1)
-        )
         os.environ.copy = MagicMock(return_value={})
         po.cmd_checker("glxgears", "0000:00:00.0", "nvidia", 1)
-        # check run_offload_cmd executing correct command
-        mock_runner.assert_called_with(
-            ["timeout", "1", "glxgears"],
-            self.nv_env,
-        )
         # check check_offload function get correct args
         po.check_offload.assert_called_with("glxgears", "0", "NV", 1)
 
-    @patch("prime_offload_tester.PrimeOffloader.cmd_runner")
-    def test_not_found(self, mock_runner):
+    def test_not_found(self):
         po = PrimeOffloader()
         po.find_card_id = MagicMock(return_value="0")
         po.find_card_name = MagicMock(return_value="NV")
-        po._reformat_cmd_timeout = MagicMock(
-            return_value=(["timeout", "20", "glxgears"], 20)
-        )
         po.check_offload = MagicMock(return_value="")
         os.environ.copy = MagicMock(return_value={})
         po.check_result = True
         with self.assertRaises(SystemExit):
             po.cmd_checker("glxgears", "0000:00:00.0", "nvidia", 1)
-        # check cmd_checker executing correct command
-        mock_runner.assert_called_with(
-            ["timeout", "20", "glxgears"],
-            self.nv_env,
-        )
         # check check_offload function get correct args
-        po.check_offload.assert_called_with("glxgears", "0", "NV", 20)
+        po.check_offload.assert_called_with("glxgears", "0", "NV", 1)
 
 
 class ParseArgsTests(unittest.TestCase):
@@ -700,7 +630,6 @@ class ParseArgsTests(unittest.TestCase):
         self.assertEqual(rv.pci, "0000:00:01.0")
         self.assertEqual(rv.driver, "nvidia")
         self.assertEqual(rv.timeout, 5)
-
 
 class MainTests(unittest.TestCase):
     @patch("prime_offload_tester.PrimeOffloader.parse_args")


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
While testing without pci id, user couldn't know the process is running
on which renderer. Therefore, this change is going to:
* add a new function to get which GPU is executing the command that could help user to make sure the renderer is not llvmpipe.
* refactor some codes to make reuse easier.
* add PCI ID in the log to make verify easier.

The jobs.pxu and test-plan.pxu will be in another PR, and the draft jobs and test-plan that use this new function as below:

```
plugin: shell
category_id: com.canonical.plainbox::graphics
id: graphics/auto_glxgears
flags: also-after-suspend
user: root
requires:
    executable.name == 'glxgears'
    dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower','Space-saving']
command:
    prime_offload_tester.py -c glxgears -t 30
summary:
    Test that glxgears works for current video card
purpose:
     Tests the basic 3D capabilities of your current video card. This test covers all devices without an integrated display, such as desktops.

plugin: shell
category_id: com.canonical.plainbox::graphics
id: graphics/auto_glxgears_fullscreen
flags: also-after-suspend
user: root
requires:
    executable.name == 'glxgears'
    dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower','Space-saving']
command:
     prime_offload_tester.py -c "glxgears -fullscreen" -t 30
summary:
    Test that glxgears works in full screen mode for current video card
purpose:
     Tests the basic full screen 3D capabilities of your current video card. This test covers all devices without an integrated display, such as desktops.
plugin: user-interact-verify
category_id: com.canonical.plainbox::graphics
id: graphics/valid_glxgears
flags: also-after-suspend
user: root
requires:
    executable.name == 'glxgears'
    dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower','Space-saving']
command:
     prime_offload_tester.py -c glxgears -t 30
summary:
    Test that glxgears works for current video card
purpose:
     Tests the basic 3D capabilities of your current video card. This test covers all devices without an integrated display, such as desktops.
steps:
     1. Click "Test" to execute an OpenGL demo. Press ESC at any time to close.
     2. Verify that the animation is not jerky or slow.
verification:
     1. Did the 3d animation appear?
     2. Was the animation free from slowness/jerkiness?

plugin: user-interact-verify
category_id: com.canonical.plainbox::graphics
id: graphics/valid_glxgears_fullscreen
flags: also-after-suspend
user: root
requires:
    executable.name == 'glxgears'
    dmi.product in ['Desktop','Low Profile Desktop','Tower','Mini Tower','Space-saving']
command:
     prime_offload_tester.py -c "glxgears -fullscreen" -t 30
summary:
    Test that glxgears works in full screen mode for current video card
purpose:
     Tests the basic full screen 3D capabilities of your current video card. This test covers all devices without an integrated display, such as desktops.
steps:
     1. Click "Test" to execute an OpenGL demo. Press ESC at any time to close.
     2. Verify that the animation is not jerky or slow.
verification:
     1. Did the 3d animation appear?
     2. Was the animation free from slowness/jerkiness?
```

```
id: graphics-gpu-cert-automated
unit: test plan
_name: Graphics tests (Automated)
_description:
 Graphics tests (Automated)
include:
~ skip ~
 graphics/auto_glxgears                         certification-status=blocker
 graphics/auto_glxgears_fullscreen              certification-status=blocker
~ skip ~
bootstrap_include:
    graphics_card

id: graphics-gpu-cert-manual
unit: test plan
_name: Graphics tests (Manual)
_description:
 Graphics tests (Manual)
include:
~ skip ~
 graphics/valid_glxgears                        certification-status=blocker
 graphics/valid_glxgears_fullscreen             certification-status=blocker
~ skip ~
bootstrap_include:
    graphics_card
```

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
Unit test and
laptop: [auto](https://certification.canonical.com/hardware/202001-27667/submission/369177/), [manual](https://certification.canonical.com/hardware/202001-27667/submission/369178/)
desktop: [auto](https://certification.canonical.com/hardware/202401-33394/submission/369179/), [manual](https://certification.canonical.com/hardware/202401-33394/submission/369181/)
