### PR TITLE
Restore netplan config even when exception is raised (bugfix)

### DIFF
--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -218,7 +218,10 @@ def write_test_config(config):
 
 def delete_test_config():
     print_head("Delete the test file")
-    os.remove(NETPLAN_TEST_CFG)
+    try:
+        os.remove(NETPLAN_TEST_CFG)
+    except FileNotFoundError:
+        print("Test config {} not found, ignoring...".format(NETPLAN_TEST_CFG))
     print()
 
 

--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -460,6 +460,7 @@ def handle_original_np_config():
     try:
         yield
     finally:
+        delete_test_config()
         netplan_config_restore()
         netplan_apply_config()
 

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -822,7 +822,6 @@ class TestMain(TestCase):
         mock_renderer.return_value = "networkd"
         mock_wait_routable.return_value = True
         mock_ping.return_value = True
-        mock_apply.return_value = True
 
         # Execute
         main()
@@ -875,7 +874,7 @@ class TestMain(TestCase):
         mock_args.renderer = "networkd"
         mock_parse_args.return_value = mock_args
         mock_renderer.return_value = "networkd"
-        mock_apply.return_value = False
+        mock_apply.side_effect = SystemExit("ERROR: failed netplan apply call")
 
         # Execute and Assert
         with self.assertRaises(SystemExit):
@@ -921,7 +920,6 @@ class TestMain(TestCase):
         mock_parse_args.return_value = mock_args
         mock_renderer.return_value = "networkd"
         mock_wait_routable.return_value = True
-        mock_apply.return_value = True
         mock_ping.return_value = False
 
         # Execute and Assert
@@ -930,5 +928,6 @@ class TestMain(TestCase):
 
         self.assertEqual(mock_delete.call_count, 1)
         self.assertEqual(mock_restore.call_count, 1)
+        self.assertEqual(mock_apply.call_count, 2)
         self.assertEqual(mock_print_journal.call_count, 1)
         mock_ping.assert_called_once_with("wlan0", "networkd")

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -838,7 +838,7 @@ class TestMain(TestCase):
         mock_print_address.assert_called_once_with("wlan0")
         self.assertEqual(mock_print_route.call_count, 1)
         mock_ping.assert_called_once_with("wlan0", "networkd")
-        self.assertEqual(mock_delete.call_count, 1)
+        self.assertEqual(mock_delete.call_count, 2)
         self.assertEqual(mock_restore.call_count, 1)
         self.assertEqual(mock_print_journal.call_count, 1)
 
@@ -848,20 +848,20 @@ class TestMain(TestCase):
     @patch("wifi_client_test_netplan.netplan_config_wipe")
     @patch("wifi_client_test_netplan.generate_test_config")
     @patch("wifi_client_test_netplan.write_test_config")
-    @patch("wifi_client_test_netplan.netplan_apply_config")
     @patch("wifi_client_test_netplan.time.sleep")
     @patch("wifi_client_test_netplan.wait_for_routable")
     @patch("wifi_client_test_netplan.delete_test_config")
     @patch("wifi_client_test_netplan.netplan_config_restore")
     @patch("wifi_client_test_netplan.print_journal_entries")
+    @patch("wifi_client_test_netplan.sp.call")
     def test_main_apply_config_failure(
         self,
+        mock_sp_call,
         mock_print_journal,
         mock_restore,
         mock_delete,
         mock_wait_routable,
         mock_sleep,
-        mock_apply,
         mock_write,
         mock_generate,
         mock_wipe,
@@ -874,7 +874,7 @@ class TestMain(TestCase):
         mock_args.renderer = "networkd"
         mock_parse_args.return_value = mock_args
         mock_renderer.return_value = "networkd"
-        mock_apply.side_effect = SystemExit("ERROR: failed netplan apply call")
+        mock_sp_call.return_value = 1  # Simulating an error
 
         # Execute and Assert
         with self.assertRaises(SystemExit):
@@ -882,7 +882,7 @@ class TestMain(TestCase):
 
         self.assertEqual(mock_delete.call_count, 1)
         self.assertEqual(mock_restore.call_count, 1)
-        self.assertEqual(mock_print_journal.call_count, 1)
+        self.assertEqual(mock_print_journal.call_count, 2)
 
     @patch("wifi_client_test_netplan.parse_args")
     @patch("wifi_client_test_netplan.check_and_get_renderer")
@@ -926,7 +926,7 @@ class TestMain(TestCase):
         with self.assertRaises(SystemExit):
             main()
 
-        self.assertEqual(mock_delete.call_count, 1)
+        self.assertEqual(mock_delete.call_count, 2)
         self.assertEqual(mock_restore.call_count, 1)
         self.assertEqual(mock_apply.call_count, 2)
         self.assertEqual(mock_print_journal.call_count, 1)


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Use context managers to handle original netplan config backup and restore, as well as the test config writing and removing.

Modify function `netplan_apply_config` to raise SystemExit if the
subprocess call to netplan failed for any reason.

- journal entries are still printed out to the log if there is any
SystemExit
- test config removal and original config restoration are run regardless
of what happens

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

Fix #1674

https://warthogs.atlassian.net/browse/CHECKBOX-1718

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

unit tests updated
