### PR TITLE
Add extensive CUDA testing for more machines (New)

### DIFF
--- a/providers/gpgpu/bin/run_cuda_sample_set.py
+++ b/providers/gpgpu/bin/run_cuda_sample_set.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Script to build and run cuda samples, to test cuda features on nvidia gpus.
+
+Copyright (C) 2025 Canonical Ltd.
+
+Authors
+  Antone Lassagne <antone.lassagne@canonical.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3,
+as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import argparse
+import logging
+import os
+import shutil
+import subprocess
+
+from pathlib import Path
+
+
+def cleanup_temporary_files(orig_dir, test_set):
+    """Cleanup the files and folder that were created during the tests
+
+    Args:
+        orig_dir (Path): Path of the root folder
+        test_set (number): Index of the test set
+    """
+    test_set_dir = Path(orig_dir) / test_set
+    logging.info("Cleaning up %s", test_set_dir)
+    shutil.rmtree(str(test_set_dir), ignore_errors=True)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run a set of CUDA tests with customizable configurations."
+    )
+
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="log_level",
+        action="store_const",
+        default=logging.INFO,
+        const=logging.DEBUG,
+        help="Increase logging level",
+    )
+
+    parser.set_defaults(missing_files=[])
+
+    # sub parsers
+    subparsers = parser.add_subparsers(required=True)
+    intro_parser = subparsers.add_parser("introduction", help="Introduction")
+    intro_parser.set_defaults(test_set=0)
+
+    utilities_parser = subparsers.add_parser("utilities", help="Utilities")
+    utilities_parser.set_defaults(test_set=1)
+
+    concepts_parser = subparsers.add_parser(
+        "concepts", help="Concepts_and_Techniques"
+    )
+    concepts_parser.set_defaults(test_set=2)
+    concepts_parser.set_defaults(
+        missing_files=[
+            # list of tuple with src, dest, and extension ?
+            (
+                Path("Samples")
+                / "2_Concepts_and_Techniques"
+                / "EGLStream_CUDA_Interop",
+                Path("build")
+                / "Samples"
+                / "2_Concepts_and_Techniques"
+                / "EGLStream_CUDA_Interop"
+                / "bin",
+                ".yuv",
+            )
+        ]
+    )
+
+    features_parser = subparsers.add_parser("features", help="CUDA_Features")
+    features_parser.set_defaults(test_set=3)
+
+    libraries_parser = subparsers.add_parser(
+        "libraries", help="CUDA_Libraries"
+    )
+    libraries_parser.set_defaults(test_set=4)
+
+    domain_parser = subparsers.add_parser("domain", help="Domain_Specific")
+    domain_parser.set_defaults(test_set=5)
+
+    performance_parser = subparsers.add_parser(
+        "performance", help="Performance"
+    )
+    performance_parser.set_defaults(test_set=6)
+
+    libnvvm_parser = subparsers.add_parser("libnvvm", help="libNVVM")
+    libnvvm_parser.set_defaults(test_set=7)
+    libnvvm_parser.set_defaults(
+        missing_files=[
+            (
+                Path("Samples") / "7_libNVVM" / "ptxgen",
+                Path("build") / "Samples" / "7_libNVVM" / "ptxgen" / "bin",
+                ".ll",
+            )
+        ]
+    )
+
+    platform_parser = subparsers.add_parser(
+        "platform", help="Platform_Specific"
+    )
+    platform_parser.set_defaults(test_set=8)
+    platform_parser.set_defaults(
+        missing_files=[
+            (
+                Path("Samples")
+                / "8_Platform_Specific"
+                / "Tegra"
+                / "cudaNvSciBufMultiplanar",
+                Path("build")
+                / "Samples"
+                / "8_Platform_Specific"
+                / "Tegra"
+                / "cudaNvSciBufMultiplanar"
+                / "bin",
+                ".yuv",
+            )
+        ]
+    )
+
+    parser.add_argument(
+        "--cuda-samples-version",
+        default=os.getenv("CUDA_SAMPLES_VERSION", "12.8"),
+        help="CUDA samples version.",
+    )
+    parser.add_argument(
+        "--cuda-ignore-tensorcore",
+        default=os.getenv("CUDA_IGNORE_TENSORCORE", "0"),
+        choices=["0", "1"],
+        help="Ignore TensorCores if the machine does not have them.",
+    )
+    parser.add_argument(
+        "--cuda-multigpu",
+        default=os.getenv("CUDA_MULTIGPU", "0"),
+        choices=["0", "1"],
+        help="Enable if the machine has multiple NVIDIA GPUs.",
+    )
+    parser.add_argument(
+        "--no-clone",
+        action="store_true",
+        help="[DEBUG] Don't clone the repo",
+    )
+    parser.add_argument(
+        "--keep-cache",
+        action="store_true",
+        help="[DEBUG] Keep the cache",
+    )
+
+    parser.add_argument(
+        "--cuda-ignore-tests",
+        default=os.getenv("CUDA_IGNORE_TESTS", ""),
+        help="Space-separated list of tests to ignore.",
+    )
+
+    args = parser.parse_args()
+
+    args.cuda_ignore_tests = (
+        args.cuda_ignore_tests.strip().split(" ")
+        if args.cuda_ignore_tests and args.cuda_ignore_tests.strip()
+        else []
+    )
+
+    if args.cuda_ignore_tensorcore:
+        args.cuda_ignore_tests.extend(
+            ["dmmaTensorCoreGemm", "tf32TensorCoreGemm", "bf16TensorCoreGemm"]
+        )
+
+    if args.cuda_multigpu:
+        args.cuda_ignore_tests.extend(
+            [
+                "simpleP2P",
+                "simpleAttributesMPU",
+                "simpleCUFFT_MGPU",
+                "streamOrderedAllocationP2P",
+                "simpleCUFFT_2d_MGPU",
+                "conjugateGradientMultiDeviceCG",
+            ]
+        )
+
+    return args
+
+
+def remove_add_subdirectory_line(cmake_file, dir_name):
+
+    dir_name = os.path.basename(str(dir_name))
+    cmake_file_path = Path(cmake_file)
+
+    # Read the current content of the CMakeLists.txt
+    with cmake_file_path.open("r") as file:
+        lines = file.readlines()
+
+    # Write back to the CMakeLists.txt excluding lines with the specified
+    # add_subdirectory
+    with cmake_file_path.open("w") as file:
+        for line in lines:
+            if "add_subdirectory(" + dir_name + ")" not in line:
+                file.write(line)
+
+
+def copy_and_set_permissions(src, dst, file_extension):
+    Path(dst).mkdir(parents=True, exist_ok=True)
+
+    # Copy the files with the given extension
+    for filename in os.listdir(str(src)):
+        if filename.endswith(file_extension):
+            shutil.copy(os.path.join(src, filename), dst)
+
+            # Set file permissions to remove execute bit
+            file_path = os.path.join(dst, filename)
+            os.chmod(file_path, 0o644)
+
+
+def clone_and_build(orig_dir, test_set, cuda_samples_version):
+    """Function to clone the repository and build the correct subfolder
+
+    Args:
+        orig_dir (Path): Path of the root folder
+        test_set (number): index of the set (0 to 8)
+        cuda_samples_version (_type_): tag to clone (ex: 12.8)
+
+    """
+    test_set_dir = Path(orig_dir) / test_set
+    if test_set_dir.exists():
+        raise FileExistsError("Error: folder {} exists".format(test_set_dir))
+
+    logging.info(
+        "Cloning CUDA Samples v%s. Version can be set in the manifest.",
+        cuda_samples_version,
+    )
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "-b",
+            "v" + str(cuda_samples_version),
+            "--single-branch",
+            "https://github.com/NVIDIA/cuda-samples.git",
+            str(test_set_dir),
+        ],
+        check=True,
+    )
+
+    cmake_file = test_set_dir / "CMakeLists.txt"
+    cmake_file.write_text(
+        "{}\n{}".format(
+            'set(EXECUTABLE_OUTPUT_PATH "bin")', cmake_file.read_text()
+        )
+    )
+
+    # Remove unnecessary folders
+    samples_dir = test_set_dir / "Samples"
+    for folder in samples_dir.glob("[0-9]_*/"):
+        folder_number = folder.name.split("_")[0]
+        if folder_number != test_set:
+            shutil.rmtree(str(folder))
+            remove_add_subdirectory_line(
+                Path(samples_dir, "CMakeLists.txt"), folder
+            )
+        else:
+            logging.info("Keeping directory: %s", folder.name)
+
+    # Build the sample
+    build_dir = test_set_dir / "build"
+    build_dir.mkdir(parents=True, exist_ok=True)
+    cuda_path = os.getenv("CUDA_PATH", "/usr/local/cuda")
+    subprocess.run(
+        [
+            "cmake",
+            "-DCMAKE_CUDA_ARCHITECTURES=native",
+            "-DCMAKE_CUDA_COMPILER=" + cuda_path + "/bin/nvcc",
+            "-DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/",
+            "-DCMAKE_INCLUDE_PATH=/usr/local/cuda/include",
+            str(test_set_dir),
+        ],
+        check=True,
+        cwd=str(build_dir),
+    )
+
+    subprocess.run(
+        ["make", "-j", str(os.cpu_count() - 1)],
+        cwd=str(build_dir),
+        check=True,
+    )
+
+
+# Function to run tests
+def run_tests(orig_dir, test_set, exclude_list):
+    """Run the test
+
+    Args:
+        orig_dir (Path): path of the root folder
+        test_set (_type_): index of the set (0 to 8)
+        exclude_list ([str]): list of test to skip
+
+    Returns:
+        (int, int): total tests, skipped tests
+    """
+    test_set_dir = Path(orig_dir) / test_set / "build" / "Samples"
+
+    executable_list = [
+        exe
+        for exe in test_set_dir.rglob("*/*/bin/*")
+        if os.access(str(exe), os.X_OK)
+    ]
+
+    skipped = 0
+    total = len(executable_list)
+
+    for index, exe in enumerate(executable_list, 0):
+        logging.info("Step %i of %i: %s", index, total, exe)
+
+        exe_name = exe.name
+        excluded = any(exe_name == pattern for pattern in exclude_list)
+
+        if excluded:
+            logging.info("Skipping %s", exe)
+            skipped += 1
+            continue
+
+        logging.info("Running: %s in %s", exe.name, os.path.dirname(str(exe)))
+        exe_args = "test.ll" if exe_name == "ptxgen" else None
+
+        proc = subprocess.run(
+            [str(exe), exe_args] if exe_args else [str(exe)],
+            check=True,
+            cwd=os.path.dirname(str(exe)),
+        )
+
+        code = proc.returncode if not isinstance(proc, bool) else 0
+
+        logging.error("Error code : " + str(code))
+
+    logging.info("All %i tests done,; %s skipped.", total, skipped)
+    return total, skipped
+
+
+def main():
+    args = parse_args()
+    orig_dir = Path.cwd()
+    logging.basicConfig(level=args.log_level)
+
+    try:
+        if not args.no_clone:
+            clone_and_build(
+                orig_dir, str(args.test_set), args.cuda_samples_version
+            )
+    except (subprocess.CalledProcessError, FileExistsError, OSError):
+        if not args.keep_cache:
+            cleanup_temporary_files(orig_dir, str(args.test_set))
+        raise
+
+    for src, dest, extension in args.missing_files:
+        copy_and_set_permissions(
+            orig_dir / str(args.test_set) / src,
+            orig_dir / str(args.test_set) / dest,
+            extension,
+        )
+
+    try:
+        run_tests(orig_dir, str(args.test_set), args.cuda_ignore_tests)
+
+    except subprocess.CalledProcessError:
+        logging.error("Test failed")
+        if not args.keep_cache:
+            cleanup_temporary_files(orig_dir, str(args.test_set))
+        raise
+
+    if not args.keep_cache:
+        cleanup_temporary_files(orig_dir, str(args.test_set))
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/gpgpu/tests/test_run_cuda_sample_set.py
+++ b/providers/gpgpu/tests/test_run_cuda_sample_set.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Tests for the run_cuda_sample_set.py script.
+
+Copyright 2025 Canonical Ltd.
+
+Written by:
+  Antone Lassagne <antoine.lassagne@canonical.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3,
+as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import unittest
+import os
+from unittest import mock
+from pathlib import Path
+import subprocess
+from unittest.mock import patch
+import logging
+
+import run_cuda_sample_set
+
+global clone_counter
+clone_counter = 0
+
+
+def dummy_clone(orig_dir, test_set):
+    global clone_counter
+
+    def wrapper(*args, **kwargs) -> subprocess.CompletedProcess:
+        global clone_counter
+        if clone_counter > 0:
+            return subprocess.CompletedProcess("", 0)
+        clone_counter = clone_counter + 1
+        # Create a temporary directory to simulate the workspace
+        test_set_dir_to_keep = (
+            orig_dir / test_set / "Samples" / "5_Domain_Specific"
+        )
+        test_set_dir_to_keep_2 = orig_dir / test_set / "Samples" / "3_Dummy"
+        test_set_dir_to_keep_5 = (
+            orig_dir
+            / test_set
+            / "Samples"
+            / "8_Platform_Specific"
+            / "Tegra"
+            / "cudaNvSciBufMultiplanar"
+        )
+
+        test_set_dir_to_keep_7 = (
+            orig_dir / test_set / "Samples" / "7_libNVVM" / "ptxgen"
+        )
+
+        test_set_dir_to_keep_4 = (
+            orig_dir
+            / test_set
+            / "Samples"
+            / "2_Concepts_and_Techniques"
+            / "EGLStream_CUDA_Interop"
+        )
+        test_set_dir_to_keep_4_2 = (
+            orig_dir
+            / test_set
+            / "build"
+            / "Samples"
+            / "2_Concepts_and_Techniques"
+            / "EGLStream_CUDA_Interop"
+        )
+
+        test_set_dir_to_keep_3 = orig_dir / test_set / "Samples" / "Common"
+        test_set_dir_to_trash = orig_dir / test_set / "Samples" / "0_Utilities"
+
+        test_set_dir_to_keep.mkdir(parents=True, exist_ok=True)
+        test_set_dir_to_keep_2.mkdir(parents=True, exist_ok=True)
+        test_set_dir_to_keep_3.mkdir(parents=True, exist_ok=True)
+        test_set_dir_to_keep_5.mkdir(parents=True, exist_ok=True)
+        test_set_dir_to_keep_7.mkdir(parents=True, exist_ok=True)
+        test_set_dir_to_keep_4.mkdir(parents=True, exist_ok=True)
+        test_set_dir_to_keep_4_2.mkdir(parents=True, exist_ok=True)
+        test_set_dir_to_trash.mkdir(parents=True, exist_ok=True)
+
+        with open(str(Path(test_set_dir_to_keep_4 / "truc.yuv")), "w") as file:
+            file.write("dummydum")
+
+        with open(str(Path(test_set_dir_to_keep_5 / "truc.yuv")), "w") as file:
+            file.write("dummydum")
+
+        with open(
+            str(Path(orig_dir / test_set / "CMakeLists.txt")), "w"
+        ) as file:
+            file.write("dummydum")
+
+        return subprocess.CompletedProcess("", 0)
+
+    return wrapper
+
+
+class TestCudaSamples(unittest.TestCase):
+
+    @mock.patch("subprocess.run")
+    @mock.patch("pathlib.Path.write_text")
+    @mock.patch("run_cuda_sample_set.remove_add_subdirectory_line")
+    def test_clone_and_build(
+        self,
+        mock_radd_sub_line,
+        mock_write_text,
+        mock_subprocess_run,
+    ):
+        global clone_counter
+        # Set environment variables
+        test_set = "5"
+        cuda_samples_version = 12.8
+        orig_dir = Path(".")
+        mock_subprocess_run.side_effect = dummy_clone(orig_dir, test_set)
+
+        # what if there is the wrong folder already
+        path = orig_dir / test_set
+        path.mkdir(parents=True, exist_ok=True)
+        with self.assertRaises(FileExistsError):
+            run_cuda_sample_set.clone_and_build(
+                orig_dir, test_set, cuda_samples_version
+            )
+
+        run_cuda_sample_set.cleanup_temporary_files(".", str(test_set))
+        run_cuda_sample_set.clone_and_build(
+            orig_dir, test_set, cuda_samples_version
+        )
+        run_cuda_sample_set.cleanup_temporary_files(".", str(test_set))
+        run_cuda_sample_set.cleanup_temporary_files(".", str(test_set))
+        run_cuda_sample_set.cleanup_temporary_files(".", str(0))
+
+        test_set = "2"
+        clone_counter = 0
+        run_cuda_sample_set.cleanup_temporary_files(".", str(test_set))
+        mock_subprocess_run.side_effect = dummy_clone(orig_dir, test_set)
+        run_cuda_sample_set.clone_and_build(
+            orig_dir, test_set, cuda_samples_version
+        )
+        run_cuda_sample_set.cleanup_temporary_files(".", str(test_set))
+
+        test_set = "8"
+        clone_counter = 0
+        run_cuda_sample_set.cleanup_temporary_files(".", str(test_set))
+        mock_subprocess_run.side_effect = dummy_clone(orig_dir, test_set)
+        run_cuda_sample_set.clone_and_build(
+            orig_dir, test_set, cuda_samples_version
+        )
+        run_cuda_sample_set.cleanup_temporary_files(".", str(test_set))
+
+        test_set = "7"
+        clone_counter = 0
+        run_cuda_sample_set.cleanup_temporary_files(".", str(test_set))
+        mock_subprocess_run.side_effect = dummy_clone(orig_dir, test_set)
+        run_cuda_sample_set.clone_and_build(
+            orig_dir, test_set, cuda_samples_version
+        )
+        run_cuda_sample_set.cleanup_temporary_files(".", str(test_set))
+
+    def test_remove_add_subdirectory_line(self):
+        filepath = "test.txt"
+        text = "hello"
+        with open(filepath, "w") as file:
+            file.write("first line\n")
+            file.write("add_subdirectory(" + text + ")\n")
+            file.write("add_subdirectory(hellooo)\n")
+            file.write("third line\n")
+
+        run_cuda_sample_set.remove_add_subdirectory_line(filepath, text)
+
+        with open(filepath, "r") as f:
+            lines = f.readlines()
+
+        self.assertEqual(lines[0], "first line\n")
+        self.assertEqual(lines[1], "add_subdirectory(hellooo)\n")
+        self.assertEqual(lines[2], "third line\n")
+        self.assertEqual(len(lines), 3)
+
+    @mock.patch("pathlib.Path.mkdir")
+    @mock.patch("shutil.copy")
+    @mock.patch("os.chmod")
+    def test_copy_and_set_permissions(self, mock_mkdir, mock_copy, mock_chmod):
+        with open("test.txt", "w") as file:
+            file.write("first line\n")
+        run_cuda_sample_set.copy_and_set_permissions(".", ".", ".txt")
+        os.remove("test.txt")
+
+    @mock.patch("subprocess.run", return_value=True)
+    def test_run_test(self, mock_run):
+        # Create a temporary directory to simulate the workspace
+        orig_dir = Path(".")
+        exe_dir = (
+            orig_dir
+            / "3"
+            / "build"
+            / "Samples"
+            / "5_Domain_Specific"
+            / "truc"
+            / "bin"
+        )
+        exe_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create the dummy script and write the echo command to it
+        with open(str(Path(exe_dir / "3.sh")), "w") as file:
+            file.write("#!/bin/bash\n")
+            file.write("echo hello world 1\n")
+
+        with open(str(Path(exe_dir / "test2")), "w") as file:
+            file.write("#!/bin/bash\n")
+            file.write("echo hello world 2\n")
+
+        with open(str(Path(exe_dir / "test1")), "w") as file:
+            file.write("#!/bin/bash\n")
+            file.write("echo hello world 3\n")
+        with open(str(Path(exe_dir / "testnope")), "w") as file:
+            file.write("#!/bin/bash\n")
+
+        os.chmod(str(Path(exe_dir / "3.sh")), 0o755)
+        os.chmod(str(Path(exe_dir / "test2")), 0o755)
+        os.chmod(str(Path(exe_dir / "test1")), 0o755)
+
+        total, skipped = run_cuda_sample_set.run_tests("./", "3", ["test1"])
+        self.assertEqual(total, 3)
+        self.assertEqual(skipped, 1)
+        run_cuda_sample_set.cleanup_temporary_files("./", str(3))
+
+    @mock.patch(
+        "run_cuda_sample_set.parse_args",
+        return_value=run_cuda_sample_set.argparse.Namespace(
+            no_clone=False,
+            keep_cache=False,
+            cuda_ignore_tensorcore="1",
+            cuda_multigpu="1",
+            cuda_ignore_tests="test1 test2",
+            test_set="2",
+            cuda_samples_version="12.8",
+            missing_files=[(".", ".", ".txt")],
+            log_level=logging.INFO,
+        ),
+    )
+    @mock.patch(
+        "run_cuda_sample_set.clone_and_build",
+        side_effect=FileExistsError("File exist patched."),
+    )
+    @mock.patch(
+        "run_cuda_sample_set.run_tests",
+        side_effect=subprocess.CalledProcessError(
+            "File exist patched.", cmd=""
+        ),
+    )
+    def test_main(self, mock_run, mock_clone, mock_args):
+        with self.assertRaises(FileExistsError):
+            run_cuda_sample_set.main()
+        mock_clone.side_effect = None
+        with self.assertRaises(subprocess.CalledProcessError):
+            run_cuda_sample_set.main()
+
+        mock_run.side_effect = None
+        run_cuda_sample_set.main()
+
+    @patch("run_cuda_sample_set.argparse")
+    def test_parse_args(self, argparse_mock):
+        run_cuda_sample_set.parse_args()

