### PR TITLE
[CHECKBOX-1737] Remove iperf stress test case from a test plan (Infra)

### DIFF
--- a/providers/base/units/ethernet/test-plan.pxu
+++ b/providers/base/units/ethernet/test-plan.pxu
@@ -138,7 +138,6 @@ include:
     ethernet/info_automated_server          certification-status=non-blocker
     ethernet/ethtool_info                   certification-status=non-blocker
     ethernet/ethertool_check_.*             certification-status=non-blocker
-    ethernet/sru_iperf3_stress_device-.*    certification-status=blocker
 bootstrap_include:
     device
     executable


### PR DESCRIPTION
## Description

This change removes the `ethernet/sru_iperf3_stress_device-{__index__}_{interface}` test case from the `server-ethernet-sru` test plan. This plan is part of the large `server-regression` test plan which is currenly in use for server regression tests. 


## Resolved issues

Resolves CHECKBOX-1737

## Documentation

No documentation changes for this removal.

## Tests

