### PR TITLE
Update canonical-certiciation-precheck for new USB device rules (bugfix)

### DIFF
--- a/providers/certification-server/tools/canonical-certification-precheck
+++ b/providers/certification-server/tools/canonical-certification-precheck
@@ -366,8 +366,8 @@ for disk in $(lsblk -r | grep disk | cut -f 1 -d " "); do
         fi
     fi
 done
-if [ -z "$usb2_disks" ]; then
-    echo " No USB2 disks detected."
+if [ -z "$usb2_disks" ] && [ -z "$usb3_disks" ]; then
+    echo " No USB disks detected."
     all_ok="N"
 else
     echo " Detected USB2 disk(s): ${usb2_disks[*]}"


### PR DESCRIPTION
Title: Updated canonical-certification-precheck script to accept system with USB3 disk but no USB2 disk (bugfix)

## Description

This PR adjusts the logic of the USB tests to flag a lack of a USB2 device only if the system also lacks a USB3 device. If both devices are present, the script still checks for suitable filesystems on both devices, since presumably the tester wants to test both devices in this case.

## Resolved issues

https://github.com/canonical/checkbox/issues/1801

## Documentation

No documentation changes are needed. The Server Self-Test Guide doesn't delve deep enough into this issue to need changing, 

## Tests

I deployed a node and tested with all combinations of USB2 and USB3 drives plugged in and removed; and with the drives correctly partitioned and not. The script passed the configurations in which the USB2 drive was removed when the USB3 drive was present and complained (correctly) when the USB3 drive was unplugged or when either drive was plugged in but had no valid partition.
