### PR TITLE
Howto use match (infra)

### DIFF
--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -14,3 +14,4 @@ These how-to guides cover key operations and processes in Checkbox.
    agent-service
    freeze-checkbox-version
    launcher/*
+   using-match

--- a/docs/how-to/using-match.rst
+++ b/docs/how-to/using-match.rst
@@ -8,7 +8,7 @@ subset of a testplan.
 To only re-run the ``wireless`` portion of the ``sru`` testplan, use the
 following launcher:
 
-.. code-block:: none
+.. code-block:: ini
 
   [test plan]
   unit = com.canonical.certification::sru
@@ -19,7 +19,8 @@ following launcher:
 
 To only re-run the wifi ``bg_np`` and ``ac_np`` tests for ``wlan0``:
 
-.. code-block:: none
+.. code-block:: ini
+  :emphasize-lines: 7-8
 
   [test plan]
   unit = com.canonical.certification::sru
@@ -32,7 +33,8 @@ To only re-run the wifi ``bg_np`` and ``ac_np`` tests for ``wlan0``:
 
 To re-run all wireless tests but ``bg_np``:
 
-.. code-block:: none
+.. code-block:: ini
+  :emphasize-lines: 6-7
 
   [test plan]
   unit = com.canonical.certification::sru

--- a/docs/how-to/using-match.rst
+++ b/docs/how-to/using-match.rst
@@ -1,11 +1,11 @@
 Using ``match``
 ^^^^^^^^^^^^^^^
 
-When a subset of test plan run fails, it can be expensive to re-run it all.
-To aid with this ``match`` was introduced. It allows you to re-run only a
-subset of a testplan.
+When a subset of a test plan run fails, it can be expensive to re-run it all.
+To help with this, the ``match`` keyword was introduced. It allows you to re-run only a
+subset of a test plan.
 
-To only re-run the ``wireless`` portion of the ``sru`` testplan, use the
+To only re-run the ``wireless`` portion of the ``sru`` test plan, use the
 following launcher:
 
 .. code-block:: ini
@@ -15,7 +15,7 @@ following launcher:
   forced = yes
 
   [test selection]
-  match=.*wireless.*
+  match = .*wireless.*
 
 To only re-run the WiFi ``bg_np`` and ``ac_np`` tests for ``wlan0``:
 
@@ -27,7 +27,7 @@ To only re-run the WiFi ``bg_np`` and ``ac_np`` tests for ``wlan0``:
   forced = yes
 
   [test selection]
-  match=
+  match =
     com.canonical.certification::wireless/wireless_connection_open_ac_np_wlan0
     com.canonical.certification::wireless/wireless_connection_open_bg_np_wlan0
 
@@ -41,8 +41,8 @@ To re-run all wireless tests but ``bg_np``:
   forced = yes
 
   [test selection]
-  exclude=.*wireless.*bg_np.*
-  match=.*wireless.*
+  exclude = .*wireless.*bg_np.*
+  match = .*wireless.*
 
 Key features of ``match``:
 

--- a/docs/how-to/using-match.rst
+++ b/docs/how-to/using-match.rst
@@ -2,8 +2,15 @@ Using ``match``
 ^^^^^^^^^^^^^^^
 
 When a subset of a test plan run fails, it can be expensive to re-run it all.
-To help with this, the ``match`` keyword was introduced. It allows you to re-run only a
-subset of a test plan.
+To help with this, the ``match`` keyword was introduced. It allows you to
+re-run only a subset of a test plan.
+
+Key features of ``match``:
+
+* All tests in the bootstrap section will always be included
+* Test Selection screen is still shown and functional, but only matching tests are shown
+* Matched tests pull their dependencies automatically
+* ``exclude`` has the priority over ``match``
 
 To only re-run the ``wireless`` portion of the ``sru`` test plan, use the
 following launcher:
@@ -43,10 +50,3 @@ To re-run all wireless tests but ``bg_np``:
   [test selection]
   exclude = .*wireless.*bg_np.*
   match = .*wireless.*
-
-Key features of ``match``:
-
-* All tests in the bootstrap section will always be included
-* Test Selection screen is still shown and functional, but only matching tests are shown
-* Matched tests pull their dependencies automatically
-* ``exclude`` has the priority over ``match``

--- a/docs/how-to/using-match.rst
+++ b/docs/how-to/using-match.rst
@@ -1,0 +1,50 @@
+Using ``match``
+^^^^^^^^^^^^^^^
+
+When a subset of test plan run fails, it can be expensive to re-run it all.
+To aid with this ``match`` was introduced. It allows you to re-run only a
+subset of a testplan.
+
+To only re-run the ``wireless`` portion of the ``sru`` testplan, use the
+following launcher:
+
+.. code-block:: none
+
+  [test plan]
+  unit = com.canonical.certification::sru
+  forced = yes
+
+  [test selection]
+  match=.*wireless.*
+
+To only re-run the wifi ``bg_np`` and ``ac_np`` tests for ``wlan0``:
+
+.. code-block:: none
+
+  [test plan]
+  unit = com.canonical.certification::sru
+  forced = yes
+
+  [test selection]
+  match=
+    com.canonical.certification::wireless/wireless_connection_open_ac_np_wlan0
+    com.canonical.certification::wireless/wireless_connection_open_bg_np_wlan0
+
+To re-run all wireless tests but ``bg_np``:
+
+.. code-block:: none
+
+  [test plan]
+  unit = com.canonical.certification::sru
+  forced = yes
+
+  [test selection]
+  exclude=.*wireless.*bg_np.*
+  match=.*wireless.*
+
+Key features of ``match``:
+
+* All tests in the bootstrap section will always be included
+* Test Selection screen is still shown and functional, but only matching tests are shown
+* Matched tests pull their dependencies automatically
+* ``exclude`` has the priority over ``match``

--- a/docs/how-to/using-match.rst
+++ b/docs/how-to/using-match.rst
@@ -17,7 +17,7 @@ following launcher:
   [test selection]
   match=.*wireless.*
 
-To only re-run the wifi ``bg_np`` and ``ac_np`` tests for ``wlan0``:
+To only re-run the WiFi ``bg_np`` and ``ac_np`` tests for ``wlan0``:
 
 .. code-block:: ini
   :emphasize-lines: 7-8


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Document the new `match` feature with a handy howto

## Resolved issues

Fixes: CHECKBOX-1542

## Documentation

This is the documentation

## Tests

N/A
