### PR TITLE
Add DSS integration tests (New)

### DIFF
--- a/contrib/checkbox-dss-validation/bin/install-deps
+++ b/contrib/checkbox-dss-validation/bin/install-deps
@@ -85,7 +85,7 @@ main() {
     echo -e "\nStep 4/5: Installing data-science-stack snap from channel $dss_snap_channel"
     sudo snap install data-science-stack --channel "$dss_snap_channel"
 
-    echo -e "\nStep 3/5: Installing git and python3-venv for DSS integration tests"
+    echo -e "\nStep 5/5: Installing git and python3-venv for DSS integration tests"
     DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a sudo -E apt install -y git python3-venv
 }
 

--- a/contrib/checkbox-dss-validation/bin/install-deps
+++ b/contrib/checkbox-dss-validation/bin/install-deps
@@ -71,19 +71,22 @@ main() {
         esac
     done
 
-    echo -e "\n Step 1/4: Setting up microk8s"
+    echo -e "\n Step 1/5: Setting up microk8s"
     setup_microk8s_snap "$microk8s_snap_channel"
 
-    echo -e "\n Step 2/4: Setting up kubectl"
+    echo -e "\n Step 2/5: Setting up kubectl"
     setup_kubectl_snap "$kubectl_snap_channel"
 
     # intel_gpu_top command used for host-level GPU check
     # jq used for cases where jsonpath is insufficient for parsing json results
-    echo -e "\nStep 3/4: Installing intel-gpu-tools"
+    echo -e "\nStep 3/5: Installing intel-gpu-tools"
     DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a sudo -E apt install -y intel-gpu-tools jq
 
-    echo -e "\nStep 4/4: Installing data-science-stack snap from channel $dss_snap_channel"
+    echo -e "\nStep 4/5: Installing data-science-stack snap from channel $dss_snap_channel"
     sudo snap install data-science-stack --channel "$dss_snap_channel"
+
+    echo -e "\nStep 3/5: Installing git and python3-venv for DSS integration tests"
+    DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a sudo -E apt install -y git python3-venv
 }
 
 main "$@"

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/jobs.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/jobs.pxu
@@ -271,7 +271,7 @@ command:
   set -eou pipefail
   OPERATOR_VERSION="24.6.2"
   microk8s enable gpu --driver=operator --version="${OPERATOR_VERSION}"
-  check_cuda_rollout.sh
+  check_nvidia_gpu_rollout.sh
 
 id: nvidia_gpu_addon/validations_succeed
 category_id: dss-regress

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/jobs.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/jobs.pxu
@@ -368,3 +368,70 @@ depends: dss/create_tensorflow_cuda_notebook
 _summary: Check that DSS can be purged
 estimated_duration: 5m
 command: timeout 5m run_dss.sh purge
+
+id: dss_integration_tests/setup
+category_id: dss-regress
+flags: simple
+imports:
+  from com.canonical.certification import executable
+  from com.canonical.certification import package
+requires:
+  executable.name == 'git'
+  executable.name == 'python3'
+  package.name == 'python3-venv'
+depends: dss/purge
+_summary: Checkout and setup the DSS integration tests
+estimated_duration: 5m
+command:
+  set -eo pipefail
+  export DSS_CLONE_PATH="/tmp/data-science-stack"
+  if [ ! -d "$DSS_CLONE_PATH" ]; then
+    echo "cloning DSS repo"
+    git clone https://github.com/canonical/data-science-stack.git "$DSS_CLONE_PATH"
+  fi
+  cd "$DSS_CLONE_PATH"
+  echo "Latest commit in DSS repo:"
+  git log --name-status HEAD^..HEAD
+  if [ ! -d ".venv" ]; then
+    echo "creating venv"
+    python3 -m venv .venv
+    echo "install tox"
+    .venv/bin/pip install tox
+  fi
+  echo "Setup complete for DSS integration tests"
+
+id: dss_integration_tests/cpu
+category_id: dss-regress
+flags: simple
+imports:
+  from com.canonical.certification import executable
+  from com.canonical.certification import package
+requires:
+  executable.name == 'dss'
+depends: dss_integration_tests/setup
+_summary: Check that all DSS integration tests for CPU pass
+estimated_duration: 15m
+command:
+  set -eo pipefail
+  cd /tmp/data-science-stack
+  .venv/bin/tox -e integration
+  echo "DSS integration tests passed on CPU"
+
+id: dss_integration_tests/nvidia_gpu
+category_id: dss-regress
+flags: simple
+imports:
+  from com.canonical.certification import executable
+  from com.canonical.certification import package
+requires:
+  executable.name == 'dss'
+depends:
+  dss_integration_tests/setup
+  nvidia_gpu_addon/validations_succeed
+_summary: Check that all DSS integration tests for NVIDIA GPU pass
+estimated_duration: 15m
+command:
+  set -eo pipefail
+  cd /tmp/data-science-stack
+  .venv/bin/tox -e integration-gpu
+  echo "DSS integration tests passed on NVIDIA GPU"

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
@@ -36,6 +36,9 @@ include:
     cuda/tensorflow_can_use_cuda
     dss/remove_tensorflow_cuda_notebook
     dss/purge
+    dss_integration_tests/setup
+    dss_integration_tests/cpu
+    dss_integration_tests/nvidia_gpu
 bootstrap_include:
     com.canonical.certification::executable
     com.canonical.certification::snap


### PR DESCRIPTION
## Description

- In the `install-deps` script, add installing `git` and `python3-venv` to be able to setup for the running the DSS integration tests from their [repo](https://github.com/canonical/data-science-stack).
- Add a job to clone the [data-scienc-stack](https://github.com/canonical/data-science-stack) repo, and to setup and `venv` with `tox` for running the tests.
- Add a job to run the CPU integration tests from the repo.
- Add a job to run the NVIDIA GPU integration tests from the repo if the NVIDIA GPU addon was successfully enabled and validated in the K8s cluster.
- Fix script name for checking NVIDIA GPU rollout.

### TODO

- [ ] Parse Commit hash from DSS snap to determine what version of the repo to check out

## Resolved issues

- (Started as) Part of [CHECKBOX-1693](https://warthogs.atlassian.net/browse/CHECKBOX-1693)
- [CHECKBOX-1870](https://warthogs.atlassian.net/browse/CHECKBOX-1870)

## Documentation

No changes to Checkbox documentation.

## Tests

There are no new unit-tests added.  A full run of the checkbox-provider in Testflinger can be found [here](https://testflinger.canonical.com/jobs/07e36b77-4f36-44b2-9e83-5a9ba3feca26).


[CHECKBOX-1693]: https://warthogs.atlassian.net/browse/CHECKBOX-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CHECKBOX-1870]: https://warthogs.atlassian.net/browse/CHECKBOX-1870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