### PR TITLE
Add suspend stats related check (Bugfix)

### DIFF
--- a/providers/base/bin/suspend_stats.py
+++ b/providers/base/bin/suspend_stats.py
@@ -125,7 +125,7 @@ class SuspendStats:
 
         parser.add_argument(
             "check_type",
-            help="The type to take e.g. after_suspend or any_failure."
+            help="The type to take e.g. after_suspend or any_failure.",
         )
 
         return parser.parse_args(args)

--- a/providers/base/bin/suspend_stats.py
+++ b/providers/base/bin/suspend_stats.py
@@ -94,12 +94,7 @@ class SuspendStats:
 
         :returns: return Ture while system is under after suspend status
         """
-        return (
-            self.contents["success"] != "0"
-            and self.contents["failed_prepare"] == "0"
-            and self.contents["failed_suspend"] == "0"
-            and self.contents["failed_resume"] == "0"
-        )
+        return self.contents["success"] != "0"
 
     def is_any_failed(self) -> bool:
         """
@@ -107,7 +102,10 @@ class SuspendStats:
 
         :returns: return Ture while one failed during suspend
         """
-        return self.contents["fail"] != "0"
+        for c, v in self.contents.items():
+            if c.startswith("fail") and v != "0":
+                return True
+        return False
 
     def parse_args(self, args=sys.argv[1:]):
         """

--- a/providers/base/bin/suspend_stats.py
+++ b/providers/base/bin/suspend_stats.py
@@ -56,7 +56,7 @@ class SuspendStats:
         content = {}
 
         with open(debugfs, "r") as d:
-            for p in filter(None, (line.strip() for line in d)):
+            for p in filter(None, (line.strip() for line in d.readlines())):
                 if p != "failures:" and ":" in p:
                     kv = p.split(":")
                     if len(kv) > 1:

--- a/providers/base/tests/test_suspend_stats.py
+++ b/providers/base/tests/test_suspend_stats.py
@@ -131,7 +131,9 @@ class MainTests(unittest.TestCase):
     @patch("suspend_stats.SuspendStats.parse_args")
     @patch("suspend_stats.SuspendStats.get_last_failed_device")
     @patch("suspend_stats.SuspendStats.print_all_content")
-    def test_run_failed_device_succ(self, mock_print, mock_device, mock_parse_args):
+    def test_run_failed_device_succ(
+        self, mock_print, mock_device, mock_parse_args
+    ):
         args_mock = MagicMock()
         args_mock.type = "failed_device"
         args_mock.print = True
@@ -143,7 +145,9 @@ class MainTests(unittest.TestCase):
     @patch("suspend_stats.SuspendStats.parse_args")
     @patch("suspend_stats.SuspendStats.get_last_failed_device")
     @patch("suspend_stats.SuspendStats.print_all_content")
-    def test_run_failed_device_fail(self, mock_print, mock_device, mock_parse_args):
+    def test_run_failed_device_fail(
+        self, mock_print, mock_device, mock_parse_args
+    ):
         args_mock = MagicMock()
         args_mock.type = "failed_device"
         args_mock.print = True
@@ -156,7 +160,9 @@ class MainTests(unittest.TestCase):
     @patch("suspend_stats.SuspendStats.parse_args")
     @patch("suspend_stats.SuspendStats.get_last_failed_device")
     @patch("suspend_stats.SuspendStats.print_all_content")
-    def test_run_failed_device_fail_no_raise(self, mock_print, mock_device, mock_parse_args):
+    def test_run_failed_device_fail_no_raise(
+        self, mock_print, mock_device, mock_parse_args
+    ):
         args_mock = MagicMock()
         args_mock.type = "failed_device"
         args_mock.print = False

--- a/providers/base/tests/test_suspend_stats.py
+++ b/providers/base/tests/test_suspend_stats.py
@@ -150,15 +150,15 @@ class TestSuspendStats(unittest.TestCase):
         self.assertTrue(stats.is_after_suspend())
 
         stats.contents["failed_prepare"] = "1"
-        self.assertFalse(stats.is_after_suspend())
+        self.assertTrue(stats.is_after_suspend())
 
         stats.contents["failed_prepare"] = "0"
         stats.contents["failed_suspend"] = "1"
