### PR TITLE
Fix not seeing debug file after 24.04 (BugFix)

### DIFF
--- a/providers/base/units/info/jobs.pxu
+++ b/providers/base/units/info/jobs.pxu
@@ -304,7 +304,7 @@ plugin: attachment
 category_id: com.canonical.plainbox::info
 id: installer_debug.gz
 user: root
-command: [ -f /var/log/installer/debug ] && gzip -9 -c /var/log/installer/debug
+command: [ -d /var/log/installer ] && tar zcvf installer.tgz /var/log/installer
 estimated_duration: 0.1
 _purpose: Attaches the installer debug log if it exists.
 _summary: Attach the installer's debug log for diagnostic purposes.


### PR DESCRIPTION
## Description

The subiquity no longer create debug file, and all files inside
the installer does benefit the diagnosis.

## Tests

I tested the bash command on 24.04 desktop and 22.04 desktop and it can archive everything under /var/log/installer 