### PR TITLE
Fix clear old sessions for local (BugFix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
+++ b/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
@@ -73,7 +73,7 @@ def handle_top_parser(args, ctx):
         logging.basicConfig(level=logging_level)
         set_all_loggers_level(logging.DEBUG)
         ctx.args.debug = True
-    if "--verbose" in sys.argv or "-v" in sys.argv:
+    elif "--verbose" in sys.argv or "-v" in sys.argv:
         logging_level = logging.INFO
         logging.basicConfig(level=logging_level)
         set_all_loggers_level(logging.INFO)

--- a/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
+++ b/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
@@ -22,14 +22,14 @@ Checkbox Launcher Interpreter Application
 
 import gettext
 import logging
-import os
-import subprocess
 import sys
+
+import checkbox_ng
 
 from plainbox.impl.jobcache import ResourceJobCache
 from plainbox.impl.session.assistant import SessionAssistant
 
-from checkbox_ng.config import load_configs
+from checkbox_ng.utils import set_all_loggers_level
 from checkbox_ng.launcher.subcommands import (
     Launcher,
     List,
@@ -60,6 +60,35 @@ class Context:
 
     def reset_sa(self):
         self.sa = SessionAssistant()
+
+
+def handle_top_parser(args, ctx):
+    """
+    The top level parser may not contain all args as "launcher" is inserted
+    to get a default command. Lets handle the args as stings here and unify the
+    args (from the top level parser) and ctx.args (from the sub parser)
+    """
+    if "--debug" in sys.argv:
+        logging_level = logging.DEBUG
+        logging.basicConfig(level=logging_level)
+        set_all_loggers_level(logging.DEBUG)
+        ctx.args.debug = True
+    if "--verbose" in sys.argv or "-v" in sys.argv:
+        logging_level = logging.INFO
+        logging.basicConfig(level=logging_level)
+        set_all_loggers_level(logging.INFO)
+        ctx.args.verbose = True
+    if "--clear-cache" in sys.argv:
+        ResourceJobCache().clear()
+        ctx.args.clear_cache = True
+    if "--clear-old-sessions" in sys.argv:
+        old_sessions = [s[0] for s in ctx.sa.get_old_sessions()]
+        ctx.sa.delete_sessions(old_sessions)
+        ctx.args.clear_old_sessions = True
+    if "--version" in sys.argv:
+        print(checkbox_ng.__version__)
+        raise SystemExit(0)
+    return ctx
 
 
 def main():
@@ -105,6 +134,7 @@ def main():
             )
 
     top_parser = argparse.ArgumentParser()
+    # You must handle these args in the function above, see docstring
     top_parser.add_argument(
         "-v",
         "--verbose",
@@ -148,21 +178,7 @@ def main():
     sub_args = subcmd_parser.parse_args(sys.argv[subcmd_index + 1 :])
     sa = SessionAssistant()
     ctx = Context(sub_args, sa)
-    try:
-        socket.getaddrinfo("localhost", 443)  # 443 for HTTPS
-    except Exception:
-        pass
-    if "--clear-cache" in sys.argv:
-        ResourceJobCache().clear()
-    if "--clear-old-sessions" in sys.argv:
-        old_sessions = [s[0] for s in sa.get_old_sessions()]
-        sa.delete_sessions(old_sessions)
-    if args.verbose:
-        logging_level = logging.INFO
-        logging.basicConfig(level=logging_level)
-    if args.debug:
-        logging_level = logging.DEBUG
-        logging.basicConfig(level=logging_level)
+    ctx = handle_top_parser(args, ctx)
     return subcmd.invoked(ctx)
 
 

--- a/checkbox-ng/checkbox_ng/launcher/test_checkbox_cli.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_checkbox_cli.py
@@ -76,7 +76,7 @@ class TestHandleTopParser(TestCase):
     def test_clear_cache(self, mock_cache):
         ctx = mock.MagicMock()
         result = handle_top_parser(None, ctx)
-        mock_cache().clear.assert_called_once()
+        self.assertTrue(mock_cache().clear.called)
         self.assertTrue(result.args.clear_cache)
 
     @mock.patch("sys.argv", ["--clear-old-sessions"])

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -724,13 +724,29 @@ class TestLauncher(TestCase):
     def test__auto_resume_session_autoresume(self):
         self_mock = MagicMock()
         resume_candidate_mock = MagicMock(id="session_to_resume")
+        # session id wasnt provided directly via the cli
         self_mock.ctx.args.session_id = None
+        # --clear-old-sessions wasn't used
+        self_mock.ctx.args.clear_old_sessions = False
         self_mock._should_autoresume_last_run.return_value = True
 
         self.assertTrue(
             Launcher._auto_resume_session(self_mock, [resume_candidate_mock])
         )
         self.assertTrue(self_mock._resume_session.called)
+
+    def test__auto_resume_session_no_autoresume_on_clear(self):
+        self_mock = MagicMock()
+        resume_candidate_mock = MagicMock(id="session_to_resume")
+        # session id wasnt provided directly via the cli
+        self_mock.ctx.args.session_id = None
+        # --clear-old-sessions was used, so we don't autoresume
+        self_mock.ctx.args.clear_old_sessions = True
+
+        self.assertFalse(
+            Launcher._auto_resume_session(self_mock, [resume_candidate_mock])
+        )
+        self.assertFalse(self_mock._resume_session.called)
 
     def test__auto_resume_session_no_autoresume(self):
         self_mock = MagicMock()

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -724,7 +724,7 @@ class TestLauncher(TestCase):
     def test__auto_resume_session_autoresume(self):
         self_mock = MagicMock()
         resume_candidate_mock = MagicMock(id="session_to_resume")
-        # session id wasnt provided directly via the cli
+        # session id wasn't provided directly via the cli
         self_mock.ctx.args.session_id = None
         # --clear-old-sessions wasn't used
         self_mock.ctx.args.clear_old_sessions = False
@@ -738,7 +738,7 @@ class TestLauncher(TestCase):
     def test__auto_resume_session_no_autoresume_on_clear(self):
         self_mock = MagicMock()
         resume_candidate_mock = MagicMock(id="session_to_resume")
-        # session id wasnt provided directly via the cli
+        # session id wasn't provided directly via the cli
         self_mock.ctx.args.session_id = None
         # --clear-old-sessions was used, so we don't autoresume
         self_mock.ctx.args.clear_old_sessions = True

--- a/checkbox-ng/checkbox_ng/test_utils.py
+++ b/checkbox-ng/checkbox_ng/test_utils.py
@@ -17,7 +17,7 @@
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-from checkbox_ng.utils import newline_join
+from checkbox_ng.utils import newline_join, set_all_loggers_level
 
 """Tests for checkbox_ng.utils"""
 
@@ -43,3 +43,27 @@ class TestNewlineJoin(unittest.TestCase):
     def test_newline_join_with_no_arguments(self):
         expected_result = ""
         self.assertEqual(newline_join(""), expected_result)
+
+
+class TestSetAllLoggersLevel(unittest.TestCase):
+    @unittest.mock.patch("checkbox_ng.utils.logging")
+    def test_set_all_loggers_level(self, logging_mock):
+        class FakeLogger:
+            def __init__(self, name, level):
+                self.name = name
+                self.level = level
+
+            def setLevel(self, level):
+                self.level = level
+
+        logging_mock.root.manager.loggerDict = {
+            "some": FakeLogger("some", 10),
+            "other": FakeLogger("other", 230),
+        }
+        set_all_loggers_level(0)
+        self.assertTrue(
+            all(
+                x.level == 0
+                for x in logging_mock.root.manager.loggerDict.values()
+            )
+        )

--- a/checkbox-ng/checkbox_ng/utils.py
+++ b/checkbox-ng/checkbox_ng/utils.py
@@ -20,10 +20,23 @@
 Generic utility functions.
 """
 import json
+import logging
 import textwrap
 import datetime
 
 from plainbox.impl.color import Colorizer
+
+
+def set_all_loggers_level(level):
+    """
+    Sets the level of loggers already instantiated
+    """
+    logging.root.setLevel(level)
+    for logger in logging.root.manager.loggerDict.values():
+        try:
+            logger.setLevel(level)
+        except AttributeError:
+            pass
 
 
 def newline_join(head: str, *tail: str) -> str:

--- a/checkbox-ng/plainbox/impl/session/resume.py
+++ b/checkbox-ng/plainbox/impl/session/resume.py
@@ -491,6 +491,7 @@ class MetaDataHelper7MixIn(MetaDataHelper6MixIn):
             session_repr["metadata"],
             key="last_job_start_time",
             value_type=float,
+            value_none=True,
         )
 
 

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -172,7 +172,7 @@ class Scenario:
                 self._assign_outcome(*outcome)
         else:
             if self.launcher:
-                cmd = self.LAUNCHER_PATH
+                cmd += " " + self.LAUNCHER_PATH
             outcome = self.local_machine.start(
                 cmd=cmd,
                 env=self.environment,

--- a/metabox/metabox/core/utils.py
+++ b/metabox/metabox/core/utils.py
@@ -18,6 +18,7 @@
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 import re
 from typing import NamedTuple
+from subprocess import CalledProcessError
 
 __all__ = ("tag", "ExecuteResult")
 
@@ -37,6 +38,13 @@ class ExecuteResult(NamedTuple):
     stdout: str
     stderr: str
     outstr_full: str
+
+    def check(self, timeout=0):
+        if self.exit_code == 0:
+            return True
+        raise CalledProcessError(
+            self.exit_code, "", output=self.stdout, stderr=self.stderr
+        )
 
 
 class _re:

--- a/metabox/metabox/tools/session_corruptor.py
+++ b/metabox/metabox/tools/session_corruptor.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 
 def corrupt(path):
-    with gzip.open(str(path), "rb") as f:
+    with gzip.open(str(path), "rt") as f:
         session = json.load(f)
     session["session"]["desired_job_list"].append(
         "@ invalid id - intentionally corrupted session"

--- a/metabox/metabox/tools/session_corruptor.py
+++ b/metabox/metabox/tools/session_corruptor.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 
 def corrupt(path):
-    with gzip.open(str(path)) as f:
+    with gzip.open(str(path), "rb") as f:
         session = json.load(f)
     session["session"]["desired_job_list"].append(
         "@ invalid id - intentionally corrupted session"

--- a/metabox/metabox/tools/session_corruptor.py
+++ b/metabox/metabox/tools/session_corruptor.py
@@ -1,0 +1,24 @@
+import gzip
+import json
+
+from pathlib import Path
+
+
+def corrupt(path):
+    with gzip.open(str(path)) as f:
+        session = json.load(f)
+    session["session"]["desired_job_list"].append(
+        "@ invalid id - intentionally corrupted session"
+    )
+    with gzip.open(str(path), "wt") as f:
+        json.dump(session, f)
+
+
+def main():
+    for session in Path("/var/tmp/checkbox-ng/sessions").glob("*/session"):
+        print("Corrupting session", str(session))
+        corrupt(session)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This fixes the `--clear-old-sessions` flag being overall ignored, also, it fixes the way that these flags are used for local only.

Lastly, it fixes a missing catch for both local and remote, that would make the agent crash when a selected job is deleted (from an update or manually) and a session is then resumed (as the error won't be InvalidJobError but CorruptedSessionError).

## Resolved issues

Fixes: CHECKBOX-1710

## Documentation

N/A

## Tests

New metabox test that stresses this scenario for local
