### PR TITLE
Correct the camera job cmd with right camera tests (Bugfix)

### DIFF
--- a/providers/base/units/camera/jobs.pxu
+++ b/providers/base/units/camera/jobs.pxu
@@ -35,7 +35,7 @@ _summary: Webcam video display test for {product_slug}
 estimated_duration: 120.0
 depends: camera/detect
 command:
-  camera_test.py display -d /dev/{name}
+  camera_test.py video -d /dev/{name}
 _purpose:
     This test will check that the {product_slug} camera works
 _steps:
@@ -81,7 +81,7 @@ _summary: Webcam still image capture test for {product_slug}
 estimated_duration: 120.0
 depends: camera/detect
 command:
-  camera_test.py still -d /dev/{name}
+  camera_test.py image -d /dev/{name}
 _purpose:
     This test will check that the {product_slug} works
 _steps:


### PR DESCRIPTION
## Description
Correct job cmd  the `id: camera/display_{name}` and `id: camera/still_{name}`.

I saw it updated in #1400 's [commit](https://github.com/canonical/checkbox/pull/1400/commits/cb30c5595bda7a0c2ff34588d14386f0cd9f86ea), but missing after the PR merged.

## Resolved issues
```
-----------[ Webcam still image capture test for Intel_MIPI_Camera ]------------
ID: com.canonical.certification::camera/still_video0
Category: com.canonical.plainbox::camera
Purpose:

This test will check that the Intel_MIPI_Camera works

Steps:

1. Click on Test to display a still image from the camera for ten seconds.

Pick an action
    => press ENTER to continue
  c => add a comment
  s => skip this job
  q => save the session and quit
[csq]: 
... 8< -------------------------------------------------------------------------
usage: camera_test.py [-h] [--debug] {detect,led,video,image,resolutions} ...
camera_test.py: error: argument test: invalid choice: 'still' (choose from 'detect', 'led', 'video', 'image', 'resolutions')
------------------------------------------------------------------------- >8 ---


--------------[ Webcam video display test for Intel_MIPI_Camera ]---------------
ID: com.canonical.certification::camera/display_video0
Category: com.canonical.plainbox::camera
Purpose:

This test will check that the Intel_MIPI_Camera camera works

Steps:

1. Click on Test to display a video capture from the camera for ten seconds.

Pick an action
    => press ENTER to continue
  c => add a comment
  s => skip this job
  q => save the session and quit
[csq]: 
... 8< -------------------------------------------------------------------------
usage: camera_test.py [-h] [--debug] {detect,led,video,image,resolutions} ...
camera_test.py: error: argument test: invalid choice: 'display' (choose from 'detect', 'led', 'video', 'image', 'resolutions')

```


## Documentation



## Tests


