### PR TITLE
Report what failed in metabox tests (infra)

### DIFF
--- a/metabox/metabox/core/actions.py
+++ b/metabox/metabox/core/actions.py
@@ -53,7 +53,7 @@ class ActionBase:
 
     def __call__(self, scn):
         assert self.handler is not None
-        getattr(scn, self.handler)(*self.args, **self.kwargs)
+        return getattr(scn, self.handler)(*self.args, **self.kwargs)
 
     def __str__(self):
         kwargs_str = ", ".join(

--- a/metabox/metabox/core/actions.py
+++ b/metabox/metabox/core/actions.py
@@ -20,6 +20,7 @@
 This module defines the Actions classes.
 
 """
+import pprint
 
 __all__ = [
     "Start",
@@ -53,6 +54,16 @@ class ActionBase:
     def __call__(self, scn):
         assert self.handler is not None
         getattr(scn, self.handler)(*self.args, **self.kwargs)
+
+    def __str__(self):
+        kwargs_str = ", ".join(
+            f"{key}={pprint.pformat(value)}"
+            for key, value in self.kwargs.items()
+        )
+        args_str = ", ".join(pprint.pformat(arg) for arg in self.args)
+        # if both are defined, separate them with a comma, else nothing
+        arg_repr_str = ", ".join(arg for arg in (args_str, kwargs_str) if arg)
+        return "{}({})".format(type(self).__name__, arg_repr_str)
 
 
 class Start(ActionBase):

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -291,9 +291,9 @@ class Runner:
                 # let's escape < from the all outputs to avoid confusing loguru
                 # loguru assumes that <> is used for colorizing
                 logger.error("The following steps failed")
-                failed_steps = "\n".join(str(x) for x in scn.failures)
-                failed_steps = failed_steps.replace("<", r"\<")
-                logger.error(failed_steps)
+                for failed_steps in scn.failures:
+                    step = str(failed_steps).replace("<", r"\<")
+                    logger.error("  - {}".format(step))
 
                 output = scn.get_output_streams().strip().replace("<", r"\<")
                 logger.error("Scenario output:\n" + output)

--- a/metabox/metabox/core/runner.py
+++ b/metabox/metabox/core/runner.py
@@ -284,15 +284,20 @@ class Runner:
                 )
             )
             scn.run()
-            if not scn.has_passed():
+            if scn.failures:
                 self.failed = True
                 logger.error(scenario_description + " scenario has failed.")
 
-                # let's escape < from the output to avoid confusing loguru
+                # let's escape < from the all outputs to avoid confusing loguru
                 # loguru assumes that <> is used for colorizing
-                output = scn.get_output_streams().strip().replace("<", r"\<")
+                logger.error("The following steps failed")
+                failed_steps = "\n".join(str(x) for x in scn.failures)
+                failed_steps = failed_steps.replace("<", r"\<")
+                logger.error(failed_steps)
 
+                output = scn.get_output_streams().strip().replace("<", r"\<")
                 logger.error("Scenario output:\n" + output)
+
                 if self.hold_on_fail:
                     if scn.mode == "remote":
                         msg = (

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -223,13 +223,18 @@ class Scenario:
     def send(self, data):
         assert self._pts is not None
         self._pts.send(data.encode("utf-8"), binary=True)
+        # send raises an exception on failure
+        return True
 
     def sleep(self, secs):
         time.sleep(secs)
+        return True
 
     def signal(self, signal):
         assert self._pts is not None
         self._pts.send_signal(signal)
+        # same as send, this uses send under the hood
+        return True
 
     def select_test_plan(self, testplan_id, timeout=60):
         assert self._pts is not None

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -27,6 +27,8 @@ import re
 import time
 import shlex
 
+from pylxd.exceptions import NotFound
+
 from metabox.core.actions import Start, Expect, Send, SelectTestPlan
 from metabox.core.aggregator import aggregator
 
@@ -108,7 +110,7 @@ class Scenario:
                 # step that fail explicitly return false or raise an exception
                 if not step(self):
                     self.failures.append(step)
-            except (TimeoutError, ConnectionError):
+            except (TimeoutError, ConnectionError, NotFound):
                 self.failures.append(step)
                 break
         if self._pts:

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -106,7 +106,7 @@ class Scenario:
                 step.kwargs["interactive"] = interactive
             try:
                 # step that fail explicitly return false or raise an exception
-                if step(self) not in [True, None]:
+                if not step(self):
                     self.failures.append(step)
             except (TimeoutError, ConnectionError):
                 self.failures.append(step)
@@ -181,6 +181,7 @@ class Scenario:
                 self._pts = outcome
             else:
                 self._assign_outcome(*outcome)
+        return True  # return code is checked with a different operator
 
     def start_all(self, interactive=False, timeout=0):
         self.start_agent()
@@ -264,6 +265,7 @@ class Scenario:
                 self.agent_machine.reboot(timeout)
         else:
             self.local_machine.reboot(timeout)
+        return True
 
     def put(self, filepath, data, mode=None, uid=1000, gid=1000, target="all"):
         if self.mode == "remote":
@@ -276,6 +278,8 @@ class Scenario:
                 self.agent_machine.put(filepath, data, mode, uid, gid)
         else:
             self.local_machine.put(filepath, data, mode, uid, gid)
+        # put raises an exception on failure
+        return True
 
     def switch_on_networking(self, target="all"):
         if self.mode == "remote":
@@ -288,6 +292,7 @@ class Scenario:
                 self.agent_machine.switch_on_networking()
         else:
             self.local_machine.switch_on_networking()
+        return True
 
     def switch_off_networking(self, target="all"):
         if self.mode == "remote":
@@ -300,6 +305,7 @@ class Scenario:
                 self.agent_machine.switch_off_networking()
         else:
             self.local_machine.switch_off_networking()
+        return True
 
     def stop_agent(self):
         return self.agent_machine.stop_agent()
@@ -318,7 +324,7 @@ class Scenario:
         if privileged:
             cmd = ["sudo"] + cmd
         cmd_str = shlex.join(cmd)
-        self.run_cmd(cmd_str, target=target, timeout=timeout)
+        return self.run_cmd(cmd_str, target=target, timeout=timeout)
 
     def run_manage(self, args, timeout=0, target="all"):
         """
@@ -326,7 +332,7 @@ class Scenario:
         """
         path = "/home/ubuntu/checkbox/metabox/metabox/metabox-provider"
         cmd = f"bash -c 'cd {path} ; python3 manage.py {args}'"
-        self.run_cmd(cmd, target=target, timeout=timeout)
+        return self.run_cmd(cmd, target=target, timeout=timeout)
 
     def assert_in_file(self, pattern, path):
         """


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Metabox doesn't report what failed in a test, quite interestingly there is a TODO that it should actually do it. This makes it so it does.

`# TODO: add storing of what actually failed in the assert methods`

## Resolved issues

Fixes: CHECKBOX-1699

## Documentation

N/A

## Tests

Old output
```
14:17:17 | ERROR    [local][('jammy',)] basic.template_expansion.InvalidUnitErrorUserVisible scenario has failed.
14:17:17 | ERROR    Scenario output:
[... the full _stdout and _stderr of the scenario ...] 
```

New output:
```
14:17:17 | ERROR    [local][('jammy',)] basic.template_expansion.InvalidUnitErrorUserVisible scenario has failed.
14:17:17 | ERROR    The following steps failed
14:17:17 | ERROR    AssertPrinted('Outcome: job passsed') # Note: I modified a few asserts here to make them fail
AssertPrinted('Outcome: job failedd')
AssertPrinted('Outcome: job failedd')
14:17:17 | ERROR    Scenario output:
[... the full _stdout and _stderr of the scenario ...] 
```