### PR TITLE
Fix crashes when copying the same file (bugfix)

### DIFF
--- a/providers/base/bin/wifi_nmcli_backup.py
+++ b/providers/base/bin/wifi_nmcli_backup.py
@@ -82,8 +82,11 @@ def save_connections(keyfile_list):
         backup_loc = SAVE_DIR / basedir
 
         os.makedirs(backup_loc, exist_ok=True)
-        save_f = shutil.copy(f, backup_loc)
-        print("  Saved copy at {}".format(save_f))
+        try:
+            save_f = shutil.copy(f, backup_loc)
+            print("  Saved copy at {}".format(save_f))
+        except shutil.SameFileError:
+            print("  Skipping, file already exists at {}".format(f))
 
 
 def restore_connections():


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

From `shutil.copy.__doc__`
> If source and destination are the same file, a SameFileError will be raised.

Use `try except` to catch and ignore it.

## Resolved issues
```
stdout
------
Save connection /etc/NetworkManager/system-connections/Canonical.nmconnection
  Found file /etc/NetworkManager/system-connections/Canonical.nmconnection

stderr
------
Traceback (most recent call last):
  File "/tmp/nest-gvho97n3.e3cfd3167235d403c10f31edea128da281c47194c161bbd2e146795f65cdfc15/wifi_nmcli_backup.py", line 110, in <module>
    save_connections(get_nm_keyfiles())
  File "/tmp/nest-gvho97n3.e3cfd3167235d403c10f31edea128da281c47194c161bbd2e146795f65cdfc15/wifi_nmcli_backup.py", line 85, in save_connections
    save_f = shutil.copy(f, backup_loc)
  File "/usr/lib/python3.10/shutil.py", line 417, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.10/shutil.py", line 234, in copyfile
    raise SameFileError("{!r} and {!r} are the same file".format(src, dst))
shutil.SameFileError: '/etc/NetworkManager/system-connections/Canonical.nmconnection' and '/etc/NetworkManager/system-connections/Canonical.nmconnection' are the same file
```