### PR TITLE
Add new collectors and remove fetch-on-checkpoint mechanism (New)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/resume.py
+++ b/checkbox-ng/plainbox/impl/session/resume.py
@@ -1268,29 +1268,6 @@ class SessionResumeHelper7(MetaDataHelper7MixIn, SessionResumeHelper6):
     pass
 
 
-class SessionResumeHelper8(SessionResumeHelper7):
-    def _restore_SessionState_system_information(
-        self, session_state, session_repr
-    ):
-        _validate(session_repr, key="system_information", value_type=dict)
-        system_information = CollectorOutputs(
-            {
-                tool_name: CollectionOutput.from_dict(tool_output_json)
-                for (tool_name, tool_output_json) in session_repr[
-                    "system_information"
-                ].items()
-            }
-        )
-        session_state.system_information = system_information
-
-    def _build_SessionState(self, session_repr, early_cb=None):
-        session_state = super()._build_SessionState(session_repr, early_cb)
-        self._restore_SessionState_system_information(
-            session_state, session_repr
-        )
-        return session_state
-
-
 def _validate(obj, **flags):
     """Multi-purpose extraction and validation function."""
     # Fetch data from the container OR use json_repr directly

--- a/checkbox-ng/plainbox/impl/session/suspend.py
+++ b/checkbox-ng/plainbox/impl/session/suspend.py
@@ -665,17 +665,5 @@ class SessionSuspendHelper7(SessionSuspendHelper6):
         return data
 
 
-class SessionSuspendHelper8(SessionSuspendHelper7):
-    VERSION = 8
-
-    def _repr_SessionState(self, obj, session_dir):
-        data = super()._repr_SessionState(obj, session_dir)
-        data["system_information"] = {
-            tool_name: tool_output.to_dict()
-            for (tool_name, tool_output) in obj.system_information.items()
-        }
-        return data
-
-
 # Alias for the most recent version
-SessionSuspendHelper = SessionSuspendHelper8
+SessionSuspendHelper = SessionSuspendHelper7

--- a/checkbox-ng/plainbox/impl/session/system_information.py
+++ b/checkbox-ng/plainbox/impl/session/system_information.py
@@ -16,7 +16,7 @@ class CollectorOutputs(dict):
     collector will include in its output
     """
 
-    COLLECTOR_OUTPUTS_VERSION = 1
+    COLLECTOR_OUTPUTS_VERSION = 2
 
     def to_json(self) -> str:
         to_dump = {
@@ -263,6 +263,32 @@ class ImageInfoCollector(Collector):
                 str(vendor.IMAGE_INFO),
             ],
             version_cmd=["python3", str(vendor.IMAGE_INFO), "--version"],
+        )
+
+
+class DmesgCollector(Collector):
+    COLLECTOR_NAME = "dmesg"
+
+    def __init__(self):
+        super().__init__(
+            collection_cmd=["dmesg", "--json"],
+            version_cmd=["dmesg", "--version"],
+        )
+
+
+class JournalctlCollector(Collector):
+    COLLECTOR_NAME = "journalctl"
+
+    def __init__(self):
+        super().__init__(
+            collection_cmd=[
+                "journalctl",
+                "--output",
+                "json",
+                "--since",
+                "-3 days",
+            ],
+            version_cmd=["journalctl", "--version"],
         )
 
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

It is often useful to analyze the logs after a session is done to see why something went south. In order to do this, this PR adds a journal and a dmesg collector to system information. 

This PR also moves the collection to the end of the session. I was about to create some complex machinery to run some collectors at the start of a run and some at the end, but I talked myself out of it. The collection was placed where it was placed because we thought we could use it during the run somehow. This idea went out of the window and all that is remaining now is the cost of running the collection at the start of the run, which is about 3s just to run inxi on my machine, for any session that is started, even if no submission is ever generated. I don't think the value we get (which is nothing right now) justifies this cost. If we will ever want to do something with that data during the run we can always revert (partially) this commit and tag the collectors/create functions to call them at finalize and first checkpoint, for now, I think we should do the easy thing and just collect at the end.

## Resolved issues

Fixes: CHECKBOX-1753

## Documentation

N/A

## Tests

Tried this locally, in general I don't expect this to cause major issues as collectors can safely fail
