### PR TITLE
Add ipmitool as a Suggests dependency of base (New)

### DIFF
--- a/providers/base/debian/control
+++ b/providers/base/debian/control
@@ -51,6 +51,7 @@ Suggests: fswebcam,
           render-bench,
           stress,
           wmctrl,
+          ipmitool,
           ${plainbox:Suggests}
 Replaces: plainbox-provider-checkbox (<< 2.0.0)
 Breaks: plainbox-provider-checkbox (<< 2.0.0)


### PR DESCRIPTION
## Description

`ipmitool` is used by at least one of the jobs in the base provider, but it is not marked as a dependency in the package.

## Resolved issues

## Documentation

## Tests

