### PR TITLE
Fixed issue with usb string comparison (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -249,7 +249,7 @@ class USBStorage(StorageWatcher):
                 ).group(1)
 
         # Look for insertion action
-        if "USB Mass Storage device detected" or "uas" in line_str:
+        if "USB Mass Storage device detected" in line_str or "uas" in line_str:
             self.action = "insertion"
 
         # Look for removal action

--- a/checkbox-support/checkbox_support/tests/test_run_watcher.py
+++ b/checkbox-support/checkbox_support/tests/test_run_watcher.py
@@ -464,9 +464,10 @@ class TestRunWatcher(unittest.TestCase):
         line_str = "Invalid line"
         mock_thunderbolt_storage = MagicMock()
         mock_thunderbolt_storage.action = None
-        MediacardStorage._parse_journal_line(mock_thunderbolt_storage, line_str)
+        MediacardStorage._parse_journal_line(
+            mock_thunderbolt_storage, line_str
+        )
         self.assertEqual(mock_thunderbolt_storage.action, None)
-
 
     @patch("checkbox_support.scripts.run_watcher.USBStorage", spec=USBStorage)
     def test_main_usb(self, mock_usb_storage):

--- a/checkbox-support/checkbox_support/tests/test_run_watcher.py
+++ b/checkbox-support/checkbox_support/tests/test_run_watcher.py
@@ -282,49 +282,63 @@ class TestRunWatcher(unittest.TestCase):
         USBStorage._validate_removal(mock_usb_storage)
 
     def test_usb_storage_parse_journal_line(self):
-        mock_usb_storage = MagicMock()
-
         line_str = "new high-speed USB device"
+        mock_usb_storage = MagicMock()
         USBStorage._parse_journal_line(mock_usb_storage, line_str)
         self.assertEqual(mock_usb_storage.device, "high_speed_usb")
 
         line_str = "new SuperSpeed USB device"
+        mock_usb_storage = MagicMock()
         USBStorage._parse_journal_line(mock_usb_storage, line_str)
         self.assertEqual(mock_usb_storage.device, "super_speed_usb")
 
         line_str = "new SuperSpeed Gen 1 USB device"
+        mock_usb_storage = MagicMock()
         USBStorage._parse_journal_line(mock_usb_storage, line_str)
         self.assertEqual(mock_usb_storage.device, "super_speed_gen1_usb")
 
         line_str = "new SuperSpeed Plus Gen 2x1 USB device"
+        mock_usb_storage = MagicMock()
         USBStorage._parse_journal_line(mock_usb_storage, line_str)
         self.assertEqual(
             mock_usb_storage.device, "super_speed_plus_gen2x1_usb"
         )
 
         line_str = "new high-speed USB device number 1 using ehci_hcd"
+        mock_usb_storage = MagicMock()
         USBStorage._parse_journal_line(mock_usb_storage, line_str)
         self.assertEqual(mock_usb_storage.driver, "ehci_hcd")
 
         line_str = "new high-speed USB device number 4 using xhci_hcd"
+        mock_usb_storage = MagicMock()
         USBStorage._parse_journal_line(mock_usb_storage, line_str)
         self.assertEqual(mock_usb_storage.driver, "xhci_hcd")
 
         line_str = "USB Mass Storage device detected"
+        mock_usb_storage = MagicMock()
         USBStorage._parse_journal_line(mock_usb_storage, line_str)
         self.assertEqual(mock_usb_storage.action, "insertion")
 
         line_str = "kernel: scsi host0: uas"
+        mock_usb_storage = MagicMock()
         USBStorage._parse_journal_line(mock_usb_storage, line_str)
         self.assertEqual(mock_usb_storage.action, "insertion")
 
         line_str = "USB disconnect, device"
+        mock_usb_storage = MagicMock()
         USBStorage._parse_journal_line(mock_usb_storage, line_str)
         self.assertEqual(mock_usb_storage.action, "removal")
 
         line_str = "sdb: sdb1"
+        mock_usb_storage = MagicMock()
         USBStorage._parse_journal_line(mock_usb_storage, line_str)
         self.assertEqual(mock_usb_storage.mounted_partition, "sdb1")
