### PR TITLE
Add manifest gate for obex tests (bugfix)

### DIFF
--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -434,10 +434,12 @@ id: bluetooth/bluetooth_obex_send
 depends: bluetooth/detect-output
 estimated_duration: 10.0
 environ: BTDEVADDR PLAINBOX_PROVIDER_DATA
+imports: from com.canonical.plainbox import manifest
 requires:
  package.name == 'bluez' or snap.name == 'bluez'
  executable.name == 'obexftp' and executable.name == 'hcitool'
  device.category == 'BLUETOOTH'
+ manifest.has_bt_obex_support == 'True'
 command:
   if [ -z "$BTDEVADDR" ]
   then

--- a/providers/base/units/bluetooth/manifest.pxu
+++ b/providers/base/units/bluetooth/manifest.pxu
@@ -7,3 +7,8 @@ unit: manifest entry
 id: has_bt_smart
 _name: A Bluetooth Module with Smart (4.0 or later) Support
 value-type: bool
+
+unit: manifest entry
+id: has_bt_obex_support
+_name: A Bluetooth Module with OBEX Support
+value-type: bool

--- a/providers/base/units/bluetooth/manifest.pxu
+++ b/providers/base/units/bluetooth/manifest.pxu
@@ -10,5 +10,5 @@ value-type: bool
 
 unit: manifest entry
 id: has_bt_obex_support
-_name: A Bluetooth Module with OBEX Support
+_name: A Bluetooth Module with OBject EXchange (OBEX) Support
 value-type: bool

--- a/providers/base/units/suspend/suspend.pxu
+++ b/providers/base/units/suspend/suspend.pxu
@@ -106,11 +106,13 @@ _purpose: This test executes an iperf connection performance/stability test agai
 plugin: shell
 category_id: com.canonical.plainbox::suspend
 id: suspend/bluetooth_obex_browse_before_suspend
+imports: from com.canonical.plainbox import manifest
 estimated_duration: 10.0
 requires:
  package.name == 'bluez'
  executable.name == 'obexftp'
  device.category == 'BLUETOOTH'
+ manifest.has_bt_obex_support == 'True'
 command:
   if [ -z "$BTDEVADDR" ]
   then
@@ -135,11 +137,13 @@ _purpose:
 plugin: shell
 category_id: com.canonical.plainbox::suspend
 id: suspend/bluetooth_obex_get_before_suspend
+imports: from com.canonical.plainbox import manifest
 estimated_duration: 20.0
 requires:
  package.name == 'bluez'
  executable.name == 'obexftp'
  device.category == 'BLUETOOTH'
+ manifest.has_bt_obex_support == 'True'
 command:
   if [ -z "$BTDEVADDR" ]
   then
@@ -1016,12 +1020,14 @@ _summary: Grab and compare Bluetooth hardware addresses before and after suspend
 plugin: shell
 category_id: com.canonical.plainbox::suspend
 id: suspend/bluetooth_obex_browse_after_suspend
+imports: from com.canonical.plainbox import manifest
 depends: suspend/suspend_advanced_auto
 estimated_duration: 10.0
 requires:
  package.name == 'bluez'
  executable.name == 'obexftp'
  device.category == 'BLUETOOTH'
+ manifest.has_bt_obex_support == 'True'
 command:
   if [ -z "$BTDEVADDR" ]
   then
@@ -1046,12 +1052,14 @@ _summary: Perform an automated Bluetooth test to emulate browsing on a remote de
 plugin: shell
 category_id: com.canonical.plainbox::suspend
 id: suspend/bluetooth_obex_browse_after_suspend_auto
+imports: from com.canonical.plainbox import manifest
 depends: suspend/suspend_advanced_auto
 estimated_duration: 20.0
 requires:
  package.name == 'bluez'
  executable.name == 'obexftp'
  device.category == 'BLUETOOTH'
+ manifest.has_bt_obex_support == 'True'
 command:
   if [ -z "$BTDEVADDR" ]
   then
@@ -1076,12 +1084,14 @@ _summary: Automate a Bluetooth browsing test on a remote device using the BTDEVA
 plugin: shell
 category_id: com.canonical.plainbox::suspend
 id: suspend/bluetooth_obex_get_after_suspend
+imports: from com.canonical.plainbox import manifest
 estimated_duration: 20.0
 depends: suspend/suspend_advanced_auto
 requires:
  package.name == 'bluez'
  executable.name == 'obexftp'
  device.category == 'BLUETOOTH'
+ manifest.has_bt_obex_support == 'True'
 command:
   if [ -z "$BTDEVADDR" ]
   then
@@ -1105,12 +1115,14 @@ _summary: Automate the process of receiving a file from a remote host via Blueto
 plugin: shell
 category_id: com.canonical.plainbox::suspend
 id: suspend/bluetooth_obex_get_after_suspend_auto
+imports: from com.canonical.plainbox import manifest
 depends: suspend/suspend_advanced_auto
 estimated_duration: 20.0
 requires:
  package.name == 'bluez'
  executable.name == 'obexftp'
  device.category == 'BLUETOOTH'
+ manifest.has_bt_obex_support == 'True'
 command:
   if [ -z "$BTDEVADDR" ]
   then

--- a/providers/sru/units/sru-rt.pxu
+++ b/providers/sru/units/sru-rt.pxu
@@ -35,5 +35,4 @@ exclude:
     stress/memory_stress_ng
     audio/valid-sof-firmware-sig
     miscellanea/check_prerelease
-    suspend/bluetooth_obex_.*
     miscellanea/debsums

--- a/providers/sru/units/sru.pxu
+++ b/providers/sru/units/sru.pxu
@@ -91,8 +91,6 @@ exclude:
     stress/memory_stress_ng
     audio/valid-sof-firmware-sig
     miscellanea/check_prerelease
-    suspend/bluetooth_obex_.*
-    bluetooth/.*_obex_.*
     miscellanea/debsums
     miscellanea/ubuntu-desktop-recommends
     miscellanea/ubuntu-desktop-minimal-recommends
@@ -156,8 +154,6 @@ exclude:
     stress/memory_stress_ng
     audio/valid-sof-firmware-sig
     miscellanea/check_prerelease
-    suspend/bluetooth_obex_.*
     miscellanea/debsums
-    bluetooth/.*_obex_.*
     miscellanea/ubuntu-desktop-recommends
     miscellanea/ubuntu-desktop-minimal-recommends


### PR DESCRIPTION

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The obex test was introduced with the only gate being the presence of the software to test it. This is problematic because the software will always be installed in the snap, but not all platforms support this extension. Additionally one needs the hardware to test this capability as well. For this reason we have decided to introduce a new manifest to gate the execution of this test because it is currently failing in sru (we had to manually exclude it) and in snap testing (where it is non-trivial to exclude). 

This also removes the test from the exclusion list, this way once we have the hardware to do sru obex tests we just need to enable it via the manifest without changing the test plans

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1646

## Documentation

N/A

## Tests

N/A

## WARNING: This modifies com.canonical.certification::sru-server
