### PR TITLE
Fix the parser so that it doesn't loop forever (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/test_xparsers.py
+++ b/checkbox-ng/plainbox/impl/test_xparsers.py
@@ -1,8 +1,9 @@
 # This file is part of Checkbox.
 #
-# Copyright 2012-2015 Canonical Ltd.
+# Copyright 2012-2024 Canonical Ltd.
 # Written by:
 #   Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
@@ -18,7 +19,7 @@
 import doctest
 import unittest
 
-from plainbox.impl.xparsers import WordList, Error
+from plainbox.impl.xparsers import WordList, Error, Text
 
 
 def load_tests(loader, tests, ignore):
@@ -65,3 +66,9 @@ class WordParserTests(unittest.TestCase):
         entries = parsed.entries
         self.assertEqual(len(entries), 1)
         self.assertTrue(isinstance(entries[0], Error))
+
+    def test_error_word(self):
+        entries = WordList.parse("a=").entries
+        self.assertEqual(len(entries), 2)
+        self.assertTrue(isinstance(entries[0], Text))
+        self.assertTrue(isinstance(entries[1], Error))

--- a/checkbox-ng/plainbox/impl/test_xparsers.py
+++ b/checkbox-ng/plainbox/impl/test_xparsers.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 import doctest
+import unittest
+
+from plainbox.impl.xparsers import WordList, Error
 
 
 def load_tests(loader, tests, ignore):
@@ -25,3 +28,40 @@ def load_tests(loader, tests, ignore):
         )
     )
     return tests
+
+
+class WordParserTests(unittest.TestCase):
+
+    def test_no_loop_forever_unterminated_word_parsable_prefix(self):
+        """
+        This made the parser loop forever because it would fail to parse from
+        `"`, accidentally go back to `,` parse `,` correctly and fail again
+        on `"` forever
+        """
+        parsed = WordList.parse(',"a')  # loops forever
+        entries = parsed.entries
+        self.assertEqual(len(entries), 1)
+        self.assertTrue(isinstance(entries[0], Error))
+
+    def test_no_loop_forever_unterminated_word_parsable_prefix_word(self):
+        """
+        This made the parser loop forever because it would fail to parse from
+        `"`, accidentally go back to `1` parse `1` correctly and fail again
+        on `"` forever. Only difference with the one above is that is actually
+        does parse something, the 1
+        """
+        parsed = WordList.parse('1 "a')  # loops forever
+        entries = parsed.entries
+        self.assertEqual(len(entries), 2)
+        self.assertTrue(isinstance(entries[1], Error))
+
+    def test_no_crash_unterminated_word_no_prefix(self):
+        """
+        This made the parser crash because it tried to go back to the state
+        before parsing but the boundary check was wrong (there was one more
+        state in the stack)
+        """
+        parsed = WordList.parse('"a')  # crash
+        entries = parsed.entries
+        self.assertEqual(len(entries), 1)
+        self.assertTrue(isinstance(entries[0], Error))

--- a/checkbox-ng/plainbox/impl/xparsers.py
+++ b/checkbox-ng/plainbox/impl/xparsers.py
@@ -672,6 +672,15 @@ class WordList(Node):
                 continue
             elif token == scanner.TokenEnum.WORD:
                 entries.append(Text(lineno, col_offset, lexeme))
+            elif token == scanner.TokenEnum.INVALID:
+                entries.append(
+                    Error(
+                        lineno,
+                        col_offset,
+                        "Missing end of word: {!r}".format(lexeme),
+                    )
+                )
+                break
             else:
                 entries.append(
                     Error(

--- a/checkbox-ng/plainbox/impl/xparsers.py
+++ b/checkbox-ng/plainbox/impl/xparsers.py
@@ -1,8 +1,9 @@
 # This file is part of Checkbox.
 #
-# Copyright 2012-2015 Canonical Ltd.
+# Copyright 2012-2024 Canonical Ltd.
 # Written by:
 #   Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/checkbox-ng/plainbox/impl/xscanners.py
+++ b/checkbox-ng/plainbox/impl/xscanners.py
@@ -1,8 +1,9 @@
 # This file is part of Checkbox.
 #
-# Copyright 2012-2017 Canonical Ltd.
+# Copyright 2012-2024 Canonical Ltd.
 # Written by:
 #   Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

When validating units, Checkbox tries to parse fields to see if there are any errors with them. Turns out that if a field contains an un-terminated string`"...`, that will cause the parser to always loop forever or crash with an assertion error. This was affecting a test run today due to a non-sluggified name getting templated into a job. This manifested itself as an infinited crash-restore loop due to also an un-related error (if the session gets stuck on an infinite loop, the controller tries to reconnect eventually, Checkbox refuses to "recover" during bootstrapping, restarting the session)

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1622

## Documentation

This also documents how the parser works because it is quite something

## Tests

This also adds the tests I used to reproduce the issue
