### PR TITLE
Add DSS reboot testing (New)

### DIFF
--- a/contrib/checkbox-dss-validation/bin/dss-validation-with-reboot-launcher
+++ b/contrib/checkbox-dss-validation/bin/dss-validation-with-reboot-launcher
@@ -1,0 +1,17 @@
+[launcher]
+app_id = com.canonical.contrib.dss-validation:checkbox
+launcher_version = 1
+stock_reports = text, submission_files
+
+[test plan]
+unit = com.canonical.contrib::dss-validation-with-reboot
+forced = yes
+
+[test selection]
+forced = yes
+
+[ui]
+type = silent
+auto_retry = yes
+max_attempts = 2
+delay_before_retry = 10

--- a/contrib/checkbox-dss-validation/bin/validate-with-gpu-and-reboot
+++ b/contrib/checkbox-dss-validation/bin/validate-with-gpu-and-reboot
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+print_usage() {
+    echo "Usage:"
+    echo "  validate-with-gpu-and-reboot IP"
+    echo ""
+    echo "  IP  IP address of the System Under Test"
+    echo "      'localhost' or '127.0.0.1' are not accepted"
+    echo ""
+    exit 1
+}
+
+if [ $# -ne 1 ]; then
+    print_usage
+fi
+
+if [ "$1" = "localhost" ]; then
+    print_usage
+elif [ "$1" = "127.0.0.1" ]; then
+    print_usage
+fi
+
+exec checkbox-cli-wrapper control "$1" "$SNAP"/bin/dss-validation-with-reboot-launcher

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/jobs.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/jobs.pxu
@@ -350,7 +350,9 @@ depends: dss/initialize
 _summary: Check that the DSS checks pass after reboot.  This job performs the reboot.
 estimated_duration: 5m
 user: root
-command: echo "rebooting"
+command:
+  echo "rebooting"
+  reboot
 
 id: dss/wait_after_reboot
 category_id: dss-regress

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/jobs.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/jobs.pxu
@@ -340,3 +340,248 @@ depends: dss/create_tensorflow_cuda_notebook
 _summary: Check that the Tensorflow CUDA notebook can be removed
 estimated_duration: 1m
 command: check_dss.sh can_remove_notebook tensorflow-cuda
+
+# Reboot and re-test ##########################################################
+
+id: dss/reboot
+category_id: dss-regress
+flags: simple noreturn
+depends: dss/initialize
+_summary: Check that the DSS checks pass after reboot.  This job performs the reboot.
+estimated_duration: 5m
+user: root
+command: echo "rebooting"
+
+id: dss/wait_after_reboot
+category_id: dss-regress
+flags: simple
+depends: dss/reboot
+_summary: Check that the DSS checks pass after reboot.  This job waits after reboot.
+estimated_duration: 1m
+command: sleep 90
+
+id: dss/initialize_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires:
+  executable.name == 'dss'
+  executable.name == 'microk8s'
+_summary: Check that the DSS environment initializes after reboot
+depends: dss/wait_after_reboot
+estimated_duration: 2m
+command: check_dss.sh can_be_initialized
+
+id: dss/status_mlflow_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+_summary: Check that the dss mlflow is deployed after reboot
+depends: dss/initialize_after_reboot
+estimated_duration: 5s
+command: check_dss.sh mlflow_status_is_ready
+
+id: dss/create_pytorch_cpu_notebook_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends: dss/status_mlflow_after_reboot
+_summary: Check that an PyTorch CPU notebook can be successfully created after reboot
+estimated_duration: 3m
+command: check_dss.sh can_create_notebook pytorch-cpu-ar --image=pytorch
+
+id: cpu/pytorch_can_use_cpu_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'microk8s'
+depends: dss/create_pytorch_cpu_notebook_after_reboot
+_summary: Check that PyTorch can use CPU in notebook created after reboot
+estimated_duration: 1m
+command: check_notebook.sh pytorch-cpu-ar can_run_python_script_in_pod verifying_pytorch_can_use_cpu
+
+id: dss/remove_pytorch_cpu_notebook_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends: dss/create_pytorch_cpu_notebook_after_reboot
+_summary: Check that the PyTorch CPU notebook created after reboot can be removed
+estimated_duration: 1m
+command: check_dss.sh can_remove_notebook pytorch-cpu-ar
+
+id: dss/create_tensorflow_cpu_notebook_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends: dss/status_mlflow_after_reboot
+_summary: Check that an Tensorflow CPU notebook can be successfully created after reboot
+estimated_duration: 3m
+command: check_dss.sh can_create_notebook tensorflow-cpu-ar --image=tensorflow
+
+id: cpu/tensorflow_can_use_cpu_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'microk8s'
+depends: dss/create_tensorflow_cpu_notebook_after_reboot
+_summary: Check that Tensorflow can use CPU in notebook created after reboot
+estimated_duration: 1m
+command: check_notebook.sh tensorflow-cpu-ar can_run_python_script_in_pod verifying_tensorflow_can_use_cpu
+
+id: dss/remove_tensorflow_cpu_notebook_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends: dss/create_tensorflow_cpu_notebook_after_reboot
+_summary: Check that the Tensorflow CPU notebook created after reboot can be removed
+estimated_duration: 1m
+command: check_dss.sh can_remove_notebook tensorflow-cpu-ar
+
+id: dss/status_intel_gpu_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends:
+  dss/status_mlflow_after_reboot
+  dss/status_intel_gpu
+_summary: Check that DSS status still has Intel GPU acceleration enabled after reboot
+estimated_duration: 5s
+command: check_dss.sh intel_gpu_acceleration_is_enabled
+
+id: dss/create_tensorflow_intel_notebook_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends: dss/status_intel_gpu_after_reboot
+_summary: Check that a Tensorflow Intel notebook can be successfully created after reboot
+estimated_duration: 3m
+command: check_dss.sh can_create_notebook tensorflow-intel-ar --image tensorflow-intel
+
+id: xpu/tensorflow_can_use_xpu_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'microk8s'
+depends: dss/create_tensorflow_intel_notebook_after_reboot
+_summary: Check that Tensorflow can use XPU in the notebook created after reboot
+estimated_duration: 1m
+command: check_notebook.sh tensorflow-intel-ar can_run_python_script_in_pod verifying_tensorflow_can_use_xpu
+
+id: dss/remove_tensorflow_intel_notebook_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends: dss/create_tensorflow_intel_notebook_after_reboot
+_summary: Check that the Tensorflow Intel notebook created after reboot can be removed
+estimated_duration: 1m
+command: check_dss.sh can_remove_notebook tensorflow-intel-ar
+
+id: dss/create_pytorch_intel_notebook_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends: dss/status_intel_gpu_after_reboot
+_summary: Check that a PyTorch Intel notebook can be successfully created after reboot
+estimated_duration: 3m
+command: check_dss.sh can_create_notebook pytorch-intel-ar --image pytorch-intel
+
+id: xpu/pytorch_can_use_xpu_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'microk8s'
+depends: dss/create_pytorch_intel_notebook_after_reboot
+_summary: Check that Pytorch can use XPU in the notebook created after reboot
+estimated_duration: 1m
+command: check_notebook.sh pytorch-intel-ar can_run_python_script_in_pod verifying_pytorch_can_use_xpu
+
+id: dss/remove_pytorch_intel_notebook_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends: dss/create_pytorch_intel_notebook_after_reboot
+_summary: Check that the PyTorch Intel notebook created after reboot can be removed
+estimated_duration: 1m
+command: check_dss.sh can_remove_notebook pytorch-intel-ar
+
+id: dss/status_nvidia_gpu_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends:
+  dss/status_nvidia_gpu
+  dss/status_mlflow_after_reboot
+_summary: Check that dss status still has NVIDIA GPU acceleration enabled after reboot
+estimated_duration: 5s
+command: check_dss.sh nvidia_gpu_acceleration_is_enabled
+
+id: dss/create_pytorch_cuda_notebook_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends: dss/status_nvidia_gpu_after_reboot
+_summary: Check that an PyTorch CUDA notebook can be successfully created after reboot
+estimated_duration: 3m
+command: check_dss.sh can_create_notebook pytorch-cuda-ar --image=pytorch-cuda
+
+id: cuda/pytorch_can_use_cuda_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'microk8s'
+depends: dss/create_pytorch_cuda_notebook_after_reboot
+_summary: Check PyTorch can use CUDA in the notebook created after reboot
+estimated_duration: 1m
+command: check_notebook.sh pytorch-cuda-ar can_run_python_script_in_pod verifying_pytorch_can_use_cuda
+
+id: dss/remove_pytorch_cuda_notebook_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends: dss/create_pytorch_cuda_notebook_after_reboot
+_summary: Check that the PyTorch CUDA notebook created after reboot can be removed
+estimated_duration: 1m
+command: check_dss.sh can_remove_notebook pytorch-cuda-ar
+
+id: dss/create_tensorflow_cuda_notebook_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends: dss/status_nvidia_gpu_after_reboot
+_summary: Check that an Tensorflow CUDA notebook can be successfully created after reboot
+estimated_duration: 3m
+command: check_dss.sh can_create_notebook tensorflow-cuda-ar --image=tensorflow-cuda
+
+id: cuda/tensorflow_can_use_cuda_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'microk8s'
+depends: dss/create_tensorflow_cuda_notebook_after_reboot
+_summary: Check Tensorflow can use CUDA in the notebook created after reboot
+estimated_duration: 1m
+command: check_notebook.sh tensorflow-cuda-ar can_run_python_script_in_pod verifying_tensorflow_can_use_cuda
+
+id: dss/remove_tensorflow_cuda_notebook_after_reboot
+category_id: dss-regress
+flags: simple
+imports: from com.canonical.certification import executable
+requires: executable.name == 'dss'
+depends: dss/create_tensorflow_cuda_notebook_after_reboot
+_summary: Check that the Tensorflow CUDA notebook created after reboot can be removed
+estimated_duration: 1m
+command: check_dss.sh can_remove_notebook tensorflow-cuda-ar

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
@@ -39,3 +39,13 @@ bootstrap_include:
     com.canonical.certification::executable
     com.canonical.certification::snap
     com.canonical.certification::graphics_card
+
+id: dss-validation-with-reboot
+unit: test plan
+_name: DSS validations with Intel and NVIDIA GPUs if available, with reboot
+include:
+    dss/initialize
+bootstrap_include:
+    com.canonical.certification::executable
+    com.canonical.certification::snap
+    com.canonical.certification::graphics_card

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
@@ -40,12 +40,47 @@ bootstrap_include:
     com.canonical.certification::snap
     com.canonical.certification::graphics_card
 
+id: dss-validation-reboot
+unit: test plan
+_name: Reboot before performing DSS validations again
+include:
+    dss/reboot
+    dss/wait_after_reboot
+
+id: dss-validation-after-reboot
+unit: test plan
+_name: DSS validations with Intel and NVIDIA GPUs if available, after reboot
+include:
+    dss/initialize_after_reboot
+    dss/status_mlflow_after_reboot
+    dss/create_pytorch_cpu_notebook_after_reboot
+    cpu/pytorch_can_use_cpu_after_reboot
+    dss/remove_pytorch_cpu_notebook_after_reboot
+    dss/create_tensorflow_cpu_notebook_after_reboot
+    cpu/tensorflow_can_use_cpu_after_reboot
+    dss/remove_tensorflow_cpu_notebook_after_reboot
+    dss/status_intel_gpu_after_reboot
+    dss/create_tensorflow_intel_notebook_after_reboot
+    xpu/tensorflow_can_use_xpu_after_reboot
+    dss/remove_tensorflow_intel_notebook_after_reboot
+    dss/create_pytorch_intel_notebook_after_reboot
+    xpu/pytorch_can_use_xpu_after_reboot
+    dss/remove_pytorch_intel_notebook_after_reboot
+    dss/status_nvidia_gpu_after_reboot
+    dss/create_pytorch_cuda_notebook_after_reboot
+    cuda/pytorch_can_use_cuda_after_reboot
+    dss/remove_pytorch_cuda_notebook_after_reboot
+    dss/create_tensorflow_cuda_notebook_after_reboot
+    cuda/tensorflow_can_use_cuda_after_reboot
+    dss/remove_tensorflow_cuda_notebook_after_reboot
+bootstrap_include:
+    com.canonical.certification::executable
+
 id: dss-validation-with-reboot
 unit: test plan
 _name: DSS validations with Intel and NVIDIA GPUs if available, with reboot
 include:
-    dss/initialize
-bootstrap_include:
-    com.canonical.certification::executable
-    com.canonical.certification::snap
-    com.canonical.certification::graphics_card
+nested_part:
+  dss-validation
+  dss-validation-reboot
+  dss-validation-after-reboot

--- a/contrib/checkbox-dss-validation/snap/snapcraft.yaml
+++ b/contrib/checkbox-dss-validation/snap/snapcraft.yaml
@@ -50,6 +50,9 @@ apps:
     command: bin/install-deps
   remove-deps:
     command: bin/remove-deps
+  validate-with-gpu-and-reboot:
+    command-chain: [bin/wrapper_local]
+    command: bin/validate-with-gpu-and-reboot
 
 passthrough:
   hooks:


### PR DESCRIPTION
> [!NOTE]
> This is a POC to get feedback on.  #1725 and its children need to be merged before this PR can be put into the final shape.

## Description

- Added three new test-plans.
  - First one reboots the machine
  - Second one performs tests on DSS that need to pass after reboot.
  - Third one uses the original test-plan and the two new ones above as nested parts, running first the original plan, then the reboot + "after reboot" tests.
- Added a new script / app to the `checkbox-dss` snap that now runs the test plan with reboot.
  - It explicitly requires IP to a remote that needs to be controlled.

- Missing:
  - update to README
  - bump snap version?
  - GH workflow using Testflinger multi-job to perform the tests.

## Resolved issues

- [CHECKBOX-1692](https://warthogs.atlassian.net/browse/CHECKBOX-1692)

## Documentation

No changes to Checkbox documentation.

## Tests

> [!NOTE]
> Work in Progress


[CHECKBOX-1692]: https://warthogs.atlassian.net/browse/CHECKBOX-1692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