### PR TITLE
Pin actions (infra)

### DIFF
--- a/.github/actions/checkbox_source_deb/action.yaml
+++ b/.github/actions/checkbox_source_deb/action.yaml
@@ -28,7 +28,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - name: Install dependencies
       shell: bash
       run: |

--- a/.github/actions/checkbox_source_deb/action.yaml
+++ b/.github/actions/checkbox_source_deb/action.yaml
@@ -77,7 +77,7 @@ runs:
           cp -rT "$action_path" "$workdir_path"
         fi
     - name: Submit and monitor job
-      uses: canonical/testflinger/.github/actions/submit@main
+      uses: canonical/testflinger/.github/actions/submit@2c10f8bbb78532c12034dc668971ddae3b44edc9
       with:
         poll: true
         job-path: tools/lab_dispatch/job.yaml

--- a/.github/actions/checkbox_source_deb/action.yaml
+++ b/.github/actions/checkbox_source_deb/action.yaml
@@ -28,7 +28,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - name: Install dependencies
       shell: bash
       run: |

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -12,7 +12,7 @@ jobs:
   check-with-black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - uses: psf/black@stable

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
-      - uses: psf/black@stable
+      - uses: psf/black@8a737e727ac5ab2f1d4cf5876720ed276dc8dc4b
         with:
           options: "--check --diff --line-length 79 --extend-exclude '/vendor/'"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -12,7 +12,7 @@ jobs:
   check-with-black:
     runs-on: ubuntu-latest
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - uses: psf/black@stable

--- a/.github/workflows/checkbox-beta-release.yml
+++ b/.github/workflows/checkbox-beta-release.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y gh
       - name: Checkout checkbox monorepo
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -45,7 +45,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Copy deb packages from edge to beta ppa

--- a/.github/workflows/checkbox-beta-release.yml
+++ b/.github/workflows/checkbox-beta-release.yml
@@ -31,9 +31,10 @@ jobs:
       - name: Verify Promotion Conditions
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           # check if can_promote but ignore (only print an error) if the workflow was manually triggered
-          tools/release/can_promote_edge.py || ${{ github.event_name == 'workflow_dispatch' }}
+          tools/release/can_promote_edge.py || [ "$WORKFLOW_DISPATCH" == "true" ]
 
   checkbox_deb_packages:
     needs: should-run

--- a/.github/workflows/checkbox-beta-release.yml
+++ b/.github/workflows/checkbox-beta-release.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y gh
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -45,7 +45,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Copy deb packages from edge to beta ppa

