### PR TITLE
Run `ethernet/ping_interface` unless hidden manifest set (e.g. lab runs) (new)

### DIFF
--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -155,13 +155,14 @@ jobs:
         run: |
           OUTPUT=$(python3 tools/compare_manifests.py manifest_main.json manifest_pr.json)
           if [[ "$OUTPUT" ]]; then
+            echo "Differences: $OUTPUT"
             echo "New hidden manifest entries found. Checking DUT configuration in the lab..."
             curl -X POST \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${DUT_CONFIG_TOKEN}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/canonical/ce-oem-dut-checkbox-configuration/dispatches \
-              -d '{"event_type":"check-missing-manifests","client_payload":{"manifest-entries":"$OUTPUT", "commit": "${{ github.sha }}"}}'
+              -d "{\"event_type\":\"check-missing-manifests\",\"client_payload\":{\"manifest-entries\":\"$OUTPUT\", \"commit\": \"${{ github.sha }}\"}}"
           else
             echo "No new hidden manifest entries found. No need to check DUT configuration in the lab."
           fi

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -116,3 +116,52 @@ jobs:
           else
             echo "No diff found"
           fi
+
+  check_missing_manifests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Checkbox monorepo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install dependencies, Checkbox and providers
+        run: |
+          sudo apt update
+          sudo apt install -y -qq python3 python3-venv jq libsystemd-dev
+          python3 -m venv venv
+          . venv/bin/activate
+          python3 -m pip install checkbox-ng/
+          python3 -m pip install checkbox-support/
+          python3 providers/resource/manage.py develop
+          python3 providers/base/manage.py develop
+          python3 providers/certification-client/manage.py develop
+          python3 providers/tpm2/manage.py develop
+          python3 providers/sru/manage.py develop
+      - name: Export manifest entries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # we are on current branch/commit
+          . venv/bin/activate
+          # Export list of manifest entries as a JSON array
+          checkbox-cli list 'manifest entry' | python -c 'import sys, json;print(json.dumps([m.replace("manifest entry","").strip().strip("\'") for m in sys.stdin.readlines()]))' > manifest_pr.json
+          git checkout origin/main
+          checkbox-cli list 'manifest entry' | python -c 'import sys, json;print(json.dumps([m.replace("manifest entry","").strip().strip("\'") for m in sys.stdin.readlines()]))' > manifest_main.json
+          # back to PR branch
+          git checkout -
+      - name: Trigger workflow in DUT config repo
+        run: |
+          OUTPUT=$(python3 tools/compare_manifests.py manifest_main.json manifest_pr.json)
+          if [[ "$OUTPUT" ]]; then
+            echo "New hidden manifest entries found. Checking DUT configuration in the lab..."
+            curl -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.DUT_CONFIG_PAT }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/canonical/ce-oem-dut-checkbox-configuration/actions/dispatches \
+              -d '{"event_type":"check-missing-manifests","client_payload":{"manifest-entries":"$OUTPUT", "commit": "${{ github.sha }}"}}'
+              -d '{"ref":"main","inputs":{"manifest-entries":"$OUTPUT"}}'
+          else
+            echo "No new hidden manifest entries found. No need to check DUT configuration in the lab."
+

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -139,9 +139,6 @@ jobs:
           python3 providers/tpm2/manage.py develop
           python3 providers/sru/manage.py develop
       - name: Export manifest entries
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DUT_CONFIG_TOKEN: ${{ secrets.DUT_CONFIG_PAT }}
         run: |
           # we are on current branch/commit
           . venv/bin/activate
@@ -152,6 +149,9 @@ jobs:
           # back to PR branch
           git checkout -
       - name: Trigger workflow in DUT config repo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DUT_CONFIG_TOKEN: ${{ secrets.DUT_CONFIG_PAT }}
         run: |
           OUTPUT=$(python3 tools/compare_manifests.py manifest_main.json manifest_pr.json)
           if [[ "$OUTPUT" ]]; then

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -141,6 +141,7 @@ jobs:
       - name: Export manifest entries
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DUT_CONFIG_TOKEN: ${{ secrets.DUT_CONFIG_PAT }}
         run: |
           # we are on current branch/commit
           . venv/bin/activate
@@ -157,11 +158,10 @@ jobs:
             echo "New hidden manifest entries found. Checking DUT configuration in the lab..."
             curl -X POST \
               -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer ${{ secrets.DUT_CONFIG_PAT }}" \
+              -H "Authorization: Bearer ${DUT_CONFIG_TOKEN}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/canonical/ce-oem-dut-checkbox-configuration/dispatches \
               -d '{"event_type":"check-missing-manifests","client_payload":{"manifest-entries":"$OUTPUT", "commit": "${{ github.sha }}"}}'
