### PR TITLE
Add dss integration tests and update Testflinger queues in GH workflow (New)

### DIFF
--- a/.github/workflows/testflinger-contrib-dss-regression.yaml
+++ b/.github/workflows/testflinger-contrib-dss-regression.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         dss_channel:
           - 1/stable
-          - 1/candidate
+          - latest/stable
           - latest/edge
         microk8s_channel:
           - 1.28/stable

--- a/.github/workflows/testflinger-contrib-dss-regression.yaml
+++ b/.github/workflows/testflinger-contrib-dss-regression.yaml
@@ -31,11 +31,11 @@ jobs:
           - 1.28/stable
           - 1.31/stable
         queue:
-          - name: dell-precision-3470-c30322 #ADL iGPU + NVIDIA GPU
+          - name: dell-precision-3470 #ADL iGPU + NVIDIA GPU
             provision_data: "distro: jammy"
-          - name: dell-precision-5680-c31665 #RPL iGPU + Arc Pro A60M dGPU
+          - name: dell-precision-5680 #RPL iGPU + Arc Pro A60M dGPU
             provision_data: "url: http://10.102.196.9/somerville/Platforms/jellyfish-muk/X96_A00/dell-bto-jammy-jellyfish-muk-X96-20230419-19_A00.iso"
-          - name: nvidia-dgx-station-c25989  # NO iGPU + NVIDIA GPU
+          - name: nvidia-dgx-station  # NO iGPU + NVIDIA GPU
             provision_data: "distro: jammy"
     steps:
       - name: Check out code

--- a/contrib/checkbox-dss-validation/bin/install-deps
+++ b/contrib/checkbox-dss-validation/bin/install-deps
@@ -80,13 +80,13 @@ main() {
     # intel_gpu_top command used for host-level GPU check
     # jq used for cases where jsonpath is insufficient for parsing json results
     echo -e "\nStep 3/5: Installing intel-gpu-tools"
-    DEBIAN_FRONTEND=noninteractive sudo apt install -y intel-gpu-tools jq
+    DEBIAN_FRONTEND=noninteractive sudo -E apt install -y intel-gpu-tools jq
 
     echo -e "\nStep 4/5: Installing data-science-stack snap from channel $dss_snap_channel"
     sudo snap install data-science-stack --channel "$dss_snap_channel"
 
     echo -e "\nStep 5/5: Installing python3-venv and git for DSS integration tests"
-    DEBIAN_FRONTEND=noninteractive sudo apt install -y python3-venv git
+    DEBIAN_FRONTEND=noninteractive sudo -E apt install -y python3-venv git
 }
 
 main "$@"

--- a/contrib/checkbox-dss-validation/bin/install-deps
+++ b/contrib/checkbox-dss-validation/bin/install-deps
@@ -80,13 +80,13 @@ main() {
     # intel_gpu_top command used for host-level GPU check
     # jq used for cases where jsonpath is insufficient for parsing json results
     echo -e "\nStep 3/5: Installing intel-gpu-tools"
-    DEBIAN_FRONTEND=noninteractive sudo -E apt install -y intel-gpu-tools jq
+    DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a sudo -E apt install -y intel-gpu-tools jq
 
     echo -e "\nStep 4/5: Installing data-science-stack snap from channel $dss_snap_channel"
     sudo snap install data-science-stack --channel "$dss_snap_channel"
 
     echo -e "\nStep 5/5: Installing python3-venv and git for DSS integration tests"
-    DEBIAN_FRONTEND=noninteractive sudo -E apt install -y python3-venv git
+    DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a sudo -E apt install -y python3-venv git
 }
 
 main "$@"

