### PR TITLE
Use the retry decorator in WiFi tests (Bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/retry.py
+++ b/checkbox-support/checkbox_support/helpers/retry.py
@@ -99,7 +99,7 @@ def fake_run_with_retry(f, max_attempts, delay, *args, **kwargs):
     return f(*args, **kwargs)
 
 
-mock_timeout = functools.partial(
+mock_retry = functools.partial(
     patch,
     "checkbox_support.helpers.retry.run_with_retry",
     new=fake_run_with_retry,

--- a/checkbox-support/checkbox_support/helpers/retry.py
+++ b/checkbox-support/checkbox_support/helpers/retry.py
@@ -47,7 +47,9 @@ def run_with_retry(f, max_attempts, delay, *args, **kwargs):
             "delay should be at least 1 ({} was used)".format(delay)
         )
     for attempt in range(1, max_attempts + 1):
-        attempt_string = "Attempt {}/{}".format(attempt, max_attempts)
+        attempt_string = "Attempt {}/{} (function '{}')".format(
+            attempt, max_attempts, f.__name__
+        )
         print()
         print("=" * len(attempt_string))
         print(attempt_string)

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -187,9 +187,9 @@ def wait_for_connected(interface, essid):
         "d show {}".format(interface)
     )
     print_cmd(cmd)
-    output = sp.check_output(shlex.split(cmd))
-    print(output.decode(sys.stdout.encoding))
-    state, ssid = output.decode(sys.stdout.encoding).strip().splitlines()
+    output = sp.check_output(shlex.split(cmd), universal_newlines=True)
+    print(output)
+    state, ssid = output.strip().splitlines()
 
     if state.startswith("100") and ssid == essid:
         print("Reached connected state with ESSID: {}".format(essid))

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -391,7 +391,7 @@ def main():
         turn_down_nm_connections()
         try:
             args.func(args)
-        except Exception as e:
+        except Exception:
             # The test is not required to run as root, but root access is
             # required for journal access so only attempt to print when e.g.
             # running under Remote

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -397,7 +397,7 @@ def main():
             # running under Remote
             if os.geteuid() == 0:
                 print_journal_entries(start_time)
-            raise e
+            raise
         finally:
             turn_up_connection(activated_uuid)
             delete_test_ap_ssid_connection()

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -192,9 +192,10 @@ def wait_for_connected(interface, essid):
     if state.startswith("100") and ssid == essid:
         print("Reached connected state with ESSID: {}".format(essid))
     elif ssid != essid:
-        error_msg = "ERROR: did not reach connected state with ESSID: {}\nESSID mismatch:\n  Excepted:{}\n  Actually:{}".format(
-            essid, ssid, essid
-        )
+        error_msg = (
+            "ERROR: did not reach connected state with ESSID: {}\n"
+            "ESSID mismatch:\n  Excepted:{}\n  Actually:{}"
+        ).format(essid, ssid, essid)
         raise SystemExit(error_msg)
     elif not state.startswith("100"):
         error_msg = "State is not connected: {}".format(state)

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -172,10 +172,12 @@ def perform_ping_test(interface):
     if target:
         count = 5
         result = ping(target, interface, count, 10)
-        if result["received"] == count:
-            return True
-
-    return False
+        if result["received"] != count:
+            raise ValueError(
+                "{} packets expected but only {} received".format(
+                    count, result["received"]
+                )
+            )
 
 
 @retry(max_attempts=5, delay=1)

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -91,7 +91,7 @@ def turn_down_nm_connections():
         print("Turn down connection", name)
         cmd = "nmcli c down {}".format(uuid)
         print_cmd(cmd)
-        sp.run(shlex.split(cmd), check=True)
+        sp.check_call(shlex.split(cmd))
         print("{} {} is down now".format(name, uuid))
     print()
 
@@ -104,7 +104,7 @@ def delete_test_ap_ssid_connection():
         return
     cmd = "nmcli c delete TEST_CON"
     print_cmd(cmd)
-    sp.run(shlex.split(cmd), check=True)
+    sp.check_call(shlex.split(cmd))
     print("TEST_CON is deleted")
 
 
@@ -113,7 +113,7 @@ def device_rescan():
     print_head("Calling a rescan")
     cmd = "nmcli d wifi rescan"
     print_cmd(cmd)
-    sp.run(shlex.split(cmd), check=True)
+    sp.check_call(shlex.split(cmd))
     print()
 
 
@@ -208,7 +208,7 @@ def wait_for_connected(interface, essid):
 def connection(cmd, device):
     print_head("Connection attempt")
     print_cmd(cmd)
-    sp.run(shlex.split(cmd), check=True)
+    sp.check_call(shlex.split(cmd))
 
     # Make sure the connection is brought up
     turn_up_connection("TEST_CON")

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -227,13 +227,34 @@ def wait_for_connected(interface, essid, max_wait=5):
     return connected
 
 
+def connection(cmd, device):
+    print_head("Connection attempt")
+    print_cmd(cmd)
+    sp.run(shlex.split(cmd), check=True)
+
+    # Make sure the connection is brought up
+    turn_up_connection("TEST_CON")
+
+    print_head("Ensure interface is connected")
+    wait_for_connected(device, "TEST_CON")
+
+    print_head("Display address")
+    print_address_info(device)
+
+    print_head("Display route table")
+    print_route_info()
+
+    print_head("Perform a ping test")
+    perform_ping_test(device)
+    print("Connection test passed\n")
+
+
 def open_connection(args):
     # Configure the connection
     # ipv4.dhcp-timeout 30 : ensure plenty of time to get address
     # ipv6.method ignore : I believe that NM can report the device as Connected
     #                      if an IPv6 address is setup. This should ensure in
     #                      this test we are using IPv4
-    print_head("Connection attempt")
     cmd = (
         "nmcli c add con-name TEST_CON "
         "ifname {} "
@@ -244,31 +265,7 @@ def open_connection(args):
         "ipv4.dhcp-timeout 30 "
         "ipv6.method ignore".format(args.device, args.essid)
     )
-    print_cmd(cmd)
-    sp.call(shlex.split(cmd))
-
-    # Make sure the connection is brought up
-    turn_up_connection("TEST_CON")
-
-    print_head("Ensure interface is connected")
-    reached_connected = wait_for_connected(args.device, "TEST_CON")
-
-    rc = 1
-    if reached_connected:
-        print_head("Display address")
-        print_address_info(args.device)
-
-        print_head("Display route table")
-        print_route_info()
-
-        print_head("Perform a ping test")
-        test_result = perform_ping_test(args.device)
-        if test_result:
-            rc = 0
-            print("Connection test passed\n")
-        else:
-            print("Connection test failed\n")
-    return rc
+    connection(cmd, args.device)
 
 
 def secured_connection(args):
@@ -277,7 +274,6 @@ def secured_connection(args):
     # ipv6.method ignore : I believe that NM can report the device as Connected
     #                      if an IPv6 address is setup. This should ensure in
     #                      this test we are using IPv4
-    print_head("Connection attempt")
     cmd = (
         "nmcli c add con-name TEST_CON "
         "ifname {} "
@@ -292,31 +288,7 @@ def secured_connection(args):
             args.device, args.essid, args.exchange, args.psk
         )
     )
