### PR TITLE
Fix netplan config uc16 (BugFix)

### DIFF
--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -26,6 +26,7 @@ import ipaddress
 import yaml
 
 from gateway_ping_test import ping
+from checkbox_support.snap_utils.system import get_series
 
 print = functools.partial(print, flush=True)
 
@@ -48,18 +49,6 @@ else:
 
 NETPLAN_CFG_PATHS = ("/etc/netplan", "/lib/netplan", "/run/netplan")
 NETPLAN_TEST_CFG = "/etc/netplan/99-CREATED-BY-CHECKBOX.yaml"
-
-
-def get_ubuntu_version():
-    """Get Ubuntu release version"""
-    try:
-        with open("/etc/lsb-release", "r") as lsb:
-            for line in lsb.readlines():
-                (key, value) = line.split("=", 1)
-                if key == "DISTRIB_RELEASE":
-                    return value.strip()
-    except OSError:
-        return None
 
 
 def netplan_renderer():
@@ -182,8 +171,8 @@ def generate_test_config(interface, ssid, psk, address, dhcp, wpa3, renderer):
     access_point = {ssid: {}}
     # If psk is provided, add it to the "auth" section
     if psk:
-        ubuntu_version = get_ubuntu_version()
-        if ubuntu_version and "16" in ubuntu_version:
+        ubuntu_version = int(get_series().split(".")[0])
+        if ubuntu_version == 16:
             access_point[ssid] = {"password": psk}
         else:
             access_point[ssid] = {"auth": {"password": psk}}

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -25,7 +25,6 @@ import io
 import sys
 from unittest.mock import call
 from wifi_client_test_netplan import (
-    get_ubuntu_version,
     netplan_renderer,
     check_and_get_renderer,
     netplan_config_backup,
@@ -44,7 +43,7 @@ from wifi_client_test_netplan import (
 
 class WifiClientTestNetplanTests(TestCase):
     @patch(
-        "wifi_client_test_netplan.get_ubuntu_version",
+        "wifi_client_test_netplan.get_series",
         new=MagicMock(return_value="20.04"),
     )
     def test_open_ap_with_dhcp(self):
@@ -69,7 +68,7 @@ class WifiClientTestNetplanTests(TestCase):
         self.assertEqual(result.strip(), expected_output.strip())
 
     @patch(
-        "wifi_client_test_netplan.get_ubuntu_version",
+        "wifi_client_test_netplan.get_series",
         new=MagicMock(return_value="20.04"),
     )
     def test_private_ap_with_dhcp(self):
@@ -96,7 +95,7 @@ class WifiClientTestNetplanTests(TestCase):
         self.assertEqual(result.strip(), expected_output.strip())
 
     @patch(
-        "wifi_client_test_netplan.get_ubuntu_version",
+        "wifi_client_test_netplan.get_series",
         new=MagicMock(return_value="16.04"),
     )
     def test_private_ap_with_dhcp_ubuntu_16_04(self):
@@ -123,7 +122,7 @@ class WifiClientTestNetplanTests(TestCase):
         self.assertEqual(result.strip(), expected_output.strip())
 
     @patch(
-        "wifi_client_test_netplan.get_ubuntu_version",
+        "wifi_client_test_netplan.get_series",
         new=MagicMock(return_value="20.04"),
     )
     def test_private_ap_with_wpa3(self):
@@ -150,7 +149,7 @@ class WifiClientTestNetplanTests(TestCase):
         self.assertEqual(result.strip(), expected_output.strip())
 
     @patch(
-        "wifi_client_test_netplan.get_ubuntu_version",
+        "wifi_client_test_netplan.get_series",
         new=MagicMock(return_value="20.04"),
     )
     def test_static_ip_no_dhcp(self):
@@ -179,7 +178,7 @@ class WifiClientTestNetplanTests(TestCase):
         self.assertEqual(result.strip(), expected_output.strip())
 
     @patch(
-        "wifi_client_test_netplan.get_ubuntu_version",
+        "wifi_client_test_netplan.get_series",
         new=MagicMock(return_value="20.04"),
     )
     def test_no_ssid_fails(self):
@@ -322,22 +321,6 @@ class WifiClientTestNetplanTests(TestCase):
             self.assertFalse(args.wpa3)
             self.assertIsNone(args.psk)
             self.assertEqual(args.address, "")
-
-    def test_get_ubuntu_version_20_04(self):
-        data = (
-            "DISTRIB_ID=Ubuntu\n"
-            "DISTRIB_RELEASE=20.04\n"
-            "DISTRIB_CODENAME=focal\n"
-            'DISTRIB_DESCRIPTION="Ubuntu 20.04.2 LTS"'
-        )
-        with patch("builtins.open", new_callable=mock_open, read_data=data):
-            version = get_ubuntu_version()
-            self.assertEqual(version, "20.04")
-
-    def test_get_ubuntu_version_error(self):
-        with patch("builtins.open", side_effect=OSError):
-            version = get_ubuntu_version()
-            self.assertIsNone(version)
 
     @patch(
         "builtins.open",


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Wireless tests started failing for ubuntu core 16 after a change in Checkbox was introduced to use a different netplan config. The auth field was added to the netplan config, which seems to be incompatible with the Ubuntu Core 16 netplan config.

We are now checking the ubuntu version and using the old configuration for ubuntu 16.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

[CHECKBOX-1611](https://warthogs.atlassian.net/browse/CHECKBOX-1611)
#1538 

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Test run of the netplan tests in one of the failing devices using ubuntu core 16:
https://certification.canonical.com/hardware/201811-26649/submission/401743/

[CHECKBOX-1611]: https://warthogs.atlassian.net/browse/CHECKBOX-1611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