### PR TITLE
add wwan reconnection test

### DIFF
--- a/providers/base/bin/wwan_tests.py
+++ b/providers/base/bin/wwan_tests.py
@@ -334,7 +334,7 @@ def _ping_test(if_name):
 
 class ThreeGppConnection:
 
-    def invoked(self):
+    def register_argument(self):
         parser = argparse.ArgumentParser()
         parser.add_argument(
             "hw_id", type=str, help="The hardware ID of the modem"
@@ -353,22 +353,25 @@ class ThreeGppConnection:
             default=30,
             help="delay before ping test",
         )
-        args = parser.parse_args(sys.argv[2:])
+        return parser.parse_args(sys.argv[2:])
 
-        mm = MMCLI()
-        mm_id = mm.equipment_id_to_mm_id(args.hw_id)
-        wwan_control_if = mm.get_primary_port(mm_id)
+    def invoked(self):
+
+        args = self.register_argument()
 
         ret_code = 1
         try:
-            _create_3gpp_connection(wwan_control_if, args.apn)
-            _wwan_radio_on()
-            time.sleep(args.wwan_setup_time)
-            ret_code = _ping_test(args.wwan_net_if)
+            with WWANTestCtx(args.hw_id, True, True) as ctx:
+                wwan_control_if = ctx.mm_obj.get_primary_port(
+                    str(ctx.modem_idx)
+                )
+                _create_3gpp_connection(wwan_control_if, args.apn)
+                time.sleep(args.wwan_setup_time)
+                ret_code = _ping_test(args.wwan_net_if)
         except subprocess.SubprocessError:
             pass
         _destroy_3gpp_connection()
-        _wwan_radio_off()
+
         sys.exit(ret_code)
 
 
@@ -453,25 +456,33 @@ class CountModems:
 
 class Resources:
 
-    def invoked(self):
+    def register_arguments(self):
         parser = argparse.ArgumentParser()
         parser.add_argument(
             "--use-cli",
             action="store_true",
             help="Use mmcli for all calls rather than dbus",
         )
-        args = parser.parse_args(sys.argv[2:])
+        return parser.parse_args(sys.argv[2:])
+
+    def invoked(self):
+        args = self.register_arguments()
         if args.use_cli:
             mm = MMCLI()
         else:
             mm = MMDbus()
+
         for m in mm.get_modem_ids():
             print("mm_id: {}".format(m))
             print("hw_id: {}".format(mm.get_equipment_id(m)))
             print("manufacturer: {}".format(mm.get_manufacturer(m)))
             print("model: {}".format(mm.get_model_name(m)))
-            print("firmware_revision: {}".format(mm.get_firmware_revision(m)))
-            print("hardware_revision: {}".format(mm.get_hardware_revision(m)))
+            print(
+                "firmware_revision: {}".format(mm.get_firmware_revision(m))
+            )
+            print(
+                "hardware_revision: {}".format(mm.get_hardware_revision(m))
+            )
             print()
 
 

--- a/providers/base/units/wwan/jobs.pxu
+++ b/providers/base/units/wwan/jobs.pxu
@@ -32,9 +32,10 @@ template-unit: job
 id: wwan/gsm-connection-{manufacturer}-{model}-{hw_id}-auto
 template-id: wwan/gsm-connection-manufacturer-model-hw_id-auto
 _summary: Verify a GSM broadband modem can create a data connection
+_template-summary: Verify a GSM broadband modem can create a data connection multiple times
 _purpose:
- Any modems discovered by the resource job that list GSM support
- will be tested to ensure a data connection can be made.
+  Any modems discovered by the resource job that list GSM support
+  will be tested to ensure a data connection can be made.
 plugin: shell
 command:
   BEGIN_CONNECTION_TEST_TS=$(date '+%Y-%m-%d %H:%M:%S')
@@ -56,6 +57,12 @@ requires:
   manifest.has_wwan_module == 'True'
   manifest.has_sim_card == 'True'
   snap.name == 'modem-manager' or package.name == 'modemmanager'
+_siblings:
+    [{{
+      "id": "wwan/gsm-reconnection-{manufacturer}-{model}-{hw_id}-auto",
+      "_summary": "Verify a GSM broadband modem can recreate a data connection",
+      "depends": "wwan/gsm-connection-{manufacturer}-{model}-{hw_id}-auto"
+    }}]
 
 unit: template
 template-resource: wwan_resource

--- a/providers/base/units/wwan/test-plan.pxu
+++ b/providers/base/units/wwan/test-plan.pxu
@@ -18,6 +18,7 @@ include:
     wwan/detect    certification-status=blocker
     wwan/3gpp-scan-manufacturer-model-hw_id-auto
     wwan/gsm-connection-.*-auto    certification-status=blocker
+    wwan/gsm-reconnection-.*-auto    certification-status=blocker
     wwan/check-sim-present-.*-auto
 bootstrap_include:
     wwan_resource


### PR DESCRIPTION
## Description
Extend the wwan connection tests to support multiple cycle connection tests, we found an issue that the LTE connection could not be established at second round.

As discussed internally with the QA team, we have all agreed that the default number of test runs for WWAN connections tests is 2.

## Resolved issues
Here is the support ticket: 00379830.

Our SWE has identified this issue is related to the modem firmware and modem-manager snap, and they are trying to add a patch to modem-manager snap as a workaround.

## Documentation
N/A

## Tests
list bootstrapped results (with hacking resource):
```
(venv) stanley@stanley-ThinkPad-T490:~/Desktop/Git_Repos/checkbox-github/providers/base$ checkbox.checkbox-cli list-bootstrapped com.canonical.certification::wwan-automated
$PROVIDERPATH is defined, so following provider sources are ignored ['/home/stanley/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Using sideloaded provider: checkbox-provider-base, version 4.2.0.dev99 from /var/tmp/checkbox-providers/base
Skipped file: /var/tmp/checkbox-providers/base/bin/__pycache__/wwan_tests.cpython-38.pyc
Skipped file: /var/tmp/checkbox-providers/base/units/stress/suspend_cycles_reboot.md
com.canonical.certification::package
com.canonical.plainbox::manifest
com.canonical.certification::snap
com.canonical.certification::wwan/detect
com.canonical.certification::wwan/check-sim-present-honghai-modelc-testid-auto
com.canonical.certification::wwan/3gpp-scan-honghai-modelc-testid-auto
com.canonical.certification::wwan/gsm-connection-honghai-modelc-testid-auto
com.canonical.certification::wwan/gsm-reconnection-honghai-modelc-testid-auto
com.canonical.certification::sleep
com.canonical.certification::rtc
com.canonical.certification::suspend/suspend_advanced_auto
com.canonical.certification::after-suspend-wwan/3gpp-scan-honghai-modelc-testid-auto
```