### PR TITLE
Turn dangerous_grade_core_image into a hidden manifest (bugfix)

### DIFF
--- a/providers/base/units/image/jobs.pxu
+++ b/providers/base/units/image/jobs.pxu
@@ -81,7 +81,7 @@ _summary: Check that the model grade is correctly set
 imports: from com.canonical.plainbox import manifest
 requires:
  lsb.distributor_id == "Ubuntu Core" and int(lsb.release) >= 20
- manifest.dangerous_grade_core_image == 'False'
+ manifest._dangerous_grade_core_image == 'False'
 _purpose:
  Images with the 'dangerous' grade (the lowest of all available grades)
  results in certain security measures being relaxed.

--- a/providers/base/units/image/manifest.pxu
+++ b/providers/base/units/image/manifest.pxu
@@ -1,5 +1,6 @@
 unit: manifest entry
-id: dangerous_grade_core_image
+id: _dangerous_grade_core_image
 _name: Image is using 'dangerous' grade (should be set to 'No' unless you're doing SRU testing)
 _prompt: Does this setup have the following configuration?
 value-type: bool
+hidden-reason: Only images being used in lab testing can use 'dangerous' model grade


### PR DESCRIPTION
## Description

Switch `dangerous_grade_core_image` to a hidden manifest so that it doesn't appear in the UI when tester are running Checkbox, since this manifest is only to be used for lab testing purposes.

## Resolved issues

Fix [CHECKBOX-1743](https://warthogs.atlassian.net/browse/CHECKBOX-1743)



## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->


[CHECKBOX-1743]: https://warthogs.atlassian.net/browse/CHECKBOX-1743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