-        self.assertFalse(stats.is_after_suspend())
+        self.assertTrue(stats.is_after_suspend())
 
         stats.contents["failed_suspend"] = "0"
         stats.contents["failed_resume"] = "1"
-        self.assertFalse(stats.is_after_suspend())
+        self.assertTrue(stats.is_after_suspend())
 
     @patch("suspend_stats.SuspendStats.__init__")
     def test_is_any_failed(self, mock_init):
@@ -174,6 +174,17 @@ class TestSuspendStats(unittest.TestCase):
 
         stats.contents["fail"] = "0"
         self.assertFalse(stats.is_any_failed())
+
+        stats.contents["failed_prepare"] = "1"
+        self.assertTrue(stats.is_any_failed())
+
+        stats.contents["failed_prepare"] = "0"
+        stats.contents["failed_suspend"] = "1"
+        self.assertTrue(stats.is_any_failed())
+
+        stats.contents["failed_suspend"] = "0"
+        stats.contents["failed_resume"] = "1"
+        self.assertTrue(stats.is_any_failed())
 
     @patch("suspend_stats.SuspendStats.__init__")
     def test_parse_args_valid(self, mock_init):

--- a/providers/base/tests/test_suspend_stats.py
+++ b/providers/base/tests/test_suspend_stats.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2025 Canonical Ltd.
+# Written by:
+#   Hanhsuan Lee <hanhsuan.lee@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest.mock import patch, mock_open, MagicMock
+import unittest
+
+from suspend_stats import SuspendStats
+
+
+class TestSuspendStats(unittest.TestCase):
+    @patch("os.walk")
+    @patch("builtins.open", new_callable=mock_open, read_data="1\n")
+    def test_collect_content_under_directory(self, mock_file, mock_os_walk):
+        mock_os_walk.return_value = [
+            (
+                "/sys/power/suspend_stats/",
+                [],
+                ["success", "failed_suspend", "fail", "last_failed_dev"],
+            ),
+        ]
+
+        stats = SuspendStats()
+        expected_content = {
+            "success": "1",
+            "failed_suspend": "1",
+            "fail": "1",
+            "last_failed_dev": "1",
+        }
+
+        self.assertEqual(stats.contents, expected_content)
+
+    def test_is_after_suspend(self):
+        stats = SuspendStats()
+        stats.contents = {
+            "success": "1",
+            "failed_suspend": "0",
+            "fail": "0",
+            "last_failed_dev": "",
+        }
+        self.assertTrue(stats.is_after_suspend())
+
+        stats.contents["failed_suspend"] = "1"
+        self.assertFalse(stats.is_after_suspend())
+
+    def test_is_device_failed(self):
+        stats = SuspendStats()
+        stats.contents = {
+            "success": "1",
+            "failed_suspend": "0",
+            "fail": "1",
+            "last_failed_dev": "",
+        }
+        self.assertTrue(stats.is_device_failed())
+
+        stats.contents["fail"] = "0"
+        self.assertFalse(stats.is_device_failed())
+
+    def test_get_last_failed_device(self):
+        stats = SuspendStats()
+
+        stats.contents = {
+            "success": "1",
+            "failed_suspend": "0",
+            "fail": "1",
+            "last_failed_dev": "deviceA",
+        }
+        self.assertEqual(stats.get_last_failed_device(), "deviceA")
+
+        stats.contents["fail"] = "0"
+        self.assertEqual(
+            stats.get_last_failed_device(), "There is no failed device"
+        )
+
+    def test_parse_args_valid(self):
+        stats = SuspendStats()
+        args = ["valid", "--print"]
+        rv = stats.parse_args(args)
+
+        self.assertEqual(rv.type, "valid")
+        self.assertTrue(rv.print)
+
+    def test_parse_args_failed_device(self):
+        stats = SuspendStats()
+        args = ["failed_device", "--print"]
+        rv = stats.parse_args(args)
+
+        self.assertEqual(rv.type, "failed_device")
+        self.assertTrue(rv.print)
+
+
+class MainTests(unittest.TestCase):
+    @patch("suspend_stats.SuspendStats.parse_args")
+    @patch("suspend_stats.SuspendStats.is_after_suspend")
+    @patch("suspend_stats.SuspendStats.print_all_content")
+    def test_run_valid_succ(self, mock_print, mock_after, mock_parse_args):
+        args_mock = MagicMock()
+        args_mock.type = "valid"
+        args_mock.print = True
+        mock_parse_args.return_value = args_mock
+        mock_after.return_value = True
+        self.assertEqual(SuspendStats().main(), None)
+
+    @patch("suspend_stats.SuspendStats.parse_args")
+    @patch("suspend_stats.SuspendStats.is_after_suspend")
+    @patch("suspend_stats.SuspendStats.print_all_content")
+    def test_run_valid_fail(self, mock_print, mock_after, mock_parse_args):
+        args_mock = MagicMock()
+        args_mock.type = "valid"
+        args_mock.print = False
+        mock_parse_args.return_value = args_mock
+        mock_after.return_value = False
+        with self.assertRaises(SystemExit):
+            SuspendStats().main()
+
+    @patch("suspend_stats.SuspendStats.parse_args")
+    @patch("suspend_stats.SuspendStats.get_last_failed_device")
+    @patch("suspend_stats.SuspendStats.print_all_content")
+    def test_run_failed_device_succ(self, mock_print, mock_device, mock_parse_args):
+        args_mock = MagicMock()
+        args_mock.type = "failed_device"
+        args_mock.print = True
+        args_mock.raise_exit = False
+        mock_parse_args.return_value = args_mock
+        mock_device.return_value = "There is no failed device"
+        self.assertEqual(SuspendStats().main(), None)
+
+    @patch("suspend_stats.SuspendStats.parse_args")
+    @patch("suspend_stats.SuspendStats.get_last_failed_device")
+    @patch("suspend_stats.SuspendStats.print_all_content")
+    def test_run_failed_device_fail(self, mock_print, mock_device, mock_parse_args):
+        args_mock = MagicMock()
+        args_mock.type = "failed_device"
+        args_mock.print = True
+        args_mock.raise_exit = True
+        mock_parse_args.return_value = args_mock
+        mock_device.return_value = "deviceA"
+        with self.assertRaises(SystemExit):
+            SuspendStats().main()
+
+    @patch("suspend_stats.SuspendStats.parse_args")
+    @patch("suspend_stats.SuspendStats.get_last_failed_device")
+    @patch("suspend_stats.SuspendStats.print_all_content")
+    def test_run_failed_device_fail_no_raise(self, mock_print, mock_device, mock_parse_args):
+        args_mock = MagicMock()
+        args_mock.type = "failed_device"
+        args_mock.print = False
+        args_mock.raise_exit = False
+        mock_parse_args.return_value = args_mock
+        mock_device.return_value = "deviceA"
+        self.assertEqual(SuspendStats().main(), None)
+
+    @patch("suspend_stats.SuspendStats.parse_args")
+    def test_run_nothing(self, mock_parse_args):
+        args_mock = MagicMock()
+        args_mock.type = "Unknown"
+        args_mock.print = False
+        args_mock.raise_exit = False
+        mock_parse_args.return_value = args_mock
+        self.assertEqual(SuspendStats().main(), None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/providers/base/tests/test_suspend_stats.py
+++ b/providers/base/tests/test_suspend_stats.py
@@ -89,14 +89,18 @@ class TestSuspendStats(unittest.TestCase):
         result = stats.parse_suspend_stats_in_debugfs()
         self.assertEqual(result, expected_output)
 
-    def test_empty_directory(self):
+    @patch("suspend_stats.SuspendStats.__init__")
+    def test_empty_directory(self, mock_init):
+        mock_init.return_value = None
         stats = SuspendStats()
         with tempfile.TemporaryDirectory() as tmp_dir:
             self.assertEqual(
                 stats.collect_content_under_directory(tmp_dir), {}
             )
 
-    def test_single_file(self):
+    @patch("suspend_stats.SuspendStats.__init__")
+    def test_single_file(self, mock_init):
+        mock_init.return_value = None
         stats = SuspendStats()
         with tempfile.TemporaryDirectory() as tmp_dir:
             file_path = Path(tmp_dir) / "test.txt"
@@ -105,7 +109,9 @@ class TestSuspendStats(unittest.TestCase):
             result = stats.collect_content_under_directory(tmp_dir)
             self.assertEqual(result, {"test.txt": "Line1"})
 
-    def test_multiple_files(self):
+    @patch("suspend_stats.SuspendStats.__init__")
+    def test_multiple_files(self, mock_init):
+        mock_init.return_value = None
         stats = SuspendStats()
         with tempfile.TemporaryDirectory() as tmp_dir:
             file_path_1 = Path(tmp_dir) / "file1.txt"
@@ -119,15 +125,19 @@ class TestSuspendStats(unittest.TestCase):
                 result, {"file1.txt": "Line11", "file2.txt": "Line21"}
             )
 
