### PR TITLE
Fix kernel config bug (BugFix)

### DIFF
--- a/providers/base/tests/test_kernel_config.py
+++ b/providers/base/tests/test_kernel_config.py
@@ -39,11 +39,28 @@ class TestKernelConfig(TestCase):
     ):
         uname_mock.return_value = MagicMock(release="5.4.0-42-generic")
         decode_mock.return_value = [{"kernel": "pc-kernel"}]
-        exists_mock.return_value = True
-
+        exists_mock.side_effect = (
+            lambda x: x == "/snap/pc-kernel/current/config-5.4.0-42-generic"
+        )
         self.assertEqual(
             get_kernel_config_path(),
             "/snap/pc-kernel/current/config-5.4.0-42-generic",
+        )
+
+    @patch("kernel_config.os.uname")
+    @patch("kernel_config.decode")
+    @patch("kernel_config.os.path.exists")
+    def test_get_kernel_config_path_host(
+        self, exists_mock, decode_mock, uname_mock
+    ):
+        uname_mock.return_value = MagicMock(release="5.4.0-42-generic")
+        decode_mock.return_value = []
+        exists_mock.side_effect = (
+            lambda x: x == "/var/lib/snapd/hostfs/boot/config-5.4.0-42-generic"
+        )
+        self.assertEqual(
+            get_kernel_config_path(),
+            "/var/lib/snapd/hostfs/boot/config-5.4.0-42-generic",
         )
 
     @patch("kernel_config.os.uname")
@@ -54,8 +71,9 @@ class TestKernelConfig(TestCase):
     ):
         uname_mock.return_value = MagicMock(release="5.4.0-42-generic")
         decode_mock.return_value = []
-        exists_mock.return_value = True
-
+        exists_mock.side_effect = (
+            lambda x: x == "/boot/config-5.4.0-42-generic"
+        )
         self.assertEqual(
             get_kernel_config_path(), "/boot/config-5.4.0-42-generic"
         )
@@ -131,6 +149,7 @@ class TestKernelConfig(TestCase):
 
     @patch("kernel_config.os.uname")
     @patch("kernel_config.print")
+    @patch("kernel_config.get_kernel_config_path", MagicMock())
     def test_check_flag_present(self, print_mock, uname_mock):
         uname_mock.return_value = MagicMock(release="6.8.0-45-generic")
         data = (
@@ -149,6 +168,7 @@ class TestKernelConfig(TestCase):
 
     @patch("kernel_config.os.uname")
     @patch("kernel_config.print", MagicMock())
+    @patch("kernel_config.get_kernel_config_path", MagicMock())
     def test_check_flag_not_present(self, uname_mock):
         uname_mock.return_value = MagicMock(release="6.8.0-45-generic")
         data = (
@@ -168,6 +188,7 @@ class TestKernelConfig(TestCase):
 
     @patch("kernel_config.os.uname")
     @patch("kernel_config.print", MagicMock())
+    @patch("kernel_config.get_kernel_config_path", MagicMock())
     def test_check_flag_commented(self, uname_mock):
         uname_mock.return_value = MagicMock(release="6.8.0-45-generic")
         data = (

--- a/providers/base/tests/test_kernel_config.py
+++ b/providers/base/tests/test_kernel_config.py
@@ -31,24 +31,6 @@ from kernel_config import (
 
 class TestKernelConfig(TestCase):
 
-    # def get_kernel_config_path():
-    #     """Retrieve the path to the kernel configuration file."""
-    #     kernel_version = os.uname().release
-    #     for model in decode(Snapd().get_assertions("model")):
-    #         resource = model_to_resource(model)
-    #         if resource.get("kernel"):
-    #             config_path = "/snap/{}/current/config-{}".format(
-    #                 resource["kernel"], kernel_version
-    #             )
-    #             if os.path.exists(config_path):
-    #                 return config_path
-
-    #     config_path = "/boot/config-{}".format(kernel_version)
-    #     if os.path.exists(config_path):
-    #         return config_path
-
-    #     raise SystemExit("Kernel configuration not found.")
-
     @patch("kernel_config.os.uname")
     @patch("kernel_config.decode")
     @patch("kernel_config.os.path.exists")


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

Some devices were failing the kernel config tests because they were trying to access the configuration from the kernel snap despite being on classic, because the “on_ubuntucore” flag is true despite being a classic image.

Now we are checking if the file exists before gathering the config information.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
https://warthogs.atlassian.net/browse/CHECKBOX-1787
## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Classic device running checkbox snap (one of the failing devices):
https://certification.canonical.com/submissions/status/308164
This device is running checkbox from edge, and another test is failing here:
 -  ☒ : [DEPRECATED, use 'os' instead] Collect information about installed operating system (os-release)
This should be fixed after Pierre's fix


Submission for core device (uc24) failed for some reason...
https://certification.canonical.com/submissions/status/308164
But here is the submission file:
[submission_2025-03-07T20.06.19.676506.zip](https://github.com/user-attachments/files/19179856/submission_2025-03-07T20.06.19.676506.zip)
