### PR TITLE
Add LXD GPU passthrough tests (New)

### DIFF
--- a/.github/workflows/tox-provider-gpgpu.yaml
+++ b/.github/workflows/tox-provider-gpgpu.yaml
@@ -47,6 +47,10 @@ jobs:
           python-version: ${{ matrix.python }}
         env:
           PIP_TRUSTED_HOST: pypi.python.org pypi.org files.pythonhosted.org
+      - name: Install libsystemd-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsystemd-dev
       - name: Install tox
         run: pip install tox
       - name: Run tox

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -74,8 +74,10 @@ GPU_VENDORS = {
                 "security.secureboot=false",
             ],
             "config_cmds": [
+                "apt-get -q update",
+                "apt-get -q upgrade",
                 "apt-get -q install -y ubuntu-drivers-common",
-                "ubuntu-drivers install",
+                "ubuntu-drivers install --gpgpu",
             ],
         },
     },

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -328,7 +328,7 @@ def test_lxd_gpu(args):
         logging.info("Passing GPU %s through to %s", args.pci, instance.name)
         instance.add_device("gpu", "gpu", options=["pci={}".format(args.pci)])
 
-        logging.info("Waiting for system to be up")
+        logging.info("Waiting for %s to be up", instance.name)
         run_with_retry(
             instance.run,
             5,
@@ -361,7 +361,7 @@ def test_lxdvm_gpu(args):
             options=GPU_VENDORS[args.vendor]["lxdvm"].get("launch_options")
         )
 
-        logging.info("Waiting for system to be up")
+        logging.info("Waiting for %s to be up", instance.name)
         run_with_retry(
             instance.run,
             5,
@@ -373,12 +373,23 @@ def test_lxdvm_gpu(args):
         logging.info("Passing GPU %s through to %s", args.pci, instance.name)
         instance.add_device("gpu", "gpu", ["pci={}".format(args.pci)])
 
-        logging.info("Configuring instance")
+        logging.info("Waiting for %s to be up", instance.name)
+        run_with_retry(
+            instance.run,
+            5,
+            5,
+            "systemctl is-system-running --wait",
+            on_guest=True,
+        )
+
+        logging.info("Configuring %s", instance.name)
         for cmd in GPU_VENDORS[args.vendor]["lxdvm"].get("config_cmds", []):
             instance.run(cmd, on_guest=True)
+
+        logging.info("Restarting %s", instance.name)
         instance.restart()
 
-        logging.info("Waiting for system to be up")
+        logging.info("Waiting for %s to be up", instance.name)
         run_with_retry(
             instance.run,
             5,

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -206,7 +206,7 @@ class LXD:
         )
         self.run("lxc delete --force {}".format(self.name), ignore_errors=True)
 
-    def launch(self, options: Optional[List] = None):
+    def launch(self, options: Optional[List[str]] = None):
         """Sets up and creates the instance."""
         cmd = ["lxc", "launch", self.image_alias.hex, self.name]
         if options:
@@ -229,7 +229,10 @@ class LXD:
         self.run("lxc restart {}".format(self.name))
 
     def add_device(
-        self, device: str, device_type: str, options: Optional[List] = None
+        self,
+        device: str,
+        device_type: str,
+        options: Optional[List[str]] = None,
     ):
         """Adds a device to the LXD instance."""
         if not options:
@@ -260,7 +263,7 @@ class LXDVM(LXD):
                 )
             )
 
-    def launch(self, options: Optional[List] = None):
+    def launch(self, options: Optional[List[str]] = None):
         logging.debug("Initializing virtual machine")
         cmd = ["lxc", "init"]
         if not self.image and not self.template:

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -319,12 +319,10 @@ def test_lxd_gpu(args):
         logging.info("Waiting for network to be up")
         time.sleep(20)
 
-        instance.run("sudo snap install mixbench", on_guest=True)
+        instance.run("snap install mixbench", on_guest=True)
         # XXX: Connecting manually until request is granted
         # https://forum.snapcraft.io/t/autoconnect-request-for-mixbench/43881
-        instance.run(
-            "sudo snap connect mixbench:hardware-observe", on_guest=True
-        )
+        instance.run("snap connect mixbench:hardware-observe", on_guest=True)
 
         run_gpu_test(
             instance,
@@ -357,12 +355,10 @@ def test_lxdvm_gpu(args):
         logging.info("Waiting for network to be up")
         time.sleep(20)
 
-        instance.run("sudo snap install mixbench", on_guest=True)
+        instance.run("snap install mixbench", on_guest=True)
         # XXX: Connecting manually until request is granted
         # https://forum.snapcraft.io/t/autoconnect-request-for-mixbench/43881
-        instance.run(
-            "sudo snap connect mixbench:hardware-observe", on_guest=True
-        )
+        instance.run("snap connect mixbench:hardware-observe", on_guest=True)
 
         run_gpu_test(
             instance,

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -232,6 +232,13 @@ class LXD:
             )
         )
 
+    def __enter__(self):
+        self.init_lxd()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self.cleanup()
+
 
 class LXDVM(LXD):
     """This class represents a LXD VM instance."""
@@ -301,7 +308,7 @@ def test_lxd_gpu(args):
     logging.info("Executing LXD GPU passthrough test")
 
     instance = LXD(args.template, args.rootfs)
-    try:
+    with LXD(args.template, args.rootfs) as instance:
         instance.init_lxd()
         options = []
         if args.vendor == "nvidia":
@@ -319,16 +326,13 @@ def test_lxd_gpu(args):
         )
 
         run_gpu_test(instance, args.count, args.threshold)
-    finally:
-        instance.cleanup()
 
 
 def test_lxdvm_gpu(args):
     """Tests GPU passthrough with a LXD virtual machine."""
     logging.info("Executing LXD VM GPU passthrough test")
 
-    instance = LXDVM(args.template, args.image)
-    try:
+    with LXDVM(args.template, args.image) as instance:
         instance.init_lxd()
         instance.launch(
             options=["-d root,size=50GB", "-c security.secureboot=false"]
@@ -357,8 +361,6 @@ def test_lxdvm_gpu(args):
         )
 
         run_gpu_test(instance, args.count, args.threshold)
-    finally:
-        instance.cleanup()
 
 
 def parse_args():

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -206,10 +206,8 @@ class LXD:
 
     def init_lxd(self):
         """Initializes LXD."""
-        if self.run("lxd waitready --timeout=5").returncode == 0:
-            return
-        self.run("lxd init --auto", check=True)
-
+        if self.run("lxd waitready --timeout=5").returncode != 0:
+            self.run("lxd init --auto", check=True)
         self.insert_images()
 
     def cleanup(self):
@@ -222,7 +220,7 @@ class LXD:
         if not options:
             options = []
 
-        cmd = "lxc launch {} {}".format(self.image_alias, self.name)
+        cmd = "lxc launch {} {}".format(self.image_alias.hex, self.name)
         if options:
             cmd = "{} {}".format(cmd, " ".join(options))
         self.run(cmd, check=True)

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -310,7 +310,6 @@ def test_lxd_gpu(args):
 
     instance = LXD(args.template, args.rootfs)
     with LXD(args.template, args.rootfs) as instance:
-        instance.init_lxd()
         instance.launch(
             options=GPU_VENDORS[args.vendor]["lxd"].get("launch_options")
         )
@@ -337,7 +336,6 @@ def test_lxdvm_gpu(args):
     logging.info("Executing LXD VM GPU passthrough test")
 
     with LXDVM(args.template, args.image) as instance:
-        instance.init_lxd()
         instance.launch(
             options=GPU_VENDORS[args.vendor]["lxdvm"].get("launch_options")
         )

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -75,7 +75,7 @@ GPU_VENDORS = {
                 repo_line="{} /".format(NVIDIA_URL),
                 gpg_url="{}/3bf863cc.pub".format(NVIDIA_URL),
                 gpg_fingerprint="EB693B3035CD5710E231E123A4B469963BF863CC",
-                pinfile="{}/cuda-{}.pin".format(
+                pinfile="{}/cuda-ubuntu{}.pin".format(
                     NVIDIA_URL, RELEASE.replace(".", "")
                 ),
             )

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -72,7 +72,18 @@ GPU_VENDORS = {
     },
 }
 GPU_RUNS = 20
+"""How many times to run the GPU test.
+
+This can be overwritten by the `--count` option or by setting the environment
+variable `LXD_GPU_RUNS`. With priority in that order.
+"""
+
 GPU_THRESHOLD_SEC = 12.0  # TODO: finetune
+"""The threshold for the GPU test to pass.
+
+This can be overwritten by the `--threshold` option or by setting the
+environment variable `LXD_GPU_THRESHOLD`. With priority in that order.
+"""
 
 
 class LXD:

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -90,7 +90,7 @@ This can be overwritten by the `--count` option or by setting the environment
 variable `LXD_GPU_RUNS`. With priority in that order.
 """
 
-GPU_THRESHOLD_SEC = 12.0  # TODO: finetune
+GPU_THRESHOLD_SEC = 12.0
 """The threshold for the GPU test to pass.
 
 This can be overwritten by the `--threshold` option or by setting the

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -85,14 +85,14 @@ class LXD:
         name: str = "testbed",
         remote: str = "ubuntu:",
     ):
