### PR TITLE
[ce-oem] Give user the DBus permission when running at remote mode (Bugfix)

### DIFF
--- a/providers/base/units/power-management/jobs.pxu
+++ b/providers/base/units/power-management/jobs.pxu
@@ -124,6 +124,7 @@ requires:
   module.name == 'platform_profile'
   package.name == 'power-profiles-daemon'
   platform_profile.supported == 'True'
+user: root
 command: switch_power_mode.py
 _description:
   This test will check if the power mode could be switched.


### PR DESCRIPTION
## Description

Give user the DBus permission when running at remote mode

## Resolved issues

[#1656](https://github.com/canonical/checkbox/issues/1656)

## Tests
```
$ checkbox-cli run com.canonical.certification::power-management/switch_power_mode
Outcome: job passed
==============[ Running job 4 / 4. Estimated time left: 0:00:10 ]===============
---------------------[ power-management/switch_power_mode ]---------------------
ID: com.canonical.certification::power-management/switch_power_mode
Category: com.canonical.plainbox::power-management
... 8< -------------------------------------------------------------------------
Power mode choices: ['low-power', 'balanced', 'performance']
Switch to low-power successfully.
Switch to balanced successfully.
Switch to performance successfully.
------------------------------------------------
```