### PR TITLE
Fix slugify when str is empty/none (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/slugify.py
+++ b/checkbox-support/checkbox_support/helpers/slugify.py
@@ -27,7 +27,7 @@ def slugify(_string):
     identifers.
     """
     if not _string:
-        return "_"
+        return _string
 
     valid_chars = frozenset(
         "_{}{}".format(string.ascii_letters, string.digits)

--- a/checkbox-support/checkbox_support/helpers/slugify.py
+++ b/checkbox-support/checkbox_support/helpers/slugify.py
@@ -26,6 +26,9 @@ def slugify(_string):
     Transform any string to one that can be used in filenames and Python
     identifers.
     """
+    if not _string:
+        return "_"
+
     valid_chars = frozenset(
         "_{}{}".format(string.ascii_letters, string.digits)
     )

--- a/checkbox-support/checkbox_support/tests/test_slugify.py
+++ b/checkbox-support/checkbox_support/tests/test_slugify.py
@@ -41,3 +41,7 @@ class TestSlugify(TestCase):
     def test_slugify_string_starting_with_number(self):
         result = slugify("123abc")
         self.assertEqual(result, "_123abc")
+
+    def test_slugify_empty_string(self):
+        result = slugify("")
+        self.assertEqual(result, "_")

--- a/checkbox-support/checkbox_support/tests/test_slugify.py
+++ b/checkbox-support/checkbox_support/tests/test_slugify.py
@@ -44,4 +44,8 @@ class TestSlugify(TestCase):
 
     def test_slugify_empty_string(self):
         result = slugify("")
-        self.assertEqual(result, "_")
+        self.assertEqual(result, "")
+
+    def test_slugify_none(self):
+        result = slugify(None)
+        self.assertEqual(result, None)


### PR DESCRIPTION
## Description

Currently the `slugify` function assumes the `_string` argument is not empty/`None`. However, I saw this when trying to run some tests on `hinyari`. One of the device attributes was empty, but existed.

```
Traceback (most recent call last):
  File "/home/ubuntu/checkbox/providers/resource/bin/udev_resource.py", line 198, in <module>
    main()
  File "/home/ubuntu/checkbox/providers/resource/bin/udev_resource.py", line 194, in main
    dump_udev_db(udev)
  File "/home/ubuntu/checkbox/providers/resource/bin/udev_resource.py", line 76, in dump_udev_db
    value = getattr(device, attribute)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/checkbox_support/parsers/udevadm.py", line 933, in vendor_slug
    return slugify(self.vendor)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/checkbox_support/helpers/slugify.py", line 33, in slugify
    if _string[0].isdigit():
```

## Resolved issues

## Documentation

## Tests

Added a unit test
