### PR TITLE
Multishell support and add assertion on min. timeout (bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/timeout.py
+++ b/checkbox-support/checkbox_support/helpers/timeout.py
@@ -130,7 +130,7 @@ def run_with_timeout(f, timeout_s, *args, **kwargs):
     process.join(timeout_s)
 
     if process.is_alive():
-        # this kills the whole process tree, not just the child
+        # this tries to kill the whole process tree, not just the child.
         kill_tree(process.pid)
         raise TimeoutError("Task unable to finish in {}s".format(timeout_s))
 

--- a/checkbox-support/checkbox_support/helpers/timeout.py
+++ b/checkbox-support/checkbox_support/helpers/timeout.py
@@ -23,6 +23,7 @@ Utility class that provides functionalities connected to placing timeouts on
 functions
 """
 import os
+import shutil
 import pickle
 import traceback
 import subprocess
@@ -48,6 +49,25 @@ def is_picklable(value):
     return False
 
 
+def kill_tree(pid):
+    """
+    Kill a process tree
+
+    This tries to force the shell to what we want instead of letting the system
+    decide. This is because `sh` kill doesn't support tree kill (-PID), so we
+    would rather avoid it
+    """
+    if shutil.which("bash"):
+        return subprocess.run(["bash", "-c", "kill -9 -{}".format(pid)])
+    elif shutil.which("zsh"):
+        return subprocess.run(["zsh", "-c", "kill -9 -{}".format(pid)])
+    with suppress(subprocess.CalledProcessError):
+        # if SHELL is sh or doesn't support -XX pid, this will fail
+        return subprocess.check_call("kill -9 -{}".format(pid), shell=True)
+    # lets at least kill the direct pid
+    return subprocess.run("kill -9 {}".format(pid), shell=True)
+
+
 def run_with_timeout(f, timeout_s, *args, **kwargs):
     """
     Runs a function with the given args and kwargs. If the function doesn't
@@ -56,6 +76,7 @@ def run_with_timeout(f, timeout_s, *args, **kwargs):
 
     Note: the function, *args and **kwargs must be picklable to use this.
     """
+    assert timeout_s > 0, "Timeout must be more than 0"
     result_queue = Queue()
     exception_queue = Queue()
 
@@ -110,7 +131,7 @@ def run_with_timeout(f, timeout_s, *args, **kwargs):
 
     if process.is_alive():
         # this kills the whole process tree, not just the child
-        subprocess.run("kill -9 -{}".format(process.pid), shell=True)
+        kill_tree(process.pid)
         raise TimeoutError("Task unable to finish in {}s".format(timeout_s))
 
     with suppress(Empty):

--- a/checkbox-support/checkbox_support/tests/test_timeout.py
+++ b/checkbox-support/checkbox_support/tests/test_timeout.py
@@ -61,7 +61,7 @@ class TestTimeoutExec(TestCase):
     def test_class_field_timeouts(self):
         some = ClassSupport(1)
         with self.assertRaises(TimeoutError):
-            run_with_timeout(some.heavy_function, 0)
+            run_with_timeout(some.heavy_function, 0.1)
 
     def test_class_field_ok_return(self):
         some = ClassSupport(0)
@@ -72,11 +72,11 @@ class TestTimeoutExec(TestCase):
 
     def test_function_timeouts(self):
         with self.assertRaises(TimeoutError):
-            run_with_timeout(heavy_function, 0, 10)
+            run_with_timeout(heavy_function, 0.1, 10)
 
     def test_function_ok_return(self):
         self.assertEqual(
-            run_with_timeout(heavy_function, 10, 0),
+            run_with_timeout(heavy_function, 10, 0.1),
             "ClassSupport return value",
         )
 
@@ -104,7 +104,7 @@ class TestTimeoutExec(TestCase):
         self.assertEqual(f(1, 2, 3), (1, 2, 3))
 
     def test_decorator_test_fail(self):
-        @timeout(0)
+        @timeout(0.1)
         def f(first, second, third):
             time.sleep(100)
             return (first, second, third)
@@ -203,7 +203,7 @@ class TestTimeoutExec(TestCase):
         ]
 
         with self.assertRaises(ValueError):
-            run_with_timeout(lambda: ..., 0)
+            run_with_timeout(lambda: ..., 0.1)
 
     @patch("checkbox_support.helpers.timeout.Queue")
     @patch("checkbox_support.helpers.timeout.Process")
@@ -215,7 +215,7 @@ class TestTimeoutExec(TestCase):
         queue_mock().get.side_effect = Empty()
 
         with self.assertRaises(SystemExit):
-            run_with_timeout(lambda: ..., 0)
+            run_with_timeout(lambda: ..., 0.1)
 
     def test_is_picklable(self):
         self.assertFalse(is_picklable(lambda: ...))


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

In the launchpad builder for Noble, the shell selected is `sh`. This is how I discovered that `sh`'s kill doesn't actually support the tree kill (`-PID` semantic). This adds a fallback mechanism (that tries to use known working shells instead of the default one), then tries the default one and if it fails tries one last time to at least kill the direct child.

This also fixes a race condition, when join timeout is 0, in very unlucky circumstances the subprocess may not be up after the join, leading to the kill failing and the subprocess leaking free. Also, a timeout of 0 doesn't make sense.

## Resolved issues

Fixes: CHECKBOX-1701

## Documentation

N/A

## Tests

Update tests
