### PR TITLE
Sd card not tested (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/tests/test_run_watcher.py
+++ b/checkbox-support/checkbox_support/tests/test_run_watcher.py
@@ -27,6 +27,7 @@ from checkbox_support.scripts.run_watcher import (
     StorageWatcher,
     USBStorage,
     MediacardStorage,
+    MediacardComboStorage,
     ThunderboltStorage,
     parse_args,
     main,
@@ -428,6 +429,91 @@ class TestRunWatcher(unittest.TestCase):
         MediacardStorage._parse_journal_line(mock_mediacard_storage, line_str)
         self.assertEqual(mock_mediacard_storage.action, None)
 
+    def test_mediacard_combo_storage_init(self):
+        mediacard_combo_storage = MediacardComboStorage(
+            "mediacard", "zapper_addr"
+        )
+        self.assertEqual(mediacard_combo_storage.storage_type, "mediacard")
+        self.assertEqual(
+            mediacard_combo_storage.zapper_usb_address, "zapper_addr"
+        )
+        self.assertIsNone(mediacard_combo_storage.mounted_partition)
+
+    def test_mediacard_combo_storage_validate_insertion(self):
+        mock_mediacard_combo_storage = MagicMock()
+        mock_mediacard_combo_storage.mounted_partition = "mmcblk0p1"
+        mock_mediacard_combo_storage.action = "insertion"
+        mock_mediacard_combo_storage.device = "SD"
+        mock_mediacard_combo_storage.address = "123456"
+        mock_mediacard_combo_storage.driver = None
+        mock_mediacard_combo_storage.number = None
+
+        MediacardComboStorage._validate_insertion(mock_mediacard_combo_storage)
+        self.assertEqual(mock_mediacard_combo_storage.test_passed, True)
+
+        mock_mediacard_combo_storage = MagicMock()
+        mock_mediacard_combo_storage.mounted_partition = "sda1"
+        mock_mediacard_combo_storage.action = "insertion"
+        mock_mediacard_combo_storage.device = "SD"
+        mock_mediacard_combo_storage.driver = "xhci_hcd"
+        mock_mediacard_combo_storage.number = 1
+        mock_mediacard_combo_storage.address = None
+
+        MediacardComboStorage._validate_insertion(mock_mediacard_combo_storage)
+        self.assertEqual(mock_mediacard_combo_storage.test_passed, True)
+
+    def test_mediacard_combo_storage_validate_removal(self):
+        mock_mediacard_combo_storage = MagicMock()
+        mock_mediacard_combo_storage.action = "removal"
+
+        MediacardComboStorage._validate_removal(mock_mediacard_combo_storage)
+        self.assertEqual(mock_mediacard_combo_storage.test_passed, True)
+
+    def test_mediacard_combo_storage_no_insertion(self):
+        mock_mediacard_combo_storage = MagicMock()
+        mock_mediacard_combo_storage.mounted_partition = None
+        mock_mediacard_combo_storage.action = ""
+        MediacardComboStorage._validate_insertion(mock_mediacard_combo_storage)
+
+    def test_mediacard_combo_storage_no_removal(self):
+        mock_mediacard_combo_storage = MagicMock()
+        mock_mediacard_combo_storage.action = ""
+        MediacardComboStorage._validate_removal(mock_mediacard_combo_storage)
+
+    def test_mediacard_combo_storage_parse_journal_line(self):
+        line_str = "mmcblk0: p1"
+        mock_mediacard_combo_storage = MagicMock()
+        MediacardComboStorage._parse_journal_line(
+            mock_mediacard_combo_storage, line_str
+        )
+        self.assertEqual(
+            mock_mediacard_combo_storage.mounted_partition, "mmcblk0p1"
+        )
+
+        line_str = "new SD card at address 123456"
+        mock_mediacard_combo_storage = MagicMock()
+        MediacardComboStorage._parse_journal_line(
+            mock_mediacard_combo_storage, line_str
+        )
+        self.assertEqual(mock_mediacard_combo_storage.action, "insertion")
+        self.assertEqual(mock_mediacard_combo_storage.device, "SD")
+        self.assertEqual(mock_mediacard_combo_storage.address, "123456")
+
+        line_str = "card 123456 removed"
+        mock_mediacard_combo_storage = MagicMock()
+        MediacardComboStorage._parse_journal_line(
+            mock_mediacard_combo_storage, line_str
+        )
+        self.assertEqual(mock_mediacard_combo_storage.action, "removal")
+
+        line_str = "Invalid line"
+        mock_mediacard_combo_storage = MagicMock()
+        mock_mediacard_combo_storage.action = None
+        MediacardComboStorage._parse_journal_line(
+            mock_mediacard_combo_storage, line_str
+        )
+        self.assertEqual(mock_mediacard_combo_storage.action, None)
+
     def test_thunderbolt_storage_init(self):
         thunderbolt_storage = ThunderboltStorage("thunderbolt", "zapper_addr")
         self.assertEqual(thunderbolt_storage.storage_type, "thunderbolt")
@@ -558,6 +644,24 @@ class TestRunWatcher(unittest.TestCase):
         watcher = mock_mediacard.return_value
         # check that the watcher is an MediacardStorage object
         self.assertIsInstance(watcher, MediacardStorage)
+
+    @patch(
+        "checkbox_support.scripts.run_watcher.MediacardComboStorage",
+        spec=MediacardComboStorage,
+    )
+    @patch("checkbox_support.scripts.run_watcher.parse_args")
+    def test_main_mediacard_combo(self, mock_parse_args, mock_mediacard):
+        mock_parse_args.return_value = argparse.Namespace(
+            testcase="insertion",
+            storage_type="mediacard_combo",
+            zapper_usb_address=None,
+        )
+        main()
+        self.assertEqual(mock_mediacard.call_count, 1)
+        # get the watcher object from main
+        watcher = mock_mediacard.return_value
+        # check that the watcher is an MediacardComboStorage object
+        self.assertIsInstance(watcher, MediacardComboStorage)
 
     @patch(
         "checkbox_support.scripts.run_watcher.ThunderboltStorage",

--- a/providers/base/units/mediacard/jobs.pxu
+++ b/providers/base/units/mediacard/jobs.pxu
@@ -5,7 +5,7 @@ category_id: com.canonical.plainbox::mediacard
 id: mediacard/mmc-storage-manual
 estimated_duration: 120 
 command:
- checkbox-support-run_watcher storage mediacard
+ checkbox-support-run_watcher storage mediacard_combo
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_card_reader == 'True'
@@ -36,7 +36,7 @@ id: mediacard/sdhc-storage-manual
 flags: also-after-suspend
 estimated_duration: 30.0
 command:
- checkbox-support-run_watcher storage mediacard
+ checkbox-support-run_watcher storage mediacard_combo
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_card_reader == 'True'
@@ -67,7 +67,7 @@ category_id: com.canonical.plainbox::mediacard
 id: mediacard/cf-storage-manual
 estimated_duration: 120
 command:
- checkbox-support-run_watcher storage mediacard
+ checkbox-support-run_watcher storage mediacard_combo
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_card_reader == 'True'
@@ -97,7 +97,7 @@ category_id: com.canonical.plainbox::mediacard
 id: mediacard/sdxc-storage-manual
 estimated_duration: 120
 command:
- checkbox-support-run_watcher storage mediacard
+ checkbox-support-run_watcher storage mediacard_combo
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_card_reader == 'True'
@@ -127,7 +127,7 @@ category_id: com.canonical.plainbox::mediacard
 id: mediacard/ms-storage-manual
 estimated_duration: 120
 command:
- checkbox-support-run_watcher storage mediacard
+ checkbox-support-run_watcher storage mediacard_combo
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_card_reader == 'True'
@@ -158,7 +158,7 @@ category_id: com.canonical.plainbox::mediacard
 id: mediacard/msp-storage-manual
 estimated_duration: 120
 command:
- checkbox-support-run_watcher storage mediacard
+ checkbox-support-run_watcher storage mediacard_combo
 user: root
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -190,7 +190,7 @@ category_id: com.canonical.plainbox::mediacard
 id: mediacard/xd-storage-manual
 estimated_duration: 120
 command:
- checkbox-support-run_watcher storage mediacard
+ checkbox-support-run_watcher storage mediacard_combo
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_card_reader == 'True'


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

The SD card reader in some PC platforms is a combo card reader combines USB & SDHC. This PR brings back the old behavior of the mediacard tests in which we were checking for both a mediacard and a USB insertion:
` checkbox-support-run_watcher storage mediacard_combo`
All of the mediacard tests have been modified to use this behavior.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/CHECKBOX-1551
#1456


## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Tested with a USB-C to SD adapter in a Laptop with 22.04
Tested on the device that was experiencing the issue: CID: [202408-34238](https://certification.canonical.com/hardware/202408-34238/)	SEN16MLK-DVT1-C1M
