### PR TITLE
Add LXD VM GPU passthrough test (New)

### DIFF
--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -42,8 +42,8 @@ GPU_VENDORS = {
             "config_cmds": [
                 "apt-get -q update -y",
                 "apt-get -q upgrade -y",
-                "apt-get -q install -y linux-generic ubuntu-drivers-common",
-                "ubuntu-drivers install --gpgpu",
+                "apt-get -q install -y ubuntu-drivers-common",
+                "ubuntu-drivers install --recommended",
             ],
         },
     },

--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -82,6 +82,7 @@ requires:
     package.name == 'lxd' or package.name == 'lxd-installer' or snap.name == 'lxd'
 category_id: gpgpu
 plugin: shell
+estimated_duration: 1m 45s
 command: gpu_passthrough.py --vendor=nvidia --pci={pci_device_name} lxd
 _purpose: Creates a LXD container and passes {pci_device_name} GPU through
 _summary: Test LXD GPU passthrough on NVIDIA GPU {pci_device_name}
@@ -97,6 +98,7 @@ requires:
     package.name == 'lxd' or package.name == 'lxd-installer' or snap.name == 'lxd'
 category_id: gpgpu
 plugin: shell
+estimated_duration: 12m
 command: gpu_passthrough.py --vendor=nvidia --pci={pci_device_name} lxdvm
 _purpose: Creates a LXD virtual machine and passes {pci_device_name} GPU through
 _summary: Test LXD VM GPU passthrough on NVIDIA GPU {pci_device_name}

--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -86,3 +86,18 @@ command: gpu_passthrough.py --vendor=nvidia --pci={pci_device_name} lxd
 _purpose: Creates a LXD container and passes {pci_device_name} GPU through
 _summary: Test LXD GPU passthrough on NVIDIA GPU {pci_device_name}
 _template-summary: Test LXD GPU passthrough on NVIDIA GPU
+
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.vendor == 'NVIDIA Corporation'
+template-id: gpgpu/lxdvm-nvidia-gpu-passthrough-pci-device-name
+id: gpgpu/lxdvm-nvidia-gpu-passthrough-{pci_device_name}
+requires:
+    executable.name == 'lxc'
+    package.name == 'lxd' or package.name == 'lxd-installer' or snap.name == 'lxd'
+category_id: gpgpu
+plugin: shell
+command: gpu_passthrough.py --vendor=nvidia --pci={pci_device_name} lxdvm
+_purpose: Creates a LXD virtual machine and passes {pci_device_name} GPU through
+_summary: Test LXD VM GPU passthrough on NVIDIA GPU {pci_device_name}
+_template-summary: Test LXD VM GPU passthrough on NVIDIA GPU

--- a/providers/gpgpu/units/test-plan.pxu
+++ b/providers/gpgpu/units/test-plan.pxu
@@ -38,7 +38,8 @@ _name: GPGPU Virtualization Passthrough Testing
 _description:
  Automated Tests for GPGPU Passthrough (non-graphical)
 include:
-    gpgpu/lxd-nvidia-gpu-passthrough-pci-device-name    certification-status=blocker
+    gpgpu/lxd-nvidia-gpu-passthrough-pci-device-name      certification-status=blocker
+    gpgpu/lxdvm-nvidia-gpu-passthrough-pci-device-name    certification-status=blocker
 bootstrap_include:
     graphics_card
     executable


### PR DESCRIPTION
## Description

- Add LXD VM physical GPU passthrough test to GPGPU provider
  - This is similar to the existing LXD container test, but it uses a virtual machine instead of a container

## Resolved issues

- Resolves CHECKBOX-1719

## Documentation

## Tests

The test was already present (though misconfigured in the setup steps), so the unit tests are already present in Checkbox.

https://certification.canonical.com/submissions/status/301364