### PR TITLE
Add new stock report to export submission.json (new)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -532,6 +532,28 @@ class ReportsStage(CheckboxUiStage):
                 self.sa.config.update_from_another(
                     additional_config, new_origin
                 )
+        elif report == "submission_json":
+            exporter = "json"
+            file_ext = ".json"
+            path = self._get_submission_file_path(file_ext)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            template = textwrap.dedent(
+                """
+                [transport:{exporter}_file]
+                path = {path}
+                type = file
+                [exporter:{exporter}]
+                unit = com.canonical.plainbox::{exporter}
+                [report:2_{exporter}_file]
+                exporter = {exporter}
+                forced = yes
+                transport = {exporter}_file
+                """
+            )
+            additional_config = Configuration.from_text(
+                template.format(exporter=exporter, path=path), new_origin
+            )
+            self.sa.config.update_from_another(additional_config, new_origin)
 
     def _get_submission_file_path(self, file_ext):
         # LP:1585326 maintain isoformat but removing ':' chars that cause

--- a/checkbox-ng/checkbox_ng/launcher/test_stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_stages.py
@@ -146,7 +146,7 @@ class TestReportsStage(TestCase):
             )
 
     @mock.patch("os.makedirs")
-    def test__prepare_stock_report(self, makedirs):
+    def test__prepare_stock_report_submission_files(self, makedirs):
         self_mock = mock.MagicMock()
         self_mock._get_submission_file_path = partial(
             ReportsStage._get_submission_file_path, self_mock
@@ -156,4 +156,21 @@ class TestReportsStage(TestCase):
         ReportsStage._prepare_stock_report(self_mock, "submission_files")
 
         self.assertEqual(self_mock.sa.config.update_from_another.call_count, 3)
+        self.assertTrue(makedirs.called)
+
+    @mock.patch("os.makedirs")
+    def test__prepare_stock_report_submission_json(self, makedirs):
+        self_mock = mock.MagicMock()
+        self_mock._get_submission_file_path = partial(
+            ReportsStage._get_submission_file_path, self_mock
+        )
+        self_mock.base_dir = "~/.local/share"
+
+        ReportsStage._prepare_stock_report(self_mock, "submission_json")
+
+        # called to adopt the generated config
+        self_mock_update_from_another = self_mock.sa.config.update_from_another
+        self.assertEqual(self_mock_update_from_another.call_count, 1)
+        config = self_mock_update_from_another.call_args[0][0]
+        self.assertFalse(config.get_problems())
         self.assertTrue(makedirs.called)

--- a/docs/reference/launcher.rst
+++ b/docs/reference/launcher.rst
@@ -102,6 +102,8 @@ future.
     * ``certification``: Send results to certification site
     * ``certification-staging``: Send results to staging version of
       certification site
+    * ``submission_json``: Writes the ``submission.json`` to ``$XDG_DATA_HOME``
+      (or ``~/.local/share`` if it is not defined)
 
     If you don't want to have any stock report automatically generated use
     ``none`` as the value.


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Often, especially when debugging, it is useful to see the submission.json. Sadly, it is currently included in the submission_files currently, so to use it one has to uncompress the files and read it every time. This pr adds a new exporter that exports just the submission.json file.

## Resolved issues

N/A

## Documentation

Documented in the appropriate section

## Tests

Launcher: 
```
#!/usr/bin/env checkbox-cli
[launcher]
launcher_version = 1
 stock_reports = submission_json
 [test plan]
 # filtering to avoid the test being out of bound
 forced = yes
 unit = 2021.com.canonical.certification::pass-and-fail
 [test selection]
 forced = yes
 [manifest]
 2021.com.canonical.certification::manifest_location = 0
```

Output:
```
(venv)  checkbox (submission_json_stock_report) >  checkbox-cli example.conf 
$PROVIDERPATH is defined, so following provider sources are ignored ['/usr/local/share/plainbox-providers-1', '/usr/share/plainbox-providers-1', '/home/h25/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Preparing...
=========[ Running job 1 / 2. Estimated time left (at least): 0:00:00 ]=========
----------------------------[ basic-shell-passing ]-----------------------------
ID: 2021.com.canonical.certification::basic-shell-passing
Category: com.canonical.plainbox::uncategorised
... 8< -------------------------------------------------------------------------
------------------------------------------------------------------------- >8 ---
Outcome: job passed
=========[ Running job 2 / 2. Estimated time left (at least): 0:00:00 ]=========
----------------------------[ basic-shell-failing ]-----------------------------
ID: 2021.com.canonical.certification::basic-shell-failing
Category: com.canonical.plainbox::uncategorised
... 8< -------------------------------------------------------------------------
------------------------------------------------------------------------- >8 ---
Outcome: job failed
[json_file]: file:///home/h25/.local/share/checkbox-ng/submission_2025-03-27T17.22.04.782472.json (URL added to: /home/h25/.local/share/checkbox-ng/submission_2025-03-27T17.22.04.782472.submission.log)
```
