### PR TITLE
Add internal microphone manifest and update some audio jobs requirements (bugfix)

### DIFF
--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -337,9 +337,9 @@ estimated_duration: 20.0
 depends: audio/playback_auto
 imports: from com.canonical.plainbox import manifest
 requires:
- (manifest.has_line_in == 'True' or manifest.has_headset == 'True')
  manifest.has_audio_playback == 'True'
  manifest.has_audio_capture == 'True'
+ manifest.has_internal_microphone == 'True'
  package.name == 'alsa-base'
  package.name == 'gstreamer1.0-plugins-good' or package.name == 'gstreamer0.10-plugins-good'
  package.name in ['pulseaudio-utils', 'pipewire']

--- a/providers/base/units/audio/manifest.pxu
+++ b/providers/base/units/audio/manifest.pxu
@@ -1,8 +1,9 @@
-# Copyright 2017 Canonical Ltd.
+# Copyright 2017-2024 Canonical Ltd.
 # All rights reserved.
 #
 # Written by:
-#   Sylvain Pineau <sylvain.pineau@canonical.com>
+#  Sylvain Pineau <sylvain.pineau@canonical.com>
+#  Pierre Equoy <pierre.equoy@canonical.com>
 
 unit: manifest entry
 id: has_audio_playback
@@ -43,5 +44,11 @@ value-type: bool
 unit: manifest entry
 id: has_internal_speakers
 _name: Internal speakers
+_prompt: Does this machine have the following audio features?
+value-type: bool
+
+unit: manifest entry
+id: has_internal_microphone
+_name: Internal microphone
 _prompt: Does this machine have the following audio features?
 value-type: bool


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

Devices without an internal microphone should not run the
`audio/alsa_record_playback_internal` job, as it requires one.

This issue was detected when reviewing test results to issue a
certificate for a desktop PC. The `audio/alsa_record_playback_internal`
job was marked as skipped, but it is a certification-blocker, so it
triggered some alerts.

## Resolved issues

The `audio/alsa_record_playback_internal` cert-blocker should have been skipped automatically in [this submission](https://certification.canonical.com/hardware/202410-35885/submission/399420/test-results/skipped/?term=alsa_record_playback_internal), but because of the missing `has_internal_microphone` manifest, it was still executed even though it didn't make sense to, leading QA to have to manually skip the job.

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
