### PR TITLE
Fix the combination of backup_loc path (Bugfix)

### DIFF
--- a/providers/base/bin/wifi_nmcli_backup.py
+++ b/providers/base/bin/wifi_nmcli_backup.py
@@ -78,7 +78,7 @@ def save_connections(keyfile_list):
             continue
 
         print("  Found file {}".format(f))
-        basedir = Path(f).parent
+        basedir = Path(f).parent.relative_to("/")
         backup_loc = SAVE_DIR / basedir
 
         os.makedirs(backup_loc, exist_ok=True)


### PR DESCRIPTION
## Description
Fix the path combination fo `backup_loc`.
The reason is `Path` can't combine the path start with "/", so need to make the `basedir` is the relative path with "/".


## Resolved issues
It will break the script if the machine connect with the wifi AP before test when it save the connection's configuration.
This will be 100% fail when  the above situation.


## Documentation



## Tests
https://certification.canonical.com/hardware/202409-35379/submission/396113/test-results/pass/

