### PR TITLE
Show the current boot id at the beginning of reboot checks and suspend checks (New)

### DIFF
--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -27,9 +27,16 @@ def get_timestamp_str() -> str:
         # take the 1st one
         uptime_seconds = f.readline().split()[0]
 
-    return "Time: {}; Uptime: {} seconds ".format(
+    return "Time: {}; Uptime: {} seconds".format(
         datetime.now().strftime("%m/%d/%Y, %H:%M:%S"), uptime_seconds
     )
+
+
+def get_current_boot_id() -> str:
+    with open("/proc/sys/kernel/random/boot_id", "r") as f:
+        # the boot_id file has a Version 4 UUID with hypens
+        # journalctl doesn't use hypens so we just remove it
+        return f.read().strip().replace("-", "")
 
 
 class DeviceInfoCollector:
@@ -470,7 +477,11 @@ def main() -> int:
     renderer_test_passed = True
     service_check_passed = True
 
-    print("Starting reboot checks. {}".format(get_timestamp_str()))
+    print(
+        "Starting reboot checks. {}. Boot ID: {}".format(
+            get_timestamp_str(), get_current_boot_id()
+        )
+    )
 
     if args.comparison_directory is not None:
         if args.output_directory is None:

--- a/providers/base/units/stress/suspend_cycles_reboot.pxu
+++ b/providers/base/units/stress/suspend_cycles_reboot.pxu
@@ -79,7 +79,7 @@ estimated_duration: 75.0
 environ: PLAINBOX_SESSION_SHARE STRESS_S3_SLEEP_DELAY STRESS_S3_WAIT_DELAY LD_LIBRARY_PATH RTC_DEVICE_FILE
 user: root
 command:
-   echo "Current boot ID is: $(cat /proc/sys/kernel/random/boot_id | tr -d -)"
+   echo "Current boot ID is: $(tr -d - < /proc/sys/kernel/random/boot_id)"
    suspend.sh 2>&1 | tee -a "$PLAINBOX_SESSION_SHARE"/suspend_cycles_with_reboot_total.log
 summary:
     Suspend and resume device (suspend cycle 1, reboot cycle 1)
@@ -105,7 +105,7 @@ environ: PLAINBOX_SESSION_SHARE STRESS_S3_SLEEP_DELAY STRESS_S3_WAIT_DELAY LD_LI
 after: stress-tests/suspend_cycles_reboot{{suspend_reboot_previous}}
 user: root
 command:
- echo "Current boot ID is: $(cat /proc/sys/kernel/random/boot_id | tr -d -)"
+ echo "Current boot ID is: $(tr -d - < /proc/sys/kernel/random/boot_id)"
  suspend.sh 2>&1 | tee -a "$PLAINBOX_SESSION_SHARE"/suspend_cycles_with_reboot_total.log
 summary:
     Suspend and resume device (suspend cycle 1, reboot cycle {{suspend_reboot_id}})
@@ -129,7 +129,7 @@ environ: PLAINBOX_SESSION_SHARE STRESS_S3_SLEEP_DELAY STRESS_S3_WAIT_DELAY LD_LI
 after: stress-tests/suspend_cycles_{{suspend_id_previous}}_reboot{{suspend_reboot_id}}
 user: root
 command:
- echo "Current boot ID is: $(cat /proc/sys/kernel/random/boot_id | tr -d -)"
+ echo "Current boot ID is: $(tr -d - < /proc/sys/kernel/random/boot_id)"
  suspend.sh 2>&1 | tee -a "$PLAINBOX_SESSION_SHARE"/suspend_cycles_with_reboot_total.log
 summary:
     Suspend and resume device (suspend cycle {{suspend_id}}, reboot cycle {{suspend_reboot_id}})

--- a/providers/base/units/stress/suspend_cycles_reboot.pxu
+++ b/providers/base/units/stress/suspend_cycles_reboot.pxu
@@ -79,6 +79,7 @@ estimated_duration: 75.0
 environ: PLAINBOX_SESSION_SHARE STRESS_S3_SLEEP_DELAY STRESS_S3_WAIT_DELAY LD_LIBRARY_PATH RTC_DEVICE_FILE
 user: root
 command:
+   echo "Current boot ID is: $(cat /proc/sys/kernel/random/boot_id | tr -d -)"
    suspend.sh 2>&1 | tee -a "$PLAINBOX_SESSION_SHARE"/suspend_cycles_with_reboot_total.log
 summary:
     Suspend and resume device (suspend cycle 1, reboot cycle 1)
@@ -104,6 +105,7 @@ environ: PLAINBOX_SESSION_SHARE STRESS_S3_SLEEP_DELAY STRESS_S3_WAIT_DELAY LD_LI
 after: stress-tests/suspend_cycles_reboot{{suspend_reboot_previous}}
 user: root
 command:
+ echo "Current boot ID is: $(cat /proc/sys/kernel/random/boot_id | tr -d -)"
  suspend.sh 2>&1 | tee -a "$PLAINBOX_SESSION_SHARE"/suspend_cycles_with_reboot_total.log
 summary:
     Suspend and resume device (suspend cycle 1, reboot cycle {{suspend_reboot_id}})
@@ -127,6 +129,7 @@ environ: PLAINBOX_SESSION_SHARE STRESS_S3_SLEEP_DELAY STRESS_S3_WAIT_DELAY LD_LI
 after: stress-tests/suspend_cycles_{{suspend_id_previous}}_reboot{{suspend_reboot_id}}
 user: root
 command:
+ echo "Current boot ID is: $(cat /proc/sys/kernel/random/boot_id | tr -d -)"
  suspend.sh 2>&1 | tee -a "$PLAINBOX_SESSION_SHARE"/suspend_cycles_with_reboot_total.log
 summary:
     Suspend and resume device (suspend cycle {{suspend_id}}, reboot cycle {{suspend_reboot_id}})


### PR DESCRIPTION
## Description

This is a simple QoL change that prints `/proc/sys/kernel/random/boot_id` at the beginning of the test. We can use this id to locate the journal log of a specific run (`journalctl -b <boot_id>`) instead of digging through a bunch of journals trying to find the right one by matching timestamps.

## Resolved issues

No real issue here just a quality of life change.

## Documentation



## Tests

Original unit tests