### PR TITLE
Save submission url to file (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -512,7 +512,7 @@ class ReportsStage(CheckboxUiStage):
                 ("tar", ".tar.xz"),
             ]:
                 path = self._get_submission_file_path(file_ext)
-                os.path.makedirs(os.path.dirname(path), exist_ok=True)
+                os.makedirs(os.path.dirname(path), exist_ok=True)
                 template = textwrap.dedent(
                     """
                     [transport:{exporter}_file]

--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -59,7 +59,9 @@ def get_submissions_timestamp():
     submission timestamp
     """
     isoformat = "%Y-%m-%dT%H.%M.%S.%f"
-    timestamp = datetime.datetime.now(datetime.UTC).strftime(isoformat)
+    timestamp = datetime.datetime.now(datetime.timezone.utc).strftime(
+        isoformat
+    )
     return timestamp
 
 

--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -698,24 +698,17 @@ class ReportsStage(CheckboxUiStage):
                                 exporter_id,
                                 exc,
                             )
-                    if result and "url" in result:
+                    result = result or {}
+                    url = result.get("url") or result.get("status_url")
+                    if url:
                         path = self._get_submission_file_path(".c3_url.log")
                         with open(path, "w+") as f:
                             print(
                                 "Submission url ({}) saved also to: {}".format(
-                                    path, result["url"]
+                                    path, url
                                 )
                             )
-                            f.write(result["url"])
-                    elif result and "status_url" in result:
-                        path = self._get_submission_file_path(".c3_url.log")
-                        with open(path, "w+") as f:
-                            print(
-                                "Submission url ({}) saved also to: {}".format(
-                                    path, result["status_url"]
-                                )
-                            )
-                            f.write(result["status_url"])
+                            f.write(url)
                 except TransportError as exc:
                     _logger.warning(
                         _("Problem occured when submitting '%s' report: %s"),

--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -542,12 +542,16 @@ class ReportsStage(CheckboxUiStage):
             "".join(["submission_", timestamp, file_ext]),
         )
 