--- a/providers/gpgpu/units/cuda.pxu
+++ b/providers/gpgpu/units/cuda.pxu
@@ -1,0 +1,47 @@
+id: gpgpu/cuda-samples-0-int
+category_id: gpgpu
+environ:
+    CUDA_SAMPLES_VERSION
+    CUDA_IGNORE_TESTS
+    CUDA_IGNORE_TENSORCORE
+    CUDA_MULTIGPU
+plugin: shell
+estimated_duration: 4
+requires:
+    graphics_card.vendor == 'NVIDIA Corporation'
+_summary: NVIDIA CUDA 0 - introduction
+command: run_cuda_sample_set.py introduction
+_siblings: [
+  { "id": "gpgpu/cuda-samples-1-utils",
+    "_summary": "NVIDIA CUDA 1 - utilities",
+    "command": "run_cuda_sample_set.py utilities"},
+  { "id": "gpgpu/cuda-samples-2-conc",
+    "_summary": "NVIDIA CUDA 2 - concepts-techniques",
+    "command": "run_cuda_sample_set.py concepts"},
+  { "id": "gpgpu/cuda-samples-3-feat",
+    "_summary": "NVIDIA CUDA 3 - features testing",
+    "command": "run_cuda_sample_set.py features"},
+  { "id": "gpgpu/cuda-samples-4-libs",
+    "_summary": "NVIDIA CUDA 4 - libraries",
+    "command": "run_cuda_sample_set.py libraries"},
+  { "id": "gpgpu/cuda-samples-5-dom",
+    "_summary": "NVIDIA CUDA 5 - domain specific",
+    "command": "run_cuda_sample_set.py domain"},
+  { "id": "gpgpu/cuda-samples-6-perf",
+    "_summary": "NVIDIA CUDA 6 - performance",
+    "command": "run_cuda_sample_set.py performance"},
+  { "id": "gpgpu/cuda-samples-7-nvvm",
+    "_summary": "NVIDIA CUDA 7 - libNVVM",
+    "command": "run_cuda_sample_set.py libnvvm"},
+  { "id": "gpgpu/cuda-samples-8-plat",
+    "_summary": "NVIDIA CUDA 8 - platform specific",
+    "command": "run_cuda_sample_set.py platform"}
+    ]
+
+unit: packaging meta-data
+os-id: debian
+Depends: cmake
+
+unit: packaging meta-data
+os-id: debian
+Depends: git

