### PR TITLE
Append to the submission log (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -710,7 +710,7 @@ class ReportsStage(CheckboxUiStage):
                                     url, path
                                 )
                             )
-                            f.writelines([url, "\n"])
+                            f.write(url + "\n")
                 except TransportError as exc:
                     _logger.warning(
                         _("Problem occured when submitting '%s' report: %s"),

--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -701,14 +701,16 @@ class ReportsStage(CheckboxUiStage):
                     result = result or {}
                     url = result.get("url") or result.get("status_url")
                     if url:
-                        path = self._get_submission_file_path(".c3_url.log")
-                        with open(path, "w+") as f:
+                        path = self._get_submission_file_path(
+                            ".submission.log"
+                        )
+                        with open(path, "a+") as f:
                             print(
-                                "Submission url ({}) saved also to: {}".format(
-                                    path, url
+                                "Submission url: {} (URL added to: {})".format(
+                                    url, path
                                 )
                             )
-                            f.write(url)
+                            f.writelines([url, "\n"])
                 except TransportError as exc:
                     _logger.warning(
                         _("Problem occured when submitting '%s' report: %s"),

--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -706,8 +706,8 @@ class ReportsStage(CheckboxUiStage):
                         )
                         with open(path, "a+") as f:
                             print(
-                                "Submission url: {} (URL added to: {})".format(
-                                    url, path
+                                "[{}]: {} (URL added to: {})".format(
+                                    params["transport"], url, path
                                 )
                             )
                             f.write(url + "\n")

--- a/checkbox-ng/checkbox_ng/launcher/test_stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_stages.py
@@ -107,7 +107,7 @@ class TestReportsStage(TestCase):
             self.assertEqual(
                 file_mock.write.call_args,
                 mock.call(
-                    "https://certification.canonical.com/submissions/status/EXAMPLE"
+                    "https://certification.canonical.com/submissions/status/EXAMPLE\n"
                 ),
             )
 
@@ -141,7 +141,7 @@ class TestReportsStage(TestCase):
             self.assertEqual(
                 file_mock.write.call_args,
                 mock.call(
-                    "https://certification.canonical.com/submissions/status/EXAMPLE"
+                    "https://certification.canonical.com/submissions/status/EXAMPLE\n"
                 ),
             )
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The submission url is part of more return values of just the C3 exporter. This was not intended intiially and makes it so the permanence on disk of the url depends on the order of exporters, which breaks the feature. Given this information though, this modifies the transport so that it appends to the log file and changes its name. This is a good idea because that way we can always to automatic manipulation of these files without having to wonder how they are called.

Namely, if a submission$NAME is created, to get the files that were generated as a part of that sumission one has to just consult the submission$NAME.submission.log file, which will contain all URIs, one per line. This is especially convenient if one happens to close the window after the submission is done.

This preserves the original intent to be able to recover the submission url from file without having to parse the checkbox-cli output.

## Resolved issues

N/A

## Documentation

N/A

## Tests

The feature was already tested
