### PR TITLE
Mock os.makedirs in launcher return codes (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -671,6 +671,7 @@ class TestLauncher(TestCase):
         Launcher.invoked(self_mock, ctx_mock)
 
 
+@patch("os.makedirs", new=MagicMock())
 class TestLauncherReturnCodes(TestCase):
     def setUp(self):
         self.launcher = Launcher()


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Test fails on launchpad because it doesn't mock the stage. Stage tries to save the C3 URL and crashes on PermissionDenied. Also, very bad idea to create the directory while running tests!

## Resolved issues

N/A

## Documentation

N/A

## Tests

N/A
