### PR TITLE
Document additional dependencies (Infra)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ install everything you need in a Python virtual environment.
 
 Install the required tools:
 
-    $ sudo apt install git python3-virtualenv libasound2-dev
+    $ sudo apt install git python3-virtualenv libasound2-dev pkg-config libsystemd-dev
 
 Prepare the development environment. If you are an external contributor and
 plan on submitting some changes, you will have to [fork the Checkbox repository


### PR DESCRIPTION
## Description

The `pkg-config` and `libsystemd-dev` packages are needed for building checkbox, but they are not in the documentation. Without them, the command "python3 -m pip install -e ." (which appears later in the documentation) fails.

Without pkg-config, I got this error:

```log
      FileNotFoundError: [Errno 2] No such file or directory: 'pkg-config'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
```

Without libsystemd-dev, I got this error:

```log
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [12 lines of output]
      Cannot find libsystemd or libsystemd-journal:
      
      Package libsystemd was not found in the pkg-config search path.
      Perhaps you should add the directory containing `libsystemd.pc'
      to the PKG_CONFIG_PATH environment variable
      Package 'libsystemd', required by 'virtual:world', not found
      
      Package libsystemd-journal was not found in the pkg-config search path.
      Perhaps you should add the directory containing `libsystemd-journal.pc'
      to the PKG_CONFIG_PATH environment variable
      Package 'libsystemd-journal', required by 'virtual:world', not found
      
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
```

To solve this, add them to the command that installs system packages for checkbox development.

## Documentation

This contribution makes changes to the contributor's documentation itself, in the `CONTRIBUTORS.md` file.
