### PR TITLE
Use indexed option directive on unit reference documentation (Infra)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,7 +20,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py
-
+   fail_on_warning: true   # Fail on all warnings to avoid broken references
 
 # Optionally declare the Python requirements required to build your docs
 python:

--- a/docs/.sphinx/_static/checkbox-doc.css
+++ b/docs/.sphinx/_static/checkbox-doc.css
@@ -1,3 +1,12 @@
+/* :option: directive for unit fields */
+.sig-name {
+    color: var(--color-code-foreground);
+}
+.sig:not(.sig-inline) {
+    background-color: var(--color-inline-code-background);
+}
+
+/* mermaid diagrams */
 .mermaid {
     display: flex;
     justify-content: center;

--- a/docs/.sphinx/spellingcheck.yaml
+++ b/docs/.sphinx/spellingcheck.yaml
@@ -26,3 +26,5 @@ matrix:
       - pre
       - spellexception
       - title
+      - span.sig-name     # ignore option directive
+      - li:has(a[href*="#cmdoption"])   # ignore option directive in genindex page

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,7 +157,8 @@ html_theme_options = {
 
 html_static_path = [".sphinx/_static"]
 html_css_files = [
-    "checkbox-doc.css" "custom.css",
+    "checkbox-doc.css",
+    "custom.css",
     "github_issue_links.css",
 ]
 html_js_files = [

--- a/docs/how-to/nested-test-plan.rst
+++ b/docs/how-to/nested-test-plan.rst
@@ -196,7 +196,7 @@ The jobs execution order is:
 How to change category or certification status of jobs coming from nested parts?
 --------------------------------------------------------------------------------
 
-The :ref:`test plan override mechanism<Test Plan category_overrides field>`
+The :option:`test plan override mechanism <test-plan category_overrides>`
 still works with nested parts. For example the ``hello`` job from the Baz
 provider was defined as a blocker and did not have a category.
 

--- a/docs/reference/units/category.rst
+++ b/docs/reference/units/category.rst
@@ -7,7 +7,7 @@ Using category units one can define logical groups of tests that deal with some
 specific testing area (for example, suspend-resume or USB support).
 
 Job definitions can be associated with at most one category using the
-``category_id`` field (see :ref:`job unit reference <Category id field>`).
+``category_id`` field (see :option:`job unit reference <job category_id>`).
 Categories can be used by particular applications to facilitate test selection.
 
 Category Fields
@@ -15,15 +15,15 @@ Category Fields
 
 There are two fields that are used by the category unit:
 
-.. _Category id field:
+.. program:: category
 
-``id``:
+.. option:: id
+
     (mandatory) - This field defines the partial identifier of the category. It
     is similar to the ``id`` field on the job definition units.
 
-.. _Category name field:
+.. option:: name
 
-``name``:
     (mandatory) - This field defines a human readable name of the category. It
     may be used in application user interfaces for displaying a group of tests.
 

--- a/docs/reference/units/exporter.rst
+++ b/docs/reference/units/exporter.rst
@@ -21,37 +21,34 @@ Fields
 
 Following fields may be used by an exporter unit.
 
-.. _Exporter id field:
+.. program:: exporter
 
-``id``:
+.. option:: id
+
     (mandatory) - Unique identifier of the exporter. This field is used to look
     up and store data so please keep it stable across the lifetime of your
     provider.
 
-.. _Exporter summary field:
+.. option:: summary
 
-``summary``:
     (optional) - A human readable name for the exporter. This value is
     available for translation into other languages. It is used when listing
     exporters. It must be one line long, ideally it should be short (50-70
     characters max).
 
-.. _Exporter entry_point field:
+.. option:: entry_point
 
-``entry_point``:
     (mandatory) - This is a key for a pkg_resources entry point from the
     plainbox.exporters namespace.
     Allowed values are: jinja2, text, xlsx, json and rfc822.
 
-.. _Exporter file_extension field:
+.. option:: file_extension
 
-``file_extension``:
     (mandatory) - Filename extension to use when the exporter stream is saved
     to a file.
 
-.. _Exporter options field:
+.. option:: options
 
-``options``:
     (optional) - comma/space/semicolon separated list of options for this
     exporter entry point. Only the following options are currently supported.
 
@@ -85,9 +82,8 @@ Following fields may be used by an exporter unit.
     jinja2:
         - without-session-desc
 
-.. _Exporter data field:
+.. option:: data
 
-``data``:
     (optional) - Extra data sent to the exporter code, to allow all kind of
     data types, the data field only accept valid JSON. For exporters using the
     jinja2 entry point, the template name and any additional paths to load

--- a/docs/reference/units/job.rst
+++ b/docs/reference/units/job.rst
@@ -21,9 +21,10 @@ Job Fields
 
 Following fields may be used by the job unit:
 
-.. _Job id field:
+.. program:: job
 
-``id``:
+.. option:: id
+
     (mandatory) - A name for the job. Should be unique, an error will
     be generated if there are duplicates. Should contain characters in
     ``[a-z0-9/-]``.
@@ -31,54 +32,71 @@ Following fields may be used by the job unit:
     backwards compatibility it is still recognized and used if ``id`` is
     missing.
 
-.. _Job summary field:
+.. option:: summary
 
-``summary``:
     (mandatory) - A human readable name for the job. This value is available
     for translation into other languages. It is used when listing jobs. It must
     be one line long, ideally it should be short (50-70 characters max).
 
-.. _Job category_id field:
+.. option:: category_id
 
-``category_id``:
     (optional) - Identifier of the :doc:`category` this job belongs to.
 
-.. _Job plugin field:
+.. option:: plugin
 
-``plugin``:
     (mandatory) - For historical reasons it's called "plugin" but it's
     better thought of as describing the "type" of job. The allowed types
     are:
 
-     :manual: jobs that require the user to perform an action and then
-          decide on the test's outcome.
-     :shell: jobs that run without user intervention and
-         automatically set the test's outcome.
-     :user-interact: jobs that require the user to perform an
-         interaction, after which the outcome is automatically set.
-     :user-interact-verify: jobs that require the user to perform an
+    .. option:: manual
+
+        Jobs that require the user to perform an action and then
+        decide on the test's outcome.
+    
+    .. option:: shell
+        
+        Jobs that run without user intervention and
+        automatically set the test's outcome.
+    
+    .. option:: user-interact
+        
+        Jobs that require the user to perform an
+        interaction, after which the outcome is automatically set.
+    
+    .. option:: user-interact-verify
+        
+        Jobs that require the user to perform an
         interaction, run a command after which the user is asked to decide on the
         test's outcome. This is essentially a manual job with a command.
-     :attachment: jobs whose command output will be attached to the
-         test report or submission.
-     :resource: A job whose command output results in a set of rfc822
-          records, containing key/value pairs, and that can be used in other
-          jobs' ``requires`` expressions.
+    
+    .. option:: attachment
+        
+        Jobs whose command output will be attached to the
+        test report or submission.
+    
+    .. option:: resource
+        
+        Jobs whose command output results in a set of rfc822
+        records, containing key/value pairs, and that can be used in other
+        jobs' ``requires`` expressions.
 
-.. _Job certification-status field:
+.. option:: certification-status
 
-``certification-status``:
     (optional) - Certification status for the given job. This is used by
     Canonical to determine the jobs that **must** be run in order to be able to
     issue a certificate. The allowed values are:
 
-    :non-blocker:
+    
+    .. option:: non-blocker
+
         This value means that a given job may fail and while that should be
         regarded as a possible future problem it will not block the
         certification process. Canonical reserves the right to promote jobs
         from *non-blocker* to *blocker*. This is the implicit certification
         status for all jobs.
-    :blocker:
+    
+    .. option:: blocker
+        
         This value means that a given job **must** pass for the certification
         process to succeed.
 
@@ -93,9 +111,8 @@ Following fields may be used by the job unit:
         Certification team can evaluate the test report and investigate the
         reasons behind such an outcome.
 
-.. _Job requires field:
+.. option:: requires
 
-``requires``:
     (optional). If specified, the job will only run if the conditions
     expressed in this field are met.
 
@@ -110,30 +127,26 @@ Following fields may be used by the job unit:
     respecting the rfc822 multi-line syntax, in which case all
     requirements must be met for the job to run ( ``and`` ed).
 
-.. _Job depends field:
+.. option:: depends
 
-``depends``:
     (optional). If specified, the job will only run if all the listed
     jobs have run and passed. Multiple job names, separated by spaces,
     can be specified.
 
-.. _Job after field:
+.. option:: after
 
-``after``:
     (optional). If specified, the job will only run if all the listed jobs have
     run (regardless of the outcome). Multiple job names, separated by spaces,
     can be specified.
 
-.. _Job salvages field:
+.. option:: salvages
 
-``salvages``:
     (optional). If specified, the job will only run if all the listed jobs have
     failed. This is useful for obtaining logs from a system when something
     fails. Multiple job names, separated by spaces, can be specified.
 
-.. _Job command field:
+.. option:: command
 
-``command``:
     (optional). A command can be provided, to be executed under specific
     circumstances.
 
@@ -153,42 +166,37 @@ Following fields may be used by the job unit:
 
     Note: A ``shell`` job without a command will do nothing.
 
-.. _Job purpose field:
+.. option:: purpose
 
-``purpose``:
     (optional). Purpose field is used in tests requiring human interaction as
     an information about what a given test is supposed to do. User interfaces
     should display content of this field prior to test execution. This field
     may be omitted if the summary field is supplied.
     Note that this field is applicable only for human interaction jobs.
 
-.. _Job steps field:
+.. option:: steps
 
-``steps``:
     (optional). Steps field depicts actions that user should perform as a part
     of job execution. User interfaces should display the content of this field
     upon starting the test.
     Note that this field is applicable only for jobs requiring the user to
     perform some actions.
 
-.. _Job verification field:
+.. option:: verification
 
-``verification``:
     (optional). Verification field is used to inform the user how they can
     resolve a given job outcome.
     Note that this field is applicable only for jobs the result of which is
     determined by the user.
 
-.. _Job user field:
+.. option:: user
 
-``user``:
     (optional). If specified, the job will be run as the user specified
     here. This is most commonly used to run jobs as the superuser
     (root).
 
-.. _Job environ field:
+.. option:: environ
 
-``environ``:
     (optional). If specified, the listed environment variables
     (separated by spaces) will be taken from the invoking environment
     (i.e. the one Checkbox is run under) and set to that value on the
@@ -201,9 +209,8 @@ Following fields may be used by the job unit:
     environment, with the downside that useful configuration specified
     in environment variables may be lost in the process.
 
-.. _Job estimated_duration field:
+.. option:: estimated_duration
 
-``estimated_duration``:
     (optional) This field contains metadata about how long the job is
     expected to run for, as a positive float value indicating
     the estimated job duration in seconds.
@@ -223,27 +230,23 @@ Following fields may be used by the job unit:
     say ``2m 30s``). We feel that sub-second granularity does is too
     unpredictable to be useful so that will not be supported in the future.
 
-.. _Job flags field:
+.. option:: flags
 
-``flags``:
     (optional) This fields contains list of flags separated by spaces or
     commas that might induce Checkbox to run the job in particular way.
     Currently, following flags are inspected by Checkbox:
 
-    .. _reset-locale flag:
-
-    ``reset-locale``:
+    .. option:: reset-locale
+        
         This flag makes Checkbox reset locale before running the job.
 
-    .. _win32 flag:
-
-    ``win32``:
+    .. option:: win32
+        
         This flag makes Checkbox run jobs' commands in windows-specific manner.
         Attach this flag to jobs that are run on Windows OS.
 
-    .. _noreturn flag:
-
-    ``noreturn``:
+    .. option:: noreturn
+        
         This flag makes Checkbox suspend execution after job's command is run.
         This prevents scenario where Checkbox continued to operate (writing
         session data to disk and so on), while other process kills it (leaving
@@ -254,24 +257,21 @@ Following fields may be used by the job unit:
         in the ``$PLAINBOX_SESSION_SHARE`` directory which can be used by the
         test to automatically resume session. (For instance after a reboot).
 
-    .. _explicit-fail flag:
-
-    ``explicit-fail``:
+    .. option:: explicit-fail
+        
         Use this flag to make entering comment mandatory, when the user
         manually fails the job.
 
-    .. _has-leftovers flag:
-
-    ``has-leftovers``:
+    .. option:: has-leftovers
+        
         This flag makes Checkbox silently ignore (and not log) any files left
         over by the execution of the command associated with a job. This flag
         is useful for jobs that don't bother with maintenance of temporary
         directories and just want to rely on the one already created by
         Checkbox.
 
-    .. _simple flag:
-
-    ``simple``:
+    .. option:: simple
+        
         This flag makes Checkbox disable certain validation advice and have
         some sensible defaults for automated test cases.  This simplification
         is meant to cut the boiler plate on jobs that are closer to unit tests
@@ -279,10 +279,10 @@ Following fields may be used by the job unit:
 
         In practice the following changes are in effect when this flag is set:
 
-         - the *plugin* field defaults to *shell*
-         - the *description* field is entirely optional
-         - the *estimated_duration* field is entirely optional
-         - the *preserve-locale* flag is entirely optional
+        - the *plugin* field defaults to *shell*
+        - the *description* field is entirely optional
+        - the *estimated_duration* field is entirely optional
+        - the *preserve-locale* flag is entirely optional
 
         A minimal job using the simple flag looks as follows::
 
@@ -290,48 +290,42 @@ Following fields may be used by the job unit:
             command: echo "Jobs are simple!"
             flags: simple
 
-    .. _preserve-cwd flag:
-
-    ``preserve-cwd``:
+    .. option:: preserve-cwd
+        
         This flag makes Checkbox run the job command in the current working
         directory without creating a temp folder (and running the command from
         this temp folder). Sometimes needed on snappy
         (See http://pad.lv/1618197)
 
-    .. _fail-on-resource flag:
-
-    ``fail-on-resource``:
+    .. option:: fail-on-resource
+        
         This flag makes Checkbox fail the job if one of the resource
         requirements evaluates to False.
 
-    .. _also-after-suspend flag:
-
-    ``also-after-suspend``:
+    .. option:: also-after-suspend
+        
         Ensure the test will be run before **and** after suspend by creating
-        a :ref:`sibling<Job siblings field>` that will depend on the automated
+        a :option:`sibling <siblings>` that will depend on the automated
         suspend job. The current job is guaranteed to run before suspend.
 
-    .. _also-after-suspend-manual flag:
-
-    ``also-after-suspend-manual``:
+    .. option:: also-after-suspend-manual
+        
         Ensure the test will be run before **and** after suspend by creating
-        a :ref:`sibling<Job siblings field>` that will depend on the manual
+        a :option:`sibling <siblings>` that will depend on the manual
         suspend job. The current job is guaranteed to run before suspend.
 
     Additional flags may be present in job definition; they are ignored.
+    
+    .. option:: cachable
 
-    .. _cachable flag:
-
-    ``cachable``:
         Saves the output of a resource job in the system, so the next time
         the session is started recorded output is used making the session
         bootstrap faster.
 
     This flag has no effect on jobs other than resource.
 
-.. _Job siblings field:
+.. option:: siblings
 
-``siblings``:
     (optional) This field creates copies of the current job definition
     but using a dictionary of overridden fields. The intend is to reduce the
     amount of job definitions when only a few changes are required to make a
@@ -411,9 +405,8 @@ Following fields may be used by the job unit:
                       "depends": "suspend/advanced"}}
                     ]
 
-.. _Job imports field:
+.. option:: imports
 
-``imports``:
     (optional) This field lists all the resource jobs that will have to be
     imported from other namespaces. This enables jobs to use resources from
     other namespaces.

--- a/docs/reference/units/manifest-entry.rst
+++ b/docs/reference/units/manifest-entry.rst
@@ -27,18 +27,18 @@ Fields
 
 Following fields may be used by a manifest entry unit.
 
-.. _Manifest Entry id field:
+.. program:: manifest-entry
 
-``id``:
+.. option:: id
+
     (mandatory) - Unique identifier of the entry. This field is used to look up
     and store data so please keep it stable across the lifetime of your
     provider. If the id starts with a ``_``, then the manifest will be hidden
     from the interactive selection. These manifests can only be given a value
     via configurations.
 
-.. _Manifest Entry name field:
+.. option:: name
 
-``name``:
     (mandatory) - A human readable name of the entry. This should read as in a
     feature matrix of a device in a store (e.g., "802.11ac wireless
     capability", or "Thunderbolt support", "Number of hard drive bays"). This
@@ -49,40 +49,35 @@ Following fields may be used by a manifest entry unit.
     The name is a translatable field so please prefix it with ``_`` as in
     ``_name: Example``.
 
-.. _Manifest Entry value-type field:
+.. option:: value-type
 
-``value-type``:
     (mandatory) - Type of value for this entry. Currently two values are
     allowed: ``bool`` for a yes/no value and ``natural`` for any natural number
     (negative numbers are rejected).
 
-.. _Manifest Entry value-units field:
+.. option:: value-units
 
-``value-units``:
     (optional) - Units in which value is measured in. This is only used when
     ``value-type`` is equal to ``natural``. For example a *"Screen size"*
     manifest entry could be measured in *"inch"* units.
 
-.. _Manifest Entry resource-key field:
+.. option:: resource-key
 
-``resource-key``:
     (optional) - Name of the resource key used to store the manifest value when
     representing the manifest as a resource record. This field defaults to the
     so-called *partial id* which is just the ``id:`` field as spelled in the
     unit definition file (so without the name space of the provider)
 
-.. _Manifest Entry prompt field:
+.. option:: prompt
 
-``prompt``:
     (optional) - Allows the manifest unit to customize the prompt presented
     when collecting values from a user. When the ``value-type`` is ``bool`` the
     default prompt is "Does this machine have this piece of hardware?", when
     the ``value-type`` is ``natural`` the default prompt is "Please enter the
     requested data".
 
-.. _Manifest Entry hidden reason:
+.. option:: hidden-reason
 
-``hidden-reason``:
     (mandatory if hidden) - Explains why a manifest unit was hidden. The reason
     should be clear and specific, as this field serves as documentation for
     future reference.

--- a/docs/reference/units/packaging-meta-data.rst
+++ b/docs/reference/units/packaging-meta-data.rst
@@ -22,16 +22,16 @@ Fields
 
 Following fields may be used by a manifest entry unit.
 
-.. _Packaging Meta Data os-id field:
+.. program:: packaging-meta-data
 
-``os-id``:
+.. option:: os-id
+
     (mandatory) - the identifier of the operating system this rule applies to.
     This is the same value as the ``ID`` field in the file ``/etc/os-release``.
     Typical values include ``debian``, ``ubuntu`` or ``fedora``.
 
-.. _Packaging Meta Data os-version-id field:
+.. option:: os-version-id
 
-``os-version-id``:
     (optional) - the identifier of the specific version of the operating system
     this rule applies to. This is the same as the ``VERSION_ID`` field in the
     file ``/etc/os-release``. If this field is not present then the rule
@@ -45,9 +45,8 @@ Following fields may be used by a manifest entry unit.
 The remaining fields are custom and depend on the packaging driver. The values
 for **Debian** are:
 
-.. _Packaging Meta Data Depends field:
+.. option:: Depends
 
-``Depends``:
     (optional) - a comma separated list of dependencies for the binary package.
     The syntax is the same as in normal Debian control files (including package
     version dependencies). This field can be split into multiple lines, for
@@ -56,14 +55,12 @@ for **Debian** are:
     an unique value for validation.
 
 
-.. _Packaging Meta Data Suggests field:
+.. option:: Suggests
 
-``Suggests``:
     (optional) - same as ``Depends``.
 
-.. _Packaging Meta Data Recommends field:
+.. option:: Recommends
 
-``Recommends``:
     (optional) - same as ``Depends``.
 
 Matching Packaging Meta-Data Units

--- a/docs/reference/units/template.rst
+++ b/docs/reference/units/template.rst
@@ -31,9 +31,12 @@ instead of::
 Template-Specific Fields
 ========================
 
-.. _Template template-id field:
+The following fields are specific to the template unit:
 
-``template-id``
+.. program:: template
+
+.. option:: template-id
+
     Unique identifier for this template. Should contain characters in
     ``[a-z0-9/-]``.
 
@@ -42,9 +45,8 @@ Template-Specific Fields
     ``stress/reboot_{iterations}_times``, the computed ``template-id`` field
     will be ``stress/reboot_iterations_times``.
 
-.. _Template template-summary field:
+.. option:: template-summary
 
-``template-summary``
     A human readable name for the template. This value is available for
     translation into other languages. It must be one line long, ideally it
     should be short (50-70 characters max).
@@ -60,26 +62,23 @@ Template-Specific Fields
     This field is optional (Checkbox will only advise you to provide one when
     running provider validation).
 
-.. _Template template-description field:
+.. option:: template-description
 
-``template-description``
     A long form description of what the template does or the kind of jobs it
     instantiates. This value is available for translation into other languages.
 
     This field is optional.
 
-.. _Template template-unit field:
+.. option:: template-unit
 
-``template-unit``
     Name of the unit type this template will generate. By default job
     definition units are generated (as if the field was specified with the
     value of ``job``) eventually but other values may be used as well.
 
     This field is optional.
 
-.. _Template template-resource field:
+.. option:: template-resource
 
-``template-resource``
     Name of the resource job (if it is a compatible resource identifier) to use
     to parametrize the template. This must either be a name of a resource job
     available in the namespace the template unit belongs to *or* a valid
@@ -88,9 +87,8 @@ Template-Specific Fields
 
     This field is mandatory.
 
-.. _Template template-imports field:
+.. option:: template-imports
 
-``template-imports``
     A resource import statement. It can be used to refer to arbitrary resource
     job by its full identifier and (optionally) give it a short variable name.
 
@@ -108,9 +106,8 @@ Template-Specific Fields
     job definition is from another provider namespace or when it is not a valid
     resource identifier and needs to be aliased.
 
-.. _Template template-filter field:
+.. option:: template-filter
 
-``template-filter``
     A resource program that limits the set of records from which template
     instances will be made. The syntax of this field is the same as the syntax
     of typical job definition unit's ``requires`` field, that is, it is a
@@ -122,9 +119,8 @@ Template-Specific Fields
 
     This field is optional.
 
-.. _Template template-engine field:
+.. option:: template-engine
 
-``template-engine``
     Name of the template engine to use, default is python string formatting
     (See PEP 3101). The only other supported engine is ``jinja2``.
 
@@ -250,7 +246,7 @@ to aid the author.
     to how many jobs have been created so far.
 
 Following parameters are only available for templates based on the Jinja2
-engine (see :ref:`Template template-engine field`):
+engine (see :option:`template template-engine`):
 
 ``__system_env__``:
     When checkbox encounters a template to render it will populate this

--- a/docs/reference/units/test-plan.rst
+++ b/docs/reference/units/test-plan.rst
@@ -11,10 +11,10 @@ Jobs are selected by either listing their identifier or a regular expression
 that matches their identifier. Listing a template identifier will select all
 the jobs instantiated by it. Selected jobs are executed in the sequence they
 appear in the list, unless they need to be reordered to satisfy dependencies
-which always take priority. It is also possible to :ref:`exclude<Test Plan
-exclude field>` jobs from the selection using the same principles.
+which always take priority. It is also possible to :option:`test-plan exclude`
+jobs from the selection using the same principles.
 
-Test plans can be :ref:`nested<Test Plan nested_part field>`, so you can
+Test plans can be :option:`test-plan nested_part`, so you can
 define several smaller test plans and combine them into a bigger one, which
 helps with maintenance and flexibility.
 
@@ -36,9 +36,10 @@ maintain backwards compatibility so some of the test plans it defines may have
 non-typical constructs required to ensure proper behavior. You don't have to
 copy such constructs when working on a new test plan from scratch
 
-.. _Test Plan id field:
+.. program:: test-plan
 
-``id``:
+.. option:: id
+
     Each test plan needs to have a unique identifier. This is exactly the same
     as with other units that have an identifier (like job definitions
     and categories).
@@ -46,9 +47,8 @@ copy such constructs when working on a new test plan from scratch
     This field is not used for display purposes but you may need to refer
     to it on command line so keeping it descriptive is useful
 
-.. _Test Plan name field:
+.. option:: name
 
-``name``:
     A human-readable name of the test plan. The name should be relatively short
     as it may be used to display a list of test plans to the test operator.
 
@@ -67,9 +67,8 @@ copy such constructs when working on a new test plan from scratch
     lines. This field should be marked as translatable by prepending the
     underscore character (\_) in front. This field is mandatory.
 
-.. _Test Plan description field:
+.. option:: description
 
-``description``:
     A human-readable description of this test plan. Here you can include as
     many or few details as you'd like. Some applications may offer a way
     of viewing this data. In general it is recommended to include a description
@@ -86,9 +85,8 @@ copy such constructs when working on a new test plan from scratch
     should be marked as translatable by prepending the underscore character
     (\_) in front. This field is optional.
 
-.. _Test Plan include field:
+.. option:: include
 
-``include``:
     A multi-line list of job identifiers, patterns matching such identifiers or
     template identifiers that should be included for execution.
 
@@ -122,9 +120,8 @@ copy such constructs when working on a new test plan from scratch
     below for examples on how you can refer to jobs from other providers
     (you simply use their fully qualified name for that).
 
-.. _Test Plan mandatory_include field:
+.. option:: mandatory_include
 
-``mandatory_include``:
     A multi-line list of job identifiers or patterns matching such identifiers
     that should always be executed.
 
@@ -142,9 +139,8 @@ copy such constructs when working on a new test plan from scratch
     Note that mandatory jobs will always be run first (along with their
     dependent jobs).
 
-.. _Test Plan bootstrap_include field:
+.. option:: bootstrap_include
 
-``bootstrap_include``:
     A multi-line list of job identifiers that should be run first, before the
     main body of testing begins. The job that should be included in the
     bootstrapping sections are the ones generating or helping to generate other
@@ -159,18 +155,16 @@ copy such constructs when working on a new test plan from scratch
     identifier and cannot be a regular expression pattern.
     Also note that only resource jobs are allowed in this section.
 
-.. _Test Plan nested_part field:
+.. option:: nested_part
 
-``nested_part``:
    A multi-line list of test-plan identifiers whose contents will become part
    of this test-plan. This is a method of creating a tree of test plans,
    something that can be useful for organization and de-duplication of test plan
    definitions. For a full discussion of this capability see
    :ref:`nested-test-plan`.
 
-.. _Test Plan exclude field:
+.. option:: exclude
 
-``exclude``:
     A multi-line list of job identifiers or patterns matching such identifiers
     that should be excluded from execution.
 
@@ -184,9 +178,8 @@ copy such constructs when working on a new test plan from scratch
 
     When a job is both included and excluded, exclusion always takes priority.
 
-.. _Test Plan category_overrides field:
+.. option:: category_overrides
 
-``category_overrides``:
     A multi-line list of category override statements.
 
     This optional field can be used to alter the natural job definition
@@ -236,17 +229,16 @@ copy such constructs when working on a new test plan from scratch
     The job definition with the partial identifier ``foo`` will be associated
     with the ``cat-2`` category.
 
-.. _Test Plan certification_status_overrides field:
+.. option:: certification_status_overrides
 
-``certification_status_overrides``:
     A multi-line list of certification status override statements.
 
-    Similar to the :ref:`category_overrides<Test Plan category_overrides field>`
+    Similar to the :option:`test-plan category_overrides`
     field, this field can be used to modify the certification status of the
     jobs matching the given regular expression.
 
     The possible values are the same as for the
-    :ref:`certification-status<Job certification-status field>` job field.
+    :option:`job certification-status` job field.
 
     For instance, the following will force every wireless job to become a
     certification blocker::
@@ -275,9 +267,8 @@ copy such constructs when working on a new test plan from scratch
 
         to apply the override to every job of every namespaces.
 
-.. _Test Plan estimated_duration field:
+.. option:: estimated_duration
 
-``estimated_duration``:
     An approximate time to execute this test plan, in seconds.
 
     This field can be expressed in two formats. The old format, a floating

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -1,3 +1,5 @@
+.. _tutorials:
+
 Tutorial
 ========
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -46,5 +46,5 @@ sections can be followed in any order - they don’t depend on each other.
 .. toctree::
    :maxdepth: 1
 
-  writing-tests/test-case
-  writing-tests/test-plan
+   writing-tests/test-case
+   writing-tests/test-plan

--- a/docs/tutorial/using-checkbox/advanced-commands.rst
+++ b/docs/tutorial/using-checkbox/advanced-commands.rst
@@ -303,5 +303,5 @@ one device to control another device, and used Checkbox commands to navigate
 the available objects in Checkbox. You are now ready to use Checkbox to test
 any kind of devices!
 
-In the :ref:`advanced tutorial<TODO>`, you will learn how to write new tests
-for Checkbox and how to create your own Checkbox-based snaps.
+In the :ref:`Writing test jobs tutorial <test_case>`, you will learn how to 
+write new tests for Checkbox and how to create your own Checkbox-based snaps.

--- a/docs/tutorial/using-checkbox/manifest.rst
+++ b/docs/tutorial/using-checkbox/manifest.rst
@@ -104,8 +104,8 @@ A bit below, we see a ``Hardware Manifest`` job being executed:
 
 This job will collect the information from the manifest file so that it
 can be used by Checkbox later for each :ref:`manifest_entry` defined in the
-providers. We can see that ``has_touchscreen`` (the :ref:`id<Manifest Entry
-id field>` of the manifest entry unit that represents whether or not this
+providers. We can see that ``has_touchscreen`` (the :option:`manifest-entry
+id` of the manifest entry unit that represents whether or not this
 device has a touch screen) is set to ``True`` because we selected it in the
 System Manifest screen.
 


### PR DESCRIPTION
## Description

The unit references currently use definition lists for explaining each field, but each element is not indexed so cannot be cross-referenced. This PR replaces those `<dl>` list and manually defined anchors with the [`:option:` directive in Sphinx](https://www.sphinx-doc.org/en/master/usage/domains/standard.html)

* Field names are defined with `.. option:: name`, and then are indexed during doc build 
  * the defined fields can be cross-referenced by using ``:option: `name` ``
* Scope can be defined with `.. program:: unit`, so that duplicated option names can be specified by adding the scope name before the field ``:option: `unit name` `` 
* Update CSS style for the generated `.sig` elements
* Update spelling check settings to ignore field names with .sig CSS class

Chore:
* Enabled `fail_on_warning` on readthedocs build to prevent broken links

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

CHECKBOX-1747

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

NA

## Tests

PR checks on Readthedocs
Preview: https://canonical-checkbox--1739.com.readthedocs.build/en/1739/reference/units/job.html
