### PR TITLE
Fix race condition in reboot_check_test's renderer test and add lsusb/lspci timeout (BugFix)

### DIFF
--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -51,11 +51,17 @@ class DeviceInfoCollector:
     # to modify, add more values in the enum
     # and reference them in required/optional respectively
 
+    COMMAND_TIMEOUT_SECONDS = 30
+
     def get_drm_info(self) -> str:
         return str(os.listdir("/sys/class/drm"))
 
     def get_wireless_info(self) -> str:
-        iw_out = sp.check_output(["iw", "dev"], universal_newlines=True)
+        iw_out = sp.check_output(
+            ["iw", "dev"],
+            timeout=self.COMMAND_TIMEOUT_SECONDS,
+            universal_newlines=True,
+        )
         lines = iw_out.splitlines()
         lines_to_write = list(
             filter(
@@ -76,6 +82,7 @@ class DeviceInfoCollector:
                 "-s",
             ],
             universal_newlines=True,
+            timeout=self.COMMAND_TIMEOUT_SECONDS,
         ).splitlines()
         out.sort()
         return "\n".join(out)
@@ -83,6 +90,7 @@ class DeviceInfoCollector:
     def get_pci_info(self) -> str:
         return sp.check_output(
             ["lspci", "-i", "{}/usr/share/misc/pci.ids".format(SNAP)],
+            timeout=self.COMMAND_TIMEOUT_SECONDS,
             universal_newlines=True,
         )
 
@@ -306,7 +314,7 @@ class HardwareRendererTester:
     def wait_for_graphical_target(self, max_wait_seconds: int) -> bool:
         """Wait for the DUT to reach graphical.target in systemd critical chain
 
-        :param max_wait_seconds: num seconds to wait at most, defaults to 120
+        :param max_wait_seconds: num seconds to wait at most
         :return: whether graphical.target was reached within max_wait_seconds
         """
 

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -319,7 +319,6 @@ class HardwareRendererTester:
         """
 
         start = time.time()
-        print("Checking if DUT has reached graphical.target...")
         while time.time() - start < max_wait_seconds:
             try:
                 out = sp.run(
@@ -334,7 +333,6 @@ class HardwareRendererTester:
                     timeout=min(5, max_wait_seconds),
                 )
                 if out.returncode == 0:
-                    print("Graphical target reached!")
                     return True
                 else:
                     time.sleep(1)
@@ -520,9 +518,12 @@ def main() -> int:
 
     if args.do_renderer_check:
         tester = HardwareRendererTester()
+        
+        print("Checking if DUT has reached graphical.target...")
         graphical_target_reached = tester.wait_for_graphical_target(
             args.graphical_target_timeout
         )
+        
         if not graphical_target_reached:
             print(
                 "[ ERR ] systemd's graphical.target was not reached",
@@ -530,9 +531,11 @@ def main() -> int:
                 "Marking the renderer test as failed.",
             )
             renderer_test_passed = False
-        elif has_desktop_environment() and tester.has_display_connection():
-            # skip renderer test if there's no display
-            renderer_test_passed = tester.is_hardware_renderer_available()
+        else:
+            print('Graphical target was reached!')
+            if has_desktop_environment() and tester.has_display_connection():
+                # skip renderer test if there's no display
+                renderer_test_passed = tester.is_hardware_renderer_available()
 
     print("Finished reboot checks. {}".format(get_timestamp_str()))
 

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -323,14 +323,15 @@ class HardwareRendererTester:
                     ],
                     stdout=sp.DEVNULL,
                     stderr=sp.DEVNULL,
+                    timeout=min(5, max_wait_seconds),
                 )
                 if out.returncode == 0:
                     print("Graphical target reached!")
                     return True
                 else:
                     time.sleep(1)
-            except sp.CalledProcessError:
-                pass
+            except sp.TimeoutExpired:
+                return False
 
         return False
 

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -10,6 +10,7 @@ import sys
 import typing as T
 from checkbox_support.scripts.image_checker import has_desktop_environment
 from datetime import datetime
+import time
 from checkbox_support.helpers.timeout import timeout
 
 
@@ -328,6 +329,8 @@ class HardwareRendererTester:
                     if out.returncode == 0:
                         print("Graphical target reached!")
                         return True
+                    else:
+                        time.sleep(1)
                 except sp.CalledProcessError:
                     pass
 

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -54,7 +54,7 @@ class DeviceInfoCollector:
     COMMAND_TIMEOUT_SECONDS = 30
 
     def get_drm_info(self) -> str:
-        return str(os.listdir("/sys/class/drm"))
+        return str(sorted(os.listdir("/sys/class/drm")))
 
     def get_wireless_info(self) -> str:
         iw_out = sp.check_output(

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -518,12 +518,12 @@ def main() -> int:
 
     if args.do_renderer_check:
         tester = HardwareRendererTester()
-        
+
         print("Checking if DUT has reached graphical.target...")
         graphical_target_reached = tester.wait_for_graphical_target(
             args.graphical_target_timeout
         )
-        
+
         if not graphical_target_reached:
             print(
                 "[ ERR ] systemd's graphical.target was not reached",
@@ -532,7 +532,7 @@ def main() -> int:
             )
             renderer_test_passed = False
         else:
-            print('Graphical target was reached!')
+            print("Graphical target was reached!")
             if has_desktop_environment() and tester.has_display_connection():
                 # skip renderer test if there's no display
                 renderer_test_passed = tester.is_hardware_renderer_available()

--- a/providers/base/tests/test_reboot_check_test.py
+++ b/providers/base/tests/test_reboot_check_test.py
@@ -165,7 +165,10 @@ class DisplayConnectionTests(unittest.TestCase):
 
         with patch("subprocess.run") as mock_run, patch(
             "time.sleep"
-        ) as mock_sleep, patch("time.time") as mock_time:
+        ) as mock_sleep, patch("time.time") as mock_time, patch(
+            "sys.argv",
+            sh_split("reboot_check_test.py -g --graphical-target-timeout 2"),
+        ):
             mock_run.side_effect = lambda *args, **kwargs: sp.CompletedProcess(
                 [],
                 1,
@@ -177,6 +180,10 @@ class DisplayConnectionTests(unittest.TestCase):
             tester = RCT.HardwareRendererTester()
 
             self.assertFalse(tester.wait_for_graphical_target(2))
+
+            mock_time.side_effect = fake_time(3)
+            tester = RCT.HardwareRendererTester()
+            self.assertEqual(RCT.main(), 1)
 
 
 class InfoDumpTests(unittest.TestCase):


### PR DESCRIPTION
## Description

- Added a method to wait for graphical.target before running unity_support_test.
- Added timeouts for lspci and lsusb

## Resolved issues

Race condition issue: https://github.com/canonical/checkbox/issues/1631 TLDR: Calling unity_support_test before graphical.target is reached will falsely report the test as failed since it can't open the display.

There was also an issue reported by Hanhsuan where lspci and lsusb can get stuck and never return, so I added a timeout for their `subprocess.run` calls.
- By "stuck" I mean lspci & lsusb are waiting indefinitely for devices to respond, which apparently can happen with broken drivers. This type of freeze can be handled by a basic timeout

## Documentation

The wait timeout can be controlled by `--graphical-target-timeout <timeout_seconds>`. This value is ignored when `-g` or `--graphics` are not specified. Default is 120 seconds

## Tests

Unit tests