### PR TITLE
Workaround WebSocketClient race condition metabox (infra)

### DIFF
--- a/metabox/metabox/core/lxd_execute.py
+++ b/metabox/metabox/core/lxd_execute.py
@@ -39,7 +39,21 @@ base_env = {
 login_shell = ["sudo", "--user", "ubuntu", "--login"]
 
 
-class InteractiveWebsocket(WebSocketClient):
+class SafeWebSocketClient(WebSocketClient):
+    def send(self, *args, **kwargs):
+        """
+        This makes it so send will raise ConnectionError when send fails
+        """
+        # there is a race condition in the base WebSocketClient that leads
+        # calls to send on terminated connections to raise an AttributeError.
+        # This mainly happens when the process crashes in an unexpected step
+        try:
+            return super().send(*args, **kwargs)
+        except AttributeError as e:
+            raise ConnectionError("Unable to send, process crashed") from e
+
+
+class InteractiveWebsocket(SafeWebSocketClient):
     # https://stackoverflow.com/a/14693789/1154487
     ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
@@ -232,7 +246,7 @@ def interactive_execute(container, cmd, env={}, verbose=False, timeout=0):
     )
 
     base_websocket_url = container.client.websocket_url
-    ctl = WebSocketClient(base_websocket_url)
+    ctl = SafeWebSocketClient(base_websocket_url)
     ctl.resource = ws_urls["control"]
     ctl.connect()
     pts = InteractiveWebsocket(base_websocket_url)

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -110,7 +110,7 @@ class Scenario:
                 step.kwargs["interactive"] = interactive
             try:
                 step(self)
-            except TimeoutError:
+            except (TimeoutError, ConnectionError):
                 self._checks.append(False)
                 break
         if self._pts:


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

There is a race condition in the `WebSocketClient` library. This makes metabox crash (without finishing the test run) when the controller or local crashes before sending something to it. This fixes it

## Resolved issues

Partially fixes: CHECKBOX-1699

## Documentation

Big comment explaining why this is done

## Tests

N/A
