### PR TITLE
Security scanning zizmor (infra)

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: psf/black@stable
         with:
           options: "--check --diff --line-length 79 --extend-exclude '/vendor/'"

--- a/.github/workflows/checkbox-beta-release.yml
+++ b/.github/workflows/checkbox-beta-release.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Verify Promotion Conditions
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -43,6 +44,8 @@ jobs:
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Copy deb packages from edge to beta ppa
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/checkbox-ce-oem-daily-build.yml
+++ b/.github/workflows/checkbox-ce-oem-daily-build.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check for commits
         id: commit_check
         env:

--- a/.github/workflows/checkbox-ce-oem-edge-builds.yml
+++ b/.github/workflows/checkbox-ce-oem-edge-builds.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Add LP credentials
         run: |
           mkdir -p ~/.local/share/snapcraft/provider/launchpad/

--- a/.github/workflows/checkbox-core-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-core-snap-daily-builds.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Copy over the common files for series ${{ matrix.releases }}
         run: |
           cd checkbox-core-snap/

--- a/.github/workflows/checkbox-promote-beta-to-candidate.yml
+++ b/.github/workflows/checkbox-promote-beta-to-candidate.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
     - name: Checkout checkbox monorepo
       uses: actions/checkout@v4
+      with:
+          persist-credentials: false
 
     - name: Create job file (by instantiating template)
       id: create-job

--- a/.github/workflows/checkbox-snap-daily-builds.yml
+++ b/.github/workflows/checkbox-snap-daily-builds.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Copy over the common files for series ${{ matrix.type }}${{ matrix.releases }}
         run: |
           cd checkbox-snap/

--- a/.github/workflows/checkbox-stable-release.yml
+++ b/.github/workflows/checkbox-stable-release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install dependencies
         run: |
           which curl || (sudo apt update && sudo apt install curl -y)
@@ -56,6 +57,8 @@ jobs:
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Copy deb packages from testing to stable ppa
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/checkbox-tics.yml
+++ b/.github/workflows/checkbox-tics.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '00 19 * * *'
   workflow_dispatch:
- 
+
 permissions:
   contents: read
 
@@ -14,6 +14,8 @@ jobs:
     environment: TICS
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check for commits
         id: commit_check
         env:

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: Wandalen/wretry.action/main@v3.4.0_js_action
         name: Make LP pull the monorepo
         env:
@@ -69,6 +70,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: Wandalen/wretry.action/main@v3.4.0_js_action
         name: Update the recipe in the checkbox PPA
         env:

--- a/.github/workflows/deb-sanity-builds.yml
+++ b/.github/workflows/deb-sanity-builds.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: Wandalen/wretry.action/main@v3.4.0_js_action
         name: Make LP pull the monorepo
         env:
@@ -48,6 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: Wandalen/wretry.action/main@v3.4.0_js_action
         name: Update the recipe in the checkbox PPA
         env:

--- a/.github/workflows/deb_validator.yaml
+++ b/.github/workflows/deb_validator.yaml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - name: Checkout Checkbox monorepo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # needed by providers that pull checkbox-support
       - name: Install PPA and dependencies
         run: |

--- a/.github/workflows/dispatch_lab_job.yaml
+++ b/.github/workflows/dispatch_lab_job.yaml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Get current commit SHA
         id: get_sha

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Aspell
         run: |
@@ -57,6 +59,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: woke
         uses: get-woke/woke-action@v0
@@ -82,6 +86,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install the doc framework
         working-directory: docs/

--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Use git diff to see if there are any changes in the metabox and checkbox-ng directories
         id: check_diff
         run: |
@@ -51,6 +52,8 @@ jobs:
     steps:
       - name: Checkout Checkbox monorepo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup LXD
         uses: canonical/setup-lxd@main
       - name: Add ZFS storage

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install dependencies, Checkbox and providers
         run: |
           sudo apt install -y -qq python3 python3-venv jq libsystemd-dev

--- a/.github/workflows/snapcraft8_builds.yaml
+++ b/.github/workflows/snapcraft8_builds.yaml
@@ -41,6 +41,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Copy over the common files for series ${{ matrix.releases }}
         run: |
           cd checkbox-core-snap/
@@ -126,6 +127,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Copy over the common files for series ${{ matrix.type }}${{ matrix.releases }}
         run: |
           cd checkbox-snap/