+    @patch("suspend_stats.SuspendStats.__init__")
     @patch("pathlib.Path.iterdir")
-    def test_invalid_search_directories(self, mock_path):
+    def test_invalid_search_directories(self, mock_path, mock_init):
+        mock_init.return_value = None
         stats = SuspendStats()
         mock_path.side_effect = FileNotFoundError
 
         with self.assertRaises(FileNotFoundError):
             stats.collect_content_under_directory("/non/existent/directory")
 
-    def test_is_after_suspend(self):
+    @patch("suspend_stats.SuspendStats.__init__")
+    def test_is_after_suspend(self, mock_init):
+        mock_init.return_value = None
         stats = SuspendStats()
         stats.contents = {
             "success": "1",
@@ -150,7 +160,9 @@ class TestSuspendStats(unittest.TestCase):
         stats.contents["failed_resume"] = "1"
         self.assertFalse(stats.is_after_suspend())
 
-    def test_is_any_failed(self):
+    @patch("suspend_stats.SuspendStats.__init__")
+    def test_is_any_failed(self, mock_init):
+        mock_init.return_value = None
         stats = SuspendStats()
         stats.contents = {
             "success": "1",
@@ -163,14 +175,18 @@ class TestSuspendStats(unittest.TestCase):
         stats.contents["fail"] = "0"
         self.assertFalse(stats.is_any_failed())
 
-    def test_parse_args_valid(self):
+    @patch("suspend_stats.SuspendStats.__init__")
+    def test_parse_args_valid(self, mock_init):
+        mock_init.return_value = None
         stats = SuspendStats()
         args = ["after_suspend"]
         rv = stats.parse_args(args)
 
         self.assertEqual(rv.check_type, "after_suspend")
 
-    def test_parse_args_any(self):
+    @patch("suspend_stats.SuspendStats.__init__")
+    def test_parse_args_any(self, mock_init):
+        mock_init.return_value = None
         stats = SuspendStats()
         args = ["any_failure"]
         rv = stats.parse_args(args)
@@ -179,20 +195,28 @@ class TestSuspendStats(unittest.TestCase):
 
 
 class MainTests(unittest.TestCase):
+    @patch("suspend_stats.SuspendStats.__init__")
     @patch("suspend_stats.SuspendStats.parse_args")
     @patch("suspend_stats.SuspendStats.is_after_suspend")
     @patch("suspend_stats.SuspendStats.print_all_content")
-    def test_run_valid_succ(self, mock_print, mock_after, mock_parse_args):
+    def test_run_valid_succ(
+        self, mock_print, mock_after, mock_parse_args, mock_init
+    ):
+        mock_init.return_value = None
         args_mock = MagicMock()
         args_mock.check_type = "after_suspend"
         mock_parse_args.return_value = args_mock
         mock_after.return_value = True
         self.assertEqual(SuspendStats().main(), None)
 
+    @patch("suspend_stats.SuspendStats.__init__")
     @patch("suspend_stats.SuspendStats.parse_args")
     @patch("suspend_stats.SuspendStats.is_after_suspend")
     @patch("suspend_stats.SuspendStats.print_all_content")
-    def test_run_valid_fail(self, mock_print, mock_after, mock_parse_args):
+    def test_run_valid_fail(
+        self, mock_print, mock_after, mock_parse_args, mock_init
+    ):
+        mock_init.return_value = None
         args_mock = MagicMock()
         args_mock.check_type = "after_suspend"
         mock_parse_args.return_value = args_mock
@@ -200,33 +224,36 @@ class MainTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             SuspendStats().main()
 
+    @patch("suspend_stats.SuspendStats.__init__")
     @patch("suspend_stats.SuspendStats.parse_args")
     @patch("suspend_stats.SuspendStats.is_any_failed")
     @patch("suspend_stats.SuspendStats.print_all_content")
-    def test_run_any_succ(self, mock_print, mock_any, mock_parse_args):
+    def test_run_any_succ(
+        self, mock_print, mock_any, mock_parse_args, mock_init
+    ):
+        mock_init.return_value = None
         args_mock = MagicMock()
         args_mock.check_type = "any_failure"
         mock_parse_args.return_value = args_mock
         mock_any.return_value = False
         self.assertEqual(SuspendStats().main(), None)
 
+    @patch("suspend_stats.SuspendStats.__init__")
     @patch("suspend_stats.SuspendStats.parse_args")
     @patch("suspend_stats.SuspendStats.is_any_failed")
     @patch("suspend_stats.SuspendStats.print_all_content")
-    def test_run_any_fail(self, mock_print, mock_any, mock_parse_args):
+    def test_run_any_fail(
+        self, mock_print, mock_any, mock_parse_args, mock_init
+    ):
+        mock_init.return_value = None
         args_mock = MagicMock()
         args_mock.check_type = "any_failure"
         mock_parse_args.return_value = args_mock
         mock_any.return_value = True
+        stats = SuspendStats()
+        stats.contents["fail"] = "0"
         with self.assertRaises(SystemExit):
-            SuspendStats().main()
-
-    @patch("suspend_stats.SuspendStats.parse_args")
-    def test_run_nothing(self, mock_parse_args):
-        args_mock = MagicMock()
-        args_mock.type = "Unknown"
-        mock_parse_args.return_value = args_mock
-        self.assertEqual(SuspendStats().main(), None)
+            stats.main()
 
 
 if __name__ == "__main__":

--- a/providers/base/tests/test_suspend_stats.py
+++ b/providers/base/tests/test_suspend_stats.py
@@ -64,10 +64,12 @@ class TestSuspendStats(unittest.TestCase):
         SuspendStats()
 
         mock_collect.assert_called_once_with("/sys/power/suspend_stats/")
-        mock_parse.assert_called_once()
+        mock_parse.assert_called_once_with()
 
+    @patch("suspend_stats.SuspendStats.__init__")
     @patch("builtins.open", new_callable=mock_open, read_data=debugfs)
-    def test_parse_suspend_stats(self, mock_file):
+    def test_parse_suspend_stats(self, mock_file, mock_init):
+        mock_init.return_value = None
         stats = SuspendStats()
         expected_output = {
             "success": "1",

--- a/providers/base/tests/test_suspend_stats.py
+++ b/providers/base/tests/test_suspend_stats.py
@@ -125,9 +125,7 @@ class MainTests(unittest.TestCase):
     @patch("suspend_stats.SuspendStats.parse_args")
     @patch("suspend_stats.SuspendStats.is_any_failed")
     @patch("suspend_stats.SuspendStats.print_all_content")
-    def test_run_any_succ(
-        self, mock_print, mock_any, mock_parse_args
-    ):
+    def test_run_any_succ(self, mock_print, mock_any, mock_parse_args):
         args_mock = MagicMock()
         args_mock.type = "any"
         args_mock.print = False
@@ -138,9 +136,7 @@ class MainTests(unittest.TestCase):
     @patch("suspend_stats.SuspendStats.parse_args")
     @patch("suspend_stats.SuspendStats.is_any_failed")
     @patch("suspend_stats.SuspendStats.print_all_content")
-    def test_run_any_fail(
-        self, mock_print, mock_any, mock_parse_args
-    ):
+    def test_run_any_fail(self, mock_print, mock_any, mock_parse_args):
         args_mock = MagicMock()
         args_mock.type = "any"
         args_mock.print = True

--- a/providers/base/units/suspend/suspend.pxu
+++ b/providers/base/units/suspend/suspend.pxu
@@ -1717,24 +1717,24 @@ command:
 _purpose: Attaches the FWTS oops results log to the submission after suspend
 _summary: Attach FWTS oops results log post-suspend.
 
-id: suspend/is_suspend_success
+id: suspend/valid_suspend_status
 plugin: shell
 category_id: com.canonical.plainbox::suspend
 depends: suspend/suspend_advanced_auto
 estimated_duration: 5s
 command: suspend_stats.py valid -p
 summary:
-    Test this machine suspend status is failed or not
+    Test this machine suspend status is success or not
 description:
     If the suspend is successed, the count in /sys/power/suspend_stats/success will be non zero
     and the /sys/power/suspend_stats/failed_suspend will be zero
 
-id: suspend/is_device_suspend_success
+id: suspend/any_fail_during_suspend
 plugin: shell
 category_id: com.canonical.plainbox::suspend
 depends: suspend/suspend_advanced_auto
 estimated_duration: 5s
-command: suspend_stats.py failed_device -p -r
+command: suspend_stats.py any -p
 summary:
     Test all devices in this machine suspend status is failed or not
 description:

--- a/providers/base/units/suspend/suspend.pxu
+++ b/providers/base/units/suspend/suspend.pxu
@@ -1741,7 +1741,7 @@ command: suspend_stats.py any_failure
 summary:
     Tests if any device in this machine reports a suspend failure
 description:
-    If the DUT suspended successfully, /sys/power/suspend_stats/fail
-    and fail in /sys/kernel/debug/suspend_stats will be zero.
+    If the DUT suspended successfully, /sys/power/suspend_stats/fail*
+    and fail* in /sys/kernel/debug/suspend_stats will be zero.
     If a device failed /sys/power/suspend_stats/last_failed_dev
     and last_failed_dev in /sys/kernel/debug/suspend_stats will show the failed device

--- a/providers/base/units/suspend/suspend.pxu
+++ b/providers/base/units/suspend/suspend.pxu
@@ -1716,3 +1716,28 @@ command:
  [ -e "${PLAINBOX_SESSION_SHARE}"/fwts_oops_results_after_s3.log ] && xz -c "${PLAINBOX_SESSION_SHARE}"/fwts_oops_results_after_s3.log
 _purpose: Attaches the FWTS oops results log to the submission after suspend
 _summary: Attach FWTS oops results log post-suspend.
+
+id: suspend/is_suspend_success
+plugin: shell
+category_id: com.canonical.plainbox::suspend
+depends: suspend/suspend_advanced_auto
+estimated_duration: 5s
+command: suspend_stats.py valid -p
+summary:
+    Test this machine suspend status is failed or not
+description:
+    If the suspend is successed, the count in /sys/power/suspend_stats/success will be non zero
+    and the /sys/power/suspend_stats/failed_suspend will be zero
+
+id: suspend/is_device_suspend_success
+plugin: shell
+category_id: com.canonical.plainbox::suspend
+depends: suspend/suspend_advanced_auto
+estimated_duration: 5s
+command: suspend_stats.py failed_device -p -r
+summary:
+    Test all devices in this machine suspend status is failed or not
+description:
+    If the suspend is successed, the count in /sys/power/suspend_stats/success will be non zero
+    and the /sys/power/suspend_stats/fail will be zero. If there is device failed,
+    /sys/power/suspend_stats/last_failed_dev will show the failed device

--- a/providers/base/units/suspend/suspend.pxu
+++ b/providers/base/units/suspend/suspend.pxu
@@ -1717,27 +1717,29 @@ command:
 _purpose: Attaches the FWTS oops results log to the submission after suspend
 _summary: Attach FWTS oops results log post-suspend.
 
-id: suspend/valid_suspend_status
+id: suspend/validate_suspend_status
 plugin: shell
 category_id: com.canonical.plainbox::suspend
 depends: suspend/suspend_advanced_auto
 estimated_duration: 5s
-command: suspend_stats.py valid -p
+command: suspend_stats.py after_suspend
 summary:
-    Test this machine suspend status is success or not
+    Tests that the machine suspended correctly
 description:
-    If the suspend is successed, the count in /sys/power/suspend_stats/success will be non zero
-    and the /sys/power/suspend_stats/failed_suspend will be zero
+    Query sysfs and debugfs for the amount of times the system was suspended.
+    We expect the count in /sys/power/suspend_stats/success
+    and suscess in /sys/kernel/debugfs/suspend_stats to be non zero
 
-id: suspend/any_fail_during_suspend
+id: suspend/any_suspend_failure
 plugin: shell
 category_id: com.canonical.plainbox::suspend
 depends: suspend/suspend_advanced_auto
 estimated_duration: 5s
-command: suspend_stats.py any -p
+command: suspend_stats.py any_failure
 summary:
-    Test all devices in this machine suspend status is failed or not
+    Tests if any device in this machine reports a suspend failure
 description:
-    If the suspend is successed, the count in /sys/power/suspend_stats/success will be non zero
-    and the /sys/power/suspend_stats/fail will be zero. If there is device failed,
-    /sys/power/suspend_stats/last_failed_dev will show the failed device
+    If the DUT suspended successfully, /sys/power/suspend_stats/fail
+    and fail in /sys/kernel/debug/suspend_stats will be zero.
+    If a device failed /sys/power/suspend_stats/last_failed_dev
+    and last_failed_dev in /sys/kernel/debug/suspend_stats will show the failed device

--- a/providers/base/units/suspend/suspend.pxu
+++ b/providers/base/units/suspend/suspend.pxu
@@ -1722,6 +1722,7 @@ plugin: shell
 category_id: com.canonical.plainbox::suspend
 depends: suspend/suspend_advanced_auto
 estimated_duration: 5s
+user: root
 command: suspend_stats.py after_suspend
 summary:
     Tests that the machine suspended correctly
@@ -1735,6 +1736,7 @@ plugin: shell
 category_id: com.canonical.plainbox::suspend
 depends: suspend/suspend_advanced_auto
 estimated_duration: 5s
+user: root
 command: suspend_stats.py any_failure
 summary:
     Tests if any device in this machine reports a suspend failure

--- a/providers/base/units/suspend/test-plan.pxu
+++ b/providers/base/units/suspend/test-plan.pxu
@@ -46,8 +46,8 @@ include:
     suspend/audio_after_suspend_auto                    certification-status=blocker
     suspend/cpu_after_suspend_auto                      certification-status=blocker
     suspend/memory_after_suspend_auto                   certification-status=blocker
-    suspend/is_suspend_success
-    suspend/is_device_suspend_success
+    suspend/valid_suspend_status
+    suspend/any_fail_during_suspend
 bootstrap_include:
     device
 

--- a/providers/base/units/suspend/test-plan.pxu
+++ b/providers/base/units/suspend/test-plan.pxu
@@ -46,6 +46,8 @@ include:
     suspend/audio_after_suspend_auto                    certification-status=blocker
     suspend/cpu_after_suspend_auto                      certification-status=blocker
     suspend/memory_after_suspend_auto                   certification-status=blocker
+    suspend/is_suspend_success
+    suspend/is_device_suspend_success
 bootstrap_include:
     device
 

--- a/providers/base/units/suspend/test-plan.pxu
+++ b/providers/base/units/suspend/test-plan.pxu
@@ -46,8 +46,8 @@ include:
     suspend/audio_after_suspend_auto                    certification-status=blocker
     suspend/cpu_after_suspend_auto                      certification-status=blocker
     suspend/memory_after_suspend_auto                   certification-status=blocker
-    suspend/valid_suspend_status
-    suspend/any_fail_during_suspend
+    suspend/validate_suspend_status
+    suspend/any_suspend_failure
 bootstrap_include:
     device
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
## WARNING: This modifies com.canonical.certification::sru-server
According to the `suspend_advanced_auto` is the dependency for all after suspend jobs, it would be better to do more tests for this concept to fix #1579.
Therefore, this PR is the first step to collect information by:
1. `valid_suspend_status` is used to check `success` should be non zero
2. `any_fail_during_supend` is used to check `fail` should be zero

If everything woks well, `valid_suspend_status`  will be merge into  `suspend_advanced_auto` in the future.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
#1579 

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
succ [202001-27667](https://certification.canonical.com/hardware/202001-27667/submission/409333/)
fail [202412-36131](https://certification.canonical.com/hardware/202412-36131/submission/409332/)
