### PR TITLE
Prettier output for the wifi_test (bugfix)

### DIFF
--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -191,19 +191,22 @@ def wait_for_connected(interface, essid):
     print_cmd(cmd)
     output = sp.check_output(shlex.split(cmd), universal_newlines=True)
     print(output)
-    state, ssid = output.strip().splitlines()
+    # if state is not connected, no ssid will be provided
+    state, *ssid = output.strip().splitlines()
+    ssid = next(iter(ssid), None)
 
     if state.startswith("100") and ssid == essid:
         print("Reached connected state with ESSID: {}".format(essid))
+    elif not state.startswith("100"):
+        error_msg = "State is not connected: {}".format(state)
+        raise SystemExit(error_msg)
     elif ssid != essid:
         error_msg = (
             "ERROR: did not reach connected state with ESSID: {}\n"
             "ESSID mismatch:\n  Excepted:{}\n  Actually:{}"
         ).format(essid, ssid, essid)
         raise SystemExit(error_msg)
-    elif not state.startswith("100"):
-        error_msg = "State is not connected: {}".format(state)
-        raise SystemExit(error_msg)
+
     print()
 
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

If the wifi test fails to connect it spits out a weird  `not enough values to unpack (expected 2, got 1)` instead of just reporting that the test failed to connect. This fixes that.

## Resolved issues

Fixes: CHECKBOX-1759
Fixes: https://github.com/canonical/checkbox/issues/1737

## Documentation

Explained why I used next and `*` in a comment above

## Tests

N/A
