### PR TITLE
moved release_info to checkbox support (New)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/release_info.py
+++ b/checkbox-support/checkbox_support/helpers/release_info.py
@@ -1,0 +1,37 @@
+import re
+from contextlib import suppress
+
+
+def get_release_file_content():
+    with suppress(FileNotFoundError):
+        with open("/var/lib/snapd/hostfs/etc/os-release", "r") as fp:
+            return fp.read()
+    with open("/etc/os-release", "r") as fp:
+        return fp.read()
+
+
+def get_release_info():
+
+    release_file_content = get_release_file_content()
+
+    os_release_map = {
+        "NAME": "distributor_id",
+        "PRETTY_NAME": "description",
+        "VERSION_ID": "release",
+        "VERSION_CODENAME": "codename",
+    }
+    os_release = {}
+    lines = filter(bool, release_file_content.strip().splitlines())
+    for line in lines:
+        (key, value) = line.split("=", 1)
+        if key in os_release_map:
+            k = os_release_map[key]
+            # Strip out quotes and newlines
+            os_release[k] = re.sub('["\n]', "", value)
+    # this is needed by C3, on core there is no VERSION_CODENAME, lets put
+    # description (PRETTY_NAME) here by default or unknown (which should be
+    # impossible but resources aren't supposed to crash)
+    os_release["codename"] = os_release.get(
+        "codename", os_release.get("description", "unknown")
+    )
+    return os_release

--- a/providers/resource/bin/graphics_card_resource.py
+++ b/providers/resource/bin/graphics_card_resource.py
@@ -24,7 +24,7 @@ import subprocess
 import shlex
 
 from checkbox_support.helpers.slugify import slugify
-import os_resource
+from checkbox_support.helpers.release_info import get_release_info
 
 
 def compare_ubuntu_release_version(_version):
@@ -32,8 +32,7 @@ def compare_ubuntu_release_version(_version):
     Compare ubuntu release version.
     If host version is higher or equal provided, it will return True.
     """
-    release_file_content = os_resource.get_release_file_content()
-    os_version = os_resource.get_release_info(release_file_content)["release"]
+    os_version = get_release_info()["release"]
     try:
         from packaging import version
 

--- a/providers/resource/bin/os_resource.py
+++ b/providers/resource/bin/os_resource.py
@@ -24,8 +24,6 @@ import sys
 
 def main():
     release_info = get_release_info()
-    print("Release information:")
-    print(release_info)
     for key, value in release_info.items():
         print("%s: %s" % (key, value))
 

--- a/providers/resource/bin/os_resource.py
+++ b/providers/resource/bin/os_resource.py
@@ -17,46 +17,15 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 #
-import re
+
+from checkbox_support.helpers.release_info import get_release_info
 import sys
-from contextlib import suppress
-
-
-def get_release_file_content():
-    with suppress(FileNotFoundError):
-        with open("/var/lib/snapd/hostfs/etc/os-release", "r") as fp:
-            return fp.read()
-    with open("/etc/os-release", "r") as fp:
-        return fp.read()
-
-
-def get_release_info(release_file_content: str):
-    os_release_map = {
-        "NAME": "distributor_id",
-        "PRETTY_NAME": "description",
-        "VERSION_ID": "release",
-        "VERSION_CODENAME": "codename",
-    }
-    os_release = {}
-    lines = filter(bool, release_file_content.strip().splitlines())
-    for line in lines:
-        (key, value) = line.split("=", 1)
-        if key in os_release_map:
-            k = os_release_map[key]
-            # Strip out quotes and newlines
-            os_release[k] = re.sub('["\n]', "", value)
-    # this is needed by C3, on core there is no VERSION_CODENAME, lets put
-    # description (PRETTY_NAME) here by default or unknown (which should be
-    # impossible but resources aren't supposed to crash)
-    os_release["codename"] = os_release.get(
-        "codename", os_release.get("description", "unknown")
-    )
-    return os_release
 
 
 def main():
-    release_file_content = get_release_file_content()
-    release_info = get_release_info(release_file_content)
+    release_info = get_release_info()
+    print("Release information:")
+    print(release_info)
     for key, value in release_info.items():
         print("%s: %s" % (key, value))
 

--- a/providers/resource/tests/test_graphics_card_resource.py
+++ b/providers/resource/tests/test_graphics_card_resource.py
@@ -24,7 +24,7 @@ import graphics_card_resource
 
 class GraphicsCardResourceTests(unittest.TestCase):
 
-    @patch("os_resource.get_release_info")
+    @patch("graphics_card_resource.get_release_info")
     def test_compare_ubuntu_release_version(self, mock_release_info):
         mock_release_info.return_value = {"release": "24.04"}
         result = graphics_card_resource.compare_ubuntu_release_version("22.04")
@@ -38,7 +38,7 @@ class GraphicsCardResourceTests(unittest.TestCase):
         "packaging.version.parse",
         side_effect=ImportError("Cannot import version"),
     )
-    @patch("os_resource.get_release_info")
+    @patch("graphics_card_resource.get_release_info")
     def test_compare_ubuntu_release_version_with_import_error(
         self, mock_release_info, mock_version
     ):


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

I've moved the `get_release_info()` function from the os_resource to checkbox support helpers so we can use the same function elsewhere.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Tested running os and lsb resource jobs:
```
=========================[ Running Selected Test Plan ]=========================
==============[ Running job 1 / 2. Estimated time left: 0:00:03 ]===============
-----[ Collect information about installed operating system (os-release) ]------
ID: com.canonical.certification::os
Category: com.canonical.certification::information_gathering
... 8< -------------------------------------------------------------------------
description: Ubuntu 24.04.2 LTS
distributor_id: Ubuntu
release: 24.04
codename: noble
------------------------------------------------------------------------- >8 ---
Outcome: job passed
==============[ Running job 2 / 2. Estimated time left: 0:00:02 ]===============
[ [DEPRECATED, use 'os' instead] Collect information about installed operating system (os-release) ]
ID: com.canonical.certification::lsb
Category: com.canonical.certification::information_gathering
... 8< -------------------------------------------------------------------------
description: Ubuntu 24.04.2 LTS
distributor_id: Ubuntu
release: 24.04
codename: noble
------------------------------------------------------------------------- >8 ---
Outcome: job passed
==================================[ Results ]===================================
 ☑ : Collect information about installed operating system (os-release)
 ☑ : [DEPRECATED, use 'os' instead] Collect information about installed operating system (os-release)
 ```