### PR TITLE
Install AMD GPU setup script in deb package (BugFix)

### DIFF
--- a/providers/gpgpu/debian/checkbox-provider-gpgpu.install
+++ b/providers/gpgpu/debian/checkbox-provider-gpgpu.install
@@ -2,3 +2,4 @@ debian/tmp/usr/share/checkbox-provider-gpgpu/*
 debian/tmp/usr/share/plainbox-providers-1/*.provider
 usr/bin/test-gpgpu
 providers/gpgpu/tools/gpu-setup /usr/bin/
+providers/gpgpu/tools/amd-gpu-setup /usr/bin/


### PR DESCRIPTION
## Description

- AMD GPU setup script is currently not being installed with the deb package.

## Resolved issues

## Documentation

## Tests