--- a/providers/gpgpu/units/test-plan.pxu
+++ b/providers/gpgpu/units/test-plan.pxu
@@ -45,3 +45,23 @@ bootstrap_include:
     executable
     package
     snap
+
+id: gpgpu-cuda-features
+unit: test plan
+_name: NVIDIA CUDA Feature testing
+_description: Feature testing for various CUDA versions
+include:
+    gpgpu/cuda-samples-0-int        certification-status=non-blocker
+    gpgpu/cuda-samples-1-utils      certification-status=non-blocker
+    gpgpu/cuda-samples-2-conc       certification-status=non-blocker
+    gpgpu/cuda-samples-3-feat       certification-status=non-blocker
+    gpgpu/cuda-samples-4-libs       certification-status=non-blocker
+    gpgpu/cuda-samples-5-dom        certification-status=non-blocker
+    gpgpu/cuda-samples-6-perf       certification-status=non-blocker
+    gpgpu/cuda-samples-7-nvvm       certification-status=non-blocker
+    gpgpu/cuda-samples-8-plat       certification-status=non-blocker
+bootstrap_include:
+    graphics_card
+    executable
+    package
+    snap


### PR DESCRIPTION
The current CUDA-related tests in the GPGPU test plan are using a snap package that contains the CUDA runtimes. Thus it does not really test what the client will have on his machine, not does it allow to chose specific version or architecture. Right now it is only compatible with CUDA 12.8, amd64 desktops and arm server machines. This PR adds other tests that compile what is required at runtime. They assume that both the driver and CUDA are installed. They allow to choose the sample version, as well as specific sets of features.

- It's based on a shell script that download, build an runs the cuda samples. 
- The script takes an argument, a number between 0 and 8. That makes 9 test in one test plan, to split the tests.
- Some environment variables can be set in the manifest. They mainly allow to chose a specific CUDA version, but also to enable / disable specific CUDA features, or to skip some tests entirely for specific platforms.

This PR was tested on both a Desktop machine and a specific Nvidia machine (the target). The documentation does not mention any unit-testing of bash file, but I'm open to suggestions.