### PR TITLE
fix test failed issue while rpmsg is running (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpmsg_load_firmware.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpmsg_load_firmware.py
@@ -59,18 +59,18 @@ class RpmsgLoadFirmwareTest:
 
     def _teardown(self):
         self.rpmsg_state = "stop"
-        self._firmware_path = self._previous_config["firmware_path"]
-        self._firmware_file = self._previous_config["firmware_file"]
+        self.firmware_path = self._previous_config["firmware_path"]
+        self.firmware_file = self._previous_config["firmware_file"]
         if (
-            self._firmware_file.strip()
-            and self._previous_config["rpmsg_state"] == "running"
+            self.firmware_file.strip() != "(null)"
+            and self._previous_config["rpmsg_state"].strip() == "running"
         ):
             # start RPMSG again when firmware file been configured
             self.rpmsg_state = "start"
 
     @property
     def firmware_path(self) -> str:
-        return self._firmware_path.read_text()
+        return self._firmware_path.read_text().strip()
 
     @firmware_path.setter
     def firmware_path(self, value: str) -> None:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/rpmsg/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/rpmsg/jobs.pxu
@@ -57,7 +57,9 @@ _summary: Reload Remote Processor firmware to {firmware} via RPMSG {device}
 id: ce-oem-rpmsg/reload-rp-firmware-test-{firmware}-{device}
 category_id: rpmsg
 estimated_duration: 60
-requires: manifest.has_rpmsg == 'True'
+requires:
+    manifest.has_rpmsg == 'True'
+    manifest.has_rpmsg_firmware_load == 'True'
 imports: from com.canonical.plainbox import manifest
 flags: also-after-suspend
 user: root

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/rpmsg/manifest.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/rpmsg/manifest.pxu
@@ -2,3 +2,8 @@ unit: manifest entry
 id: has_rpmsg
 _name: Remote Processor Messaging (rpmsg) framework supported?
 value-type: bool
+
+unit: manifest entry
+id: has_rpmsg_firmware_load
+_name: Change the RPMSG running firmware is supported?
+value-type: bool


### PR DESCRIPTION
fix test failed issue while rpmsg is running by default

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
the `rpmsg_load_firmware.py` scripts would crashed with following situation.
1. when the rpmsg is enabled by default, the state would be `running`
2. the state can be configure as "start" or "stop" only.

So this PR is trying to addressed these two issues.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
None
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-remoteproc
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
```
iotuc@ubuntu:~$ sudo checkbox-shiner.shell 
checkbox-shiner runtime shell, type 'exit' to quit the session
root@ubuntu:/home/iotuc# python3 /var/tmp/checkbox-providers/checkbox-provider-ce-oem/bin/rpmsg_load_firmware.py test-reload --device remoteproc0 --file rpmsg_lite_str_echo_rtos_imxcm4.elf --path /home/iotuc
2025-01-22 05:50:17 INFO     # Start load M4 firmware test
2025-01-22 05:50:17 INFO     Stop the Remote processor
2025-01-22 05:50:17 INFO     Configure the firmware file to rpmsg_lite_str_echo_rtos_imxcm4.elf and firmware path to /home/iotuc
2025-01-22 05:50:17 INFO     Start the Remote processor
2025-01-22 05:50:17 INFO     # start time: 1737525017.3082879
2025-01-22 05:50:17 INFO     Validate RPMSG related log from journal logs
2025-01-22 05:50:17 INFO     start stage: remoteproc remoteproc0: powering up imx-rproc
2025-01-22 05:50:17 INFO     boot_image stage: remoteproc remoteproc0: Booting fw image rpmsg_lite_str_echo_rtos_imxcm4.elf, size 158324
2025-01-22 05:50:17 INFO     ready stage: remoteproc remoteproc0: remote processor imx-rproc is now up
2025-01-22 05:50:17 INFO     # Reload M4 firmware successful
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