-    def _prepare_transports(self):
-        self.base_dir = os.path.join(
+    @property
+    def base_dir(self):
+        base_dir = os.path.join(
             os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share/")),
             "checkbox-ng",
         )
-        os.makedirs(self.base_dir, exist_ok=True)
+        os.makedirs(base_dir, exist_ok=True)
+        return base_dir
+
+    def _prepare_transports(self):
         self._available_transports = get_all_transports()
         self.transports = dict()
 

--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -27,6 +27,7 @@ import logging
 import os
 import textwrap
 import time
+import functools
 
 from plainbox.abc import IJobResult
 from plainbox.i18n import pgettext as C_
@@ -49,6 +50,17 @@ from checkbox_ng.launcher.run import (
 _ = gettext.gettext
 
 _logger = logging.getLogger("checkbox-ng.launcher.stages")
+
+
+@functools.lru_cache(maxsize=1)
+def get_submissions_timestamp():
+    """
+    This is so that one session produces only artifacts with the same
+    submission timestamp
+    """
+    isoformat = "%Y-%m-%dT%H.%M.%S.%f"
+    timestamp = datetime.datetime.now(datetime.UTC).strftime(isoformat)
+    return timestamp
 
 
 class CheckboxUiStage(metaclass=abc.ABCMeta):
@@ -522,8 +534,7 @@ class ReportsStage(CheckboxUiStage):
     def _get_submission_file_path(self, file_ext):
         # LP:1585326 maintain isoformat but removing ':' chars that cause
         # issues when copying files.
-        isoformat = "%Y-%m-%dT%H.%M.%S.%f"
-        timestamp = datetime.datetime.now(datetime.UTC).strftime(isoformat)
+        timestamp = get_submissions_timestamp()
         return os.path.join(
             self.base_dir,
             "".join(["submission_", timestamp, file_ext]),

--- a/checkbox-ng/checkbox_ng/launcher/test_stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_stages.py
@@ -17,9 +17,10 @@
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from pathlib import Path
 from unittest import TestCase, mock
 
-from checkbox_ng.launcher.stages import MainLoopStage
+from checkbox_ng.launcher.stages import MainLoopStage, ReportsStage
 
 
 class TestMainLoopStage(TestCase):
@@ -63,3 +64,82 @@ class TestMainLoopStage(TestCase):
             )
 
         self.assertEqual(result_builder.outcome, "skip")
+
+
+class TestReportsStage(TestCase):
+    def test__get_submission_file_path(self):
+        # LP:1585326 maintain isoformat but removing ':' chars that cause
+        # issues when copying files.
+        self_mock = mock.MagicMock()
+        self_mock.base_dir = "~/.some_path"
+
+        path = ReportsStage._get_submission_file_path(self_mock, ".tmp")
+        self.assertNotIn(path, ":")
+
+    def test__export_results_c3_prints_also_to_file(self):
+        """
+        That the the c3 exporter also reports back the C3 submission url after
+        submitting
+        """
+        self_mock = mock.MagicMock()
+        self_mock.is_interactive = False
+        config_mock = self_mock.sa.config
+        config_mock.get_value.return_value = "none"
+
+        def get_parametric_sections(section):
+            if section == "report":
+                return {"c3": {"exporter": "tar", "transport": "c3"}}
+            elif section == "exporter":
+                return {"tar": {"unit": "some_id"}}
+            return {}
+
+        config_mock.get_parametric_sections = get_parametric_sections
+        self_mock._export_fn = None
+        self_mock.sa.export_to_transport.return_value = {
+            "status_url": "https://certification.canonical.com/submissions/status/EXAMPLE"
+        }
+        mock_open = mock.mock_open()
+        with mock.patch("checkbox_ng.launcher.stages.open", mock_open) as f:
+            ReportsStage._export_results(self_mock)
+            file_mock = f.return_value
+            self.assertTrue(file_mock.write.called)
+            self.assertEqual(
+                file_mock.write.call_args,
+                mock.call(
+                    "https://certification.canonical.com/submissions/status/EXAMPLE"
+                ),
+            )
+
+    def test__export_results_c3_legacy_prints_also_to_file(self):
+        """
+        That the the c3 legacy exporter also reports back the C3 submission url
+        after submitting
+        """
+        self_mock = mock.MagicMock()
+        self_mock.is_interactive = False
+        config_mock = self_mock.sa.config
+        config_mock.get_value.return_value = "none"
+
+        def get_parametric_sections(section):
+            if section == "report":
+                return {"c3": {"exporter": "tar", "transport": "c3"}}
+            elif section == "exporter":
+                return {"tar": {"unit": "some_id"}}
+            return {}
+
+        config_mock.get_parametric_sections = get_parametric_sections
+        self_mock._export_fn = None
+        self_mock.sa.export_to_transport.return_value = {
+            "url": "https://certification.canonical.com/submissions/status/EXAMPLE"
+        }
+        mock_open = mock.mock_open()
+        with mock.patch("checkbox_ng.launcher.stages.open", mock_open) as f:
+            ReportsStage._export_results(self_mock)
+            file_mock = f.return_value
+            self.assertTrue(file_mock.write.called)
+            self.assertEqual(
+                file_mock.write.call_args,
+                mock.call(
+                    "https://certification.canonical.com/submissions/status/EXAMPLE"
+                ),
+            )

--- a/checkbox-ng/checkbox_ng/launcher/test_stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_stages.py
@@ -18,6 +18,7 @@
 
 
 from pathlib import Path
+from functools import partial
 from unittest import TestCase, mock
 
 from checkbox_ng.launcher.stages import MainLoopStage, ReportsStage
@@ -143,3 +144,15 @@ class TestReportsStage(TestCase):
                     "https://certification.canonical.com/submissions/status/EXAMPLE"
                 ),
             )
+
+    @mock.patch("os.makedirs")
+    def test__prepare_stock_report(self, makedirs):
+        self_mock = mock.MagicMock()
+        self_mock._get_submission_file_path = partial(
+            ReportsStage._get_submission_file_path, self_mock
+        )
+
+        ReportsStage._prepare_stock_report(self_mock, "submission_files")
+
+        self.assertEqual(self_mock.sa.config.update_from_another.call_count, 3)
+        self.assertTrue(makedirs.called)

--- a/checkbox-ng/checkbox_ng/launcher/test_stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_stages.py
@@ -151,6 +151,7 @@ class TestReportsStage(TestCase):
         self_mock._get_submission_file_path = partial(
             ReportsStage._get_submission_file_path, self_mock
         )
+        self_mock.base_dir = "~/.local/share"
 
         ReportsStage._prepare_stock_report(self_mock, "submission_files")
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

When submitting to C3, Checkbox receives a submission URL. This url is printed to the console. It is very hard and hackish to retreive this URL from the stdout of the process, therefore this adds a new rule to the exporter that also propagates this URL to a file on disk, printing the location like others do

## Resolved issues

N/A

## Documentation

N/A

## Tests

This adds two new unit tests for the functionality + 1 for a small refactoring
