### PR TITLE
Add DSS integration tests for CPU and NVIDIA GPU (New)

### DIFF
--- a/contrib/checkbox-dss-validation/bin/install-deps
+++ b/contrib/checkbox-dss-validation/bin/install-deps
@@ -80,7 +80,7 @@ main() {
     # intel_gpu_top command used for host-level GPU check
     # jq used for cases where jsonpath is insufficient for parsing json results
     echo -e "\nStep 3/4: Installing intel-gpu-tools"
-    DEBIAN_FRONTEND=noninteractive sudo apt install -y intel-gpu-tools jq
+    DEBIAN_FRONTEND=noninteractive sudo apt install -y python3-venv intel-gpu-tools jq
 
     echo -e "\nStep 4/4: Installing data-science-stack snap from channel $dss_snap_channel"
     sudo snap install data-science-stack --channel "$dss_snap_channel"

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/check_cuda.sh
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/check_cuda.sh
@@ -41,6 +41,7 @@ help_function() {
     echo "Test cases currently implemented:"
     echo -e "\t<gpu_addon_can_be_enabled>: check_nvidia_gpu_addon_can_be_enabled"
     echo -e "\t<gpu_validations_succeed>: check_nvidia_gpu_validations_succeed"
+    exit 1
 }
 
 main() {

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/check_dss.sh
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/check_dss.sh
@@ -71,6 +71,7 @@ help_function() {
     echo -e "\t<nvidia_gpu_acceleration_is_enabled>: check_dss_has_nvidia_gpu_acceleration_enabled"
     echo -e "\t<can_create_notebook>: check_dss_can_create_notebook <notebook_name> [args]"
     echo -e "\t<can_remove_notebook>: check_dss_can_remove_notebook <notebook_name>"
+    exit 1
 }
 
 main() {

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/check_dss.sh
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/check_dss.sh
@@ -54,6 +54,11 @@ check_dss_can_remove_notebook() {
     fi
 }
 
+check_dss_can_be_purged() {
+    dss purge
+    echo "Test success: dss purged."
+}
+
 help_function() {
     echo "This script is used for generic tests related to DSS"
     echo "Usage: check_dss.sh <test_case> [args]..."
@@ -78,6 +83,7 @@ main() {
     nvidia_gpu_acceleration_is_enabled) check_dss_status_contains "NVIDIA GPU acceleration: Enabled.*" ;;
     can_create_notebook) check_dss_can_create_notebook "${@:2}" ;;
     can_remove_notebook) check_dss_can_remove_notebook "${@:2}" ;;
+    can_be_purged) check_dss_can_be_purged ;;
     *) help_function ;;
     esac
     popd

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/check_dss_integration_tests.sh
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/check_dss_integration_tests.sh
@@ -42,6 +42,7 @@ help_function() {
     echo "Test cases currently implemented:"
     echo -e "\t<pass_on_cpu>"
     echo -e "\t<pass_on_nvidia_gpu>"
+    exit 1
 }
 
 main() {

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/check_dss_integration_tests.sh
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/check_dss_integration_tests.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+DSS_REPO_CLONE_PATH="$HOME/data-science-stack"
+DSS_REPO_REV="main"
+
+_ensure_microk8s_config_is_in_place() {
+    sudo microk8s.kubectl config view --raw | sudo tee "${SNAP_REAL_HOME}/.kube/config" >/dev/null
+}
+
+_ensure_dss_repo_is_checked_out() {
+    if [ ! -d "$DSS_REPO_CLONE_PATH" ]; then
+        git clone https://github.com/canonical/data-science-stack.git "$DSS_REPO_CLONE_PATH"
+    fi
+    git -C "$DSS_REPO_CLONE_PATH" checkout "$DSS_REPO_REV"
+    echo "Current git branch for DSS repo: $(git branch --show-current)"
+    echo "Latest commit:"
+    git -C "$DSS_REPO_CLONE_PATH" log --name-status HEAD^..HEAD
+}
+_ensure_dss_python_env_is_setup() {
+    pushd "$DSS_REPO_CLONE_PATH"
+    if [ ! -d ".venv" ]; then
+        python3 -m venv .venv
+    fi
+    .venv/bin/pip install tox
+    popd
+}
+
+check_dss_integration_tests_pass() {
+    pushd "$DSS_REPO_CLONE_PATH"
+    echo "starting DSS integration tests: $1"
+    .venv/bin/tox -e "$1" -- -vv -s
+    echo "Tests passed: DSS integration tests '$1'"
+    popd
+}
+
+help_function() {
+    echo "This script is used for running integration tests from DSS"
+    echo "Usage: check_dss_integration_tests <test_case>"
+    echo
+    echo "Test cases currently implemented:"
+    echo -e "\t<pass_on_cpu>"
+    echo -e "\t<pass_on_nvidia_gpu>"
+}
+
+main() {
+    _ensure_microk8s_config_is_in_place
+    _ensure_dss_repo_is_checked_out
+    _ensure_dss_python_env_is_setup
+
+    case ${1} in
+    pass_on_cpu) check_dss_integration_tests_pass "integration" ;;
+    pass_on_nvidia_gpu)  check_dss_integration_tests_pass "integration-gpu" ;;
+    *) help_function ;;
+    esac
+}
+
+main "$@"

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/check_intel.sh
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/check_intel.sh
@@ -119,6 +119,7 @@ help_function() {
     echo -e "\t<at_least_one_gpu_is_available>: check_at_least_one_intel_gpu_is_available"
     echo -e "\t<capacity_slots_for_gpus_match>: check_capacity_slots_for_intel_gpus_match"
     echo -e "\t<allocatable_slots_for_gpus_match>: check_allocatable_slots_for_intel_gpus_match"
+    exit 1
 }
 
 main() {

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/check_notebook.sh
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/check_notebook.sh
@@ -33,6 +33,7 @@ help_function() {
     echo -e "\t\t\t- verifying_tensorflow_can_use_xpu"
     echo -e "\t\t\t- verifying_pytorch_can_use_cuda"
     echo -e "\t\t\t- verifying_tensorflow_can_use_cuda"
+    exit 1
 }
 
 main() {

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/jobs.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/jobs.pxu
@@ -369,7 +369,7 @@ requires:
 depends: dss/purge
 _summary: Check that all DSS integration tests for CPU pass
 estimated_duration: 1m
-command: check_dss_integration_tests.sh can_be_purged pass_on_cpu
+command: check_dss_integration_tests.sh pass_on_cpu
 
 id: dss_integration_tests/nvidia_gpu
 category_id: dss-regress
@@ -386,4 +386,4 @@ depends:
   nvidia_gpu_addon/validations_succeed
 _summary: Check that all DSS integration tests for NVIDIA GPUs
 estimated_duration: 1m
-command: check_dss_integration_tests.sh can_be_purged pass_on_nvidia_gpu
+command: check_dss_integration_tests.sh pass_on_nvidia_gpu

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/jobs.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/jobs.pxu
@@ -340,3 +340,50 @@ depends: dss/create_tensorflow_cuda_notebook
 _summary: Check that the Tensorflow CUDA notebook can be removed
 estimated_duration: 1m
 command: check_dss.sh can_remove_notebook tensorflow-cuda
+
+# DSS integration test jobs ###################################################
+
+id: dss/purge
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends: dss/initialize
+_summary: Check that DSS can be purged
+estimated_duration: 1m
+command: check_dss.sh can_be_purged
+
+# NOTE: DSS Integration tests expect DSS to not be initialized
+#  hence they also depend on the dss/purge job
+
+id: dss_integration_tests/cpu
+category_id: dss-regress
+flags: simple
+imports:
+  from com.canonical.certification import executable
+  from com.canonical.certification import package
+requires:
+  executable.name == 'dss'
+  executable.name == 'python3'
+  package.name == 'python3-venv'
+depends: dss/purge
+_summary: Check that all DSS integration tests for CPU pass
+estimated_duration: 1m
+command: check_dss_integration_tests.sh can_be_purged pass_on_cpu
+
+id: dss_integration_tests/nvidia_gpu
+category_id: dss-regress
+flags: simple
+imports:
+  from com.canonical.certification import executable
+  from com.canonical.certification import package
+requires:
+  executable.name == 'dss'
+  executable.name == 'python3'
+  package.name == 'python3-venv'
+depends:
+  dss/purge
+  nvidia_gpu_addon/validations_succeed
+_summary: Check that all DSS integration tests for NVIDIA GPUs
+estimated_duration: 1m
+command: check_dss_integration_tests.sh can_be_purged pass_on_nvidia_gpu

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
@@ -35,7 +35,11 @@ include:
     dss/create_tensorflow_cuda_notebook
     cuda/tensorflow_can_use_cuda
     dss/remove_tensorflow_cuda_notebook
+    dss/purge
+    dss_integration_tests/cpu
+    dss_integration_tests/nvidia_gpu
 bootstrap_include:
     com.canonical.certification::executable
     com.canonical.certification::snap
     com.canonical.certification::graphics_card
+    com.canonical.certification::package


### PR DESCRIPTION
## Description

Added integration tests from the [`data-science-stack` repo](https://github.com/canonical/data-science-stack).  These tests need to be run at the very end, and require that DSS is not initialized, because the integration tests themselves initialize and purge DSS and check for relevant success.  Integration tests for NVIDIA GPU also require that the relevant k8s plugin is setup.

The Git repo is cloned, the relevant virtual environment is created, and the tests are executed using `tox` from the virtual environment.

## Resolved issues

- [CHECKBOX-1667](https://warthogs.atlassian.net/browse/CHECKBOX-1667)

## Documentation

There are no changes to the documentation.

## Tests

The relevant DSS workflow run: https://github.com/canonical/checkbox/actions/runs/12143951564

<details>
<summary><em>to save ourselves some time...</em></summary>

The job linked above was actually run on a different branch, which consists of commits from this PR, and PR #1634 together.  This is because the workflow runs can take a very long time, and while their changes don't overlap, the two PRs are worth testing together.

</details>

The failures on testing DSS latest/edge are expected due to a [reported issue](https://github.com/canonical/data-science-stack/issues/191) and do not stem from these changes to Checkbox.  The one failure testing DSS latest/stable is during provisioning from Testflinger, before the Checkbox validations are even installed.

[CHECKBOX-1667]: https://warthogs.atlassian.net/browse/CHECKBOX-1667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