--- a/contrib/checkbox-dss-validation/bin/install-deps
+++ b/contrib/checkbox-dss-validation/bin/install-deps
@@ -71,19 +71,22 @@ main() {
         esac
     done
 
-    echo -e "\n Step 1/4: Setting up microk8s"
+    echo -e "\n Step 1/5: Setting up microk8s"
     setup_microk8s_snap "$microk8s_snap_channel"
 
-    echo -e "\n Step 2/4: Setting up kubectl"
+    echo -e "\n Step 2/5: Setting up kubectl"
     setup_kubectl_snap "$kubectl_snap_channel"
 
     # intel_gpu_top command used for host-level GPU check
     # jq used for cases where jsonpath is insufficient for parsing json results
-    echo -e "\nStep 3/4: Installing intel-gpu-tools"
+    echo -e "\nStep 3/5: Installing intel-gpu-tools"
     DEBIAN_FRONTEND=noninteractive sudo apt install -y intel-gpu-tools jq
 
-    echo -e "\nStep 4/4: Installing data-science-stack snap from channel $dss_snap_channel"
+    echo -e "\nStep 4/5: Installing data-science-stack snap from channel $dss_snap_channel"
     sudo snap install data-science-stack --channel "$dss_snap_channel"
+
+    echo -e "\nStep 5/5: Installing python3-venv and git for DSS integration tests"
+    DEBIAN_FRONTEND=noninteractive sudo apt install -y python3-venv git
 }
 
 main "$@"

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/jobs.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/jobs.pxu
@@ -340,3 +340,92 @@ depends: dss/create_tensorflow_cuda_notebook
 _summary: Check that the Tensorflow CUDA notebook can be removed
 estimated_duration: 1m
 command: check_dss.sh can_remove_notebook tensorflow-cuda
+
+# DSS integration tests #######################################################
+
+# NOTE:@motjuste: tmp impl, until #1725 is merged
+id: dss/purge
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends: dss/initialize
+_summary: Check that DSS can be purged
+estimated_duration: 10m
+command: dss purge
+
+id: dss_integration_tests/setup
+category_id: dss-regress
+flags: simple
+imports:
+  from com.canonical.certification import executable
+  from com.canonical.certification import package
+requires:
+  executable.name == 'git'
+  executable.name == 'python3'
+  package.name == 'python3-venv'
+depends: dss/purge
+_summary: Checkout and setup the DSS integration tests
+estimated_duration: 5m
+command:
+  set -eo pipefail
+  export DSS_CLONE_PATH="$HOME/data-science-stack"
+  if [ ! -d "$DSS_CLONE_PATH" ]; then
+    echo "cloning DSS repo"
+    git clone https://github.com/canonical/data-science-stack.git "$DSS_CLONE_PATH"
+  fi
+  pushd "$DSS_CLONE_PATH"
+  echo "Latest commit in DSS repo:"
+  git log --name-status HEAD^..HEAD
+  if [ ! -d ".venv" ]; then
+    echo "creating venv"
+    python3 -m venv .venv
+    echo "install tox"
+    .venv/bin/pip install tox
+  fi
+  popd
+  echo "Setup complete for DSS integration tests"
+
+id: dss_integration_tests/cpu
+category_id: dss-regress
+flags: simple
+imports:
+  from com.canonical.certification import executable
+  from com.canonical.certification import package
+requires:
+  executable.name == 'dss'
+  executable.name == 'python3'
+  package.name == 'python3-venv'
+depends: dss_integration_tests/setup
+_summary: Check that all DSS integration tests for CPU pass
+estimated_duration: 15m
+command:
+  set -eo pipefail
+  export DSS_CLONE_PATH="$HOME/data-science-stack"
+  pushd "$DSS_CLONE_PATH"
+  .venv/bin/tox -e integration
+  popd
+  echo "DSS integration tests passed on CPU"
+
+id: dss_integration_tests/nvidia_gpu
+category_id: dss-regress
+flags: simple
+imports:
+  from com.canonical.certification import executable
+  from com.canonical.certification import package
+requires:
+  executable.name == 'dss'
+  executable.name == 'python3'
+  package.name == 'python3-venv'
+depends:
+  dss_integration_tests/setup
+  nvidia_gpu_addon/validations_succeed
+_summary: Check that all DSS integration tests for NVIDIA GPU pass
+estimated_duration: 15m
+command:
+  set -eo pipefail
+  export DSS_CLONE_PATH="$HOME/data-science-stack"
+  pushd "$DSS_CLONE_PATH"
+  .venv/bin/tox -e integration-gpu
+  popd
+  echo "DSS integration tests passed on NVIDIA GPU"

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
@@ -35,7 +35,12 @@ include:
     dss/create_tensorflow_cuda_notebook
     cuda/tensorflow_can_use_cuda
     dss/remove_tensorflow_cuda_notebook
