### PR TITLE
Fix GPGPU provider distribution (New)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -57,6 +57,12 @@ package-repositories:
     ppa: checkbox-dev/stable
   - type: apt
     ppa: colin-king/stress-ng
+  - type: apt
+    architectures: [amd64]
+    formats: [deb]
+    path: /
+    key-id: EB693B3035CD5710E231E123A4B469963BF863CC
+    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64
 
 parts:
   version-calculator:

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -61,6 +61,12 @@ package-repositories:
     ppa: checkbox-dev/stable
   - type: apt
     ppa: colin-king/stress-ng
+  - type: apt
+    architectures: [amd64]
+    formats: [deb]
+    path: /
+    key-id: EB693B3035CD5710E231E123A4B469963BF863CC
+    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64
 
 parts:
   version-calculator:

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -61,6 +61,12 @@ package-repositories:
     ppa: checkbox-dev/stable
   - type: apt
     ppa: colin-king/stress-ng
+  - type: apt
+    architectures: [amd64]
+    formats: [deb]
+    path: /
+    key-id: EB693B3035CD5710E231E123A4B469963BF863CC
+    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64
 
 parts:
   version-calculator:

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -65,6 +65,12 @@ package-repositories:
     ppa: checkbox-dev/stable
   - type: apt
     ppa: colin-king/stress-ng
+  - type: apt
+    architectures: [amd64]
+    formats: [deb]
+    path: /
+    key-id: EB693B3035CD5710E231E123A4B469963BF863CC
+    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64
 
 parts:
   version-calculator:

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -63,6 +63,12 @@ slots:
 package-repositories:
   - type: apt
     ppa: colin-king/stress-ng
+  - type: apt
+    architectures: [amd64]
+    formats: [deb]
+    path: /
+    key-id: EB693B3035CD5710E231E123A4B469963BF863CC
+    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64
 
 parts:
   version-calculator:


### PR DESCRIPTION
## Description

Currently, the GPGPU provider depends on the user running a setup script after installing the provider. This script sets up the NVIDIA/AMD repositories to get the required packages from upstream (i.e. CUDA toolkit or ROCm). This has worked so far, but it is negatively affecting the way we test the provider, especially with automated setups.

## Resolved issues

Resolves CHECKBOX-1519

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
