### PR TITLE
proviers/base: add requires for bluetooth4/beacon_eddystone_url_* (New)

### DIFF
--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -287,6 +287,11 @@ user: root
 flags: also-after-suspend
 category_id: com.canonical.plainbox::bluetooth
 estimated_duration: 10
+requires:
+  package.name == 'bluez' or snap.name == 'bluez'
+  {%- if __on_ubuntucore__ %}
+  connections.slot == 'bluez:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:bluez'
+  {% endif -%}
 
 unit: template
 template-resource: bluez-internal-rfcomm-tests

--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -285,7 +285,7 @@ command:
  checkbox-support-eddystone_scanner -D {{ interface }}
 plugin: shell
 user: root
-flags: also-after-suspend
+flags: also-after-suspend fail-on-resource
 category_id: com.canonical.plainbox::bluetooth
 estimated_duration: 10
 requires:

--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -276,22 +276,23 @@ requires:
 unit: template
 template-resource: device
 template-filter: device.category == 'BLUETOOTH'
+template-engine: jinja2
 template-unit: job
-id: bluetooth4/beacon_eddystone_url_{interface}
+id: bluetooth4/beacon_eddystone_url_{{ interface }}
 template-id: bluetooth4/beacon_eddystone_url_interface
-_summary: Test system can get beacon EddyStone URL advertisements on the {interface} adapter
+_summary: Test system can get beacon EddyStone URL advertisements on the {{ interface }} adapter
 command:
- checkbox-support-eddystone_scanner -D {interface}
+ checkbox-support-eddystone_scanner -D {{ interface }}
 plugin: shell
 user: root
 flags: also-after-suspend
 category_id: com.canonical.plainbox::bluetooth
 estimated_duration: 10
 requires:
-  package.name == 'bluez' or snap.name == 'bluez'
-  {%- if __on_ubuntucore__ %}
-  connections.slot == 'bluez:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:bluez'
-  {% endif -%}
+ package.name == 'bluez' or snap.name == 'bluez'
+ {%- if __on_ubuntucore__ %}
+ connections.slot == 'bluez:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:bluez'
+ {% endif -%}
 
 unit: template
 template-resource: bluez-internal-rfcomm-tests


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->
## WARNING: This modifies com.canonical.certification::sru-server

## Description


<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

In order to pass, the test bluetooth4/beacon_eddystone_url_* needs:
- bluez package/snap (+ adequate connections for ubuntu core)

This PR add `requires` section to the test bluetooth4/beacon_eddystone_url_*

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

During Intel IOTG certification test run, we bumped into this test failure for server classic image,
It took us some time to realize that the bluez package is missing, this time spent can be saved with this
`requires` section

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

N/A

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
The test runs successfully on 22.04 server image