### PR TITLE
Move to output parameter via expansion (infra)

### DIFF
--- a/.github/workflows/checkbox-daily-cross-builds.yaml
+++ b/.github/workflows/checkbox-daily-cross-builds.yaml
@@ -48,8 +48,9 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Build (retries on fail)
-        uses: Wandalen/wretry.action@master
+      - id: snap_build
+        name: Build (retries on fail)
+        uses: Wandalen/wretry.action@v3.4.0_js_action
         with:
           attempt_limit: 5
           action: canonical/snapcraft-multiarch-action@v1
@@ -71,7 +72,7 @@ jobs:
         name: Upload the snap as artifact
         with:
           name: runtime_snap${{ matrix.release }}_${{ matrix.arch }}.snap
-          path: checkbox-core-snap/*/*.snap
+          path: ${{ steps.snap_build.outputs.snap }}
 
       - name: Publish track
         if: inputs.store_upload
@@ -79,7 +80,7 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
         with:
-          snap: checkbox-core-snap/*/*.snap
+          snap: ${{ steps.snap_build.outputs.snap }}
           release: latest/edge
 
   snap-frontend:
@@ -126,8 +127,9 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Build (retries on fail)
-        uses: Wandalen/wretry.action@master
+      - id: snap_build
+        name: Build (retries on fail)
+        uses: Wandalen/wretry.action@v3.4.0_js_action
         with:
           attempt_limit: 5
           action: canonical/snapcraft-multiarch-action@v1
@@ -149,7 +151,7 @@ jobs:
         name: Upload the snaps as artefacts
         with:
           name: frontend_snaps_${{ matrix.type }}${{ matrix.release }}_${{matrix.arch}}.snap
-          path: checkbox-snap/*/*.snap
+          path: ${{ steps.snap_build.outputs.snap }}
 
       - name: Publish track
         if: inputs.store_upload
@@ -157,7 +159,7 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
         with:
-          snap: checkbox-snap/*/*.snap
+          snap: ${{ steps.snap_build.outputs.snap }}
           # channel is ucXX for uc snaps and XX.04 for classic snaps
           release: ${{ matrix.type == 'uc' && format('uc{0}', matrix.release) || format('{0}.04', matrix.release) }}/edge
 
@@ -167,6 +169,6 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
         with:
-          snap: checkbox-snap/*/*.snap
+          snap: ${{ steps.snap_build.outputs.snap }}
           # classic 24.04 is published to latest/edge as well
           release: latest/edge

--- a/.github/workflows/checkbox-daily-native-builds.yaml
+++ b/.github/workflows/checkbox-daily-native-builds.yaml
@@ -54,7 +54,8 @@ jobs:
           sudo apt update && sudo apt install -qq -y python3-setuptools-scm
           ./prepare.sh series${{ matrix.release }}
 
-      - uses: Wandalen/wretry.action@v3.4.0_js_action
+      - id: snap_build
+        uses: Wandalen/wretry.action@v3.4.0_js_action
         name: Build the snap
         timeout-minutes: 600 # 10hours
         with:
@@ -79,7 +80,7 @@ jobs:
         name: Upload the snap as artifact
         with:
           name: checkbox${{ matrix.release }}_${{ matrix.arch }}
-          path: checkbox-core-snap/series${{ matrix.release }}/*.snap
+          path: ${{ steps.snap_build.outputs.snap }}
 
       - name: Publish track
         if: inputs.store_upload
@@ -87,7 +88,7 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
         with:
-          snap: checkbox-core-snap/*/*.snap
+          snap: ${{ steps.snap_build.outputs.snap }}
           release: latest/edge
 
   snap_frontend_native:
@@ -128,7 +129,8 @@ jobs:
           sudo apt update && sudo apt install -qq -y python3-setuptools-scm
           ./prepare_${{ matrix.type }}.sh series_${{ matrix.type }}${{ matrix.release }}
 
-      - uses: Wandalen/wretry.action@v3.4.0_js_action
+      - id: snap_build
+        uses: Wandalen/wretry.action@v3.4.0_js_action
         name: Building the snaps
         timeout-minutes: 600 # 10hours
         with:
@@ -153,7 +155,7 @@ jobs:
         name: Upload the snaps as artefacts
         with:
           name: series_${{ matrix.type }}${{ matrix.release }}${{ matrix.arch }}
-          path: checkbox-snap/series_${{ matrix.type }}${{ matrix.release }}/*.snap
+          path: ${{ steps.snap_build.outputs.snap }}
 
       - name: Publish track
         if: inputs.store_upload
@@ -161,7 +163,7 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
         with:
-          snap: checkbox-snap/*/*.snap
+          snap: ${{ steps.snap_build.outputs.snap }}
           # channel is ucXX for uc snaps and XX.04 for classic snaps
           release: ${{ matrix.type == 'uc' && format('uc{0}', matrix.release) || format('{0}.04', matrix.release) }}/edge
 
@@ -171,6 +173,6 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
         with:
-          snap: checkbox-snap/*/*.snap
+          snap: ${{ steps.snap_build.outputs.snap }}
           # classic 24.04 is published to latest/edge as well
           release: latest/edge


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The current implementation doesn't work because the upload artifact action doesn't support globs. This goes to the output paramter to the snap building action to get the same result that we wanted to get in the other case.

## Resolved issues

N/A

## Documentation

N/A

## Tests

See: https://github.com/canonical/checkbox/actions/runs/13658334143
See: https://github.com/canonical/checkbox/actions/runs/13658363158 (failures are due to the brownout)
Failing workflow: https://github.com/canonical/checkbox/actions/runs/13637347230/job/38119282521