### PR TITLE
Expose Checkbox version in JSON output (submission.json) (new)

### DIFF
--- a/checkbox-ng/plainbox/impl/exporter/jinja2.py
+++ b/checkbox-ng/plainbox/impl/exporter/jinja2.py
@@ -45,6 +45,7 @@ except ImportError:  # renamed in jinja2 3.1
 
 
 from plainbox import get_version_string
+from plainbox import __version__ as checkbox_version
 from plainbox.abc import ISessionStateExporter
 from plainbox.impl.exporter import SessionStateExporterBase
 from plainbox.impl.result import OUTCOME_METADATA_MAP
@@ -109,6 +110,7 @@ class Jinja2SessionStateExporter(SessionStateExporterBase):
         self._client_version = client_version or get_version_string()
         # Remember client name
         self._client_name = client_name
+        self._checkbox_version = checkbox_version
 
         self.option_list = None
         self.template = None
@@ -195,6 +197,7 @@ class Jinja2SessionStateExporter(SessionStateExporterBase):
             "OUTCOME_METADATA_MAP": OUTCOME_METADATA_MAP,
             "client_name": self._client_name,
             "client_version": self._client_version,
+            "checkbox_version": self._checkbox_version,
             "manager": session_manager,
             "app_blob": app_blob_data,
             "options": self.option_list,
@@ -220,6 +223,7 @@ class Jinja2SessionStateExporter(SessionStateExporterBase):
             "OUTCOME_METADATA_MAP": OUTCOME_METADATA_MAP,
             "client_name": self._client_name,
             "client_version": self._client_version,
+            "checkbox_version": self._checkbox_version,
             "manager_list": session_manager_list,
             "app_blob": {},
             "options": self.option_list,

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.json
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.json
@@ -6,6 +6,8 @@
 {%- set system_information = state.system_information -%}
 {
     "title": {{ state.metadata.title | jsonify | safe }},
+    "client_version": {{ client_version | jsonify | safe }},
+    "checkbox_version": {{ checkbox_version | jsonify | safe }},
 {%- if "testplan_id" in app_blob %}
 {%- if app_blob['testplan_id'] %}
     "testplan_id": {{ app_blob['testplan_id'] | jsonify | safe }},

--- a/submission-schema/schema.json
+++ b/submission-schema/schema.json
@@ -11,6 +11,12 @@
                 "title": {
                     "type": "string"
                 },
+                "client_version": {
+                    "type": "string"
+                },
+                "checkbox_version": {
+                    "type": "string"
+                },
                 "testplan_id": {
                     "type": "string"
                 },


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The Jinja2 template data already has `client_version`, which internally
uses the `plainbox.get_version_string()` function to return either the
Checkbox version as a string like

    Checkbox 3.3.1.dev333+gbe9508960.d20240701

either information about the Snap being used, if Checkbox is run as a
snap:

    checkbox 4.2.0-dev127 (10238)

This commit adds a `checkbox_version` field that always contains only
the Checkbox version, without any additional string, such as :

    3.3.1.dev333+gbe9508960.d20240701

This allows for a more precise tracking of what version of the Checkbox
framework is used for debugging purposes.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

Fix #1580 

https://warthogs.atlassian.net/browse/CHECKBOX-1643
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

Checkbox JSON schema updated to reflect the new properties.

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

1. Run checkbox-cli and select a test plan to run.
2. End the session and make sure a submission archive is created
3. Check the `submission.json` file and make sure it contains the `client_version` and `checkbox_version` fields, such as:

```json
{
    "title": "session title",
    "client_version": "Checkbox 3.3.1.dev333+gbe9508960.d20240701",
    "checkbox_version": "3.3.1.dev333+gbe9508960.d20240701",
    "testplan_id": "com.canonical.certification::acpi-automated",
    "custom_joblist": false,
   (...)
}
```

Also tested the changes from within a snap. The resulting `submission.json` starts with:


```json
{
    "title": "session title",
    "client_version": "checkbox 4.2.0-dev127 (10238)",
    "checkbox_version": "4.2.0.dev127",
    "testplan_id": "com.canonical.certification::acpi-automated",
    "custom_joblist": false,
...
}
```