### PR TITLE
Backward compatible hidden check (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/urwid_ui.py
@@ -1072,7 +1072,7 @@ class ManifestBrowser:
             q: [
                 manifest
                 for manifest in manifests
-                if manifest["hidden"] == hidden
+                if manifest.get("hidden", False) == hidden
             ]
             for q, manifests in question_manifests.items()
         }


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This change was not supposed to be backward incompatible. This fixes it, default is False as before the hidden_manifests change, no manifest was hidden

## Resolved issues

Fixes: CHECKBOX-1735
Fixes: https://github.com/canonical/checkbox/issues/1716

## Documentation

N/A

## Tests

I installed checkbox stable, that doesnt have this feature, and connected running the provided test plan. It didn't crash as in the bug report
