### PR TITLE
Add 'json' as a new special formatter for list (New)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -1237,7 +1237,8 @@ class List:
             help=_(
                 (
                     "output format, as passed to print function. "
-                    "Use '?' to list possible values"
+                    "Use '?' to list possible values. "
+                    "Use 'json' to print all objects as a json"
                 )
             ),
         )
@@ -1581,10 +1582,13 @@ def print_objs(group, sa, show_attrs=False, filter_fun=None, json_repr=False):
     childrens = obj.children
     while childrens:
         obj = childrens.pop()
-        if group is None or obj.group == group:
-            obj.attrs.update({"unit": obj.group, "name": obj.name})
-            to_print.append(obj.attrs)
         childrens += obj.children or []
+        if group and obj.group != group:
+            continue
+        obj_repr = {"unit": obj.group, "name": obj.name}
+        if show_attrs:
+            obj_repr.update(obj.attrs)
+        to_print.append(obj_repr)
     json.dump(to_print, sys.stdout)
 
 

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -1551,6 +1551,7 @@ def get_all_jobs(sa):
 
 
 def print_objs(group, sa, show_attrs=False, filter_fun=None, json_repr=False):
+    # note: group is unit type (including internal units like File)
     providers = sa.get_selected_providers()
     obj = Explorer(providers).get_object_tree()
 
@@ -1575,11 +1576,13 @@ def print_objs(group, sa, show_attrs=False, filter_fun=None, json_repr=False):
     if not json_repr:
         return _show(obj, "")
 
+    assert not filter_fun, "The json exporter doesn't support filtering"
     to_print = []
     childrens = obj.children
     while childrens:
         obj = childrens.pop()
         if group is None or obj.group == group:
+            obj.attrs.update({"unit": obj.group, "name": obj.name})
             to_print.append(obj.attrs)
         childrens += obj.children or []
     json.dump(to_print, sys.stdout)

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -31,6 +31,7 @@ from plainbox.impl.unit.template import TemplateUnit
 
 from checkbox_ng.launcher.subcommands import (
     Expand,
+    List,
     Launcher,
     ListBootstrapped,
     IncompatibleJobError,
@@ -38,7 +39,76 @@ from checkbox_ng.launcher.subcommands import (
     IJobResult,
     request_comment,
     generate_resume_candidate_description,
+    print_objs,
 )
+
+
+class TestSharedFunctions(TestCase):
+    def make_unit_mock(self, **kwargs):
+        to_r = MagicMock(**kwargs)
+        try:
+            # name is a kwarg of mock, so we need to set it manually
+            to_r.name = kwargs["name"]
+        except KeyError:
+            pass
+        return to_r
+
+    def get_test_tree(self):
+        # made this uniform as the function should be able to handle any valid
+        # unit tree
+        return self.make_unit_mock(
+            group="service",
+            children=[
+                self.make_unit_mock(
+                    group="exporter",
+                    children=None,
+                    name="exporter name",
+                    attrs={"id": "exporter id"},
+                ),
+                self.make_unit_mock(
+                    group="job",
+                    name="job name",
+                    children=None,
+                    attrs={"id": "job id"},
+                ),
+            ],
+        )
+
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("checkbox_ng.launcher.subcommands.Explorer")
+    def test_print_objs_nojson(self, mock_explorer, stdout_mock):
+        mock_explorer().get_object_tree.return_value = self.get_test_tree()
+
+        print_objs(group="job", sa=MagicMock(), show_attrs=True)
+        printed = stdout_mock.getvalue()
+        self.assertIn("job name", printed)
+        self.assertIn("job id", printed)
+        self.assertNotIn("exporter id", printed)
+        self.assertNotIn("exporter id", printed)
+
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("checkbox_ng.launcher.subcommands.Explorer")
+    def test_print_objs_json(self, mock_explorer, stdout_mock):
+        mock_explorer().get_object_tree.return_value = self.get_test_tree()
+        print_objs(
+            group="job", sa=MagicMock(), show_attrs=True, json_repr=True
+        )
+        printed = stdout_mock.getvalue()
+        self.assertIn("job name", printed)
+        self.assertIn("job id", printed)
+        self.assertNotIn("exporter id", printed)
+        self.assertNotIn("exporter id", printed)
+
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("checkbox_ng.launcher.subcommands.Explorer")
+    def test_print_objs_json_print_all(self, mock_explorer, stdout_mock):
+        mock_explorer().get_object_tree.return_value = self.get_test_tree()
+        print_objs(group=None, sa=MagicMock(), show_attrs=True, json_repr=True)
+        printed = stdout_mock.getvalue()
+        self.assertIn("job name", printed)
+        self.assertIn("job id", printed)
+        self.assertIn("exporter id", printed)
+        self.assertIn("exporter id", printed)
 
 
 class TestLauncher(TestCase):

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -103,12 +103,16 @@ class TestSharedFunctions(TestCase):
     @patch("checkbox_ng.launcher.subcommands.Explorer")
     def test_print_objs_json_print_all(self, mock_explorer, stdout_mock):
         mock_explorer().get_object_tree.return_value = self.get_test_tree()
-        print_objs(group=None, sa=MagicMock(), show_attrs=True, json_repr=True)
+        print_objs(
+            group=None, sa=MagicMock(), show_attrs=False, json_repr=True
+        )
         printed = stdout_mock.getvalue()
         self.assertIn("job name", printed)
-        self.assertIn("job id", printed)
-        self.assertIn("exporter id", printed)
-        self.assertIn("exporter id", printed)
+        self.assertNotIn(
+            "job id", printed
+        )  # job id is an attr, so shouldnt be here
+        self.assertIn("exporter name", printed)
+        self.assertNotIn("exporter id", printed)  # same for exporter id
 
 
 class TestLauncher(TestCase):

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -71,6 +71,12 @@ class TestSharedFunctions(TestCase):
                     children=None,
                     attrs={"id": "job id"},
                 ),
