### PR TITLE
Add OTG automated tests with RPYC server (New)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic22/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic22/snap/snapcraft.yaml
@@ -45,6 +45,7 @@ parts:
       - device-tree-compiler
       - linuxptp
       - snmp
+      - python3-rpyc
     override-prime: |
       snapcraftctl prime
       rm lib/systemd/system/alsa-utils.service

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic24/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic24/snap/snapcraft.yaml
@@ -45,6 +45,7 @@ parts:
       - device-tree-compiler
       - linuxptp
       - snmp
+      - python3-rpyc
     override-prime: |
       craftctl default
       rm lib/systemd/system/alsa-utils.service

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc22/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc22/snap/snapcraft.yaml
@@ -82,6 +82,7 @@ parts:
       - device-tree-compiler
       - linuxptp
       - snmp
+      - python3-rpyc
     override-prime: |
       snapcraftctl prime
       rm lib/systemd/system/alsa-utils.service
@@ -100,8 +101,6 @@ parts:
       - python3-urwid
       - python3-xlsxwriter
       - python3-requests-oauthlib
-    python-packages:
-      - rpyc
   input-pcspkr:
     plugin: nil
     after: [checkbox-provider-ce-oem]

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc22/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc22/snap/snapcraft.yaml
@@ -100,6 +100,8 @@ parts:
       - python3-urwid
       - python3-xlsxwriter
       - python3-requests-oauthlib
+    python-packages:
+      - rpyc
   input-pcspkr:
     plugin: nil
     after: [checkbox-provider-ce-oem]

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc24/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc24/snap/snapcraft.yaml
@@ -82,6 +82,7 @@ parts:
       - device-tree-compiler
       - linuxptp
       - snmp
+      - python3-rpyc
     override-prime: |
       craftctl default
       rm lib/systemd/system/alsa-utils.service
@@ -100,8 +101,6 @@ parts:
       - python3-urwid
       - python3-xlsxwriter
       - python3-requests-oauthlib
-    python-packages:
-      - rpyc
   input-pcspkr:
     plugin: nil
     after: [checkbox-provider-ce-oem]

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc24/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc24/snap/snapcraft.yaml
@@ -100,6 +100,8 @@ parts:
       - python3-urwid
       - python3-xlsxwriter
       - python3-requests-oauthlib
+    python-packages:
+      - rpyc
   input-pcspkr:
     plugin: nil
     after: [checkbox-provider-ce-oem]

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/multiple_otg.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/multiple_otg.py
@@ -90,15 +90,22 @@ def prepare_env():
         teardown()
 
 
+def dump_otg_info(configs):
+    pass
+
+
 class OtgTest():
 
-    def mass_storage_test(self):
+    def info(self):
         pass
 
-    def ethernet_test(self):
+    def mass_storage(self):
         pass
 
-    def serial_test(self):
+    def ethernet(self):
+        pass
+
+    def serial(self):
         pass
 
 
@@ -107,12 +114,21 @@ def register_arguments():
         description="OTG test method"
     )
 
-    parser.add_argument(
+    sub_parser = parser.add_subparsers(
+        dest="mode",
+        required=True,
+    )
+    test_parser = sub_parser.add_parser("test")
+    test_parser.add_argument(
         "-t",
         "--type",
         required=True,
         choices=["mass_storage", "ethernet", "serial"]
     )
+    test_parser.add_argument("-a", "--address", required=True, type=str)
+
+    info_parser = sub_parser.add_parser("info")
+    info_parser.add_argument("-c", "--config", required=True, type=str)
 
     return parser.parse_args()
 
@@ -120,7 +136,10 @@ def register_arguments():
 def main():
     args = register_arguments()
     with prepare_env():
-        getattr(OtgTest, args.type)(args)
+        if args.mode == "test":
+            getattr(OtgTest, args.type)(args)
+        elif args.mode == "info":
+            dump_otg_info(args.config)
 
 
 if __name__ == "__main__":

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/multiple_otg.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/multiple_otg.py
@@ -1,0 +1,97 @@
+import logging
+import os
+import subprocess
+
+from contextlib import contextmanager
+from pathlib import Path
+
+
+MODULE_MAPPING = {
+    "usb": "usb_f_mass_storage",
+    "ethernet": "usb_f_ecm",
+    "serial": "usb_f_acm",
+}
+OTG_MODULE = "libcomposite"
+GADGET_PATH = "/sys/kernel/config/usb_gadget"
+
+
+def _get_otg_module():
+    ret = subprocess.run(
+        "lsmod | grep {}".format(OTG_MODULE),
+        shell=True,
+        universal_newlines=True
+    )
+    return ret.stdout.strip()
+
+
+def enable_otg_module():
+    disable_otg_related_modules()
+
+    if not _get_otg_module():
+        subprocess.run("modprode {}".format(OTG_MODULE))
+
+
+def disable_otg_related_modules():
+    ret = subprocess.run("lsmod | awk '/^libcomposite/ {print $4}'")
+    if ret.returncode == 0:
+        for module in ret.stdout.split(","):
+            subprocess.run("modprobe -r {}".format(module))
+
+
+def _initial_gadget():
+    logging.info("initial gadget")
+    enable_otg_module()
+
+    ret = subprocess.run("mount | configfs")
+    if not ret.stdout.strip():
+        subprocess.run(
+            "mount -t configfs none {}".format(os.path.split(GADGET_PATH))
+        )
+
+def _create_otg_configs():
+    logging.info("create gadget")
+    path_g1 = os.path.join(GADGET_PATH, "g1")
+    os.makedirs(path_g1)
+
+    path_lang = os.path.join(path_g1, "strings", "0x409") # english lang
+    os.makedirs(path_lang)
+
+    path_g1 = Path(path_g1)
+    vid_file = path_g1.joinpath("idVendor")
+    vid_file.write_text("0xabcd")
+    pid_file = path_g1.joinpath("idProduct")
+    pid_file.write_text("0x9999")
+
+    # create configs
+    path_config = path_g1.joinpath("configs", "c.1")
+    os.makedirs(path_config)
+
+    max_power_file = path_config.joinpath("MaxPower")
+    max_power_file.write_text("120")
+
+
+def otg_testing(method):
+    pass
+
+
+def teardown():
+    pass
+
+@contextmanager
+def prepare_env():
+    try:
+        _initial_gadget()
+        _create_otg_configs()
+    except Exception as err:
+        logging.error(err)
+    finally:
+        teardown()
+
+
+def main():
+    with prepare_env():
+        otg_testing()
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/multiple_otg.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/multiple_otg.py
@@ -1,5 +1,7 @@
+import argparse
 import logging
 import os
+import shutil
 import subprocess
 
 from contextlib import contextmanager
@@ -70,12 +72,12 @@ def _create_otg_configs():
     max_power_file.write_text("120")
 
 
-def otg_testing(method):
-    pass
-
-
 def teardown():
-    pass
+    path_obj = Path(GADGET_PATH).joinpath("g1", "UDC")
+    path_obj.write_text("")
+
+    shutil.rmtree(GADGET_PATH)
+
 
 @contextmanager
 def prepare_env():
@@ -88,9 +90,37 @@ def prepare_env():
         teardown()
 
 
+class OtgTest():
+
+    def mass_storage_test(self):
+        pass
+
+    def ethernet_test(self):
+        pass
+
+    def serial_test(self):
+        pass
+
+
+def register_arguments():
+    parser = argparse.ArgumentParser(
+        description="OTG test method"
+    )
+
+    parser.add_argument(
+        "-t",
+        "--type",
+        required=True,
+        choices=["mass_storage", "ethernet", "serial"]
+    )
+
+    return parser.parse_args()
+
+
 def main():
+    args = register_arguments()
     with prepare_env():
-        otg_testing()
+        getattr(OtgTest, args.type)(args)
 
 
 if __name__ == "__main__":

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/multiple_otg.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/multiple_otg.py
@@ -74,8 +74,7 @@ class OtgConfigFsOperatorBase:
         self.enable_otg_module([OTG_MODULE])
         self.usb_gadget_node = Path(
             tempfile.TemporaryDirectory(
-                dir=self.root_path.joinpath("usb_gadget"),
-                prefix="udc_"
+                dir=self.root_path.joinpath("usb_gadget"), prefix="udc_"
             ).name
         )
         self.otg_setup()
@@ -87,7 +86,10 @@ class OtgConfigFsOperatorBase:
         logging.debug("Clean up OTG configurations")
         self._cleanup_usb_gadget()
         cur_modules = [
-            mod for mod in self._get_child_modules() if mod not in self._child_modules]
+            mod
+            for mod in self._get_child_modules()
+            if mod not in self._child_modules
+        ]
         self.disable_otg_related_modules(cur_modules)
         if self._child_modules:
             self.enable_otg_module(self._child_modules)
