### PR TITLE
Support float castable values instead of just floats (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/resume.py
+++ b/checkbox-ng/plainbox/impl/session/resume.py
@@ -1082,7 +1082,13 @@ class SessionResumeHelper1(MetaDataHelper1MixIn):
     def _build_IOLogRecord(cls, record_repr):
         """Convert the representation of IOLogRecord back the object."""
         _validate(record_repr, value_type=list)
-        delay = _validate(record_repr, key=0, value_type=float)
+        delay = _validate(record_repr, key=0)
+        try:
+            delay = float(delay)
+        except ValueError:
+            raise CorruptedSessionError(
+                "IOLogRecord has invalid delay {}".format(delay)
+            )
         if delay < 0:
             # TRANSLATORS: please keep delay untranslated
             raise CorruptedSessionError(_("delay cannot be negative"))

--- a/checkbox-ng/plainbox/impl/session/test_resume.py
+++ b/checkbox-ng/plainbox/impl/session/test_resume.py
@@ -812,7 +812,9 @@ class IOLogRecordResumeTests(TestCaseWithParameters):
         verify that _build_IOLogRecord() checks that ``delay`` is float
         """
         with self.assertRaises(CorruptedSessionError):
-            self.parameters.resume_cls._build_IOLogRecord([0, "stdout", ""])
+            self.parameters.resume_cls._build_IOLogRecord(
+                ["abc", "stdout", ""]
+            )
 
     def test_build_IOLogRecord_negative_delay(self):
         """


### PR DESCRIPTION


<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The new behaviour may introduce units that produce iologs in 0 time. This causes the validation after resume to crash and burn because 0 is not a float, but an integer. This fixes the issue by allowing any value that is float castable (which is slightly more than just integers, but I see no point in being strict about the timestamp of the iolog production!)

## Resolved issues

Fix: CHECKBOX-1709

## Documentation

N;/A

## Tests

N/A
