### PR TITLE
various - update platform constraints on some jobs to not run on either Power arch (ppc64le and ppc64el) (BugFix)

### DIFF
--- a/providers/base/units/cpu/jobs.pxu
+++ b/providers/base/units/cpu/jobs.pxu
@@ -5,7 +5,7 @@ estimated_duration: 150.0
 requires:
  executable.name == 'fwts'
  'userspace' in cpuinfo.governors
- cpuinfo.platform not in ("ppc64el", "s390x")
+ cpuinfo.platform not in ("ppc64el", "ppc64le", "s390x")
 user: root
 environ: PLAINBOX_SESSION_SHARE LD_LIBRARY_PATH SNAP
 command:
@@ -27,7 +27,7 @@ estimated_duration: 150.0
 requires:
  executable.name == 'fwts'
  'userspace' in cpuinfo.governors
- cpuinfo.platform not in ("ppc64el", "s390x")
+ cpuinfo.platform not in ("ppc64el", "ppc64le", "s390x")
 user: root
 environ: PLAINBOX_SESSION_SHARE LD_LIBRARY_PATH SNAP
 command:
@@ -212,7 +212,7 @@ id: cpu/cstates
 estimated_duration: 10.0
 requires:
  executable.name == 'fwts'
- cpuinfo.platform not in ("aarch64", "armv7l", "s390x")
+ cpuinfo.platform not in ("aarch64", "armv7l", "ppc64el", "ppc64le", "s390x")
 user: root
 category_id: com.canonical.plainbox::cpu
 _summary:

--- a/providers/base/units/miscellanea/jobs.pxu
+++ b/providers/base/units/miscellanea/jobs.pxu
@@ -365,12 +365,12 @@ category_id: com.canonical.plainbox::miscellanea
 estimated_duration: 10.0
 requires:
  executable.name == 'fwts'
- cpuinfo.platform in ("ppc64el")
+ cpuinfo.platform in ("ppc64el", "ppc64le")
 user: root
 _description:
- Run Firmware Test Suite (fwts) olog tests (ppc64el only).
+ Run Firmware Test Suite (fwts) olog tests (IBM Power only).
 _summary:
- Run FWTS OLOG check on ppc64el
+ Run FWTS OLOG check on Power systems
 environ: PLAINBOX_SESSION_SHARE
 command:
  checkbox-support-fwts_test -l "$PLAINBOX_SESSION_SHARE"/fwts_olog_results.log -t olog

--- a/providers/base/units/power-management/jobs.pxu
+++ b/providers/base/units/power-management/jobs.pxu
@@ -226,7 +226,7 @@ category_id: com.canonical.plainbox::power-management
 id: power-management/tickless_idle
 flags: also-after-suspend
 estimated_duration: 1.0
-requires: cpuinfo.platform in ('i386', 'x86_64', 'ppc64el', 'pSeries')
+requires: cpuinfo.platform in ('i386', 'x86_64', 'ppc64el', 'ppc64le', 'pSeries')
 _purpose: Check to see if CONFIG_NO_HZ is set in the kernel (this is just a simple regression check)
 command:
  zgrep 'CONFIG_NO_HZ=y' /boot/config-"$(uname -r)" >/dev/null 2>&1 || ( echo "WARNING: Tickless Idle is NOT set" >&2 && exit 1 )
@@ -531,7 +531,7 @@ category_id: com.canonical.plainbox::power-management
 id: power-management/tickless_idle_{kernel}
 template-id: power-management/tickless_idle_kernel
 estimated_duration: 1.0
-requires: cpuinfo.platform in ('i386', 'x86_64', 'ppc64el', 'pSeries')
+requires: cpuinfo.platform in ('i386', 'x86_64', 'ppc64el', 'ppc64le', 'pSeries')
 _purpose: Check to see if CONFIG_NO_HZ is set in the kernel (this is just a simple regression check)
 command:
  zgrep 'CONFIG_NO_HZ=y' /snap/{kernel}/current/config-"$(uname -r)" >/dev/null 2>&1 || ( echo "WARNING: Tickless Idle is NOT set" >&2 && exit 1 )


### PR DESCRIPTION
## Description
For jobs in checkbox-provider-base that are meant to run, or not run, on Power arch systesm, ensure that the constraint specifies both ppc64le and ppc64el to ensure the jobs don't run on known Power systems.

## WARNING: This modifies com.canonical.certification::sru-server
(had to add thius apparently)

## Resolved issues

Fixes SERVERCERT-253
Fixes #879 

## Documentation

NA - just adds consistency in power arch constraints 

## Tests

