### PR TITLE
providers/base/bin/stress-ng-test.py Provide the exact command executed for each stressor (New)

### DIFF
--- a/providers/base/bin/stress_ng_test.py
+++ b/providers/base/bin/stress_ng_test.py
@@ -81,6 +81,7 @@ class StressNg:
         command = "stress-ng --aggressive --verify --timeout {} {} {}".format(
             self.sng_timeout, self.extra_options, stressor_list
         )
+        print("Running command: {}".format(command))
         time_str = time.strftime("%d %b %H:%M", time.gmtime())
         if len(self.stressors) == 1:
             print(


### PR DESCRIPTION
Provide the exact command executed for each stressor or set of stressors. Fixes CHECKBOX-1734

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
Short addition to provide the exact command checkbox runs for a given stressor or set of stressors in the stress-ng tests to make it easier to later re-run a single stressor by hand when investigating failures.

## Resolved issues

Resolves CHECKBOX-1734
Resolves #1713

## Documentation

No docs changes needed.

## Tests

Executed cpu, disk and memory stress tests locally (using very abbreviated runtimes) to confirm that the commands were provided for each test case.  In the case of the disk and memory tests, which run them individually, output looks like this:

```
$ sudo ./stress_ng_test.py disk -d /dev/sdc -b 1
Using test directory: '/mnt/sdc/tmp/stress-ng-33748cb3-e56f-11ef-a0bc-d8bbc1046e12'
Estimated total run time is 0 minutes

Running command: stress-ng --aggressive --verify --timeout 1 --temp-path /mnt/sdc/tmp/stress-ng-33748cb3-e56f-11ef-a0bc-d8bbc1046e12 --hdd-opts dsync --readahead-bytes 16M -k --aio 0
07 Feb 16:18: Running stress-ng aio stressor for 1 seconds...
stress-ng: info:  [2993691] setting to a 1 secs run per stressor
stress-ng: info:  [2993691] dispatching hogs: 20 aio
stress-ng: info:  [2993691] skipped: 0
stress-ng: info:  [2993691] passed: 19: aio (19)
stress-ng: info:  [2993691] failed: 0
stress-ng: info:  [2993691] metrics untrustworthy: 0
stress-ng: info:  [2993691] successful run completed in 1.05 secs

Running command: stress-ng --aggressive --verify --timeout 1 --temp-path /mnt/sdc/tmp/stress-ng-33748cb3-e56f-11ef-a0bc-d8bbc1046e12 --hdd-opts dsync --readahead-bytes 16M -k --aiol 0
07 Feb 16:18: Running stress-ng aiol stressor for 1 seconds...
stress-ng: info:  [2993761] setting to a 1 secs run per stressor
stress-ng: info:  [2993761] dispatching hogs: 20 aiol
stress-ng: info:  [2993761] skipped: 0
stress-ng: info:  [2993761] passed: 19: aiol (19)
stress-ng: info:  [2993761] failed: 0
stress-ng: info:  [2993761] metrics untrustworthy: 0
stress-ng: info:  [2993761] successful run completed in 1.08 secs
```

and for CPU:
`
$ sudo ./stress_ng_test.py cpu -b 1
Estimated total run time is 0 minutes

Running command: stress-ng --aggressive --verify --timeout 1 --metrics-brief --tz --times --af-alg 0 --bsearch 0 --context 0 --cpu 0 --crypt 0 --hsearch 0 --longjmp 0 --lsearch 0 --matrix 0 --qsort 0 --str 0 --stream 0 --tsearch 0 --vecmath 0 --wcs 0
07 Feb 17:15: Running multiple stress-ng stressors in parallel for 1
seconds...
`
