### PR TITLE
Use process tree to detect if the subprocess child is gone (bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/tests/test_timeout.py
+++ b/checkbox-support/checkbox_support/tests/test_timeout.py
@@ -167,32 +167,25 @@ class TestTimeoutExec(TestCase):
         Checkbox waits for all children to be done)
         """
 
-        def inner(pid_pipe):
-            pid_pipe.send(os.getpid())
-            pid_pipe.close()
+        def inner():
             time.sleep(1e4)
 
-        def outer(pid_pipe):
-            inner_p = multiprocessing.Process(target=inner, args=(pid_pipe,))
+        def outer():
+            inner_p = multiprocessing.Process(target=inner)
             inner_p.start()
             inner_p.join()
 
         @timeout(0.1)
-        def f(pid_pipe):
-            outer_p = multiprocessing.Process(target=outer, args=(pid_pipe,))
+        def f():
+            outer_p = multiprocessing.Process(target=outer)
             outer_p.start()
             outer_p.join()
 
-        read, write = multiprocessing.Pipe()
         with self.assertRaises(TimeoutError):
-            f(write)
-        with self.assertRaises(OSError):
-            pid = read.recv()
-            # give the process a few ms to wind down
-            time.sleep(0.01)
-            # this throws an exception if the process we are trying to send
-            # a signal to doesn't exist
-            os.kill(pid, 0)
+            f()
+        # give the process a few ms to wind down
+        time.sleep(0.1)
+        self.assertEqual(multiprocessing.active_children(), [])
 
     @patch("checkbox_support.helpers.timeout.Queue")
     @patch("checkbox_support.helpers.timeout.Process")


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This test is unreliable as there is a race condition between the process winding down and the actual pid being checked. Checking the process tree is more reliable, as children will be recorded in the multiprocessing tree (they inherit the names as well) so we are able to query and see if they are still alive.

## Resolved issues

Builds intermittendly failing on LP (deb)

## Documentation

N/A

## Tests

Tested locally
