### PR TITLE
Use wwan-automated nested part in SRU test plan (bugfix)

### DIFF
--- a/providers/sru/units/sru.pxu
+++ b/providers/sru/units/sru.pxu
@@ -54,7 +54,7 @@ nested_part:
     mediacard-cert-automated
     mediacard-automated
     memory-automated
-    mobilebroadband-cert-automated
+    wwan-automated
     ethernet-cert-automated
     networking-cert-automated
     optical-cert-automated
@@ -68,6 +68,7 @@ nested_part:
     before-suspend-reference-cert-full
     # suspend point
     after-suspend-reference-cert-full
+    after-suspend-wwan-automated
     after-suspend-touchscreen-cert-automated
     after-suspend-wireless-cert-automated
     # The following tests should run BEFORE the automated tests. The reboot and


### PR DESCRIPTION
## WARNING: This modifies com.canonical.certification::sru-server

## Description

Replace` mobilebroadband-cert-automated` with `wwan-automated` nested part, as the `wwan-automated` test plan includes better coverage for WWAN-related tests.

Add `after-suspend-wwan-automated` counterpart to make sure there are no issues with WWAN after resuming from suspend.

This is a follow-up to work done by QA in the certification-client desktop test plans (see https://github.com/canonical/checkbox/pull/821)

***IMPORTANT:*** PR #1500 is required before merging this.

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->



<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

Fix CER-2738
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

Used `checkbox-cli expand com.canonical.certification::sru` to generate the list of executed jobs and templates before and after applying this patch. The diff is the following:

```diff
$ diff /var/tmp/cer-2738-before.log /var/tmp/cer-2738-after.log 
2a3
> Job 'com.canonical.certification::after-suspend-wwan/detect'
74,75d74
< Job 'com.canonical.certification::mobilebroadband/cdma_connection'
< Job 'com.canonical.certification::mobilebroadband/gsm_connection'
140a140,143
> Template 'com.canonical.certification::wwan/3gpp-scan-manufacturer-model-hw_id-auto'
> Template 'com.canonical.certification::wwan/check-sim-present-manufacturer-model-hw_id-auto'
> Job 'com.canonical.certification::wwan/detect'
> Template 'com.canonical.certification::wwan/gsm-connection-manufacturer-model-hw_id-auto'
```

showing that:

- a modem detection job is run before and after suspend
- a job to check if a SIM card is present is added
- a job to scan the 3g++ connections available is added
- an automated GSM connection job is still present to replace the one used in the mobilebroadband test plan