-              -d '{"ref":"main","inputs":{"manifest-entries":"$OUTPUT"}}'
           else
             echo "No new hidden manifest entries found. No need to check DUT configuration in the lab."
           fi

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -164,4 +164,5 @@ jobs:
               -d '{"ref":"main","inputs":{"manifest-entries":"$OUTPUT"}}'
           else
             echo "No new hidden manifest entries found. No need to check DUT configuration in the lab."
+          fi
 

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -145,9 +145,9 @@ jobs:
           # we are on current branch/commit
           . venv/bin/activate
           # Export list of manifest entries as a JSON array
-          checkbox-cli list 'manifest entry' | python -c 'import sys, json;print(json.dumps([m.replace("manifest entry","").strip().strip("\'") for m in sys.stdin.readlines()]))' > manifest_pr.json
+          checkbox-cli list 'manifest entry' | python -c 'import sys, json;print(json.dumps([m.replace("manifest entry","").strip().strip('\'') for m in sys.stdin.readlines()]))' > manifest_pr.json
           git checkout origin/main
-          checkbox-cli list 'manifest entry' | python -c 'import sys, json;print(json.dumps([m.replace("manifest entry","").strip().strip("\'") for m in sys.stdin.readlines()]))' > manifest_main.json
+          checkbox-cli list 'manifest entry' | python -c 'import sys, json;print(json.dumps([m.replace("manifest entry","").strip().strip('\'') for m in sys.stdin.readlines()]))' > manifest_main.json
           # back to PR branch
           git checkout -
       - name: Trigger workflow in DUT config repo

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -154,6 +154,7 @@ jobs:
           DUT_CONFIG_TOKEN: ${{ secrets.DUT_CONFIG_PAT }}
         run: |
           OUTPUT=$(python3 tools/compare_manifests.py manifest_main.json manifest_pr.json)
+          COMMIT=$(git rev-parse HEAD)
           if [[ "$OUTPUT" ]]; then
             echo "Differences: $OUTPUT"
             echo "New hidden manifest entries found. Checking DUT configuration in the lab..."
@@ -162,7 +163,7 @@ jobs:
               -H "Authorization: Bearer ${DUT_CONFIG_TOKEN}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/canonical/ce-oem-dut-checkbox-configuration/dispatches \
-              -d "{\"event_type\":\"check-missing-manifests\",\"client_payload\":{\"manifest-entries\":\"$OUTPUT\", \"commit\": \"${{ github.sha }}\"}}"
+              -d "{\"event_type\":\"check-missing-manifests\",\"client_payload\":{\"manifest-entries\":\"$OUTPUT\", \"commit\": \"$COMMIT\"}}"
           else
             echo "No new hidden manifest entries found. No need to check DUT configuration in the lab."
           fi

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -145,9 +145,9 @@ jobs:
           # we are on current branch/commit
           . venv/bin/activate
           # Export list of manifest entries as a JSON array
-          checkbox-cli list 'manifest entry' | python -c 'import sys, json;print(json.dumps([m.replace("manifest entry","").strip().strip('\'') for m in sys.stdin.readlines()]))' > manifest_pr.json
+          checkbox-cli list 'manifest entry' --format=json > manifest_pr.json
           git checkout origin/main
-          checkbox-cli list 'manifest entry' | python -c 'import sys, json;print(json.dumps([m.replace("manifest entry","").strip().strip('\'') for m in sys.stdin.readlines()]))' > manifest_main.json
+          checkbox-cli list 'manifest entry' --format=json > manifest_main.json
           # back to PR branch
           git checkout -
       - name: Trigger workflow in DUT config repo

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -159,7 +159,7 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.DUT_CONFIG_PAT }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/canonical/ce-oem-dut-checkbox-configuration/actions/dispatches \
+              https://api.github.com/repos/canonical/ce-oem-dut-checkbox-configuration/dispatches \
               -d '{"event_type":"check-missing-manifests","client_payload":{"manifest-entries":"$OUTPUT", "commit": "${{ github.sha }}"}}'
               -d '{"ref":"main","inputs":{"manifest-entries":"$OUTPUT"}}'
           else

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -362,6 +362,13 @@ When non-blocking issues are encountered by the reviewer, they mark the PR "appr
 
 They are not confident in making a call, delegating explicitly in a comment to a reviewer who they believe _can_ make a call, as quickly and as early as possible in the process.
 
+### New hidden manifest entry
+
+If your PR is about adding a new hidden [manifest entry], please ensure this
+new entry has been input in the configuration (`manifest.json`) file used by
+the devices in the lab. This is currently done by modifying the manifest files
+in a [separate repository].
+
 ## Documentation
 
 [Checkbox documentation] lives in the `docs/` directory and is deployed on
@@ -423,3 +430,5 @@ changes using a pull request.
 [sign your commits]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
 [github-runner-operator]: https://github.com/canonical/github-runner-operator
 [this SO thread]: https://stackoverflow.com/a/70484849/504931
