### PR TITLE
Add info to rejected jobs list in `submission.json` (new)

### DIFF
--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.json
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.json
@@ -108,16 +108,16 @@
     {%- endfor %}
     ],
     "rejected-jobs": [
-    {%- for job_id, job_state in job_state_map|dictsort if job_id in state.metadata.rejected_jobs %}
+    {%- for job_id in state.metadata.rejected_jobs %}
         {
             "id": "{{ job_id|strip_ns }}",
             "full_id": "{{ job_id }}",
-            "name": "{{ job_state.job.tr_summary() }}",
-            "plugin": "{{ job_state.job.plugin }}",
-            "certification_status": "{{ job_state.effective_certification_status }}",
-            "category": "{{ category_map[job_state.effective_category_id] }}",
-            "category_id": "{{ job_state.effective_category_id }}",
-            "template_id": {{ job_state.job.template_id | jsonify | safe }}
+            "name": "{{ job_state_map[job_id].job.tr_summary() }}",
+            "plugin": "{{ job_state_map[job_id].job.plugin }}",
+            "certification_status": "{{ job_state_map[job_id].effective_certification_status }}",
+            "category": "{{ category_map[job_state_map[job_id].effective_category_id] }}",
+            "category_id": "{{ job_state_map[job_id].effective_category_id }}",
+            "template_id": {{ job_state_map[job_id].job.template_id | jsonify | safe }}
         }{%- if not loop.last -%},{%- endif %}
     {%- endfor %}
     ],

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.json
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.json
@@ -108,9 +108,15 @@
     {%- endfor %}
     ],
     "rejected-jobs": [
-    {%- for job_id in state.metadata.rejected_jobs %}
+    {%- for job in state.metadata.rejected_jobs %}
         {
-            "full_id": "{{ job_id }}"
+            "id": "{{ job['partial_id'] }}",
+            "full_id": "{{ job['id'] }}",
+            "name": "{{ job['name'] }}",
+            "category": "{{ category_map[job['category_id']] }}",
+            "category_id": "{{ job['category_id'] }}",
+            "plugin": "{{ job['plugin'] }}",
+            "template_id": {{ job['template_id'] | jsonify | safe }}
         }{%- if not loop.last -%},{%- endif %}
     {%- endfor %}
     ],

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.json
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.json
@@ -108,15 +108,16 @@
     {%- endfor %}
     ],
     "rejected-jobs": [
-    {%- for job in state.metadata.rejected_jobs %}
+    {%- for job_id, job_state in job_state_map|dictsort if job_id in state.metadata.rejected_jobs %}
         {
-            "id": "{{ job['partial_id'] }}",
-            "full_id": "{{ job['id'] }}",
-            "name": "{{ job['name'] }}",
-            "category": "{{ category_map[job['category_id']] }}",
-            "category_id": "{{ job['category_id'] }}",
-            "plugin": "{{ job['plugin'] }}",
-            "template_id": {{ job['template_id'] | jsonify | safe }}
+            "id": "{{ job_id|strip_ns }}",
+            "full_id": "{{ job_id }}",
+            "name": "{{ job_state.job.tr_summary() }}",
+            "plugin": "{{ job_state.job.plugin }}",
+            "certification_status": "{{ job_state.effective_certification_status }}",
+            "category": "{{ category_map[job_state.effective_category_id] }}",
+            "category_id": "{{ job_state.effective_category_id }}",
+            "template_id": {{ job_state.job.template_id | jsonify | safe }}
         }{%- if not loop.last -%},{%- endif %}
     {%- endfor %}
     ],

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -999,19 +999,10 @@ class SessionAssistant:
         desired_job_list = []
         rejected_job_list = []
         for job_id in self.get_static_todo_list():
-            job = self._context.get_unit(job_id, "job")
             if job_id in selection:
-                desired_job_list.append(job)
+                desired_job_list.append(self._context.get_unit(job_id, "job"))
             else:
-                job_repr = {
-                    "partial_id": job.partial_id,
-                    "id": job.id,
-                    "name": job.tr_summary(),
-                    "category_id": job.category_id,
-                    "plugin": job.plugin,
-                    "template_id": job.template_id,
-                }
-                rejected_job_list.append(job_repr)
+                rejected_job_list.append(job_id)
         self._metadata.rejected_jobs = rejected_job_list
         self._context.state.update_desired_job_list(desired_job_list)
 

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -999,10 +999,19 @@ class SessionAssistant:
         desired_job_list = []
         rejected_job_list = []
         for job_id in self.get_static_todo_list():
+            job = self._context.get_unit(job_id, "job")
             if job_id in selection:
-                desired_job_list.append(self._context.get_unit(job_id, "job"))
+                desired_job_list.append(job)
             else:
-                rejected_job_list.append(job_id)
+                job_repr = {
+                    "partial_id": job.partial_id,
+                    "id": job.id,
+                    "name": job.tr_summary(),
+                    "category_id": job.category_id,
+                    "plugin": job.plugin,
+                    "template_id": job.template_id,
+                }
+                rejected_job_list.append(job_repr)
         self._metadata.rejected_jobs = rejected_job_list
         self._context.state.update_desired_job_list(desired_job_list)
 

