### PR TITLE
Fix os resource script (bugfix)

### DIFF
--- a/providers/resource/bin/os_resource.py
+++ b/providers/resource/bin/os_resource.py
@@ -20,15 +20,18 @@
 import os
 import re
 import sys
+from contextlib import suppress
 
 
-def get_release_file_path():
-    if "SNAP_NAME" in os.environ:
-        return "/var/lib/snapd/hostfs/etc/os-release"
-    return "/etc/os-release"
+def get_release_file_content():
+    with suppress(FileNotFoundError):
+        with open("/var/lib/snapd/hostfs/etc/os-release", "r") as fp:
+            return fp.read()
+    with open("/etc/os-release", "r") as fp:
+        return fp.read()
 
 
-def get_release_info(release_file_path):
+def get_release_info(release_file_content: str):
     os_release_map = {
         "NAME": "distributor_id",
         "PRETTY_NAME": "description",
@@ -36,8 +39,8 @@ def get_release_info(release_file_path):
         "VERSION_CODENAME": "codename",
     }
     os_release = {}
-    with open(release_file_path, "r") as lsb:
-        for line in lsb.readlines():
+    for line in release_file_content.strip().splitlines():
+        if line:
             (key, value) = line.split("=", 1)
             if key in os_release_map:
                 k = os_release_map[key]
@@ -47,8 +50,8 @@ def get_release_info(release_file_path):
 
 
 def main():
-    release_file_path = get_release_file_path()
-    release_info = get_release_info(release_file_path)
+    release_file_content = get_release_file_content()
+    release_info = get_release_info(release_file_content)
     for key, value in release_info.items():
         print("%s: %s" % (key, value))
 

--- a/providers/resource/tests/test_os_resource.py
+++ b/providers/resource/tests/test_os_resource.py
@@ -1,45 +1,74 @@
 import os
 import textwrap
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, mock_open, MagicMock
 
 import os_resource
 
 
-class LsbResourceTests(unittest.TestCase):
-    @patch.dict(os.environ, {"SNAP_NAME": "test"})
-    def test_get_release_file_path_snap(self):
-        path = os_resource.get_release_file_path()
-        self.assertEqual(path, "/var/lib/snapd/hostfs/etc/os-release")
+class OsResourceTests(unittest.TestCase):
+    os_release_data = textwrap.dedent(
+        """
+        PRETTY_NAME="Ubuntu 24.04.2 LTS"
+        NAME="Ubuntu"
+        VERSION_ID="24.04"
+        VERSION="24.04.2 LTS (Noble Numbat)"
+        VERSION_CODENAME=noble
+        ID=ubuntu
+        ID_LIKE=debian
+        HOME_URL="https://www.ubuntu.com/"
+        SUPPORT_URL="https://help.ubuntu.com/"
+        BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+        PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+        UBUNTU_CODENAME=noble
+        LOGO=ubuntu-logo
+        """
+    ).strip()
 
-    def test_get_release_file_path_deb(self):
-        path = os_resource.get_release_file_path()
-        self.assertEqual(path, "/etc/os-release")
+    def test_get_release_file_content(self):
+        with patch(
+            "os_resource.open", mock_open(read_data=self.os_release_data)
+        ):
+            os_release_data = os_resource.get_release_file_content()
+        self.assertIn("UBUNTU_CODENAME=noble\n", os_release_data)
+
+    def test_get_release_file_content_classic(self):
+        open_mock = MagicMock()
+        with open_mock() as f:
+            f.read.side_effect = [
+                FileNotFoundError("first"),
+                self.os_release_data,
+            ]
+        with patch("os_resource.open", open_mock):
+            os_release_data = os_resource.get_release_file_content()
+        self.assertIn("UBUNTU_CODENAME=noble\n", os_release_data)
 
     def test_get_release_info(self):
-        data = textwrap.dedent(
-            """
-            PRETTY_NAME="Ubuntu 24.04.2 LTS"
-            NAME="Ubuntu"
-            VERSION_ID="24.04"
-            VERSION="24.04.2 LTS (Noble Numbat)"
-            VERSION_CODENAME=noble
-            ID=ubuntu
-            ID_LIKE=debian
-            HOME_URL="https://www.ubuntu.com/"
-            SUPPORT_URL="https://help.ubuntu.com/"
-            BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
-            PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
-            UBUNTU_CODENAME=noble
-            LOGO=ubuntu-logo
-            """
-        ).strip()
-        with patch("os_resource.open", mock_open(read_data=data)) as _:
-            os_release = os_resource.get_release_info("")
+        os_release = os_resource.get_release_info(self.os_release_data)
         expected = {
             "distributor_id": "Ubuntu",
             "description": "Ubuntu 24.04.2 LTS",
             "release": "24.04",
             "codename": "noble",
+        }
+        self.assertEqual(os_release, expected)
+
+    def test_get_release_info_empty_lines(self):
+        os_release_data = textwrap.dedent(
+            """
+        PRETTY_NAME="Ubuntu 22.04.5 LTS"
+
+        NAME="Ubuntu"
+        VERSION_ID="22.04"
+
+        VERSION_CODENAME=jammy
+        """
+        ).strip()
+        os_release = os_resource.get_release_info(os_release_data)
+        expected = {
+            "distributor_id": "Ubuntu",
+            "description": "Ubuntu 22.04.5 LTS",
+            "release": "22.04",
+            "codename": "jammy",
         }
         self.assertEqual(os_release, expected)


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

Replace `get_release_file_path` function with `get_release_file_content`
that tries to access `/var/lib/snapd/hostfs/etc/os-release`. If this
file doesn't exist, it means we are not calling the script from within a
snap, so it tries to access `/etc/os-release` instead.

`get_release_info` now takes the content of the `os-release` file as
parameter and ignores empty lines.

The issue was introduced with previous PR #1748

## Resolved issues

Prevent the os resource job from failing like this (example found the submission from a run using Checkbox in the edge channel):

```json
{
            "id": "lsb",
            "full_id": "com.canonical.certification::lsb",
            "name": "[DEPRECATED, use &#39;os&#39; instead] Collect information about installed operating system (os-release)",
            "certification_status": "non-blocker",
            "category": "Gathers information about the DUT",
            "category_id": "com.canonical.certification::information_gathering",
            "status": "fail",
            "outcome": "fail",
            "comments": null,
            "io_log": "Traceback (most recent call last):\n  File \"/tmp/nest-kopwzdp5.810b3c2c743e7de21a0c69775e0ca9675ca511eed3b76c394124412985b763db/os_resource.py\", line 57, in <module>\n    sys.exit(main())\n  File \"/tmp/nest-kopwzdp5.810b3c2c743e7de21a0c69775e0ca9675ca511eed3b76c394124412985b763db/os_resource.py\", line 51, in main\n    release_info = get_release_info(release_file_path)\n  File \"/tmp/nest-kopwzdp5.810b3c2c743e7de21a0c69775e0ca9675ca511eed3b76c394124412985b763db/os_resource.py\", line 39, in get_release_info\n    with open(release_file_path, \"r\") as lsb:\nFileNotFoundError: [Errno 2] No such file or directory: '/var/lib/snapd/hostfs/etc/os-release'\n",
            "type": "test",
            "project": "certification",
            "duration": 0.15081572532653809,
            "plugin": "resource",
            "template_id": null
        },
```

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