+[manifest entry]: https://canonical-checkbox.readthedocs-hosted.com/en/stable/reference/units/manifest-entry.html
+[separate repository]: https://github.com/canonical/ce-oem-dut-checkbox-configuration

--- a/providers/base/units/ethernet/jobs.pxu
+++ b/providers/base/units/ethernet/jobs.pxu
@@ -209,6 +209,9 @@ template-resource: device
 template-filter: device.category == 'NETWORK' and device.interface != 'UNKNOWN'
 id: ethernet/ping_{interface}
 template-id: ethernet/ping_interface
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest._ignore_disconnected_ethernet_interfaces == 'False'
 _summary: Can ping another machine over Ethernet port {interface}
 _purpose: Check Ethernet works by pinging another machine
 plugin: shell

--- a/providers/base/units/ethernet/manifest.pxu
+++ b/providers/base/units/ethernet/manifest.pxu
@@ -12,4 +12,6 @@ unit: manifest entry
 id: _ignore_disconnected_ethernet_interfaces
 _name: Ignore disconnected Ethernet interfaces
 value-type: bool
-hidden-reason: All Ethernet interfaces should be tested during enablement. However, when running regression tests in the lab, only one interface may be connected, but that should not trigger any failure.
+hidden-reason: All Ethernet interfaces should be tested during enablement.
+  However, when running regression tests in the lab, only one interface may be
+  connected, but that should not trigger any failure.

--- a/providers/base/units/ethernet/manifest.pxu
+++ b/providers/base/units/ethernet/manifest.pxu
@@ -7,3 +7,9 @@ unit: manifest entry
 id: has_ethernet_wake_on_lan_support
 _name: Wake-on-LAN support through Ethernet port
 value-type: bool
+
+unit: manifest entry
+id: _ignore_disconnected_ethernet_interfaces
+_name: Ignore disconnected Ethernet interfaces
+value-type: bool
+hidden-reason: All Ethernet interfaces should be tested during enablement. However, when running regression tests in the lab, only one interface may be connected, but that should not trigger any failure.

--- a/providers/base/units/ethernet/test-plan.pxu
+++ b/providers/base/units/ethernet/test-plan.pxu
@@ -81,6 +81,7 @@ estimated_duration: 1m
 include:
     ethernet/detect    certification-status=blocker
     ethernet/ping_.*   certification-status=blocker
+    ethernet/ping-with-any-cable-interface  certification-status=blocker
 bootstrap_include:
     device
 
@@ -112,6 +113,7 @@ estimated_duration: 1m
 include:
     after-suspend-ethernet/detect
     after-suspend-ethernet/ping_.*
+    after-suspend-ethernet/ping-with-any-cable-interface
 bootstrap_include:
     device
 

--- a/tools/compare_manifests.py
+++ b/tools/compare_manifests.py
@@ -12,12 +12,17 @@ def open_json(json_file: str) -> list[str]:
     return json_data
 
 
-def diff_manifests(manifest1: list[str], manifest2: list[str]) -> list[str]:
+def diff_manifests(manifest1: list[dict], manifest2: list[dict]) -> list[str]:
     """
     Return a list of hidden manifests that are present in manifest2 but not in
     manifest1.
     """
-    return [k for k in manifest2 if k not in manifest1 if "::_" in k]
+    return [
+        k["name"]
+        for k in manifest2
+        if k not in manifest1
+        if "::_" in k["name"]
+    ]
 
 
 def main(args):

