### PR TITLE
Add requres manifest entry to wifi scanning (BugFix)

### DIFF
--- a/providers/base/units/wireless/jobs.pxu
+++ b/providers/base/units/wireless/jobs.pxu
@@ -23,6 +23,7 @@ command:
   wifi_nmcli_test.py scan {{ interface }}
 plugin: shell
 category_id: com.canonical.plainbox::wireless
+imports: from com.canonical.plainbox import manifest
 estimated_duration: 6
 _purpose:
  Check system can find a wireless network AP nearby


### PR DESCRIPTION
## Description

The requires (or depends) is missing, this adds the requires as I think the depends is missing for a reason

## Resolved issues

Fixes: CHECKBOX-1729

## Documentation

N/A

## Tests

Modifying `/var/tmp/checkbox-ng/machine-manifest.json` to contain the following:
```json
{
  "com.canonical.certification::has_wlan_adapter": true
}
```
Running checkbox via the following runs the test:
```
$ checkbox-cli run "com.canonical.certification::device" "com.canonical.certification::wireless/wireless_scanning_.*"
[...]
==================================[ Results ]===================================
 ☑ : Collect information about hardware devices (udev)
 ☑ : Hardware Manifest
 ☑ : Identify what service is managing each physical network interface
 ☑ : Test system can discover Wi-Fi networks on wlan0
```

Setting the value in the `machine-manfiest.json` to false and running the above command again we get:
```
$ checkbox-cli run "com.canonical.certification::device" "com.canonical.certification::wireless/wireless_scanning_.*"
[...]
==============[ Running job 3 / 3. Estimated time left: 0:00:06 ]===============
--------------[ Test system can discover Wi-Fi networks on wlan0 ]--------------
ID: com.canonical.certification::wireless/wireless_scanning_wlan0
Category: com.canonical.plainbox::wireless
Job cannot be started because:
 - resource expression "manifest.has_wlan_adapter == 'True'" evaluates to false
Outcome: job cannot be started
Finalizing session that hasn't been submitted anywhere: checkbox-run-2025-02-06T14.43.10
==================================[ Results ]===================================
 ☑ : Collect information about hardware devices (udev)
 ☑ : Hardware Manifest
 ☑ : Identify what service is managing each physical network interface
 ☐ : Test system can discover Wi-Fi networks on wlan0
```
## WARNING: This modifies com.canonical.certification::sru-server
