### PR TITLE
Fail snap refresh/revert jobs if the `snap_update_test.py` script fails (bugfix)

### DIFF
--- a/providers/base/bin/snap_update_test.py
+++ b/providers/base/bin/snap_update_test.py
@@ -162,7 +162,10 @@ class SnapRefreshRevert:
             if checkbox_session_dir:
                 result = {
                     "outcome": "fail",
-                    "comments": "Marking the test as failed because it raised the following:"
+                    "comments": (
+                        "Marking the test as failed because it raised"
+                        " the following:"
+                    )
                     + str(exc),
                 }
                 result_filename = os.path.join(

--- a/providers/base/bin/snap_update_test.py
+++ b/providers/base/bin/snap_update_test.py
@@ -162,7 +162,8 @@ class SnapRefreshRevert:
             if checkbox_session_dir:
                 result = {
                     "outcome": "fail",
-                    "comments": "Marking the test as failed because it raised the following:" + str(exc),
+                    "comments": "Marking the test as failed because it raised the following:"
+                    + str(exc),
                 }
                 result_filename = os.path.join(
                     checkbox_session_dir, "__result"

--- a/providers/base/bin/snap_update_test.py
+++ b/providers/base/bin/snap_update_test.py
@@ -162,7 +162,7 @@ class SnapRefreshRevert:
             if checkbox_session_dir:
                 result = {
                     "outcome": "fail",
-                    "comments": exc.message,
+                    "comments": "Marking the test as failed because it raised the following:" + str(exc),
                 }
                 result_filename = os.path.join(
                     checkbox_session_dir, "__result"

--- a/providers/base/bin/snap_update_test.py
+++ b/providers/base/bin/snap_update_test.py
@@ -285,7 +285,7 @@ def main(args):
     )
     parser.add_argument(
         "--timeout",
-        default=300,
+        default=600,
         help="Timeout for each task, in seconds (default: %(default)s))",
     )
 

--- a/providers/base/bin/snap_update_test.py
+++ b/providers/base/bin/snap_update_test.py
@@ -25,7 +25,9 @@ import os
 import sys
 import time
 
-from checkbox_support.snap_utils.snapd import Snapd, SnapdRequestError
+from checkbox_support.snap_utils.snapd import Snapd
+from checkbox_support.snap_utils.snapd import AsyncException
+from checkbox_support.snap_utils.snapd import SnapdRequestError
 
 
 def guess_snaps() -> list:
@@ -155,7 +157,7 @@ class SnapRefreshRevert:
                 channel=self.snap_info.tracking_channel,
                 revision=self.revision,
             )
-        except SnapdRequestError as exc:
+        except (SnapdRequestError, AsyncException) as exc:
             checkbox_session_dir = os.getenv("PLAINBOX_SESSION_SHARE")
             if checkbox_session_dir:
                 result = {
@@ -187,7 +189,7 @@ class SnapRefreshRevert:
         )
         try:
             response = self.snapd.revert(self.name)
-        except SnapdRequestError as exc:
+        except (SnapdRequestError, AsyncException) as exc:
             checkbox_session_dir = os.getenv("PLAINBOX_SESSION_SHARE")
             if checkbox_session_dir:
                 result = {

--- a/providers/base/units/snapd/jobs.pxu
+++ b/providers/base/units/snapd/jobs.pxu
@@ -32,7 +32,7 @@ requires:
  (snap_revision_info.name == "{name}") and snap_revision_info.stable_rev != snap_revision_info.original_installed_rev
  manifest.need_{type}_snap_update_test == "True"
 command:
- set -eo pipefail
+ set -o pipefail
  path="$PLAINBOX_SESSION_SHARE/{name}_snap_revision_info"
  logpath="$PLAINBOX_SESSION_SHARE/snap-refresh-{type}-{name}-to-stable-rev.log"
  snap_update_test.py --refresh --revision {stable_rev} --info-path "$path" {name} | tee "$logpath"
@@ -82,7 +82,7 @@ category_id: snapd
 user: root
 depends: snapd/snap-verify-after-refresh-{type}-{name}-to-stable-rev
 command:
- set -eo pipefail
+ set -o pipefail
  path="$PLAINBOX_SESSION_SHARE/{name}_snap_revision_info"
  logpath="$PLAINBOX_SESSION_SHARE/snap-revert-{type}-{name}-from-stable-rev.log"
  snap_update_test.py --revert --info-path "$path" {name} | tee "$logpath"
@@ -145,7 +145,7 @@ requires:
  (snap_revision_info.name == "{name}") and snap_revision_info.base_rev != snap_revision_info.original_installed_rev
  manifest.need_{type}_snap_update_test == "True"
 command:
- set -eo pipefail
+ set -o pipefail
  path="$PLAINBOX_SESSION_SHARE/{name}_snap_revision_info"
  logpath="$PLAINBOX_SESSION_SHARE/snap-refresh-{type}-{name}-to-base-rev.log"
  snap_update_test.py --refresh --revision {base_rev} --info-path "$path" {name} | tee "$logpath"
@@ -195,7 +195,7 @@ category_id: snapd
 user: root
 depends: snapd/snap-verify-after-refresh-{type}-{name}-to-base-rev
 command:
- set -eo pipefail
+ set -o pipefail
  path="$PLAINBOX_SESSION_SHARE/{name}_snap_revision_info"
  logpath="$PLAINBOX_SESSION_SHARE/snap-revert-{type}-{name}-from-base-rev.log"
  snap_update_test.py --revert --info-path "$path" {name} | tee "$logpath"

--- a/providers/base/units/snapd/jobs.pxu
+++ b/providers/base/units/snapd/jobs.pxu
@@ -32,6 +32,7 @@ requires:
  (snap_revision_info.name == "{name}") and snap_revision_info.stable_rev != snap_revision_info.original_installed_rev
  manifest.need_{type}_snap_update_test == "True"
 command:
+ set -eo pipefail
  path="$PLAINBOX_SESSION_SHARE/{name}_snap_revision_info"
  logpath="$PLAINBOX_SESSION_SHARE/snap-refresh-{type}-{name}-to-stable-rev.log"
  snap_update_test.py --refresh --revision {stable_rev} --info-path "$path" {name} | tee "$logpath"
@@ -81,6 +82,7 @@ category_id: snapd
 user: root
 depends: snapd/snap-verify-after-refresh-{type}-{name}-to-stable-rev
 command:
+ set -eo pipefail
  path="$PLAINBOX_SESSION_SHARE/{name}_snap_revision_info"
  logpath="$PLAINBOX_SESSION_SHARE/snap-revert-{type}-{name}-from-stable-rev.log"
  snap_update_test.py --revert --info-path "$path" {name} | tee "$logpath"
@@ -143,6 +145,7 @@ requires:
  (snap_revision_info.name == "{name}") and snap_revision_info.base_rev != snap_revision_info.original_installed_rev
  manifest.need_{type}_snap_update_test == "True"
 command:
+ set -eo pipefail
  path="$PLAINBOX_SESSION_SHARE/{name}_snap_revision_info"
  logpath="$PLAINBOX_SESSION_SHARE/snap-refresh-{type}-{name}-to-base-rev.log"
  snap_update_test.py --refresh --revision {base_rev} --info-path "$path" {name} | tee "$logpath"
@@ -192,6 +195,7 @@ category_id: snapd
 user: root
 depends: snapd/snap-verify-after-refresh-{type}-{name}-to-base-rev
 command:
+ set -eo pipefail
  path="$PLAINBOX_SESSION_SHARE/{name}_snap_revision_info"
  logpath="$PLAINBOX_SESSION_SHARE/snap-revert-{type}-{name}-from-base-rev.log"
  snap_update_test.py --revert --info-path "$path" {name} | tee "$logpath"


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Adding `set -eo pipefail` in the snapd refresh/revert jobs that initiate
a reboot ensures that:

- any failure in the `snap_update_test.py` is not masked by the pipe
command (this is achieved by `set -o pipefail`)
- if an exception occurs while issuing a refresh or revert snap command, the script records the issue using a special Checkbox mechanism (`__result` file in the session sharing directory) and raise an exception. This will not prevent the job from rebooting, but when resuming, the job will be marked as failed.

Minor: increase timeout to 10 minutes to try to limit the number of issues on slow devices.


<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

- CHECKBOX-1671
- #1615 

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
