### PR TITLE
Add cycler method for cycling change the resolution and transform (New)

### DIFF
--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -107,7 +107,7 @@ class MonitorConfigGnome(MonitorConfig):
 
     def cycle(
         self,
-        res: bool = True,
+        resolution: bool = True,
         transform: bool = False,
         resolution_filter: Callable[[List[Mode]], List[Mode]] = None,
         action: Callable[..., Any] = None,
@@ -117,7 +117,7 @@ class MonitorConfigGnome(MonitorConfig):
         Automatically cycle through the supported monitor configurations.
 
         Args:
-            res: Cycling the resolution or not.
+            resolution: Cycling the resolution or not.
 
             transform: Cycling the transform or not.
 
@@ -136,7 +136,7 @@ class MonitorConfigGnome(MonitorConfig):
         # ["normal": 0, "left": 1, "inverted": 6, "right": 3]
         trans_list = [0, 1, 6, 3] if transform else [0]
 
-        # for multiple monitors, we need to create res combination
+        # for multiple monitors, we need to create resolution combination
         state = self._get_current_state()
         for monitor, modes in state[1].items():
             monitors.append(monitor)
@@ -178,7 +178,7 @@ class MonitorConfigGnome(MonitorConfig):
                 self._apply_monitors_config(state[0], logical_monitors)
                 if action:
                     action(uni_string, **kwargs)
-            if not res:
+            if not resolution:
                 break
         # change back to preferred monitor configuration
         self.set_extended_mode()

--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -110,7 +110,7 @@ class MonitorConfigGnome(MonitorConfig):
         self,
         res: bool = True,
         max_res_amount: int = 5,
-        trans: bool = False,
+        transform: bool = False,
         log: Callable[..., Any] = None,
         action: Callable[..., Any] = None,
         **kwargs
@@ -124,7 +124,7 @@ class MonitorConfigGnome(MonitorConfig):
             max_res_amount: Limit the number of tested configurations
                 to avoid an unnecessarily large test matrix.
 
-            trans: Cycling the transform or not.
+            transform: Cycling the transform or not.
 
             log: For logging, the string is constructed by
                  [monitor name]_[resolution]_[transform]_.
@@ -138,7 +138,7 @@ class MonitorConfigGnome(MonitorConfig):
         monitors = []
         modes_list = []
         # ["normal": 0, "left": 1, "inverted": 6, "right": 3]
-        trans_list = [0, 1, 6, 3] if trans else [0]
+        trans_list = [0, 1, 6, 3] if transform else [0]
 
         # for multiple monitors, we need to create res combination
         state = self._get_current_state()
@@ -151,10 +151,8 @@ class MonitorConfigGnome(MonitorConfig):
             for trans in trans_list:
                 logical_monitors = []
                 position_x = 0
-                m_list = list(mode)
                 uni_string = ""
-                for monitor in monitors:
-                    m = m_list.pop(0)
+                for monitor, m in zip(monitors, mode):
                     uni_string += "{}_{}_{}_".format(
                         monitor,
                         m.resolution,

--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -87,9 +87,7 @@ class MonitorConfigGnome(MonitorConfig):
         position_x = 0
         for monitor, modes in state[1].items():
             try:
-                target_mode = next(
-                    mode for mode in modes if mode.is_preferred
-                )
+                target_mode = next(mode for mode in modes if mode.is_preferred)
             except StopIteration:
                 target_mode = self._get_mode_at_max(modes)
             extended_logical_monitors.append(
@@ -113,8 +111,8 @@ class MonitorConfigGnome(MonitorConfig):
         res: bool = True,
         max_res_amount: int = 5,
         trans: bool = False,
-        log: Callable[str, Any] = None,
-        action: Callable[str, Any] = None,
+        log: Callable[[str, ...], Any] = None,
+        action: Callable[[str, ...], Any] = None,
         **kwargs
     ):
         """

--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -106,7 +106,7 @@ class MonitorConfigGnome(MonitorConfig):
         self._apply_monitors_config(state[0], extended_logical_monitors)
         return configuration
 
-    def cycler(
+    def cycle(
         self,
         res: bool = True,
         max_res_amount: int = 5,
@@ -116,13 +116,13 @@ class MonitorConfigGnome(MonitorConfig):
         **kwargs
     ):
         """
-        Cycling change the monitors configurations automatically
+        Automatically cycle through the supported monitor configurations.
 
         Args:
             res: Cycling the resolution or not.
 
-            max_res_amount: The supported resolution might be a lot
-                            and this could limited test amount.
+            max_res_amount: Limit the number of tested configurations
+                to avoid an unnecessarily large test matrix.
 
             trans: Cycling the transform or not.
 

--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -109,7 +109,7 @@ class MonitorConfigGnome(MonitorConfig):
         self,
         res: bool = True,
         transform: bool = False,
-        resolution_filter: Callable[List[Mode], List[Mode]] = None,
+        resolution_filter: Callable[[List[Mode]], List[Mode]] = None,
         action: Callable[..., Any] = None,
         **kwargs
     ):

--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -111,8 +111,8 @@ class MonitorConfigGnome(MonitorConfig):
         res: bool = True,
         max_res_amount: int = 5,
         trans: bool = False,
-        log: Callable[[str, ...], Any] = None,
-        action: Callable[[str, ...], Any] = None,
+        log: Callable[..., Any] = None,
+        action: Callable[..., Any] = None,
         **kwargs
     ):
         """

--- a/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
@@ -320,7 +320,7 @@ class MonitorConfigGnomeTests(unittest.TestCase):
     def test_cycle_no_cycling(self, mock_dbus_proxy):
         """
         Test the cycle could get the right monitors configuration
