### PR TITLE
Ignore nvidia modules in kernel taint test (BugFix)

### DIFF
--- a/providers/base/bin/kernel_taint_test.py
+++ b/providers/base/bin/kernel_taint_test.py
@@ -96,6 +96,10 @@ def remove_ignored_modules(modules):
         "znvpair",
         "zunicode",
         "zzstd",
+        "nvidia_uvm",
+        "nvidia_drm",
+        "nvidia_modeset",
+        "nvidia",
     ]
     for ignore_mod in ignored_modules:
         try:


### PR DESCRIPTION
## Description

- Adds NVIDIA modules to kernel taint test ignore list
  - `nvidia_uvm`, `nvidia_drm`, `nvidia_modeset`, and `nvidia`

## Resolved issues

Resolves CHECKBOX-989

## Documentation

## Tests
