### PR TITLE
Skip power/suspend LED tests when device is using s2idle (New)

### DIFF
--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -29,7 +29,7 @@ estimated_duration: 180
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_led_power == 'True'
- suspend.type != 's2idle'
+ suspend_state.type != 's2idle'
 
 plugin: manual
 category_id: led
@@ -38,7 +38,7 @@ estimated_duration: 30.0
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_led_suspend == 'True'
- suspend.type != 's2idle'
+ suspend_state.type != 's2idle'
 depends: suspend/suspend_advanced_auto
 _purpose:
  Suspend LED verification.

--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -29,6 +29,7 @@ estimated_duration: 180
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_led_power == 'True'
+ suspend.type != 's2idle'
 
 plugin: manual
 category_id: led
@@ -37,6 +38,7 @@ estimated_duration: 30.0
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_led_suspend == 'True'
+ suspend.type != 's2idle'
 depends: suspend/suspend_advanced_auto
 _purpose:
  Suspend LED verification.

--- a/providers/base/units/led/test-plan.pxu
+++ b/providers/base/units/led/test-plan.pxu
@@ -113,7 +113,7 @@ include:
     led/sysfs_led_brightness_off_.*
 bootstrap_include:
     dmi
-    suspend
+    suspend_state
 
 id: led-indicator-manual
 unit: test plan

--- a/providers/base/units/led/test-plan.pxu
+++ b/providers/base/units/led/test-plan.pxu
@@ -113,6 +113,7 @@ include:
     led/sysfs_led_brightness_off_.*
 bootstrap_include:
     dmi
+    suspend
 
 id: led-indicator-manual
 unit: test plan

--- a/providers/base/units/suspend/test-plan.pxu
+++ b/providers/base/units/suspend/test-plan.pxu
@@ -25,7 +25,7 @@ include:
     led/power-blink-suspend                        certification-status=blocker
     led/suspend                                    certification-status=blocker
 bootstrap_include:
-    suspend
+    suspend_state
 
 id: before-suspend-reference-cert-automated
 unit: test plan

--- a/providers/base/units/suspend/test-plan.pxu
+++ b/providers/base/units/suspend/test-plan.pxu
@@ -24,6 +24,8 @@ include:
     suspend/oops_results_after_suspend.log
     led/power-blink-suspend                        certification-status=blocker
     led/suspend                                    certification-status=blocker
+bootstrap_include:
+	suspend
 
 id: before-suspend-reference-cert-automated
 unit: test plan

--- a/providers/base/units/suspend/test-plan.pxu
+++ b/providers/base/units/suspend/test-plan.pxu
@@ -25,7 +25,7 @@ include:
     led/power-blink-suspend                        certification-status=blocker
     led/suspend                                    certification-status=blocker
 bootstrap_include:
-	suspend
+    suspend
 
 id: before-suspend-reference-cert-automated
 unit: test plan

--- a/providers/resource/bin/suspend_resource.py
+++ b/providers/resource/bin/suspend_resource.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+
+def get_mem_sleep_types():
+    with open("/sys/power/mem_sleep", "r") as fp:
+        types = fp.read().strip()
+    return types.split()
+
+
+def get_supported_suspend_type(types: list[str]):
+    for type in types:
+        if type.startswith("[") and type.endswith("]"):
+            return type[1:-1]
+    return None
+
+
+def main():
+    types = get_mem_sleep_types()
+    suspend_type = get_supported_suspend_type(types)
+    print("type: {}".format(suspend_type))
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/resource/bin/suspend_resource.py
+++ b/providers/resource/bin/suspend_resource.py
@@ -7,7 +7,7 @@ def get_mem_sleep_types():
     return types.split()
 
 
-def get_supported_suspend_type(types: list[str]):
+def get_supported_suspend_type(types):
     for type in types:
         if type.startswith("[") and type.endswith("]"):
             return type[1:-1]

--- a/providers/resource/bin/suspend_resource.py
+++ b/providers/resource/bin/suspend_resource.py
@@ -7,17 +7,23 @@ def get_mem_sleep_types():
     return types.split()
 
 
-def get_supported_suspend_type(types):
-    for type in types:
-        if type.startswith("[") and type.endswith("]"):
-            return type[1:-1]
-    return None
+def get_supported_suspend_types(types):
+    supported_types = {}
+    for t in types:
+        if t.startswith("[") and t.endswith("]"):
+            supported_types[t[1:-1]] = "yes"
+        elif t:
+            supported_types[t] = "no"
+    return supported_types
 
 
 def main():
     types = get_mem_sleep_types()
-    suspend_type = get_supported_suspend_type(types)
-    print("type: {}".format(suspend_type))
+    supported_types = get_supported_suspend_types(types)
+    for type, active in supported_types.items():
+        print("type:", type)
+        print("active:", active)
+        print()
 
 
 if __name__ == "__main__":

--- a/providers/resource/jobs/resource.pxu
+++ b/providers/resource/jobs/resource.pxu
@@ -542,7 +542,7 @@ _summary: Check whether a desktop session is available and of which type.
 environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 command: desktop_session_resource.py resources
 
-id: suspend
+id: suspend_state
 plugin: resource
 _summary: Provide supported suspend type ("deep", "s2idle", etc.)
 command: suspend_resource.py