@@ -201,6 +203,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Add LP credentials
         run: |
           mkdir -p ~/.local/share/snapcraft/
@@ -275,6 +278,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Add LP credentials
         run: |
           mkdir -p ~/.local/share/snapcraft/

--- a/.github/workflows/testflinger-contrib-dss-regression.yaml
+++ b/.github/workflows/testflinger-contrib-dss-regression.yaml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Build job file from template
         run: |
           sed -e "s|REPLACE_BRANCH|${BRANCH}|" \

--- a/.github/workflows/tox-checkbox-ng.yaml
+++ b/.github/workflows/tox-checkbox-ng.yaml
@@ -32,6 +32,8 @@ jobs:
             tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
       # error. To fix this, we have set up manually PIP_TRUSTED_HOST, checking
       # first that we can "curl" the hosts, since they will fail in case of

--- a/.github/workflows/tox-checkbox-ng.yaml
+++ b/.github/workflows/tox-checkbox-ng.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: checkbox-ng

--- a/.github/workflows/tox-checkbox-support.yaml
+++ b/.github/workflows/tox-checkbox-support.yaml
@@ -32,6 +32,8 @@ jobs:
             tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
       # error. To fix this, we have set up manually PIP_TRUSTED_HOST, checking
       # first that we can "curl" the hosts, since they will fail in case of

--- a/.github/workflows/tox-checkbox-support.yaml
+++ b/.github/workflows/tox-checkbox-support.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: checkbox-support

--- a/.github/workflows/tox-contrib-pc-sanity.yaml
+++ b/.github/workflows/tox-contrib-pc-sanity.yaml
@@ -25,6 +25,8 @@ jobs:
             tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tox-contrib-pc-sanity.yaml
+++ b/.github/workflows/tox-contrib-pc-sanity.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: pc-sanity

--- a/.github/workflows/tox-contrib-provider-ce-oem.yaml
+++ b/.github/workflows/tox-contrib-provider-ce-oem.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: contrib-provider-ce-oem

--- a/.github/workflows/tox-contrib-provider-ce-oem.yaml
+++ b/.github/workflows/tox-contrib-provider-ce-oem.yaml
@@ -32,6 +32,8 @@ jobs:
             tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
       # error. To fix this, we have set up manually PIP_TRUSTED_HOST, checking
       # first that we can "curl" the hosts, since they will fail in case of

--- a/.github/workflows/tox-provider-base.yaml
+++ b/.github/workflows/tox-provider-base.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-base

--- a/.github/workflows/tox-provider-base.yaml
+++ b/.github/workflows/tox-provider-base.yaml
@@ -32,6 +32,8 @@ jobs:
             tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
       # error. To fix this, we have set up manually PIP_TRUSTED_HOST, checking
       # first that we can "curl" the hosts, since they will fail in case of

--- a/.github/workflows/tox-provider-certification-client.yaml
+++ b/.github/workflows/tox-provider-certification-client.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-certification-client

--- a/.github/workflows/tox-provider-certification-client.yaml
+++ b/.github/workflows/tox-provider-certification-client.yaml
@@ -32,11 +32,12 @@ jobs:
             tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
       # error. To fix this, we have set up manually PIP_TRUSTED_HOST, checking
       # first that we can "curl" the hosts, since they will fail in case of
       # expired/invalid/self-signed certificate.
-
       - name: Workaround SSL Certificates manual verification for Python
         run: |
           curl --fail --silent --show-error https://pypi.python.org

--- a/.github/workflows/tox-provider-certification-server.yaml
+++ b/.github/workflows/tox-provider-certification-server.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-certification-server

--- a/.github/workflows/tox-provider-certification-server.yaml
+++ b/.github/workflows/tox-provider-certification-server.yaml
@@ -32,6 +32,8 @@ jobs:
             tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
       # error. To fix this, we have set up manually PIP_TRUSTED_HOST, checking
       # first that we can "curl" the hosts, since they will fail in case of

--- a/.github/workflows/tox-provider-docker.yaml
+++ b/.github/workflows/tox-provider-docker.yaml
@@ -32,6 +32,8 @@ jobs:
             tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
       # error. To fix this, we have set up manually PIP_TRUSTED_HOST, checking
       # first that we can "curl" the hosts, since they will fail in case of

