### PR TITLE
Update stress_ng_test.py

### DIFF
--- a/providers/base/bin/stress_ng_test.py
+++ b/providers/base/bin/stress_ng_test.py
@@ -141,9 +141,9 @@ def stress_cpu(args):
         "vecmath",
         "wcs",
     ]
-    # Add 10% to runtime; will forcefully terminate if stress-ng
+    # Add 300% to runtime; will forcefully terminate if stress-ng
     # fails to return in that time.
-    end_time = 1.1 * args.base_time
+    end_time = 3 * args.base_time
     print(
         "Estimated total run time is {:.0f} minutes\n".format(
             args.base_time / 60


### PR DESCRIPTION
For a large configuration server with 480 cores and 2TiB memory, it need over 2 times time to finish the CPU stress test. For example, below value of timeout is 900 seconds, but stress-ng actually takes over 30 minutes(1807.05 secs) to complete(10% runtime is not enough). $ sudo  /usr/lib/checkbox-provider-base/bin/stress_ng_test.py cpu -b 900 stress-ng: info:  [139734] load average: 535.37 989.84 2322.35 stress-ng: info:  [139734] skipped: 0
stress-ng: info:  [139734] passed: 7199: af-alg (479) bsearch (480) context (480) cpu (480) crypt (480) hsearch (480) longjmp (480) lsearch (480) matrix (480) qsort (480) str (480) stream (480) tsearch (480) vecmath (480) wcs (480) stress-ng: info:  [139734] failed: 0
stress-ng: info:  [139734] metrics untrustworthy: 0 stress-ng: info:  [139734] successful run completed in 30 mins, 7.05 secs

retval is 0
**************************************************************
* stress-ng test passed! **************************************************************

So it is better to increase the timeout from 10% to 300%.

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
