### PR TITLE
Add arm64 to GPGPU provider (New)

### DIFF
--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -57,7 +57,7 @@ This can be overwritten by the `--count` option or by setting the environment
 variable `LXD_GPU_RUNS`. With priority in that order.
 """
 
-GPU_THRESHOLD_SEC = 12.0
+GPU_THRESHOLD_SEC = 30
 """The threshold for the GPU test to pass.
 
 This can be overwritten by the `--threshold` option or by setting the

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -57,7 +57,7 @@ This can be overwritten by the `--count` option or by setting the environment
 variable `LXD_GPU_RUNS`. With priority in that order.
 """
 
-GPU_THRESHOLD_SEC = 30
+GPU_THRESHOLD_SEC = 12.0
 """The threshold for the GPU test to pass.
 
 This can be overwritten by the `--threshold` option or by setting the

--- a/providers/gpgpu/debian/control
+++ b/providers/gpgpu/debian/control
@@ -16,7 +16,7 @@ Build-Depends: checkbox-ng,
 Standards-Version: 3.9.6
 
 Package: checkbox-provider-gpgpu
-Architecture: all
+Architecture: any-amd64 arm64
 Depends: checkbox-provider-base, fwts, ipmitool, ${plainbox:Depends}, ${misc:Depends}
 Suggests: ubuntu-drivers-common, ${plainbox:Suggests}
 X-Plainbox-Provider: yes

--- a/providers/gpgpu/debian/control
+++ b/providers/gpgpu/debian/control
@@ -24,7 +24,7 @@ Description: Checkbox provider for GPGPU testing
  This package provides a test plan and tooling to be used by Canonical for the
  testing and certification of GPGPU devices in "server" computer systems
  .
- This provider depends heavily on the installation of the latest nVidia drivers
- and the CUDA tool kit from nVidia, as well as testing software hosted on
- github.
+ This provider depends heavily on the installation of the latest NVIDIA drivers
+ and the CUDA tool kit from NVIDIA, as well as testing software hosted on
+ GitHub.
 

--- a/providers/gpgpu/debian/control
+++ b/providers/gpgpu/debian/control
@@ -17,7 +17,7 @@ Standards-Version: 3.9.6
 
 Package: checkbox-provider-gpgpu
 Architecture: all
-Depends: checkbox-provider-base, ${plainbox:Depends}, ${misc:Depends}
+Depends: checkbox-provider-base, fwts, ipmitool, ${plainbox:Depends}, ${misc:Depends}
 Suggests: ubuntu-drivers-common, ${plainbox:Suggests}
 X-Plainbox-Provider: yes
 Description: Checkbox provider for GPGPU testing

--- a/providers/gpgpu/debian/control
+++ b/providers/gpgpu/debian/control
@@ -16,7 +16,7 @@ Build-Depends: checkbox-ng,
 Standards-Version: 3.9.6
 
 Package: checkbox-provider-gpgpu
-Architecture: amd64
+Architecture: all
 Depends: checkbox-provider-base, ${plainbox:Depends}, ${misc:Depends}
 Suggests: ubuntu-drivers-common, ${plainbox:Suggests}
 X-Plainbox-Provider: yes

--- a/providers/gpgpu/debian/control
+++ b/providers/gpgpu/debian/control
@@ -17,7 +17,7 @@ Standards-Version: 3.9.6
 
 Package: checkbox-provider-gpgpu
 Architecture: any-amd64 arm64
-Depends: checkbox-provider-base, fwts, ipmitool, ${plainbox:Depends}, ${misc:Depends}
+Depends: checkbox-provider-base, ${plainbox:Depends}, ${misc:Depends}
 Suggests: ubuntu-drivers-common, ${plainbox:Suggests}
 X-Plainbox-Provider: yes
 Description: Checkbox provider for GPGPU testing

--- a/providers/gpgpu/debian/postinst
+++ b/providers/gpgpu/debian/postinst
@@ -6,4 +6,4 @@ if [[ "$machine" = "x86_64" ]]; then
 	snap install rocm-validation-suite
 fi
 
-snap install gpu-burn cuda-samples
+snap install lxd gpu-burn cuda-samples

--- a/providers/gpgpu/debian/postinst
+++ b/providers/gpgpu/debian/postinst
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
-snap install gpu-burn rocm-validation-suite cuda-samples
+machine=$(uname -m)
+
+if [[ "$machine" = "x86_64" ]]; then
+	snap install rocm-validation-suite
+fi
+
+snap install gpu-burn cuda-samples

--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -5,7 +5,7 @@ estimated_duration: 14400
 requires:
     graphics_card.vendor == 'NVIDIA Corporation'
     snap.name == 'gpu-burn'
-    uname.machine == 'x86_64'
+    uname.machine in ['x86_64', 'aarch64']
 _summary: NVIDIA GPGPU stress testing
 command:
     set -eo pipefail
@@ -19,7 +19,7 @@ estimated_duration: 4
 requires:
     graphics_card.vendor == 'NVIDIA Corporation'
     snap.name == 'cuda-samples'
-    uname.machine == 'x86_64'
+    uname.machine in ['x86_64', 'aarch64']
 _summary: NVIDIA GPGPU query device test
 command: cuda-samples 1_Utilities deviceQueryDrv deviceQueryDrv
 _siblings: [


### PR DESCRIPTION
## Description

- Add `arm64` support for NVIDIA GPGPU tests
  - The LXD VM passthrough test will fail for now, that is an upstream issue, not an issue with the test.
  - Most of the CUDA sample tests depend on a binary file that is only provided for `amd64`. Only `deviceQueryDrv` works for now.
- Increased LXD passthrough threshold to account for more systems
- Ensure `lxd` snap is installed for GPGPU tests

## Resolved issues

Resolves SERVCERT-1809

## Documentation

## Tests

[Submission on `hinyari`](https://certification.canonical.com/hardware/202409-35559/submission/414630/)

