### PR TITLE
Os release should always provide codename (bugfix)

### DIFF
--- a/providers/resource/bin/os_resource.py
+++ b/providers/resource/bin/os_resource.py
@@ -38,13 +38,18 @@ def get_release_info(release_file_content: str):
         "VERSION_CODENAME": "codename",
     }
     os_release = {}
-    for line in release_file_content.strip().splitlines():
-        if line:
-            (key, value) = line.split("=", 1)
-            if key in os_release_map:
-                k = os_release_map[key]
-                # Strip out quotes and newlines
-                os_release[k] = re.sub('["\n]', "", value)
+    lines = filter(bool, release_file_content.strip().splitlines())
+    for line in lines:
+        (key, value) = line.split("=", 1)
+        if key in os_release_map:
+            k = os_release_map[key]
+            # Strip out quotes and newlines
+            os_release[k] = re.sub('["\n]', "", value)
+    # this is needed by C3, on core there is no VERSION_CODENAME, lets put
+    # description here by default which will yield
+    os_release["codename"] = os_release.get(
+        "codename", os_release.get("description", "unknown")
+    )
     return os_release
 
 

--- a/providers/resource/bin/os_resource.py
+++ b/providers/resource/bin/os_resource.py
@@ -46,7 +46,8 @@ def get_release_info(release_file_content: str):
             # Strip out quotes and newlines
             os_release[k] = re.sub('["\n]', "", value)
     # this is needed by C3, on core there is no VERSION_CODENAME, lets put
-    # description here by default which will yield
+    # description (PRETTY_NAME) here by default or unknown (which should be
+    # impossible but resources aren't supposed to crash)
     os_release["codename"] = os_release.get(
         "codename", os_release.get("description", "unknown")
     )

--- a/providers/resource/tests/test_os_resource.py
+++ b/providers/resource/tests/test_os_resource.py
@@ -71,3 +71,25 @@ class OsResourceTests(unittest.TestCase):
             "codename": "jammy",
         }
         self.assertEqual(os_release, expected)
+
+    def test_get_release_info_core_no_codename(self):
+        # core doesn't have codename
+        os_release_data = textwrap.dedent(
+            """
+            NAME="Ubuntu Core"
+            VERSION="22"
+            ID=ubuntu-core
+            PRETTY_NAME="Ubuntu Core 22"
+            VERSION_ID="22"
+            HOME_URL="https://snapcraft.io/"
+            BUG_REPORT_URL="https://bugs.launchpad.net/snappy/
+            """
+        ).strip()
+        os_release = os_resource.get_release_info(os_release_data)
+        expected = {
+            "distributor_id": "Ubuntu Core",
+            "description": "Ubuntu Core 22",
+            "release": "22",
+            "codename": "Ubuntu Core 22",
+        }
+        self.assertEqual(os_release, expected)


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This bugfix didn't take into consideration that ubuntu core doesn't have a codename. This patch provides backward compatibility by using the description (which is the pretty name of the os) as a codename (which is indeed proper for core).

## Resolved issues

Fixes: CHECKBOX-1793

## Documentation

Added a comment

## Tests

Added a test