-    print_cmd(cmd)
-    sp.call(shlex.split(cmd))
-
-    # Make sure the connection is brought up
-    turn_up_connection("TEST_CON")
-
-    print_head("Ensure interface is connected")
-    reached_connected = wait_for_connected(args.device, "TEST_CON")
-
-    rc = 1
-    if reached_connected:
-        print_head("Display address")
-        print_address_info(args.device)
-
-        print_head("Display route table")
-        print_route_info()
-
-        print_head("Perform a ping test")
-        test_result = perform_ping_test(args.device)
-        if test_result:
-            rc = 0
-            print("Connection test passed\n")
-        else:
-            print("Connection test failed\n")
-    return rc
+    connection(cmd, args.device)
 
 
 def hotspot(args):

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-# Copyright 2017-2019 Canonical Ltd.
+# Copyright 2017-2024 Canonical Ltd.
 # All rights reserved.
 #
 # Written by:
 #   Jonathan Cave <jonathan.cave@canonical.com>
 #   Taihsiang Ho <taihsiang.ho@canonical.com>
+#   Isaac Yang <isaac.yang@canonical.com>
+#   Pierre Equoy <pierre.equoy@canonical.com>
 #
 # wireless connection tests using nmcli
 

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -144,37 +144,37 @@ class TestTurnDownNmConnections(unittest.TestCase):
         self.assertEqual(get_connections_mock.call_count, 1)
         sp_call_mock.assert_not_called()
 
-    @patch("wifi_nmcli_test.sp.run")
+    @patch("wifi_nmcli_test.sp.check_call")
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
         return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
     )
     def test_turn_down_single_connection(
-        self, get_connections_mock, sp_run_mock
+        self, get_connections_mock, sp_check_call_mock
     ):
         turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
-        sp_run_mock.assert_called_once_with(
-            "nmcli c down uuid1".split(), check=True
+        sp_check_call_mock.assert_called_once_with(
+            "nmcli c down uuid1".split()
         )
 
-    @patch("wifi_nmcli_test.sp.run")
+    @patch("wifi_nmcli_test.sp.check_call")
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
         return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
     )
     def test_turn_down_single_connection_with_exception(
-        self, get_connections_mock, sp_run_mock
+        self, get_connections_mock, sp_check_call_mock
     ):