--- a/providers/resource/jobs/resource.pxu
+++ b/providers/resource/jobs/resource.pxu
@@ -541,3 +541,8 @@ plugin: resource
 _summary: Check whether a desktop session is available and of which type.
 environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 command: desktop_session_resource.py resources
+
+id: suspend
+plugin: resource
+_summary: Provide supported suspend type ("deep", "s2idle", etc.)
+command: suspend_resource.py

--- a/providers/resource/tests/test_suspend_resource.py
+++ b/providers/resource/tests/test_suspend_resource.py
@@ -1,0 +1,38 @@
+import unittest
+import io
+from unittest.mock import patch, mock_open
+
+import suspend_resource
+
+
+class SuspendResourceTests(unittest.TestCase):
+
+    @patch(
+        "builtins.open", new_callable=mock_open, read_data="s2idle [deep]\n"
+    )
+    def test_get_mem_sleep_types(self, mock_open):
+        types = suspend_resource.get_mem_sleep_types()
+        self.assertEqual(types, ["s2idle", "[deep]"])
+
+    def test_get_supported_suspend_type(self):
+        types = ["s2idle", "[deep]"]
+        supported_type = suspend_resource.get_supported_suspend_type(types)
+        self.assertEqual(supported_type, "deep")
+        types = [
+            "[s2idle]",
+        ]
+        supported_type = suspend_resource.get_supported_suspend_type(types)
+        self.assertEqual(supported_type, "s2idle")
+        types = [
+            "",
+        ]
+        supported_type = suspend_resource.get_supported_suspend_type(types)
+        self.assertEqual(supported_type, None)
+
+    @patch("suspend_resource.get_mem_sleep_types")
+    @patch("suspend_resource.get_supported_suspend_type")
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_main(self, mock_stdout, mock_supported_type, mock_mem_sleep):
+        mock_supported_type.return_value = "s2idle"
+        suspend_resource.main()
+        self.assertEqual(mock_stdout.getvalue(), "type: s2idle\n")

--- a/providers/resource/tests/test_suspend_resource.py
+++ b/providers/resource/tests/test_suspend_resource.py
@@ -14,25 +14,32 @@ class SuspendResourceTests(unittest.TestCase):
         types = suspend_resource.get_mem_sleep_types()
         self.assertEqual(types, ["s2idle", "[deep]"])
 
-    def test_get_supported_suspend_type(self):
+    def test_get_supported_suspend_types(self):
         types = ["s2idle", "[deep]"]
-        supported_type = suspend_resource.get_supported_suspend_type(types)
-        self.assertEqual(supported_type, "deep")
+        supported_types = suspend_resource.get_supported_suspend_types(types)
+        expected = {
+            "deep": "yes",
+            "s2idle": "no",
+        }
+        self.assertEqual(supported_types, expected)
         types = [
             "[s2idle]",
         ]
-        supported_type = suspend_resource.get_supported_suspend_type(types)
-        self.assertEqual(supported_type, "s2idle")
+        supported_types = suspend_resource.get_supported_suspend_types(types)
+        expected = {
+            "s2idle": "yes",
+        }
+        self.assertEqual(supported_types, expected)
         types = [
             "",
         ]
-        supported_type = suspend_resource.get_supported_suspend_type(types)
-        self.assertEqual(supported_type, None)
+        supported_types = suspend_resource.get_supported_suspend_types(types)
+        self.assertEqual(supported_types, {})
 
     @patch("suspend_resource.get_mem_sleep_types")
-    @patch("suspend_resource.get_supported_suspend_type")
+    @patch("suspend_resource.get_supported_suspend_types")
     @patch("sys.stdout", new_callable=io.StringIO)
-    def test_main(self, mock_stdout, mock_supported_type, mock_mem_sleep):
-        mock_supported_type.return_value = "s2idle"
+    def test_main(self, mock_stdout, mock_supported_types, mock_mem_sleep):
+        mock_supported_types.return_value = {"s2idle": "yes"}
         suspend_resource.main()
-        self.assertEqual(mock_stdout.getvalue(), "type: s2idle\n")
+        self.assertEqual(mock_stdout.getvalue(), "type: s2idle\nactive: yes\n\n")

--- a/providers/resource/tests/test_suspend_resource.py
+++ b/providers/resource/tests/test_suspend_resource.py
@@ -42,4 +42,6 @@ class SuspendResourceTests(unittest.TestCase):
     def test_main(self, mock_stdout, mock_supported_types, mock_mem_sleep):
         mock_supported_types.return_value = {"s2idle": "yes"}
         suspend_resource.main()
-        self.assertEqual(mock_stdout.getvalue(), "type: s2idle\nactive: yes\n\n")
+        self.assertEqual(
+            mock_stdout.getvalue(), "type: s2idle\nactive: yes\n\n"
+        )


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

- Create a new `suspend` resource that provides the type of suspend being used on the device (`deep`, `s2idle`, etc.)
- Use this suspend type as a requirement to prevent running Power/Suspend LED tests when s2idle is being used

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

Fix https://warthogs.atlassian.net/browse/CHECKBOX-1746

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

- Unit tests
- Tested locally by running the 24.04 manual desktop test plan, selecting the `led/power-blink-suspend` and `led/suspend` tests:
  - a desktop reporting `s2idle [deep]`: the LED tests are executed
  - a laptop reporting `[s2idle]`: the LED tests are skipped