### PR TITLE
Add origin information to Checkbox JSON submission (new)

### DIFF
--- a/checkbox-ng/plainbox/__init__.py
+++ b/checkbox-ng/plainbox/__init__.py
@@ -54,3 +54,50 @@ def get_version_string():
     else:
         version_string = "{} {}".format("Checkbox", __version__)
     return version_string
+
+
+def get_origin():
+    """
+    Return a dictionary containing information such as the version and what
+    packaging method is being used (Python virtual environment, Snap or
+    Debian).
+    """
+    import os
+    import subprocess
+
+    if os.getenv("SNAP_NAME"):
+        origin = {
+            "name": "Checkbox",
+            "version": __version__,
+            "packaging": {
+                "type": "snap",
+                "name": os.getenv("SNAP_NAME"),
+                "version": os.getenv("SNAP_VERSION"),
+                "revision": os.getenv("SNAP_REVISION"),
+            },
+        }
+    elif os.getenv("VIRTUAL_ENV"):
+        origin = {
+            "name": "Checkbox",
+            "version": __version__,
+            "packaging": {
+                "type": "source",
+                "version": __version__,
+            },
+        }
+    else:
+        dpkg_info = subprocess.check_output(
+            ["dpkg", "-S", __path__[0]], universal_newlines=True
+        )
+        # 'python3-checkbox-ng: /usr/lib/python3/dist-packages/plainbox\n'
+        package_name = dpkg_info.split(":")[0]
+        origin = {
+            "name": "Checkbox",
+            "version": __version__,
+            "packaging": {
+                "type": "debian",
+                "name": package_name,
+                "version": __version__,
+            },
+        }
+    return origin

--- a/checkbox-ng/plainbox/__init__.py
+++ b/checkbox-ng/plainbox/__init__.py
@@ -102,7 +102,7 @@ def get_origin():
                 },
             }
         # if all of the above failed and dpkg is not available on the system...
-        except FileNotFoundError:
+        except (FileNotFoundError, subprocess.CalledProcessError):
             origin = {
                 "name": "Checkbox",
                 "version": __version__,

--- a/checkbox-ng/plainbox/__init__.py
+++ b/checkbox-ng/plainbox/__init__.py
@@ -86,18 +86,30 @@ def get_origin():
             },
         }
     else:
-        dpkg_info = subprocess.check_output(
-            ["dpkg", "-S", __path__[0]], universal_newlines=True
-        )
-        # 'python3-checkbox-ng: /usr/lib/python3/dist-packages/plainbox\n'
-        package_name = dpkg_info.split(":")[0]
-        origin = {
-            "name": "Checkbox",
-            "version": __version__,
-            "packaging": {
-                "type": "debian",
-                "name": package_name,
+        try:
+            dpkg_info = subprocess.check_output(
+                ["dpkg", "-S", __path__[0]], universal_newlines=True
+            )
+            # 'python3-checkbox-ng: /usr/lib/python3/dist-packages/plainbox\n'
+            package_name = dpkg_info.split(":")[0]
+            origin = {
+                "name": "Checkbox",
                 "version": __version__,
-            },
-        }
+                "packaging": {
+                    "type": "debian",
+                    "name": package_name,
+                    "version": __version__,
+                },
+            }
+        # if all of the above failed and dpkg is not available on the system...
+        except FileNotFoundError:
+            origin = {
+                "name": "Checkbox",
+                "version": __version__,
+                "packaging": {
+                    "type": "unknown",
+                    "name": "unknown",
+                    "version": "unknown",
+                },
+            }
     return origin

--- a/checkbox-ng/plainbox/impl/exporter/jinja2.py
+++ b/checkbox-ng/plainbox/impl/exporter/jinja2.py
@@ -45,7 +45,7 @@ except ImportError:  # renamed in jinja2 3.1
 
 
 from plainbox import get_version_string
-from plainbox import __version__ as checkbox_version
+from plainbox import get_origin
 from plainbox.abc import ISessionStateExporter
 from plainbox.impl.exporter import SessionStateExporterBase
 from plainbox.impl.result import OUTCOME_METADATA_MAP
@@ -110,7 +110,6 @@ class Jinja2SessionStateExporter(SessionStateExporterBase):
         self._client_version = client_version or get_version_string()
         # Remember client name
         self._client_name = client_name
-        self._checkbox_version = checkbox_version
 
         self.option_list = None
         self.template = None
@@ -197,7 +196,7 @@ class Jinja2SessionStateExporter(SessionStateExporterBase):
             "OUTCOME_METADATA_MAP": OUTCOME_METADATA_MAP,
             "client_name": self._client_name,
             "client_version": self._client_version,
-            "checkbox_version": self._checkbox_version,
+            "origin": get_origin(),
             "manager": session_manager,
             "app_blob": app_blob_data,
             "options": self.option_list,
