### PR TITLE
Fix missing `subprocess.PIPE` in reboot_check_test.py (Bugfix)

### DIFF
--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -311,9 +311,7 @@ def get_failed_services() -> T.List[str]:
         "--plain",  # plaintext, otherwise it includes color codes
     ]
 
-    return sp.run(
-        command, stdout=sp.PIPE, universal_newlines=True
-    ).stdout.splitlines()
+    return sp.check_output(command, universal_newlines=True).splitlines()
 
 
 def create_parser():

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -41,8 +41,8 @@ class DeviceInfoCollector:
         return str(os.listdir("/sys/class/drm"))
 
     def get_wireless_info(self) -> str:
-        iw_out = sp.check_output(["iw", "dev"])
-        lines = iw_out.decode().splitlines()
+        iw_out = sp.check_output(["iw", "dev"], universal_newlines=True)
+        lines = iw_out.splitlines()
         lines_to_write = list(
             filter(
                 lambda line: "addr" in line
@@ -60,13 +60,15 @@ class DeviceInfoCollector:
                 "-f",
                 '"{}"/var/lib/usbutils/usb.ids'.format(RUNTIME_ROOT),
                 "-s",
-            ]
-        ).decode()
+            ],
+            universal_newlines=True
+        )
 
     def get_pci_info(self) -> str:
         return sp.check_output(
-            ["lspci", "-i", "{}/usr/share/misc/pci.ids".format(SNAP)]
-        ).decode()
+            ["lspci", "-i", "{}/usr/share/misc/pci.ids".format(SNAP)],
+            universal_newlines=True
+        )
 
     def compare_device_lists(
         self,
@@ -242,6 +244,7 @@ class HardwareRendererTester:
         unity_support_output = sp.run(
             ["{}/usr/lib/nux/unity_support_test".format(RUNTIME_ROOT), "-p"],
             stdout=sp.PIPE,
+            universal_newlines=True
         )
         if unity_support_output.returncode != 0:
             print(
@@ -254,7 +257,7 @@ class HardwareRendererTester:
 
         is_hardware_rendered = (
             self.parse_unity_support_output(
-                unity_support_output.stdout.decode()
+                unity_support_output.stdout
             ).get("Not software rendered")
             == "yes"
         )
@@ -308,7 +311,7 @@ def get_failed_services() -> T.List[str]:
         "--plain",  # plaintext, otherwise it includes color codes
     ]
 
-    return sp.run(command, stdout=sp.PIPE).stdout.decode().splitlines()
+    return sp.run(command, stdout=sp.PIPE, universal_newlines=True).stdout.splitlines()
 
 
 def create_parser():

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -61,13 +61,13 @@ class DeviceInfoCollector:
                 '"{}"/var/lib/usbutils/usb.ids'.format(RUNTIME_ROOT),
                 "-s",
             ],
-            universal_newlines=True
+            universal_newlines=True,
         )
 
     def get_pci_info(self) -> str:
         return sp.check_output(
             ["lspci", "-i", "{}/usr/share/misc/pci.ids".format(SNAP)],
-            universal_newlines=True
+            universal_newlines=True,
         )
 
     def compare_device_lists(
@@ -244,7 +244,7 @@ class HardwareRendererTester:
         unity_support_output = sp.run(
             ["{}/usr/lib/nux/unity_support_test".format(RUNTIME_ROOT), "-p"],
             stdout=sp.PIPE,
-            universal_newlines=True
+            universal_newlines=True,
         )
         if unity_support_output.returncode != 0:
             print(
@@ -256,9 +256,9 @@ class HardwareRendererTester:
             return False
 
         is_hardware_rendered = (
-            self.parse_unity_support_output(
-                unity_support_output.stdout
-            ).get("Not software rendered")
+            self.parse_unity_support_output(unity_support_output.stdout).get(
+                "Not software rendered"
+            )
             == "yes"
         )
         if is_hardware_rendered:
@@ -311,7 +311,9 @@ def get_failed_services() -> T.List[str]:
         "--plain",  # plaintext, otherwise it includes color codes
     ]
 
-    return sp.run(command, stdout=sp.PIPE, universal_newlines=True).stdout.splitlines()
+    return sp.run(
+        command, stdout=sp.PIPE, universal_newlines=True
+    ).stdout.splitlines()
 
 
 def create_parser():

--- a/providers/base/tests/test_reboot_check_test.py
+++ b/providers/base/tests/test_reboot_check_test.py
@@ -9,8 +9,10 @@ import subprocess as sp
 
 
 def do_nothing(args: T.List[str], **kwargs):
-    return sp.CompletedProcess(args, 0, "".encode(), "".encode())
-
+    if "universal_newlines" in kwargs:
+        return sp.CompletedProcess(args, 0, "", "")
+    else:
+        return sp.CompletedProcess(args, 0, "".encode(), "".encode())
 
 class UnitySupportParserTests(unittest.TestCase):
     def setUp(self):
@@ -131,9 +133,8 @@ class DisplayConnectionTests(unittest.TestCase):
         mock_run: MagicMock,
         mock_parse: MagicMock,
     ):
