### PR TITLE
Fix black photo issue on intel MIPI cameras (Bugfix)

### DIFF
--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -544,18 +544,6 @@ class CameraTest:
         valve.set_property("drop", True)
         pipeline.add(valve)
 
-        # Add encoder
-        encoder = self.Gst.ElementFactory.make("jpegenc", "encoder")
-        # snapshot=True sends a EOS downstream
-        # when the first buffer reaches jpegenc
-        encoder.set_property("snapshot", True)
-        pipeline.add(encoder)
-
-        # Add sink
-        sink = self.Gst.ElementFactory.make("filesink", "sink")
-        sink.set_property("location", filename)
-        pipeline.add(sink)
-
         # Link elements
         source.link(caps)
         rgb_capture.link(valve)
@@ -574,8 +562,20 @@ class CameraTest:
             valve.link(sink)
 
         else:
+            # Add encoder
+            encoder = self.Gst.ElementFactory.make("jpegenc", "encoder")
+            # snapshot=True sends a EOS downstream
+            # when the first buffer reaches jpegenc
+            encoder.set_property("snapshot", True)
+            pipeline.add(encoder)
             valve.link(encoder)
             encoder.link(sink)
+
+        # Add sink
+        sink = self.Gst.ElementFactory.make("filesink", "sink")
+        sink.set_property("location", filename)
+        pipeline.add(sink)
+
         # source ! rgbcapture ! valve ! encoder ! filesink
 
         # Connect the bus to the message handler

--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -542,7 +542,9 @@ class CameraTest:
         # Add valve, note that we can't rely on the default value of drop
         # it varies by installations
         valve = self.Gst.ElementFactory.make("valve", "photo-valve")
-        assert valve, "Valve element could not be created"
+        if not valve:
+            raise RuntimeError("Valve element could not be created")
+
         valve.set_property("drop", True)
         pipeline.add(valve)
 

--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -549,7 +549,7 @@ class CameraTest:
         rgb_capture.link(valve)
 
         # Add sink, use multifilesink to avoid large jpeg files.
-        # filesink does not stop writing after it receives the 1st buffer 
+        # filesink does not stop writing after it receives the 1st buffer
         sink = self.Gst.ElementFactory.make("multifilesink", "sink")
         sink.set_property("location", filename)
         pipeline.add(sink)

--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -557,7 +557,7 @@ class CameraTest:
 
             def stop_jpeg_pipeline():
                 self.timeout["stop_jpeg_pipeline"] = None
-                self._stop_pipeline()
+                self.pipeline.send_event(self.Gst.Event.new_eos())
 
             # cannot use jpegenc here, so we directly link to the sink
             # give it 1 extra second in case MainLoop checks this timeout first
@@ -569,9 +569,6 @@ class CameraTest:
         else:
             # Add encoder
             encoder = self.Gst.ElementFactory.make("jpegenc", "encoder")
-            # snapshot=True sends a EOS downstream
-            # when the first buffer reaches jpegenc
-            encoder.set_property("snapshot", True)
             pipeline.add(encoder)
             valve.link(encoder)
             encoder.link(sink)
@@ -592,9 +589,9 @@ class CameraTest:
             90, self._on_timeout
         )
         if self.photo_wait_seconds > 0:
-
             def open_valve():
                 self.timeout["open_valve"] = None
+                print("Opening valve!")
                 valve.set_property("drop", False)
 
             self.timeout["open_valve"] = self.GLib.timeout_add_seconds(

--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -416,7 +416,13 @@ class CameraTest:
         """
         Captures an image to a file
         """
-        pixelformat = self._get_default_format()["pixelformat"]
+        default_format = self._get_default_format()
+        pixelformat = default_format["pixelformat"]
+        assert (
+            len(default_format["resolutions"]) > 0
+        ), "No default resolution was found"
+        # list[(int, int)]
+        self._width, self._height = default_format["resolutions"][0] 
         if self.output:
             self._capture_image(
                 self.output, self._width, self._height, pixelformat

--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -589,6 +589,7 @@ class CameraTest:
             90, self._on_timeout
         )
         if self.photo_wait_seconds > 0:
+
             def open_valve():
                 self.timeout["open_valve"] = None
                 print("Opening valve!")
@@ -844,7 +845,7 @@ class CameraTest:
         if not formats:
             raise SystemExit("No supported formats found")
         format = formats[0]
-        print(format)
+
         return format
 
     def _validate_image(self, filename, width, height):

--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -556,6 +556,7 @@ class CameraTest:
         if pixelformat == "MJPG":
 
             def stop_jpeg_pipeline():
+                # this relies on the eos handler in _on_gst_message
                 self.timeout["stop_jpeg_pipeline"] = None
                 self.pipeline.send_event(self.Gst.Event.new_eos())
 

--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -422,7 +422,7 @@ class CameraTest:
             len(default_format["resolutions"]) > 0
         ), "No default resolution was found"
         # list[(int, int)]
