### PR TITLE
Move to relative argument for TF submit (infra)

### DIFF
--- a/tools/lab_dispatch/generic_source.yaml
+++ b/tools/lab_dispatch/generic_source.yaml
@@ -4,13 +4,13 @@ output_timeout: 1800
 $INPUT_DATA_SOURCE
 test_data:
   attachments:
-    - local: "tools/lab_dispatch/resources/manifest.conf"
+    - local: "resources/manifest.conf"
       agent: "manifest.conf"
-    - local: "tools/lab_dispatch/resources/checkbox.no-manifest.partial.conf"
+    - local: "resources/checkbox.no-manifest.partial.conf"
       agent: "checkbox.no-manifest.partial.conf"
-    - local: "tools/lab_dispatch/build_install_deb.py"
+    - local: "build_install_deb.py"
       agent: "build_install_deb.py"
-    - local: "tools/lab_dispatch/launcher_override.conf"
+    - local: "launcher_override.conf"
       agent: "launcher_override.conf"
   test_cmds: |
     #!/usr/bin/env bash


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Testflinger now uses relative argument paths for attachment by default but it didnt when we created the action. This updates it because else it doesn't work anymore

## Resolved issues

Fixes: https://github.com/canonical/checkbox/actions/runs/12432916030/job/34713353072

## Documentation

N/A

## Tests

See: https://github.com/canonical/checkbox/actions/runs/12433006305/job/34713629085
