### PR TITLE
Only check changed paths (infra)

### DIFF
--- a/.github/workflows/deb_validator.yaml
+++ b/.github/workflows/deb_validator.yaml
@@ -84,7 +84,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -qq -y dpkg-dev
       - name: Prepare installation
-        run: mv ${{ matrix.path }}/debian .
+        env:
+          MATRIX_PATH: ${{ matrix.path }}
+        run: mv "$MATRIX_PATH/debian" .
       - name: Install dependencies
         run: sudo apt-get build-dep .
       - name: Build source, test and build binary

--- a/.github/workflows/deb_validator.yaml
+++ b/.github/workflows/deb_validator.yaml
@@ -52,7 +52,6 @@ jobs:
             if changed $path; then
               paths+=("\"$path\"");
             fi;
-            echo $path
           done
           path_array=`echo "["${paths[*]}"]" | sed 's/" "/","/g'`
           echo "paths=$path_array" >> $GITHUB_OUTPUT

--- a/.github/workflows/deb_validator.yaml
+++ b/.github/workflows/deb_validator.yaml
@@ -29,7 +29,37 @@ on:
   workflow_dispatch:
 
 jobs:
+  get_path_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      paths: ${{ steps.paths.outputs.paths }}
+    steps:
+      - name: Checkout Checkbox monorepo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - id: paths
+        run: |
+          DIFF=$(git diff --name-only origin/main)
+          changed(){ echo "$DIFF" | grep -o $1; }
+
+          paths=()
+          for path in \
+              checkbox-ng \
+              checkbox-support \
+              providers/*/; do
+            if changed $path; then
+              paths+=("\"$path\"");
+            fi;
+            echo $path
+          done
+          path_array=`echo "["${paths[*]}"]" | sed 's/" "/","/g'`
+          echo "paths=$path_array" >> $GITHUB_OUTPUT
+
+
   deb_validation:
+    needs: get_path_matrix
     strategy:
       fail-fast: false
       matrix:
@@ -40,16 +70,7 @@ jobs:
           - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
-        path:
-          - checkbox-ng
-          - checkbox-support
-          - providers/base
-          - providers/certification-client
-          - providers/certification-server
-          - providers/gpgpu
-          - providers/resource
-          - providers/sru
-          - providers/tpm2
+        path: ${{ fromJson(needs.get_path_matrix.outputs.paths) }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Checkbox monorepo


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This makes the pipeline slightly less wasteful by only re-testing directories that did actually change.

## Resolved issues

N/A

## Documentation

N/A

## Tests

See this commit for the pipeline in action: https://github.com/canonical/checkbox/actions/runs/13372119135
See this commit for the pipeline not running (as it should): [27bc0df](https://github.com/canonical/checkbox/pull/1733/commits/27bc0dfd0a90253c1c440af6230676ccd31b8ec6)