-        self._width, self._height = default_format["resolutions"][0] 
+        self._width, self._height = default_format["resolutions"][0]
         if self.output:
             self._capture_image(
                 self.output, self._width, self._height, pixelformat

--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -548,6 +548,11 @@ class CameraTest:
         source.link(caps)
         rgb_capture.link(valve)
 
+        # Add sink
+        sink = self.Gst.ElementFactory.make("filesink", "sink")
+        sink.set_property("location", filename)
+        pipeline.add(sink)
+
         if pixelformat == "MJPG":
 
             def stop_jpeg_pipeline():
@@ -570,11 +575,6 @@ class CameraTest:
             pipeline.add(encoder)
             valve.link(encoder)
             encoder.link(sink)
-
-        # Add sink
-        sink = self.Gst.ElementFactory.make("filesink", "sink")
-        sink.set_property("location", filename)
-        pipeline.add(sink)
 
         # source ! rgbcapture ! valve ! encoder ! filesink
 

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -21,7 +21,6 @@ import textwrap
 import sys
 
 import unittest
-from unittest import mock
 from unittest.mock import patch, MagicMock, call, mock_open
 
 from camera_test import (
@@ -789,6 +788,19 @@ class CameraTestTests(unittest.TestCase):
         mock_camera = MagicMock()
         mock_camera._get_supported_formats.return_value = []
         with self.assertRaises(SystemExit):
+            CameraTest._get_default_format(mock_camera)
+
+    def test_get_default_format_broken_format(self):
+        mock_camera = MagicMock()
+
+        mock_camera._get_supported_formats.return_value = [
+            {
+                "pixelformat": "YUYV",
+                "description": "YUYV",
+                "resolutions": [],
+            }
+        ]
+        with self.assertRaises(ValueError):
             CameraTest._get_default_format(mock_camera)
 
     @patch("os.path.exists")

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -228,9 +228,10 @@ class CameraTestTests(unittest.TestCase):
 
     def test_on_timeout(self):
         mock_camera = MagicMock()
+        mock_camera.timeout = {}
         CameraTest._on_timeout(mock_camera)
         self.assertEqual(mock_camera._stop_pipeline.call_count, 1)
-        self.assertEqual(mock_camera.timeout, None)
+        self.assertEqual(mock_camera.timeout['global_timeout'], None)
 
     def test_supported_formats_to_string(self):
         formats = [
@@ -492,6 +493,7 @@ class CameraTestTests(unittest.TestCase):
     def test_capture_image_gstreamer_remove_timeout(self):
         mock_camera = MagicMock()
         mock_camera.photo_wait_seconds = 3
+        mock_camera.timeout = {}
         mock_camera.GLib.timeout_add_seconds.return_value = "timeout"
         CameraTest._capture_image_gstreamer(
             mock_camera, "/tmp/test.jpg", 640, 480, "RG10"

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -507,12 +507,13 @@ class CameraTestTests(unittest.TestCase):
         open_valve_inserted = False
         for mock_timeout_call in mock_GLib_timout_add.call_args_list:
             callback = mock_timeout_call.args[1]
+            print(str(callback), dir(callback), flush=sys.stderr)
 
             if "stop_jpeg_pipeline" in str(callback):
                 stop_jpeg_pipeline_inserted = True
                 callback()
                 self.assertIsNone(mock_camera.timeout["stop_jpeg_pipeline"])
-            
+
             if "open_valve" in str(callback):
                 open_valve_inserted = True
                 callback()

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -21,6 +21,7 @@ import textwrap
 import sys
 
 import unittest
+from unittest import mock
 from unittest.mock import patch, MagicMock, call, mock_open
 
 from camera_test import (
@@ -503,7 +504,9 @@ class CameraTestTests(unittest.TestCase):
         self.assertEqual(mock_GLib_timout_add.call_count, 3)
 
         stop_jpeg_pipeline_inserted = False
+        print(mock_GLib_timout_add.call_args_list)
         for mock_timeout_call in mock_GLib_timout_add.call_args_list:
+            print(dir(mock_timeout_call))
             callback = mock_timeout_call.args[1]
             if (
                 hasattr(callback, "__name__")
@@ -511,9 +514,7 @@ class CameraTestTests(unittest.TestCase):
             ):
                 stop_jpeg_pipeline_inserted = True
                 callback()
-                self.assertIsNone(
-                    mock_camera.timeout["stop_jpeg_pipeline"], None
-                )
+                self.assertIsNone(mock_camera.timeout["stop_jpeg_pipeline"])
         self.assertTrue(stop_jpeg_pipeline_inserted)
 
     def test_capture_image_gstreamer_error(self):

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -335,6 +335,7 @@ class CameraTestTests(unittest.TestCase):
 
     def test_setup_video_gstreamer_error(self):
         mock_camera = MagicMock()
+        mock_camera.photo_wait_seconds = 3
         mock_camera.GLib.Error = Exception
         mock_camera.GLib.MainLoop.return_value.run.side_effect = Exception()
         mock_camera.Gst.State.NULL = "null"
@@ -400,6 +401,7 @@ class CameraTestTests(unittest.TestCase):
     @patch("os.path.getsize")
     def test_capture_image_fswebcam(self, mock_get_size, mock_check_call):
         mock_camera = MagicMock()
+        mock_camera.photo_wait_seconds = 3
         mock_get_size.return_value = 1
         result = CameraTest._capture_image_fswebcam(
             mock_camera, "/tmp/test.jpg", 640, 480, "MJPG"
@@ -411,6 +413,7 @@ class CameraTestTests(unittest.TestCase):
     @patch("os.path.getsize")
     def test_capture_image_fswebcam_empty(self, mock_get_size):
         mock_camera = MagicMock()
+        mock_camera.photo_wait_seconds = 3
         mock_get_size.return_value = 0
         result = CameraTest._capture_image_fswebcam(
             mock_camera, "/tmp/test.jpg", 640, 480, "YUYV"
@@ -420,6 +423,7 @@ class CameraTestTests(unittest.TestCase):
     @patch("camera_test.check_call")
     def test_capture_image_fswebcam_error(self, mock_check_call):
         mock_camera = MagicMock()
+        mock_camera.photo_wait_seconds = 3
         mock_check_call.return_value = OSError()
         result = CameraTest._capture_image_fswebcam(
             mock_camera, "/tmp/test.jpg", 640, 480, "YUYV"
@@ -428,6 +432,7 @@ class CameraTestTests(unittest.TestCase):
 
     def test_capture_image_gstreamer(self):
         mock_camera = MagicMock()
+        mock_camera.photo_wait_seconds = 3
         mock_make = mock_camera.Gst.ElementFactory.make
         mock_camera.Gst.State.PLAYING = "playing"
 
@@ -451,6 +456,7 @@ class CameraTestTests(unittest.TestCase):
 
     def test_capture_image_gstreamer_bayer(self):
         mock_camera = MagicMock()
+        mock_camera.photo_wait_seconds = 3
         mock_make = mock_camera.Gst.ElementFactory.make
 
         CameraTest._capture_image_gstreamer(
@@ -472,6 +478,7 @@ class CameraTestTests(unittest.TestCase):
 
     def test_capture_image_gstreamer_error(self):
         mock_camera = MagicMock()
+        mock_camera.photo_wait_seconds = 3
         mock_camera.GLib.Error = Exception
         mock_camera.GLib.MainLoop.return_value.run.side_effect = Exception()
         mock_camera.Gst.State.NULL = "null"
@@ -482,8 +489,9 @@ class CameraTestTests(unittest.TestCase):
         self.assertEqual(mock_camera.main_loop.run.call_count, 1)
         mock_camera.pipeline.set_state.assert_called_with("null")
 
-    def test_capture_image_gstreamer_remove_timepout(self):
+    def test_capture_image_gstreamer_remove_timeout(self):
         mock_camera = MagicMock()
+        mock_camera.photo_wait_seconds = 3
         mock_camera.GLib.timeout_add_seconds.return_value = "timeout"
         CameraTest._capture_image_gstreamer(
             mock_camera, "/tmp/test.jpg", 640, 480, "RG10"

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -507,14 +507,14 @@ class CameraTestTests(unittest.TestCase):
         open_valve_inserted = False
         for mock_timeout_call in mock_GLib_timout_add.call_args_list:
             callback = mock_timeout_call.args[1]
-            print(str(callback), dir(callback), flush=sys.stderr)
+            print(repr(callback), dir(callback), flush=sys.stderr)
 
-            if "stop_jpeg_pipeline" in str(callback):
+            if "stop_jpeg_pipeline" in repr(callback):
                 stop_jpeg_pipeline_inserted = True
                 callback()
                 self.assertIsNone(mock_camera.timeout["stop_jpeg_pipeline"])
 
-            if "open_valve" in str(callback):
+            if "open_valve" in repr(callback):
                 open_valve_inserted = True
                 callback()
                 self.assertIsNone(mock_camera.timeout["open_valve"])

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -231,7 +231,7 @@ class CameraTestTests(unittest.TestCase):
         mock_camera.timeout = {}
         CameraTest._on_timeout(mock_camera)
         self.assertEqual(mock_camera._stop_pipeline.call_count, 1)
-        self.assertEqual(mock_camera.timeout['global_timeout'], None)
+        self.assertEqual(mock_camera.timeout["global_timeout"], None)
 
     def test_supported_formats_to_string(self):
         formats = [

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -503,24 +503,12 @@ class CameraTestTests(unittest.TestCase):
         # now simulate the timeout
         self.assertEqual(mock_GLib_timout_add.call_count, 3)
 
-        stop_jpeg_pipeline_inserted = False
-        open_valve_inserted = False
         for mock_timeout_call in mock_GLib_timout_add.call_args_list:
             callback = mock_timeout_call.args[1]
-            print(repr(callback), dir(callback), flush=sys.stderr)
+            callback()
 
-            if "stop_jpeg_pipeline" in repr(callback):
-                stop_jpeg_pipeline_inserted = True
-                callback()
-                self.assertIsNone(mock_camera.timeout["stop_jpeg_pipeline"])
-
-            if "open_valve" in repr(callback):
-                open_valve_inserted = True
-                callback()
-                self.assertIsNone(mock_camera.timeout["open_valve"])
-
-        self.assertTrue(stop_jpeg_pipeline_inserted)
-        self.assertTrue(open_valve_inserted)
+        self.assertIsNone(mock_camera.timeout["stop_jpeg_pipeline"])
+        self.assertIsNone(mock_camera.timeout["open_valve"])
 
     def test_capture_image_gstreamer_error(self):
         mock_camera = MagicMock()

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -441,6 +441,7 @@ class CameraTestTests(unittest.TestCase):
             [
                 call("v4l2src", "video-source"),
                 call("capsfilter", "caps"),
+                call('valve', 'photo-valve'),
                 call("jpegenc", "encoder"),
                 call("filesink", "sink"),
             ],
@@ -463,6 +464,7 @@ class CameraTestTests(unittest.TestCase):
                 call("v4l2src", "video-source"),
                 call("capsfilter", "caps"),
                 call("bayer2rgb", "bayer2rgb"),
+                call("valve", "photo-valve"),
                 call("jpegenc", "encoder"),
                 call("filesink", "sink"),
             ],

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -442,14 +442,14 @@ class CameraTestTests(unittest.TestCase):
         )
         make_calls = mock_make.call_args_list
         print(make_calls, flush=sys.stderr)
-        self.assertEqual(
+        self.assertListEqual(
             make_calls,
             [
                 call("v4l2src", "video-source"),
                 call("capsfilter", "caps"),
                 call("valve", "photo-valve"),
+                call("filesink", "sink"),  # this gets created earlier
                 call("jpegenc", "encoder"),
-                call("filesink", "sink"),
             ],
         )
         mock_camera.pipeline.set_state.assert_has_calls([call("playing")])
@@ -472,8 +472,8 @@ class CameraTestTests(unittest.TestCase):
                 call("capsfilter", "caps"),
                 call("bayer2rgb", "bayer2rgb"),
                 call("valve", "photo-valve"),
-                call("jpegenc", "encoder"),
                 call("filesink", "sink"),
+                call("jpegenc", "encoder"),
             ],
         )
 

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -504,9 +504,9 @@ class CameraTestTests(unittest.TestCase):
         self.assertEqual(mock_GLib_timout_add.call_count, 3)
 
         stop_jpeg_pipeline_inserted = False
-        print(mock_GLib_timout_add.call_args_list)
+        print(mock_GLib_timout_add.call_args_list, flush=sys.stderr)
         for mock_timeout_call in mock_GLib_timout_add.call_args_list:
-            print(dir(mock_timeout_call))
+            print(dir(mock_timeout_call), flush=sys.stderr)
             callback = mock_timeout_call.args[1]
             if (
                 hasattr(callback, "__name__")

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -441,7 +441,7 @@ class CameraTestTests(unittest.TestCase):
             [
                 call("v4l2src", "video-source"),
                 call("capsfilter", "caps"),
-                call('valve', 'photo-valve'),
+                call("valve", "photo-valve"),
                 call("jpegenc", "encoder"),
                 call("filesink", "sink"),
             ],

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -505,7 +505,8 @@ class CameraTestTests(unittest.TestCase):
 
         for mock_timeout_call in mock_GLib_timout_add.call_args_list:
             callback = mock_timeout_call.args[1]
-            callback()
+            if callable(callback):
+                callback()
 
         self.assertIsNone(mock_camera.timeout["stop_jpeg_pipeline"])
         self.assertIsNone(mock_camera.timeout["open_valve"])

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -449,7 +449,7 @@ class CameraTestTests(unittest.TestCase):
                 call("v4l2src", "video-source"),
                 call("capsfilter", "caps"),
                 call("valve", "photo-valve"),
-                call("filesink", "sink"),  # this gets created earlier
+                call("multifilesink", "sink"),  # this gets created earlier
                 call("jpegenc", "encoder"),
             ],
         )
@@ -473,7 +473,7 @@ class CameraTestTests(unittest.TestCase):
                 call("capsfilter", "caps"),
                 call("bayer2rgb", "bayer2rgb"),
                 call("valve", "photo-valve"),
-                call("filesink", "sink"),
+                call("multifilesink", "sink"),
                 call("jpegenc", "encoder"),
             ],
         )
@@ -495,21 +495,18 @@ class CameraTestTests(unittest.TestCase):
                 call("v4l2src", "video-source"),
                 call("capsfilter", "caps"),
                 call("valve", "photo-valve"),
-                call("filesink", "sink"),
+                call("multifilesink", "sink"),
             ],
         )
         self.assertTrue(mock_GLib_timout_add.called)
         # now simulate the timeout
         self.assertEqual(mock_GLib_timout_add.call_count, 3)
-
-        print("\nmock timeout\n")
-        # print(mock_GLib_timout_add.call_args_list, dir(mock_GLib_timout_add))
         for mock_timeout_call in mock_GLib_timout_add.call_args_list:
             # 0 extracts the (timeout_seconds, handler) tuple
             # 1 grabs the handler, then call it
             mock_timeout_call[0][1]()
 
-        self.assertIsNone(mock_camera.timeout["stop_jpeg_pipeline"])
+        self.assertIsNone(mock_camera.timeout["eos_timeout"])
         self.assertIsNone(mock_camera.timeout["open_valve"])
 
     def test_capture_image_gstreamer_error(self):

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -477,6 +477,26 @@ class CameraTestTests(unittest.TestCase):
             ],
         )
 
+    def test_capture_image_gstreamer_jpeg(self):
+        mock_camera = MagicMock()
+        mock_camera.photo_wait_seconds = 3
+        mock_make = mock_camera.Gst.ElementFactory.make
+
+        CameraTest._capture_image_gstreamer(
+            mock_camera, "/tmp/test.jpg", 640, 480, "MJPG"
+        )
+        make_calls = mock_make.call_args_list
+        print(make_calls, flush=sys.stderr)
+        self.assertListEqual(
+            make_calls,
+            [
+                call("v4l2src", "video-source"),
+                call("capsfilter", "caps"),
+                call("valve", "photo-valve"),
+                call("filesink", "sink"),
+            ],
+        )
+
     def test_capture_image_gstreamer_error(self):
         mock_camera = MagicMock()
         mock_camera.photo_wait_seconds = 3

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -482,14 +482,13 @@ class CameraTestTests(unittest.TestCase):
         mock_camera = MagicMock()
         mock_camera.photo_wait_seconds = 3
         mock_camera.timeout = {}
-        mock_make = mock_camera.Gst.ElementFactory.make
         mock_GLib_timout_add = mock_camera.GLib.timeout_add_seconds
 
         CameraTest._capture_image_gstreamer(
             mock_camera, "/tmp/test.jpg", 640, 480, "MJPG"
         )
-        make_calls = mock_make.call_args_list
-        print(make_calls, flush=sys.stderr)
+        make_calls = mock_camera.Gst.ElementFactory.make.call_args_list
+        print(make_calls, flush=True)
         self.assertListEqual(
             make_calls,
             [
@@ -503,10 +502,12 @@ class CameraTestTests(unittest.TestCase):
         # now simulate the timeout
         self.assertEqual(mock_GLib_timout_add.call_count, 3)
 
+        print("\nmock timeout\n")
+        # print(mock_GLib_timout_add.call_args_list, dir(mock_GLib_timout_add))
         for mock_timeout_call in mock_GLib_timout_add.call_args_list:
-            callback = mock_timeout_call.args[1]
-            if callable(callback):
-                callback()
+            # 0 extracts the (timeout_seconds, handler) tuple
+            # 1 grabs the handler, then call it
+            mock_timeout_call[0][1]()
 
         self.assertIsNone(mock_camera.timeout["stop_jpeg_pipeline"])
         self.assertIsNone(mock_camera.timeout["open_valve"])

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -504,18 +504,22 @@ class CameraTestTests(unittest.TestCase):
         self.assertEqual(mock_GLib_timout_add.call_count, 3)
 
         stop_jpeg_pipeline_inserted = False
-        print(mock_GLib_timout_add.call_args_list, flush=sys.stderr)
+        open_valve_inserted = False
         for mock_timeout_call in mock_GLib_timout_add.call_args_list:
-            print(dir(mock_timeout_call), flush=sys.stderr)
             callback = mock_timeout_call.args[1]
-            if (
-                hasattr(callback, "__name__")
-                and callback.__name__ == "stop_jpeg_pipeline"
-            ):
+
+            if "stop_jpeg_pipeline" in str(callback):
                 stop_jpeg_pipeline_inserted = True
                 callback()
                 self.assertIsNone(mock_camera.timeout["stop_jpeg_pipeline"])
+            
+            if "open_valve" in str(callback):
+                open_valve_inserted = True
+                callback()
+                self.assertIsNone(mock_camera.timeout["open_valve"])
+
         self.assertTrue(stop_jpeg_pipeline_inserted)
+        self.assertTrue(open_valve_inserted)
 
     def test_capture_image_gstreamer_error(self):
         mock_camera = MagicMock()


### PR DESCRIPTION
## Description

The gstreamer pipeline in the current `camera_test.py` was having trouble with cameras that require a "boot up time" because it was taking the 1st buffer, which is blank for these cameras, that reaches filesink. This PR adds a valve element that dynamically opens while the pipeline is running to allow the source to stay open for a few seconds before the photo is taken. 

There was also an issue where `<CameraTest>._width` and `<CameraTest>._height` were never updated from 640x480 after we query the supported formats. This breaks on intel MIPI cameras because it only supports 1280x720 and it will complain about not-negotiated caps $\Rightarrow$ `Error: Internal data stream error` when `<Pipeline>.set_state(Gst.State.PLAYING)` is called. This is fixed as well but I'm not too sure if this was intentional. Do later tests depend on the image being 640x480?

## Resolved issues

#1537 

## Documentation

The number of seconds to delay can be set by `--wait-seconds <num_seconds>`. Default is 3.

## Tests

- Original unit tests.
- Validated on a few machines running 24.04 with intel MIPI cameras and the test runs normally. Machines with USB cameras are nice as usual and pass the test too.