### PR TITLE
Ignore common file extensions in ignored files warning (BugFix)

### DIFF
--- a/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
@@ -35,6 +35,7 @@ from plainbox.impl.secure.providers.v1 import IQNValidator
 from plainbox.impl.secure.providers.v1 import Provider1
 from plainbox.impl.secure.providers.v1 import Provider1Definition
 from plainbox.impl.secure.providers.v1 import Provider1PlugIn
+from plainbox.impl.secure.providers.v1 import ProviderContentLoader
 from plainbox.impl.secure.providers.v1 import UnitPlugIn
 from plainbox.impl.secure.providers.v1 import VersionValidator
 from plainbox.impl.secure.rfc822 import FileTextSource
@@ -911,3 +912,22 @@ class Provider1Tests(TestCase):
             base_dir=self.BASE_DIR,
         )
         self.assertEqual(mock_gettext.bindtextdomain.call_args_list, [])
+
+
+@mock.patch("plainbox.impl.secure.providers.v1.logger")
+class ProviderContentLoaderTests(TestCase):
+    def test__warn_ignored_file_warned(self, logger_mock):
+        self_mock = mock.MagicMock()
+        self_mock.provider.units_dir = "/some/path"
+        ProviderContentLoader._warn_ignored_file(
+            self_mock, "/some/path/script.py"
+        )
+        self.assertTrue(logger_mock.warning.called)
+
+    def test__warn_ignored_file_ignored(self, logger_mock):
+        self_mock = mock.MagicMock()
+        self_mock.provider.units_dir = "/some/path"
+        ProviderContentLoader._warn_ignored_file(
+            self_mock, "/some/path/__pycache__/script.pyc"
+        )
+        self.assertFalse(logger_mock.warning.called)

--- a/checkbox-ng/plainbox/impl/secure/providers/v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/v1.py
@@ -661,31 +661,28 @@ class ProviderContentLoader:
 
     def _warn_ignored_file(self, filename):
         """
-        Print an warning message for each file that is skipped at loading
-        Do not print warning for all skipped files, do it only for file that is located
-        inside a official provider folder (bin, data, units, ..).
+        Print a warning message for each file that is skipped at loading.
+        Do not print warning for all skipped files. Ignore common text formats,
+        compiled bytcode python files, etc. Files to warn about should also be
+        located inside an official provider folder (bin, data, units, ...).
         """
-        if (
-            (
-                self.provider.units_dir
-                and filename.startswith(self.provider.units_dir)
+        if all(
+            not filename.endswith(ext)
+            for ext in (
+                ".md",
+                ".txt",
+                ".pyc",
             )
-            or (
-                self.provider.jobs_dir
-                and filename.startswith(self.provider.jobs_dir)
+        ) and any(
+            filename.startswith(path)
+            for path in (
+                self.provider.units_dir,
+                self.provider.jobs_dir,
+                self.provider.data_dir,
+                self.provider.bin_dir,
+                self.provider.locale_dir,
             )
-            or (
-                self.provider.data_dir
-                and filename.startswith(self.provider.data_dir)
-            )
-            or (
-                self.provider.bin_dir
-                and filename.startswith(self.provider.bin_dir)
-            )
-            or (
-                self.provider.locale_dir
-                and filename.startswith(self.provider.locale_dir)
-            )
+            if path
         ):
             logger.warning("Skipped file: %s", filename)
 


### PR DESCRIPTION
## Description

- Add an ignore list for common file extension types that shouldn't trigger a warning.

## Resolved issues

- Resolves #565

## Documentation

## Tests

Tested locally.
