### PR TITLE
filter out the cpu governor test when cpb is enable (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/cpufreq_governors.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/cpufreq_governors.py
@@ -217,6 +217,32 @@ class CPUScalingHandler:
             print("ERROR: Fail to get scaling driver from {}".format(path))
             return ""
 
+    def get_cpb(self, policy=0) -> str:
+        """
+        Get the core performance boost (cpb) used by a specific CPU policy.
+        Ref. https://en.wikipedia.org/wiki/AMD_Turbo_Core
+
+        Args:
+            policy (int): The CPU policy number to query (default is 0).
+
+        Returns:
+            str: The value of the cpb for the specified policy.
+                 1 means enabled, 0 means disabled.
+        """
+        path = os.path.join(
+            self.sys_cpu_dir,
+            "cpufreq",
+            "policy{}".format(policy),
+            "cpb",
+        )
+        try:
+            with open(path, "r") as attr_file:
+                line = attr_file.read()
+                return line.strip()
+        except IOError:
+            print("ERROR: Fail to get cpb from {}".format(path))
+            return ""
+
     def print_policies_list(self) -> bool:
         """
         Print the list of CPU policies and their corresponding scaling drivers
@@ -230,9 +256,11 @@ class CPUScalingHandler:
         if not self.cpu_policies:
             return False
         for policy in self.cpu_policies:
-            driver = self.get_scaling_driver(policy)
             print("policy: {}".format(policy))
-            print("scaling_driver: {}".format(driver))
+            print(
+                "scaling_driver: {}".format(self.get_scaling_driver(policy))
+            )
+            print("cpb: {}".format(self.get_cpb(policy)))
             print()
         return True
 
@@ -632,7 +660,7 @@ class CPUScalingTest:
                     success = False
                     logging.error(
                         "Could not verify that cpu frequency has close to "
-                        "frequency %s MHz",
+                        "%s frequency %s MHz",
                         frequencies_mapping[governor][1],
                         (frequencies_mapping[governor][0] / 1000),
                     )

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/cpu/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/cpu/jobs.pxu
@@ -20,11 +20,11 @@ command: cpufreq_governors.py --driver-detect
 unit: template
 template-resource: cpufreq_policy_list
 template-unit: job
-template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate' and cpufreq_policy_list.cpb != '1'
 id: ce-oem-cpu/cpufreq-governor-performance-policy{policy}
 _summary: Test "performance" scaling governor on policy{policy}
 _description:
-    This job sets the governor to "performance" and 
+    This job sets the governor to "performance" and
     verifies whether the frequency is maximum.
 plugin: shell
 user: root
@@ -37,11 +37,11 @@ command: cpufreq_governors.py --policy {policy} --governor performance
 unit: template
 template-resource: cpufreq_policy_list
 template-unit: job
-template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate' and cpufreq_policy_list.cpb != '1'
 id: ce-oem-cpu/cpufreq-governor-powersave-policy{policy}
 _summary: Test "powersave" scaling governor on policy{policy}
 _description:
-    This job sets the governor to "powersave" and 
+    This job sets the governor to "powersave" and
     verifies whether the frequency is minimum.
 plugin: shell
 user: root
@@ -54,11 +54,11 @@ command: cpufreq_governors.py --policy {policy} --governor powersave
 unit: template
 template-resource: cpufreq_policy_list
 template-unit: job
-template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate' and cpufreq_policy_list.cpb != '1'
 id: ce-oem-cpu/cpufreq-governor-userspace-policy{policy}
 _summary: Test "userspace" scaling governor on policy{policy}
 _description:
-    This job sets the governor to "userspace" and 
+    This job sets the governor to "userspace" and
     verifies the frequency when setting it to maximum
     and minimum.
 plugin: shell
@@ -72,7 +72,7 @@ command: cpufreq_governors.py --policy {policy} --governor userspace
 unit: template
 template-resource: cpufreq_policy_list
 template-unit: job
-template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate' and cpufreq_policy_list.cpb != '1'
 id: ce-oem-cpu/cpufreq-governor-schedutil-policy{policy}
 _summary: Test "schedutil" scaling governor on policy{policy}
 _description:
@@ -91,7 +91,7 @@ command: cpufreq_governors.py --policy {policy} --governor schedutil
 unit: template
 template-resource: cpufreq_policy_list
 template-unit: job
-template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate' and cpufreq_policy_list.cpb != '1'
 id: ce-oem-cpu/cpufreq-governor-ondemand-policy{policy}
 _summary: Test "ondemand" scaling governor on policy{policy}
 _description:
@@ -110,7 +110,7 @@ command: cpufreq_governors.py --policy {policy} --governor ondemand
 unit: template
 template-resource: cpufreq_policy_list
 template-unit: job
-template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate' and cpufreq_policy_list.cpb != '1'
 id: ce-oem-cpu/cpufreq-governor-conservative-policy{policy}
 _summary: Test "conservative" scaling governor on policy{policy}
 _description:


### PR DESCRIPTION
## Description
On the AMD platform, when the `Core performance boost` is enabled, the CPU scaling frequency is control by the `AMD driver`. So bypass these CPU governor test for AMD CPU with CPB is enabeld

## Documentation
N/A

## Tests
```
ubuntu@ubuntu:~$ checkbox-ce-oem.checkbox-cli list-bootstrapped com.canonical.contrib::ce-oem-cpu-automated
$PROVIDERPATH is defined, so following provider sources are ignored ['/snap/checkbox-ce-oem/527/providers/checkbox-provider-ce-oem', '/home/ubuntu/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Using sideloaded provider: checkbox-provider-ce-oem, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-ce-oem
Skipped file: /var/tmp/checkbox-providers/checkbox-provider-ce-oem/bin/gst_utils.py
com.canonical.contrib::ce-oem-cpu/cpufreq_driver_detect
```