### PR TITLE
Fix gpu-burn test estimated duration (BugFix)

### DIFF
--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -1,7 +1,7 @@
 id: gpgpu/gpu-burn
 category_id: gpgpu
 plugin: shell
-estimated_duration: 300
+estimated_duration: 14400
 requires:
     graphics_card.vendor == 'NVIDIA Corporation'
     snap.name == 'gpu-burn'


### PR DESCRIPTION
## Description

Update the GPU Burn estimated duration to match the test execution time in seconds.

## Resolved issues

## Documentation

## Tests
