### PR TITLE
Add a manifest entry to check if a SIM card is inserted (New)

### DIFF
--- a/providers/base/units/wwan/jobs.pxu
+++ b/providers/base/units/wwan/jobs.pxu
@@ -54,6 +54,7 @@ imports: from com.canonical.plainbox import manifest
 depends: wwan/check-sim-present-{manufacturer}-{model}-{hw_id}-auto
 requires:
   manifest.has_wwan_module == 'True'
+  manifest.has_sim_card == 'True'
   snap.name == 'modem-manager' or package.name == 'modemmanager'
 
 unit: template
@@ -74,6 +75,7 @@ flags: preserve-locale also-after-suspend preserve-cwd
 imports: from com.canonical.plainbox import manifest
 requires:
   manifest.has_wwan_module == 'True'
+  manifest.has_sim_card == 'True'
   snap.name == 'modem-manager' or package.name == 'modemmanager'
 
 unit: template
@@ -100,6 +102,7 @@ flags: preserve-locale also-after-suspend preserve-cwd
 imports: from com.canonical.plainbox import manifest
 requires:
   manifest.has_wwan_module == 'True'
+  manifest.has_sim_card == 'True'
   snap.name == 'modem-manager' or package.name == 'modemmanager'
 
 unit: template
@@ -122,6 +125,7 @@ depends: wwan/check-sim-present-{manufacturer}-{model}-{hw_id}-auto
 imports: from com.canonical.plainbox import manifest
 requires:
   manifest.has_wwan_module == 'True'
+  manifest.has_sim_card == 'True'
   snap.name == 'modem-manager' or package.name == 'modemmanager'
 
 id: wwan/detect-manual
@@ -141,6 +145,7 @@ imports: from com.canonical.plainbox import manifest
 category_id: wwan
 requires:
     manifest.has_wwan_module == 'True'
+  manifest.has_sim_card == 'True'
 
 id: wwan/check-sim-present-manual
 plugin: manual
@@ -159,6 +164,7 @@ imports: from com.canonical.plainbox import manifest
 category_id: wwan
 requires:
     manifest.has_wwan_module == 'True'
+  manifest.has_sim_card == 'True'
 depends:
     wwan/detect-manual
 
@@ -191,6 +197,7 @@ category_id: wwan
 imports: from com.canonical.plainbox import manifest
 requires:
     manifest.has_wwan_module == 'True'
+  manifest.has_sim_card == 'True'
 depends:
     wwan/check-sim-present-manual
 
@@ -231,5 +238,6 @@ category_id: wwan
 imports: from com.canonical.plainbox import manifest
 requires:
     manifest.has_wwan_module == 'True'
+  manifest.has_sim_card == 'True'
 depends:
     wwan/check-sim-present-manual

--- a/providers/base/units/wwan/jobs.pxu
+++ b/providers/base/units/wwan/jobs.pxu
@@ -144,7 +144,7 @@ flags:  also-after-suspend
 imports: from com.canonical.plainbox import manifest
 category_id: wwan
 requires:
-    manifest.has_wwan_module == 'True'
+  manifest.has_wwan_module == 'True'
   manifest.has_sim_card == 'True'
 
 id: wwan/check-sim-present-manual
@@ -163,10 +163,10 @@ flags:  also-after-suspend
 imports: from com.canonical.plainbox import manifest
 category_id: wwan
 requires:
-    manifest.has_wwan_module == 'True'
+  manifest.has_wwan_module == 'True'
   manifest.has_sim_card == 'True'
 depends:
-    wwan/detect-manual
+  wwan/detect-manual
 
 id: wwan/gsm-connection-manual
 plugin: manual
@@ -196,10 +196,10 @@ flags:  also-after-suspend
 category_id: wwan
 imports: from com.canonical.plainbox import manifest
 requires:
-    manifest.has_wwan_module == 'True'
+  manifest.has_wwan_module == 'True'
   manifest.has_sim_card == 'True'
 depends:
-    wwan/check-sim-present-manual
+  wwan/check-sim-present-manual
 
 id: wwan/gsm-connection-interrupted-manual
 plugin: manual
@@ -237,7 +237,7 @@ flags: also-after-suspend
 category_id: wwan
 imports: from com.canonical.plainbox import manifest
 requires:
-    manifest.has_wwan_module == 'True'
+  manifest.has_wwan_module == 'True'
   manifest.has_sim_card == 'True'
 depends:
-    wwan/check-sim-present-manual
+  wwan/check-sim-present-manual

--- a/providers/base/units/wwan/manifest.pxu
+++ b/providers/base/units/wwan/manifest.pxu
@@ -8,3 +8,8 @@ unit: manifest entry
 id: has_wwan_module
 _name: A WWAN Module
 value-type: bool
+
+unit: manifest entry
+id: has_sim_card
+_name: A working SIM card inserted
+value-type: bool


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

By creating a `has_sim_card` manifest entry and using it as a requirement on WWAN jobs that need a SIM card, this PR ensure these jobs will not fail if a WWAN is found, but has no working SIM card inserted. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

#1493 

https://warthogs.atlassian.net/browse/CHECKBOX-1578

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

As I don't have a device with a WWAN module, nor a SIM card I could use, I just checked the status of the 24.04 test plan before and after applying this patch by calling `checkbox-cli expand "com.canonical.certification::client-cert-desktop-24-04" --format json | jq` on `main` and on this branch, and comparing the results (we can see the requirement on `manifest.has_sim_card` shows up):

```diff
5453c5453
<     "requires": " manifest.has_wwan_module == 'True'\n snap.name == 'modem-manager' or package.name == 'modemmanager'",
---
>     "requires": " manifest.has_wwan_module == 'True'\n manifest.has_sim_card == 'True'\n snap.name == 'modem-manager' or package.name == 'modemmanager'",
5472c5472
<     "requires": " manifest.has_wwan_module == 'True'\n snap.name == 'modem-manager' or package.name == 'modemmanager'",
---
>     "requires": " manifest.has_wwan_module == 'True'\n manifest.has_sim_card == 'True'\n snap.name == 'modem-manager' or package.name == 'modemmanager'",
5507c5507
<     "requires": " manifest.has_wwan_module == 'True'\n snap.name == 'modem-manager' or package.name == 'modemmanager'",
---
>     "requires": " manifest.has_wwan_module == 'True'\n manifest.has_sim_card == 'True'\n snap.name == 'modem-manager' or package.name == 'modemmanager'",
```

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
