### PR TITLE
Add reference to manifest entries in expand subcommand help (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -1306,11 +1306,11 @@ class Expand:
     def register_arguments(self, parser):
         parser.formatter_class = RawDescriptionHelpFormatter
         parser.description = (
-            "Expand a given test plan: display all the jobs and templates "
-            "that are defined in this test plan and that would be executed "
-            "if ran. This is useful to visualize the full list of jobs and "
-            "templates for complex test plans that consist of many nested "
-            "parts with different 'include' and 'exclude' sections.\n\n"
+            "Expand a given test plan: display all the jobs, templates and "
+            "manifest entries that are defined in this test plan and that "
+            " would be executed if ran. This is useful to visualize the full "
+            "list of units called for complex test plans that consist of many "
+            "nested parts with different 'include' and 'exclude' sections.\n\n"
             "NOTE: the elements listed here are not sorted by execution "
             "order. To see the execution order, please use the "
             "'list-bootstrapped' command instead."


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Following https://github.com/canonical/checkbox/pull/1489, the `expand` subcommand now also lists manifest entries. This is now reflected in the subcommand help.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

```
$ checkbox-cli expand --help
usage: checkbox-cli [-h] [-f FORMAT] TEST_PLAN

Expand a given test plan: display all the jobs, templates and manifest entries that are defined in this test plan and that  would be executed if ran. This is useful to visualize the full list of units called for complex test plans that consist of many nested parts with different 'include' and 'exclude' sections.

NOTE: the elements listed here are not sorted by execution order. To see the execution order, please use the 'list-bootstrapped' command instead.

positional arguments:
  TEST_PLAN             test-plan id to expand

options:
  -h, --help            show this help message and exit
  -f FORMAT, --format FORMAT
                        output format: 'text' or 'json' (default: text)

```

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
