### PR TITLE
Update cuda-samples snap arguments (BugFix)

### DIFF
--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -21,17 +21,17 @@ requires:
     snap.name == 'cuda-samples'
     uname.machine == 'x86_64'
 _summary: NVIDIA GPGPU query device test
-command: cuda-samples deviceQueryDrv
+command: cuda-samples 1_Utilities deviceQueryDrv deviceQueryDrv
 _siblings: [
   { "id": "gpgpu/vector-add-drv",
     "_summary": "NVIDIA GPGPU vector addition test",
-    "command": "cuda-samples vectorAddDrv"},
+    "command": "cuda-samples 0_Introduction vectorAddDrv vectorAddDrv"},
   { "id": "gpgpu/matrix-mul-drv",
     "_summary": "NVIDIA GPGPU matrix multiplication test",
-    "command": "cuda-samples matrixMulDrv"},
+    "command": "cuda-samples 0_Introduction matrixMulDrv matrixMulDrv"},
   { "id": "gpgpu/simple-texture-drv",
     "_summary": "NVIDIA GPGPU simple textures test",
-    "command": "cuda-samples simpleTextureDrv"}
+    "command": "cuda-samples 0_Introduction simpleTextureDrv simpleTextureDrv"}
   ]
 
 id: gpgpu/rvs-gpup


### PR DESCRIPTION
## Description

- I updated the `cuda-samples` snap's launcher script as a result of breaking changes in the upstream build process.
  - The launcher script now takes in the sample's group, sample name, and executable name

~~(waiting on the [current build](https://github.com/pedro-avalos/cuda-samples-snap/actions/runs/13577020064) to finish)~~ The build finished and I have pushed the snap to stable

## Resolved issues

## Documentation

## Tests