+                self.make_unit_mock(
+                    group="template",
+                    name="template name",
+                    children=None,
+                    attrs={"id": "template id"},
+                ),
             ],
         )
 
@@ -113,6 +119,18 @@ class TestSharedFunctions(TestCase):
         )  # job id is an attr, so shouldnt be here
         self.assertIn("exporter name", printed)
         self.assertNotIn("exporter id", printed)  # same for exporter id
+
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("checkbox_ng.launcher.subcommands.Explorer")
+    def test_print_objs_json_print_all_jobs(self, mock_explorer, stdout_mock):
+        mock_explorer().get_object_tree.return_value = self.get_test_tree()
+        print_objs(
+            group="all-jobs", sa=MagicMock(), show_attrs=False, json_repr=True
+        )
+        printed = stdout_mock.getvalue()
+        self.assertIn("job name", printed)
+        self.assertIn("template name", printed)
+        self.assertNotIn("exporter name", printed)
 
 
 class TestLauncher(TestCase):


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Often we want list to expose some data that then we query and modify via grep/sed, this is not a great way to go about it and we would prefer using jq (especially because --format is hard to use effectively). This adds the possibility to do it.

## Resolved issues

N/A

## Documentation

Help string was updated

## Tests

The addition (and the printer itself) was updated. 

To test this run: (this will list all jobs)
```
checkbox-cli list 'job' --format=json --attrs | jq 
```

To test this run: (this will list all manifests)
```
checkbox-cli list 'manifest entry' --format=json --attrs | jq 
```

Small additional proof of this working:
- all jobs
```
(venv)  checkbox-ng (list_json) >  checkbox-cli list all-jobs | grep "id: " | wc -l 
1462
(venv)  checkbox-ng (list_json) >  checkbox-cli list all-jobs -f json --attrs | jq ".[] | .id"   | wc -l
1462
```
- jobs
```
(venv)  checkbox-ng (list_json) >  checkbox-cli list job  | wc -l
1119
(venv)  checkbox-ng (list_json) >  checkbox-cli list job -f json --attrs | jq ".[] | .id"   | wc -l
1119
```
template:
```
(venv)  checkbox-ng (list_json) >  checkbox-cli list template -f json --attrs | jq ".[] | .id"   | wc -l
343
(venv)  checkbox-ng (list_json) >  checkbox-cli list template  | wc -l
Skipped file: /home/h25/prj/canonical/checkbox/metabox/metabox/metabox-provider/units/some.yaml
343
```
manifest entry
```
(venv)  checkbox-ng (list_json) >  checkbox-cli list "manifest entry" -f json --attrs | jq ".[] | .id"   | wc -l
98
(venv)  checkbox-ng (list_json) >  checkbox-cli list "manifest entry"  | wc -l
98
```