### PR TITLE
Add v4l-utils snap dependency (New)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -124,6 +124,7 @@ parts:
     source: checkbox-support
     source-type: local
     stage-packages:
+      - v4l-utils
       - python3-dbus
       - python3-dev
       - python3-evdev

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -131,6 +131,7 @@ parts:
       - python3-requests-unixsocket
       - libbluetooth3
       - libsystemd0
+      - v4l-utils
     python-packages:
       - pynmea2
       - pybluez

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -135,6 +135,7 @@ parts:
       - python3-pyparsing
       - python3-requests-unixsocket
       - libsystemd0
+      - v4l-utils
       # added to stage python:
       - libpython3-stdlib
       - libpython3.8-stdlib

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -139,6 +139,7 @@ parts:
       - python3-pyparsing
       - python3-requests-unixsocket
       - libsystemd0
+      - v4l-utils
       # added to stage python:
       - libpython3-stdlib
       - libpython3.10-stdlib

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -104,6 +104,7 @@ parts:
       - python3-bluez
       - python3-pyparsing
       - libsystemd0
+      - v4l-utils
       # added to stage python:
       - libpython3-stdlib
       - libpython3.12-stdlib


### PR DESCRIPTION
## Description

Added v4l-utils dependency for the snap version of checkbox

## Resolved issues

## Documentation

## Tests

Built the `checkbox22` and `checkbox24` snaps by following the [build guide](https://github.com/canonical/checkbox/tree/main/checkbox-core-snap) and installed them locally on machines running ubuntu 22 & 24 respectively. `v4l2-compliance` and `v4l2-ctl` commands exist inside `checkbox.shell` even though the host machine doesn't have it installed.
