### PR TITLE
Make bpftrace amd64 and arm64 only (infra)

### DIFF
--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -258,7 +258,6 @@ parts:
       - bc
       - bluez-tests
       - bonnie++
-      - bpftrace
       - cryptsetup-bin
       - dbus
       - debsums
@@ -328,6 +327,9 @@ parts:
         - python3-rpi.gpio # only in focal
       - on arm64:
         - python3-rpi.gpio # only in focal
+        - bpftrace
+      - on amd64:
+        - bpftrace
     build-packages:
       - libasound2-dev
       - libcap-dev


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Armhf build of core22 are broken. this fixes them

## Resolved issues

Fixes: CHECKBOX-1694

## Documentation

N/A

## Tests

```
Build status as of 2024-12-10 16:24:46.130241:
	arch=armhf	state=Successfully built
	arch=arm64	state=Successfully built
	arch=amd64	state=Successfully built
        Snapped checkbox22_4.3.0-dev27_armhf.snap
        Build log available at 'checkbox22_armhf.1.txt'
        Snapped checkbox22_4.3.0-dev27_arm64.snap
        Build log available at 'checkbox22_arm64.txt'
        Snapped checkbox22_4.3.0-dev27_amd64.snap
        Build log available at 'checkbox22_amd64.txt'
        Build complete.
```