-        (without res and trans change) and send to ApplyMonitorsConfig.
+        (without res and transform change) and send to ApplyMonitorsConfig.
         """
 
         mock_proxy = Mock()
@@ -379,7 +379,7 @@ class MonitorConfigGnomeTests(unittest.TestCase):
         # mock callback
         mock_callback = MagicMock()
         gnome_monitor.cycle(
-            res=False, trans=False, log=mock_callback, action=mock_callback
+            res=False, transform=False, log=mock_callback, action=mock_callback
         )
 
         logical_monitors = [

--- a/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
@@ -382,7 +382,7 @@ class MonitorConfigGnomeTests(unittest.TestCase):
         gnome_monitor.cycle(
             res=False,
             transform=False,
-            log=mock_callback,
+            resoultion_filter=mock_callback,
             action=mock_callback,
         )
 

--- a/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
@@ -380,7 +380,10 @@ class MonitorConfigGnomeTests(unittest.TestCase):
         # mock callback
         mock_callback = MagicMock()
         gnome_monitor.cycle(
-            res=False, transform=False, log=mock_callback, action=mock_callback
+            res=False,
+            transform=False,
+            log=mock_callback,
+            action=mock_callback,
         )
 
         logical_monitors = [
@@ -406,5 +409,7 @@ class MonitorConfigGnomeTests(unittest.TestCase):
             cancellable=None,
         )
         argument_string = mock_callback.call_args[0][0]
-        pattern = re.compile("HDMI-1_2560x1440_normal_eDP-1_1920x1200_normal_|eDP-1_1920x1200_normal_HDMI-1_2560x1440_normal_")
+        p1 = "HDMI-1_2560x1440_normal_"
+        p2 = "eDP-1_1920x1200_normal_"
+        pattern = re.compile("{}{}|{}{}".format(p1, p2, p2, p1))
         assert pattern.match(argument_string)

--- a/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import unittest
 from unittest.mock import patch, Mock, MagicMock
@@ -404,6 +405,6 @@ class MonitorConfigGnomeTests(unittest.TestCase):
             timeout_msec=-1,
             cancellable=None,
         )
-        mock_callback.assert_called_with(
-            "HDMI-1_2560x1440_normal_eDP-1_1920x1200_normal_"
-        )
+        argument_string = mock_callback.call_args[0][0]
+        pattern = re.compile("HDMI-1_2560x1440_normal_eDP-1_1920x1200_normal_|eDP-1_1920x1200_normal_HDMI-1_2560x1440_normal_")
+        assert pattern.match(argument_string)

--- a/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
@@ -380,7 +380,7 @@ class MonitorConfigGnomeTests(unittest.TestCase):
         # mock callback
         mock_callback = MagicMock()
         gnome_monitor.cycle(
-            res=False,
+            resolution=False,
             transform=False,
             resoultion_filter=mock_callback,
             action=mock_callback,

--- a/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
@@ -232,9 +232,9 @@ class MonitorConfigGnomeTests(unittest.TestCase):
         self.assertDictEqual(configuration, expected)
 
     @patch("checkbox_support.dbus.gnome_monitor.Gio.DBusProxy")
-    def test_cycler(self, mock_dbus_proxy):
+    def test_cycle(self, mock_dbus_proxy):
         """