-        sp_run_mock.side_effect = subprocess.CalledProcessError("", 1)
+        sp_check_call_mock.side_effect = subprocess.CalledProcessError("", 1)
         with self.assertRaises(subprocess.CalledProcessError):
             turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
-        sp_run_mock.assert_called_once_with(
-            "nmcli c down uuid1".split(), check=True
+        sp_check_call_mock.assert_called_once_with(
+            "nmcli c down uuid1".split()
         )
 
-    @patch("wifi_nmcli_test.sp.run")
+    @patch("wifi_nmcli_test.sp.check_call")
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
         return_value={
@@ -183,19 +183,19 @@ class TestTurnDownNmConnections(unittest.TestCase):
         },
     )
     def test_turn_down_multiple_connections(
-        self, get_connections_mock, sp_run_mock
+        self, get_connections_mock, sp_check_call_mock
     ):
         turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
         calls = [
-            call("nmcli c down uuid1".split(), check=True),
-            call("nmcli c down uuid2".split(), check=True),
+            call("nmcli c down uuid1".split()),
+            call("nmcli c down uuid2".split()),
         ]
-        sp_run_mock.assert_has_calls(calls, any_order=True)
+        sp_check_call_mock.assert_has_calls(calls, any_order=True)
 
 
 class TestDeleteTestApSsidConnection(unittest.TestCase):
-    @patch("wifi_nmcli_test.sp.run")
+    @patch("wifi_nmcli_test.sp.check_call")
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
         return_value={
@@ -204,7 +204,7 @@ class TestDeleteTestApSsidConnection(unittest.TestCase):
     )
     @patch("wifi_nmcli_test.print")
     def test_delete_existing_test_con(
-        self, print_mock, get_nm_wireless_connections_mock, sp_run_mock
+        self, print_mock, get_nm_wireless_connections_mock, sp_check_call_mock
     ):
         delete_test_ap_ssid_connection()
         print_mock.assert_called_with("TEST_CON is deleted")
@@ -311,7 +311,7 @@ class TestWaitForConnected(unittest.TestCase):
 
 
 class TestConnection(unittest.TestCase):
-    @patch("wifi_nmcli_test.sp.run", new=MagicMock())
+    @patch("wifi_nmcli_test.sp.check_call", new=MagicMock())
     @patch("wifi_nmcli_test.print_route_info", new=MagicMock())
     @patch("wifi_nmcli_test.print_address_info", new=MagicMock())
     @patch("wifi_nmcli_test.turn_up_connection", new=MagicMock())
@@ -329,7 +329,7 @@ class TestConnection(unittest.TestCase):
         wait_for_connected_mock.assert_called_with("wlan0", "TEST_CON")
         perform_ping_test_mock.assert_called_with("wlan0")
 
