### PR TITLE
Umount the device first during mount_usb_storage() (#1587) (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/usb_read_write.py
+++ b/checkbox-support/checkbox_support/scripts/usb_read_write.py
@@ -170,6 +170,8 @@ def mount_usb_storage(partition):
         # use pipe so I could hide message like
         # "umount: /tmp/tmpjzwb6lys: not mounted"
         subprocess.call(["umount", FOLDER_TO_MOUNT], stderr=subprocess.PIPE)
+        # umount device_to_mount such as "umount /dev/mmcblk0p1" to avoid when the storage type is ntfs, which could not be mounted twice.
+        subprocess.call(["umount", device_to_mount], stderr=subprocess.PIPE)
         # mount the target device/partition
         # if the return code of the shell command is non-zero,
         # means something wrong.

--- a/checkbox-support/checkbox_support/scripts/usb_read_write.py
+++ b/checkbox-support/checkbox_support/scripts/usb_read_write.py
@@ -167,13 +167,15 @@ def mount_usb_storage(partition):
 
     try:
         device_to_mount = os.path.join("/dev", partition)
-        # use pipe so I could hide message like
-        # "umount: /tmp/tmpjzwb6lys: not mounted"
+
+        # Unmounting the folder ignoring any "not mounted" error messages.
         subprocess.call(["umount", FOLDER_TO_MOUNT], stderr=subprocess.PIPE)
+        
         # Unmounting the device (e.g., "/dev/mmcblk0p1") to ensure the storage
         # device is fully detached. This prevents issues with certain
         # filesystem types like NTFS, which cannot be mounted multiple times.
         subprocess.call(["umount", device_to_mount], stderr=subprocess.PIPE)
+        
         # mount the target device/partition
         # if the return code of the shell command is non-zero,
         # means something wrong.

--- a/checkbox-support/checkbox_support/scripts/usb_read_write.py
+++ b/checkbox-support/checkbox_support/scripts/usb_read_write.py
@@ -170,12 +170,12 @@ def mount_usb_storage(partition):
 
         # Unmounting the folder ignoring any "not mounted" error messages.
         subprocess.call(["umount", FOLDER_TO_MOUNT], stderr=subprocess.PIPE)
-        
+
         # Unmounting the device (e.g., "/dev/mmcblk0p1") to ensure the storage
         # device is fully detached. This prevents issues with certain
         # filesystem types like NTFS, which cannot be mounted multiple times.
         subprocess.call(["umount", device_to_mount], stderr=subprocess.PIPE)
-        
+
         # mount the target device/partition
         # if the return code of the shell command is non-zero,
         # means something wrong.

--- a/checkbox-support/checkbox_support/scripts/usb_read_write.py
+++ b/checkbox-support/checkbox_support/scripts/usb_read_write.py
@@ -170,7 +170,9 @@ def mount_usb_storage(partition):
         # use pipe so I could hide message like
         # "umount: /tmp/tmpjzwb6lys: not mounted"
         subprocess.call(["umount", FOLDER_TO_MOUNT], stderr=subprocess.PIPE)
-        # umount device_to_mount such as "umount /dev/mmcblk0p1" to avoid when the storage type is ntfs, which could not be mounted twice.
+        # Unmounting the device (e.g., "/dev/mmcblk0p1") to ensure the storage
+        # device is fully detached. This prevents issues with certain
+        # filesystem types like NTFS, which cannot be mounted multiple times.
         subprocess.call(["umount", device_to_mount], stderr=subprocess.PIPE)
         # mount the target device/partition
         # if the return code of the shell command is non-zero,


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix) (#1587)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

##  Description

To prevent the inserted storage from failing to mount twice, first ensure it is unmounted.

Because the OS will auto-mount the inserted storage, the existing `subprocess.call(["mount", device_to_mount, FOLDER_TO_MOUNT])` command will cause an error if the format of inserted storage is NTFS.

Perform an `umount`  on  `device_to_mount` (e.g., for the media card in #1587, it would be  `umount /dev/mmcblk0p1`) before attempting to mount it again to avoid this issue.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
Fix (#1587)

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
1. Run `checkbox-cli run com.canonical.certification::mediacard/sdhc-storage-manual`
2. Insert mediacard as prompt:
```

--------- Testing insertion ---------


INSERT NOW


Timeout: 30 seconds
```
3. After detectd the card, checkbox will do the read/write test.

### With the above change, it shows:
```
--------- Testing insertion --------

INSERT NOW


Timeout: 30 seconds
INFO: usable partition: mmcblk0p1
INFO: Device: ultra high speed SDR104 SDHC
INFO: Address: 59b4
INFO: Mediacard insertion test passed.

------- Insertion test passed -------

--------- Testing read/write --------
DEBUG:generating a random file
DEBUG:try to mount usb storage for testing
DEBUG:mount /dev/mmcblk0p1 on /tmp/tmpp76jsgp1 successfully.
DEBUG:===================
DEBUG:writing test begins
DEBUG:===================
DEBUG:Apply command: ['dd', 'if=/tmp/tmphkvvfmg9', 'of=/tmp/tmpp76jsgp1/tmphkvvfmg90', 'bs=1M', 'oflag=sync']
DEBUG:['100+1 records in', '100+1 records out', '104858730 bytes (105 MB, 100 MiB) copied, 7.43403 s, 14.1 MB/s', '']
DEBUG:No I/O errors found in dmesg
```
### Without the change, it shows:

```

--------- Testing insertion --------

INSERT NOW


Timeout: 30 seconds
INFO: usable partition: mmcblk0p1
INFO: Device: ultra high speed SDR104 SDHC
INFO: Address: 59b4
INFO: Mediacard insertion test passed.

------- Insertion test passed -------

--------- Testing read/write --------
DEBUG:generating a random file
DEBUG:try to mount usb storage for testing
Mount is denied because the NTFS volume is already exclusively opened.
The volume may be already mounted, or another software may use it which
could be identified for example by the help of the 'fuser' command.
ERROR:mount /dev/mmcblk0p1 on /tmp/tmph37fxtlq failed.
INFO:context manager exit: unmount USB storage
umount: /tmp/tmph37fxtlq: not mounted.
WARNING:umount /tmp/tmph37fxtlq failed.
INFO:Remove temporary folders and files.
```
