### PR TITLE
Add manifest units to expand output (New)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -1393,7 +1393,8 @@ class Expand:
                 obj["certification-status"] = (
                     self.get_effective_certification_status(unit)
                 )
-                obj["template-id"] = unit.template_id
+                if unit.template_id:
+                    obj["template-id"] = unit.template_id
             obj_list.append(obj)
 
         obj_list.sort(key=lambda x: x.get("template-id", x["id"]) or x["id"])

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -24,8 +24,8 @@ from argparse import SUPPRESS
 from collections import defaultdict
 from string import Formatter
 from tempfile import TemporaryDirectory
-import textwrap
 import fnmatch
+import itertools
 import contextlib
 import gettext
 import json
@@ -1324,6 +1324,37 @@ class Expand:
             help=_("output format: 'text' or 'json' (default: %(default)s)"),
         )
 
+    def _get_relevant_manifest_units(self, jobs_and_templates_list):
+        """
+        Get all manifest units that are cited in the jobs_and_templates_list
+        resource expressions
+        """
+        # get all manifest units
+        manifest_units = filter(
+            lambda unit: unit.unit == "manifest entry",
+            self.sa._context.unit_list,
+        )
+        # get all jobs/templates that have a requires and do require a manifest
+        # entry
+        job_requires = [
+            requires
+            for requires in map(
+                lambda x: x.get_record_value("requires"),
+                jobs_and_templates_list,
+            )
+            if requires and "manifest" in requires
+        ]
+
+        # only return manifest entries that are actually required by any job in
+        # the list
+        return filter(
+            lambda manifest_unit: any(
+                "manifest.{}".format(manifest_unit.partial_id) in require
+                for require in job_requires
+            ),
+            manifest_units,
+        )
+
     def invoked(self, ctx):
         self.ctx = ctx
         session_title = "checkbox-expand-{}".format(ctx.args.TEST_PLAN)
@@ -1340,46 +1371,35 @@ class Expand:
         tp = self.sa._context._test_plan_list[0]
         tp_us = TestPlanUnitSupport(tp)
         self.override_list = tp_us.override_list
+
         jobs_and_templates_list = select_units(
             all_jobs_and_templates,
             [tp.get_mandatory_qualifier()] + [tp.get_qualifier()],
         )
-        manifest_units = filter(
-            lambda unit: unit.unit == "manifest entry",
-            self.sa._context.unit_list,
+        relevant_manifest_units = self._get_relevant_manifest_units(
+            jobs_and_templates_list
         )
-        requires = list(
-            filter(
-                lambda x: x and "manifest" in x,
-                map(
-                    lambda x: x.get_record_value("requires"),
-                    jobs_and_templates_list,
-                ),
-            )
+
+        units_to_print = itertools.chain(
+            relevant_manifest_units, iter(jobs_and_templates_list)
         )
-        manifest_units = list(
-            filter(
-                lambda x: any(
-                    x.id.rsplit(":", 1)[-1] in require for require in requires
-                ),
-                manifest_units,
-            )
-        )
-        jobs_and_templates_list = manifest_units + jobs_and_templates_list
         obj_list = []
-        for unit in jobs_and_templates_list:
+        for unit in units_to_print:
             obj = unit._raw_data.copy()
             obj["unit"] = unit.unit
             obj["id"] = unit.id  # To get the fully qualified id
-            obj["certification-status"] = (
-                self.get_effective_certification_status(unit)
-            )
-            if hasattr(unit, "template_id") and unit.template_id:
+            # these two don't make sense for manifest units
+            if unit.unit != "manifest entry":
+                obj["certification-status"] = (
+                    self.get_effective_certification_status(unit)
+                )
                 obj["template-id"] = unit.template_id
             obj_list.append(obj)
-        obj_list.sort(key=lambda x: x.get("template-id", x["id"]))
+
+        obj_list.sort(key=lambda x: x.get("template-id", x["id"]) or x["id"])
+
         if ctx.args.format == "json":
-            print(json.dumps(obj_list, sort_keys=True))
+            json.dump(obj_list, sys.stdout, sort_keys=True)
         else:
             for obj in obj_list:
                 if obj["unit"] == "template":

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -855,17 +855,22 @@ class TestExpand(TestCase):
                 "template-id": "test-template",
                 "id": "test-{res}",
                 "template-summary": "Test Template Summary",
+                "requires": "manifest.some == 'True'",
             }
         )
         job1 = JobDefinition(
             {
                 "id": "job1",
+                "requires": "manifest.other == 'Other'",
             }
         )
         mock_select_units.return_value = [job1, template1]
         self.ctx.args.TEST_PLAN = "test-plan1"
         self.launcher.invoked(self.ctx)
         self.assertIn("Template 'test-template'", stdout.getvalue())
+        self.assertIn("Manifest 'some'", stdout.getvalue())
+        self.assertIn("Manifest 'other'", stdout.getvalue())
+        self.assertNotIn("Manifest 'not_selected'", stdout.getvalue())
 
     @patch("sys.stdout", new_callable=StringIO)
     @patch("checkbox_ng.launcher.subcommands.TestPlanUnitSupport")


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

We need a way to programmatically fetch the list of manifest entries needed to run a test plan. This makes it easier to automatically verify manifests in CI, track changes to testplans manifest entries and more. This adds manifest units to the `expand` command filtering out those that aren't used in the testplan.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1555

## Documentation

This adds plenty comments to the expander.

## Tests

WIP
