### PR TITLE
Fix touchscreen tests on ARM64 via remote (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -539,6 +539,7 @@ def get_execution_environment(job, environ, session_id, nest_dir):
                 "QT_QPA_PLATFORM",
                 "QT_QPA_PLATFORMTHEME",
                 "QT_DEBUG_PLUGINS",
+                "QML2_IMPORT_PATH",
             ]
             for key, value in env.items():
                 if key in copy_vars or key.startswith("SNAP"):
@@ -640,6 +641,7 @@ def get_differential_execution_environment(
             "QT_QPA_PLATFORM",
             "QT_QPA_PLATFORMTHEME",
             "QT_DEBUG_PLUGINS",
+            "QML2_IMPORT_PATH",
         ]
         for key, value in base_env.items():
             if key in copy_vars or key.startswith("SNAP"):


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

When running the touchscreen tests via remote, the user is promted to rotate the rectangle on a window but the `user-interact-verify` job (silently) fails to start the window at all. When the stderr is un-silenced, the following error is printed in the console:
```
file:///snap/checkboxXX/[...]/touch_zoom_test.qml:74 Timer is not a type
```
Timer is a builtin type of QT and this happens for any other type (removing the timer just makes it fail on the next builtin type). 

After much investigation, and thanks to the reported fact that the test starts fine if launched from the `checkbox.shell` or locally, I found that the problem is the missing envvar in this PR. This fixes the propagation of the envvar. I have whitelisted it instead of explicitly requiring it in the test because I believe that one doesn't have to understand exactly how QT works when writing a test, so they don't need to reason about which QT envvars are needed. 

## Resolved issues

Fixes: CHECKBOX-1511
Fixes: https://github.com/canonical/checkbox/issues/1371

## Documentation

N/A

## Tests

I have built and ran the test via remote with the following launcher. The window now shows up even via remote when before it did not.
```
    #!/usr/bin/env checkbox-cli
    [launcher]
    launcher_version = 1
    stock_reports = text
    [test plan]
    unit = com.canonical.certification::touchscreen-cert-manual
    forced = yes
    [test selection]
    forced=yes
    exclude=com.canonical.certification::touchscreen/drag-n-drop
    match = com.canonical.certification::touchscreen/multitouch-rotate
    [manifest]
    com.canonical.certification::has_touchscreen=yes
```

To test it yourself use [this checkbox24 snap](https://drive.google.com/file/d/135Ftfy7wj1wCCUq7S9BzBKPeAEE8kx9Y/view?usp=sharing), built from this branch (or build it yourself on arm64):
1. Install the snap
2. Install the frontend
3. Run remote with the above launcher
4. Press Return
5. A window with a blue rectangle should show up on the DUT

> Note: This is a core24 runtime snap. Remember CheckboxXX core only work on the XX version (so this doesn't work on jammy, only noble), if you want to test it on jammy I can build a core22 snap for you, just let me know
