### PR TITLE
Print time stamps and drm connection status values in reboot checks (New)

### DIFF
--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -9,6 +9,7 @@ import filecmp
 import sys
 import typing as T
 from checkbox_support.scripts.image_checker import has_desktop_environment
+from datetime import datetime
 
 
 # Checkbox could run in a snap container, so we need to prepend this root path
@@ -18,14 +19,16 @@ RUNTIME_ROOT = os.getenv("CHECKBOX_RUNTIME", default="")
 SNAP = os.getenv("SNAP", default="")
 
 
-def get_uptime_seconds() -> float:
+def get_timestamp_str() -> str:
     with open("/proc/uptime", "r") as f:
         # uptime file always have 2 numbers
         # uptime_seconds total_idle_seconds
         # take the 1st one
-        uptime_seconds = float(f.readline().split()[0])
+        uptime_seconds = f.readline().split()[0]
 
-    return uptime_seconds
+    return "Time: {}; Uptime: {} seconds ".format(
+        datetime.now().strftime("%m/%d/%Y, %H:%M:%S"), uptime_seconds
+    )
 
 
 class DeviceInfoCollector:
@@ -240,7 +243,7 @@ class HardwareRendererTester:
             except FileNotFoundError:
                 # this just means we don't have a status file
                 # => no connection, continue to the next
-                print(" - {} does not have a status file".format(gpu))
+                pass
             except Exception as e:
                 print("Unexpected error: ", e, file=sys.stderr)
 
@@ -418,11 +421,7 @@ def main() -> int:
     renderer_test_passed = True
     service_check_passed = True
 
-    print(
-        "Starting reboot checks at {} seconds after boot.".format(
-            get_uptime_seconds()
-        )
-    )
+    print("Starting reboot checks. {}".format(get_timestamp_str()))
 
     if args.comparison_directory is not None:
         if args.output_directory is None:
@@ -474,11 +473,7 @@ def main() -> int:
             # skip renderer test if there's no display
             renderer_test_passed = tester.is_hardware_renderer_available()
 
-    print(
-        "Finished reboot checks at {} seconds after boot.".format(
-            get_uptime_seconds()
-        )
-    )
+    print("Finished reboot checks. {}".format(get_timestamp_str()))
 
     if (
         fwts_passed

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -18,6 +18,9 @@ RUNTIME_ROOT = os.getenv("CHECKBOX_RUNTIME", default="")
 SNAP = os.getenv("SNAP", default="")
 
 
+def get_uptime(): ...
+
+
 class DeviceInfoCollector:
 
     class Device:
@@ -215,6 +218,7 @@ class HardwareRendererTester:
 
         print("These nodes", possible_gpu_nodes, "exist")
 
+        connected_to_display = False
         for gpu in possible_gpu_nodes:
             # for each gpu, check for connection
             # return true if anything is connected
@@ -222,21 +226,23 @@ class HardwareRendererTester:
                 with open("{}/{}/status".format(DRM_PATH, gpu)) as status_file:
                     if status_file.read().strip().lower() == "connected":
                         print("{} is connected to display!".format(gpu))
-                        return True
+                        connected_to_display = True
             except FileNotFoundError:
                 # this just means we don't have a status file
                 # => no connection, continue to the next
-                pass
+                print("{} does not have a status file".format(gpu))
             except Exception as e:
                 print("Unexpected error: ", e, file=sys.stderr)
 
-        print(
-            "No display is connected. This case will be skipped.",
-            "Maybe the display cable is not connected?",
-            "If the device is not supposed to have a display,"
-            "then skipping is expected",
-        )
-        return False
+        if not connected_to_display:
+            print(
+                "No display is connected. This case will be skipped.",
+                "Maybe the display cable is not connected?",
+                "If the device is not supposed to have a display,"
+                "then skipping is expected.",
+            )
+
+        return connected_to_display
 
     def is_hardware_renderer_available(self) -> bool:
         """


### PR DESCRIPTION
## Description

We were having some difficulty narrowing down the cause when checkbox reports the DUT was not doing hardware rendering. It was kinda hard to tell if it was due to:
 - checkbox running so early in the boot process that none of the graphics related steps were even started by Ubuntu 
 - the DUT is actually broken 
 - display connection was moved to another output (like `cardUnknown`) 

This PR adds a timestamp output and lists all the drm connection status during the test

## Resolved issues

No real issue here, this is more like a QoL change for QA

## Documentation

Sample output:
![image](https://github.com/user-attachments/assets/6b53dce3-f5c3-4609-b2dd-f1c53c75ee50)


## Tests

Original unit tests pass
