### PR TITLE
Fix snap refresh verification job dependency (bugfix)

### DIFF
--- a/providers/base/units/snapd/jobs.pxu
+++ b/providers/base/units/snapd/jobs.pxu
@@ -63,7 +63,7 @@ plugin: shell
 estimated_duration: 30s
 category_id: snapd
 user: root
-depends: snapd/reboot-after-snap-refresh-{type}-{name}-to-stable-rev
+depends: snapd/snap-refresh-{type}-{name}-to-stable-rev
 command:
  path="$PLAINBOX_SESSION_SHARE/{name}_snap_revision_info"
  snap_update_test.py --verify-refresh --info-path "$path" {name}


### PR DESCRIPTION
## Description

When implementing [changes for the gadget/snapd/kernel snap refresh](https://github.com/canonical/checkbox/pull/1124), one of the job dependencies was not updated properly.

The `snapd/reboot-after-snap-refresh-{type}-{name}-to-stable-rev` job does not exist anymore, so the
`snapd/snap-verify-after-refresh-{type}-{name}-to-stable-rev` should depend on the refresh job itself (which was modified in the aforementioned PR to do the reboot itself).

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->



<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

An issue that showed up while testing a customer project:

https://certification.canonical.com/hardware/202302-31257/submission/393904/test-results/?term=cascade-kernel-to-base-rev

See [discussion on MM](https://chat.canonical.com/canonical/pl/auese9ysi38p9873hnmo6h95wc) for more information.

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

Running `checkbox-cli list-bootstrapped com.canonical.certification::snap-refresh-revert` on my laptop yield the following results:

Before this patch:

```
com.canonical.certification::snap_revision_info
com.canonical.certification::snapd/snap-refresh-snapd-snapd-to-base-rev
com.canonical.certification::snapd/log-attach-after-snap-refresh-snapd-snapd-to-base-rev
com.canonical.certification::snapd/snap-verify-after-refresh-snapd-snapd-to-base-rev
com.canonical.certification::snapd/snap-revert-snapd-snapd-from-base-rev
com.canonical.certification::snapd/log-attach-after-snap-revert-snapd-snapd-from-base-rev
com.canonical.certification::snapd/snap-verify-after-revert-snapd-snapd-from-base-rev
com.canonical.certification::snapd/snap-refresh-snapd-snapd-to-stable-rev
com.canonical.certification::snapd/log-attach-after-snap-refresh-snapd-snapd-to-stable-rev
```

After this patch:

```
com.canonical.certification::snap_revision_info
com.canonical.certification::snapd/snap-refresh-snapd-snapd-to-base-rev
com.canonical.certification::snapd/log-attach-after-snap-refresh-snapd-snapd-to-base-rev
com.canonical.certification::snapd/snap-verify-after-refresh-snapd-snapd-to-base-rev
com.canonical.certification::snapd/snap-revert-snapd-snapd-from-base-rev
com.canonical.certification::snapd/log-attach-after-snap-revert-snapd-snapd-from-base-rev
com.canonical.certification::snapd/snap-verify-after-revert-snapd-snapd-from-base-rev
com.canonical.certification::snapd/snap-refresh-snapd-snapd-to-stable-rev
com.canonical.certification::snapd/log-attach-after-snap-refresh-snapd-snapd-to-stable-rev
com.canonical.certification::snapd/snap-verify-after-refresh-snapd-snapd-to-stable-rev
com.canonical.certification::snapd/snap-revert-snapd-snapd-from-stable-rev
com.canonical.certification::snapd/log-attach-after-snap-revert-snapd-snapd-from-stable-rev
com.canonical.certification::snapd/snap-verify-after-revert-snapd-snapd-from-stable-rev
```

(the last 4 jobs are now present that are verifying the snap after an update to stable channel, and then running extra revert and verification steps)