--- a/.github/workflows/checkbox-ce-oem-daily-build.yml
+++ b/.github/workflows/checkbox-ce-oem-daily-build.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       new_commit_count: ${{ steps.commit_check.outputs.new_commit_count }}
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/checkbox-ce-oem-daily-build.yml
+++ b/.github/workflows/checkbox-ce-oem-daily-build.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       new_commit_count: ${{ steps.commit_check.outputs.new_commit_count }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/checkbox-ce-oem-edge-builds.yml
+++ b/.github/workflows/checkbox-ce-oem-edge-builds.yml
@@ -57,7 +57,7 @@ jobs:
             path: contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_${{ matrix.type }}${{ matrix.releases }}
             snapcraft-channel: 7.x/stable
             snapcraft-args: remote-build --build-for amd64,arm64,armhf --launchpad-accept-public-upload --build-id $SNAPCRAFT_BUILDER_ID
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         name: Upload logs on failure
         if: failure()
         with:
@@ -66,7 +66,7 @@ jobs:
             /home/runner/.cache/snapcraft/log/
             /home/runner/.local/state/snapcraft/log/
             contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_${{ matrix.type }}${{ matrix.releases }}/checkbox*.txt
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         name: Upload the snaps as artefacts
         with:
           name: ce_oem_snap${{ matrix.type }}${{ matrix.releases }}

--- a/.github/workflows/checkbox-ce-oem-edge-builds.yml
+++ b/.github/workflows/checkbox-ce-oem-edge-builds.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Print Launchpad build repository
         run: |
           echo "Building at: https://git.launchpad.net/~ce-certification-qa/+snap/$SNAPCRAFT_BUILDER_ID"
-      - uses: Wandalen/wretry.action@v3.4.0_js_action
+      - uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea
         name: Building the snaps
         timeout-minutes: 600 # 10hours
         with:
@@ -71,7 +71,7 @@ jobs:
         with:
           name: ce_oem_snap${{ matrix.type }}${{ matrix.releases }}
           path: contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_${{ matrix.type }}${{ matrix.releases }}/*.snap
-      - uses: Wandalen/wretry.action@v3.4.0_js_action
+      - uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea
         name: Upload the snaps to the store
         timeout-minutes: 600 # 10hours
         with:

--- a/.github/workflows/checkbox-ce-oem-edge-builds.yml
+++ b/.github/workflows/checkbox-ce-oem-edge-builds.yml
@@ -33,7 +33,7 @@ jobs:
       SNAPCRAFT_BUILDER_ID: checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ github.run_id }}
     name: Frontend ${{ matrix.type }}${{ matrix.releases }}
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/checkbox-ce-oem-edge-builds.yml
+++ b/.github/workflows/checkbox-ce-oem-edge-builds.yml
@@ -33,7 +33,7 @@ jobs:
       SNAPCRAFT_BUILDER_ID: checkbox-${{ matrix.type }}${{ matrix.releases }}-${{ github.run_id }}
     name: Frontend ${{ matrix.type }}${{ matrix.releases }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/checkbox-daily-cross-builds.yaml
+++ b/.github/workflows/checkbox-daily-cross-builds.yaml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     name: Runtime ${{ matrix.release }} (${{ matrix.arch }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -116,7 +116,7 @@ jobs:
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     name: Frontend ${{ matrix.type }}${{ matrix.release }} (${{ matrix.arch }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/checkbox-daily-cross-builds.yaml
+++ b/.github/workflows/checkbox-daily-cross-builds.yaml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Publish track
         if: inputs.store_upload
-        uses: canonical/action-publish@v1
+        uses: canonical/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
         with:
@@ -159,7 +159,7 @@ jobs:
       - name: Publish track
         # this is done this way because the store doesn't allow the same artifact to be uploaded twice
         if: inputs.store_upload && (matrix.release != 24 || matrix.type != 'classic')
-        uses: canonical/action-publish@v1
+        uses: canonical/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
         with:
@@ -169,7 +169,7 @@ jobs:
 
       - name: Publish track + latest
         if: inputs.store_upload && matrix.release == 24 && matrix.type == 'classic'
-        uses: canonical/action-publish@v1
+        uses: canonical/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
         with:

--- a/.github/workflows/checkbox-daily-cross-builds.yaml
+++ b/.github/workflows/checkbox-daily-cross-builds.yaml
@@ -61,7 +61,7 @@ jobs:
             architecture: ${{ matrix.arch }}
             path: checkbox-core-snap/series${{ matrix.release }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         name: Upload logs on failure
         if: failure()
         with:
@@ -71,7 +71,7 @@ jobs:
             /home/runner/.local/state/snapcraft/log/
             checkbox-core-snap/series${{ matrix.release }}/checkbox*.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         name: Upload the snap as artifact
         with:
           name: runtime_snap${{ matrix.release }}_${{ matrix.arch }}.snap
@@ -140,7 +140,7 @@ jobs:
             architecture: ${{ matrix.arch }}
             path: checkbox-snap/series_${{ matrix.type }}${{ matrix.release }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         name: Upload logs on failure
         if: failure()
         with:
@@ -150,7 +150,7 @@ jobs:
             /home/runner/.local/state/snapcraft/log/
             checkbox-snap/series_${{ matrix.type }}${{ matrix.release }}/checkbox*.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         name: Upload the snaps as artefacts
         with:
           name: frontend_snaps_${{ matrix.type }}${{ matrix.release }}_${{matrix.arch}}.snap

--- a/.github/workflows/checkbox-daily-cross-builds.yaml
+++ b/.github/workflows/checkbox-daily-cross-builds.yaml
@@ -128,7 +128,7 @@ jobs:
           ./prepare_${{ matrix.type }}.sh series_${{ matrix.type }}${{ matrix.release }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
 
       - id: snap_build
         name: Build (retries on fail)

--- a/.github/workflows/checkbox-daily-cross-builds.yaml
+++ b/.github/workflows/checkbox-daily-cross-builds.yaml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     name: Runtime ${{ matrix.release }} (${{ matrix.arch }})
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -116,7 +116,7 @@ jobs:
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     name: Frontend ${{ matrix.type }}${{ matrix.release }} (${{ matrix.arch }})
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/checkbox-daily-cross-builds.yaml
+++ b/.github/workflows/checkbox-daily-cross-builds.yaml
@@ -49,11 +49,11 @@ jobs:
           ./prepare.sh series${{ matrix.release }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
 
       - id: snap_build
         name: Build (retries on fail)
-        uses: Wandalen/wretry.action@v3.4.0_js_action
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea
         with:
           attempt_limit: 5
           action: canonical/snapcraft-multiarch-action@v1
@@ -132,7 +132,7 @@ jobs:
 
       - id: snap_build
         name: Build (retries on fail)
-        uses: Wandalen/wretry.action@v3.4.0_js_action
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea
         with:
           attempt_limit: 5
           action: canonical/snapcraft-multiarch-action@v1

--- a/.github/workflows/checkbox-daily-native-builds.yaml
+++ b/.github/workflows/checkbox-daily-native-builds.yaml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     name: Runtime ${{ matrix.release }}  (${{matrix.arch}})
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -122,7 +122,7 @@ jobs:
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     name: Frontend ${{ matrix.type }}${{ matrix.release }} (${{matrix.arch}})
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/checkbox-daily-native-builds.yaml
+++ b/.github/workflows/checkbox-daily-native-builds.yaml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     name: Runtime ${{ matrix.release }}  (${{matrix.arch}})
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -122,7 +122,7 @@ jobs:
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     name: Frontend ${{ matrix.type }}${{ matrix.release }} (${{matrix.arch}})
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/checkbox-daily-native-builds.yaml
+++ b/.github/workflows/checkbox-daily-native-builds.yaml
@@ -70,7 +70,7 @@ jobs:
             path: checkbox-core-snap/series${{ matrix.release }}
             snapcraft-channel: ${{ matrix.snapcraft_version }}/stable
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         name: Upload logs on failure
         if: failure()
         with:
@@ -80,7 +80,7 @@ jobs:
             /home/runner/.local/state/snapcraft/log/
             checkbox-core-snap/series${{ matrix.release }}/checkbox*.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         name: Upload the snap as artifact
         with:
           name: checkbox${{ matrix.release }}_${{ matrix.arch }}
@@ -145,7 +145,7 @@ jobs:
             path: checkbox-snap/series_${{ matrix.type }}${{ matrix.release }}
             snapcraft-channel: ${{ matrix.snapcraft_version }}/stable
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         name: Upload logs on failure
         if: failure()
         with:
@@ -155,7 +155,7 @@ jobs:
             /home/runner/.local/state/snapcraft/log/
             checkbox-snap/series_${{ matrix.type }}${{ matrix.release }}/checkbox*.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         name: Upload the snaps as artefacts
         with:
           name: series_${{ matrix.type }}${{ matrix.release }}${{ matrix.arch }}

--- a/.github/workflows/checkbox-daily-native-builds.yaml
+++ b/.github/workflows/checkbox-daily-native-builds.yaml
@@ -59,7 +59,7 @@ jobs:
           ./prepare.sh series${{ matrix.release }}
 
       - id: snap_build
-        uses: Wandalen/wretry.action@v3.4.0_js_action
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea
         name: Build the snap
         timeout-minutes: 600 # 10hours
         with:
@@ -134,7 +134,7 @@ jobs:
           ./prepare_${{ matrix.type }}.sh series_${{ matrix.type }}${{ matrix.release }}
 
       - id: snap_build
-        uses: Wandalen/wretry.action@v3.4.0_js_action
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea
         name: Building the snaps
         timeout-minutes: 600 # 10hours
         with:

--- a/.github/workflows/checkbox-daily-native-builds.yaml
+++ b/.github/workflows/checkbox-daily-native-builds.yaml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Publish track
         if: inputs.store_upload
-        uses: canonical/action-publish@v1
+        uses: canonical/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
         with:
@@ -164,7 +164,7 @@ jobs:
       - name: Publish track
         # this is done this way because the store doesn't allow the same artifact to be uploaded twice
         if: inputs.store_upload && (matrix.release != 24 || matrix.type != 'classic')
-        uses: canonical/action-publish@v1
+        uses: canonical/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
         with:
@@ -174,7 +174,7 @@ jobs:
 
       - name: Publish track + latest
         if: inputs.store_upload && matrix.release == 24 && matrix.type == 'classic'
-        uses: canonical/action-publish@v1
+        uses: canonical/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
         with:

--- a/.github/workflows/checkbox-promote-beta-to-candidate.yml
+++ b/.github/workflows/checkbox-promote-beta-to-candidate.yml
@@ -59,7 +59,7 @@ jobs:
             checkbox_track: uc22
     steps:
     - name: Checkout checkbox monorepo
-      uses: actions/checkout@v4
+      uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
           persist-credentials: false
 

--- a/.github/workflows/checkbox-promote-beta-to-candidate.yml
+++ b/.github/workflows/checkbox-promote-beta-to-candidate.yml
@@ -59,7 +59,7 @@ jobs:
             checkbox_track: uc22
     steps:
     - name: Checkout checkbox monorepo
-      uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
           persist-credentials: false
 

--- a/.github/workflows/checkbox-promote-beta-to-candidate.yml
+++ b/.github/workflows/checkbox-promote-beta-to-candidate.yml
@@ -80,7 +80,7 @@ jobs:
         echo "job=$JOB_PATH" >> $GITHUB_OUTPUT
 
     - name: Submit job
-      uses: canonical/testflinger/.github/actions/submit@main
+      uses: canonical/testflinger/.github/actions/submit@2c10f8bbb78532c12034dc668971ddae3b44edc9
       with:
         poll: true
         job-path: ${{ steps.create-job.outputs.job }}

--- a/.github/workflows/checkbox-stable-release.yml
+++ b/.github/workflows/checkbox-stable-release.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout checkbox monorepo
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -60,7 +60,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Copy deb packages from testing to stable ppa

--- a/.github/workflows/checkbox-stable-release.yml
+++ b/.github/workflows/checkbox-stable-release.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -60,7 +60,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Copy deb packages from testing to stable ppa

--- a/.github/workflows/checkbox-tics.yml
+++ b/.github/workflows/checkbox-tics.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: TICS
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
 

--- a/.github/workflows/checkbox-tics.yml
+++ b/.github/workflows/checkbox-tics.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: TICS
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
 

--- a/.github/workflows/checkbox-tics.yml
+++ b/.github/workflows/checkbox-tics.yml
@@ -75,7 +75,7 @@ jobs:
           echo "::endgroup::"
 
       - name: TICS GitHub Action
-        uses: tiobe/tics-github-action@v3
+        uses: tiobe/tics-github-action@88cb795a736d2ca885753bec6ed2c8b03e3f892f
         with:
           mode: qserver
           project: checkbox

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       new_commit_count: ${{ steps.commit_check.outputs.new_commit_count }}
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       new_commit_count: ${{ steps.commit_check.outputs.new_commit_count }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -70,7 +70,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: Wandalen/wretry.action/main@v3.4.0_js_action
+      - uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea
         name: Make LP pull the monorepo
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
@@ -74,7 +74,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: Wandalen/wretry.action/main@v3.4.0_js_action
+      - uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea
         name: Update the recipe in the checkbox PPA
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
@@ -84,7 +84,7 @@ jobs:
           attempt_limit: 60   # max 1 hour of retries
           command: |
             tools/release/lp_update_recipe.py checkbox --recipe ${{ matrix.recipe }} --new-version $(tools/release/get_version.py --dev-suffix --output-format deb) --revision $GITHUB_SHA
-      - uses: Wandalen/wretry.action/main@v3.4.0_js_action
+      - uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea
         name: Build and wait result
         timeout-minutes: 780 # 13hours
         env:

--- a/.github/workflows/deb-daily-builds.yml
+++ b/.github/workflows/deb-daily-builds.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -70,7 +70,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/deb-sanity-builds.yml
+++ b/.github/workflows/deb-sanity-builds.yml
@@ -17,7 +17,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -47,7 +47,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/deb-sanity-builds.yml
+++ b/.github/workflows/deb-sanity-builds.yml
@@ -17,7 +17,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -47,7 +47,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq -y python3-launchpadlib
       - name: Checkout checkbox monorepo
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/deb-sanity-builds.yml
+++ b/.github/workflows/deb-sanity-builds.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: Wandalen/wretry.action/main@v3.4.0_js_action
+      - uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea
         name: Make LP pull the monorepo
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
@@ -51,7 +51,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: Wandalen/wretry.action/main@v3.4.0_js_action
+      - uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea
         name: Update the recipe in the checkbox PPA
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
@@ -61,7 +61,7 @@ jobs:
           attempt_limit: 60   # max 1 hour of retries
           command: |
             tools/release/lp_update_recipe.py checkbox --recipe ${{ matrix.recipe }} --new-version $(tools/release/get_version.py --dev-suffix --output-format deb) --revision $GITHUB_SHA
-      - uses: Wandalen/wretry.action/main@v3.4.0_js_action
+      - uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea
         name: Build and wait result
         timeout-minutes: 780 # 13hours
         env:

--- a/.github/workflows/deb_validator.yaml
+++ b/.github/workflows/deb_validator.yaml
@@ -38,7 +38,7 @@ jobs:
       paths: ${{ steps.paths.outputs.paths }}
     steps:
       - name: Checkout Checkbox monorepo
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -82,7 +82,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Checkbox monorepo
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # needed by providers that pull checkbox-support

--- a/.github/workflows/deb_validator.yaml
+++ b/.github/workflows/deb_validator.yaml
@@ -38,7 +38,7 @@ jobs:
       paths: ${{ steps.paths.outputs.paths }}
     steps:
       - name: Checkout Checkbox monorepo
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -82,7 +82,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Checkbox monorepo
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # needed by providers that pull checkbox-support

--- a/.github/workflows/dispatch_lab_job.yaml
+++ b/.github/workflows/dispatch_lab_job.yaml
@@ -36,7 +36,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
 

--- a/.github/workflows/dispatch_lab_job.yaml
+++ b/.github/workflows/dispatch_lab_job.yaml
@@ -36,7 +36,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
 

--- a/.github/workflows/dispatch_lab_job.yaml
+++ b/.github/workflows/dispatch_lab_job.yaml
@@ -45,7 +45,7 @@ jobs:
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Run the spec
-        uses: canonical/checkbox/.github/actions/checkbox_source_deb@main
+        uses: canonical/checkbox/.github/actions/checkbox_source_deb@e85a72288135b48873cd6364f9b85941c1bce552
         with:
           data_source: ${{ matrix.spec.data_source }}
           queue: ${{ matrix.spec.queue }}

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -64,7 +64,7 @@ jobs:
           persist-credentials: false
 
       - name: woke
-        uses: get-woke/woke-action@v0
+        uses: get-woke/woke-action@b2ec032c4a2c912142b38a6a453ad62017813ed0
         with:
           # Cause the check to fail on any broke rules
           fail-on-error: true

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
 
@@ -59,7 +59,7 @@ jobs:
         - X64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
 
@@ -86,7 +86,7 @@ jobs:
         working-directory: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
 

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: docs
     steps:
       - name: Checkout
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
 
@@ -59,7 +59,7 @@ jobs:
         - X64
     steps:
       - name: Checkout
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
 
@@ -86,7 +86,7 @@ jobs:
         working-directory: docs
     steps:
       - name: Checkout
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
 

--- a/.github/workflows/label-cert-blocker-issue.yaml
+++ b/.github/workflows/label-cert-blocker-issue.yaml
@@ -1,4 +1,5 @@
 name: Label issue related to cert-blocker test cases
+permissions: {}
 on:
   issues:
     types: [opened]

--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       required_run: ${{ steps.check_diff.outputs.required_run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -54,7 +54,7 @@ jobs:
       PYCHARM_HOSTED: True
     steps:
       - name: Checkout Checkbox monorepo
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Setup LXD

--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup LXD
-        uses: canonical/setup-lxd@main
+        uses: canonical/setup-lxd@2fa6235ef2dfd3288e0de09edac03f2ebf922968
       - name: Add ZFS storage
         run: |
           lxc storage list

--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       required_run: ${{ steps.check_diff.outputs.required_run }}
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -54,7 +54,7 @@ jobs:
       PYCHARM_HOSTED: True
     steps:
       - name: Checkout Checkbox monorepo
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Setup LXD

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Checkbox monorepo
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Checkbox monorepo
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Checkbox monorepo
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Checkbox monorepo
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/testflinger-contrib-dss-regression.yaml
+++ b/.github/workflows/testflinger-contrib-dss-regression.yaml
@@ -41,7 +41,7 @@ jobs:
             provision_data: "distro: jammy"
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Build job file from template

--- a/.github/workflows/testflinger-contrib-dss-regression.yaml
+++ b/.github/workflows/testflinger-contrib-dss-regression.yaml
@@ -41,7 +41,7 @@ jobs:
             provision_data: "distro: jammy"
     steps:
       - name: Check out code
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Build job file from template

--- a/.github/workflows/testflinger-contrib-dss-regression.yaml
+++ b/.github/workflows/testflinger-contrib-dss-regression.yaml
@@ -54,7 +54,7 @@ jobs:
           ${GITHUB_WORKSPACE}/contrib/checkbox-dss-validation/testflinger/job-def.yaml > \
           ${GITHUB_WORKSPACE}/job.yaml
       - name: Submit testflinger job
-        uses: canonical/testflinger/.github/actions/submit@main
+        uses: canonical/testflinger/.github/actions/submit@2c10f8bbb78532c12034dc668971ddae3b44edc9
         with:
           poll: true
           job-path: ${GITHUB_WORKSPACE}/job.yaml

--- a/.github/workflows/tox-checkbox-ng.yaml
+++ b/.github/workflows/tox-checkbox-ng.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED

--- a/.github/workflows/tox-checkbox-ng.yaml
+++ b/.github/workflows/tox-checkbox-ng.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: checkbox-ng

--- a/.github/workflows/tox-checkbox-ng.yaml
+++ b/.github/workflows/tox-checkbox-ng.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-checkbox-ng.yaml
+++ b/.github/workflows/tox-checkbox-ng.yaml
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-checkbox-support.yaml
+++ b/.github/workflows/tox-checkbox-support.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED

--- a/.github/workflows/tox-checkbox-support.yaml
+++ b/.github/workflows/tox-checkbox-support.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: checkbox-support

--- a/.github/workflows/tox-checkbox-support.yaml
+++ b/.github/workflows/tox-checkbox-support.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-checkbox-support.yaml
+++ b/.github/workflows/tox-checkbox-support.yaml
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-contrib-pc-sanity.yaml
+++ b/.github/workflows/tox-contrib-pc-sanity.yaml
@@ -25,7 +25,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Setup Python

--- a/.github/workflows/tox-contrib-pc-sanity.yaml
+++ b/.github/workflows/tox-contrib-pc-sanity.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: pc-sanity

--- a/.github/workflows/tox-contrib-pc-sanity.yaml
+++ b/.github/workflows/tox-contrib-pc-sanity.yaml
@@ -25,11 +25,11 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
       - name: Install tox

--- a/.github/workflows/tox-contrib-pc-sanity.yaml
+++ b/.github/workflows/tox-contrib-pc-sanity.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
       - name: Install tox

--- a/.github/workflows/tox-contrib-provider-ce-oem.yaml
+++ b/.github/workflows/tox-contrib-provider-ce-oem.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED

--- a/.github/workflows/tox-contrib-provider-ce-oem.yaml
+++ b/.github/workflows/tox-contrib-provider-ce-oem.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: contrib-provider-ce-oem

--- a/.github/workflows/tox-contrib-provider-ce-oem.yaml
+++ b/.github/workflows/tox-contrib-provider-ce-oem.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-contrib-provider-ce-oem.yaml
+++ b/.github/workflows/tox-contrib-provider-ce-oem.yaml
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-contrib-provider-dss.yaml
+++ b/.github/workflows/tox-contrib-provider-dss.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-dss

--- a/.github/workflows/tox-contrib-provider-dss.yaml
+++ b/.github/workflows/tox-contrib-provider-dss.yaml
@@ -26,7 +26,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Setup Python

--- a/.github/workflows/tox-contrib-provider-dss.yaml
+++ b/.github/workflows/tox-contrib-provider-dss.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-contrib-provider-dss.yaml
+++ b/.github/workflows/tox-contrib-provider-dss.yaml
@@ -26,11 +26,11 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-base.yaml
+++ b/.github/workflows/tox-provider-base.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED

--- a/.github/workflows/tox-provider-base.yaml
+++ b/.github/workflows/tox-provider-base.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-base

--- a/.github/workflows/tox-provider-base.yaml
+++ b/.github/workflows/tox-provider-base.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-base.yaml
+++ b/.github/workflows/tox-provider-base.yaml
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-certification-client.yaml
+++ b/.github/workflows/tox-provider-certification-client.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED

--- a/.github/workflows/tox-provider-certification-client.yaml
+++ b/.github/workflows/tox-provider-certification-client.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-certification-client.yaml
+++ b/.github/workflows/tox-provider-certification-client.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-certification-client

--- a/.github/workflows/tox-provider-certification-client.yaml
+++ b/.github/workflows/tox-provider-certification-client.yaml
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-certification-server.yaml
+++ b/.github/workflows/tox-provider-certification-server.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED

--- a/.github/workflows/tox-provider-certification-server.yaml
+++ b/.github/workflows/tox-provider-certification-server.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-certification-server

--- a/.github/workflows/tox-provider-certification-server.yaml
+++ b/.github/workflows/tox-provider-certification-server.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-certification-server.yaml
+++ b/.github/workflows/tox-provider-certification-server.yaml
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-docker.yaml
+++ b/.github/workflows/tox-provider-docker.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED

--- a/.github/workflows/tox-provider-docker.yaml
+++ b/.github/workflows/tox-provider-docker.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-docker.yaml
+++ b/.github/workflows/tox-provider-docker.yaml
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-genio.yaml
+++ b/.github/workflows/tox-provider-genio.yaml
@@ -33,7 +33,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED

--- a/.github/workflows/tox-provider-genio.yaml
+++ b/.github/workflows/tox-provider-genio.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-genio

--- a/.github/workflows/tox-provider-genio.yaml
+++ b/.github/workflows/tox-provider-genio.yaml
@@ -33,7 +33,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
@@ -46,7 +46,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-genio.yaml
+++ b/.github/workflows/tox-provider-genio.yaml
@@ -46,7 +46,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-gpgpu.yaml
+++ b/.github/workflows/tox-provider-gpgpu.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED

--- a/.github/workflows/tox-provider-gpgpu.yaml
+++ b/.github/workflows/tox-provider-gpgpu.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-gpgpu

--- a/.github/workflows/tox-provider-gpgpu.yaml
+++ b/.github/workflows/tox-provider-gpgpu.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-gpgpu.yaml
+++ b/.github/workflows/tox-provider-gpgpu.yaml
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-iiotg.yaml
+++ b/.github/workflows/tox-provider-iiotg.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED

--- a/.github/workflows/tox-provider-iiotg.yaml
+++ b/.github/workflows/tox-provider-iiotg.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-iiotg.yaml
+++ b/.github/workflows/tox-provider-iiotg.yaml
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-iiotg.yaml
+++ b/.github/workflows/tox-provider-iiotg.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-iiotg

--- a/.github/workflows/tox-provider-resource.yaml
+++ b/.github/workflows/tox-provider-resource.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED

--- a/.github/workflows/tox-provider-resource.yaml
+++ b/.github/workflows/tox-provider-resource.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-resource

--- a/.github/workflows/tox-provider-resource.yaml
+++ b/.github/workflows/tox-provider-resource.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-resource.yaml
+++ b/.github/workflows/tox-provider-resource.yaml
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-sru.yaml
+++ b/.github/workflows/tox-provider-sru.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED

--- a/.github/workflows/tox-provider-sru.yaml
+++ b/.github/workflows/tox-provider-sru.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-sru.yaml
+++ b/.github/workflows/tox-provider-sru.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: provider-sru

--- a/.github/workflows/tox-provider-sru.yaml
+++ b/.github/workflows/tox-provider-sru.yaml
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-tpm2.yaml
+++ b/.github/workflows/tox-provider-tpm2.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED

--- a/.github/workflows/tox-provider-tpm2.yaml
+++ b/.github/workflows/tox-provider-tpm2.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-tpm2.yaml
+++ b/.github/workflows/tox-provider-tpm2.yaml
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-tutorial.yaml
+++ b/.github/workflows/tox-provider-tutorial.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED

--- a/.github/workflows/tox-provider-tutorial.yaml
+++ b/.github/workflows/tox-provider-tutorial.yaml
@@ -32,7 +32,7 @@ jobs:
           - python: "3.10"
             tox_env_name: "py310"
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       # Python 3.5 setup was failing because of a CERTIFICATE_VERIFY_FAILED
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-provider-tutorial.yaml
+++ b/.github/workflows/tox-provider-tutorial.yaml
@@ -45,7 +45,7 @@ jobs:
           curl --fail --silent --show-error https://pypi.org
           curl --fail --silent --show-error https://files.pythonhosted.org
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python }}
         env:

--- a/.github/workflows/tox-tools-release.yaml
+++ b/.github/workflows/tox-tools-release.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: "3.10"
       - name: Install tox

--- a/.github/workflows/tox-tools-release.yaml
+++ b/.github/workflows/tox-tools-release.yaml
@@ -20,11 +20,11 @@ jobs:
         working-directory: tools/release
     runs-on: ubuntu-latest
     steps:
-      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Setup Python
-        uses: action/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: "3.10"
       - name: Install tox

--- a/.github/workflows/tox-tools-release.yaml
+++ b/.github/workflows/tox-tools-release.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Run tox
         run: tox -e py310
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: release-tools

--- a/.github/workflows/tox-tools-release.yaml
+++ b/.github/workflows/tox-tools-release.yaml
@@ -20,7 +20,7 @@ jobs:
         working-directory: tools/release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Setup Python

--- a/.github/workflows/validate_workflows.yaml
+++ b/.github/workflows/validate_workflows.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Checkbox monorepo
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Install action-validator with asdf
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Checkbox monorepo
-        uses: actions/checkout@v4
+        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Install zizmor from crates.io

--- a/.github/workflows/validate_workflows.yaml
+++ b/.github/workflows/validate_workflows.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Checkbox monorepo
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Install action-validator with asdf
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Checkbox monorepo
-        uses: action/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
       - name: Install zizmor from crates.io

--- a/.github/workflows/validate_workflows.yaml
+++ b/.github/workflows/validate_workflows.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install zizmor from crates.io
-        uses: baptiste0928/cargo-install@v3
+        uses: baptiste0928/cargo-install@91c5da15570085bcde6f4d7aed98cb82d6769fd3
         with:
           crate: zizmor
           version: '1.4.1'

--- a/.github/workflows/validate_workflows.yaml
+++ b/.github/workflows/validate_workflows.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install action-validator with asdf
-        uses: asdf-vm/actions/install@v3
+        uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6
         with:
           tool_versions: |
             action-validator 0.6.0

--- a/.github/workflows/validate_workflows.yaml
+++ b/.github/workflows/validate_workflows.yaml
@@ -41,4 +41,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          zizmor $(ls .github/workflows/*.{yaml,yml})
+          zizmor --pedantic $(ls .github/workflows/*.{yaml,yml})


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

As a response to the recent breach in one commonly used action we have decided to pin all of our actions to their revision, in order to be less exposed to this kind of vulnerability in the future

## Resolved issues

Fixes: CHECKBOX-1796

## Documentation

N/A

## Tests

N/A
