### PR TITLE
Added a check in the job "test-store-config" for missing store field (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/snap_utils/asserts.py
+++ b/checkbox-support/checkbox_support/snap_utils/asserts.py
@@ -65,6 +65,10 @@ def model_to_resource(model_assertion):
                     resource["{}_track".format(key)] = track
                 else:
                     resource[key] = val
+
+    # Check if the model has a store
+    if "store" not in resource:
+        resource["store"] = "unknown"
     return resource
 
 

--- a/checkbox-support/checkbox_support/snap_utils/tests/test_asserts.py
+++ b/checkbox-support/checkbox_support/snap_utils/tests/test_asserts.py
@@ -85,6 +85,7 @@ class TestModelAsserts(unittest.TestCase):
             "kernel_track": "18",
             "gadget": "pc",
             "gadget_track": "18",
+            "store": "unknown",
         }
         self.assertDictEqual(correct_resource, model_to_resource(a))
         with self.assertRaises(StopIteration):
@@ -107,6 +108,7 @@ class TestModelAsserts(unittest.TestCase):
             "gadget_track": "20/edge",
             "kernel": "pc-kernel",
             "kernel_track": "20/edge",
+            "store": "unknown",
         }
         self.assertDictEqual(correct_resource, model_to_resource(a))
         with self.assertRaises(StopIteration):
@@ -133,6 +135,7 @@ class TestModelAsserts(unittest.TestCase):
             "brand-id": "generic",
             "model": "generic-classic",
             "sign-key-sha3-384": "d-JcZF9nD9eBw7bwMnH61x-bklnQOhQud1Is6o_cn2wTj8EYDi9musrIT9z2MdAa",
+            "store": "unknown",
         }
         self.assertDictEqual(correct_resource, model_to_resource(a))
         self.assertNotIn("kernel", model_to_resource(a))
@@ -160,6 +163,7 @@ class TestModelAsserts(unittest.TestCase):
             "brand-id": "generic",
             "model": "generic-classic",
             "sign-key-sha3-384": "d-JcZF9nD9eBw7bwMnH61x-bklnQOhQud1Is6o_cn2wTj8EYDi9musrIT9z2MdAa",
+            "store": "unknown",
         }
         self.assertDictEqual(correct_resource, model_to_resource(a))
         self.assertNotIn("kernel", model_to_resource(a))

--- a/providers/base/units/snapd/snapd.pxu
+++ b/providers/base/units/snapd/snapd.pxu
@@ -254,6 +254,7 @@ environ: TEST_SNAP SNAPD_TASK_TIMEOUT SNAPD_POLL_INTERVAL CHECKBOX_RUNTIME
 unit: template
 template-resource: com.canonical.certification::model_assertion
 template-unit: job
+template-filter: model_assertion.store not in ('unknown')
 id: snappy/test-store-config-{store}
 template-id: snappy/test-store-config-store
 _summary: Test that image is using the correct snappy store configuration.


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

With the new template checks, we discovered an error with the "snappy/test-store-config-store" test. The test was trying to be created even if no store was declared.
```
CategorySnapdIO LogTemplate 'com.canonical.certification::snappy/test-store-config-store' generated an invalid unit. Field 'command' has value 'echo "Expected store ID:"
echo "$STORE_ID"
echo
echo "Store ID in model assertion:"
echo "{store}"
[ "$STORE_ID" == "{store}" ]' but the template-resource didn't generate any value for 'store'
```

Now we set the store field in the "model_resource" to "unknown" and filter that in the templated test
 
## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

#1663 

N/A

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

After running a reduced version of the snappy automated tests, the test-store-config test is not templated anymore
