### PR TITLE
Update canonical-certification-precheck instructions for GPGPU (New)

### DIFF
--- a/providers/certification-server/tools/canonical-certification-precheck
+++ b/providers/certification-server/tools/canonical-certification-precheck
@@ -908,16 +908,15 @@ fi
 GPGPU_Check() {
 echoname "GPGPU Identification"
 if lspci | grep "3D controller [0302]"; then
-    gpu="GPGPU Detected"
+    gpu="GPGPU detected"
     echo " $gpu"
     echo " In order to test the discovered GPGPU device(s)"
     echo " You will need to install the checkbox-provider-gpgpu"
-    echo " package and run the gpu-setup script to install"
-    echo " the necessary drivers and toolkit."
+    echo " package"
     eval info${i}=\"$gpu\"
     info
 else
-    gpu="No GPGPU Detected"
+    gpu="No GPGPU detected"
     echo " $gpu"
     eval info${i}=\"$gpu\"
     info


### PR DESCRIPTION
## Description

The instructions on installing using the GPGPU provider is outdated. We don't use the `gpu-setup` script anymore

## Resolved issues

## Documentation

## Tests
