### PR TITLE
Removed custom implementation and using cv2 (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/psnr.py
+++ b/checkbox-support/checkbox_support/scripts/psnr.py
@@ -51,6 +51,7 @@ def psnr_args() -> argparse.ArgumentParser:
     )
     return parser.parse_args()
 
+
 def _get_frame_resolution(capture) -> Tuple[int, int]:
     return (
         int(capture.get(cv2.CAP_PROP_FRAME_WIDTH)),

--- a/checkbox-support/checkbox_support/scripts/psnr.py
+++ b/checkbox-support/checkbox_support/scripts/psnr.py
@@ -51,37 +51,6 @@ def psnr_args() -> argparse.ArgumentParser:
     )
     return parser.parse_args()
 
-
-def _get_psnr(I1: np.ndarray, I2: np.ndarray) -> float:
-    """
-    Calculate the Peak Signal-to-Noise Ratio (PSNR) between two frames.
-
-    Args:
-        I1 (np.ndarray): Reference frame.
-        I2 (np.ndarray): Frame to be compared with the reference.
-
-    Returns:
-        float: PSNR value indicating the quality of I2 compared to I1.
-    """
-    # Calculate the absolute difference
-    s1 = cv2.absdiff(I1, I2)
-    # cannot make a square on 8 bits
-    s1 = np.float32(s1)
-    # Calculate squared differences
-    s1 = s1 * s1
-    # Sum of squared differences per channel
-    sse = s1.sum()
-    # sum channels
-    if sse <= 1e-10:
-        # for small values return zero
-        return 0.0
-    else:
-        shape = I1.shape
-        mse = 1.0 * sse / (shape[0] * shape[1] * shape[2])
-        psnr = 10.0 * np.log10((255 * 255) / mse)
-    return psnr
-
-
 def _get_frame_resolution(capture) -> Tuple[int, int]:
     return (
         int(capture.get(cv2.CAP_PROP_FRAME_WIDTH)),
@@ -124,7 +93,7 @@ def get_average_psnr(
     for _ in range(total_frame_count):
         _, frameReference = capt_refrnc.read()
         _, frameUnderTest = capt_undTst.read()
-        psnr = _get_psnr(frameReference, frameUnderTest)
+        psnr = cv2.PSNR(frameReference, frameUnderTest)
         psnr_each_frame.append(psnr)
 
     psnr_array = np.array(psnr_each_frame)


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

For some weird reason, when the two images were the same, the tests were failing in later versions of python (3.13), but not in early ones. This was probably due to a rounding error.
```
# python 3.8
>>> _get_psnr(img1, img2)
1.0686215807909677e-07
# python 3.13
>>> _get_psnr(img1, img2)
0.0
```

Nevertheless, the implementation of the algorithm was wrong, and it returned 0 instead of a big value if the images were exactly the same. 

I've just changed it to use the default one from opencv (`cv2.PSNR`)
## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
Tested with python 3.13