### PR TITLE
Hidden manifests implementation (new)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -639,7 +639,8 @@ class RemoteController(ReportsStage, MainLoopStage):
 
     def select_jobs(self, all_jobs):
         if self.launcher.get_value("test selection", "forced"):
-            self._save_manifest(interactive=False)
+            if self.launcher.manifest:
+                self._save_manifest(interactive=False)
         else:
             _logger.info("controller: Selecting jobs.")
             reprs = json.loads(self.sa.get_jobs_repr(all_jobs))

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -639,8 +639,7 @@ class RemoteController(ReportsStage, MainLoopStage):
 
     def select_jobs(self, all_jobs):
         if self.launcher.get_value("test selection", "forced"):
-            if self.launcher.manifest:
-                self._save_manifest(interactive=False)
+            self._save_manifest(interactive=False)
         else:
             _logger.info("controller: Selecting jobs.")
             reprs = json.loads(self.sa.get_jobs_repr(all_jobs))

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -1345,14 +1345,13 @@ class Expand:
         # the list
         # Note: This doesn't take into consideration the manifest namespace so
         #       it may be inaccurate (overinclusive) when manifests are aliased
-        all_manifests = filter(
+        return filter(
             lambda manifest_unit: any(
                 "manifest.{}".format(manifest_unit.partial_id) in require
                 for require in job_requires
             ),
             manifest_units,
         )
-        return filter(lambda x: not x.is_hidden, all_manifests)
 
     def invoked(self, ctx):
         self.ctx = ctx

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -706,7 +706,8 @@ class Launcher(MainLoopStage, ReportsStage):
 
     def _pick_jobs_to_run(self):
         if self.configuration.get_value("test selection", "forced"):
-            self._save_manifest(interactive=False)
+            if self.configuration.manifest:
+                self._save_manifest(interactive=False)
             # by default all tests are selected; so we're done here
             return
         job_list = [

--- a/checkbox-ng/plainbox/impl/providers/manifest/bin/plainbox-manifest-resource
+++ b/checkbox-ng/plainbox/impl/providers/manifest/bin/plainbox-manifest-resource
@@ -30,18 +30,22 @@ _ = gettext.gettext
 
 
 def main():
-    """ Main function. """
-    gettext.textdomain('plainbox-provider-manifest')
-    gettext.bindtextdomain('plainbox-provider-manifest',
-                           os.getenv('PLAINBOX_PROVIDER_LOCALE_DIR'))
+    """Main function."""
+    gettext.textdomain("plainbox-provider-manifest")
+    gettext.bindtextdomain(
+        "plainbox-provider-manifest", os.getenv("PLAINBOX_PROVIDER_LOCALE_DIR")
+    )
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-m', '--manifest', metavar='PATH',
-        default='/var/tmp/checkbox-ng/machine-manifest.json',
-        help=_('Path to alternate machine manifest'))
+        "-m",
+        "--manifest",
+        metavar="PATH",
+        default="/var/tmp/checkbox-ng/machine-manifest.json",
+        help=_("Path to alternate machine manifest"),
+    )
     args = parser.parse_args()
     if os.path.isfile(args.manifest):
-        with open(args.manifest, 'rt', encoding='UTF-8') as stream:
+        with open(args.manifest, "rt", encoding="UTF-8") as stream:
             manifest = json.load(stream)
     else:
         manifest = {}
@@ -51,12 +55,15 @@ def main():
         print("ns: {}".format(provider.namespace))
         print("name: {}".format(provider.name))
         for unit in provider.unit_list:
-            if unit.Meta.name != 'manifest entry':
+            if unit.Meta.name != "manifest entry":
                 continue
-            print("{}: {}".format(
-                unit.resource_key, manifest.get(unit.id, '')))
+            print(
+                "{}: {}".format(
+                    unit.resource_key, manifest.get(unit.id, "False")
+                )
+            )
         print()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/checkbox-ng/plainbox/impl/providers/manifest/bin/plainbox-manifest-resource
+++ b/checkbox-ng/plainbox/impl/providers/manifest/bin/plainbox-manifest-resource
@@ -29,13 +29,6 @@ from plainbox.impl.providers.v1 import all_providers
 _ = gettext.gettext
 
 
