### PR TITLE
Added tests for IOMMU config (New)

### DIFF
--- a/providers/base/bin/kernel_config.py
+++ b/providers/base/bin/kernel_config.py
@@ -30,8 +30,8 @@ def get_kernel_config_path():
     kernel_version = os.uname().release
     if on_ubuntucore():
         kernel_snap = get_kernel_snap()
-        return f"/snap/{kernel_snap}/current/config-{kernel_version}"
-    return f"/boot/config-{kernel_version}"
+        return "/snap/{}/current/config-{}".format(kernel_snap, kernel_version)
+    return "/boot/config-{}".format(kernel_version)
 
 
 def get_configuration(output=None):
@@ -69,7 +69,7 @@ def check_flag(flag, min_version):
                 print("Flag {} is present and set to 'y'.".format(flag))
                 return
 
-    raise SystemExit("Flag {} not found in the config.".format(flag))
+    raise SystemExit("Flag {} not found in the kernel config.".format(flag))
 
 
 def parse_args():

--- a/providers/base/bin/kernel_config.py
+++ b/providers/base/bin/kernel_config.py
@@ -16,7 +16,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
-
 import argparse
 import os
 import shutil
@@ -55,7 +54,7 @@ def check_flag(flag, min_version):
         min_version
     ):
         print(
-            "Skipping flag check as kernel version"
+            "Skipping: kernel version"
             " {} is lower than {}.".format(kernel_version, min_version)
         )
         return
@@ -70,7 +69,7 @@ def check_flag(flag, min_version):
                 print("Flag {} is present and set to 'y'.".format(flag))
                 return
 
-    raise SystemExit("Flag {} not found in the kernel config.".format(flag))
+    raise SystemExit("Flag {} not found in the config.".format(flag))
 
 
 def parse_args():

--- a/providers/base/bin/kernel_config.py
+++ b/providers/base/bin/kernel_config.py
@@ -54,8 +54,9 @@ def check_flag(flag, min_version):
         min_version
     ):
         print(
-            "Skipping: kernel version"
-            " {} is lower than {}.".format(kernel_version, min_version)
+            "Kernel version is {}.".format(kernel_version),
+            "Versions lower than {} don't require ".format(min_version),
+            "the flag {} to be set.".format(flag),
         )
         return
 
@@ -63,18 +64,9 @@ def check_flag(flag, min_version):
     with open(kernel_config_path) as config:
         # Check the header and ignore arm architecture configurations
         lines = config.readlines()
-        header = lines[:4]
-        values = lines[4:]
-
-        for line in header:
-            if "Kernel Configuration" in line:
-                if "arm" in line:
-                    print("Skipping: arm architecture detected.")
-                    return
-                break
 
         # Look for the flag in the configuration
-        for line in values:
+        for line in lines:
             line = line.strip()
             if line.startswith("#"):
                 continue  # Ignore commented lines

--- a/providers/base/bin/kernel_config.py
+++ b/providers/base/bin/kernel_config.py
@@ -74,7 +74,7 @@ def check_flag(flag, min_version):
             line = line.strip()
             if line.startswith("#"):
                 continue  # Ignore commented lines
-            if line == "{}=y".format(flag):
+            if "{}=y".format(flag) in line:
                 print("Flag {} is present and set to 'y'.".format(flag))
                 return
 