-    @patch("wifi_nmcli_test.sp.run", new=MagicMock())
+    @patch("wifi_nmcli_test.sp.check_call", new=MagicMock())
     @patch("wifi_nmcli_test.print_route_info", new=MagicMock())
     @patch("wifi_nmcli_test.print_address_info", new=MagicMock())
     @patch("wifi_nmcli_test.turn_up_connection", new=MagicMock())

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -36,6 +36,9 @@ from wifi_nmcli_test import (
     connection,
     open_connection,
     secured_connection,
+    print_address_info,
+    print_route_info,
+    perform_ping_test,
     hotspot,
     parser_args,
     main,
@@ -398,6 +401,45 @@ class TestSecuredConnection(unittest.TestCase):
         args.psk = "password123"
         secured_connection(args)
         self.assertIn("wifi-sec", mock_connection.call_args[0][0])
+
+
+class TestDeviceRescan(unittest.TestCase):
+    @patch("wifi_nmcli_test.sp.run")
+    def test_device_rescan_success(self, mock_sp_run):
+        device_rescan()
+
+
+class TestPrintAddressInfo(unittest.TestCase):
+    @patch("wifi_nmcli_test.sp.run")
+    def test_print_address_info_success(self, mock_sp_run):
+        print_address_info("wlan0")
+
+
+class TestPrintRouteInfo(unittest.TestCase):
+    @patch("wifi_nmcli_test.sp.run")
+    def test_print_route_info_success(self, mock_sp_run):
+        print_route_info()
+
+
+@patch("wifi_nmcli_test.ping")
+@patch("wifi_nmcli_test.sp.check_output")
+class TestPerformPingTest(unittest.TestCase):
+    def test_perform_ping_test_success(self, mock_check_output, mock_ping):
+        mock_ping.return_value = {
+            "transmitted": 5,
+            "received": 5,
+            "pct_loss": 0,
+        }
+        perform_ping_test("wlan0")
+
+    def test_perform_ping_test_failure(self, mock_check_output, mock_ping):
+        mock_ping.return_value = {
+            "transmitted": 5,
+            "received": 0,
+            "pct_loss": 0,
+        }
+        with self.assertRaises(ValueError):
+            perform_ping_test("wlan0")
 
 
 class TestParserArgs(unittest.TestCase):

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -404,20 +404,20 @@ class TestSecuredConnection(unittest.TestCase):
 
 
 class TestDeviceRescan(unittest.TestCase):
-    @patch("wifi_nmcli_test.sp.run")
-    def test_device_rescan_success(self, mock_sp_run):
+    @patch("wifi_nmcli_test.sp.check_call")
+    def test_device_rescan_success(self, mock_sp_check_call):
         device_rescan()
 
 
 class TestPrintAddressInfo(unittest.TestCase):
-    @patch("wifi_nmcli_test.sp.run")
-    def test_print_address_info_success(self, mock_sp_run):
+    @patch("wifi_nmcli_test.sp.call")
+    def test_print_address_info_success(self, mock_sp_call):
         print_address_info("wlan0")
 
 
 class TestPrintRouteInfo(unittest.TestCase):
-    @patch("wifi_nmcli_test.sp.run")
-    def test_print_route_info_success(self, mock_sp_run):
+    @patch("wifi_nmcli_test.sp.call")
+    def test_print_route_info_success(self, mock_sp_call):
         print_route_info()
 
 

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -450,6 +450,7 @@ class TestParserArgs(unittest.TestCase):
         self.assertEqual(args.band, "5GHz")
 
 
+@mock_retry()
 class TestMainFunction(unittest.TestCase):
 
     @patch("wifi_nmcli_test.delete_test_ap_ssid_connection", new=MagicMock())

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -381,7 +381,7 @@ class TestOpenConnection(unittest.TestCase):
         args.exchange = "wpa-psk"
         args.psk = "password123"
         open_connection(args)
-        self.assertNotIn("wifi-sec", mock_connection.call_args.args[0])
+        self.assertNotIn("wifi-sec", mock_connection.call_args[0][0])
 
 
 class TestSecuredConnection(unittest.TestCase):
@@ -397,7 +397,7 @@ class TestSecuredConnection(unittest.TestCase):
         args.exchange = "wpa-psk"
         args.psk = "password123"
         secured_connection(args)
-        self.assertIn("wifi-sec", mock_connection.call_args.args[0])
+        self.assertIn("wifi-sec", mock_connection.call_args[0][0])
 
 
 class TestParserArgs(unittest.TestCase):

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -278,7 +278,7 @@ class TestWaitForConnected(unittest.TestCase):
         "wifi_nmcli_test.sp.check_output",
         MagicMock(
             side_effect=[
-                b"100:connected\nTestESSID",
+                "100:connected\nTestESSID\n",
             ]
         ),
     )
@@ -289,7 +289,7 @@ class TestWaitForConnected(unittest.TestCase):
 
     @patch(
         "wifi_nmcli_test.sp.check_output",
-        MagicMock(return_value=b"30:disconnected\nTestESSID"),
+        MagicMock(return_value="30:disconnected\nTestESSID\n"),
     )
     @patch("wifi_nmcli_test.print_cmd", new=MagicMock())
     def test_wait_for_connected_failure_due_to_timeout(self):
@@ -300,7 +300,7 @@ class TestWaitForConnected(unittest.TestCase):
 
     @patch(
         "wifi_nmcli_test.sp.check_output",
-        MagicMock(return_value=b"100:connected\nWrongESSID"),
+        MagicMock(return_value="100:connected\nWrongESSID\n"),
     )
     @patch("wifi_nmcli_test.print_cmd", new=MagicMock())
     def test_wait_for_connected_failure_due_to_essid_mismatch(self):


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

The main *raisons d'être* of this PR are:

- Use the [newly developed retry decorator](https://github.com/canonical/checkbox/pull/1453) available in checkbox-support to implement a retry mechanism in the `wifi_nmcli_test.py` script. This is done to prevent an often seen failure in the lab where the usual answer is to rerun the whole test plan. Now, the WiFi test retries up to 5 times, adding a delay between each retry.
- Refactor the script so that functions raise exceptions instead of returning/handling return codes. This is required for the retry decorator to work properly, and is generally speaking a good practice in Python.


## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

CHECKBOX-1543

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

Nothing is modified in terms of Checkbox jobs or external-facing documentation.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

- Unit tests pass on Python 3.5+
- The script was tested successfully on my laptop