-def default_value(unit):
-    return {
-        "bool": "False",
-        "natural": "0",
-    }.get(unit.value_type, "")
-
-
 def main():
     """Main function."""
     gettext.textdomain("plainbox-provider-manifest")
@@ -67,7 +60,7 @@ def main():
             print(
                 "{}: {}".format(
                     unit.resource_key,
-                    manifest.get(unit.id, default_value(unit)),
+                    manifest.get(unit.id, unit.default_value()),
                 )
             )
         print()

--- a/checkbox-ng/plainbox/impl/providers/manifest/bin/plainbox-manifest-resource
+++ b/checkbox-ng/plainbox/impl/providers/manifest/bin/plainbox-manifest-resource
@@ -29,6 +29,13 @@ from plainbox.impl.providers.v1 import all_providers
 _ = gettext.gettext
 
 
+def default_value(unit):
+    return {
+        "bool": "False",
+        "natural": "0",
+    }.get(unit.value_type, "")
+
+
 def main():
     """Main function."""
     gettext.textdomain("plainbox-provider-manifest")
@@ -59,7 +66,8 @@ def main():
                 continue
             print(
                 "{}: {}".format(
-                    unit.resource_key, manifest.get(unit.id, "False")
+                    unit.resource_key,
+                    manifest.get(unit.id, default_value(unit)),
                 )
             )
         print()

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -1318,10 +1318,9 @@ class SessionAssistant:
 
     def _parse_value(self, m, value):
         try:
-            if m.value_type == "bool":
-                return self._strtobool(value)
-            elif m.value_type == "natural":
-                return int(value)
+            return {"bool": self._strtobool, "natural": int}[m.value_type](
+                value
+            )
         except ValueError:
             raise SystemExit(
                 ("Invalid manifest {} value '{}'").format(

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -33,42 +33,47 @@ import logging
 import os
 import shlex
 import time
+from collections import defaultdict
 from tempfile import SpooledTemporaryFile
 
 
 from checkbox_ng.app_context import application_name
 
-from plainbox.abc import IJobResult
-from plainbox.abc import IJobRunnerUI
-from plainbox.abc import ISessionStateTransport
+from plainbox.abc import IJobResult, IJobRunnerUI, ISessionStateTransport
 from plainbox.i18n import gettext as _
 from plainbox.impl.config import Configuration
 from plainbox.impl.decorators import raises
-from plainbox.impl.developer import UnexpectedMethodCall
-from plainbox.impl.developer import UsageExpectation
 from plainbox.impl.execution import UnifiedRunner
+from plainbox.impl.developer import (
+    UnexpectedMethodCall,
+    UsageExpectation,
+)
 from plainbox.impl.providers import get_providers
-from plainbox.impl.result import JobResultBuilder
-from plainbox.impl.result import MemoryJobResult
+from plainbox.impl.result import JobResultBuilder, MemoryJobResult
 from plainbox.impl.runner import JobRunnerUIDelegate
 from plainbox.impl.secure.origin import Origin
-from plainbox.impl.secure.qualifiers import select_units
-from plainbox.impl.secure.qualifiers import FieldQualifier
-from plainbox.impl.secure.qualifiers import JobIdQualifier
-from plainbox.impl.secure.qualifiers import PatternMatcher
-from plainbox.impl.secure.qualifiers import RegExpJobQualifier
-from plainbox.impl.session import SessionMetaData
-from plainbox.impl.session import SessionPeekHelper
-from plainbox.impl.session import SessionResumeError
+from plainbox.impl.secure.qualifiers import (
+    select_units,
+    FieldQualifier,
+    JobIdQualifier,
+    PatternMatcher,
+    RegExpJobQualifier,
+)
+from plainbox.impl.session import (
+    SessionMetaData,
+    SessionPeekHelper,
+    SessionResumeError,
+)
 from plainbox.impl.session.jobs import InhibitionCause
 from plainbox.impl.session.manager import SessionManager
-from plainbox.impl.session.restart import IRestartStrategy
-from plainbox.impl.session.restart import detect_restart_strategy
-from plainbox.impl.session.restart import RemoteDebRestartStrategy
+from plainbox.impl.session.restart import (
+    IRestartStrategy,
+    detect_restart_strategy,
+    RemoteDebRestartStrategy,
+)
 from plainbox.impl.session.resume import IncompatibleJobError
 from plainbox.impl.session.storage import WellKnownDirsHelper
-from plainbox.impl.transport import OAuthTransport
-from plainbox.impl.transport import TransportError
+from plainbox.impl.transport import OAuthTransport, TransportError
 from plainbox.impl.unit.exporter import ExporterError
 from plainbox.impl.unit.unit import Unit
 from plainbox.vendor import morris
@@ -1305,7 +1310,43 @@ class SessionAssistant:
         ]
 
     def _strtobool(self, val):
-        return val.lower() in ("y", "yes", "t", "true", "on", "1")
+        if str(val).lower() in ("y", "yes", "t", "true", "on", "1"):
+            return True
+        elif str(val).lower() in ("n", "no", "f", "false", "off", "0"):
+            return False
+        raise ValueError(val)
+
+    def _get_default_prompt(self, manifest_type):
+        if manifest_type == "bool":
+            return "Does this machine have this piece of hardware?"
+        elif manifest_type == "natural":
+            return "Please enter the requested data:"
+        raise SystemExit(
+            "Unsupported manifest value-type: '%s'", manifest_type
+        )
+
+    def _parse_value(self, m, value):
+        try:
+            if m.value_type == "bool":
+                return self._strtobool(value)
+            elif m.value_type == "natural":
+                return int(value)
+        except ValueError:
+            raise SystemExit(
+                ("Invalid manifest {} value '{}'").format(
+                    m.id,
+                    value,
+                )
+            )
+
+    def _default_value(self, m):
+        if m.value_type == "bool":
+            return "False"
+        elif m.value_type == "natural":
+            return "-1"
+        raise SystemExit(
+            "Invalid manifest type {} (Type: {})".format(m.id, m.value_type)
+        )
 
     @raises(SystemExit, UnexpectedMethodCall)
     def get_manifest_repr(self) -> "Dict[List[Dict]]":
@@ -1323,74 +1364,60 @@ class SessionAssistant:
         """
         UsageExpectation.of(self).enforce()
         # XXX: job_state_map is a bit low level, can we avoid that?
-        jsm = self._context.state.job_state_map
-        todo_list = [
-            job
-            for job in self._context.state.run_list
-            if jsm[job.id].result.outcome is None
-        ]
-        expression_list = []
-        manifest_id_set = set()
-        for job in todo_list:
-            if job.get_resource_program():
-                expression_list.extend(
-                    job.get_resource_program().expression_list
-                )
-        for e in expression_list:
-            manifest_id_set.update(e.manifest_id_list)
+        job_state_map = self._context.state.job_state_map
+        run_list = self._context.state.run_list
+
+        def didnt_run_yet(job):
+            return job_state_map[job.id].result.outcome is None
+
+        todo_list = filter(didnt_run_yet, run_list)
+        resource_programs = (job.get_resource_program() for job in todo_list)
+        resource_programs = filter(bool, resource_programs)
+        manifest_id_set = set(
+            manifest_id
+            for resource_program in resource_programs
+            for expression in resource_program.expression_list
+            for manifest_id in expression.manifest_id_list
+        )
+
         manifest_list = [
             unit
             for unit in self._context.unit_list
             if unit.Meta.name == "manifest entry"
             and unit.id in manifest_id_set
         ]
-        manifest_cache = {}
-        manifest = WellKnownDirsHelper.manifest_file()
-        if os.path.isfile(manifest):
-            with open(manifest, "rt", encoding="UTF-8") as stream:
-                manifest_cache = json.load(stream)
-        if self._config is not None and self._config.manifest:
-            for manifest_id in self._config.manifest:
-                manifest_cache.update(
-                    {manifest_id: self._config.manifest[manifest_id]}
-                )
-        manifest_info_dict = dict()
+        disk_manifest = {}
+        manifest_path = WellKnownDirsHelper.manifest_file()
+        if os.path.isfile(manifest_path):
+            with open(manifest_path, "rt", encoding="UTF-8") as stream:
+                disk_manifest = json.load(stream)
+        try:
+            config_manifest = self._config.manifest or {}
+        except AttributeError:
+            config_manifest = {}
+        manifest_info_dict = defaultdict(list)
         for m in manifest_list:
-            prompt = m.prompt()
-            if prompt is None:
-                if m.value_type == "bool":
-                    prompt = "Does this machine have this piece of hardware?"
-                elif m.value_type == "natural":
-                    prompt = "Please enter the requested data:"
-                else:
-                    _logger.error("Unsupported value-type: '%s'", m.value_type)
-                    continue
-            if prompt not in manifest_info_dict:
-                manifest_info_dict[prompt] = []
-            manifest_info = {
-                "id": m.id,
-                "partial_id": m.partial_id,
-                "name": m.name,
-                "value_type": m.value_type,
-            }
-            try:
-                value = manifest_cache[m.id]
-                if m.value_type == "bool":
-                    if isinstance(manifest_cache[m.id], str):
-                        value = self._strtobool(manifest_cache[m.id])
-                elif m.value_type == "natural":
-                    value = int(manifest_cache[m.id])
-            except ValueError:
-                _logger.error(
-                    ("Invalid manifest %s value '%s'"),
-                    m.id,
-                    manifest_cache[m.id],
-                )
-                raise SystemExit(1)
-            except KeyError:
-                value = None
-            manifest_info.update({"value": value})
-            manifest_info_dict[prompt].append(manifest_info)
+            prompt = m.prompt() or self._get_default_prompt(m.value_type)
+            value = config_manifest.get(m.id)
+            if m.is_hidden:
+                # set all hidden manifests not set in the launcher to default
+                value = value or self._default_value(m)
+            else:
+                # only load from the disk_manifest values of non-hidden manifests
+                value = value or disk_manifest.get(m.id, "")
+
+            if value:
+                value = self._parse_value(m, value)
+            manifest_info_dict[prompt].append(
+                {
+                    "id": m.id,
+                    "partial_id": m.partial_id,
+                    "name": m.name,
+                    "value_type": m.value_type,
+                    "hidden": m.is_hidden,
+                    "value": value,
+                }
+            )
         return manifest_info_dict
 
     def save_manifest(self, manifest_answers):

--- a/checkbox-ng/plainbox/impl/session/test_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_assistant.py
@@ -21,6 +21,7 @@
 """Tests for the session assistant module class."""
 
 from unittest import mock
+from functools import partial
 
 from plainbox.impl.secure.providers.v1 import Provider1
 from plainbox.impl.session.assistant import (
@@ -337,3 +338,77 @@ class SessionAssistantTests(morris.SignalTestCase):
             ["already-rejected-job", job3_id],
         )
         self_mock._context.get_unit.assert_called_once_with(job2_id, "job")
+
+    @mock.patch(
+        "plainbox.impl.session.assistant.UsageExpectation",
+        new=mock.MagicMock(),
+    )
+    @mock.patch("os.path.isfile", return_value=False)
+    def test_get_manifest_repr(self, isfile, _):
+        self_mock = mock.MagicMock()
+        self_mock._parse_value = partial(
+            SessionAssistant._parse_value, self_mock
+        )
+
+        selected_unit = mock.MagicMock(id="selected_manifest", is_hidden=False)
+        selected_unit.Meta.name = "manifest entry"
+
+        selected_but_hidden = mock.MagicMock(
+            id="_hidden_manifest", is_hidden=True
+        )
+        selected_but_hidden.Meta.name = "manifest entry"
+
+        selected_unit.prompt.return_value = (
+            selected_but_hidden.prompt.return_value
+        ) = "prompt"
+
+        unselected_unit = mock.MagicMock(id="unselected_manifest")
+        unselected_unit.Meta.name = "manifest entry"
+
+        done_job_mock = mock.MagicMock(id="done")
+        done_job_mock.result.outcome = "pass"
+
+        to_run_job_mock = mock.MagicMock(id="to_run")
+        to_run_job_mock.result.outcome = None
+        to_run_job_mock.get_resource_program.return_value = mock.MagicMock(
+            expression_list=[
+                mock.MagicMock(
+                    manifest_id_list=["selected_manifest", "_hidden_manifest"]
+                )
+            ]
+        )
+
+        to_run_no_resource = mock.MagicMock(id="no_resource")
+        to_run_no_resource.result.outcome = None
+        to_run_no_resource.get_resource_program.return_value = []
+
+        run_list = [done_job_mock, to_run_job_mock]
+        job_state_map = {job.id: job for job in run_list}
+
+        self_mock._context.state.job_state_map = job_state_map
+        self_mock._context.state.run_list = run_list
+        self_mock._context.unit_list = [
+            selected_unit,
+            selected_but_hidden,
+            unselected_unit,
+        ]
+        self_mock._config.manifest = {"_hidden_manifest": "True"}
+        manifest_info_dict = SessionAssistant.get_manifest_repr(self_mock)
+
+        self.assertEqual(len(manifest_info_dict), 1)
+        self.assertEqual(
+            [x["id"] for x in list(manifest_info_dict.values())[0]],
+            ["selected_manifest", "_hidden_manifest"],
+        )
+
+    def test__strtobool(self, _):
+        strtobool = SessionAssistant._strtobool
+        self.assertTrue(
+            all(strtobool(None, x) for x in ("true", "t", "True", "yes"))
+        )
+        self.assertFalse(
+            any(strtobool(None, x) for x in ("false", "f", "False", "no"))
+        )
+
+        with self.assertRaises(ValueError):
+            strtobool(None, "value")

--- a/checkbox-ng/plainbox/impl/unit/manifest.py
+++ b/checkbox-ng/plainbox/impl/unit/manifest.py
@@ -64,6 +64,18 @@ class ManifestEntryUnit(UnitWithId):
         """Prompt presented (translated)."""
         return self.get_translated_record_value("prompt")
 
+    def default_prompt(self):
+        return {
+            "bool": "Does this machine have this piece of hardware?",
+            "natural": "Please enter the requested data:",
+        }[self.value_type]
+
+    def default_value(self):
+        return {
+            "bool": "False",
+            "natural": "0",
+        }.get(self.value_type, "")
+
     @property
     def value_type(self):
         """

--- a/checkbox-ng/plainbox/impl/unit/manifest.py
+++ b/checkbox-ng/plainbox/impl/unit/manifest.py
@@ -95,6 +95,16 @@ class ManifestEntryUnit(UnitWithId):
         """
         return self.get_record_value("resource-key", self.partial_id)
 
+    @property
+    def hidden_reason(self):
+        """
+        Reason why a manifest entry was hidden.
+
+        This is a "required" documentation field to preserve the reason why a
+        manifest entry was hidden (or introduced hidden)
+        """
+        return self.get_record_value("hidden-reason")
+
     class Meta:
 
         name = "manifest entry"

--- a/checkbox-ng/plainbox/impl/unit/manifest.py
+++ b/checkbox-ng/plainbox/impl/unit/manifest.py
@@ -23,7 +23,10 @@ import logging
 from plainbox.impl.symbol import SymbolDef
 from plainbox.impl.unit import concrete_validators
 from plainbox.impl.unit.unit_with_id import UnitWithId
-from plainbox.impl.unit.validators import MemberOfFieldValidator
+from plainbox.impl.unit.validators import (
+    MemberOfFieldValidator,
+    PresentFieldValidator,
+)
 
 logger = logging.getLogger("plainbox.unit.manifest")
 
@@ -39,6 +42,10 @@ class ManifestEntryUnit(UnitWithId):
     quantitative) of a device under test. Manifest data is provided externally
     and cannot or should not be detected by the code running on the device.
     """
+
+    @property
+    def is_hidden(self):
+        return self.partial_id.startswith("_")
 
     @property
     def name(self):
@@ -100,6 +107,7 @@ class ManifestEntryUnit(UnitWithId):
             value_type = "value-type"
             value_unit = "value-unit"
             resource_key = "resource-key"
+            hidden_reason = "hidden-reason"
 
         field_validators = {
             fields.name: [
@@ -119,4 +127,10 @@ class ManifestEntryUnit(UnitWithId):
                 # OPTIONAL
             ],
             fields.resource_key: [concrete_validators.untranslatable],
+            fields.hidden_reason: [
+                PresentFieldValidator(
+                    message="hidden_reason is mandatory for hidden manifests",
+                    onlyif=lambda unit: unit.is_hidden,
+                )
+            ],
         }

--- a/checkbox-ng/plainbox/impl/unit/test_manifest.py
+++ b/checkbox-ng/plainbox/impl/unit/test_manifest.py
@@ -41,7 +41,7 @@ class UnitWithIdFieldValidationTests(TestCase):
             ManifestEntryUnit({"value-type": "natural"}).default_value()
         )
         self.assertTrue(
-            ManifestEntryUnit({"value-type": "bool"}).default_prompt()
+            ManifestEntryUnit({"value-type": "bool"}).default_value()
         )
 
     def test_raises_no_hidden_reason(self):