-        Test the cycler could get the right monitors configuration
+        Test the cycle could get the right monitors configuration
         and send to ApplyMonitorsConfig.
         """
 
@@ -291,7 +291,7 @@ class MonitorConfigGnomeTests(unittest.TestCase):
             [],
             {},
         )
-        gnome_monitor.cycler()
+        gnome_monitor.cycle()
 
         logical_monitors = [
             (0, 0, 1.0, 0, True, [("eDP-1", "1920x1200@59.950", {})]),
@@ -317,9 +317,9 @@ class MonitorConfigGnomeTests(unittest.TestCase):
         )
 
     @patch("checkbox_support.dbus.gnome_monitor.Gio.DBusProxy")
-    def test_cycler_no_cycling(self, mock_dbus_proxy):
+    def test_cycle_no_cycling(self, mock_dbus_proxy):
         """
-        Test the cycler could get the right monitors configuration
+        Test the cycle could get the right monitors configuration
         (without res and trans change) and send to ApplyMonitorsConfig.
         """
 
@@ -378,7 +378,7 @@ class MonitorConfigGnomeTests(unittest.TestCase):
         )
         # mock callback
         mock_callback = MagicMock()
-        gnome_monitor.cycler(
+        gnome_monitor.cycle(
             res=False, trans=False, log=mock_callback, action=mock_callback
         )
 

--- a/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
@@ -405,5 +405,5 @@ class MonitorConfigGnomeTests(unittest.TestCase):
             cancellable=None,
         )
         mock_callback.assert_called_with(
-            "eDP-1_1920x1200_normal_HDMI-1_2560x1440_normal_"
+            "HDMI-1_2560x1440_normal_eDP-1_1920x1200_normal_"
         )

--- a/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
@@ -315,3 +315,95 @@ class MonitorConfigGnomeTests(unittest.TestCase):
             timeout_msec=-1,
             cancellable=None,
         )
+
+    @patch("checkbox_support.dbus.gnome_monitor.Gio.DBusProxy")
+    def test_cycler_no_cycling(self, mock_dbus_proxy):
+        """
+        Test the cycler could get the right monitors configuration
+        (without res and trans change) and send to ApplyMonitorsConfig.
+        """
+
+        mock_proxy = Mock()
+        mock_dbus_proxy.new_for_bus_sync.return_value = mock_proxy
+
+        gnome_monitor = MonitorConfigGnome()
+        mock_proxy.call_sync.return_value = (
+            1,
+            [
+                (
+                    ("eDP-1", "LGD", "0x06b3", "0x00000000"),
+                    [
+                        (
+                            "1920x1200@59.950",
+                            1920,
+                            1200,
+                            59.950172424316406,
+                            1.0,
+                            [1.0, 2.0],
+                            {
+                                "is-current": GLib.Variant("b", True),
+                                "is-preferred": GLib.Variant("b", True),
+                            },
+                        )
+                    ],
+                    {
+                        "is-builtin": GLib.Variant("b", True),
+                        "display-name": GLib.Variant("s", "Built-in display"),
+                    },
+                ),
+                (
+                    ("HDMI-1", "LGD", "0x06b3", "0x00000000"),
+                    [
+                        (
+                            "2560x1440@59.950",
+                            2560,
+                            1440,
+                            59.950172424316406,
+                            1.0,
+                            [1.0, 2.0],
+                            {
+                                "is-current": GLib.Variant("b", True),
+                                "is-preferred": GLib.Variant("b", True),
+                            },
+                        )
+                    ],
+                    {
+                        "is-builtin": GLib.Variant("b", False),
+                        "display-name": GLib.Variant("s", "External Display"),
+                    },
+                ),
+            ],
+            [],
+            {},
+        )
+        # mock callback
+        mock_callback = MagicMock()
+        gnome_monitor.cycler(
+            res=False, trans=False, log=mock_callback, action=mock_callback
+        )
+
+        logical_monitors = [
+            (0, 0, 1.0, 0, True, [("eDP-1", "1920x1200@59.950", {})]),
+            (1920, 0, 1.0, 0, False, [("HDMI-1", "2560x1440@59.950", {})]),
+        ]
+
+        expected_logical_monitors = GLib.Variant(
+            "(uua(iiduba(ssa{sv}))a{sv})",
+            (
+                1,
+                1,
+                logical_monitors,
+                {},
+            ),
+        )
+
+        mock_proxy.call_sync.assert_called_with(
+            method_name="ApplyMonitorsConfig",
+            parameters=expected_logical_monitors,
+            flags=Gio.DBusCallFlags.NONE,
+            timeout_msec=-1,
+            cancellable=None,
+        )
+        mock_callback.assert_called_with(
+            "eDP-1_1920x1200_normal_HDMI-1_2560x1440_normal_"
+        )


### PR DESCRIPTION


<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
According to the #855 , parsing the output from gnome_randr is not acceptable. Therefore, add cycler method for cycling change the resolution and transform to instead of modifying the old gnome_randr_cycle.py.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
[The private bug](https://bugs.launchpad.net/civet-cat/+bug/2036172)

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
