### PR TITLE
Add Lunar Lake CPUID (New)

### DIFF
--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -209,7 +209,8 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
         "Sierra Forest":    ['0xa06f3'],
         "Granite Rapids":   ['0xa06e0', '0xa06d0'],
         "Meteor Lake":      ['0xa06a4'],
-        "Arrow Lake":       ['0xc0660']
+        "Arrow Lake":       ['0xc0660'],
+        "Lunar Lake":       ["0xb06d1"]
     }
     for key in CPUIDS.keys():
         for value in CPUIDS[key]:


### PR DESCRIPTION
## Description

This PR makes a small change to define the Lunar Lake CPUID in the list of other CPU generations.

## Resolved issues

Resolves C3-767.

## Documentation

N/A

## Tests

Automated tests already cover this functionality.