### PR TITLE
Add --oom-avoid-bytes option to stress-ng tests to prevent frequent OOM (bugfix)

### DIFF
--- a/providers/base/bin/stress_ng_test.py
+++ b/providers/base/bin/stress_ng_test.py
@@ -78,9 +78,10 @@ class StressNg:
         # LP:1983122 ensure the final stressor in the list is properly defined
         stressor_list = stressor_list + " {}".format(self.thread_count)
 
-        command = "stress-ng --aggressive --verify --timeout {} {} {}".format(
-            self.sng_timeout, self.extra_options, stressor_list
-        )
+        command = (
+            "stress-ng --aggressive --verify --oom-avoid-bytes 10% "
+            "--timeout {} {} {}"
+        ).format(self.sng_timeout, self.extra_options, stressor_list)
         print("Running command: {}".format(command))
         time_str = time.strftime("%d %b %H:%M", time.gmtime())
         if len(self.stressors) == 1:

--- a/providers/base/units/stress/stress-ng.pxu
+++ b/providers/base/units/stress/stress-ng.pxu
@@ -27,7 +27,7 @@ estimated_duration: 30.0
 environ: STRESS_NG_STRESSORS_TIMEOUT
 command:
  cd /var/tmp || exit $?
- stress-ng --{stressor} 0 --timeout "${{STRESS_NG_STRESSORS_TIMEOUT:-30}}" --skip-silent --verbose
+ stress-ng --{stressor} 0 --timeout "${{STRESS_NG_STRESSORS_TIMEOUT:-30}}" --oom-avoid-bytes 10% --skip-silent --verbose
  # Error code definition - 3(no resource), 4(not implemented)
  EXIT_CODE=$?
  echo "EXIT_CODE="$EXIT_CODE


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Recent versions of stress-ng include the `--oom-avoid-bytes` option to specify how much free memory should be kept un-allocated to try to give enough headroom to avoid the OOM killer from terminating processes.

Adding this option to the main stress-ng command with a threshold of 10%.

See discussion in https://github.com/ColinIanKing/stress-ng/pull/270 for more information.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

- https://github.com/canonical/checkbox/issues/1391
- https://warthogs.atlassian.net/browse/CHECKBOX-1522
- https://github.com/canonical/checkbox/issues/727
- https://github.com/canonical/checkbox/issues/54
- https://github.com/canonical/checkbox/issues/37

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

Tested on a desktop image running 24.04, with the latest version of Checkbox snap modified to use the new option in this patch:

- [before](https://github.com/canonical/checkbox/issues/1391#issuecomment-2612547010), the stress test crashes with kernel panic in the logs
- [after](https://github.com/canonical/checkbox/issues/1391#issuecomment-2655738766), the test completes and Checkbox provides an output

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
