### PR TITLE
Add Granite Rapids CPUID (BugFix)

### DIFF
--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -208,7 +208,7 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
         "Westmere":         ['0x2065', '0x206c', '0x206f'],
         "Whisky Lake":      ['0x806eb', '0x806ec'],
         "Sierra Forest":    ['0xa06f3'],
-        "Granite Rapids":   ['0xa06e0', '0xa06d0'],
+        "Granite Rapids":   ['0xa06e0', '0xa06d0', '0xa06d1'],
         "Meteor Lake":      ['0xa06a4'],
         "Arrow Lake":       ['0xc0660'],
         "Lunar Lake":       ["0xb06d1"]


### PR DESCRIPTION
## Description

Adds a CPUID for Granite Rapids.

## Resolved issues

- Resolves CHECKBOX-1672
- Resolves #1617 

## Documentation

## Tests