-        self.template_url: Optional[str] = template_url
-        self.image_url: Optional[str] = image_url
-        self.name: str = name
-        self.remote: str = remote
-        self.image_alias: uuid.UUID = uuid.uuid4()
+        self.template_url = template_url
+        self.image_url = image_url
+        self.name = name
+        self.remote = remote
+        self.image_alias = uuid.uuid4()
 
-        self._template: Optional[str] = None
-        self._image: Optional[str] = None
+        self._template = None
+        self._image = None
 
     @property
     def template(self) -> Optional[str]:

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -222,7 +222,7 @@ class LXD:
         if not options:
             options = []
 
-        cmd = "lxc launch {} {}".format(self.image, self.name)
+        cmd = "lxc launch {} {}".format(self.image_alias, self.name)
         if options:
             cmd = "{} {}".format(cmd, " ".join(options))
         self.run(cmd, check=True)

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -211,7 +211,7 @@ class LXD:
         cmd = ["lxc", "launch", self.image_alias.hex, self.name]
         if options:
             cmd += options
-        self.run(shlex.join(cmd))
+        self.run(" ".join(cmd))
 
     def stop(self, force: bool = False):
         """Stops LXD instance."""
@@ -274,7 +274,7 @@ class LXDVM(LXD):
         cmd += [self.name, "--vm"]
         if options:
             cmd += options
-        self.run(shlex.join(cmd))
+        self.run(" ".join(cmd))
 
         logging.debug("Starting virtual machine")
         self.run("lxc start {}".format(self.name))

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -315,7 +315,8 @@ def test_lxd_gpu(args):
         time.sleep(20)
 
         instance.run("sudo snap install mixbench", on_guest=True)
-        # XXX: https://forum.snapcraft.io/t/autoconnect-request-for-mixbench/43881
+        # XXX: Connecting manually until request is granted
+        # https://forum.snapcraft.io/t/autoconnect-request-for-mixbench/43881
         instance.run(
             "sudo snap connect mixbench:hardware-observe", on_guest=True
         )
@@ -352,7 +353,8 @@ def test_lxdvm_gpu(args):
         time.sleep(20)
 
         instance.run("sudo snap install mixbench", on_guest=True)
-        # XXX: https://forum.snapcraft.io/t/autoconnect-request-for-mixbench/43881
+        # XXX: Connecting manually until request is granted
+        # https://forum.snapcraft.io/t/autoconnect-request-for-mixbench/43881
         instance.run(
             "sudo snap connect mixbench:hardware-observe", on_guest=True
         )

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -148,8 +148,8 @@ class LXD:
                 universal_newlines=True,
             )
         except subprocess.CalledProcessError as e:
-            logging.debug("Command failed: %s", cmd)
-            logging.debug(" STDOUT: %s", e.stdout)
+            logging.error("Command failed: %s", cmd)
+            logging.info(" STDOUT: %s", e.stdout)
             if not ignore_errors:
                 raise
 
@@ -348,7 +348,7 @@ def test_lxdvm_gpu(args):
         # Add and configure GPU device
         instance.add_device("gpu", "gpu", ["pci={}".format(args.pci)])
         for cmd in GPU_VENDORS[args.vendor]["lxdvm"].get("config_cmds", []):
-            logging.debug("Configuring instance")
+            logging.info("Configuring instance")
             instance.run(cmd, on_guest=True)
         instance.restart()
 

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -64,10 +64,8 @@ class Repository:
     pinfile: Optional[str] = None
 
 