--- a/submission-schema/schema.json
+++ b/submission-schema/schema.json
@@ -187,6 +187,16 @@
                 },
                 "plugin": {
                     "$ref": "#/definitions/Plugin"
+                },
+                "template_id": {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
                 }
             },
             "required": [
@@ -200,7 +210,9 @@
                 "io_log",
                 "name",
                 "outcome",
-                "status"
+                "status",
+                "plugin",
+                "template_id"
             ],
             "title": "Result"
         },

--- a/submission-schema/schema.json
+++ b/submission-schema/schema.json
@@ -542,12 +542,36 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                "id": {
+                    "type": "string"
+                },
                 "full_id": {
                     "type": "string"
-                }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "category": {
+                    "type": "string"
+                },
+                "category_id": {
+                    "type": "string"
+                },
+                "plugin": {
+                    "$ref": "#/definitions/Plugin"
+                },
+                "template_id": {
+                    "type": "string"
+                },
             },
             "required": [
-                "full_id"
+                "id",
+                "full_id",
+                "name",
+                "category",
+                "category_id",
+                "plugin",
+                "template_id"
             ],
             "title": "RejectedJob"
         },
@@ -645,7 +669,9 @@
                 "shell",
                 "user-interact-verify",
                 "user-interact",
-                "manual"
+                "manual",
+                "attachment",
+                "resource"
             ],
             "title": "Plugin"
         },

--- a/submission-schema/schema.json
+++ b/submission-schema/schema.json
@@ -551,18 +551,28 @@
                 "name": {
                     "type": "string"
                 },
+                "plugin": {
+                    "$ref": "#/definitions/Plugin"
+                },
+                "certification_status": {
+                    "$ref": "#/definitions/CertificationStatus"
+                },
                 "category": {
                     "type": "string"
                 },
                 "category_id": {
                     "type": "string"
                 },
-                "plugin": {
-                    "$ref": "#/definitions/Plugin"
-                },
                 "template_id": {
-                    "type": "string"
-                },
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }
             },
             "required": [
                 "id",

--- a/submission-schema/schema.json
+++ b/submission-schema/schema.json
@@ -196,7 +196,8 @@
                         {
                             "type": "string"
                         }
-                    ]
+                    ],
+                    "description": "If the job is instantiated from a template, this field points to its origin template."
                 }
             },
             "required": [
@@ -583,7 +584,8 @@
                         {
                             "type": "string"
                         }
-                    ]
+                    ],
+                    "description": "If the job is instantiated from a template, this field points to its origin template."
                 }
             },
             "required": [


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
Developments in Checkbox and C3 require more information being shared between the two.

C3 uses the `submission.json` file generated by Checkbox when creating the submission archive. This JSON file contains a `rejected-jobs` section that, until now, only contained the `full_id` of the jobs being de-selected.

With this PR, the exported submission.json includes more information in the `rejected-jobs` array, similarly to what `results` contain. This includes partial id and full id, plugin (which allows us to know what kind of job this is, including attachment, resource, etc.), and effective category and certification status (blocker or non-blocker).

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/CHECKBOX-1597

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Ran the following test with the version in `main` and the version in this branch:

1. Run `checkbox-cli`
2. Select the 24.04 desktop test plan
3. Deselect all the jobs (by pressing `D`)
4. Run the tests

Compare the number of rejected jobs in both cases to make sure we have the same outcome:

```
$ jq '.["rejected-jobs"] | length' submission_before_patch.json
1217
$ jq '.["rejected-jobs"] | length' submission_after_patch.json
1217
```

Here is a sample submission JSON file from a run on my laptop: [submission_after_effective.json](https://github.com/user-attachments/files/17211303/submission_after_effective.json)

Note that, exactly like jobs that have been run (present in `results` section), the jobs in `rejected-jobs` include the effective certification_status and category. For instance, the `camera/detect` job is marked as a cert-blocker:

```json
        {
            "id": "camera/detect",
            "full_id": "com.canonical.certification::camera/detect",
            "name": "This Automated test attempts to detect a camera.",
            "plugin": "shell",
            "certification_status": "blocker",
            "category": "",
            "category_id": "com.canonical.plainbox::camera",
            "template_id": null
        },
```

The rejected-jobs also include attachment and resource jobs:

```json
        {
            "id": "camera/multiple-resolution-images-attachment_video0",
            "full_id": "com.canonical.certification::camera/multiple-resolution-images-attachment_video0",
            "name": "Attach an image from the multiple resolution images test for Integrated_Webcam_FHD__Integrat",
            "plugin": "attachment",
            "certification_status": "non-blocker",
            "category": "",
            "category_id": "com.canonical.plainbox::camera",
            "template_id": "com.canonical.certification::camera/multiple-resolution-images-attachment_name"
        },
...
        {
            "id": "cdimage",
            "full_id": "com.canonical.certification::cdimage",
            "name": "Collect information about installation media (casper)",
            "plugin": "resource",
            "certification_status": "non-blocker",
            "category": "Gathers information about the DUT",
            "category_id": "com.canonical.certification::information_gathering",
            "template_id": null
        },
```