--- a/checkbox-ng/plainbox/impl/unit/test_manifest.py
+++ b/checkbox-ng/plainbox/impl/unit/test_manifest.py
@@ -1,0 +1,58 @@
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from unittest import TestCase
+
+from plainbox.impl.unit.manifest import ManifestEntryUnit
+
+
+class UnitWithIdFieldValidationTests(TestCase):
+
+    def test_is_hidden(self):
+        self.assertTrue(ManifestEntryUnit({"id": "_hidden"}).is_hidden)
+        self.assertFalse(ManifestEntryUnit({"id": "visible"}).is_hidden)
+
+    def test_default_prompt(self):
+        self.assertTrue(
+            ManifestEntryUnit({"value-type": "natural"}).default_prompt()
+        )
+        self.assertTrue(
+            ManifestEntryUnit({"value-type": "bool"}).default_prompt()
+        )
+
+    def test_default_value(self):
+        self.assertTrue(
+            ManifestEntryUnit({"value-type": "natural"}).default_value()
+        )
+        self.assertTrue(
+            ManifestEntryUnit({"value-type": "bool"}).default_prompt()
+        )
+
+    def test_raises_no_hidden_reason(self):
+        res = ManifestEntryUnit(
+            {
+                "id": "_hidden",
+                "value-type": "bool",
+                "_name": "Hidden manifest",
+                "unit": "manifest",
+            }
+        ).check()
+        self.assertEqual(len(res), 1)
+        res = res[0]
+        self.assertIn("hidden_reason is mandatory", res.message)

