### PR TITLE
Also promote uc24, change default latest (infra)

### DIFF
--- a/.github/workflows/checkbox-stable-release.yml
+++ b/.github/workflows/checkbox-stable-release.yml
@@ -85,15 +85,10 @@ jobs:
           sudo snap install snapcraft --classic
       - name: Promote checkbox core snaps to the stable channel
         run: |
-          snapcraft promote checkbox16 --from-channel latest/beta --to-channel latest/candidate --yes
           snapcraft promote checkbox16 --from-channel latest/beta --to-channel latest/stable --yes
-          snapcraft promote checkbox18 --from-channel latest/beta --to-channel latest/candidate --yes
           snapcraft promote checkbox18 --from-channel latest/beta --to-channel latest/stable --yes
-          snapcraft promote checkbox20 --from-channel latest/beta --to-channel latest/candidate --yes
           snapcraft promote checkbox20 --from-channel latest/beta --to-channel latest/stable --yes
-          snapcraft promote checkbox22 --from-channel latest/beta --to-channel latest/candidate --yes
           snapcraft promote checkbox22 --from-channel latest/beta --to-channel latest/stable --yes
-          snapcraft promote checkbox24 --from-channel latest/beta --to-channel latest/candidate --yes
           snapcraft promote checkbox24 --from-channel latest/beta --to-channel latest/stable --yes
 
   checkbox_snap:
@@ -114,23 +109,14 @@ jobs:
           sudo snap install snapcraft --classic
       - name: Promote checkbox snaps to the stable channel
         run: |
-          snapcraft promote checkbox --from-channel uc16/beta --to-channel uc16/candidate --yes
           snapcraft promote checkbox --from-channel uc16/beta --to-channel uc16/stable --yes
-          snapcraft promote checkbox --from-channel uc18/beta --to-channel uc18/candidate --yes
           snapcraft promote checkbox --from-channel uc18/beta --to-channel uc18/stable --yes
-          snapcraft promote checkbox --from-channel uc20/beta --to-channel uc20/candidate --yes
           snapcraft promote checkbox --from-channel uc20/beta --to-channel uc20/stable --yes
-          snapcraft promote checkbox --from-channel uc22/beta --to-channel uc22/candidate --yes
           snapcraft promote checkbox --from-channel uc22/beta --to-channel uc22/stable --yes
-          snapcraft promote checkbox --from-channel 16.04/beta --to-channel 16.04/candidate --yes
+          snapcraft promote checkbox --from-channel uc24/beta --to-channel uc22/stable --yes
           snapcraft promote checkbox --from-channel 16.04/beta --to-channel 16.04/stable --yes
-          snapcraft promote checkbox --from-channel 18.04/beta --to-channel 18.04/candidate --yes
           snapcraft promote checkbox --from-channel 18.04/beta --to-channel 18.04/stable --yes
-          snapcraft promote checkbox --from-channel 20.04/beta --to-channel 20.04/candidate --yes
           snapcraft promote checkbox --from-channel 20.04/beta --to-channel 20.04/stable --yes
-          snapcraft promote checkbox --from-channel 22.04/beta --to-channel 22.04/candidate --yes
           snapcraft promote checkbox --from-channel 22.04/beta --to-channel 22.04/stable --yes
-          snapcraft promote checkbox --from-channel 24.04/beta --to-channel 24.04/candidate --yes
           snapcraft promote checkbox --from-channel 24.04/beta --to-channel 24.04/stable --yes
-          snapcraft promote checkbox --from-channel 22.04/beta --to-channel latest/candidate --yes
-          snapcraft promote checkbox --from-channel 22.04/beta --to-channel latest/stable --yes
+          snapcraft promote checkbox --from-channel 24.04/beta --to-channel latest/stable --yes


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

When I first introduced the workflow, I forgot uc24. Also, the switch of latest to.. latest, is long overdue

Minor: this removes explicit promo to candidate as it doesn't really make sense, when promoting to stable, candidate is imlicitly overwritten
```
  uc24/stable:                   4.3.0-dev71  2025-02-14 (12408) 11MB -
  uc24/candidate:                ↑                                    
```

## Resolved issues

Fixes: CHECKBOX-1752

## Documentation

N/A

## Tests

N/A
