### PR TITLE
Log to error logger all problems (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -942,6 +942,8 @@ class SessionState:
         # Update all job readiness state
         self._recompute_job_readiness()
         # Return all dependency problems to the caller
+        for problem in problems:
+            logger.error("Dependency problem: %s", str(problem))
         return problems
 
     def get_estimated_duration(self, manual_overhead=30.0):


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Currently dependency problems found by the dependency solver are returned to the caller of `update_desired_job_list`. All callers of these function beside the ones in tests ignore this list, and this makes it so if you have  a dependency issue in your testplan, you will never know. This PR fixes this issue (partially) by logging an error before returning the list. It is impossible to handle this in a different manner because most of the functions that call this function do not have access to the ui printer nor any facility to easily bubble up this list.

## Resolved issues

Fixes: CHECKBOX-1818

## Documentation

N/A

## Tests

Before this patch: (Silently exits, no way to know what went wrong)
```
(venv)  checkbox (main) >  checkbox-cli --clear-old-sessions example.conf 
$PROVIDERPATH is defined, so following provider sources are ignored ['/usr/local/share/plainbox-providers-1', '/usr/share/plainbox-providers-1', '/home/h25/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Preparing...
==[ Bootstrap 2021.com.canonical.certification::powermode_ids_resource (1/1) ]==
```

After this patch: (Complains about the errors, the missing dependency is there in the first line)
```
(venv)  checkbox (main) >  checkbox-cli --clear-old-sessions example.conf 
$PROVIDERPATH is defined, so following provider sources are ignored ['/usr/local/share/plainbox-providers-1', '/usr/share/plainbox-providers-1', '/home/h25/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Preparing...
==[ Bootstrap 2021.com.canonical.certification::powermode_ids_resource (1/1) ]==
ERROR:plainbox.session.state:Dependency problem: missing dependency: '2021.com.canonical.certification::.' (ordering)
ERROR:plainbox.session.state:Dependency problem: missing dependency: '2021.com.canonical.certification::powermode/set_a' (direct)
ERROR:plainbox.session.state:Dependency problem: missing dependency: '2021.com.canonical.certification::powermode/reboot_a' (direct)
ERROR:plainbox.session.state:Dependency problem: missing dependency: '2021.com.canonical.certification::powermode/read_a' (ordering)
ERROR:plainbox.session.state:Dependency problem: missing dependency: '2021.com.canonical.certification::powermode/set_b' (direct)
ERROR:plainbox.session.state:Dependency problem: missing dependency: '2021.com.canonical.certification::powermode/reboot_b' (direct)
ERROR:plainbox.session.state:Dependency problem: missing dependency: '2021.com.canonical.certification::powermode/read_b' (ordering)
ERROR:plainbox.session.state:Dependency problem: missing dependency: '2021.com.canonical.certification::powermode/set_c' (direct)
ERROR:plainbox.session.state:Dependency problem: missing dependency: '2021.com.canonical.certification::powermode/reboot_c' (direct)
```