--- a/docs/reference/units/manifest-entry.rst
+++ b/docs/reference/units/manifest-entry.rst
@@ -32,7 +32,9 @@ Following fields may be used by a manifest entry unit.
 ``id``:
     (mandatory) - Unique identifier of the entry. This field is used to look up
     and store data so please keep it stable across the lifetime of your
-    provider.
+    provider. If the id starts with a ``_``, then the manifest will be hidden
+    from the interactive selection. These manifests can only be given a value
+    via configurations.
 
 .. _Manifest Entry name field:
 
@@ -77,6 +79,13 @@ Following fields may be used by a manifest entry unit.
     default prompt is "Does this machine have this piece of hardware?", when
     the ``value-type`` is ``natural`` the default prompt is "Please enter the
     requested data".
+
+.. _Manifest Entry hidden reason:
+
+``hidden-reason``:
+    (mandatory if hidden) - Explains why a manifest unit was hidden. The reason
+    should be clear and specific, as this field serves as documentation for
+    future reference.
 
 Example
 -------

--- a/metabox/metabox/metabox-provider/units/hidden-manifests.pxu
+++ b/metabox/metabox/metabox-provider/units/hidden-manifests.pxu
@@ -1,0 +1,43 @@
+unit: manifest entry
+id: _hidden_manifest
+_name: Hidden manifest entry for testing - Failure if shown
+hidden-reason: This is a test manifest to validate the feature
+value-type: bool
+
+unit: manifest entry
+id: shown_manifest
+_name: Shown manifest to check that non-hidden are shown
+value-type: bool
+
+unit: job
+id: job_requires_hidden
+_summary: Test that requires the hidden manifest to be set
+_purpose: This job will only run when the hidden manifest is set
+plugin: shell
+command: true
+estimated_duration: 1s
+imports: from com.canonical.plainbox import manifest
+requires:
+  manifest._hidden_manifest == 'True'
+  manifest.shown_manifest == 'True'
+
+unit: job
+id: job_requires_not_hidden
+_summary: Test that requires the hidden manifest to be unset
+_purpose: This job will only run when the hidden manifest is False (unset)
+plugin: shell
+command: true
+estimated_duration: 1s
+imports: from com.canonical.plainbox import manifest
+requires:
+  manifest._hidden_manifest == 'False'
+  manifest.shown_manifest == 'True'
+
+id: hidden_manifest_testplan
+unit: test plan
+_name: Hidden Manifests test plan
+_description:
+  Test plan used to test that hidden manifests work as intended
+include:
+  job_requires_hidden
+  job_requires_not_hidden