+
+        line_str = "Invalid line"
+        mock_usb_storage = MagicMock()
+        mock_usb_storage.action = None
+        USBStorage._parse_journal_line(mock_usb_storage, line_str)
+        self.assertEqual(mock_usb_storage.action, None)
 
     def test_mediacard_storage_init(self):
         mediacard_storage = MediacardStorage(
@@ -364,21 +378,28 @@ class TestRunWatcher(unittest.TestCase):
         MediacardStorage._validate_removal(mock_mediacard_storage)
 
     def test_mediacard_storage_parse_journal_line(self):
-        mock_mediacard_storage = MagicMock()
-
         line_str = "mmcblk0: p1"
+        mock_mediacard_storage = MagicMock()
         MediacardStorage._parse_journal_line(mock_mediacard_storage, line_str)
         self.assertEqual(mock_mediacard_storage.mounted_partition, "mmcblk0p1")
 
         line_str = "new SD card at address 123456"
+        mock_mediacard_storage = MagicMock()
         MediacardStorage._parse_journal_line(mock_mediacard_storage, line_str)
         self.assertEqual(mock_mediacard_storage.action, "insertion")
         self.assertEqual(mock_mediacard_storage.device, "SD")
         self.assertEqual(mock_mediacard_storage.address, "123456")
 
         line_str = "card 123456 removed"
+        mock_mediacard_storage = MagicMock()
         MediacardStorage._parse_journal_line(mock_mediacard_storage, line_str)
         self.assertEqual(mock_mediacard_storage.action, "removal")
+
+        line_str = "Invalid line"
+        mock_mediacard_storage = MagicMock()
+        mock_mediacard_storage.action = None
+        MediacardStorage._parse_journal_line(mock_mediacard_storage, line_str)
+        self.assertEqual(mock_mediacard_storage.action, None)
 
     def test_thunderbolt_storage_init(self):
         thunderbolt_storage = ThunderboltStorage(
@@ -417,9 +438,8 @@ class TestRunWatcher(unittest.TestCase):
         ThunderboltStorage._validate_removal(mock_thunderbolt_storage)
 
     def test_thunderbolt_storage_parse_journal_line(self):
-        mock_thunderbolt_storage = MagicMock()
-
         line_str = "nvme0n1: p1"
+        mock_thunderbolt_storage = MagicMock()
         ThunderboltStorage._parse_journal_line(
             mock_thunderbolt_storage, line_str
         )
@@ -428,16 +448,25 @@ class TestRunWatcher(unittest.TestCase):
         )
 
         line_str = "thunderbolt 1-1: new device found"
+        mock_thunderbolt_storage = MagicMock()
         ThunderboltStorage._parse_journal_line(
             mock_thunderbolt_storage, line_str
         )
         self.assertEqual(mock_thunderbolt_storage.action, "insertion")
 
         line_str = "thunderbolt 1-1: device disconnected"
+        mock_thunderbolt_storage = MagicMock()
         ThunderboltStorage._parse_journal_line(
             mock_thunderbolt_storage, line_str
         )
         self.assertEqual(mock_thunderbolt_storage.action, "removal")
+
+        line_str = "Invalid line"
+        mock_thunderbolt_storage = MagicMock()
+        mock_thunderbolt_storage.action = None
+        MediacardStorage._parse_journal_line(mock_thunderbolt_storage, line_str)
+        self.assertEqual(mock_thunderbolt_storage.action, None)
+
 
     @patch("checkbox_support.scripts.run_watcher.USBStorage", spec=USBStorage)
     def test_main_usb(self, mock_usb_storage):


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Taking a look at https://github.com/canonical/checkbox/issues/1456 I saw that there is an error in the "insertion" condition.
Explanation
The line:

python
Copy code
if "USB Mass Storage device detected" or "uas" in line_str:
does not work as intended because of the way Python evaluates conditional expressions. Here's what's happening step by step:

Expression Evaluation Order:

Python evaluates "USB Mass Storage device detected" first.
Since non-empty strings are considered True in a boolean context, "USB Mass Storage device detected" evaluates to True.
Therefore, the entire expression before the or operator is True.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
N/A

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->
N/A

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
Run Storage tests (22.04 laptop)
`checkbox-cli run com.canonical.certification::usb3-cert-manual`