### PR TITLE
Prevent mandatory jobs from being added to the list of rejected jobs (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -1010,7 +1010,7 @@ class SessionAssistant:
         for job_id in self.get_static_todo_list():
             if job_id in selection:
                 desired_job_list.append(self._context.get_unit(job_id, "job"))
-            else:
+            elif job_id not in self.get_mandatory_jobs():
                 self._metadata.rejected_jobs.append(job_id)
         self._context.state.update_desired_job_list(desired_job_list)
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

When user de-selects jobs in the UI, they may de-select mandatory jobs.
These jobs, even if de-selected, will still be added to the list of jobs
to run later on, and will be executed.

Therefore, they should not be part of the rejected jobs list.

This problem does not happen when using the `match` feature.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

While investigating #1557 , I found this other issue.

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Apart from the unit test being updated, I ran the following test:

Launch Checkbox using this launcher:

```
[test plan]
unit = com.canonical.certification::client-cert-iot-ubuntucore-22-automated
forced = yes
```

De-select every job and run the test.

Check the generated `submission.json`:

- mandatory jobs (for instance `manifest`) are executed (part of `results`), **_and_** they are not in the `rejected-jobs` list.
- all the other jobs that have been de-selected are in `rejected-jobs`.