### PR TITLE
Add reboot and re-test to Testflinger job for DSS validation (New)

### DIFF
--- a/contrib/checkbox-dss-validation/testflinger/job-def.yaml
+++ b/contrib/checkbox-dss-validation/testflinger/job-def.yaml
@@ -59,3 +59,26 @@ test_data:
     ssh ubuntu@$DEVICE_IP '
       checkbox-dss.validate-with-gpu
     '
+
+    # Reboot the machine
+    ssh -t ubuntu@$DEVICE_IP '
+      SLEEP_SECS=15
+      >&2 echo "[INFO]: sleeping for ${SLEEP_SECS} seconds before rebooting."
+      sleep ${SLEEP_SECS}
+      >&2 echo "[INFO]: rebooting now.  Best of luck!"
+      sudo reboot
+    ' || >&2 echo "reboot started with exit code $?"
+
+    SLEEP_SECS=30
+    >&2 echo "[INFO]: sleeping for ${SLEEP_SECS} seconds for reboot to finish."
+    sleep ${SLEEP_SECS}
+    >&2 echo "[INFO]: attempting to reconnect."
+
+    # Re-test after reboot, attempting to connect max 30 times, waiting 10 sec each time
+    ssh -t ubuntu@$DEVICE_IP -o 'ConnectionAttempts 30' -o 'ConnectTimeout 10' '
+      SLEEP_SECS=60
+      >&2 echo "[INFO]: sleeping for ${SLEEP_SECS} seconds for things to settle down a bit."
+      sleep ${SLEEP_SECS}
+      sudo microk8s status --wait-ready
+      checkbox-dss.validate-with-gpu
+    '


### PR DESCRIPTION
## Description

The updates are only to the job definition template used by the [GitHub workflow](https://github.com/canonical/checkbox/blob/main/.github/workflows/testflinger-contrib-dss-regression.yaml) for running the DSS validations on machines from Testflinger.  We reboot the machine and re-run the validations, with some delay in the middle to let things settle down.  

## Resolved issues

- [CHECKBOX-1669](https://warthogs.atlassian.net/browse/CHECKBOX-1669)

## Documentation

There are no changes to the documentation.

## Tests

The relevant DSS workflow run: https://github.com/canonical/checkbox/actions/runs/12143951564

<details>
<summary><em>to save ourselves some time...</em></summary>

The job linked above was actually run on a different branch, which consists of commits from this PR, and PR #1633 together.  This is because the workflow runs can take a very long time, and while their changes don't overlap, the two PRs are worth testing together.

</details>

The failures on testing DSS latest/edge are expected due to a [reported issue](https://github.com/canonical/data-science-stack/issues/191) and do not stem from these changes to Checkbox.  The one failure testing DSS latest/stable is during provisioning from Testflinger, before the Checkbox validations are even installed.

[CHECKBOX-1669]: https://warthogs.atlassian.net/browse/CHECKBOX-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