### PR TITLE
Add switch_power_mode in pc-sanity (New)

### DIFF
--- a/contrib/pc-sanity/units/pc-sanity/pc-sanity.pxu
+++ b/contrib/pc-sanity/units/pc-sanity/pc-sanity.pxu
@@ -23,6 +23,7 @@ include:
     com.canonical.certification::power-management/check-turbostat-s2i-cpu-residency
     com.canonical.certification::power-management/check-turbostat-s2i-s0ix-residency
     com.canonical.certification::power-management/check-turbostat-s2i-gfxrc6-residency
+    com.canonical.certification::power-management/switch_power_mode
     com.canonical.certification::miscellanea/intel-rapl
     com.canonical.certification::miscellanea/intel-rapl-mmio_.*
     com.canonical.certification::miscellanea/intel-p-state


### PR DESCRIPTION
## Description

Run switch_power_mode by default in pc-sanity, so that we could find the powermode switching issue ASAP.

https://bugs.launchpad.net/sutton/+bug/2060793