+    dss/purge
+    dss_integration_tests/setup
+    dss_integration_tests/cpu
+    dss_integration_tests/nvidia_gpu
 bootstrap_include:
     com.canonical.certification::executable
     com.canonical.certification::snap
     com.canonical.certification::graphics_card
+    com.canonical.certification::package

--- a/contrib/checkbox-dss-validation/testflinger/job-def.yaml
+++ b/contrib/checkbox-dss-validation/testflinger/job-def.yaml
@@ -10,9 +10,9 @@ test_data:
 
     # Clone repo from appropriate branch/commit.
     ssh ubuntu@$DEVICE_IP '
-      DEBIAN_FRONTEND=noninteractive sudo -E apt update
-      DEBIAN_FRONTEND=noninteractive sudo -E apt -y upgrade
-      DEBIAN_FRONTEND=noninteractive sudo -E apt -y install git
+      DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a sudo -E apt update
+      DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a sudo -E apt -y upgrade
+      DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a sudo -E apt -y install git
       git clone -b REPLACE_BRANCH \
         https://github.com/canonical/checkbox.git \
         ~ubuntu/checkbox

--- a/contrib/checkbox-dss-validation/testflinger/job-def.yaml
+++ b/contrib/checkbox-dss-validation/testflinger/job-def.yaml
@@ -10,9 +10,9 @@ test_data:
 
     # Clone repo from appropriate branch/commit.
     ssh ubuntu@$DEVICE_IP '
-      DEBIAN_FRONTEND=noninteractive sudo apt update
-      DEBIAN_FRONTEND=noninteractive sudo apt -y upgrade
-      DEBIAN_FRONTEND=noninteractive sudo apt -y install git
+      DEBIAN_FRONTEND=noninteractive sudo -E apt update
+      DEBIAN_FRONTEND=noninteractive sudo -E apt -y upgrade
+      DEBIAN_FRONTEND=noninteractive sudo -E apt -y install git
       git clone -b REPLACE_BRANCH \
         https://github.com/canonical/checkbox.git \
         ~ubuntu/checkbox


### PR DESCRIPTION
## Description

This is one piece of the original PR #1724, and should not be merged before merging #1725. 

It adds jobs to clone and run integration tests from the DSS repo on CPU and NVIDIA GPUs.  It is required that DSS has been purged before running these tests, so an interim functioning job has been added to do that, while the better implementation for the `dss/purge` job gets merged as part of #1725.

In order to run the tests, `python3-venv` and `git` need to be installed, and they are added to the `isntall-deps` script, alongside other minor improvements to running the `apt install`s in that script non-interactively.

The GitHub workflow for running checkbox-dss on machines from Testflinger has been updated:
- appropriate snap channels for DSS have been updated.
- the TF queues have been made less device-specific to help with potentially more runs in parallel.

## Resolved issues

- Part of [CHECKBOX-1693](https://warthogs.atlassian.net/browse/CHECKBOX-1693)

## Documentation

No changes to the Checkbox documentation.

## Tests

There are no changes to the tests.

[CHECKBOX-1693]: https://warthogs.atlassian.net/browse/CHECKBOX-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