-NVIDIA_URL = (
-    "https://developer.download.nvidia.com/compute/cuda/repos/{}/{}".format(
-        RELEASE.replace(".", ""), ARCH
-    )
+NVIDIA_URL = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu{}/{}".format(
+    RELEASE.replace(".", ""), ARCH
 )
 GPU_VENDORS = {
     "nvidia": {

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -324,6 +324,8 @@ def test_lxd_gpu(args):
         instance.launch(
             options=GPU_VENDORS[args.vendor]["lxd"].get("launch_options")
         )
+
+        logging.info("Passing GPU %s through to %s", args.pci, instance.name)
         instance.add_device("gpu", "gpu", options=["pci={}".format(args.pci)])
 
         logging.info("Waiting for system to be up")
@@ -363,15 +365,16 @@ def test_lxdvm_gpu(args):
         run_with_retry(
             instance.run,
             5,
-            2,
+            5,
             "systemctl is-system-running --wait",
             on_guest=True,
         )
 
-        # Add and configure GPU device
+        logging.info("Passing GPU %s through to %s", args.pci, instance.name)
         instance.add_device("gpu", "gpu", ["pci={}".format(args.pci)])
+
+        logging.info("Configuring instance")
         for cmd in GPU_VENDORS[args.vendor]["lxdvm"].get("config_cmds", []):
-            logging.info("Configuring instance")
             instance.run(cmd, on_guest=True)
         instance.restart()
 
@@ -379,7 +382,7 @@ def test_lxdvm_gpu(args):
         run_with_retry(
             instance.run,
             5,
-            2,
+            5,
             "systemctl is-system-running --wait",
             on_guest=True,
         )

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -58,7 +58,14 @@ ARCH = os.uname().machine
 GPU_VENDORS = {
     "nvidia": {
         "test": "mixbench.cuda",
-        "lxd": {"launch_options": ["-c", "nvidia.runtime=true"]},
+        "lxd": {
+            "launch_options": [
+                "-c",
+                "nvidia.runtime=true",
+                "-c",
+                "nvidia.driver.capabilities=all",
+            ]
+        },
         "lxdvm": {
             "launch_options": [
                 "-d",

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -58,9 +58,14 @@ ARCH = os.uname().machine
 GPU_VENDORS = {
     "nvidia": {
         "test": "mixbench.cuda",
-        "lxd": {"launch_options": ["-c nvidia.runtime=true"]},
+        "lxd": {"launch_options": ["-c", "nvidia.runtime=true"]},
         "lxdvm": {
-            "launch_options": [],
+            "launch_options": [
+                "-d",
+                "root,size=50GB",
+                "-c",
+                "security.secureboot=false",
+            ],
             "config_cmds": [
                 "apt-get -q install -y ubuntu-drivers-common",
                 "ubuntu-drivers install",

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -245,10 +245,7 @@ class LXDVM(LXD):
                 )
             )
 
-    def launch(self, options=None):
-        if not options:
-            options = []
-
+    def launch(self, options: Optional[List] = None):
         logging.debug("Initializing virtual machine")
         cmd = ["lxc", "init"]
         if not self.image and not self.template:

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -505,65 +505,74 @@ def test_lxdvm_gpu(args):
 
 def parse_args():
     """Parses command-line arguments."""
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="GPU passthrough tests")
+    subparsers = parser.add_subparsers()
+
     parser.add_argument(
         "-v",
         "--verbose",
+        dest="log_level",
         action="store_const",
         default=logging.INFO,
         const=logging.DEBUG,
         help="Increase logging level",
     )
-    parser.add_argument("--pci", type=str, help="PCI address of GPU")
-    parser.add_argument(
+
+    test_group = parser.add_argument_group("test")
+    test_group.add_argument(
         "--threshold",
         type=float,
         default=float(os.getenv("LXD_GPU_THRESHOLD") or GPU_THRESHOLD_SEC),
         help="Threshold (sec) for GPU test",
     )
-    parser.add_argument(
+    test_group.add_argument(
         "--count",
         type=int,
         default=int(os.getenv("LXD_GPU_RUNS") or GPU_RUNS),
         help="Times to run GPU test",
     )
-    parser.add_argument(
+
+    gpu_group = parser.add_argument_group("gpu")
+    gpu_group.add_argument(
+        "--pci", type=str, help="PCI address of GPU", required=True
+    )
+    gpu_group.add_argument(
         "--vendor",
         type=str,
         choices=GPU_VENDORS.keys(),
-        default="nvidia",
         help="GPU vendor",
+        required=True,
     )
 
-    lxd_group = parser.add_argument_group("lxd")
-    lxd_group.add_argument(
+    lxd_subparser = subparsers.add_parser("lxd", help="Run on LXD container")
+    lxd_subparser.add_argument(
         "--template",
         type=str,
         default=os.getenv("LXD_TEMPLATE"),
         help="URL to template",
     )
-    lxd_group.add_argument(
+    lxd_subparser.add_argument(
         "--rootfs",
         type=str,
         default=os.getenv("LXD_ROOTFS"),
         help="URL to rootfs image",
     )
-    lxd_group.set_defaults(func=test_lxd_gpu)
+    lxd_subparser.set_defaults(func=test_lxd_gpu)
 
-    lxdvm_group = parser.add_argument_group("lxdvm")
-    lxdvm_group.add_argument(
+    lxdvm_subparser = subparsers.add_parser("lxdvm", help="Run on LXD VM")
+    lxdvm_subparser.add_argument(
         "--template",
         type=str,
         default=os.getenv("LXD_TEMPLATE"),
         help="URL to template",
     )
-    lxdvm_group.add_argument(
+    lxdvm_subparser.add_argument(
         "--image",
         type=str,
         default=os.getenv("KVM_IMAGE"),
         help="URL to image",
     )
-    lxd_group.set_defaults(func=test_lxdvm_gpu)
+    lxdvm_subparser.set_defaults(func=test_lxdvm_gpu)
 
     return parser.parse_args()
 

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -30,7 +30,7 @@ import uuid
 from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
-from checkbox_support.helpers.retry import run_with_retry
+from checkbox_support.helpers.retry import retry, run_with_retry
 from plainbox.impl.decorators import cached_property
 
 try:
@@ -152,21 +152,13 @@ class LXD:
             if not ignore_errors:
                 raise
 
+    @retry(5, 2)
     def download_image(self, url, filename):
         """Downloads LXD files for same release as host machine."""
+        if os.path.isfile(filename):
+            return
         logging.debug("Attempting download of %s from %s", filename, url)
-        try:
-            urllib.request.urlretrieve(url, filename)
-        except (
-            IOError,
-            OSError,
-            urllib.error.HTTPError,
-            urllib.error.URLError,
-        ) as e:
-            logging.exception(e)
-        except ValueError as verr:
-            logging.exception(verr)
-
+        urllib.request.urlretrieve(url, filename)
         if not os.path.isfile(filename):
             raise FileNotFoundError(filename)
 

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -442,16 +442,13 @@ def test_lxd_gpu(args):
     instance = LXD(args.template, args.rootfs)
     try:
         instance.init_lxd()
-        instance.launch()
+        options = []
+        if args.vendor == "nvidia":
+            options = ["-c nvidia.runtime=true"]
+        instance.launch(options=options)
 
         # Add and configure GPU device
         instance.add_device("gpu", "gpu", options=["pci={}".format(args.pci)])
-        if args.vendor == "nvidia":
-            logging.info("Passing NVIDIA runtime through to instance")
-            instance.run(
-                "lxc config set {} nvidia.runtime=true".format(instance.name),
-                check=True,
-            )
 
         logging.info("Waiting for network to be up")
         time.sleep(20)

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -113,9 +113,6 @@ class LXD:
         self.remote = remote
         self.image_alias = uuid.uuid4()
 
-        self._template = None
-        self._image = None
-
     @cached_property
     def template(self) -> Optional[str]:
         """Gets path to template tarball."""

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -67,12 +67,7 @@ GPU_VENDORS = {
             ]
         },
         "lxdvm": {
-            "launch_options": [
-                "-d",
-                "root,size=50GB",
-                "-c",
-                "security.secureboot=false",
-            ],
+            "launch_options": ["-c", "security.secureboot=false"],
             "config_cmds": [
                 "apt-get -q -U upgrade",
                 "apt-get -q install -y linux-generic ubuntu-drivers-common",

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -69,7 +69,8 @@ GPU_VENDORS = {
         "lxdvm": {
             "launch_options": ["-c", "security.secureboot=false"],
             "config_cmds": [
-                "apt-get -q -U upgrade",
+                "apt-get -q update -y",
+                "apt-get -q upgrade -y",
                 "apt-get -q install -y linux-generic ubuntu-drivers-common",
                 "ubuntu-drivers install --gpgpu",
             ],

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -270,7 +270,7 @@ class LXDVM(LXD):
             logging.debug("No local image, importing from remote")
             cmd += ["{}{}".format(self.remote, RELEASE)]
         else:
-            cmd += [self.image]
+            cmd += [self.image_alias.hex]
         cmd += [self.name, "--vm"]
         if options:
             cmd += options

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -64,7 +64,7 @@ class Repository:
     pinfile: Optional[str] = None
 
 
-NVIDIA_URL = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu{}/{}".format(
+NVIDIA_URL = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu{}/{}".format(  # noqa: E501
     RELEASE.replace(".", ""), ARCH
 )
 GPU_VENDORS = {
@@ -446,8 +446,6 @@ def test_lxd_gpu(args):
         if args.vendor == "nvidia":
             options = ["-c nvidia.runtime=true"]
         instance.launch(options=options)
-
-        # Add and configure GPU device
         instance.add_device("gpu", "gpu", options=["pci={}".format(args.pci)])
 
         logging.info("Waiting for network to be up")

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -147,12 +147,14 @@ class LXD:
             cmd = "lxc exec {} -- {}".format(self.name, cmd)
         stderr_pipe = subprocess.STDOUT if log_stderr else subprocess.DEVNULL
         try:
-            _ = subprocess.check_output(
+            logging.debug("Command: %s", cmd)
+            out = subprocess.check_output(
                 shlex.split(cmd),
                 stderr=stderr_pipe,
                 stdin=subprocess.DEVNULL,
                 universal_newlines=True,
             )
+            logging.debug(" STDOUT: %s", out)
         except subprocess.CalledProcessError as e:
             logging.error("Command failed: %s", cmd)
             logging.info(" STDOUT: %s", e.stdout)

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -333,9 +333,6 @@ def test_lxd_gpu(args):
 
         logging.info("Installing mixbench snap")
         instance.run("snap install mixbench", on_guest=True)
-        # XXX: Connecting manually until request is granted
-        # https://forum.snapcraft.io/t/autoconnect-request-for-mixbench/43881
-        instance.run("snap connect mixbench:hardware-observe", on_guest=True)
 
         run_gpu_test(
             instance,
@@ -376,9 +373,6 @@ def test_lxdvm_gpu(args):
 
         logging.info("Installing mixbench snap")
         instance.run("snap install mixbench", on_guest=True)
-        # XXX: Connecting manually until request is granted
-        # https://forum.snapcraft.io/t/autoconnect-request-for-mixbench/43881
-        instance.run("snap connect mixbench:hardware-observe", on_guest=True)
 
         run_gpu_test(
             instance,

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+"""Script to test virtualization GPU passthrough functionality.
+
+Copyright (C) 2024 Canonical Ltd.
+
+Authors
+  Pedro Avalos Jimenez <pedro.avalosjimenez@canonical.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3,
+as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import argparse
+import logging
+import os
+import shlex
+import subprocess
+import time
+import urllib
+import uuid
+from dataclasses import dataclass
+from typing import List, Optional
+from urllib.parse import urlparse
+
+try:
+    import distro
+
+    if distro.id() == "ubuntu-core":
+        RELEASE = "{}.04".format(distro.version())
+        CODENAME = "focal"
+        if distro.version() == "18":
+            CODENAME = "bionic"
+        elif distro.version() == "16":
+            CODENAME = "xenial"
+    else:
+        RELEASE = distro.version()
+        CODENAME = distro.codename().split()[0].lower()
+except ImportError:
+    import lsb_release  # type: ignore
+
+    RELEASE = lsb_release.get_distro_information()["RELEASE"]
+    CODENAME = lsb_release.get_distro_information()["CODENAME"]
+
+ARCH = os.uname().machine
+
+
+@dataclass
+class Repository:
+    """Represents an apt repository."""
+
+    name: str
+    repo_line: str
+    gpg_url: str
+    gpg_fingerprint: str
+    pinfile: Optional[str] = None
+
+
+NVIDIA_URL = (
+    "https://developer.download.nvidia.com/compute/cuda/repos/{}/{}".format(
+        RELEASE.replace(".", ""), ARCH
+    )
+)
+GPU_VENDORS = {
+    "nvidia": {
+        "repos": [
+            Repository(
+                name="cuda",
+                repo_line="{} /".format(NVIDIA_URL),
+                gpg_url="{}/3bf863cc.pub".format(NVIDIA_URL),
+                gpg_fingerprint="EB693B3035CD5710E231E123A4B469963BF863CC",
+                pinfile="{}/cuda-{}.pin".format(
+                    NVIDIA_URL, RELEASE.replace(".", "")
+                ),
+            )
+        ],
+    },
+}
+GPU_RUNS = 20
+GPU_THRESHOLD_SEC = 12.0  # TODO: finetune
+
+
+class LXD:
+    """This class represents a LXD instance."""
+
+    def __init__(
+        self,
+        template_url: Optional[str] = None,
+        image_url: Optional[str] = None,
+        name: str = "testbed",
+        remote: str = "ubuntu:",
+    ):
+        self.template_url: Optional[str] = template_url
+        self.image_url: Optional[str] = image_url
+        self.name: str = name
+        self.remote: str = remote
+        self.image_alias: uuid.UUID = uuid.uuid4()
+
+        self._template: Optional[str] = None
+        self._image: Optional[str] = None
+
+    @property
+    def template(self) -> Optional[str]:
+        """Gets path to template tarball."""
+        if not self._template and self.template_url:
+            targetfile = urlparse(self.template_url).path.split("/")[-1]
+            filename = os.path.join("/tmp", targetfile)
+            if not os.path.isfile(filename):
+                self.download_image(self.template_url, filename)
+            self._template = filename
+
+        return self._template
+
+    @property
+    def image(self) -> Optional[str]:
+        """Gets path to image tarball."""
+        if not self._image and self.image_url:
+            targetfile = urlparse(self.image_url).path.split("/")[-1]
+            filename = os.path.join("/tmp", targetfile)
+            if not os.path.isfile(filename):
+                self.download_image(self.image_url, filename)
+            self._image = filename
+
+        return self._image
+
+    def run(
+        self,
+        cmd: str,
+        log_stderr: bool = True,
+        on_guest: bool = False,
+        check: bool = False,
+    ) -> subprocess.CompletedProcess:
+        """Runs a command on the host or instance."""
+        if on_guest:
+            cmd = "lxc exec {} -- {}".format(self.name, cmd)
+        proc = subprocess.run(
+            shlex.split(cmd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
+            universal_newlines=True,
+            check=False,
+        )
+
+        logging.debug("Command: %s", cmd)
+        if proc.stdout:
+            logging.debug(" STDOUT: %s", proc.stdout)
+        if log_stderr and proc.stderr:
+            logging.debug(" STDERR: %s", proc.stderr)
+
+        if check:
+            proc.check_returncode()
+
+        return proc
+
+    def download_image(self, url, filename):
+        """Downloads LXD files for same release as host machine."""
+        logging.debug("Attempting download of %s from %s", filename, url)
+        try:
+            urllib.request.urlretrieve(url, filename)
+        except (
+            IOError,
+            OSError,
+            urllib.error.HTTPError,
+            urllib.error.URLError,
+        ) as e:
+            logging.exception(e)
+        except ValueError as verr:
+            logging.exception(verr)
+
+        if not os.path.isfile(filename):
+            raise FileNotFoundError(filename)
+
+    def insert_images(self):
+        """Insert LXD template and image images."""
+        if self.template and self.image:
+            logging.debug("Importing images into LXD")
+            self.run(
+                "lxc image import {} rootfs {} --alias {}".format(
+                    self.template, self.image, self.image_alias.hex
+                ),
+                check=True,
+            )
+        else:
+            logging.debug("No local images, attempting import from remote")
+            retries = 2
+            for _ in range(retries):
+                proc = self.run(
+                    "lxc image copy {}{} local: --alias {}".format(
+                        self.remote, RELEASE, self.image_alias.hex
+                    )
+                )
+                if proc.returncode == 0:
+                    return
+                logging.error("Error encountered while importing images")
+                logging.error("Attempting up to %d times", retries)
+            raise RuntimeError("Images could not be inserted")
+
+    def init_lxd(self):
+        """Initializes LXD."""
+        if self.run("lxd waitready --timeout=5").returncode == 0:
+            return
+        self.run("lxd init --auto", check=True)
+
+        self.insert_images()
+
+    def cleanup(self):
+        """Cleans up instance."""
+        self.run("lxc image delete {}".format(self.image_alias.hex))
+        self.run("lxc delete {}".format(self.name))
+
+    def launch(self, options: Optional[List] = None):
+        """Sets up and creates the instance."""
+        if not options:
+            options = []
+
+        cmd = "lxc launch {} {}".format(self.image, self.name)
+        if options:
+            cmd = "{} {}".format(cmd, " ".join(options))
+        self.run(cmd, check=True)
+
+    def stop(self, force: bool = False):
+        """Stops LXD instance."""
+        cmd = "lxc stop {}".format(self.name)
+        if force:
+            cmd += " --force"
+        self.run(cmd, check=True)
+
+    def start(self):
+        """Starts LXD instance."""
+        self.run("lxc start {}".format(self.name), check=True)
+
+    def restart(self):
+        """Restarts LXD instance."""
+        self.run("lxc restart {}".format(self.name), check=True)
+
+    def add_device(
+        self, device: str, device_type: str, options: Optional[List] = None
+    ):
+        """Adds a device to the LXD instance."""
+        if not options:
+            options = []
+        self.run(
+            "lxc config device add {} {} {} {}".format(
+                self.name, device, device_type, " ".join(options)
+            ),
+            check=True,
+        )
+
+
+class LXDVM(LXD):
+    """This class represents a LXD VM instance."""
+
+    def insert_images(self):
+        if self.template and self.image:
+            logging.debug("Importing images into LXD")
+            self.run(
+                "lxc image import {} {} --alias {}".format(
+                    self.template, self.image, self.image_alias.hex
+                ),
+                check=True,
+            )
+
+    def launch(self, options=None):
+        if not options:
+            options = []
+
+        logging.debug("Initializing virtual machine")
+        if not self.image and not self.template:
+            logging.debug("No local image, importing from remote")
+            cmd = "lxc init {}{} {} --vm".format(
+                self.remote, RELEASE, self.name
+            )
+        else:
+            cmd = "lxc init {} {} --vm".format(self.image, self.name)
+        if options:
+            cmd = "{} {}".format(cmd, " ".join(options))
+        self.run(cmd, check=True)
+
+        logging.debug("Starting virtual machine")
+        self.run("lxc start {}".format(self.name), check=True)
+
+    def add_device(self, device: str, device_type: str, options=None):
+        # Hot plugging is only supported on containers
+        self.stop(force=True)
+        super().add_device(device, device_type, options)
+        self.start()
+
+
+# XXX: If we package the mixbench program, this wouldn't be needed
+def add_apt_repo(instance: LXD, repo: Repository):
+    """Adds an APT repository to a LXD instance."""
+    logging.debug("Downloading GPG key from %s", repo.gpg_url)
+    temp_keyring = "./tmp.gpg"
+    gpg_dest = "/usr/share/keyrings/{}.gpg".format(repo.name)
+    instance.run(
+        "wget -O {}.gpg '{}'".format(repo.name, repo.gpg_url),
+        on_guest=True,
+        check=True,
+    )
+    instance.run(
+        "gpg --no-default-keyring --keyring {} --import {}.gpg".format(
+            temp_keyring, repo.name
+        ),
+        on_guest=True,
+        check=True,
+    )
+    instance.run(
+        "gpg --no-default-keyring --keyring {} --fingerprint {}".format(
+            temp_keyring, repo.gpg_fingerprint
+        ),
+        on_guest=True,
+        check=True,
+    )
+    instance.run(
+        "gpg --yes --no-default-keyring --keyring {} --export -o {}".format(
+            temp_keyring, gpg_dest
+        ),
+        on_guest=True,
+        check=True,
+    )
+    instance.run(
+        "rm {0} {0}~ ./{1}.gpg".format(temp_keyring, repo.name),
+        on_guest=True,
+        check=True,
+    )
+
+    if repo.pinfile:
+        pinfile_dest = "/etc/apt/preferences.d/{}-pin-600".format(repo.name)
+        if repo.pinfile.startswith("http"):
+            logging.debug("Downloading pinfile")
+            cmd = "wget -O {} {}".format(pinfile_dest, repo.pinfile)
+        else:
+            logging.debug("Creating pinfile")
+            cmd = "bash -c \"echo -e '{}' | tee {}\"".format(
+                repo.pinfile, pinfile_dest
+            )
+        instance.run(cmd, on_guest=True, check=True)
+
+    logging.debug("Setting up APT repository: %s", repo.name)
+    repo_dest = "/etc/apt/sources.list.d/{}.list".format(repo.name)
+    list_file = "deb [signed-by={}] {}".format(gpg_dest, repo.repo_line)
+    instance.run(
+        "bash -c \"echo '{}' | tee {}\"".format(list_file, repo_dest),
+        on_guest=True,
+        check=True,
+    )
+
+    logging.debug("Updating APT cache")
+    instance.run("apt-get -q update", on_guest=True, check=True)
+
+
+# TODO: Package test program (e.g., as a snap) to simplify this logic
+#       If we package mixbench, then this function goes away entirely
+def build_gpu_test(instance: LXD, vendor: str):
+    """Builds the GPU passthrough test."""
+    test_name = ""
+    cmake_cmd = "cmake ../mixbench-{test_name}"
+
+    # Add necessary APT repositories to instance
+    for repo in GPU_VENDORS[vendor].get("repos", []):
+        add_apt_repo(instance, repo)
+
+    if vendor == "nvidia":
+        logging.debug("Installing CUDA Toolkit on instance")
+        packages = ["build-essential", "cmake", "cuda-toolkit"]
+        instance.run(
+            "apt-get -q install -y --no-install-recommends {}".format(
+                " ".join(packages)
+            ),
+            on_guest=True,
+            check=True,
+        )
+
+        logging.debug("Finding CUDA capability for GPU")
+        cuda_arch = "native"
+        proc = instance.run(
+            "nvidia-smi --query-gpu=compute_cap --format=csv,noheader",
+            on_guest=True,
+        )
+        if proc.returncode == 0 and proc.stdout:
+            cuda_arch = proc.stdout.strip().replace(".", "")
+        logging.debug("Using CUDA architecture '%s'", cuda_arch)
+
+        test_name = "cuda"
+        nvcc_path = "/usr/local/cuda/bin/nvcc"
+        cmake_cmd = "CUDACXX={} {} -DCMAKE_CUDA_ARCHITECTURES={}".format(
+            nvcc_path, cmake_cmd, cuda_arch
+        )
+
+    logging.info("Fetching and compiling GPU passthrough test on instance")
+    cmds = [
+        "set -e",
+        "git clone https://github.com/ekondis/mixbench.git",
+        "mkdir mixbench/build-{}".format(test_name),
+        "cd mixbench/build-{}".format(test_name),
+        cmake_cmd.format(test_name=test_name),
+        "make",
+        "ln -s ~/mixbench/build-{0}/mixbench-{0} ~/vgpu-test".format(
+            test_name
+        ),
+    ]
+    instance.run(
+        "bash -c '{}'".format("; ".join(cmds)), on_guest=True, check=True
+    )
+
+
+def run_gpu_test(
+    instance: LXD,
+    run_count: int = GPU_RUNS,
+    threshold_sec: float = GPU_THRESHOLD_SEC,
+):
+    """Executes GPU passthrough test."""
+    logging.info("Running GPU passthrough test %d times", run_count)
+    total_runtime_sec = 0.0
+    for i in range(run_count):
+        tic = time.time()
+        # XXX: If we package the test, this line needs to be updated
+        instance.run("./test", on_guest=True, check=True)
+        toc = time.time()
+        runtime_sec = toc - tic
+        total_runtime_sec += runtime_sec
+        logging.debug("Runtime #%d (sec): %f", i, runtime_sec)
+
+    avg_runtime_sec = total_runtime_sec / run_count
+    logging.info("Average runtime (sec): %f", avg_runtime_sec)
+    if avg_runtime_sec >= threshold_sec:
+        logging.error(
+            "Average runtime %fs greater than threshold %fs",
+            avg_runtime_sec,
+            threshold_sec,
+        )
+        raise SystemExit(1)
+
+
+def test_lxd_gpu(args):
+    """Tests GPU passthrough with a LXD container."""
+    logging.info("Executing LXD GPU passthrough test")
+
+    instance = LXD(args.template, args.rootfs)
+    try:
+        instance.init_lxd()
+        instance.launch()
+
+        # Add and configure GPU device
+        instance.add_device("gpu", "gpu", options=["pci={}".format(args.pci)])
+        if args.vendor == "nvidia":
+            logging.info("Passing NVIDIA runtime through to instance")
+            instance.run(
+                "lxc config set {} nvidia.runtime=true".format(instance.name),
+                check=True,
+            )
+
+        logging.info("Waiting for network to be up")
+        time.sleep(20)
+
+        build_gpu_test(instance, args.vendor)
+        run_gpu_test(instance, args.count, args.threshold)
+    finally:
+        instance.cleanup()
+
+
+def test_lxdvm_gpu(args):
+    """Tests GPU passthrough with a LXD virtual machine."""
+    logging.info("Executing LXD VM GPU passthrough test")
+
+    instance = LXDVM(args.template, args.image)
+    try:
+        instance.init_lxd()
+        instance.launch(
+            options=["-d root,size=50GB", "-c security.secureboot=false"]
+        )
+
+        logging.info("Waiting for network to be up")
+        time.sleep(20)
+
+        # Add and configure GPU device
+        instance.add_device("gpu", "gpu", ["pci={}".format(args.pci)])
+        if args.vendor == "nvidia":
+            logging.debug("Installing ubuntu-drivers tool")
+            instance.run(
+                "apt-get -q install -y ubuntu-drivers-common",
+                on_guest=True,
+                check=True,
+            )
+            instance.run("ubuntu-drivers install", on_guest=True, check=True)
+        instance.restart()
+
+        logging.info("Waiting for network to be up")
+        time.sleep(20)
+
+        build_gpu_test(instance, args.vendor)
+        run_gpu_test(instance, args.count, args.threshold)
+    finally:
+        instance.cleanup()
+
+
+def parse_args():
+    """Parses command-line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_const",
+        default=logging.INFO,
+        const=logging.DEBUG,
+        help="Increase logging level",
+    )
+    parser.add_argument("--pci", type=str, help="PCI address of GPU")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=float(os.getenv("LXD_GPU_THRESHOLD") or GPU_THRESHOLD_SEC),
+        help="Threshold (sec) for GPU test",
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=int(os.getenv("LXD_GPU_RUNS") or GPU_RUNS),
+        help="Times to run GPU test",
+    )
+    parser.add_argument(
+        "--vendor",
+        type=str,
+        choices=GPU_VENDORS.keys(),
+        default="nvidia",
+        help="GPU vendor",
+    )
+
+    lxd_group = parser.add_argument_group("lxd")
+    lxd_group.add_argument(
+        "--template",
+        type=str,
+        default=os.getenv("LXD_TEMPLATE"),
+        help="URL to template",
+    )
+    lxd_group.add_argument(
+        "--rootfs",
+        type=str,
+        default=os.getenv("LXD_ROOTFS"),
+        help="URL to rootfs image",
+    )
+    lxd_group.set_defaults(func=test_lxd_gpu)
+
+    lxdvm_group = parser.add_argument_group("lxdvm")
+    lxdvm_group.add_argument(
+        "--template",
+        type=str,
+        default=os.getenv("LXD_TEMPLATE"),
+        help="URL to template",
+    )
+    lxdvm_group.add_argument(
+        "--image",
+        type=str,
+        default=os.getenv("KVM_IMAGE"),
+        help="URL to image",
+    )
+    lxd_group.set_defaults(func=test_lxdvm_gpu)
+
+    return parser.parse_args()
+
+
+def main():
+    """Main entrypoint to the program."""
+    args = parse_args()
+
+    logging.basicConfig(level=args.log_level)
+    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -335,6 +335,7 @@ def test_lxd_gpu(args):
             on_guest=True,
         )
 
+        logging.info("Installing mixbench snap")
         instance.run("snap install mixbench", on_guest=True)
         # XXX: Connecting manually until request is granted
         # https://forum.snapcraft.io/t/autoconnect-request-for-mixbench/43881
@@ -383,6 +384,7 @@ def test_lxdvm_gpu(args):
             on_guest=True,
         )
 
+        logging.info("Installing mixbench snap")
         instance.run("snap install mixbench", on_guest=True)
         # XXX: Connecting manually until request is granted
         # https://forum.snapcraft.io/t/autoconnect-request-for-mixbench/43881

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -364,7 +364,7 @@ def test_lxdvm_gpu(args):
         instance.wait_until_running()
 
         logging.info("Passing GPU %s through to %s", args.pci, instance.name)
-        instance.add_device("gpu", "gpu", ["pci={}".format(args.pci)])
+        instance.add_device("gpu", "gpu", options=["pci={}".format(args.pci)])
 
         logging.info("Waiting for %s to be up", instance.name)
         instance.wait_until_running()

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -30,6 +30,8 @@ import uuid
 from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
+from plainbox.impl.decorators import cached_property
+
 try:
     import distro
 
@@ -105,29 +107,25 @@ class LXD:
         self._template = None
         self._image = None
 
-    @property
+    @cached_property
     def template(self) -> Optional[str]:
         """Gets path to template tarball."""
-        if not self._template and self.template_url:
-            targetfile = urlparse(self.template_url).path.split("/")[-1]
-            filename = os.path.join("/tmp", targetfile)
-            if not os.path.isfile(filename):
-                self.download_image(self.template_url, filename)
-            self._template = filename
+        if not self.template_url:
+            return None
+        targetfile = urlparse(self.template_url).path.split("/")[-1]
+        filename = os.path.join("/tmp", targetfile)
+        self.download_image(self.template_url, filename)
+        return filename
 
-        return self._template
-
-    @property
+    @cached_property
     def image(self) -> Optional[str]:
         """Gets path to image tarball."""
-        if not self._image and self.image_url:
-            targetfile = urlparse(self.image_url).path.split("/")[-1]
-            filename = os.path.join("/tmp", targetfile)
-            if not os.path.isfile(filename):
-                self.download_image(self.image_url, filename)
-            self._image = filename
-
-        return self._image
+        if not self.image_url:
+            return None
+        targetfile = urlparse(self.image_url).path.split("/")[-1]
+        filename = os.path.join("/tmp", targetfile)
+        self.download_image(self.image_url, filename)
+        return filename
 
     def run(
         self,

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -74,9 +74,8 @@ GPU_VENDORS = {
                 "security.secureboot=false",
             ],
             "config_cmds": [
-                "apt-get -q update",
-                "apt-get -q upgrade",
-                "apt-get -q install -y ubuntu-drivers-common",
+                "apt-get -q -U upgrade",
+                "apt-get -q install -y linux-generic ubuntu-drivers-common",
                 "ubuntu-drivers install --gpgpu",
             ],
         },

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -400,9 +400,7 @@ def build_gpu_test(instance: LXD, vendor: str):
         "cd mixbench/build-{}".format(test_name),
         cmake_cmd.format(test_name=test_name),
         "make",
-        "ln -s ~/mixbench/build-{0}/mixbench-{0} ~/vgpu-test".format(
-            test_name
-        ),
+        "ln -s ~/mixbench/build-{0}/mixbench-{0} ~/test".format(test_name),
     ]
     instance.run(
         "bash -c '{}'".format("; ".join(cmds)), on_guest=True, check=True

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -215,7 +215,7 @@ class LXD:
     def cleanup(self):
         """Cleans up instance."""
         self.run("lxc image delete {}".format(self.image_alias.hex))
-        self.run("lxc delete {}".format(self.name))
+        self.run("lxc delete --force {}".format(self.name))
 
     def launch(self, options: Optional[List] = None):
         """Sets up and creates the instance."""

--- a/providers/gpgpu/tests/test_gpu_passthrough.py
+++ b/providers/gpgpu/tests/test_gpu_passthrough.py
@@ -280,17 +280,35 @@ class TestLXDVM(TestCase):
 class TestMain(TestCase):
     def test_add_apt_repo_no_pinfile(self, logging_mock):
         instance = MagicMock()
-        repo = MagicMock(pinfile=None)
+        repo = {
+            "name": "",
+            "repo_line": "",
+            "gpg_url": "",
+            "gpg_fingerprint": "",
+            "pinfile": None,
+        }
         add_apt_repo(instance, repo)
 
     def test_add_apt_repo_download_pinfile(self, logging_mock):
         instance = MagicMock()
-        repo = MagicMock(pinfile="https://ubuntu.com/pinfile")
+        repo = {
+            "name": "",
+            "repo_line": "",
+            "gpg_url": "",
+            "gpg_fingerprint": "",
+            "pinfile": "https://ubuntu.com/pinfile",
+        }
         add_apt_repo(instance, repo)
 
     def test_add_apt_repo_text_pinfile(self, logging_mock):
         instance = MagicMock()
-        repo = MagicMock(pinfile="Package: *\nPin: ...")
+        repo = {
+            "name": "",
+            "repo_line": "",
+            "gpg_url": "",
+            "gpg_fingerprint": "",
+            "pinfile": "Package: *\nPin: ...",
+        }
         add_apt_repo(instance, repo)
 
     def test_build_gpu_test(self, logging_mock):

--- a/providers/gpgpu/tests/test_gpu_passthrough.py
+++ b/providers/gpgpu/tests/test_gpu_passthrough.py
@@ -269,6 +269,10 @@ class TestLXD(TestCase):
         self_mock = MagicMock()
         LXD.add_device(self_mock, "gpu", "gpu", ["pci=0000:0a:00.0"])
 
+    def test_wait_until_running(self, logging_mock):
+        self_mock = MagicMock()
+        LXD.wait_until_running(self_mock)
+
     @patch.object(LXD, "cleanup")
     @patch.object(LXD, "init_lxd")
     def test_context_manager(self, init_lxd_mock, cleanup_mock, logging_mock):

--- a/providers/gpgpu/tests/test_gpu_passthrough.py
+++ b/providers/gpgpu/tests/test_gpu_passthrough.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Tests for the gpu_passthrough.py script.
+Copyright 2024 Canonical Ltd.
+Written by:
+  Pedro Avalos Jimenez <pedro.avalosjimenez@canonical.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3,
+as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import os
+import subprocess
+import urllib.error
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from gpu_passthrough import (
+    LXD,
+    LXDVM,
+    add_apt_repo,
+    build_gpu_test,
+    main,
+    parse_args,
+    run_gpu_test,
+    test_lxd_gpu,
+    test_lxdvm_gpu,
+)
+
+
+@patch("gpu_passthrough.logging")
+class TestLXD(TestCase):
+    def test_template_none(self, logging_mock):
+        lxd = LXD(template_url=None)
+        self.assertIsNone(lxd.template)
+
+    @patch("os.path.isfile", return_value=True)
+    @patch(
+        "gpu_passthrough.urlparse",
+        return_value=MagicMock(path="ubuntu.com/template"),
+    )
+    def test_template_exists(self, urlparse_mock, isfile_mock, logging_mock):
+        lxd = LXD(template_url="https://ubuntu.com/template")
+        self.assertEqual(lxd.template, "/tmp/template")
+
+    @patch.object(LXD, "download_image")
+    @patch("os.path.isfile", return_value=False)
+    @patch(
+        "gpu_passthrough.urlparse",
+        return_value=MagicMock(path="ubuntu.com/template"),
+    )
+    def test_template_download(
+        self, urlparse_mock, isfile_mock, download_image_mock, logging_mock
+    ):
+        lxd = LXD(template_url="https://ubuntu.com/template")
+        self.assertEqual(lxd.template, "/tmp/template")
+
+    def test_image_none(self, logging_mock):
+        lxd = LXD(image_url=None)
+        self.assertIsNone(lxd.image)
+
+    @patch("os.path.isfile", return_value=True)
+    @patch(
+        "gpu_passthrough.urlparse",
+        return_value=MagicMock(path="ubuntu.com/image"),
+    )
+    def test_image_exists(self, urlparse_mock, isfile_mock, logging_mock):
+        lxd = LXD(image_url="https://ubuntu.com/image")
+        self.assertEqual(lxd.image, "/tmp/image")
+
+    @patch.object(LXD, "download_image")
+    @patch("os.path.isfile", return_value=False)
+    @patch(
+        "gpu_passthrough.urlparse",
+        return_value=MagicMock(path="ubuntu.com/image"),
+    )
+    def test_image_download(
+        self, urlparse_mock, isfile_mock, download_image_mock, logging_mock
+    ):
+        lxd = LXD(image_url="https://ubuntu.com/image")
+        self.assertEqual(lxd.image, "/tmp/image")
+
+    @patch(
+        "subprocess.run",
+        return_value=MagicMock(returncode=0, stdout="success", stderr=""),
+    )
+    def test_run_success(self, run_mock, logging_mock):
+        self_mock = MagicMock()
+        try:
+            LXD.run(self_mock, "ip a")
+        except subprocess.CalledProcessError:
+            self.fail("run raised CalledProcessError")
+
+    @patch(
+        "subprocess.run",
+        return_value=MagicMock(returncode=0, stdout="success", stderr=""),
+    )
+    def test_run_on_guest_success(self, run_mock, logging_mock):
+        self_mock = MagicMock()
+        try:
+            LXD.run(self_mock, "ip a", on_guest=True)
+        except subprocess.CalledProcessError:
+            self.fail("run raised CalledProcessError")
+
+    @patch(
+        "subprocess.run",
+        return_value=MagicMock(returncode=1, stdout="", stderr="fail"),
+    )
+    def test_run_fail(self, run_mock, logging_mock):
+        run_mock().check_returncode.side_effect = [
+            subprocess.CalledProcessError(
+                run_mock.returncode, "ip a", run_mock.stdout, run_mock.stderr
+            )
+        ]
+        self_mock = MagicMock()
+        with self.assertRaises(subprocess.CalledProcessError):
+            LXD.run(self_mock, "ip a", check=True)
+
+    @patch("os.path.isfile", return_value=True)
+    @patch("urllib.request.urlretrieve")
+    def test_download_image_success(
+        self, urlretrieve_mock, isfile_mock, logging_mock
+    ):
+        self_mock = MagicMock()
+        try:
+            LXD.download_image(
+                self_mock, "https://ubuntu.com/image", "/tmp/image"
+            )
+        except FileNotFoundError:
+            self.fail("download_image raised FileNotFoundError")
+
+    @patch("os.path.isfile", return_value=False)
+    @patch("urllib.request.urlretrieve", side_effect=IOError)
+    def test_download_image_http_error(
+        self, urlretrieve_mock, isfile_mock, logging_mock
+    ):
+        self_mock = MagicMock()
+        with self.assertRaises(FileNotFoundError):
+            LXD.download_image(
+                self_mock, "https://ubuntu.com/image", "/tmp/image"
+            )
+
+    @patch("os.path.isfile", return_value=False)
+    @patch("urllib.request.urlretrieve", side_effect=ValueError)
+    def test_download_image_val_error(
+        self, urlretrieve_mock, isfile_mock, logging_mock
+    ):
+        self_mock = MagicMock()
+        with self.assertRaises(FileNotFoundError):
+            LXD.download_image(
+                self_mock, "https://ubuntu.com/image", "/tmp/image"
+            )
+
+    def test_insert_images_local_success(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.template = "/tmp/template"
+        self_mock.image = "/tmp/image"
+        LXD.insert_images(self_mock)
+
+    def test_insert_images_remote_success(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.template = None
+        self_mock.image = None
+        self_mock.remote = "ubuntu:"
+        self_mock.run.return_value = MagicMock(returncode=0)
+        try:
+            LXD.insert_images(self_mock)
+        except RuntimeError:
+            self.fail("insert_images raised RuntimeError")
+
+    def test_insert_images_remote_fail(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.template = None
+        self_mock.image = None
+        self_mock.remote = "ubuntu:"
+        self_mock.run.return_value = MagicMock(returncode=1)
+        with self.assertRaises(RuntimeError):
+            LXD.insert_images(self_mock)
+
+    def test_init_lxd_already_running(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.run.return_value = MagicMock(returncode=0)
+        LXD.init_lxd(self_mock)
+        self.assertEqual(self_mock.run.call_count, 1)
+
+    def test_init_lxd_success(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.run.side_effect = [
+            MagicMock(returncode=1),
+            MagicMock(returncode=0),
+        ]
+        LXD.init_lxd(self_mock)
+        self.assertEqual(self_mock.run.call_count, 2)
+        self.assertTrue(self_mock.insert_images.called)
+
+    def test_cleanup_success(self, logging_mock):
+        self_mock = MagicMock()
+        LXD.cleanup(self_mock)
+
+    def test_launch_no_options(self, logging_mock):
+        self_mock = MagicMock()
+        LXD.launch(self_mock)
+
+    def test_launch_options(self, logging_mock):
+        self_mock = MagicMock()
+        LXD.launch(self_mock, ["-d root,size=50GB"])
+
+    def test_stop_no_force(self, logging_mock):
+        self_mock = MagicMock()
+        LXD.stop(self_mock)
+
+    def test_stop_force(self, logging_mock):
+        self_mock = MagicMock()
+        LXD.stop(self_mock, force=True)
+
+    def test_start(self, logging_mock):
+        self_mock = MagicMock()
+        LXD.start(self_mock)
+
+    def test_restart(self, logging_mock):
+        self_mock = MagicMock()
+        LXD.restart(self_mock)
+
+    def test_add_device_no_options(self, logging_mock):
+        self_mock = MagicMock()
+        LXD.add_device(self_mock, "gpu", "gpu")
+
+    def test_add_device_options(self, logging_mock):
+        self_mock = MagicMock()
+        LXD.add_device(self_mock, "gpu", "gpu", ["pci=0000:0a:00.0"])
+
+
+@patch("gpu_passthrough.logging")
+class TestLXDVM(TestCase):
+    def test_insert_images(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.template = "/tmp/template"
+        self_mock.image = "/tmp/image"
+        LXDVM.insert_images(self_mock)
+
+    def test_insert_images_no_images(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.template = None
+        self_mock.image = None
+        LXDVM.insert_images(self_mock)
+
+    def test_launch_images(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.template = "/tmp/template"
+        self_mock.image = "/tmp/image"
+        LXDVM.launch(self_mock)
+
+    def test_launch_no_images(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.template = None
+        self_mock.image = None
+        LXDVM.launch(self_mock)
+
+    def test_launch_options(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.template = None
+        self_mock.image = None
+        LXDVM.launch(self_mock, options=["-d root,size=50GB"])
+
+    @patch("gpu_passthrough.super")
+    def test_add_device(self, super_mock, logging_mock):
+        self_mock = MagicMock()
+        LXDVM.add_device(self_mock, "gpu", "gpu")
+
+
+@patch("gpu_passthrough.logging")
+class TestMain(TestCase):
+    def test_add_apt_repo_no_pinfile(self, logging_mock):
+        instance = MagicMock()
+        repo = MagicMock(pinfile=None)
+        add_apt_repo(instance, repo)
+
+    def test_add_apt_repo_download_pinfile(self, logging_mock):
+        instance = MagicMock()
+        repo = MagicMock(pinfile="https://ubuntu.com/pinfile")
+        add_apt_repo(instance, repo)
+
+    def test_add_apt_repo_text_pinfile(self, logging_mock):
+        instance = MagicMock()
+        repo = MagicMock(pinfile="Package: *\nPin: ...")
+        add_apt_repo(instance, repo)
+
+    def test_build_gpu_test(self, logging_mock):
+        instance = MagicMock()
+        build_gpu_test(instance, "nvidia")
+
+    @patch("time.time", side_effect=[0, 1])
+    def test_run_gpu_test_success(self, time_mock, logging_mock):
+        instance = MagicMock()
+        try:
+            run_gpu_test(instance, run_count=1, threshold_sec=2)
+        except SystemExit:
+            self.fail("run_gpu_test raised SystemExit")
+
+    @patch("time.time", side_effect=[0, 2])
+    def test_run_gpu_test_failure(self, time_mock, logging_mock):
+        instance = MagicMock()
+        with self.assertRaises(SystemExit):
+            run_gpu_test(instance, run_count=1, threshold_sec=1)
+
+    @patch("gpu_passthrough.run_gpu_test")
+    @patch("gpu_passthrough.build_gpu_test")
+    @patch("time.sleep")
+    @patch("gpu_passthrough.LXD")
+    def test_test_lxd_gpu(
+        self, lxd_mock, sleep_mock, build_mock, run_mock, logging_mock
+    ):
+        args = MagicMock(vendor="nvidia")
+        test_lxd_gpu(args)
+
+    @patch("gpu_passthrough.run_gpu_test")
+    @patch("gpu_passthrough.build_gpu_test")
+    @patch("time.sleep")
+    @patch("gpu_passthrough.LXDVM")
+    def test_test_lxdvm_gpu(
+        self, lxdvm_mock, sleep_mock, build_mock, run_mock, logging_mock
+    ):
+        args = MagicMock(vendor="nvidia")
+        test_lxdvm_gpu(args)
+
+    @patch("gpu_passthrough.argparse")
+    def test_parse_args(self, argparse_mock, logging_mock):
+        parse_args()
+
+    @patch("gpu_passthrough.parse_args")
+    def test_main(self, parse_args_mock, logging_mock):
+        main()

--- a/providers/gpgpu/tests/test_gpu_passthrough.py
+++ b/providers/gpgpu/tests/test_gpu_passthrough.py
@@ -25,8 +25,6 @@ from checkbox_support.helpers.retry import mock_retry
 from gpu_passthrough import (
     LXD,
     LXDVM,
-    add_apt_repo,
-    build_gpu_test,
     main,
     parse_args,
     run_gpu_test,
@@ -284,43 +282,6 @@ class TestLXDVM(TestCase):
 
 @patch("gpu_passthrough.logging")
 class TestMain(TestCase):
-    def test_add_apt_repo_no_pinfile(self, logging_mock):
-        instance = MagicMock()
-        repo = {
-            "name": "",
-            "repo_line": "",
-            "gpg_url": "",
-            "gpg_fingerprint": "",
-            "pinfile": None,
-        }
-        add_apt_repo(instance, repo)
-
-    def test_add_apt_repo_download_pinfile(self, logging_mock):
-        instance = MagicMock()
-        repo = {
-            "name": "",
-            "repo_line": "",
-            "gpg_url": "",
-            "gpg_fingerprint": "",
-            "pinfile": "https://ubuntu.com/pinfile",
-        }
-        add_apt_repo(instance, repo)
-
-    def test_add_apt_repo_text_pinfile(self, logging_mock):
-        instance = MagicMock()
-        repo = {
-            "name": "",
-            "repo_line": "",
-            "gpg_url": "",
-            "gpg_fingerprint": "",
-            "pinfile": "Package: *\nPin: ...",
-        }
-        add_apt_repo(instance, repo)
-
-    def test_build_gpu_test(self, logging_mock):
-        instance = MagicMock()
-        build_gpu_test(instance, "nvidia")
-
     @patch("time.time", side_effect=[0, 1])
     def test_run_gpu_test_success(self, time_mock, logging_mock):
         instance = MagicMock()

--- a/providers/gpgpu/tests/test_gpu_passthrough.py
+++ b/providers/gpgpu/tests/test_gpu_passthrough.py
@@ -269,6 +269,14 @@ class TestLXD(TestCase):
         self_mock = MagicMock()
         LXD.add_device(self_mock, "gpu", "gpu", ["pci=0000:0a:00.0"])
 
+    @patch.object(LXD, "cleanup")
+    @patch.object(LXD, "init_lxd")
+    def test_context_manager(self, init_lxd_mock, cleanup_mock, logging_mock):
+        with LXD() as _:
+            pass
+        self.assertTrue(init_lxd_mock.called)
+        self.assertTrue(cleanup_mock.called)
+
 
 @mock_retry()
 @patch("gpu_passthrough.logging")
@@ -329,17 +337,19 @@ class TestMain(TestCase):
             run_gpu_test(instance, "test", run_count=1, threshold_sec=1)
 
     @patch("gpu_passthrough.run_gpu_test")
-    @patch("time.sleep")
+    @patch("gpu_passthrough.run_with_retry")
     @patch("gpu_passthrough.LXD")
-    def test_test_lxd_gpu(self, lxd_mock, sleep_mock, run_mock, logging_mock):
+    def test_test_lxd_gpu(
+        self, lxd_mock, run_with_retry_mock, run_mock, logging_mock
+    ):
         args = MagicMock(vendor="nvidia")
         test_lxd_gpu(args)
 
     @patch("gpu_passthrough.run_gpu_test")
-    @patch("time.sleep")
+    @patch("gpu_passthrough.run_with_retry")
     @patch("gpu_passthrough.LXDVM")
     def test_test_lxdvm_gpu(
-        self, lxdvm_mock, sleep_mock, run_mock, logging_mock
+        self, lxdvm_mock, run_with_retry_mock, run_mock, logging_mock
     ):
         args = MagicMock(vendor="nvidia")
         test_lxdvm_gpu(args)

--- a/providers/gpgpu/tests/test_gpu_passthrough.py
+++ b/providers/gpgpu/tests/test_gpu_passthrough.py
@@ -229,17 +229,17 @@ class TestLXD(TestCase):
         self_mock = MagicMock()
         LXD.cleanup(self_mock)
 
-    @patch("shlex.join")
-    def test_launch_no_options(self, shlex_join_mock, logging_mock):
-        self_mock = MagicMock(name="testbed")
+    def test_launch_no_options(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.name = "testbed"
         self_mock.image_alias = MagicMock(
             hex="656382d4-d820-4d01-944b-82b5b63041a7"
         )
         LXD.launch(self_mock)
 
-    @patch("shlex.join")
-    def test_launch_options(self, shlex_join_mock, logging_mock):
-        self_mock = MagicMock(name="testbed")
+    def test_launch_options(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.name = "testbed"
         self_mock.image_alias = MagicMock(
             hex="656382d4-d820-4d01-944b-82b5b63041a7"
         )
@@ -293,24 +293,35 @@ class TestLXDVM(TestCase):
         self_mock.image = None
         LXDVM.insert_images(self_mock)
 
-    @patch("shlex.join")
-    def test_launch_images(self, shlex_join_mock, logging_mock):
-        self_mock = MagicMock(
-            name="testbed", template="/tmp/template", image="/tmp/image"
+    def test_launch_images(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.name = "testbed"
+        self_mock.template = "/tmp/template"
+        self_mock.image = "/tmp/image"
+        self_mock.image_alias = MagicMock(
+            hex="656382d4-d820-4d01-944b-82b5b63041a7"
         )
         LXDVM.launch(self_mock)
 
-    @patch("shlex.join")
-    def test_launch_no_images(self, shlex_join_mock, logging_mock):
-        self_mock = MagicMock(
-            name="testbed", remote="ubuntu:", template=None, image=None
+    def test_launch_no_images(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.name = "testbed"
+        self_mock.remote = "ubuntu:"
+        self_mock.template = None
+        self_mock.image = None
+        self_mock.image_alias = MagicMock(
+            hex="656382d4-d820-4d01-944b-82b5b63041a7"
         )
         LXDVM.launch(self_mock)
 
-    @patch("shlex.join")
-    def test_launch_options(self, shlex_join_mock, logging_mock):
-        self_mock = MagicMock(
-            name="testbed", remote="ubuntu:", template=None, image=None
+    def test_launch_options(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.name = "testbed"
+        self_mock.remote = "ubuntu:"
+        self_mock.template = None
+        self_mock.image = None
+        self_mock.image_alias = MagicMock(
+            hex="656382d4-d820-4d01-944b-82b5b63041a7"
         )
         LXDVM.launch(self_mock, options=["-d root,size=50GB"])
 

--- a/providers/gpgpu/tests/test_gpu_passthrough.py
+++ b/providers/gpgpu/tests/test_gpu_passthrough.py
@@ -318,7 +318,7 @@ class TestMain(TestCase):
     def test_run_gpu_test_success(self, time_mock, logging_mock):
         instance = MagicMock()
         try:
-            run_gpu_test(instance, run_count=1, threshold_sec=2)
+            run_gpu_test(instance, "test", run_count=1, threshold_sec=2)
         except SystemExit:
             self.fail("run_gpu_test raised SystemExit")
 
@@ -326,7 +326,7 @@ class TestMain(TestCase):
     def test_run_gpu_test_failure(self, time_mock, logging_mock):
         instance = MagicMock()
         with self.assertRaises(SystemExit):
-            run_gpu_test(instance, run_count=1, threshold_sec=1)
+            run_gpu_test(instance, "test", run_count=1, threshold_sec=1)
 
     @patch("gpu_passthrough.run_gpu_test")
     @patch("time.sleep")

--- a/providers/gpgpu/tox.ini
+++ b/providers/gpgpu/tox.ini
@@ -6,7 +6,9 @@ skipsdist=True
 [testenv]
 allowlist_externals = rm
 commands =
-    pip -q install ../../checkbox-ng
+    {envpython} -m pip -q install ../../checkbox-ng
+    # Required because this provider depends on checkbox-support scripts
+    {envpython} -m pip -q install ../../checkbox-support
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
     # Required because this provider depends on the resource and base providers

--- a/providers/gpgpu/units/gpgpu-only.pxu
+++ b/providers/gpgpu/units/gpgpu-only.pxu
@@ -9,6 +9,7 @@ nested_part:
     com.canonical.certification::server-miscellaneous
     com.canonical.certification::gpgpu-stress
     com.canonical.certification::gpgpu-automated
+    com.canonical.certification::gpgpu-virtualization
 include:
 bootstrap_include:
     device

--- a/providers/gpgpu/units/gpgpu-only.pxu
+++ b/providers/gpgpu/units/gpgpu-only.pxu
@@ -9,7 +9,7 @@ nested_part:
     com.canonical.certification::server-miscellaneous
     com.canonical.certification::gpgpu-stress
     com.canonical.certification::gpgpu-automated
-    com.canonical.certification::gpgpu-virtualization
+    com.canonical.certification::gpgpu-passthrough
 include:
 bootstrap_include:
     device

--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -82,18 +82,3 @@ command: gpu_passthrough.py --vendor=nvidia --pci={pci_device_name} lxd
 _purpose: Creates a LXD container and passes {pci_device_name} GPU through
 _summary: Test LXD GPU passthrough on NVIDIA GPU {pci_device_name}
 _template-summary: Test LXD GPU passthrough on NVIDIA GPU
-
-unit: template
-template-resource: graphics_card
-template-filter: graphics_card.vendor == 'NVIDIA Corporation'
-template-id: gpgpu/lxdvm-nvidia-gpu-passthrough-index
-id: gpgpu/lxdvm-nvidia-gpu-passthrough-{index}
-requires:
-    executable.name == 'lxc'
-    package.name == 'lxd' or package.name == 'lxd-installer' or snap.name == 'lxd'
-category_id: gpgpu
-plugin: shell
-command: gpu_passthrough.py --vendor=nvidia --pci={pci_device_name} lxdvm
-_purpose: Creates a LXD VM and passes {pci_device_name} GPU through
-_summary: Test LXD VM GPU passthrough on NVIDIA GPU {pci_device_name}
-_template-summary: Test LXD VM GPU passthrough on NVIDIA GPU

--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -67,3 +67,33 @@ _siblings: [
     "command": "rvs.py gst",
     "estimated_duration": 14400 }
   ]
+
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.vendor == 'NVIDIA Corporation'
+template-id: gpgpu/lxd-nvidia-gpu-passthrough-index
+id: gpgpu/lxd-nvidia-gpu-passthrough-{index}
+requires:
+    executable.name == 'lxc'
+    package.name == 'lxd' or package.name == 'lxd-installer' or snap.name == 'lxd'
+category_id: gpgpu
+plugin: shell
+command: gpu_passthrough.py --vendor=nvidia --pci={pci_device_name} lxd
+_purpose: Creates a LXD container and passes {pci_device_name} GPU through
+_summary: Test LXD GPU passthrough on NVIDIA GPU {pci_device_name}
+_template-summary: Test LXD GPU passthrough on NVIDIA GPU
+
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.vendor == 'NVIDIA Corporation'
+template-id: gpgpu/lxdvm-nvidia-gpu-passthrough-index
+id: gpgpu/lxdvm-nvidia-gpu-passthrough-{index}
+requires:
+    executable.name == 'lxc'
+    package.name == 'lxd' or package.name == 'lxd-installer' or snap.name == 'lxd'
+category_id: gpgpu
+plugin: shell
+command: gpu_passthrough.py --vendor=nvidia --pci={pci_device_name} lxdvm
+_purpose: Creates a LXD VM and passes {pci_device_name} GPU through
+_summary: Test LXD VM GPU passthrough on NVIDIA GPU {pci_device_name}
+_template-summary: Test LXD VM GPU passthrough on NVIDIA GPU

--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -74,6 +74,7 @@ template-filter: graphics_card.vendor == 'NVIDIA Corporation'
 template-id: gpgpu/lxd-nvidia-gpu-passthrough-index
 id: gpgpu/lxd-nvidia-gpu-passthrough-{index}
 requires:
+    graphics_card.driver == 'nvidia'
     executable.name == 'lxc'
     package.name == 'lxd' or package.name == 'lxd-installer' or snap.name == 'lxd'
 category_id: gpgpu

--- a/providers/gpgpu/units/test-plan.pxu
+++ b/providers/gpgpu/units/test-plan.pxu
@@ -23,3 +23,14 @@ include:
     gpgpu/rvs-pebb
     gpgpu/rvs-pbqt
     gpgpu/rvs-babel
+
+id gpgpu-virtualization
+unit: test plan
+_name: GPGPU Virtualization Testing
+_description:
+ Automated Tests for GPGPU Passthrough (non-graphical)
+include:
+    gpgpu/lxd-nvidia-gpu-passthrough-index
+    gpgpu/lxdvm-nvidia-gpu-passthrough-index
+bootstrap_include:
+    graphics_card

--- a/providers/gpgpu/units/test-plan.pxu
+++ b/providers/gpgpu/units/test-plan.pxu
@@ -33,3 +33,6 @@ include:
     gpgpu/lxd-nvidia-gpu-passthrough-index
 bootstrap_include:
     graphics_card
+    executable
+    package
+    snap

--- a/providers/gpgpu/units/test-plan.pxu
+++ b/providers/gpgpu/units/test-plan.pxu
@@ -24,9 +24,9 @@ include:
     gpgpu/rvs-pbqt
     gpgpu/rvs-babel
 
-id: gpgpu-virtualization
+id: gpgpu-passthrough
 unit: test plan
-_name: GPGPU Virtualization Testing
+_name: GPGPU Virtualization Passthrough Testing
 _description:
  Automated Tests for GPGPU Passthrough (non-graphical)
 include:

--- a/providers/gpgpu/units/test-plan.pxu
+++ b/providers/gpgpu/units/test-plan.pxu
@@ -24,7 +24,7 @@ include:
     gpgpu/rvs-pbqt
     gpgpu/rvs-babel
 
-id gpgpu-virtualization
+id: gpgpu-virtualization
 unit: test plan
 _name: GPGPU Virtualization Testing
 _description:

--- a/providers/gpgpu/units/test-plan.pxu
+++ b/providers/gpgpu/units/test-plan.pxu
@@ -31,6 +31,5 @@ _description:
  Automated Tests for GPGPU Passthrough (non-graphical)
 include:
     gpgpu/lxd-nvidia-gpu-passthrough-index
-    gpgpu/lxdvm-nvidia-gpu-passthrough-index
 bootstrap_include:
     graphics_card


### PR DESCRIPTION
## Description

- Created `gpu_passthrough.py` within GPGPU provider
- Added LXD container tests for GPU passthrough setups.
- Created `LXD` and `LXDVM` classes that can be used to wrap LXD container or LXD virtual machine
  - These could probably go into checkbox-support ?

## Resolved issues

- Addresses CHECKBOX-1451 and CHECKBOX-970.

## Documentation

n/a

## Tests

Tested locally on a laptop with NVIDIA GPU. Tested on `torchtusk` as well

Submission from `torchtusk`: https://certification.canonical.com/submissions/status/293943