--- a/tools/compare_manifests.py
+++ b/tools/compare_manifests.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+
+
+def open_json(json_file: str) -> list[str]:
+    json_data = []
+    with open(json_file) as fp:
+        json_data = json.load(fp)
+    return json_data
+
+
+def diff_manifests(manifest1: list[str], manifest2: list[str]) -> list[str]:
+    """
+    Return a list of hidden manifests that are present in manifest2 but not in
+    manifest1.
+    """
+    return [k for k in manifest2 if k not in manifest1 if "::_" in k]
+
+
+def main(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("manifest1", help="Path to first manifest json file.")
+    parser.add_argument("manifest2", help="Path to second manifest json file.")
+    args = parser.parse_args(args)
+    manifest1 = open_json(args.manifest1)
+    manifest2 = open_json(args.manifest2)
+    print(" ".join(diff_manifests(manifest1, manifest2)))
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/test_compare_manifests.py
+++ b/tools/test_compare_manifests.py
@@ -8,25 +8,42 @@ import compare_manifests
 class CompareManifests(unittest.TestCase):
     def test_diff_manifests_different(self):
         m1 = [
-            "com.canonical.certification::_hidden",
-            "com.canonical.certification::normal",
+            {
+                "unit": "manifest entry",
+                "name": "com.canonical.certification::_hidden",
+            },
+            {
+                "unit": "manifest entry",
+                "name": "com.canonical.certification::normal",
+            },
         ]
         m2 = [
-            "com.canonical.certification::_hidden",
-            "com.canonical.certification::normal",
-            "com.canonical.certification::_hidden_new",
+            {
+                "unit": "manifest entry",
+                "name": "com.canonical.certification::_hidden",
+            },
+            {
+                "unit": "manifest entry",
+                "name": "com.canonical.certification::normal",
+            },
+            {
+                "unit": "manifest entry",
+                "name": "com.canonical.certification::_hidden_new",
+            },
         ]
         result = compare_manifests.diff_manifests(m1, m2)
         self.assertEqual(result, ["com.canonical.certification::_hidden_new"])
 
     def test_diff_manifests_similar(self):
-        m1 = [
-            "com.canonical.certification::_hidden",
-            "com.canonical.certification::normal",
+        m = [
+            {
+                "unit": "manifest entry",
+                "name": "com.canonical.certification::_hidden",
+            },
+            {
+                "unit": "manifest entry",
+                "name": "com.canonical.certification::normal",
+            },
         ]
-        m2 = [
-            "com.canonical.certification::_hidden",
-            "com.canonical.certification::normal",
-        ]
-        result = compare_manifests.diff_manifests(m1, m2)
+        result = compare_manifests.diff_manifests(m, m)
         self.assertEqual(result, [])

--- a/tools/test_compare_manifests.py
+++ b/tools/test_compare_manifests.py
@@ -1,0 +1,32 @@
+import io
+import unittest
+from unittest.mock import patch
+
+import compare_manifests
+
+
+class CompareManifests(unittest.TestCase):
+    def test_diff_manifests_different(self):
+        m1 = [
+            "com.canonical.certification::_hidden",
+            "com.canonical.certification::normal",
+        ]
+        m2 = [
+            "com.canonical.certification::_hidden",
+            "com.canonical.certification::normal",
+            "com.canonical.certification::_hidden_new",
+        ]
+        result = compare_manifests.diff_manifests(m1, m2)
+        self.assertEqual(result, ["com.canonical.certification::_hidden_new"])
+
+    def test_diff_manifests_similar(self):
+        m1 = [
+            "com.canonical.certification::_hidden",
+            "com.canonical.certification::normal",
+        ]
+        m2 = [
+            "com.canonical.certification::_hidden",
+            "com.canonical.certification::normal",
+        ]
+        result = compare_manifests.diff_manifests(m1, m2)
+        self.assertEqual(result, [])


### PR DESCRIPTION
<!--




Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

Use newly introduced hidden manifest (see #1699) to condition the run of the `ethernet/ping_interface` template jobs. This way, in the lab where devices with multiple Ethernet interfaces usually only have one of them connected, these jobs can be skipped and the generic `ethernet/ping-with-any-cable-interface` job can be run instead (validating that the Ethernet feature works to connect to ping the gateway). To that effect, `ethernet/ping-with-any-cable-interface` is added to the `ethernet-automated` and `after-suspend-ethernet-automated` test plans, alongside the `ethernet/ping_interface` template.



## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/RTW-401

## Documentation

The hidden manifest has a `hidden-reason` field which helps for documentation.

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Create the following launcher (`my-launcher`):

```
[launcher]
launcher_version = 1
app_id = com.canonical.certification:RTW401
stock_reports = text

[test plan]
unit = com.canonical.certification::ethernet-automated
forced = yes

[test selection]
forced = yes

[manifest]
com.canonical.certification::_ignore_disconnected_ethernet_interfaces = true
```

and execute it:

```
$ checkbox-cli my-launcher
```

Observe that the `ping_{interface}` template jobs are skipped, and the `ping-with-any-cable-interface` is run:

```
==============[ Running job 3 / 4. Estimated time left: 0:00:08 ]===============
-----------[ Can ping another machine over Ethernet port enp0s31f6 ]------------
ID: com.canonical.certification::ethernet/ping_enp0s31f6
Category: com.canonical.plainbox::ethernet
Job cannot be started because:
 - resource expression "manifest._ignore_disconnected_ethernet_interfaces == 'False'" evaluates to false
Outcome: job cannot be started
==============[ Running job 4 / 4. Estimated time left: 0:00:04 ]===============
-----------[ Can ping the gateway with any cable Ethernet interface ]-----------
ID: com.canonical.certification::ethernet/ping-with-any-cable-interface
Category: com.canonical.plainbox::ethernet
... 8< -------------------------------------------------------------------------
Looking for all cable interfaces...
FAIL: Couldn't find any suitable cable interface.
------------------------------------------------------------------------- >8 ---
```

Remove the `[manifest]` section from the launcher and repeat the operation. This time, both  `ping_{interface}` template jobs and `ping-with-any-cable-interface` are run.