### PR TITLE
Update the setup lxd action (infra)

### DIFF
--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout Checkbox monorepo
         uses: actions/checkout@v4
       - name: Setup LXD
-        uses: canonical/setup-lxd@v0.1.1
+        uses: canonical/setup-lxd@main
       - name: Add ZFS storage
         run: |
           lxc storage list


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Currently the metabox action is broken due to the runner user being unable to communicate with the lxd socket. This may be due to many reasons but from the debug log I can't tell how it sets up the group for the normal user, so I'm unable to understand how it ever worked before. Regardless, updating the action (the tag is 2 years old) seems to fix the issue.

## Resolved issues

Fixes: CHECKBOX-1649

## Documentation

N/A

## Tests

failing pre patch: https://github.com/canonical/checkbox/actions/runs/11742516038/job/32714410426
passing after patch: https://github.com/canonical/checkbox/actions/runs/11743071203/job/32716219919
