### PR TITLE
Ensure cpu/clocktest does not run on the s390x architecture (BugFix)

### DIFF
--- a/providers/base/units/cpu/jobs.pxu
+++ b/providers/base/units/cpu/jobs.pxu
@@ -126,6 +126,8 @@ _purpose:
 plugin: shell
 category_id: com.canonical.plainbox::cpu
 id: cpu/clocktest
+requires:
+ cpuinfo.platform not in ("s390x")
 flags: also-after-suspend
 estimated_duration: 300.0
 command: clocktest


### PR DESCRIPTION
## Description

The cpu/clocktest test doesn't work on s390x due to issues with sched_setaffinity (as discussed in issue #422), so make sure this test doesn't run on this architecture. To do that, add a `requires` to the cpu/clocktest so it doesn't fulfill its requirements if the detected CPU architecture is "s390x".

## Resolved issues

- #422

## Tests

I haven't written any Python code for this contribution, so I don't think the test coverage has changed. Still, I ran `coverage` and attached its HTML coverage report below.

[htmlcov.zip](https://github.com/user-attachments/files/18612112/htmlcov.zip)

However, I have manually tested this change by running checkbox and making sure cpu/clocktest still runs on my x86 laptop and it did (the test description is "Tests the CPU for clock jitter"):

![image](https://github.com/user-attachments/assets/ad87edc6-e8a6-4832-814d-1abe7c8a2b49)

I don't have an IBM mainframe at hand 😅, so I tried changing "s390x" to "x86_64" to see if the test didn't run on my laptop and it didn't:

![image](https://github.com/user-attachments/assets/557555b3-476d-40a0-9d18-cb65750c9927)

I make myself available for further changes and explanations. Thank you for reviewing this!