@@ -104,11 +106,15 @@ class OtgConfigFsOperatorBase:
 
     def enable_otg_module(self, modules):
         for module in modules:
-            subprocess.run("modprobe {}".format(module), shell=True, check=True)
+            subprocess.run(
+                "modprobe {}".format(module), shell=True, check=True
+            )
 
     def disable_otg_related_modules(self, modules):
         for module in modules:
-            subprocess.run("modprobe -r {}".format(module), shell=True, check=True)
+            subprocess.run(
+                "modprobe -r {}".format(module), shell=True, check=True
+            )
 
     def otg_setup(self):
         """
@@ -150,8 +156,9 @@ class OtgConfigFsOperatorBase:
         if not function_path.exists():
             function_path.mkdir()
 
-        self.usb_gadget_node.joinpath(
-            "configs", "c.1", func_name).symlink_to(function_path, True)
+        self.usb_gadget_node.joinpath("configs", "c.1", func_name).symlink_to(
+            function_path, True
+        )
 
     def _cleanup_usb_gadget(self):
         func_name = "{}.0".format(self.OTG_FUNCTION)
@@ -207,7 +214,9 @@ class OtgMassStorageSetup(OtgConfigFsOperatorBase):
         logging.info("Create an USB image file for Mass Storage Test")
         self._usb_img = tempfile.NamedTemporaryFile("+bw", delete=False)
         subprocess.run(
-            "dd if=/dev/zero of={} bs=1M count=1024".format(self._usb_img.name),
+            "dd if=/dev/zero of={} bs=1M count=1024".format(
+                self._usb_img.name
+            ),
             shell=True,
             check=True,
         )
@@ -233,8 +242,9 @@ class OtgMassStorageSetup(OtgConfigFsOperatorBase):
 
         function_path.joinpath("lun.0", "file").write_text(self._usb_img.name)
 
-        self.usb_gadget_node.joinpath(
-            "configs", "c.1", func_name).symlink_to(function_path, True)
+        self.usb_gadget_node.joinpath("configs", "c.1", func_name).symlink_to(
+            function_path, True
+        )
 
     def detection_check_on_rpyc(self, rpyc_ip):
         logging.info("USB drive detection on RPYC")
@@ -250,11 +260,13 @@ class OtgMassStorageSetup(OtgConfigFsOperatorBase):
 
     def function_check_with_rpyc(self, rpyc_ip):
         logging.info("USB read/write testing on RPYC")
-        raise SystemExit(rpyc_client(
-            rpyc_ip,
-            "usb_storage_test",
-            self.usb_type,
-        ))
+        raise SystemExit(
+            rpyc_client(
+                rpyc_ip,
+                "usb_storage_test",
+                self.usb_type,
+            )
+        )
 
     def otg_test_process(self, rpyc_ip):
         logging.info("Start Mass Storage Testing with OTG interface")
@@ -282,7 +294,9 @@ class OtgEthernetSetup(OtgConfigFsOperatorBase):
     OTG_TARGET_MODULE = "usb_f_ecm"
 
     def _collect_net_intfs(self):
-        return [os.path.basename(intf) for intf in glob.glob("/sys/class/net/*")]
+        return [
+            os.path.basename(intf) for intf in glob.glob("/sys/class/net/*")
+        ]
 
     def otg_setup(self):
         self._net_intfs = self._collect_net_intfs()
@@ -301,7 +315,9 @@ class OtgEthernetSetup(OtgConfigFsOperatorBase):
 
         otg_net_intf = [x for x in cur_net_intfs if x not in self._net_intfs]
         if len(otg_net_intf) != 1:
-            logging.error("Found more than one new interface. %s", otg_net_intf)
+            logging.error(
+                "Found more than one new interface. %s", otg_net_intf
+            )
         else:
             logging.info("Found new network interface '%s'", otg_net_intf[0])
         self._net_dev = otg_net_intf[0]
@@ -327,7 +343,7 @@ class OtgEthernetSetup(OtgConfigFsOperatorBase):
         logging.info("Ping from DUT to Target")
         _module = SourceFileLoader(
             "_",
-            os.path.join(CHECKBOX_BASE_PROVIDER, "bin/gateway_ping_test.py")
+            os.path.join(CHECKBOX_BASE_PROVIDER, "bin/gateway_ping_test.py"),
         ).load_module()
         test_func = getattr(_module, "perform_ping_test")
         ret = test_func([self._net_dev], "169.254.0.10")
@@ -367,7 +383,9 @@ class OtgSerialSetup(OtgConfigFsOperatorBase):
 
         otg_ser_intf = [x for x in cur_ser_intfs if x not in self._ser_intfs]
         if len(otg_ser_intf) != 1:
-            logging.error("Found more than one new interface. %s", otg_ser_intf)
+            logging.error(
+                "Found more than one new interface. %s", otg_ser_intf
+            )
         else:
             logging.info("Found new network interface '%s'", otg_ser_intf[0])
         self._serial_iface = otg_ser_intf[0]
@@ -415,8 +433,8 @@ class OtgSerialSetup(OtgConfigFsOperatorBase):
                     "N",
                     1,
                     3,
-                    1024
-                )
+                    1024,
+                ),
             )
             t_thread.start()
             time.sleep(3)
@@ -482,9 +500,7 @@ def register_arguments():
 def main():
     args = register_arguments()
     if args.mode == "test":
-        otg_testing(
-            args.udc_node, args.type, args.rpyc_address, args.usb_type
-        )
+        otg_testing(args.udc_node, args.type, args.rpyc_address, args.usb_type)
     elif args.mode == "info":
         dump_otg_info(args.config)
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_client.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_client.py
@@ -1,0 +1,46 @@
+import time
+
+from importlib import import_module
+
+
+def rpyc_client(host, cmd, *args, **kwargs):
+    """
+    Run command on RPYC.
+
+    :param host: RPYC server IP address
+    :param cmd: command to be executed
+    :param args: command arguments
+    :param kwargs: command keyword arguments
+    :returns: whatever is returned by RPYC service
+    :raises SystemExit: if the connection cannot be established
+                        or the command is unknown
+                        or a service error occurs
+    """
+    try:
+        _rpyc = import_module("rpyc")
+    except ImportError:
+        try:
+            _rpyc = import_module("plainbox.vendor.rpyc")
+        except ImportError as exc:
+            msg = "RPyC not found. Neither from sys nor from Checkbox"
+            raise SystemExit(msg) from exc
+
+    for _ in range(2):
+        try:
+            conn = _rpyc.connect(host, 60000, config={"allow_all_attrs": True})
+            break
+        except ConnectionRefusedError:
+            time.sleep(1)
+    else:
+        raise SystemExit("Cannot connect to RPYC Host.")
+
+    try:
+        return getattr(conn.root, cmd)(*args, **kwargs)
+    except AttributeError:
+        raise SystemExit(
+            "RPYC host does not provide a '{}' command.".format(cmd)
+        )
+    except _rpyc.core.vinegar.GenericException as exc:
+        raise SystemExit(
+            "Zapper host failed to process the requested command."
+        ) from exc

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_client.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_client.py
@@ -17,10 +17,10 @@ def rpyc_client(host, cmd, *args, **kwargs):
     """
     for _ in range(2):
         try:
-            conn = rpyc.connect(host, 60000, config={
-                "allow_all_attrs": True,
-                "allow_exposed_attrs": False
-                }
+            conn = rpyc.connect(
+                host,
+                60000,
+                config={"allow_all_attrs": True, "allow_exposed_attrs": False},
             )
             break
         except ConnectionRefusedError:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_client.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_client.py
@@ -33,7 +33,7 @@ def rpyc_client(host, cmd, *args, **kwargs):
         wrap = rpyc.async_(func)
         res = wrap(*args, **kwargs)
         while res.ready:
-            print("Waiting for RPYC server complete %s".format(func))
+            print("Waiting for RPYC server complete {}".format(func))
             time.sleep(1)
             break
         if getattr(res._conn.root, "logs"):

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_server.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_server.py
@@ -180,7 +180,7 @@ class RpycTestService(rpyc.Service):
 
 
 def main():
-    rpyc_service = append_method_to_service(RpycTestService())
+    rpyc_service = append_method_to_service(RpycTestService)
 
     t = ThreadedServer(
         rpyc_service,

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_server.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_server.py
@@ -3,54 +3,49 @@ import logging
 import os
 import rpyc
 import sys
-import time
 
 from contextlib import redirect_stdout, redirect_stderr
-from importlib import reload
 from importlib.machinery import SourceFileLoader
-from pathlib import Path
 from rpyc.utils.server import ThreadedServer
 
-from checkbox_support.scripts import (
-    run_watcher,
-    usb_read_write,
-)
 
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 handler_std = logging.StreamHandler(sys.stdout)
 
-
+CHECKBOX_PROVIDER_CEOEM_PATH = (
+    "/snap/checkbox-ce-oem/current/providers/checkbox-provider-ce-oem/bin"
+)
 LIBS = {
     "enable_serial_server": {
-        "source": (
-            "/snap/checkbox-ce-oem/current/providers/"
-            "checkbox-provider-ce-oem/bin/serial_test.py"
+        "source": os.path.join(
+            CHECKBOX_PROVIDER_CEOEM_PATH, "serial_test.py"
         ),
         "function": "server_mode",
     },
-    "configure_local_network": {
-        "source": (
-            "/snap/checkbox-ce-oem/current/providers/"
-            "checkbox-provider-ce-oem/bin/multiple_otg.py"
-        ),
-        "function": "configure_local_network",
-    },
     "serial_check": {
-        "source": __file__,
+        "source": os.path.join(
+            CHECKBOX_PROVIDER_CEOEM_PATH, "rpyc_test_methods.py"
+        ),
         "function": "serial_check",
     },
     "ethernet_check": {
-        "source": __file__,
+        "source": os.path.join(
+            CHECKBOX_PROVIDER_CEOEM_PATH, "rpyc_test_methods.py"
+        ),
         "function": "ethernet_check",
     },
     "configure_local_network": {
-        "source": __file__,
+        "source": os.path.join(
+            CHECKBOX_PROVIDER_CEOEM_PATH, "rpyc_test_methods.py"
+        ),
         "function": "configure_local_network",
     },
     "usb_storage_test": {
-        "source": __file__,
+        "source": os.path.join(
+            CHECKBOX_PROVIDER_CEOEM_PATH, "rpyc_test_methods.py"
+        ),
         "function": "usb_storage_test",
     },
 }
@@ -69,7 +64,8 @@ def capture_io_logs(func):
             try:
                 ret = func(*args, **kwargs)
             except SystemExit as exp:
-                ret = exp.code
+                logging.error(exp.code)
+                ret = None
 
         cls.logs = "stdout logs: {}".format(stdout.getvalue())
         cls.logs += "\nstderr logs: {}".format(stderr.getvalue())
@@ -98,69 +94,6 @@ def append_method_to_service(cls):
             setattr(cls, key, capture_io_logs(func))
 
     return cls
-
-
-# Method for testing
-def _get_ethernet_ifaces():
-    return set([i.name for i in Path("/sys/class/net").iterdir()])
-
-
-def _get_serial_ifaces():
-    return set([i.name for i in Path("/dev/serial/by-id").iterdir()])
-
-
-def _device_node_detect(func, device_type=""):
-    starting_ifaces = func()
-
-    attempts = 20
-    while attempts > 0:
-        now_ifaces = func()
-        # check if something disappeared
-        if not starting_ifaces == now_ifaces & starting_ifaces:
-            raise SystemExit(
-                "Interface(s) disappeared: {}".format(
-                    ", ".join(list(starting_ifaces - now_ifaces))
-                )
-            )
-        new_ifaces = now_ifaces - starting_ifaces
-        if new_ifaces:
-            print()
-            print(
-                "New interface(s) detected: {}".format(
-                    ", ".join(list(new_ifaces))
-                )
-            )
-            return new_ifaces
-        time.sleep(1)
-        print(".", end="", flush=True)
-        attempts -= 1
-    print()
-    raise SystemExit(
-        "Failed to detect new {} interface".format(device_type)
-    )
-
-
-def serial_check():
-    return _device_node_detect(_get_serial_ifaces, "serial")
-
-
-def ethernet_check():
-    return _device_node_detect(_get_ethernet_ifaces, "ethernet")
-
-
-def usb_storage_test(usb_type):
-    logger.info("%s drive read/write testing on RPYC", usb_type)
-    usb_read_write.REPETITION_NUM = 2
-    watcher = run_watcher.USBStorage(usb_type)
-    mounted_partition = watcher.run_insertion()
-    logger.info(
-        "%s drive been mounted to %s on RPYC", usb_type, mounted_partition
-    )
-    watcher.run_storage(mounted_partition)
-    # usb_read_write been imported in run_watcher
-    # the temporary mount point been created while import it and been removed in gen_random_file function
-    # thus, we need to reload it to create temporary mount point in every testing cycle
-    reload(usb_read_write)
 
 
 class RpycTestService(rpyc.Service):

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_server.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_server.py
@@ -1,7 +1,7 @@
 import io
 import logging
+import os
 import rpyc
-import subprocess
 import sys
 import time
 
@@ -30,12 +30,12 @@ LIBS = {
         ),
         "function": "server_mode",
     },
-    "network_ping": {
+    "configure_local_network": {
         "source": (
-            "/snap/checkbox22/current/providers/"
-            "checkbox-provider-base/bin/gateway_ping_test.py"
+            "/snap/checkbox-ce-oem/current/providers/"
+            "checkbox-provider-ce-oem/bin/multiple_otg.py"
         ),
-        "function": "perform_ping_test",
+        "function": "configure_local_network",
     },
     "serial_check": {
         "source": __file__,
@@ -146,15 +146,6 @@ def serial_check():
 
 def ethernet_check():
     return _device_node_detect(_get_ethernet_ifaces, "ethernet")
-
-
-def configure_local_network(interface, net_info):
-    logger.info("set %s to %s interface on RPYC", net_info, interface)
-    subprocess.check_output(
-        "ip addr add {} dev {}".format(net_info, interface),
-        shell=True,
-        text=True,
-    )
 
 
 def usb_storage_test(usb_type):

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_server.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_server.py
@@ -9,7 +9,6 @@ from importlib.machinery import SourceFileLoader
 from rpyc.utils.server import ThreadedServer
 
 
-
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 handler_std = logging.StreamHandler(sys.stdout)
@@ -19,9 +18,7 @@ CHECKBOX_PROVIDER_CEOEM_PATH = (
 )
 LIBS = {
     "enable_serial_server": {
-        "source": os.path.join(
-            CHECKBOX_PROVIDER_CEOEM_PATH, "serial_test.py"
-        ),
+        "source": os.path.join(CHECKBOX_PROVIDER_CEOEM_PATH, "serial_test.py"),
         "function": "server_mode",
     },
     "serial_check": {
@@ -60,7 +57,9 @@ def capture_io_logs(func):
         if func.__name__ in dynamic_integrate_funcs:
             args = args[1:]
 
-        with redirect_stderr(sio_stderr) as stderr, redirect_stdout(sio_stdout) as stdout:
+        with redirect_stderr(sio_stderr) as stderr, redirect_stdout(
+            sio_stdout
+        ) as stdout:
             try:
                 ret = func(*args, **kwargs)
             except SystemExit as exp:
@@ -70,6 +69,7 @@ def capture_io_logs(func):
         cls.logs = "stdout logs: {}".format(stdout.getvalue())
         cls.logs += "\nstderr logs: {}".format(stderr.getvalue())
         return ret
+
     return wrap
 
 
@@ -87,9 +87,7 @@ def _load_method_from_file(name, file, func):
 
 def append_method_to_service(cls):
     for key, value in LIBS.items():
-        func = _load_method_from_file(
-            key, value["source"], value["function"]
-        )
+        func = _load_method_from_file(key, value["source"], value["function"])
         if func:
             setattr(cls, key, capture_io_logs(func))
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_server.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_server.py
@@ -37,6 +37,22 @@ LIBS = {
         ),
         "function": "perform_ping_test",
     },
+    "serial_check": {
+        "source": __file__,
+        "function": "serial_check",
+    },
+    "ethernet_check": {
+        "source": __file__,
+        "function": "ethernet_check",
+    },
+    "configure_local_network": {
+        "source": __file__,
+        "function": "configure_local_network",
+    },
+    "usb_storage_test": {
+        "source": __file__,
+        "function": "usb_storage_test",
+    },
 }
 dynamic_integrate_funcs = [LIBS[k]["function"] for k in LIBS.keys()]
 
@@ -73,100 +89,101 @@ def _load_method_from_file(name, file, func):
         logger.debug(e)
 
 
+def append_method_to_service(cls):
+    for key, value in LIBS.items():
+        func = _load_method_from_file(
+            key, value["source"], value["function"]
+        )
+        if func:
+            setattr(cls, key, capture_io_logs(func))
+
+    return cls
+
+
+# Method for testing
+def _get_ethernet_ifaces():
+    return set([i.name for i in Path("/sys/class/net").iterdir()])
+
+
+def _get_serial_ifaces():
+    return set([i.name for i in Path("/dev/serial/by-id").iterdir()])
+
+
+def _device_node_detect(func, device_type=""):
+    starting_ifaces = func()
+
+    attempts = 20
+    while attempts > 0:
+        now_ifaces = func()
+        # check if something disappeared
+        if not starting_ifaces == now_ifaces & starting_ifaces:
+            raise SystemExit(
+                "Interface(s) disappeared: {}".format(
+                    ", ".join(list(starting_ifaces - now_ifaces))
+                )
+            )
+        new_ifaces = now_ifaces - starting_ifaces
+        if new_ifaces:
+            print()
+            print(
+                "New interface(s) detected: {}".format(
+                    ", ".join(list(new_ifaces))
+                )
+            )
+            return new_ifaces
+        time.sleep(1)
+        print(".", end="", flush=True)
+        attempts -= 1
+    print()
+    raise SystemExit(
+        "Failed to detect new {} interface".format(device_type)
+    )
+
+
+def serial_check():
+    return _device_node_detect(_get_serial_ifaces, "serial")
+
+
+def ethernet_check():
+    return _device_node_detect(_get_ethernet_ifaces, "ethernet")
+
+
+def configure_local_network(interface, net_info):
+    logger.info("set %s to %s interface on RPYC", net_info, interface)
+    subprocess.check_output(
+        "ip addr add {} dev {}".format(net_info, interface),
+        shell=True,
+        text=True,
+    )
+
+
+def usb_storage_test(usb_type):
+    logger.info("%s drive read/write testing on RPYC", usb_type)
+    usb_read_write.REPETITION_NUM = 2
+    watcher = run_watcher.USBStorage(usb_type)
+    mounted_partition = watcher.run_insertion()
+    logger.info(
+        "%s drive been mounted to %s on RPYC", usb_type, mounted_partition
+    )
+    watcher.run_storage(mounted_partition)
+    # usb_read_write been imported in run_watcher
+    # the temporary mount point been created while import it and been removed in gen_random_file function
+    # thus, we need to reload it to create temporary mount point in every testing cycle
+    reload(usb_read_write)
+
+
 class RpycTestService(rpyc.Service):
 
     def __init__(self):
         super().__init__()
         self.logs = ""
-        for key, value in LIBS.items():
-            func = _load_method_from_file(
-                key, value["source"], value["function"]
-            )
-            if func:
-                setattr(RpycTestService, key, capture_io_logs(func))
-
-    def on_connect(self, conn):
-        # code that runs when a connection is created
-        # (to init the service, if needed)
-        pass
-
-    def on_disconnect(self, conn):
-        # code that runs after the connection has already closed
-        # (to finalize the service, if needed)
-        pass
-
-    def _get_ethernet_ifaces(self):
-        return set([i.name for i in Path("/sys/class/net").iterdir()])
-
-    def _get_serial_ifaces(self):
-        return set([i.name for i in Path("/dev/serial/by-id").iterdir()])
-
-    def _device_node_detect(self, func, device_type=""):
-        starting_ifaces = func()
-
-        attempts = 20
-        while attempts > 0:
-            now_ifaces = func()
-            # check if something disappeared
-            if not starting_ifaces == now_ifaces & starting_ifaces:
-                raise SystemExit(
-                    "Interface(s) disappeared: {}".format(
-                        ", ".join(list(starting_ifaces - now_ifaces))
-                    )
-                )
-            new_ifaces = now_ifaces - starting_ifaces
-            if new_ifaces:
-                print()
-                print(
-                    "New interface(s) detected: {}".format(
-                        ", ".join(list(new_ifaces))
-                    )
-                )
-                return new_ifaces
-            time.sleep(1)
-            print(".", end="", flush=True)
-            attempts -= 1
-        print()
-        raise SystemExit(
-            "Failed to detect new {} interface".format(device_type)
-        )
-
-    @capture_io_logs
-    def serial_check(self):
-        return self._device_node_detect(self._get_serial_ifaces, "serial")
-
-    @capture_io_logs
-    def ethernet_check(self):
-        return self._device_node_detect(self._get_ethernet_ifaces, "ethernet")
-
-    @capture_io_logs
-    def configure_local_network(self, interface, net_info):
-        logger.info("set %s to %s interface on RPYC", net_info, interface)
-        subprocess.check_output(
-            "ip addr add {} dev {}".format(net_info, interface),
-            shell=True,
-            text=True,
-        )
-
-    @capture_io_logs
-    def usb_storage_test(self, usb_type):
-        logger.info("%s drive read/write testing on RPYC", usb_type)
-        usb_read_write.REPETITION_NUM = 2
-        watcher = run_watcher.USBStorage(usb_type)
-        mounted_partition = watcher.run_insertion()
-        logger.info(
-            "%s drive been mounted to %s on RPYC", usb_type, mounted_partition
-        )
-        watcher.run_storage(mounted_partition)
-        # usb_read_write been imported in run_watcher
-        # the temporary mount point been created while import it and been removed in gen_random_file function
-        # thus, we need to reload it to create temporary mount point in every testing cycle
-        reload(usb_read_write)
 
 
 def main():
+    rpyc_service = append_method_to_service(RpycTestService())
+
     t = ThreadedServer(
-        RpycTestService,
+        rpyc_service,
         port=60000,
         logger=logger,
         protocol_config={

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_server.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_server.py
@@ -1,0 +1,181 @@
+import io
+import logging
+import rpyc
+import subprocess
+import sys
+import time
+
+from contextlib import redirect_stdout, redirect_stderr
+from importlib import reload
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from rpyc.utils.server import ThreadedServer
+
+from checkbox_support.scripts import (
+    run_watcher,
+    usb_read_write,
+)
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+handler_std = logging.StreamHandler(sys.stdout)
+
+
+LIBS = {
+    "enable_serial_server": {
+        "source": (
+            "/snap/checkbox-ce-oem/current/providers/"
+            "checkbox-provider-ce-oem/bin/serial_test.py"
+        ),
+        "function": "server_mode",
+    },
+    "network_ping": {
+        "source": (
+            "/snap/checkbox22/current/providers/"
+            "checkbox-provider-base/bin/gateway_ping_test.py"
+        ),
+        "function": "perform_ping_test",
+    },
+}
+dynamic_integrate_funcs = [LIBS[k]["function"] for k in LIBS.keys()]
+
+
+def capture_io_logs(func):
+    def wrap(*args, **kwargs):
+        sio_stdout = io.StringIO()
+        sio_stderr = io.StringIO()
+        cls = args[0]
+        if func.__name__ in dynamic_integrate_funcs:
+            args = args[1:]
+
+        with redirect_stderr(sio_stderr) as stderr, redirect_stdout(sio_stdout) as stdout:
+            try:
+                ret = func(*args, **kwargs)
+            except SystemExit as exp:
+                ret = exp.code
+
+        cls.logs = "stdout logs: {}".format(stdout.getvalue())
+        cls.logs += "\nstderr logs: {}".format(stderr.getvalue())
+        return ret
+    return wrap
+
+
+def _load_method_from_file(name, file, func):
+    try:
+        _module = SourceFileLoader(name, file).load_module()
+        return getattr(_module, func)
+    except FileNotFoundError as e:
+        logger.error("Failed to import module from %s file", file)
+        logger.debug(e)
+    except AttributeError as e:
+        logger.error("Failed to get %s function from %s file", func, file)
+        logger.debug(e)
+
+
+class RpycTestService(rpyc.Service):
+
+    def __init__(self):
+        super().__init__()
+        self.logs = ""
+        for key, value in LIBS.items():
+            func = _load_method_from_file(
+                key, value["source"], value["function"]
+            )
+            if func:
+                setattr(RpycTestService, key, capture_io_logs(func))
+
+    def on_connect(self, conn):
+        # code that runs when a connection is created
+        # (to init the service, if needed)
+        pass
+
+    def on_disconnect(self, conn):
+        # code that runs after the connection has already closed
+        # (to finalize the service, if needed)
+        pass
+
+    def _get_ethernet_ifaces(self):
+        return set([i.name for i in Path("/sys/class/net").iterdir()])
+
+    def _get_serial_ifaces(self):
+        return set([i.name for i in Path("/dev/serial/by-id").iterdir()])
+
+    def _device_node_detect(self, func, device_type=""):
+        starting_ifaces = func()
+
+        attempts = 20
+        while attempts > 0:
+            now_ifaces = func()
+            # check if something disappeared
+            if not starting_ifaces == now_ifaces & starting_ifaces:
+                raise SystemExit(
+                    "Interface(s) disappeared: {}".format(
+                        ", ".join(list(starting_ifaces - now_ifaces))
+                    )
+                )
+            new_ifaces = now_ifaces - starting_ifaces
+            if new_ifaces:
+                print()
+                print(
+                    "New interface(s) detected: {}".format(
+                        ", ".join(list(new_ifaces))
+                    )
+                )
+                return new_ifaces
+            time.sleep(1)
+            print(".", end="", flush=True)
+            attempts -= 1
+        print()
+        raise SystemExit(
+            "Failed to detect new {} interface".format(device_type)
+        )
+
+    @capture_io_logs
+    def serial_check(self):
+        return self._device_node_detect(self._get_serial_ifaces, "serial")
+
+    @capture_io_logs
+    def ethernet_check(self):
+        return self._device_node_detect(self._get_ethernet_ifaces, "ethernet")
+
+    @capture_io_logs
+    def configure_local_network(self, interface, net_info):
+        logger.info("set %s to %s interface on RPYC", net_info, interface)
+        subprocess.check_output(
+            "ip addr add {} dev {}".format(net_info, interface),
+            shell=True,
+            text=True,
+        )
+
+    @capture_io_logs
+    def usb_storage_test(self, usb_type):
+        logger.info("%s drive read/write testing on RPYC", usb_type)
+        usb_read_write.REPETITION_NUM = 2
+        watcher = run_watcher.USBStorage(usb_type)
+        mounted_partition = watcher.run_insertion()
+        logger.info(
+            "%s drive been mounted to %s on RPYC", usb_type, mounted_partition
+        )
+        watcher.run_storage(mounted_partition)
+        # usb_read_write been imported in run_watcher
+        # the temporary mount point been created while import it and been removed in gen_random_file function
+        # thus, we need to reload it to create temporary mount point in every testing cycle
+        reload(usb_read_write)
+
+
+def main():
+    t = ThreadedServer(
+        RpycTestService,
+        port=60000,
+        logger=logger,
+        protocol_config={
+            "allow_all_attrs": True,
+            "allow_exposed_attrs": False,
+        },
+    )
+    t.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_test_methods.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_test_methods.py
@@ -87,6 +87,8 @@ def usb_storage_test(usb_type):
     )
     watcher.run_storage(mounted_partition)
     # usb_read_write been imported in run_watcher
-    # the temporary mount point been created while import it and been removed in gen_random_file function
-    # thus, we need to reload it to create temporary mount point in every testing cycle
+    # the temporary mount point been created while import it
+    #   and the directory been removed in gen_random_file function
+    # thus, we need to reload it to create temporary mount point
+    #   in every testing cycle
     reload(usb_read_write)

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_test_methods.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_test_methods.py
@@ -45,9 +45,7 @@ def _device_node_detect(func, device_type=""):
         print(".", end="", flush=True)
         attempts -= 1
     print()
-    raise SystemExit(
-        "Failed to detect new {} interface".format(device_type)
-    )
+    raise SystemExit("Failed to detect new {} interface".format(device_type))
 
 
 def configure_local_network(interface, net_info):

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_test_methods.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpyc_test_methods.py
@@ -1,0 +1,94 @@
+import logging
+import subprocess
+import time
+
+from importlib import reload
+from pathlib import Path
+from checkbox_support.scripts import (
+    run_watcher,
+    usb_read_write,
+)
+
+
+# Method for testing
+def _get_ethernet_ifaces():
+    return set([i.name for i in Path("/sys/class/net").iterdir()])
+
+
+def _get_serial_ifaces():
+    return set([i.name for i in Path("/dev/serial/by-id").iterdir()])
+
+
+def _device_node_detect(func, device_type=""):
+    starting_ifaces = func()
+
+    attempts = 20
+    while attempts > 0:
+        now_ifaces = func()
+        # check if something disappeared
+        if not starting_ifaces == now_ifaces & starting_ifaces:
+            raise SystemExit(
+                "Interface(s) disappeared: {}".format(
+                    ", ".join(list(starting_ifaces - now_ifaces))
+                )
+            )
+        new_ifaces = now_ifaces - starting_ifaces
+        if new_ifaces:
+            print()
+            print(
+                "New interface(s) detected: {}".format(
+                    ", ".join(list(new_ifaces))
+                )
+            )
+            return new_ifaces
+        time.sleep(1)
+        print(".", end="", flush=True)
+        attempts -= 1
+    print()
+    raise SystemExit(
+        "Failed to detect new {} interface".format(device_type)
+    )
+
+
+def configure_local_network(interface, net_info):
+    logging.info("Turn down the link of %s interface", interface)
+    subprocess.check_output(
+        "ip link set dev {} down".format(interface),
+        shell=True,
+        text=True,
+    )
+    logging.info("Turn down the link of %s interface", interface)
+    subprocess.check_output(
+        "ip addr add {} dev {}".format(net_info, interface),
+        shell=True,
+        text=True,
+    )
+    logging.info("Turn up the link of %s interface", interface)
+    subprocess.check_output(
+        "ip link set dev {} up".format(interface),
+        shell=True,
+        text=True,
+    )
+
+
+def serial_check():
+    return _device_node_detect(_get_serial_ifaces, "serial")
+
+
+def ethernet_check():
+    return _device_node_detect(_get_ethernet_ifaces, "ethernet")
+
+
+def usb_storage_test(usb_type):
+    logging.info("%s drive read/write testing on RPYC", usb_type)
+    usb_read_write.REPETITION_NUM = 2
+    watcher = run_watcher.USBStorage(usb_type)
+    mounted_partition = watcher.run_insertion()
+    logging.info(
+        "%s drive been mounted to %s on RPYC", usb_type, mounted_partition
+    )
+    watcher.run_storage(mounted_partition)
+    # usb_read_write been imported in run_watcher
+    # the temporary mount point been created while import it and been removed in gen_random_file function
+    # thus, we need to reload it to create temporary mount point in every testing cycle
+    reload(usb_read_write)

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/serial_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/serial_test.py
@@ -132,7 +132,18 @@ def generate_random_string(length):
     return "".join(random.choice(letters) for _ in range(length))
 
 
-def server_mode(ser: Serial) -> None:
+def server_mode(
+    node,
+    type,
+    group,
+    baudrate,
+    bytesize,
+    parity,
+    stopbits,
+    timeout,
+    datasize,
+    rs485_settings,
+) -> None:
     """
     Running as a server, it will be sniffing for received string.
     And it will send the same string out.
@@ -140,6 +151,18 @@ def server_mode(ser: Serial) -> None:
     running on port /dev/ttyUSB0 as a server
     $ sudo ./serial_test.py /dev/ttyUSB0 --mode server --type USB
     """
+    ser = Serial(
+        node,
+        type,
+        group,
+        baudrate,
+        bytesize,
+        parity,
+        stopbits,
+        timeout,
+        datasize,
+        rs485_settings,
+    )
     logging.info("Listening on port {} ...".format(ser.node))
     while True:
         data = ser.recv()
@@ -150,7 +173,18 @@ def server_mode(ser: Serial) -> None:
             logging.info("Listening on port {} ...".format(ser.node))
 
 
-def client_mode(ser: Serial, data_size: int = 1024):
+def client_mode(
+    node,
+    type,
+    group,
+    baudrate,
+    bytesize,
+    parity,
+    stopbits,
+    timeout,
+    datasize,
+    rs485_settings,
+):
     """
     Running as a clinet and it will sending out a string and wait
     the string send back from server. After receive the string,
@@ -159,12 +193,24 @@ def client_mode(ser: Serial, data_size: int = 1024):
     running on port /dev/ttymxc1 as a client
     $ sudo ./serial_test.py /dev/ttymxc1 --mode client --type RS485
     """
-
-    random_string = generate_random_string(data_size)
+    ser = Serial(
+        node,
+        type,
+        group,
+        baudrate,
+        bytesize,
+        parity,
+        stopbits,
+        timeout,
+        datasize,
+        rs485_settings,
+    )
 
     # clean up the garbage in the serial before test
     while ser.recv():
         continue
+
+    random_string = generate_random_string(datasize)
     ser.send(random_string.encode())
     for i in range(1, 6):
         logging.info("Attempting receive string... {} time".format(i))
@@ -181,13 +227,36 @@ def client_mode(ser: Serial, data_size: int = 1024):
     raise SystemExit(1)
 
 
-def console_mode(ser: Serial):
+def console_mode(
+    node,
+    type,
+    group,
+    baudrate,
+    bytesize,
+    parity,
+    stopbits,
+    timeout,
+    datasize,
+    rs485_settings,
+):
     """
     Test the serial port when it is in console mode
     This test requires DUT to loop back it self.
     For example: connect the serial console port to the USB port via
     serial to usb dongle
     """
+    ser = Serial(
+        node,
+        type,
+        group,
+        baudrate,
+        bytesize,
+        parity,
+        stopbits,
+        timeout,
+        datasize,
+        rs485_settings,
+    )
     try:
         # Send 'Enter Key'
         logging.info("Sending 'Enter Key'...")
@@ -336,25 +405,49 @@ def main():
             "delay_before_tx": args.rts_delay_before_tx,
             "delay_before_rx": args.rts_delay_before_rx,
         }
-    ser = Serial(
-        args.node,
-        args.type,
-        args.group,
-        baudrate=args.baudrate,
-        bytesize=args.bytesize,
-        parity=args.parity,
-        stopbits=args.stopbits,
-        timeout=args.timeout,
-        data_size=args.datasize,
-        rs485_settings=rs485_settings,
-    )
+    else:
+        rs485_settings = None
+
 
     if args.mode == "server":
-        server_mode(ser)
+        server_mode(
+            args.node,
+            args.type,
+            args.group,
+            args.baudrate,
+            args.bytesize,
+            args.parity,
+            args.stopbits,
+            args.timeout,
+            args.datasize,
+            rs485_settings,
+        )
     elif args.mode == "client":
-        client_mode(ser, data_size=args.datasize)
+        client_mode(
+            args.node,
+            args.type,
+            args.group,
+            args.baudrate,
+            args.bytesize,
+            args.parity,
+            args.stopbits,
+            args.timeout,
+            args.datasize,
+            rs485_settings,
+        )
     elif args.mode == "console":
-        console_mode(ser)
+        console_mode(
+            args.node,
+            args.type,
+            args.group,
+            args.baudrate,
+            args.bytesize,
+            args.parity,
+            args.stopbits,
+            args.timeout,
+            args.datasize,
+            rs485_settings,
+        )
     else:
         raise SystemExit(1)
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/serial_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/serial_test.py
@@ -408,7 +408,6 @@ def main():
     else:
         rs485_settings = None
 
-
     if args.mode == "server":
         server_mode(
             args.node,

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/otg/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/otg/jobs.pxu
@@ -24,15 +24,15 @@ id: ce-oem-otg/g_serial-{USB_port}
 estimated_duration: 60
 plugin: user-interact-verify
 user: root
-imports: 
+imports:
     from com.canonical.plainbox import manifest
     from com.canonical.certification import cpuinfo
-requires: 
+requires:
     manifest.has_otg == 'True'
     cpuinfo.platform in ("aarch64", "armv7l")
 flags: also-after-suspend
 _summary: Check {USB_port} can be detected as a serial device
-_purpose: 
+_purpose:
     Check that after connecting the device under test (DUT) to another device
     (host), {USB_port} can be detected as a serial device by the host.
 _steps:
@@ -50,11 +50,11 @@ _steps:
     7. Check the string sending from the host to {USB_port} by repeating steps 4-6, but swap the send and receive sides.
 _verification:
     Does string send and receive work?
-command: 
+command:
     # shellcheck disable=SC2050
     if [ {Mode} != "otg" ]; then
         echo -e "Error: USB mode is {Mode} mode, but expected in otg mode."
-        exit 1 
+        exit 1
     fi
     multiple-otg.sh -u {UDC} -f acm
 
@@ -62,14 +62,14 @@ unit: template
 template-resource: otg_ports
 template-unit: job
 category_id: com.canonical.plainbox::usb
-id: ce-oem-otg/g_mass_storage-{USB_port} 
+id: ce-oem-otg/g_mass_storage-{USB_port}
 estimated_duration: 60
 plugin: user-interact-verify
 user: root
-imports: 
+imports:
     from com.canonical.plainbox import manifest
     from com.canonical.certification import cpuinfo
-requires: 
+requires:
     manifest.has_otg == 'True'
     cpuinfo.platform in ("aarch64", "armv7l")
 flags: also-after-suspend
@@ -79,16 +79,16 @@ _purpose:
     (host), {USB_port} can be detected as a mass storage device by the host.
 _steps:
     1. Press Enter to setup a 16 MB FAT32 image on the device.
-    2. From an Ubuntu host, connect a cable to the USB OTG port 
+    2. From an Ubuntu host, connect a cable to the USB OTG port
     (it's the USB connector) of the DUT.
 _verification:
-    The host detects and mounts a mass storage device. It has read and write 
+    The host detects and mounts a mass storage device. It has read and write
     permissions on it.
 command:
     # shellcheck disable=SC2050
     if [ {Mode} != "otg" ]; then
         echo -e "Error: USB mode is {Mode} mode, but expected in otg mode."
-        exit 1 
+        exit 1
     fi
     multiple-otg.sh -u {UDC} -f mass_storage
 
@@ -99,23 +99,23 @@ category_id: com.canonical.plainbox::usb
 id: ce-oem-otg/g_ether-{USB_port}
 plugin: user-interact-verify
 user: root
-imports: 
+imports:
     from com.canonical.plainbox import manifest
     from com.canonical.certification import cpuinfo
-requires: 
+requires:
     manifest.has_otg == 'True'
     cpuinfo.platform in ("aarch64", "armv7l")
 flags: also-after-suspend
 _summary: Check {USB_port} can be detected as USB ethernet device.
-_purpose: 
+_purpose:
     Check that after connecting the device under test (DUT) to another device
     (host), {USB_port} can be detected as a USB ethernet device by the host.
 _steps:
-    1. From an Ubuntu host, connect a cable to the USB OTG port 
+    1. From an Ubuntu host, connect a cable to the USB OTG port
      (it's the USB connector) of the {USB_port}.
     2. Press Enter to config the IP address for the USB OTG ethernet interface on the DUT.
      (IP will be 192.168.9.1/24)
-    3. On the host, config the IP address for the USB OTG ethernet interface. And it should be 
+    3. On the host, config the IP address for the USB OTG ethernet interface. And it should be
       the same subnet with {USB_port}. (eg. 192.168.9.2/24)
     4. Try to ping between the host and {USB_port}.
 _verification:
@@ -124,6 +124,103 @@ command:
     # shellcheck disable=SC2050
     if [ {Mode} != "otg" ]; then
         echo -e "Error: USB mode is {Mode} mode, but expected in otg mode."
-        exit 1 
+        exit 1
     fi
     multiple-otg.sh -u {UDC} -f ecm
+
+
+id: otg_port_mapping
+plugin: resource
+_summary: Gather list of USB ports and UDC.
+_description:
+    A USB port and UDC mapping resource that relies on the user specifying in config varirable.
+    Usage of parameter: OTG={port1}:{udc_node1}:{usb_type1} {port2}:{udc_node2}:{usb_type2} ...
+    e.g. OTG=USB-C1:11200000.usb:usb2 USB-Micro:112a1000.usb:usb3
+estimated_duration: 1s
+environ: OTG
+flags: preserve-locale
+user: root
+command:
+    if [ "$OTG" ]; then
+        multiple_otg.py info -c "$OTG"
+    else
+        echo "OTG config variable: not found"
+    fi
+
+unit: template
+template-resource: otg_port_mapping
+template-unit: job
+template-engine: jinja2
+template-id: ce-oem-otg/otg-network-test
+category_id: com.canonical.plainbox::usb
+id: ce-oem-otg/OTG-Ethernet-{{ USB_CONNECTOR }}-{{ USB_TYPE }}
+estimated_duration: 60
+plugin: shell
+user: root
+environ:
+    RYPC_SERVER
+imports:
+    from com.canonical.plainbox import manifest
+    from com.canonical.certification import cpuinfo
+requires:
+    manifest.has_otg == 'True'
+    cpuinfo.platform in ("aarch64", "armv7l")
+flags: also-after-suspend
+_summary: Check OTG {{ USB_CONNETOR }} can be detected as a network device and can ping from DUT to Server
+_description:
+    The test will setup the OTG configuration within {{ UDC_NODE }} on the device under test (DUT)
+    Then setup the USB network interface on both DUT and RPYC server and perform ping test on DUT
+command:
+    multiple_otg.py test -t ethernet -u {{ UDC_NODE }} --rpyc-address {{ RPYC_SERVER }} --usb-type {{ USB_TYPE }}
+
+unit: template
+template-resource: otg_port_mapping
+template-unit: job
+template-engine: jinja2
+template-id: ce-oem-otg/otg-serial-test
+category_id: com.canonical.plainbox::usb
+id: ce-oem-otg/OTG-Serial-{{ USB_CONNECTOR }}-{{ USB_TYPE }}
+estimated_duration: 60
+plugin: shell
+user: root
+environ:
+    RYPC_SERVER
+imports:
+    from com.canonical.plainbox import manifest
+    from com.canonical.certification import cpuinfo
+requires:
+    manifest.has_otg == 'True'
+    cpuinfo.platform in ("aarch64", "armv7l")
+flags: also-after-suspend
+_summary: Check OTG {{ USB_CONNETOR }} can be detected as a serial device and transfer data via OTG Serial
+_description:
+    The test will setup the OTG configuration within {{ UDC_NODE }} on the device under test (DUT)
+    Then start serial server on RPYC server and perform data read/write test via serial interface
+command:
+    multiple_otg.py test -t serial -u {{ UDC_NODE }} --rpyc-address {{ RPYC_SERVER }} --usb-type {{ USB_TYPE }}
+
+unit: template
+template-resource: otg_port_mapping
+template-unit: job
+template-engine: jinja2
+template-id: ce-oem-otg/otg-mass-storage-test
+category_id: com.canonical.plainbox::usb
+id: ce-oem-otg/OTG-Mass-Storage-{{ USB_CONNECTOR }}-{{ USB_TYPE }}
+estimated_duration: 60
+plugin: shell
+user: root
+environ:
+    RYPC_SERVER
+imports:
+    from com.canonical.plainbox import manifest
+    from com.canonical.certification import cpuinfo
+requires:
+    manifest.has_otg == 'True'
+    cpuinfo.platform in ("aarch64", "armv7l")
+flags: also-after-suspend
+_summary: Check OTG {{ USB_CONNETOR }} can be detected as a mass storage device and be able to access
+_description:
+    The test will setup the OTG configuration within {{ UDC_NODE }} on the device under test (DUT)
+    the USB interface will be detected as a mass storage and perform data read/write test
+command:
+    multiple_otg.py test -t mass_storage -u {{ UDC_NODE }} --rpyc-address {{ RPYC_SERVER }} --usb-type {{ USB_TYPE }}

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/otg/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/otg/jobs.pxu
@@ -130,21 +130,22 @@ command:
 
 
 id: otg_port_mapping
+category_id: com.canonical.plainbox::usb
 plugin: resource
 _summary: Gather list of USB ports and UDC.
 _description:
     A USB port and UDC mapping resource that relies on the user specifying in config varirable.
-    Usage of parameter: OTG={port1}:{udc_node1}:{usb_type1} {port2}:{udc_node2}:{usb_type2} ...
-    e.g. OTG=USB-C1:11200000.usb:usb2 USB-Micro:112a1000.usb:usb3
+    Usage of parameter: USB_OTG_MAPPING={port1}:{udc_node1}:{usb_type1} {port2}:{udc_node2}:{usb_type2} ...
+    e.g. USB_OTG_MAPPING=USB-C1:11200000.usb:usb2 USB-Micro:112a1000.usb:usb3
 estimated_duration: 1s
-environ: OTG
+environ: USB_OTG_MAPPING
 flags: preserve-locale
 user: root
 command:
-    if [ "$OTG" ]; then
-        multiple_otg.py info -c "$OTG"
+    if [ "$USB_OTG_MAPPING" ]; then
+        multiple_otg.py info -c "$USB_OTG_MAPPING"
     else
-        echo "OTG config variable: not found"
+        echo "USB_OTG_MAPPING config variable: not found"
     fi
 
 unit: template
@@ -152,8 +153,15 @@ template-resource: otg_port_mapping
 template-unit: job
 template-engine: jinja2
 template-id: ce-oem-otg/otg-network-test
+_template-summary:
+    OTG USB drive read/write test
+_purpose:
+    Validate DUT can be detected as a network device through OTG {{ USB_CONNETOR }} and can ping to RPYC Server
+_description:
+    The test will setup the OTG configuration within {{ UDC_NODE }} on the device under test (DUT)
+    Then setup the USB network interface on both DUT and RPYC server and perform ping test on DUT
 category_id: com.canonical.plainbox::usb
-id: ce-oem-otg/OTG-Ethernet-{{ USB_CONNECTOR }}-{{ USB_TYPE }}
+id: ce-oem-otg/OTG-Ethernet-on-port-{{ USB_CONNECTOR }}
 estimated_duration: 60
 plugin: shell
 user: root
@@ -164,22 +172,30 @@ imports:
     from com.canonical.certification import cpuinfo
 requires:
     manifest.has_otg == 'True'
+    manifest.has_rpyc_otg_server == 'True'
     cpuinfo.platform in ("aarch64", "armv7l")
 flags: also-after-suspend
-_summary: Check OTG {{ USB_CONNETOR }} can be detected as a network device and can ping from DUT to Server
-_description:
-    The test will setup the OTG configuration within {{ UDC_NODE }} on the device under test (DUT)
-    Then setup the USB network interface on both DUT and RPYC server and perform ping test on DUT
 command:
-    multiple_otg.py test -t ethernet -u {{ UDC_NODE }} --rpyc-address {{ RPYC_SERVER }} --usb-type {{ USB_TYPE }}
+    if [ -z "$RPYC_SERVER" ]; then
+        echo "Error: RPYC_SERVER is not defined"
+        exit 1
+    fi
+    multiple_otg.py test -t ethernet -u {{ UDC_NODE }} --rpyc-address "$RPYC_SERVER" --usb-type {{ USB_TYPE }}
 
 unit: template
 template-resource: otg_port_mapping
 template-unit: job
 template-engine: jinja2
 template-id: ce-oem-otg/otg-serial-test
+_template-summary:
+    OTG USB drive read/write test
+_purpose:
+    Validate DUT can be detected as a serial device through OTG {{ USB_CONNETOR }} and transfer data via OTG Serial
+_description:
+    The test will setup the OTG configuration within {{ UDC_NODE }} on the device under test (DUT)
+    Then start serial server on RPYC server and perform data read/write test via serial interface
 category_id: com.canonical.plainbox::usb
-id: ce-oem-otg/OTG-Serial-{{ USB_CONNECTOR }}-{{ USB_TYPE }}
+id: ce-oem-otg/OTG-Serial-on-port-{{ USB_CONNECTOR }}
 estimated_duration: 60
 plugin: shell
 user: root
@@ -190,22 +206,30 @@ imports:
     from com.canonical.certification import cpuinfo
 requires:
     manifest.has_otg == 'True'
+    manifest.has_rpyc_otg_server == 'True'
     cpuinfo.platform in ("aarch64", "armv7l")
 flags: also-after-suspend
-_summary: Check OTG {{ USB_CONNETOR }} can be detected as a serial device and transfer data via OTG Serial
-_description:
-    The test will setup the OTG configuration within {{ UDC_NODE }} on the device under test (DUT)
-    Then start serial server on RPYC server and perform data read/write test via serial interface
 command:
-    multiple_otg.py test -t serial -u {{ UDC_NODE }} --rpyc-address {{ RPYC_SERVER }} --usb-type {{ USB_TYPE }}
+    if [ -z "$RPYC_SERVER" ]; then
+        echo "Error: RPYC_SERVER is not defined"
+        exit 1
+    fi
+    multiple_otg.py test -t serial -u {{ UDC_NODE }} --rpyc-address "$RPYC_SERVER" --usb-type {{ USB_TYPE }}
 
 unit: template
 template-resource: otg_port_mapping
 template-unit: job
 template-engine: jinja2
 template-id: ce-oem-otg/otg-mass-storage-test
+_template-summary:
+    OTG USB drive read/write test
+_purpose:
+    Validate DUT can be detected as a mass storage device through OTG {{ USB_CONNETOR }} and be able to access
+_description:
+    The test will setup the OTG configuration within {{ UDC_NODE }} on the device under test (DUT)
+    the USB interface will be detected as a mass storage and perform data read/write test
 category_id: com.canonical.plainbox::usb
-id: ce-oem-otg/OTG-Mass-Storage-{{ USB_CONNECTOR }}-{{ USB_TYPE }}
+id: ce-oem-otg/OTG-Mass-Storage-on-port-{{ USB_CONNECTOR }}
 estimated_duration: 60
 plugin: shell
 user: root
@@ -216,11 +240,12 @@ imports:
     from com.canonical.certification import cpuinfo
 requires:
     manifest.has_otg == 'True'
+    manifest.has_rpyc_otg_server == 'True'
     cpuinfo.platform in ("aarch64", "armv7l")
 flags: also-after-suspend
-_summary: Check OTG {{ USB_CONNETOR }} can be detected as a mass storage device and be able to access
-_description:
-    The test will setup the OTG configuration within {{ UDC_NODE }} on the device under test (DUT)
-    the USB interface will be detected as a mass storage and perform data read/write test
 command:
-    multiple_otg.py test -t mass_storage -u {{ UDC_NODE }} --rpyc-address {{ RPYC_SERVER }} --usb-type {{ USB_TYPE }}
+    if [ -z "$RPYC_SERVER" ]; then
+        echo "Error: RPYC_SERVER is not defined"
+        exit 1
+    fi
+    multiple_otg.py test -t mass_storage -u {{ UDC_NODE }} --rpyc-address "$RPYC_SERVER" --usb-type {{ USB_TYPE }}

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/otg/manifest.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/otg/manifest.pxu
@@ -2,3 +2,8 @@ unit: manifest entry
 id: has_otg
 _name: Does platfrom supported USB OTG?
 value-type: bool
+
+unit: manifest entry
+id: has_rpyc_otg_server
+_name: Does RPYC server with OTG test services been setup?
+value-type: bool

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/otg/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/otg/test-plan.pxu
@@ -22,7 +22,12 @@ id: ce-oem-otg-automated
 unit: test plan
 _name: OTG auto tests
 _description: Automated OTG tests for devices
+bootstrap_include:
+    otg_port_mapping
 include:
+    ce-oem-otg/otg-network-test
+    ce-oem-otg/otg-serial-test
+    ce-oem-otg/otg-mass-storage-test
 
 id: after-suspend-ce-oem-otg-manual
 unit: test plan


### PR DESCRIPTION
## Description
Add OTG automated tests with RPYC server (New)
there are following changes made in this PR
- modified serial_test.py to fit to the otg testing
- rpyc_server.py 
- rpyc_client.py
- rpyc_test_methods.py
- multiple_otg.py 

## Documentation
N/A

## Tests
I have build a test snap locally and tested it on an IoT device
Noted: the OTG feature seems not working on this device in post-suspend stage.
https://certification.canonical.com/hardware/202312-33702/submission/407861/