--- a/providers/base/bin/kernel_config.py
+++ b/providers/base/bin/kernel_config.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2025 Canonical Ltd.
+# Authors:
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import os
+import shutil
+from packaging import version
+
+from checkbox_support.snap_utils.system import get_kernel_snap
+from checkbox_support.snap_utils.system import on_ubuntucore
+
+
+def get_kernel_config_path():
+    """Retrieve the path to the kernel configuration file."""
+    kernel_version = os.uname().release
+    if on_ubuntucore():
+        kernel_snap = get_kernel_snap()
+        return f"/snap/{kernel_snap}/current/config-{kernel_version}"
+    return f"/boot/config-{kernel_version}"
+
+
+def get_configuration(output=None):
+    """Retrieve and optionally save the kernel configuration."""
+    kernel_config_path = get_kernel_config_path()
+    if output:
+        shutil.copy2(kernel_config_path, output)
+    else:
+        with open(kernel_config_path) as config:
+            print(config.read())
+
+
+def check_flag(flag, min_version):
+    """Check if a specific flag is true in the kernel configuration starting
+    from a specific version."""
+
+    version_parts = os.uname().release.split("-")
+    kernel_version = "-".join(version_parts[:2])
+    if min_version and version.parse(kernel_version) < version.parse(
+        min_version
+    ):
+        print(
+            "Skipping flag check as kernel version"
+            " {} is lower than {}.".format(kernel_version, min_version)
+        )
+        return
+
+    kernel_config_path = get_kernel_config_path()
+    with open(kernel_config_path) as config:
+        for line in config:
+            line = line.strip()
+            if line.startswith("#"):
+                continue  # Ignore commented lines
+            if line == "{}=y".format(flag):
+                print("Flag {} is present and set to 'y'.".format(flag))
+                return
+
+    raise SystemExit("Flag {} not found in the kernel config.".format(flag))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output", "-o", help="Output file to store the kernel configuration"
+    )
+    parser.add_argument(
+        "--config-flag",
+        "-c",
+        help="Check if a specific flag is present in the configuration",
+    )
+    parser.add_argument(
+        "--min-version",
+        "-m",
+        help="Minimum kernel version required to check the flag",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if args.config_flag:
+        check_flag(args.config_flag, args.min_version)
+    else:
+        get_configuration(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/base/bin/kernel_config.py
+++ b/providers/base/bin/kernel_config.py
@@ -61,6 +61,15 @@ def check_flag(flag, min_version):
 
     kernel_config_path = get_kernel_config_path()
     with open(kernel_config_path) as config:
+        # Check the header and ignore arm architecture configurations
+        for line in config:
+            if "Kernel Configuration" in line:
+                if "arm" in line:
+                    print("Skipping: arm architecture detected.")
+                    return
+                break
+
+        # Look for the flag in the configuration
         for line in config:
             line = line.strip()
             if line.startswith("#"):

--- a/providers/base/bin/kernel_config.py
+++ b/providers/base/bin/kernel_config.py
@@ -62,7 +62,11 @@ def check_flag(flag, min_version):
     kernel_config_path = get_kernel_config_path()
     with open(kernel_config_path) as config:
         # Check the header and ignore arm architecture configurations
-        for line in config:
+        lines = config.readlines()
+        header = lines[:4]
+        values = lines[4:]
+
+        for line in header:
             if "Kernel Configuration" in line:
                 if "arm" in line:
                     print("Skipping: arm architecture detected.")
@@ -70,7 +74,7 @@ def check_flag(flag, min_version):
                 break
 
         # Look for the flag in the configuration
-        for line in config:
+        for line in values:
             line = line.strip()
             if line.startswith("#"):
                 continue  # Ignore commented lines

--- a/providers/base/tests/test_kernel_config.py
+++ b/providers/base/tests/test_kernel_config.py
@@ -107,8 +107,10 @@ class TestKernelConfig(TestCase):
     def test_check_flag_present(self, print_mock, uname_mock):
         uname_mock.return_value = MagicMock(release="6.8.0-45-generic")
         data = (
+            "#\n"
             "# Automatically generated file; DO NOT EDIT.\n"
             "# Linux/x86 6.8.12 Kernel Configuration\n"
+            "#\n"
             "CONFIG_INTEL_IOMMU=y\n"
             "CONFIG_INTEL_IOMMU_DEFAULT_ON=y\n"
         )
@@ -123,8 +125,10 @@ class TestKernelConfig(TestCase):
     def test_check_flag_not_present(self, uname_mock):
         uname_mock.return_value = MagicMock(release="6.8.0-45-generic")
         data = (
+            "#\n"
             "# Automatically generated file; DO NOT EDIT.\n"
             "# Linux/x86 6.8.12 Kernel Configuration\n"
+            "#\n"
             "CONFIG_INTEL_IOMMU=y\n"
         )
         with patch("builtins.open", mock_open(read_data=data)):
@@ -140,8 +144,10 @@ class TestKernelConfig(TestCase):
     def test_check_flag_commented(self, uname_mock):
         uname_mock.return_value = MagicMock(release="6.8.0-45-generic")
         data = (
+            "#\n"
             "# Automatically generated file; DO NOT EDIT.\n"
             "# Linux/x86 6.8.12 Kernel Configuration\n"
+            "#\n"
             "# CONFIG_INTEL_IOMMU_DEFAULT_ON=y\n"
         )
         with patch("builtins.open", mock_open(read_data=data)):
@@ -157,12 +163,16 @@ class TestKernelConfig(TestCase):
     def test_check_flag_arm(self, print_mock, uname_mock):
         uname_mock.return_value = MagicMock(release="6.8.0-45-generic")
         data = (
+            "#\n"
             "# Automatically generated file; DO NOT EDIT.\n"
             "# Linux/arm64 6.8.12 Kernel Configuration\n"
+            "#\n"
         )
         with patch("builtins.open", mock_open(read_data=data)):
             check_flag("CONFIG_INTEL_IOMMU_DEFAULT_ON", "6.8.0-20")
-        print_mock.assert_called_once_with("Skipping: arm architecture detected.")
+        print_mock.assert_called_once_with(
+            "Skipping: arm architecture detected."
+        )
 
     @patch("kernel_config.argparse.ArgumentParser.parse_args")
     def test_parse_args(self, parse_args_mock):

--- a/providers/base/tests/test_kernel_config.py
+++ b/providers/base/tests/test_kernel_config.py
@@ -123,7 +123,7 @@ class TestKernelConfig(TestCase):
                 check_flag("CONFIG_INTEL_IOMMU_DEFAULT_ON", "6.8.0-20")
         self.assertEqual(
             str(context.exception),
-            "Flag CONFIG_INTEL_IOMMU_DEFAULT_ON not found in the config.",
+            "Flag CONFIG_INTEL_IOMMU_DEFAULT_ON not found in the kernel config.",
         )
 
     @patch("kernel_config.os.uname")
@@ -136,7 +136,7 @@ class TestKernelConfig(TestCase):
                 check_flag("CONFIG_INTEL_IOMMU_DEFAULT_ON", "6.8.0-20")
         self.assertEqual(
             str(context.exception),
-            "Flag CONFIG_INTEL_IOMMU_DEFAULT_ON not found in the config.",
+            "Flag CONFIG_INTEL_IOMMU_DEFAULT_ON not found in the kernel config.",
         )
 
     @patch("kernel_config.argparse.ArgumentParser.parse_args")

--- a/providers/base/tests/test_kernel_config.py
+++ b/providers/base/tests/test_kernel_config.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2025 Canonical Ltd.
+# Authors:
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+from unittest.mock import patch, MagicMock, mock_open, call
+
+from kernel_config import (
+    get_kernel_config_path,
+    get_configuration,
+    check_flag,
+    parse_args,
+    main,
+)
+
+
+class TestKernelConfig(TestCase):
+    @patch("kernel_config.on_ubuntucore")
+    @patch("kernel_config.os.uname")
+    def test_get_kernel_config_path(self, uname_mock, on_core_mock):
+        on_core_mock.return_value = False
+        uname_mock.return_value = MagicMock(release="5.4.0-42-generic")
+
+        self.assertEqual(
+            get_kernel_config_path(), "/boot/config-5.4.0-42-generic"
+        )
+
+    @patch("kernel_config.get_kernel_snap")
+    @patch("kernel_config.on_ubuntucore")
+    @patch("kernel_config.os.uname")
+    def test_get_kernel_config_path_ubuntucore(
+        self, uname_mock, on_core_mock, get_kernel_mock
+    ):
+        on_core_mock.return_value = True
+        get_kernel_mock.return_value = "pc-kernel"
+        uname_mock.return_value = MagicMock(release="5.4.0-42-generic")
+
+        self.assertEqual(
+            get_kernel_config_path(),
+            "/snap/pc-kernel/current/config-5.4.0-42-generic",
+        )
+
+    @patch("kernel_config.get_kernel_config_path")
+    @patch("kernel_config.shutil.copy2")
+    @patch("kernel_config.open", MagicMock())
+    @patch("kernel_config.print", MagicMock())
+    def test_get_configuration_output(self, copy2_mock, get_path_mock):
+        get_path_mock.return_value = "/boot/config-5.4.0-42-generic"
+        get_configuration("/tmp/config")
+        copy2_mock.assert_called_once_with(
+            "/boot/config-5.4.0-42-generic", "/tmp/config"
+        )
+
+    @patch("kernel_config.get_kernel_config_path")
+    @patch("kernel_config.print")
+    @patch("kernel_config.shutil.copy2", MagicMock())
+    def test_get_configuration_print(self, print_mock, get_path_mock):
+        get_path_mock.return_value = "/boot/config-5.4.0-42-generic"
+        data = "CONFIG_INTEL_IOMMU=y\nCONFIG_INTEL_IOMMU_DEFAULT_ON=y"
+        with patch("builtins.open", mock_open(read_data=data)):
+            get_configuration()
+        print_mock.assert_called_once_with(data)
+
+    @patch("kernel_config.os.uname")
+    @patch("kernel_config.print")
+    def test_check_flag_lower_version(self, print_mock, uname_mock):
+        uname_mock.return_value = MagicMock(release="5.4.0-42-generic")
+        check_flag("CONFIG_INTEL_IOMMU_DEFAULT_ON", "6.8.0-20")
+
+        uname_mock.return_value = MagicMock(release="5.4.0-42-intel-iotg")
+        check_flag("CONFIG_INTEL_IOMMU_DEFAULT_ON", "6.8.0-20")
+
+        uname_mock.return_value = MagicMock(release="6.8.0-11-generic")
+        check_flag("CONFIG_INTEL_IOMMU_DEFAULT_ON", "6.8.0-20")
+
+        print_mock.assert_has_calls(
+            [
+                call(
+                    "Skipping: kernel version 5.4.0-42 is lower than 6.8.0-20."
+                ),
+                call(
+                    "Skipping: kernel version 5.4.0-42 is lower than 6.8.0-20."
+                ),
+                call(
+                    "Skipping: kernel version 6.8.0-11 is lower than 6.8.0-20."
+                ),
+            ]
+        )
+
+    @patch("kernel_config.os.uname")
+    @patch("kernel_config.print")
+    def test_check_flag_present(self, print_mock, uname_mock):
+        uname_mock.return_value = MagicMock(release="6.8.0-45-generic")
+        data = "CONFIG_INTEL_IOMMU=y\nCONFIG_INTEL_IOMMU_DEFAULT_ON=y"
+        with patch("builtins.open", mock_open(read_data=data)):
+            check_flag("CONFIG_INTEL_IOMMU_DEFAULT_ON", "6.8.0-20")
+        print_mock.assert_called_once_with(
+            "Flag CONFIG_INTEL_IOMMU_DEFAULT_ON is present and set to 'y'."
+        )
+
+    @patch("kernel_config.os.uname")
+    @patch("kernel_config.print")
+    def test_check_flag_not_present(self, print_mock, uname_mock):
+        uname_mock.return_value = MagicMock(release="6.8.0-45-generic")
+        data = "CONFIG_INTEL_IOMMU=y"
+        with patch("builtins.open", mock_open(read_data=data)):
+            with self.assertRaises(SystemExit) as context:
+                check_flag("CONFIG_INTEL_IOMMU_DEFAULT_ON", "6.8.0-20")
+        self.assertEqual(
+            str(context.exception),
+            "Flag CONFIG_INTEL_IOMMU_DEFAULT_ON not found in the config.",
+        )
+
+    @patch("kernel_config.os.uname")
+    @patch("kernel_config.print")
+    def test_check_flag_commented(self, print_mock, uname_mock):
+        uname_mock.return_value = MagicMock(release="6.8.0-45-generic")
+        data = "# CONFIG_INTEL_IOMMU_DEFAULT_ON=y"
+        with patch("builtins.open", mock_open(read_data=data)):
+            with self.assertRaises(SystemExit) as context:
+                check_flag("CONFIG_INTEL_IOMMU_DEFAULT_ON", "6.8.0-20")
+        self.assertEqual(
+            str(context.exception),
+            "Flag CONFIG_INTEL_IOMMU_DEFAULT_ON not found in the config.",
+        )
+
+    @patch("kernel_config.argparse.ArgumentParser.parse_args")
+    def test_parse_args(self, parse_args_mock):
+        parse_args_mock.return_value = MagicMock(
+            output="/tmp/config",
+            config_flag="CONFIG_INTEL_IOMMU",
+            min_version="6.8.0-20",
+        )
+
+        args = parse_args()
+        self.assertEqual(args.output, "/tmp/config")
+        self.assertEqual(args.config_flag, "CONFIG_INTEL_IOMMU")
+        self.assertEqual(args.min_version, "6.8.0-20")
+
+    @patch("kernel_config.get_configuration")
+    @patch("kernel_config.check_flag")
+    @patch("kernel_config.parse_args")
+    def test_main_check_flag(
+        self, parse_args_mock, check_flag_mock, get_config_mock
+    ):
+        parse_args_mock.return_value = MagicMock(
+            output=None,
+            config_flag="CONFIG_INTEL_IOMMU",
+            min_version="6.8.0-20",
+        )
+
+        main()
+        check_flag_mock.assert_called_once_with(
+            "CONFIG_INTEL_IOMMU", "6.8.0-20"
+        )
+        get_config_mock.assert_not_called()
+
+    @patch("kernel_config.get_configuration")
+    @patch("kernel_config.check_flag")
+    @patch("kernel_config.parse_args")
+    def test_main_get_configuration(
+        self, parse_args_mock, check_flag_mock, get_config_mock
+    ):
+        parse_args_mock.return_value = MagicMock(
+            output="/tmp/config",
+            config_flag=None,
+            min_version=None,
+        )
+
+        main()
+        get_config_mock.assert_called_once_with("/tmp/config")
+        check_flag_mock.assert_not_called()

--- a/providers/base/tests/test_kernel_config.py
+++ b/providers/base/tests/test_kernel_config.py
@@ -91,13 +91,19 @@ class TestKernelConfig(TestCase):
         print_mock.assert_has_calls(
             [
                 call(
-                    "Skipping: kernel version 5.4.0-42 is lower than 6.8.0-20."
+                    "Kernel version is 5.4.0-42.",
+                    "Versions lower than 6.8.0-20 don't require ",
+                    "the flag CONFIG_INTEL_IOMMU_DEFAULT_ON to be set.",
                 ),
                 call(
-                    "Skipping: kernel version 5.4.0-42 is lower than 6.8.0-20."
+                    "Kernel version is 5.4.0-42.",
+                    "Versions lower than 6.8.0-20 don't require ",
+                    "the flag CONFIG_INTEL_IOMMU_DEFAULT_ON to be set.",
                 ),
                 call(
-                    "Skipping: kernel version 6.8.0-11 is lower than 6.8.0-20."
+                    "Kernel version is 6.8.0-11.",
+                    "Versions lower than 6.8.0-20 don't require ",
+                    "the flag CONFIG_INTEL_IOMMU_DEFAULT_ON to be set.",
                 ),
             ]
         )
@@ -156,22 +162,6 @@ class TestKernelConfig(TestCase):
         self.assertEqual(
             str(context.exception),
             "Flag CONFIG_INTEL_IOMMU_DEFAULT_ON not found in the kernel config.",
-        )
-
-    @patch("kernel_config.os.uname")
-    @patch("kernel_config.print")
-    def test_check_flag_arm(self, print_mock, uname_mock):
-        uname_mock.return_value = MagicMock(release="6.8.0-45-generic")
-        data = (
-            "#\n"
-            "# Automatically generated file; DO NOT EDIT.\n"
-            "# Linux/arm64 6.8.12 Kernel Configuration\n"
-            "#\n"
-        )
-        with patch("builtins.open", mock_open(read_data=data)):
-            check_flag("CONFIG_INTEL_IOMMU_DEFAULT_ON", "6.8.0-20")
-        print_mock.assert_called_once_with(
-            "Skipping: arm architecture detected."
         )
 
     @patch("kernel_config.argparse.ArgumentParser.parse_args")

--- a/providers/base/units/info/jobs.pxu
+++ b/providers/base/units/info/jobs.pxu
@@ -467,6 +467,35 @@ estimated_duration: 0.005
 _purpose: Attaches the kernel command line used to boot
 _summary: Attach a copy of /proc/cmdline
 
+id: info/kernel_config
+plugin: shell
+category_id: com.canonical.plainbox::info
+command: 
+ kernel_config.py --output "$PLAINBOX_SESSION_SHARE"/kernel_config
+estimated_duration: 0.005
+_purpose: Gathers the kernel configuration and saves it to a file
+_summary: Gather the kernel configuration
+
+id: kernel_config_attachment
+plugin: attachment
+depends: info/kernel_config
+category_id: com.canonical.plainbox::info
+command: 
+ [ -f "$PLAINBOX_SESSION_SHARE"/kernel_config ] && cat "$PLAINBOX_SESSION_SHARE"/kernel_config
+estimated_duration: 0.005
+_purpose: Attaches the kernel configuration
+_summary: Attach a copy of the kernel configuration
+
+id: info/kernel-config-iommu-flag
+plugin: shell
+category_id: com.canonical.plainbox::info
+command: 
+ kernel_config.py --config-flag CONFIG_INTEL_IOMMU_DEFAULT_ON --min-version 6.8.0-20
+estimated_duration: 0.005
+_purpose: Checks the value of the CONFIG_INTEL_IOMMU_DEFAULT_ON flag in the kernel configuration
+_summary: Check if the kernel is compiled with IOMMU support
+
+
 plugin: shell
 category_id: com.canonical.plainbox::info
 id: info/systemd-analyze

--- a/providers/base/units/info/jobs.pxu
+++ b/providers/base/units/info/jobs.pxu
@@ -488,6 +488,7 @@ _summary: Attach a copy of the kernel configuration
 
 id: info/kernel-config-iommu-flag
 plugin: shell
+requires: cpuinfo.platform in ("i386", "x86_64")
 category_id: com.canonical.plainbox::info
 command: 
  kernel_config.py --config-flag CONFIG_INTEL_IOMMU_DEFAULT_ON --min-version 6.8.0-20

--- a/providers/base/units/miscellanea/jobs.pxu
+++ b/providers/base/units/miscellanea/jobs.pxu
@@ -27,6 +27,7 @@ depends:
  lspci_standard_config_json
  system_info_json
  kernel_cmdline_attachment
+ kernel_config_attachment
 estimated_duration: 1.0
 command: true
 _summary:

--- a/providers/base/units/submission/test-plan.pxu
+++ b/providers/base/units/submission/test-plan.pxu
@@ -25,3 +25,4 @@ mandatory_include:
     miscellanea/submission-resources
     info/systemd-analyze                  certification-status=non-blocker
     info/systemd-analyze-critical-chain   certification-status=non-blocker
+    info/kernel-config-iommu-flag           certification-status=non-blocker


### PR DESCRIPTION
  ## WARNING: This modifies com.canonical.certification::sru-server

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

We want to check if the `CONFIG_INTEL_IOMMU_DEFAULT_ON` config flag is present in versions of the kernel >=6.8.0-20

Note: I've included the test into the submission-cert-automated test-plan. It's already being run in all of the devices and it includes also some info tests, so it made sense for me to include it here. Let me know if you think it should be in another test-plan
Note: I had to remove the config iterator (see commit: removed iterator for python 3.5). I don't like this too much, but the unit tests failed in python 3.5 if I read the file line by line.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/CHECKBOX-1608


## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

Tested with:
classic image, ubuntu 24, kernel "6.8.0-52-generic"
```
-------------[ Check if the kernel is compiled with IOMMU support ]-------------
ID: com.canonical.certification::info/kernel-config-iommu-flag
Category: com.canonical.plainbox::info
... 8< -------------------------------------------------------------------------
Flag CONFIG_INTEL_IOMMU_DEFAULT_ON is present and set to 'y'.
```
core image, ubuntu 24, pc-kernel "6.11.0-17-generic"
https://certification.canonical.com/hardware/201805-26252/submission/410961/test-results/
```
-------------[ Check if the kernel is compiled with IOMMU support ]-------------
ID: com.canonical.certification::info/kernel-config-iommu-flag
Category: com.canonical.plainbox::info
... 8< -------------------------------------------------------------------------
Flag CONFIG_INTEL_IOMMU_DEFAULT_ON is present and set to 'y'.
```

core image, ubuntu 22, pc-kernel "5.15.0-132-generic"
https://certification.canonical.com/hardware/201802-26085/submission/410964/test-results/
```
-------------[ Check if the kernel is compiled with IOMMU support ]-------------
ID: com.canonical.certification::info/kernel-config-iommu-flag
Category: com.canonical.plainbox::info
... 8< -------------------------------------------------------------------------
Skipping: kernel version 5.15.0-132 is lower than 6.8.0-20.
```

core image, ubuntu 22, pc-kernel "5.15.0-132-generic"
https://certification.canonical.com/hardware/201802-26085/submission/410964/test-results/
```
-------------[ Check if the kernel is compiled with IOMMU support ]-------------
ID: com.canonical.certification::info/kernel-config-iommu-flag
Category: com.canonical.plainbox::info
... 8< -------------------------------------------------------------------------
Skipping: kernel version 5.15.0-132 is lower than 6.8.0-20.
```

core image, ubuntu 24, pi-kernel "6.8.0-1016-raspi" (ARM)
https://certification.canonical.com/hardware/202310-32203/submission/411715/test-results/
```
-------------[ Check if the kernel is compiled with IOMMU support ]-------------
ID: com.canonical.certification::info/kernel-config-iommu-flag
Category: com.canonical.plainbox::info
Job cannot be started because:
 - resource expression 'cpuinfo.platform in ("i386", "x86_64")' evaluates to false
Outcome: job cannot be started
```

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
