### PR TITLE
pc-sanity: check-production-suite should be run for any later versions (BugFix)

### DIFF
--- a/contrib/pc-sanity/bin/check-production-suite.sh
+++ b/contrib/pc-sanity/bin/check-production-suite.sh
@@ -3,6 +3,7 @@
 codename=$(lsb_release -cs)
 oemcodename=$(get-oem-info.sh --oem-codename)
 platform=$(get-oem-info.sh --platform-codename)
+release_number=$(lsb_release -rs)
 
 if [ -z "$codename" ] || [ -z "$oemcodename" ] || [ -z "$platform" ]; then
     echo "Can't get oem info from the platform"
@@ -40,10 +41,20 @@ if ! [[ "$components" == *"$oemcodename"* ]]; then
     exit 1
 fi
 
-if [ "$oemcodename" = "somerville" ]; then
+if [ "$(echo "$release_number >= 24.04" | bc -l)" -eq 1 ]; then
+    # For versions 24.04 and newer, check platform archives for all OEMs
     if ! [[ "$components" == *"$oemcodename-$platform"* ]]; then
         echo "platform archive is not ready"
         echo "$components"
         exit 1
+    fi
+elif [ "$(echo "$release_number == 22.04" | bc -l)" -eq 1 ]; then
+    # For 22.04, only check somerville
+    if [ "$oemcodename" = "somerville" ]; then
+        if ! [[ "$components" == *"$oemcodename-$platform"* ]]; then
+            echo "platform archive is not ready"
+            echo "$components"
+            exit 1
+        fi
     fi
 fi

--- a/contrib/pc-sanity/units/pc-sanity/pc-sanity-check-env.pxu
+++ b/contrib/pc-sanity/units/pc-sanity/pc-sanity-check-env.pxu
@@ -145,7 +145,7 @@ plugin: shell
 category_id: com.canonical.plainbox::miscellanea
 id: miscellanea/check_production_suite
 requires:
- lsb.release == "22.04"
+ lsb.release >= "22.04"
  package.name == 'lsb-release'
 user: root
 command: check-production-suite.sh

--- a/contrib/pc-sanity/units/pc-sanity/pc-sanity-check-env.pxu
+++ b/contrib/pc-sanity/units/pc-sanity/pc-sanity-check-env.pxu
@@ -151,4 +151,6 @@ user: root
 command: check-production-suite.sh
 _summary: Check if production suite is created properly
 _description:
- Add a job to check the production suite is created correcly.
+ Add a job to check the production suite is created correctly.
+ On Ubuntu 22.04, only checks somerville platform archives.
+ On Ubuntu 24.04 and newer versions, checks platform archives for somerville, stella, and sutton.


### PR DESCRIPTION
## Description

Run check-production-suite also for 24.04 and later versions
