### PR TITLE
Restore all jobs in the job state map (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -828,12 +828,19 @@ class SessionAssistant:
             ] = "to run bootstrapping job"
             rb = self.run_job(job.id, "silent", False)
             self.use_job_result(job.id, rb.get_result())
+        # we may have a list of rejected jobs if this session is a resumed
+        # session
+        already_rejected = [
+            JobIdQualifier(job_id, None, inclusive=False)
+            for job_id in self._context.state.metadata.rejected_jobs
+        ]
         # Perform initial selection -- we want to run everything that is
         # described by the test plan that was selected earlier.
         desired_job_list = select_units(
             self._context.state.job_list,
             [plan.get_qualifier() for plan in self._manager.test_plans]
-            + self._exclude_qualifiers,
+            + self._exclude_qualifiers
+            + already_rejected,
         )
         self._context.state.update_desired_job_list(desired_job_list)
         # Set subsequent usage expectations i.e. all of the runtime parts are

--- a/checkbox-ng/plainbox/impl/session/resume.py
+++ b/checkbox-ng/plainbox/impl/session/resume.py
@@ -780,7 +780,9 @@ class SessionResumeHelper1(MetaDataHelper1MixIn):
             except KeyError:
                 leftover_jobs.append(job_id)
 
-        leftover_jobs += session_repr["metadata"]["rejected_jobs"]
+        leftover_jobs += session_repr.get("metadata", {}).get(
+            "rejected_jobs", []
+        )
         # Process leftovers. For each iteration the leftover_jobs list should
         # shrink or we're not making any progress. If that happens we've got
         # undefined jobs (in general the session is corrupted)

--- a/checkbox-ng/plainbox/impl/session/resume.py
+++ b/checkbox-ng/plainbox/impl/session/resume.py
@@ -779,6 +779,8 @@ class SessionResumeHelper1(MetaDataHelper1MixIn):
                 self._process_job(session, jobs_repr, results_repr, job_id)
             except KeyError:
                 leftover_jobs.append(job_id)
+
+        leftover_jobs += session_repr["metadata"]["rejected_jobs"]
         # Process leftovers. For each iteration the leftover_jobs list should
         # shrink or we're not making any progress. If that happens we've got
         # undefined jobs (in general the session is corrupted)

--- a/checkbox-ng/plainbox/impl/session/suspend.py
+++ b/checkbox-ng/plainbox/impl/session/suspend.py
@@ -516,6 +516,7 @@ class SessionSuspendHelper4(SessionSuspendHelper3):
                 state object.
         """
         id_run_list = frozenset([job.id for job in obj.run_list])
+
         return {
             "jobs": {
                 state.job.id: state.job.checksum
@@ -631,7 +632,10 @@ class SessionSuspendHelper6(SessionSuspendHelper5):
                 The representation of meta-data associated with the session
                 state object.
         """
