### PR TITLE
Add the missing sort for lsusb in reboot_check_test.py and fix unused device comparison result (BugFix)

### DIFF
--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -106,7 +106,10 @@ class DeviceInfoCollector:
             expected = "{}/{}_log".format(expected_dir, device)
             actual = "{}/{}_log".format(actual_dir, device)
             if not filecmp.cmp(expected, actual):
-                print("[ WARN ] Items under {} have changed.".format(actual))
+                print(
+                    "[ WARN ] Items under {} have changed.".format(actual),
+                    file=sys.stderr,
+                )
                 self.print_diff(device, expected, actual)
 
         return True
@@ -225,7 +228,7 @@ class HardwareRendererTester:
                 # => no connection, continue to the next
                 pass
             except Exception as e:
-                print("Unexpected error: ", e)
+                print("Unexpected error: ", e, file=sys.stderr)
 
         print(
             "No display is connected. This case will be skipped.",
@@ -434,7 +437,8 @@ def main() -> int:
         failed_services = get_failed_services()
         if len(failed_services) > 0:
             print(
-                "These services failed: {}".format("\n".join(failed_services))
+                "These services failed: {}".format("\n".join(failed_services)),
+                file=sys.stderr,
             )
             service_check_passed = False
         else:

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -6,7 +6,6 @@ import subprocess as sp
 import re
 import shutil
 import filecmp
-import sys
 import typing as T
 from checkbox_support.scripts.image_checker import has_desktop_environment
 
@@ -95,16 +94,13 @@ class DeviceInfoCollector:
             expected = "{}/{}_log".format(expected_dir, device)
             actual = "{}/{}_log".format(actual_dir, device)
             if not filecmp.cmp(expected, actual):
-                print(
-                    "[ ERR ] The output of {} differs!".format(device),
-                    file=sys.stderr,
-                )
+                print("[ ERR ] The output of {} differs!".format(device))
                 with open(expected) as file_expected, open(
                     actual
                 ) as file_actual:
-                    print("Expected {} output".format(device))
+                    print("Expected {} output:".format(device))
                     print(file_expected.read())
-                    print("Actual {} output".format(device))
+                    print("Actual {} output:".format(device))
                     print(file_actual.read())
                     print("End of {} diff".format(device))
 
@@ -116,14 +112,13 @@ class DeviceInfoCollector:
             if not filecmp.cmp(expected, actual):
                 print(
                     "[ WARN ] Items under {} have changed.".format(actual),
-                    file=sys.stderr,
                 )
                 with open(expected) as file_expected, open(
                     actual
                 ) as file_actual:
-                    print("Expected {} output".format(device))
+                    print("Expected {} output:".format(device))
                     print(file_expected.read())
-                    print("Actual {} output".format(device))
+                    print("Actual {} output:".format(device))
                     print(file_actual.read())
                     print("End of {} diff".format(device))
 
@@ -233,7 +228,7 @@ class HardwareRendererTester:
                 # => no connection, continue to the next
                 pass
             except Exception as e:
-                print("Unexpected error: ", e, file=sys.stderr)
+                print("Unexpected error: ", e)
 
         print(
             "No display is connected. This case will be skipped.",
@@ -412,7 +407,7 @@ def main() -> int:
                 "[ ERR ] Please specify an output directory with the -d flag."
             )
             raise ValueError(
-                "Cmoparison directory is specified, but output directory isn't"
+                "Comparison directory is specified, but output directory isn't"
             )
         else:
             collector = DeviceInfoCollector()
@@ -421,6 +416,8 @@ def main() -> int:
                 args.comparison_directory, args.output_directory
             ):
                 print("[ OK ] Devices match!")
+            else:
+                device_comparison_passed = False
 
     # dump (no checks) if only output_directory is specified
     if args.output_directory is not None and args.comparison_directory is None:

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -54,7 +54,7 @@ class DeviceInfoCollector:
         return "\n".join(map(lambda line: line.strip(), lines_to_write))
 
     def get_usb_info(self) -> str:
