### PR TITLE
Enabling DSS testing on 1/track (Infra)

### DIFF
--- a/.github/workflows/testflinger-contrib-dss-regression.yaml
+++ b/.github/workflows/testflinger-contrib-dss-regression.yaml
@@ -24,7 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         dss_channel:
-          - latest/stable
+          - 1/stable
+          - 1/candidate
           - latest/edge
         microk8s_channel:
           - 1.28/stable


### PR DESCRIPTION
## Description

Since a new track has just been created ([reference](https://forum.snapcraft.io/t/create-new-track-for-data-science-stack/44203)) and released in snapstore, we now enable testing against `1/stable` and `1/candidate` instead of `latest/stable` (that should soon be deprecated)

