### PR TITLE
Add manifest entry for dangerous grade images (new)

### DIFF
--- a/providers/base/units/image/jobs.pxu
+++ b/providers/base/units/image/jobs.pxu
@@ -78,8 +78,10 @@ flags: preserve-locale
 id: image/model-grade
 category_id: image
 _summary: Check that the model grade is correctly set
+imports: from com.canonical.plainbox import manifest
 requires:
  lsb.distributor_id == "Ubuntu Core" and int(lsb.release) >= 20
+ manifest.dangerous_grade_core_image == 'False'
 _purpose:
  Images with the 'dangerous' grade (the lowest of all available grades)
  results in certain security measures being relaxed.

--- a/providers/base/units/image/manifest.pxu
+++ b/providers/base/units/image/manifest.pxu
@@ -1,5 +1,5 @@
 unit: manifest entry
 id: dangerous_grade_core_image
-_name: Image is using 'dangerous' grade (should NOT be the case for enablements!)
+_name: Image is using 'dangerous' grade (should be set to 'No' unless you're doing SRU testing)
 _prompt: Does this setup have the following configuration?
 value-type: bool

--- a/providers/base/units/image/manifest.pxu
+++ b/providers/base/units/image/manifest.pxu
@@ -1,0 +1,5 @@
+unit: manifest entry
+id: dangerous_grade_core_image
+_name: Image is using 'dangerous' grade (should NOT be the case for enablements!)
+_prompt: Does this setup have the following configuration?
+value-type: bool


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

In our testing lab, we need to provision some devices with Ubuntu Core
images that are set to use the 'dangerous' grade.

This will fail the `image/model-grade` test.

Add a new `dangerous_grade_core_image` manifest to decide whether or not
we should be running this test.

It will be run by default (when there is no manifest entry, its value is
set to 'False'), but by setting it to True, the test will be skipped.

![image](https://github.com/user-attachments/assets/6f72a6c4-1292-459a-8726-8346b3b89711)


## Resolved issues

Fix #1479 
Fix CHECKBOX-1572

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
