### PR TITLE
[checkbox-ce-oem] Enhance serial test to be more stable (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/serial_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/serial_test.py
@@ -161,10 +161,12 @@ def client_mode(ser: Serial, data_size: int = 1024):
     running on port /dev/ttymxc1 as a client
     $ sudo ./serial_test.py /dev/ttymxc1 --mode client --type RS485
     """
-    # clean up the garbage in the serial before test
-    while ser.recv() is not None:
-        continue
+
     random_string = generate_random_string(data_size)
+
+    # clean up the garbage in the serial before test
+    while ser.recv() :
+        continue
     ser.send(random_string.encode())
     for i in range(1, 6):
         logging.info("Attempting receive string... {} time".format(i))

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/serial_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/serial_test.py
@@ -82,7 +82,9 @@ class Serial:
             try:
                 self.group.append(self.serial_init(ser))
             except Exception:
-                raise SystemError("Failed to init serial port: {}".format(ser))
+                raise SystemError(
+                    "Failed to init serial port: {}".format(ser)
+                )
 
     def serial_init(self, node: str) -> serial.Serial:
         """Create a serial.Serial object based on the class variables"""
@@ -119,8 +121,10 @@ class Serial:
             if rcv:
                 logging.info("Received: {}".format(rcv.decode()))
         except Exception:
-            logging.exception("Received unmanageable string format")
-            raise SystemExit(1)
+            logging.exception(
+                "Received unmanageable string format {}".format(rcv)
+            )
+            return None
         return rcv
 
 
@@ -157,6 +161,9 @@ def client_mode(ser: Serial, data_size: int = 1024):
     running on port /dev/ttymxc1 as a client
     $ sudo ./serial_test.py /dev/ttymxc1 --mode client --type RS485
     """
+    # clean up the garbage in the serial before test
+    while ser.recv() is not None:
+        continue
     random_string = generate_random_string(data_size)
     ser.send(random_string.encode())
     for i in range(1, 6):
@@ -192,7 +199,9 @@ def console_mode(ser: Serial):
             logging.info("[PASS] Serial console test successful.")
         else:
             logging.error("[FAIL] Serial console test failed.")
-            logging.error("Expected response should contain ':~$' or 'login:'")
+            logging.error(
+                "Expected response should contain ':~$' or 'login:'"
+            )
             raise SystemExit(1)
     except Exception:
         logging.exception("Caught an exception.")
@@ -203,7 +212,9 @@ def create_args():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument("node", help="Serial port device node e.g. /dev/ttyS1")
+    parser.add_argument(
+        "node", help="Serial port device node e.g. /dev/ttyS1"
+    )
     parser.add_argument(
         "--mode",
         choices=["server", "client", "console"],

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/serial_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/serial_test.py
@@ -82,9 +82,7 @@ class Serial:
             try:
                 self.group.append(self.serial_init(ser))
             except Exception:
-                raise SystemError(
-                    "Failed to init serial port: {}".format(ser)
-                )
+                raise SystemError("Failed to init serial port: {}".format(ser))
 
     def serial_init(self, node: str) -> serial.Serial:
         """Create a serial.Serial object based on the class variables"""
@@ -165,7 +163,7 @@ def client_mode(ser: Serial, data_size: int = 1024):
     random_string = generate_random_string(data_size)
 
     # clean up the garbage in the serial before test
-    while ser.recv() :
+    while ser.recv():
         continue
     ser.send(random_string.encode())
     for i in range(1, 6):
@@ -201,9 +199,7 @@ def console_mode(ser: Serial):
             logging.info("[PASS] Serial console test successful.")
         else:
             logging.error("[FAIL] Serial console test failed.")
-            logging.error(
-                "Expected response should contain ':~$' or 'login:'"
-            )
+            logging.error("Expected response should contain ':~$' or 'login:'")
             raise SystemExit(1)
     except Exception:
         logging.exception("Caught an exception.")
@@ -214,9 +210,7 @@ def create_args():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument(
-        "node", help="Serial port device node e.g. /dev/ttyS1"
-    )
+    parser.add_argument("node", help="Serial port device node e.g. /dev/ttyS1")
     parser.add_argument(
         "--mode",
         choices=["server", "client", "console"],


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
1. The server mode shouldn't be exited while getting the payload that couldn't be decoded.
2. The client mode should clean the buffer before starting the test to avoid receiving non testing payload.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
https://certification.canonical.com/hardware/202405-34046/submission/408239/