-
-        mock_run.side_effect = lambda _: sp.CompletedProcess(
-            [], 1, "".encode(), "".encode()
+        mock_run.side_effect = lambda *args, **kwargs: sp.CompletedProcess(
+            [], 1, "", ""
         )
         tester = RCT.HardwareRendererTester()
         self.assertFalse(tester.is_hardware_renderer_available())
@@ -180,7 +181,7 @@ class InfoDumpTests(unittest.TestCase):
         else:
             raise Exception("Unexpected use of this mock")
 
-        return sp.CompletedProcess(args, 0, stdout.encode(), "".encode())
+        return sp.CompletedProcess(args, 0, stdout, "")
 
     @patch("subprocess.run")
     def test_info_dump_only_happy_path(self, mock_run: MagicMock):
@@ -243,7 +244,7 @@ class FailedServiceCheckerTests(unittest.TestCase):
     @patch("subprocess.run")
     def test_get_failed_services_happy_path(self, mock_run: MagicMock):
         mock_run.return_value = sp.CompletedProcess(
-            [], 0, "".encode(), "".encode()
+            [], 0, "",""
         )
         self.assertEqual(RCT.get_failed_services(), [])
 

--- a/providers/base/tests/test_reboot_check_test.py
+++ b/providers/base/tests/test_reboot_check_test.py
@@ -256,11 +256,11 @@ class FailedServiceCheckerTests(unittest.TestCase):
             [],
             0,
             "snap.checkbox.agent.service loaded failed failed Service\
-                  for snap applictaion checkbox.agent".encode(),
+                  for snap applictaion checkbox.agent",
             "",
         )
         self.assertEqual(
-            RCT.get_failed_services(), [mock_run.return_value.stdout.decode()]
+            RCT.get_failed_services(), [mock_run.return_value.stdout]
         )
 
 

--- a/providers/base/tests/test_reboot_check_test.py
+++ b/providers/base/tests/test_reboot_check_test.py
@@ -14,6 +14,7 @@ def do_nothing(args: T.List[str], **kwargs):
     else:
         return sp.CompletedProcess(args, 0, "".encode(), "".encode())
 
+
 class UnitySupportParserTests(unittest.TestCase):
     def setUp(self):
         self.tester = RCT.HardwareRendererTester()
@@ -243,9 +244,7 @@ class FailedServiceCheckerTests(unittest.TestCase):
 
     @patch("subprocess.run")
     def test_get_failed_services_happy_path(self, mock_run: MagicMock):
-        mock_run.return_value = sp.CompletedProcess(
-            [], 0, "",""
-        )
+        mock_run.return_value = sp.CompletedProcess([], 0, "", "")
         self.assertEqual(RCT.get_failed_services(), [])
 
     @patch("subprocess.run")


### PR DESCRIPTION
## Description

The new reboot check test was missing `stdout=subprocess.PIPE` in calls to `subprocess.run` which was causing it to return None for `<CompletedProcess>.stdout`

## Resolved issues
#1548 

## Documentation


## Tests

1. The original test cases pass
2. Side loaded on 202406-34083 and full wb/cb tests can be run  