--- a/metabox/metabox/scenarios/ui/manifest_menu.py
+++ b/metabox/metabox/scenarios/ui/manifest_menu.py
@@ -1,0 +1,105 @@
+# This file is part of Checkbox.
+#
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox. If not, see <http://www.gnu.org/licenses/>.
+import textwrap
+
+import metabox.core.keys as keys
+from metabox.core.actions import Expect, Send, Start, ExpectNot, Put, MkTree
+from metabox.core.scenario import Scenario
+from metabox.core.utils import tag
+
+
+@tag("manual", "interact", "manifest")
+class ManifestSelectionNoHiddenSetFalse(Scenario):
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit=2021.com.canonical.certification::hidden_manifest_testplan
+        forced = yes
+        """
+    )
+    machine_manifest = textwrap.dedent(
+        """
+        {
+            "2021.com.canonical.certification::_hidden_manifest" : true
+        }
+        """
+    )
+
+    steps = [
+        # put in the machine a manifest that sets the hidden_manifest. Given
+        # that this is an interactive session, it must be ignored
+        MkTree("/var/tmp/checkbox-ng"),
+        Put("/var/tmp/checkbox-ng/machine-manifest.json", machine_manifest),
+        Start(),
+        Expect("Press (T) to start Testing"),
+        Send("t"),
+        Expect("System Manifest"),
+        # contained in the hidden manifest name
+        ExpectNot("Failure if shown", timeout=0.1),
+        # contained in the shown manifest name
+        Expect("non-hidden are shown"),
+        Expect("Press (T) to start Testing"),
+        Send("yt"),
+        Expect("2021.com.canonical.certification::job_requires_hidden"),
+        Expect("job cannot be started"),
+        Expect("2021.com.canonical.certification::job_requires_not_hidden"),
+        Expect("job passed"),
+    ]
+
+
+@tag("manual", "interact", "manifest")
+class ManifestSelectionCanSetHiddenLauncher(Scenario):
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit=2021.com.canonical.certification::hidden_manifest_testplan
+        forced = yes
+        [manifest]
+        2021.com.canonical.certification::_hidden_manifest=True
+        """
+    )
+    machine_manifest = textwrap.dedent(
+        """
+        {
+            "2021.com.canonical.certification::_hidden_manifest" : true
+        }
+        """
+    )
+
+    steps = [
+        Start(),
+        Expect("Press (T) to start Testing"),
+        Send("t"),
+        Expect("System Manifest"),
+        # contained in the hidden manifest name
+        ExpectNot("Failure if shown", timeout=0.1),
+        # contained in the shown manifest name
+        Expect("non-hidden are shown"),
+        Expect("Press (T) to start Testing"),
+        Send("yt"),
+        Expect("2021.com.canonical.certification::job_requires_hidden"),
+        Expect("job passed"),
+        Expect("2021.com.canonical.certification::job_requires_not_hidden"),
+        Expect("job cannot be started"),
+    ]


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

We need a “hidden” manifest type to be able to include/exclude jobs runs in the lab without impact normal end user experience:

Hidden = not available for general consumption, not shown in the Manifest entries screen

hidden keyword raises questions, so need an additional hidden_reason field to explain why this manifest is not shown to the user (e.g. “No OBEX server testing required in the HW Cert lab”)

These manifest entries must be false (i.e. not set) for submissions made to issue a Certificate (Cert issuance process must include this check, this is a critical violation because it can lead to important things not being tested)

Hidden manifest IDs must start with _ (underscore). This is for easier reading/parsing/debugging, and must have a hidden-reason field to explain why they were introduced.

## Resolved issues

Fixes: CHECKBOX-1698

## Documentation

New field documented in reference

## Tests

Tested via metabox + unittest
