### PR TITLE
Fixed usb tests for xenial snap (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -120,7 +120,7 @@ class StorageWatcher(StorageInterface):
         cmd = ["journalctl", "-f", "-o", "cat"]
 
         with subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, universal_newlines=True
+            cmd, stdout=subprocess.PIPE, universal_newlines=True, bufsize=1
         ) as process:
             # Call the corresponding action method
             self._controller.action(self.testcase)

--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -1,10 +1,23 @@
 #!/usr/bin/env python3
-# Copyright 2015-2018 Canonical Ltd.
+# Copyright 2015-2025 Canonical Ltd.
 # All rights reserved.
 #
-# Written by:
+# Authors:
 #   Taihsiang Ho <taihsiang.ho@canonical.com>
 #   Sylvain Pineau <sylvain.pineau@canonical.com>
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 """
 this script monitors the systemd journal to catch insert/removal USB events
 """
@@ -115,7 +128,8 @@ class StorageWatcher(StorageInterface):
             for line in process.stdout:
                 self._process_line(line)
                 if self.test_passed:
-                    return
+                    process.terminate()
+                    break
 
     def _process_line(self, line):
         """

--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -11,12 +11,9 @@ this script monitors the systemd journal to catch insert/removal USB events
 import argparse
 import logging
 import re
-import select
 import sys
-import time
-from systemd import journal
+import subprocess
 from abc import ABC, abstractmethod
-
 from checkbox_support.helpers.timeout import timeout
 from checkbox_support.scripts.usb_read_write import (
     mount_usb_storage,
@@ -24,7 +21,6 @@ from checkbox_support.scripts.usb_read_write import (
     write_test,
     read_test,
 )
-
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -105,38 +101,35 @@ class StorageWatcher(StorageInterface):
         self._controller = controller
 
     def run(self):
-        j = journal.Reader()
-        j.seek_realtime(time.time())
-        p = select.poll()
-        p.register(j, j.get_events())
+        self.test_passed = False
 
+        # Spawn journal subprocess
+        cmd = ["journalctl", "-f", "-o", "cat"]
+        process = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, universal_newlines=True
+        )
+
+        # Call the corresponding action method
         self._controller.action(self.testcase)
 
-        while p.poll():
-            if j.process() != journal.APPEND:
-                continue
-            self._process_lines(
-                [e["MESSAGE"] for e in j if e and "MESSAGE" in e]
-            )
+        for line in process.stdout:
+            self._process_line(line)
             if self.test_passed:
                 return
 
-    def _process_lines(self, lines):
+    def _process_line(self, line):
         """
-        Process the lines from the journal and call the callback function to
+        Process one line from the journal and call the callback function to
         validate the insertion or removal of the storage.
         """
-        for line in lines:
-            line_str = str(line)
-            logger.debug(line_str)
-            if self.testcase == "insertion":
-                self._parse_journal_line(line_str)
-                self._validate_insertion()
-            elif self.testcase == "removal":
-                self._parse_journal_line(line_str)
-                self._validate_removal()
-            if self.test_passed:
-                return
+        line = line.rstrip("\n")
+        logger.debug(line)
+        if self.testcase == "insertion":
+            self._parse_journal_line(line)
+            self._validate_insertion()
+        elif self.testcase == "removal":
+            self._parse_journal_line(line)
+            self._validate_removal()
 
     @timeout(ACTION_TIMEOUT)  # 30 seconds timeout
     def run_insertion(self):
@@ -221,7 +214,9 @@ class USBStorage(StorageWatcher):
             "high_speed_usb": "new high-speed USB device",
             "super_speed_usb": "new SuperSpeed USB device",
             "super_speed_gen1_usb": "new SuperSpeed Gen 1 USB device",
-            "super_speed_plus_gen2x1_usb": "new SuperSpeed Plus Gen 2x1 USB device",
+            "super_speed_plus_gen2x1_usb": (
+                "new SuperSpeed Plus Gen 2x1 USB device"
+            ),
         }
 
         driver_log_dict = {

--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -105,17 +105,17 @@ class StorageWatcher(StorageInterface):
 
         # Spawn journal subprocess
         cmd = ["journalctl", "-f", "-o", "cat"]
-        process = subprocess.Popen(
+
+        with subprocess.Popen(
             cmd, stdout=subprocess.PIPE, universal_newlines=True
-        )
+        ) as process:
+            # Call the corresponding action method
+            self._controller.action(self.testcase)
 
-        # Call the corresponding action method
-        self._controller.action(self.testcase)
-
-        for line in process.stdout:
-            self._process_line(line)
-            if self.test_passed:
-                return
+            for line in process.stdout:
+                self._process_line(line)
+                if self.test_passed:
+                    return
 
     def _process_line(self, line):
         """

--- a/checkbox-support/checkbox_support/tests/test_run_watcher.py
+++ b/checkbox-support/checkbox_support/tests/test_run_watcher.py
@@ -39,7 +39,7 @@ class TestRunWatcher(unittest.TestCase):
 
     @patch("subprocess.Popen")
     def test_storage_watcher_run_with_insertion(self, mock_popen):
-        mock_popen.return_value.stdout = ["inserted"]
+        mock_popen.return_value.__enter__.return_value.stdout = ["inserted"]
 
         mock_storage_watcher = MagicMock()
         mock_storage_watcher._controller = ManualController()
@@ -63,7 +63,7 @@ class TestRunWatcher(unittest.TestCase):
 
     @patch("subprocess.Popen")
     def test_storage_watcher_run_with_removal(self, mock_popen):
-        mock_popen.return_value.stdout = ["removed"]
+        mock_popen.return_value.__enter__.return_value.stdout = ["removed"]
 
         mock_storage_watcher = MagicMock()
         mock_storage_watcher._controller = ManualController()


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

The automatic USB insertion test that we were running in the lab was getting stuck in xenial because it was not able to read the journalct lines for the removal section.
We have removed the dependency of `systemd.journal` in favor of reading the output of `journalctl` subprocess

We will remove the dependencies and the rest of the mentions to  `systemd.journal` in the code in a follow-up PR

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->
N/A

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Tested with the "auto" USB test on the failing device in the lab (ubuntu 16, classic snap) 

Tested with the "manual" USB test locally  (ubuntu 24, dev environment)

```
--------- Testing insertion ---------
INFO:super_speed_usb was inserted. Controller: xhci_hcd, Number: 38
INFO:usable partition: sdc1
INFO:USB3 insertion test passed.

------- Insertion test passed -------

---------- Testing removal ----------
INFO:Removal test passed.

-------- Removal test passed --------
```

 
