### PR TITLE
Fix manifest always no (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/urwid_ui.py
@@ -968,11 +968,10 @@ class ManifestQuestion(urwid.WidgetWrap):
                 state=False,
                 on_state_change=self._set_bool_value,
             )
-            if question["value"] is not None:
-                if question["value"] is True:
-                    yes.set_state(True)
-                else:
-                    no.set_state(True)
+            if question["value"] is True:
+                yes.set_state(True)
+            elif question["value"] is False:
+                no.set_state(True)
             self.display_widget = urwid.Columns(
                 [
                     urwid.Padding(urwid.Text(question["name"]), left=2),

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -1380,14 +1380,14 @@ class SessionAssistant:
         for m in manifest_list:
             prompt = m.prompt() or m.default_prompt()
             value = config_manifest.get(m.id)
-            if m.is_hidden:
-                # set all hidden manifests not set in the launcher to default
-                value = value or m.default_value()
-            else:
-                # only load from the disk_manifest values of non-hidden manifests
-                value = value or disk_manifest.get(m.id, "")
-
-            if value:
+            if value is None:
+                if m.is_hidden:
+                    # set all hidden manifests not set in the launcher to default
+                    value = m.default_value()
+                else:
+                    # only load from the disk_manifest values of non-hidden manifests
+                    value = disk_manifest.get(m.id)
+            if value is not None:
                 value = self._parse_value(m, value)
             manifest_info_dict[prompt].append(
                 {


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The default value in the selector unexpectedly changed due to `None` and `""` mixing up in the implementation. This changes the code so that `None` is always used for undefined variables in the browser/manifest repr getter.

## Resolved issues

Fixes: CHECKBOX-1786
Fixes: https://github.com/canonical/checkbox/issues/1779

## Documentation

N/A

## Tests

This improves the tests as well as it encodes the function expectations in the unit itself
