### PR TITLE
Fix output to match the script (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/vendor/image_info.py
+++ b/checkbox-ng/plainbox/vendor/image_info.py
@@ -47,8 +47,7 @@ def dcd_string_to_info(dcd_string):
     - url
     """
     # prefix, should always be present
-    dcd_string = dcd_string.replace("canonical-", "")
-    dcd_string = dcd_string.replace("oem-", "")
+    dcd_string = dcd_string.removeprefix("canonical-").strip()
     dcd_string_arr = dcd_string.split("-")
     if len(dcd_string_arr) == 5:
         project, series, kernel_type, build_date, build_number = dcd_string_arr

--- a/checkbox-ng/plainbox/vendor/test_image_info.py
+++ b/checkbox-ng/plainbox/vendor/test_image_info.py
@@ -5,27 +5,31 @@ from plainbox.vendor import image_info
 
 class TestDCDStringToInfo(TestCase):
     def test_len_5(self):
-        example = "canonical-oem-pinktiger-noble-hwe-20240709-33.iso"
+        example = "canonical-pinktiger-noble-hwe-20240709-33"
         info = image_info.dcd_string_to_info(example)
 
         self.assertEqual(info["project"], "pinktiger")
         self.assertEqual(info["series"], "noble")
+        # its 5 matched + url + base_url
+        self.assertEqual(len(info), 7)
 
     def test_len_6(self):
-        example = "canonical-oem-pinktiger-noble-oem-24.04a-20240709-33.iso"
+        example = "canonical-pinktiger-noble-oem-24.04a-20240709-33"
         info = image_info.dcd_string_to_info(example)
 
         self.assertEqual(info["project"], "pinktiger")
         self.assertEqual(info["series"], "noble")
+        # its 6 matched + url + base_url
+        self.assertEqual(len(info), 8)
 
     def test_len_7(self):
-        example = (
-            "canonical-oem-pinktiger-noble-oem-24.04a-proposed-20240709-33.iso"
-        )
+        example = "canonical-pinktiger-noble-oem-24.04a-proposed-20240709-33"
         info = image_info.dcd_string_to_info(example)
 
         self.assertEqual(info["project"], "pinktiger")
         self.assertEqual(info["series"], "noble")
+        # its 7 matched + url + base_url
+        self.assertEqual(len(info), 9)
 
     def test_len_wrong(self):
         with self.assertRaises(SystemExit):


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The image info collector is wrong, I don't recall where the oem replace comes from but it is wrong. Also, the canonical replace was slightly different, now it is replacing the prefix correctly.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1826
Internal discussion: https://chat.canonical.com/canonical/pl/in4u5zcqijrp7m35qui4isxuhw

## Documentation

N/A

## Tests

Added new tests
