### PR TITLE
Push both or either instead of double upload (infra)

### DIFF
--- a/.github/workflows/checkbox-daily-cross-builds.yaml
+++ b/.github/workflows/checkbox-daily-cross-builds.yaml
@@ -154,7 +154,8 @@ jobs:
           path: ${{ steps.snap_build.outputs.snap }}
 
       - name: Publish track
-        if: inputs.store_upload
+        # this is done this way because the store doesn't allow the same artifact to be uploaded twice
+        if: inputs.store_upload && (matrix.release != 24 || matrix.type != 'classic')
         uses: canonical/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
@@ -163,7 +164,7 @@ jobs:
           # channel is ucXX for uc snaps and XX.04 for classic snaps
           release: ${{ matrix.type == 'uc' && format('uc{0}', matrix.release) || format('{0}.04', matrix.release) }}/edge
 
-      - name: Publish latest
+      - name: Publish track + latest
         if: inputs.store_upload && matrix.release == 24 && matrix.type == 'classic'
         uses: canonical/action-publish@v1
         env:
@@ -171,4 +172,4 @@ jobs:
         with:
           snap: ${{ steps.snap_build.outputs.snap }}
           # classic 24.04 is published to latest/edge as well
-          release: latest/edge
+          release: 24.04/edge,latest/edge

--- a/.github/workflows/checkbox-daily-native-builds.yaml
+++ b/.github/workflows/checkbox-daily-native-builds.yaml
@@ -158,7 +158,8 @@ jobs:
           path: ${{ steps.snap_build.outputs.snap }}
 
       - name: Publish track
-        if: inputs.store_upload
+        # this is done this way because the store doesn't allow the same artifact to be uploaded twice
+        if: inputs.store_upload && (matrix.release != 24 || matrix.type != 'classic')
         uses: canonical/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
@@ -167,7 +168,7 @@ jobs:
           # channel is ucXX for uc snaps and XX.04 for classic snaps
           release: ${{ matrix.type == 'uc' && format('uc{0}', matrix.release) || format('{0}.04', matrix.release) }}/edge
 
-      - name: Publish latest
+      - name: Publish track + latest
         if: inputs.store_upload && matrix.release == 24 && matrix.type == 'classic'
         uses: canonical/action-publish@v1
         env:
@@ -175,4 +176,4 @@ jobs:
         with:
           snap: ${{ steps.snap_build.outputs.snap }}
           # classic 24.04 is published to latest/edge as well
-          release: latest/edge
+          release: 24.04/edge,latest/edge


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The publication of latest failed yesterday, this is due to the brownout but also the fact that the store rejects the second upload to publish latest. This replaces the second upload making the upload a single one (excluding the first one for latest, and the second one for every other)

## Resolved issues

Daily fire

## Documentation

Documented why this is done this way above the package

## Tests

N/A
