### PR TITLE
Fixed bug with timeout (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/timeout.py
+++ b/checkbox-support/checkbox_support/helpers/timeout.py
@@ -127,7 +127,14 @@ def run_with_timeout(f, timeout_s, *args, **kwargs):
 
     process = Process(target=_f, args=args, kwargs=kwargs)
     process.start()
-    process.join(timeout_s)
+    try:
+        process.join(timeout_s)
+    except BaseException:
+        # If an exception is raised in the main process, we will kill the
+        # process tree
+        kill_tree(process.pid)
+        # Re-raise so the parent can exit
+        raise
 
     if process.is_alive():
         # this tries to kill the whole process tree, not just the child.

--- a/checkbox-support/checkbox_support/tests/test_timeout.py
+++ b/checkbox-support/checkbox_support/tests/test_timeout.py
@@ -86,6 +86,12 @@ class TestTimeoutExec(TestCase):
         with self.assertRaises(ValueError):
             run_with_timeout(some_exception_raiser, 1)
 
+    @patch("checkbox_support.helpers.timeout.Process.join")
+    def test_function_exception_propagation_in_process(self, mock_join):
+        mock_join.side_effect = KeyboardInterrupt()
+        with self.assertRaises(BaseException):
+            run_with_timeout(heavy_function, 1)
+
     def test_function_systemexit_propagation(self):
         with self.assertRaises(SystemExit):
             system_exit_raiser()


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

There was a weir issue with the timeout decorator in which if the main program launched a subprocess and it was exited with a keyboard exception, it was not propagated and the subprocess continued to run despite the program being closed. This was detected with the USB tests:

```
$ fernando@IdeaPad-Pro-5 ~/checkbox (fix-journal-issue-xenial) $
python checkbox-support/checkbox_support/scripts/run_watcher.py insertion usb3

--------- Testing insertion ---------
PID: 3263961

INSERT NOW

Timeout: 30 seconds
...
KeyboardInterrupt
...

$ fernando@IdeaPad-Pro-5 ~/checkbox (fix-journal-issue-xenial) $
ps -p 3263961
    PID TTY          TIME CMD
3263961 ?        00:00:00 journalctl
$ fernando@IdeaPad-Pro-5 ~/checkbox (fix-journal-issue-xenial) $
INFO:super_speed_usb was inserted. Controller: xhci_hcd, Number: 62
INFO:usable partition: sdd
INFO:USB3 insertion test passed.

------- Insertion test passed -------
```

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
Tested on the same device that was experiencing the USB issue