@@ -223,7 +222,7 @@ class Jinja2SessionStateExporter(SessionStateExporterBase):
             "OUTCOME_METADATA_MAP": OUTCOME_METADATA_MAP,
             "client_name": self._client_name,
             "client_version": self._client_version,
-            "checkbox_version": self._checkbox_version,
+            "origin": get_origin(),
             "manager_list": session_manager_list,
             "app_blob": {},
             "options": self.option_list,

--- a/checkbox-ng/plainbox/impl/exporter/jinja2.py
+++ b/checkbox-ng/plainbox/impl/exporter/jinja2.py
@@ -94,6 +94,7 @@ class Jinja2SessionStateExporter(SessionStateExporterBase):
         timestamp=None,
         client_version=None,
         client_name="plainbox",
+        origin=None,
         exporter_unit=None,
     ):
         """
@@ -110,6 +111,7 @@ class Jinja2SessionStateExporter(SessionStateExporterBase):
         self._client_version = client_version or get_version_string()
         # Remember client name
         self._client_name = client_name
+        self._origin = origin or get_origin()
 
         self.option_list = None
         self.template = None
@@ -196,7 +198,7 @@ class Jinja2SessionStateExporter(SessionStateExporterBase):
             "OUTCOME_METADATA_MAP": OUTCOME_METADATA_MAP,
             "client_name": self._client_name,
             "client_version": self._client_version,
-            "origin": get_origin(),
+            "origin": self._origin,
             "manager": session_manager,
             "app_blob": app_blob_data,
             "options": self.option_list,
@@ -222,7 +224,7 @@ class Jinja2SessionStateExporter(SessionStateExporterBase):
             "OUTCOME_METADATA_MAP": OUTCOME_METADATA_MAP,
             "client_name": self._client_name,
             "client_version": self._client_version,
-            "origin": get_origin(),
+            "origin": self._origin,
             "manager_list": session_manager_list,
             "app_blob": {},
             "options": self.option_list,

--- a/checkbox-ng/plainbox/impl/exporter/test_html.py
+++ b/checkbox-ng/plainbox/impl/exporter/test_html.py
@@ -179,6 +179,13 @@ class HTMLExporterTests(TestCase):
             system_id="",
             timestamp="2012-12-21T12:00:00",
             client_version="Checkbox 1.0",
+            origin={
+                "name": "Checkbox",
+                "version": "1.0",
+                "packaging": {
+                    "type": "source"
+                }
+            },
             exporter_unit=self.exporter_unit,
         )
         stream = io.BytesIO()
@@ -202,6 +209,13 @@ class HTMLExporterTests(TestCase):
             system_id="",
             timestamp="2012-12-21T12:00:00",
             client_version="Checkbox 1.0",
+            origin={
+                "name": "Checkbox",
+                "version": "1.0",
+                "packaging": {
+                    "type": "source"
+                }
+            },
             exporter_unit=self.exporter_unit,
         )
         stream = io.BytesIO()

--- a/checkbox-ng/plainbox/impl/exporter/test_html.py
+++ b/checkbox-ng/plainbox/impl/exporter/test_html.py
@@ -182,9 +182,7 @@ class HTMLExporterTests(TestCase):
             origin={
                 "name": "Checkbox",
                 "version": "1.0",
-                "packaging": {
-                    "type": "source"
-                }
+                "packaging": {"type": "source"},
             },
             exporter_unit=self.exporter_unit,
         )
@@ -212,9 +210,7 @@ class HTMLExporterTests(TestCase):
             origin={
                 "name": "Checkbox",
                 "version": "1.0",
-                "packaging": {
-                    "type": "source"
-                }
+                "packaging": {"type": "source"},
             },
             exporter_unit=self.exporter_unit,
         )

--- a/checkbox-ng/plainbox/impl/exporter/test_jinja2.py
+++ b/checkbox-ng/plainbox/impl/exporter/test_jinja2.py
@@ -76,7 +76,16 @@ class Jinja2SessionStateExporterTests(TestCase):
             exporter_unit.option_list = ()
             with open(pathname, "w") as f:
                 f.write(tmpl)
-            exporter = Jinja2SessionStateExporter(exporter_unit=exporter_unit)
+            exporter = Jinja2SessionStateExporter(
+                origin={
+                    "name": "Checkbox",
+                    "version": "1.0",
+                    "packaging": {
+                        "type": "source"
+                    }
+                },
+                exporter_unit=exporter_unit,
+            )
             stream = BytesIO()
             exporter.dump_from_session_manager(self.manager_single_job, stream)
             expected_bytes = "     fail      : job name\n".encode("UTF-8")
@@ -114,7 +123,16 @@ class Jinja2SessionStateExporterTests(TestCase):
             exporter_unit.data_dir = tmp
             exporter_unit.template = template_filename
             exporter_unit.option_list = ()
-            exporter = Jinja2SessionStateExporter(exporter_unit=exporter_unit)
+            exporter = Jinja2SessionStateExporter(
+                origin={
+                    "name": "Checkbox",
+                    "version": "1.0",
+                    "packaging": {
+                        "type": "source"
+                    }
+                },
+                exporter_unit=exporter_unit
+            )
             stream = BytesIO()
             exporter.dump_from_session_manager(self.manager_single_job, stream)
 
@@ -131,7 +149,16 @@ class Jinja2SessionStateExporterTests(TestCase):
             exporter_unit.data_dir = tmp
             exporter_unit.template = template_filename
             exporter_unit.option_list = ()
-            exporter = Jinja2SessionStateExporter(exporter_unit=exporter_unit)
+            exporter = Jinja2SessionStateExporter(
+                origin={
+                    "name": "Checkbox",
+                    "version": "1.0",
+                    "packaging": {
+                        "type": "source"
+                    }
+                },
+                exporter_unit=exporter_unit
+            )
             stream = BytesIO()
             with self.assertRaises(ExporterError):
                 exporter.dump_from_session_manager(

--- a/checkbox-ng/plainbox/impl/exporter/test_jinja2.py
+++ b/checkbox-ng/plainbox/impl/exporter/test_jinja2.py
@@ -80,9 +80,7 @@ class Jinja2SessionStateExporterTests(TestCase):
                 origin={
                     "name": "Checkbox",
                     "version": "1.0",
-                    "packaging": {
-                        "type": "source"
-                    }
+                    "packaging": {"type": "source"},
                 },
                 exporter_unit=exporter_unit,
             )
@@ -104,7 +102,14 @@ class Jinja2SessionStateExporterTests(TestCase):
             exporter_unit.data_dir = tmp
             exporter_unit.template = template_filename
             exporter_unit.option_list = ()
-            exporter = Jinja2SessionStateExporter(exporter_unit=exporter_unit)
+            exporter = Jinja2SessionStateExporter(
+                origin={
+                    "name": "Checkbox",
+                    "version": "1.0",
+                    "packaging": {"type": "source"},
+                },
+                exporter_unit=exporter_unit,
+            )
             exporter.validate_json = mock.Mock(return_value=[])
             stream = BytesIO()
             exporter.validate(stream)
@@ -127,11 +132,9 @@ class Jinja2SessionStateExporterTests(TestCase):
                 origin={
                     "name": "Checkbox",
                     "version": "1.0",
-                    "packaging": {
-                        "type": "source"
-                    }
+                    "packaging": {"type": "source"},
                 },
-                exporter_unit=exporter_unit
+                exporter_unit=exporter_unit,
             )
             stream = BytesIO()
             exporter.dump_from_session_manager(self.manager_single_job, stream)
@@ -153,11 +156,9 @@ class Jinja2SessionStateExporterTests(TestCase):
                 origin={
                     "name": "Checkbox",
                     "version": "1.0",
-                    "packaging": {
-                        "type": "source"
-                    }
+                    "packaging": {"type": "source"},
                 },
-                exporter_unit=exporter_unit
+                exporter_unit=exporter_unit,
             )
             stream = BytesIO()
             with self.assertRaises(ExporterError):

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.json
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.json
@@ -6,8 +6,7 @@
 {%- set system_information = state.system_information -%}
 {
     "title": {{ state.metadata.title | jsonify | safe }},
-    "client_version": {{ client_version | jsonify | safe }},
-    "checkbox_version": {{ checkbox_version | jsonify | safe }},
+    "origin": {{ origin | jsonify | safe }},
 {%- if "testplan_id" in app_blob %}
 {%- if app_blob['testplan_id'] %}
     "testplan_id": {{ app_blob['testplan_id'] | jsonify | safe }},

--- a/checkbox-ng/plainbox/test_init.py
+++ b/checkbox-ng/plainbox/test_init.py
@@ -1,0 +1,43 @@
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Pierre Equoy <pierre.equoy@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase, mock
+
+import os
+import plainbox
+
+
+class PlainboxInitTests(TestCase):
+    @mock.patch.dict(os.environ, {"VIRTUAL_ENV": "test"})
+    def test_get_origin_venv(self):
+        origin = plainbox.get_origin()
+        self.assertEqual(origin["packaging"]["type"], "source")
+
+    @mock.patch.dict(os.environ, {"SNAP_NAME": "test"})
+    def test_get_origin_snap(self):
+        origin = plainbox.get_origin()
+        self.assertEqual(origin["packaging"]["type"], "snap")
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    @mock.patch("subprocess.check_output")
+    def test_get_origin_debian(self, mock_sp_check_output):
+        mock_sp_check_output.return_value = (
+            "python3-checkbox-ng: /usr/lib/python3/dist-packages/plainbox\n"
+        )
+        origin = plainbox.get_origin()
+        self.assertEqual(origin["packaging"]["type"], "debian")

--- a/checkbox-ng/plainbox/test_init.py
+++ b/checkbox-ng/plainbox/test_init.py
@@ -19,6 +19,7 @@
 from unittest import TestCase, mock
 
 import os
+from subprocess import CalledProcessError
 
 import plainbox
 
@@ -48,5 +49,8 @@ class PlainboxInitTests(TestCase):
     @mock.patch("subprocess.check_output")
     def test_get_origin_exception(self, mock_sp_check_output):
         mock_sp_check_output.side_effect = FileNotFoundError
+        origin = plainbox.get_origin()
+        self.assertEqual(origin["packaging"]["type"], "unknown")
+        mock_sp_check_output.side_effect = CalledProcessError(1, "error")
         origin = plainbox.get_origin()
         self.assertEqual(origin["packaging"]["type"], "unknown")

--- a/checkbox-ng/plainbox/test_init.py
+++ b/checkbox-ng/plainbox/test_init.py
@@ -19,6 +19,7 @@
 from unittest import TestCase, mock
 
 import os
+
 import plainbox
 
 
@@ -41,3 +42,11 @@ class PlainboxInitTests(TestCase):
         )
         origin = plainbox.get_origin()
         self.assertEqual(origin["packaging"]["type"], "debian")
+        self.assertEqual(origin["packaging"]["name"], "python3-checkbox-ng")
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    @mock.patch("subprocess.check_output")
+    def test_get_origin_exception(self, mock_sp_check_output):
+        mock_sp_check_output.side_effect = FileNotFoundError
+        origin = plainbox.get_origin()
+        self.assertEqual(origin["packaging"]["type"], "unknown")

--- a/submission-schema/schema.json
+++ b/submission-schema/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://certification.canonical.com/checkbox-submission.json",
     "description": "Output format for the Checkbox test framework (see more info at https://checkbox.readthedocs.io)",
     "$ref": "#/definitions/Submission",

--- a/submission-schema/schema.json
+++ b/submission-schema/schema.json
@@ -11,12 +11,47 @@
                 "title": {
                     "type": "string"
                 },
-                "client_version": {
-                    "type": "string"
-                },
-                "checkbox_version": {
-                    "type": "string"
-                },
+                "origin": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "version",
+                    "packaging"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the application used to run the test plan ('Checkbox')"
+                    },
+                    "version": {
+                        "type": "string",
+                        "description": "Version of Checkbox used to run the test plan."
+                    },
+                    "packaging": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "description": "Packaging type ('debian', 'snap', or 'source' if running in a Python virtual env"
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the package used, if any"
+                            },
+                            "version": {
+                                "type": "string",
+                                "description": "Version installed"
+                            },
+                            "revision": {
+                                "type": "string",
+                                "description": "Revision installed (only for Snaps)"
+                            }
+                        },
+                        "if": {"properties": {"type": {"const": "snap"}}},
+                        "then": {"required": ["revision"]}
+                    }
+                }
+            },
                 "testplan_id": {
                     "type": "string"
                 },

--- a/submission-schema/schema.json
+++ b/submission-schema/schema.json
@@ -29,6 +29,10 @@
                     },
                     "packaging": {
                         "type": "object",
+                        "required": [
+                            "type",
+                            "version"
+                        ],
                         "properties": {
                             "type": {
                                 "type": "string",


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

A few weeks ago, we added the Checkbox version into the submissions as a `checkbox_version` field. This submission file is consumed by C3, our Certification database. Up to recently, only Checkbox could submit data to C3, but more tools are on their way to be able to do the same. As a result, we are working on homogenizing the submission fields.

This PR removes the Checkbox-specific things (`checkbox_version` and `client_name`) and introduces an `origin` object that, in addition to version number, also contains information about the packaging type. It will then be possible to know if a submission was generated using the Snap or the Debian version of Checkbox, or if it was created using a development version (running in a Python virtual environment).

A submission created using the patch in this PR will look like this now (in this example, the information is coming from a run in a virtual environment):

```json
{
    "title": "session title",
    "origin": {"name": "Checkbox", "version": "3.3.1.dev333+gbe9508960.d20240701", "packaging": {"type": "source", "version": "3.3.1.dev333+gbe9508960.d20240701"}},
    "testplan_id": "com.canonical.certification::acpi-automated",
    "custom_joblist": false,
    "results": [
        {
...
}
```


## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/CHECKBOX-1659

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