-        return sp.check_output(
+        out = sp.check_output(
             [
                 "checkbox-support-lsusb",
                 "-f",
@@ -62,7 +62,9 @@ class DeviceInfoCollector:
                 "-s",
             ],
             universal_newlines=True,
-        )
+        ).splitlines()
+        out.sort()
+        return "\n".join(out)
 
     def get_pci_info(self) -> str:
         return sp.check_output(

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -99,6 +99,15 @@ class DeviceInfoCollector:
                     "[ ERR ] The output of {} differs!".format(device),
                     file=sys.stderr,
                 )
+                with open(expected) as file_expected, open(
+                    actual
+                ) as file_actual:
+                    print("Expected {} output".format(device))
+                    print(file_expected.read())
+                    print("Actual {} output".format(device))
+                    print(file_actual.read())
+                    print("End of {} diff".format(device))
+
                 return False
 
         for device in devices["optional"]:
@@ -109,6 +118,14 @@ class DeviceInfoCollector:
                     "[ WARN ] Items under {} have changed.".format(actual),
                     file=sys.stderr,
                 )
+                with open(expected) as file_expected, open(
+                    actual
+                ) as file_actual:
+                    print("Expected {} output".format(device))
+                    print(file_expected.read())
+                    print("Actual {} output".format(device))
+                    print(file_actual.read())
+                    print("End of {} diff".format(device))
 
         return True
 
@@ -250,10 +267,10 @@ class HardwareRendererTester:
         )
         if unity_support_output.returncode != 0:
             print(
-                "[ ERR ] unity support test returned {}".format(
-                    unity_support_output.returncode
-                ),
-                file=sys.stderr,
+                "[ ERR ] unity support test returned {}. Error is: {}".format(
+                    unity_support_output.returncode,
+                    unity_support_output.stdout,
+                )
             )
             return False
 
@@ -267,7 +284,7 @@ class HardwareRendererTester:
             print("[ OK ] This machine is using a hardware renderer!")
             return True
 
-        print("[ ERR ] Software rendering detected", file=sys.stderr)
+        print("[ ERR ] Software rendering detected")
         return False
 
     def parse_unity_support_output(
@@ -392,8 +409,7 @@ def main() -> int:
     if args.comparison_directory is not None:
         if args.output_directory is None:
             print(
-                "[ ERR ] Please specify an output directory with the -d flag.",
-                file=sys.stderr,
+                "[ ERR ] Please specify an output directory with the -d flag."
             )
             raise ValueError(
                 "Cmoparison directory is specified, but output directory isn't"
@@ -423,8 +439,7 @@ def main() -> int:
         failed_services = get_failed_services()
         if len(failed_services) > 0:
             print(
-                "These services failed: {}".format("\n".join(failed_services)),
-                file=sys.stderr,
+                "These services failed: {}".format("\n".join(failed_services))
             )
             service_check_passed = False
         else:

--- a/providers/base/tests/test_reboot_check_test.py
+++ b/providers/base/tests/test_reboot_check_test.py
@@ -302,13 +302,16 @@ class MainFunctionTests(unittest.TestCase):
         ), patch(
             "reboot_check_test.DeviceInfoCollector.compare_device_lists"
         ) as mock_compare:
-            RCT.main()
+            mock_compare.return_value = False
+
+            rv = RCT.main()
 
             self.assertEqual(
                 mock_run.call_count,
                 len(RCT.DeviceInfoCollector.DEFAULT_DEVICES["required"]),
             )  # only lspci, lsusb, iw calls
             self.assertEqual(mock_compare.call_count, 1)
+            self.assertEqual(rv, 1)
 
     @patch("subprocess.run")
     def test_main_function_full(self, mock_run: MagicMock):


### PR DESCRIPTION
## Description

- Added a sort step after calling checkbox-support-lsusb
- Suppress FWTS progress messages to make stderr cleaner and errors more visible
- Made the comparison output more verbose when a comparison fails
- Fixed an issue where device comparison result was not updated after calling `compare_device_lists`

## Resolved issues

1. The original shell script had an explicit `checkbox-support-lsusb | sort` step that was missing in the python version. Adding this back to preserve the same behavior.
2. Device comparison result was never updated. This becomes a problem if the only issue on the DUT is device comparison

## Documentation


## Tests

Unit tests

Sideloaded the fix on 202312-33267 and plugged in an USB stick during reboot to force a device difference. The fix correctly reports that the device config changed and failed the test case