-        id_run_list = frozenset([job.id for job in obj.run_list])
+        id_run_list = frozenset(
+            [job.id for job in obj.run_list] + obj.metadata.rejected_jobs
+        )
+
         return {
             "jobs": {
                 state.job.id: state.job.checksum

--- a/checkbox-ng/plainbox/impl/session/test_resume.py
+++ b/checkbox-ng/plainbox/impl/session/test_resume.py
@@ -2033,11 +2033,13 @@ class SessionJobsAndResultsResumeTests(TestCaseWithParameters):
 
     def test_simple_session_with_rejected(self):
         """
-        verify that _restore_SessionState_jobs_and_results() works when
-        faced with a representation of a simple session (no generated jobs
-        or anything "exotic").
+        verify that _restore_SessionState_jobs_and_results() also resumes in
+        the job_state_map jobs that were manually excluded from the user
+        (rejected jobs)
         """
         job = make_job(id="job")
+        # this job was de-selected by the user manually in the test selection
+        # screen
         job1 = make_job(id="job1")
         session_repr = {
             "jobs": {job.id: job.checksum, job1.id: job1.checksum},

--- a/metabox/metabox/core/lxd_execute.py
+++ b/metabox/metabox/core/lxd_execute.py
@@ -22,6 +22,8 @@ import shlex
 import threading
 import time
 
+from contextlib import suppress
+
 from loguru import logger
 import metabox.core.keys as keys
 from metabox.core.utils import ExecuteResult
@@ -113,7 +115,9 @@ class InteractiveWebsocket(WebSocketClient):
         return found
 
     def expect_not(self, data, timeout=0):
-        return not self.expect(data, timeout)
+        with suppress(TimeoutError):
+            return not self.expect(data, timeout)
+        return True
 
     def select_test_plan(self, data, timeout=0):
         if not self._lookup_by_id:

--- a/metabox/metabox/scenarios/restart/agent_respawn.py
+++ b/metabox/metabox/scenarios/restart/agent_respawn.py
@@ -207,7 +207,7 @@ class RemoteResumePreservesRejectedJobsStateMap(Scenario):
     Check that the job_state_map survives both manual closure and restarts
 
     This differs from Local because in remote the controller waits for the
-    agent to come back, we loose the output of the rebooting job and we don't
+    agent to come back, we lose the output of the rebooting job and we don't
     need to re-start the controller on reboot
     """
 

--- a/metabox/metabox/scenarios/restart/agent_respawn.py
+++ b/metabox/metabox/scenarios/restart/agent_respawn.py
@@ -165,11 +165,12 @@ class ResumeAfterFinishPreserveOutputRemote(Scenario):
 
 
 @tag("resume", "manual", "regression")
-class ResumePreservesRejectedJobsStateMap(Scenario):
+class LocalResumePreservesRejectedJobsStateMap(Scenario):
     """
     Check that the job_state_map survives both manual closure and restarts
     """
 
+    modes = ["local"]
     launcher = "# no launcher"
     steps = [
         Start(),
@@ -193,6 +194,46 @@ class ResumePreservesRejectedJobsStateMap(Scenario):
         # Part of the regression, fixing the job state map would make the
         # re-bootstrapping of the session include the excluded job
         ExpectNot("basic-shell-crashing", timeout=0.1),
+        # Here the session will try to re-generate the submission.json but it
+        # will fail if the info about the session is not complete in the job
+        # state map (as it was prior to this regression)
+        Expect("Do you want to submit 'upload to certification' report?"),
+    ]
+
+
+@tag("resume", "manual", "regression")
+class RemoteResumePreservesRejectedJobsStateMap(Scenario):
+    """
+    Check that the job_state_map survives both manual closure and restarts
+
+    This differs from Local because in remote the controller waits for the
+    agent to come back, we loose the output of the rebooting job and we don't
+    need to re-start the controller on reboot
+    """
+
+    modes = ["remote"]
+    launcher = "# no launcher"
+    steps = [
+        Start(),
+        Expect("Select test plan"),
+        SelectTestPlan(
+            "2021.com.canonical.certification::checkbox-crash-then-reboot"
+        ),
+        Send(keys.KEY_ENTER),
+        Expect("Press (T) to start"),
+        Send(keys.KEY_ENTER),
+        Expect("Crash Checkbox"),
+        Send(keys.KEY_DOWN + keys.KEY_SPACE),
+        Expect("[ ]"),
+        Send("T"),
+        Expect("Connection lost!"),
+        Expect("Do you want to submit 'upload to certification' report?"),
+        Signal(keys.SIGINT),
+        Start(),
+        # Part of the regression, fixing the job state map would make the
+        # re-bootstrapping of the session include the excluded job
+        ExpectNot("Crash Checkbox", timeout=0.1),
+        Expect("tar_file"),
         # Here the session will try to re-generate the submission.json but it
         # will fail if the info about the session is not complete in the job
         # state map (as it was prior to this regression)

--- a/metabox/metabox/scenarios/restart/agent_respawn.py
+++ b/metabox/metabox/scenarios/restart/agent_respawn.py
@@ -166,18 +166,26 @@ class ResumeAfterFinishPreserveOutputRemote(Scenario):
 
 @tag("resume", "manual", "regression")
 class ResumePreservesRejectedJobsStateMap(Scenario):
+    """
+    Check that the job_state_map survives both manual closure and restarts
+    """
+
     launcher = "# no launcher"
     steps = [
         Start(),
         Expect("Select test plan"),
-        SelectTestPlan("2021.com.canonical.certification::pass-and-crash"),
+        SelectTestPlan(
+            "2021.com.canonical.certification::checkbox-crash-then-reboot"
+        ),
         Send(keys.KEY_ENTER),
         Expect("Press (T) to start"),
         Send(keys.KEY_ENTER),
-        Expect("basic-shell-crashing"),
+        Expect("Crash Checkbox"),
         Send(keys.KEY_DOWN + keys.KEY_SPACE),
         Expect("[ ]"),
         Send("T"),
+        Expect("Waiting for the system to shut down or reboot"),
+        Start(),
         Expect("Do you want to submit 'upload to certification' report?"),
         Signal(keys.SIGINT),
         Start(),


### PR DESCRIPTION
## Description

This fixes the bug with the session that when a test is de-selected, any resume of the session will make the submission.json generation fail. This was because the job_state_map is not entirely re-loaded after the resume, but only the tests that were selected are correctly put in the map. 

Additionally, the validation of tests would not cover rejected tests (which is dangerous, as a test may be deselected for a reason, and that reason may not hold anymore). 

Finally there was a bug in the session resume where tests were only incidentally not re-run as the rejected job list was not re-evaluated after resume.

Minor: this fixes a bug with `ExpectNot`, as it wouldn't work if the checkbox controller didnt finish running, now it does

## Resolved issues

Fixes: CHECKBOX-1627
Fixes: https://github.com/canonical/checkbox/issues/1557

## Documentation

N/A

## Tests

This adds a new metabox scenario for the regression