--- a/.github/workflows/tox-provider-genio.yaml
+++ b/.github/workflows/tox-provider-genio.yaml
@@ -33,6 +33,8 @@ jobs:
             tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
       # error. To fix this, we have set up manually PIP_TRUSTED_HOST, checking
       # first that we can "curl" the hosts, since they will fail in case of

--- a/.github/workflows/tox-provider-genio.yaml
+++ b/.github/workflows/tox-provider-genio.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-genio

--- a/.github/workflows/tox-provider-gpgpu.yaml
+++ b/.github/workflows/tox-provider-gpgpu.yaml
@@ -32,6 +32,8 @@ jobs:
             tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
       # error. To fix this, we have set up manually PIP_TRUSTED_HOST, checking
       # first that we can "curl" the hosts, since they will fail in case of

--- a/.github/workflows/tox-provider-gpgpu.yaml
+++ b/.github/workflows/tox-provider-gpgpu.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-gpgpu

--- a/.github/workflows/tox-provider-iiotg.yaml
+++ b/.github/workflows/tox-provider-iiotg.yaml
@@ -32,6 +32,8 @@ jobs:
             tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
       # error. To fix this, we have set up manually PIP_TRUSTED_HOST, checking
       # first that we can "curl" the hosts, since they will fail in case of

--- a/.github/workflows/tox-provider-iiotg.yaml
+++ b/.github/workflows/tox-provider-iiotg.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-iiotg

--- a/.github/workflows/tox-provider-resource.yaml
+++ b/.github/workflows/tox-provider-resource.yaml
@@ -32,6 +32,8 @@ jobs:
             tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
       # error. To fix this, we have set up manually PIP_TRUSTED_HOST, checking
       # first that we can "curl" the hosts, since they will fail in case of

--- a/.github/workflows/tox-provider-resource.yaml
+++ b/.github/workflows/tox-provider-resource.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-resource

--- a/.github/workflows/tox-provider-sru.yaml
+++ b/.github/workflows/tox-provider-sru.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-sru

--- a/.github/workflows/tox-provider-sru.yaml
+++ b/.github/workflows/tox-provider-sru.yaml
@@ -32,6 +32,8 @@ jobs:
             tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
       # error. To fix this, we have set up manually PIP_TRUSTED_HOST, checking
       # first that we can "curl" the hosts, since they will fail in case of

--- a/.github/workflows/tox-provider-tpm2.yaml
+++ b/.github/workflows/tox-provider-tpm2.yaml
@@ -32,6 +32,8 @@ jobs:
             tox_env_name: "py310"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
       # error. To fix this, we have set up manually PIP_TRUSTED_HOST, checking
       # first that we can "curl" the hosts, since they will fail in case of

--- a/.github/workflows/tox-tools-release.yaml
+++ b/.github/workflows/tox-tools-release.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Run tox
         run: tox -e py310
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: release-tools

--- a/.github/workflows/tox-tools-release.yaml
+++ b/.github/workflows/tox-tools-release.yaml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/validate_workflows.yaml
+++ b/.github/workflows/validate_workflows.yaml
@@ -10,8 +10,10 @@ jobs:
     name: Workflow validation
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout checkbox monorepo
+      - name: Checkout Checkbox monorepo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install action-validator with asdf
         uses: asdf-vm/actions/install@v3
         with:
@@ -21,3 +23,21 @@ jobs:
         run: |
           find .github/workflows -type f \( -iname \*.yaml -o -iname \*.yml \) \
             | xargs -I {} action-validator --verbose {}
+  workflow_vulnerability_scan:
+    name: Workflow vulnerability scanning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Checkbox monorepo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install zizmor from crates.io
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: zizmor
+          version: '0.10.0'
+      - name: Scan all workflows
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          zizmor $(ls .github/workflows/*.{yaml,yml})


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This creates a new workflow to do sistematic vulnerability scanning of our PRs. This is not a silver bullet, as it will be ran only when new workflows are introduced or old ones are modified but its a good start.

This also adjusts all "problems" found by the tool so that it passes all the times now namely:
- checkout action -> do not persist token, we never pass the token implicitly around and this is an anti feature, disabled
- codecov action -> updated and mitigated a problem (codecov has a branch called v3, so we shouldn't use that reference because we trust an un-restricted branch that way)
- 

## Resolved issues

Fixes: CHECKBOX-1706

## Documentation

N/A

## Tests

Tested tox action to check that the new codecov action works: https://github.com/canonical/checkbox/actions/runs/12431986975


