### PR TITLE
Add remodel tests for Ubuntu Core 20 => 22 and 22 => 24 (New)

### DIFF
--- a/providers/base/bin/remodel_test.py
+++ b/providers/base/bin/remodel_test.py
@@ -81,7 +81,7 @@ def main():
     parser.add_argument(
         "--offline",
         help="whether the remodel should be offline",
-        action='store_true',
+        action="store_true",
     )
     args = parser.parse_args()
 

--- a/providers/base/bin/remodel_test.py
+++ b/providers/base/bin/remodel_test.py
@@ -72,7 +72,7 @@ def main():
     parser.add_argument(
         "target",
         help="which verison of ubuntu-core that should be remodeled to",
-        choices=["22", "24"]
+        choices=["22", "24"],
     )
 
     # resolve the snaps for the remodel if offline has been requested
@@ -81,7 +81,7 @@ def main():
     parser.add_argument(
         "--offline",
         help="whether the remodel should be offline",
-        action='store_true'
+        action='store_true',
     )
     args = parser.parse_args()
 

--- a/providers/base/bin/remodel_test.py
+++ b/providers/base/bin/remodel_test.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# All rights reserved.
+#
+# Written by:
+#    Authors: Philip Meulengracht <philip.meulengracht@canonical.com>
+
+import os
+import sys
+import platform
+import subprocess
+from urllib.request import urlretrieve
+
+
+def get_platform():
+    plt = platform.platform()
+    if "raspi-aarch64" in plt:
+        return "pi-arm64"
+    elif "raspi" in plt:
+        return "pi-armhf"
+    elif "x86_64" in plt:
+        return "amd64"
+    raise Exception(f"unrecognized platform {plt}")
+
+
+def resolve_target_remodel():
+    runtime = os.getenv("CHECKBOX_RUNTIME", "/snap/checkbox/current")
+    if "checkbox20" in runtime:
+        return "uc22"
+    elif "checkbox22" in runtime:
+        return "uc24"
+    raise Exception(f"unsupported version for remodel: {runtime}")
+
+
+def resolve_model(uc_ver):
+    base_uri = "https://raw.githubusercontent.com/canonical/models/"
+    branch = "refs/heads/master/"
+    model = f"ubuntu-core-{uc_ver}-{get_platform()}-dangerous.model"
+    print(f"resolving model for remodeling: {base_uri + branch + model}")
+    path, _ = urlretrieve(base_uri + branch + model, f"uc-{uc_ver}.model")
+    return path
+
+
+def resolve_snaps(uc_ver):
+    subprocess.run([
+        "snap", "download", f"core{uc_ver}",
+        f"--basename=core{uc_ver}"])
+    # for the kernel snap use beta
+    if "pi" in get_platform():
+        subprocess.run([
+            "snap", "download",
+            "pi", f"--channel={uc_ver}/edge",
+            "--basename=gadget"])
+        subprocess.run([
+            "snap", "download",
+            "pi-kernel",  f"--channel={uc_ver}/beta",
+            "--basename=kernel"])
+    else:
+        subprocess.run([
+            "snap", "download",
+            "pc", f"--channel={uc_ver}/edge",
+            "--basename=gadget"])
+        subprocess.run([
+            "snap", "download",
+            "pc-kernel",  f"--channel={uc_ver}/beta",
+            "--basename=kernel"])
+
+
+def main():
+    """Run remodel of an Ubuntu Core host."""
+
+    uc_ver = ""
+    if len(sys.argv) > 1:
+        uc_ver = sys.argv[1]
+    else:
+        uc_ver = resolve_target_remodel()
+
+    # resolve the model for the current platform
+    model_path = resolve_model(uc_ver)
+
+    # resolve the snaps for the remodel if offline has been requested
+    # (currently offline was used for testing in certain scenarios during
+    # test development) - for normal testing offline should not be needed
+    offline = False
+    if len(sys.argv) > 2 and sys.argv[2] == 'offline':
+        offline = True
+
+    if offline:
+        resolve_snaps(uc_ver)
+
+        # instantiate the offline remodel
+        print("initiating offline device remodel")
+        subprocess.run([
+            "sudo", "snap", "remodel", "--offline",
+            "--snap", f"core{uc_ver}.snap",
+            "--assertion", f"core{uc_ver}.assert",
+            "--snap", "gadget.snap",
+            "--assertion", "gadget.assert",
+            "--snap", "kernel.snap",
+            "--assertion", "kernel.assert",
+            model_path])
+    else:
+        # instantiate the remodel
+        print("initiating device remodel")
+        subprocess.run(["sudo", "snap", "remodel", model_path])
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/providers/base/bin/remodel_test.py
+++ b/providers/base/bin/remodel_test.py
@@ -42,28 +42,48 @@ def resolve_model(uc_ver):
 
 
 def resolve_snaps(uc_ver):
-    subprocess.run([
-        "snap", "download", f"core{uc_ver}",
-        f"--basename=core{uc_ver}"])
+    subprocess.run(
+        ["snap", "download", f"core{uc_ver}", f"--basename=core{uc_ver}"]
+    )
     # for the kernel snap use beta
     if "pi" in get_platform():
-        subprocess.run([
-            "snap", "download",
-            "pi", f"--channel={uc_ver}/edge",
-            "--basename=gadget"])
-        subprocess.run([
-            "snap", "download",
-            "pi-kernel",  f"--channel={uc_ver}/beta",
-            "--basename=kernel"])
+        subprocess.run(
+            [
+                "snap",
+                "download",
+                "pi",
+                f"--channel={uc_ver}/edge",
+                "--basename=gadget",
+            ]
+        )
+        subprocess.run(
+            [
+                "snap",
+                "download",
+                "pi-kernel",
+                f"--channel={uc_ver}/beta",
+                "--basename=kernel",
+            ]
+        )
     else:
-        subprocess.run([
-            "snap", "download",
-            "pc", f"--channel={uc_ver}/edge",
-            "--basename=gadget"])
-        subprocess.run([
-            "snap", "download",
-            "pc-kernel",  f"--channel={uc_ver}/beta",
-            "--basename=kernel"])
+        subprocess.run(
+            [
+                "snap",
+                "download",
+                "pc",
+                f"--channel={uc_ver}/edge",
+                "--basename=gadget",
+            ]
+        )
+        subprocess.run(
+            [
+                "snap",
+                "download",
+                "pc-kernel",
+                f"--channel={uc_ver}/beta",
+                "--basename=kernel",
+            ]
+        )
 
 
 def main():
@@ -82,7 +102,7 @@ def main():
     # (currently offline was used for testing in certain scenarios during
     # test development) - for normal testing offline should not be needed
     offline = False
-    if len(sys.argv) > 2 and sys.argv[2] == 'offline':
+    if len(sys.argv) > 2 and sys.argv[2] == "offline":
         offline = True
 
     if offline:
@@ -90,15 +110,27 @@ def main():
 
         # instantiate the offline remodel
         print("initiating offline device remodel")
-        subprocess.run([
-            "sudo", "snap", "remodel", "--offline",
-            "--snap", f"core{uc_ver}.snap",
-            "--assertion", f"core{uc_ver}.assert",
-            "--snap", "gadget.snap",
-            "--assertion", "gadget.assert",
-            "--snap", "kernel.snap",
-            "--assertion", "kernel.assert",
-            model_path])
+        subprocess.run(
+            [
+                "sudo",
+                "snap",
+                "remodel",
+                "--offline",
+                "--snap",
+                f"core{uc_ver}.snap",
+                "--assertion",
+                f"core{uc_ver}.assert",
+                "--snap",
+                "gadget.snap",
+                "--assertion",
+                "gadget.assert",
+                "--snap",
+                "kernel.snap",
+                "--assertion",
+                "kernel.assert",
+                model_path,
+            ]
+        )
     else:
         # instantiate the remodel
         print("initiating device remodel")

--- a/providers/base/units/ubuntucore/jobs.pxu
+++ b/providers/base/units/ubuntucore/jobs.pxu
@@ -50,6 +50,42 @@ _verification:
 plugin: manual
 category_id: ubuntucore
 
+id: ubuntucore/remodel-20-to-22
+category_id: ubuntucore
+_summary: Remodel Ubuntu Core 20 to 22
+_purpose:
+ Verify the system can remodel from ubuntu core 22 to 24 under normal
+ circumstances. The requirement is that the official models from canonical
+ are used for the running Ubuntu Core host. Multiple reboots will happen
+ as a part of this test.
+unit: job
+plugin: shell
+user: root
+flags: noreturn
+estimated_duration: 180.0
+command:
+  snap model | grep "ubuntu-core-20"
+  remodel_test.py 22
+  reboot
+
+id: ubuntucore/remodel-22-to-24
+category_id: ubuntucore
+_summary: Remodel Ubuntu Core 22 to 24
+_purpose:
+ Verify the system can remodel from ubuntu core 22 to 24 under normal
+ circumstances. The requirement is that the official models from canonical
+ are used for the running Ubuntu Core host. Multiple reboots will happen
+ as a part of this test.
+unit: job
+plugin: shell
+user: root
+flags: noreturn
+estimated_duration: 180.0
+command:
+  snap model | grep "ubuntu-core-22"
+  remodel_test.py 24
+  reboot
+
 unit: template
 template-resource: lsb
 template-filter: lsb.distributor_id == 'Ubuntu Core'

--- a/providers/base/units/ubuntucore/jobs.pxu
+++ b/providers/base/units/ubuntucore/jobs.pxu
@@ -50,41 +50,63 @@ _verification:
 plugin: manual
 category_id: ubuntucore
 
-id: ubuntucore/remodel-20-to-22
+id: ubuntucore/remodels
 category_id: ubuntucore
-_summary: Remodel Ubuntu Core 20 to 22
-_purpose:
- Verify the system can remodel from ubuntu core 22 to 24 under normal
- circumstances. The requirement is that the official models from canonical
- are used for the running Ubuntu Core host. Multiple reboots will happen
- as a part of this test.
-unit: job
-plugin: shell
-user: root
-flags: noreturn
-estimated_duration: 180.0
+unit: resource
 command:
-  snap model | grep "ubuntu-core-20"
-  remodel_test.py 22
-  reboot
+  echo source: 22
+  echo destination: 24
+  echo
+  echo source: 20
+  echo destination: 22
 
-id: ubuntucore/remodel-22-to-24
+id: ubuntucore/remodel-{{source}}-to-{{destination}}
 category_id: ubuntucore
-_summary: Remodel Ubuntu Core 22 to 24
+_summary: Remodel Ubuntu Core {{source}} to {{destination}}
 _purpose:
- Verify the system can remodel from ubuntu core 22 to 24 under normal
+ Verify the system can remodel from ubuntu core {{source}} to {{destination}} under normal
  circumstances. The requirement is that the official models from canonical
  are used for the running Ubuntu Core host. Multiple reboots will happen
  as a part of this test.
-unit: job
+unit: template
+template-id: ubuntucore_remodel
+template-resource: ubuntucore/remodels
+template-filter: lsb.distributor_id == 'Ubuntu Core'
+template-unit: job
 plugin: shell
 user: root
 flags: noreturn
-estimated_duration: 180.0
+estimated_duration: 300.0
 command:
-  snap model | grep "ubuntu-core-22"
-  remodel_test.py 24
-  reboot
+ snap model | grep "ubuntu-core-{{source}}"
+ remodel_test.py {{destination}}
+ reboot
+
+id: ubuntucore/remodel-check-up
+category_id: ubuntucore
+_summary: Remodel checkpoint to verify system.
+_purpose:
+ Verify the current system status, if the system is up, then we exit cleanly.
+unit: job
+plugin: shell
+user: root
+estimated_duration: 0.1
+command:
+  cat /proc/cmdline | grep snapd_recovery_mode=run
+
+id: ubuntucore/remodel-{{source}}-to-{{destination}}-verify
+category_id: ubuntucore
+_summary: Verify remodel of Ubuntu Core {{source}} to {{destination}}
+unit: template
+template-id: ubuntucore_remodel_verify
+template-resource: ubuntucore/remodels
+template-filter: lsb.distributor_id == 'Ubuntu Core'
+template-unit: job
+plugin: shell
+user: root
+estimated_duration: 0.1
+command:
+ snap model | grep "ubuntu-core-{{destination}}"
 
 unit: template
 template-resource: lsb

--- a/providers/base/units/ubuntucore/jobs.pxu
+++ b/providers/base/units/ubuntucore/jobs.pxu
@@ -79,24 +79,55 @@ requires: os.distributor_id == 'Ubuntu Core'
 template-unit: job
 plugin: shell
 user: root
-flags: noreturn
-estimated_duration: 210.0
+estimated_duration: 60.0
 command:
   set -e
   snap model
   snap model | grep "ubuntu-core-{source}"
   remodel_test.py {destination}
 
-id: ubuntucore/remodel-reboot-{source}
+id: ubuntucore/remodel-reboot-{source}-first
 category_id: ubuntucore
-_summary: Remodel checkpoint to reboot system during remodel.
+_summary: First remodel checkpoint to reboot system during remodel.
+_purpose:
+ A system reboot will be requested as a part of requesting a remodel, this serves
+ to be a checkpoint for that, and waits for the reboot to be requested.
+unit: template
+template-id: ubuntucore/remodel-reboot-first
+template-resource: ubuntucore/remodels
+requires: os.distributor_id == 'Ubuntu Core'
+template-unit: job
+plugin: shell
+user: root
+flags: noreturn
+estimated_duration: 30.0
+command:
+  set -e
+  max_attempts=30
+  attempt_num=1
+  success=false
+  while [ $success = false ] && [ $attempt_num -le $max_attempts ]; do
+    journalctl -b -u snapd | grep "Waiting for system reboot"
+    if [ $? -eq 0 ]; then
+      success=true
+    else
+      echo "Attemp $attempt_num: waiting for reboot request"
+      attempt_num=$(( attempt_num + 1 ))
+      sleep 1
+    fi
+  done
+  reboot
+
+id: ubuntucore/remodel-reboot-{source}-second
+category_id: ubuntucore
+_summary: Second remodel checkpoint to reboot system during remodel.
 _purpose:
  At this point, the remodel will start, the first reboot was to create a 
  recovery system and the next will be to start the remodel itself. 
  This will take a while and do several reboots but not be observed by
  checkbox 
 unit: template
-template-id: ubuntucore/remodel-reboot
+template-id: ubuntucore/remodel-reboot-second
 template-resource: ubuntucore/remodels
 requires: os.distributor_id == 'Ubuntu Core'
 template-unit: job

--- a/providers/base/units/ubuntucore/jobs.pxu
+++ b/providers/base/units/ubuntucore/jobs.pxu
@@ -80,28 +80,46 @@ template-unit: job
 plugin: shell
 user: root
 flags: noreturn
-estimated_duration: 300.0
+estimated_duration: 210.0
 command:
   set -e
+  snap model
   snap model | grep "ubuntu-core-{source}"
   remodel_test.py {destination}
 
-id: ubuntucore/remodel-check-up-{source}
+id: ubuntucore/remodel-reboot-{source}
 category_id: ubuntucore
-_summary: Remodel checkpoint to verify system.
+_summary: Remodel checkpoint to reboot system during remodel.
 _purpose:
- Verify the current system status, if the system is up, then we exit cleanly.
+ At this point, the remodel will start, the first reboot was to create a 
+ recovery system and the next will be to start the remodel itself. 
+ This will take a while and do several reboots but not be observed by
+ checkbox 
 unit: template
-template-id: ubuntucore/remodel-check-up
+template-id: ubuntucore/remodel-reboot
 template-resource: ubuntucore/remodels
 requires: os.distributor_id == 'Ubuntu Core'
 template-unit: job
 plugin: shell
 user: root
-estimated_duration: 0.1
+flags: noreturn
+estimated_duration: 300.0
 command:
   set -e
-  cat /proc/cmdline | grep snapd_recovery_mode=run
+  max_attempts=60
+  attempt_num=1
+  success=false
+  while [ $success = false ] && [ $attempt_num -le $max_attempts ]; do
+    journalctl -b -u snapd | grep "Waiting for system reboot"
+    if [ $? -eq 0 ]; then
+      success=true
+    else
+      echo "Attemp $attempt_num: waiting for reboot request"
+      attempt_num=$(( attempt_num + 1 ))
+      sleep 5
+    fi
+  done
+  reboot
 
 id: ubuntucore/remodel-{source}-to-{destination}-verify
 category_id: ubuntucore
@@ -116,6 +134,11 @@ user: root
 estimated_duration: 0.1
 command:
   set -e
+  cat /proc/cmdline
+  snap model
+  snap changes
+  systemctl is-active ssh
+  cat /proc/cmdline | grep snapd_recovery_mode=run
   snap model | grep "ubuntu-core-{destination}"
 
 unit: template

--- a/providers/base/units/ubuntucore/jobs.pxu
+++ b/providers/base/units/ubuntucore/jobs.pxu
@@ -51,8 +51,12 @@ plugin: manual
 category_id: ubuntucore
 
 id: ubuntucore/remodels
+_summary: Create a list of remodel tests
+_description:
+    Remodeling is supported for the below versions, and variants of the remodeling
+    test must be created for each
 category_id: ubuntucore
-unit: resource
+plugin: resource
 command:
   echo source: 22
   echo destination: 24
@@ -60,53 +64,59 @@ command:
   echo source: 20
   echo destination: 22
 
-id: ubuntucore/remodel-{{source}}-to-{{destination}}
+id: ubuntucore/remodel-{source}-to-{destination}
 category_id: ubuntucore
-_summary: Remodel Ubuntu Core {{source}} to {{destination}}
+_summary: Remodel Ubuntu Core {source} to {destination}
 _purpose:
- Verify the system can remodel from ubuntu core {{source}} to {{destination}} under normal
+ Verify the system can remodel from ubuntu core {source} to {destination} under normal
  circumstances. The requirement is that the official models from canonical
  are used for the running Ubuntu Core host. Multiple reboots will happen
  as a part of this test.
 unit: template
-template-id: ubuntucore_remodel
+template-id: ubuntucore/remodel
 template-resource: ubuntucore/remodels
-template-filter: lsb.distributor_id == 'Ubuntu Core'
+requires: os.distributor_id == 'Ubuntu Core'
 template-unit: job
 plugin: shell
 user: root
 flags: noreturn
 estimated_duration: 300.0
 command:
- snap model | grep "ubuntu-core-{{source}}"
- remodel_test.py {{destination}}
- reboot
+  set -e
+  snap model | grep "ubuntu-core-{source}"
+  remodel_test.py {destination}
 
-id: ubuntucore/remodel-check-up
+id: ubuntucore/remodel-check-up-{source}
 category_id: ubuntucore
 _summary: Remodel checkpoint to verify system.
 _purpose:
  Verify the current system status, if the system is up, then we exit cleanly.
-unit: job
-plugin: shell
-user: root
-estimated_duration: 0.1
-command:
-  cat /proc/cmdline | grep snapd_recovery_mode=run
-
-id: ubuntucore/remodel-{{source}}-to-{{destination}}-verify
-category_id: ubuntucore
-_summary: Verify remodel of Ubuntu Core {{source}} to {{destination}}
 unit: template
-template-id: ubuntucore_remodel_verify
+template-id: ubuntucore/remodel-check-up
 template-resource: ubuntucore/remodels
-template-filter: lsb.distributor_id == 'Ubuntu Core'
+requires: os.distributor_id == 'Ubuntu Core'
 template-unit: job
 plugin: shell
 user: root
 estimated_duration: 0.1
 command:
- snap model | grep "ubuntu-core-{{destination}}"
+  set -e
+  cat /proc/cmdline | grep snapd_recovery_mode=run
+
+id: ubuntucore/remodel-{source}-to-{destination}-verify
+category_id: ubuntucore
+_summary: Verify remodel of Ubuntu Core {source} to {destination}
+unit: template
+template-id: ubuntucore/remodel-verify
+template-resource: ubuntucore/remodels
+requires: os.distributor_id == 'Ubuntu Core'
+template-unit: job
+plugin: shell
+user: root
+estimated_duration: 0.1
+command:
+  set -e
+  snap model | grep "ubuntu-core-{destination}"
 
 unit: template
 template-resource: lsb

--- a/providers/base/units/ubuntucore/test-plan.pxu
+++ b/providers/base/units/ubuntucore/test-plan.pxu
@@ -34,7 +34,8 @@ bootstrap_include:
     ubuntucore/remodels
 include:
     ubuntucore/remodel-20-to-22
-    ubuntucore/remodel-reboot-20
+    ubuntucore/remodel-reboot-20-first
+    ubuntucore/remodel-reboot-20-second
     ubuntucore/remodel-20-to-22-verify
 
 id: ubuntucore-22-team
@@ -46,5 +47,6 @@ bootstrap_include:
     ubuntucore/remodels
 include:
     ubuntucore/remodel-22-to-24
-    ubuntucore/remodel-reboot-22
+    ubuntucore/remodel-reboot-22-first
+    ubuntucore/remodel-reboot-22-second
     ubuntucore/remodel-22-to-24-verify

--- a/providers/base/units/ubuntucore/test-plan.pxu
+++ b/providers/base/units/ubuntucore/test-plan.pxu
@@ -24,3 +24,21 @@ include:
     ubuntucore/os-recovery-mode
     ubuntucore/os-fail-boot-(?!with-refresh-control).*
     ubuntucore/sshd
+
+id: ubuntucore-20-team
+unit: test plan
+_name: Automated tests from the Ubuntu Core Team for Ubuntu Core 20
+_description: Runs automated OS feature tests for Ubuntu Core 20 devices.
+include:
+    ubuntucore/remodel-20-to-22
+    ubuntucore/remodel-check-up
+    ubuntucore/remodel-20-to-22-verify
+
+id: ubuntucore-22-team
+unit: test plan
+_name: Automated tests from the Ubuntu Core Team for Ubuntu Core 20
+_description: Runs automated OS feature tests for Ubuntu Core 20 devices.
+include:
+    ubuntucore/remodel-22-to-24
+    ubuntucore/remodel-check-up
+    ubuntucore/remodel-22-to-24-verify

--- a/providers/base/units/ubuntucore/test-plan.pxu
+++ b/providers/base/units/ubuntucore/test-plan.pxu
@@ -29,16 +29,22 @@ id: ubuntucore-20-team
 unit: test plan
 _name: Automated tests from the Ubuntu Core Team for Ubuntu Core 20
 _description: Runs automated OS feature tests for Ubuntu Core 20 devices.
+bootstrap_include:
+    os
+    ubuntucore/remodels
 include:
     ubuntucore/remodel-20-to-22
-    ubuntucore/remodel-check-up
+    ubuntucore/remodel-check-up-20
     ubuntucore/remodel-20-to-22-verify
 
 id: ubuntucore-22-team
 unit: test plan
 _name: Automated tests from the Ubuntu Core Team for Ubuntu Core 20
 _description: Runs automated OS feature tests for Ubuntu Core 20 devices.
+bootstrap_include:
+    os
+    ubuntucore/remodels
 include:
     ubuntucore/remodel-22-to-24
-    ubuntucore/remodel-check-up
+    ubuntucore/remodel-check-up-22
     ubuntucore/remodel-22-to-24-verify

--- a/providers/base/units/ubuntucore/test-plan.pxu
+++ b/providers/base/units/ubuntucore/test-plan.pxu
@@ -34,7 +34,7 @@ bootstrap_include:
     ubuntucore/remodels
 include:
     ubuntucore/remodel-20-to-22
-    ubuntucore/remodel-check-up-20
+    ubuntucore/remodel-reboot-20
     ubuntucore/remodel-20-to-22-verify
 
 id: ubuntucore-22-team
@@ -46,5 +46,5 @@ bootstrap_include:
     ubuntucore/remodels
 include:
     ubuntucore/remodel-22-to-24
-    ubuntucore/remodel-check-up-22
+    ubuntucore/remodel-reboot-22
     ubuntucore/remodel-22-to-24-verify


### PR DESCRIPTION
## Description

Introduce two new tests, one specifically for Ubuntu Core 20 that verifies the possibility of remodeling to Ubuntu Core 22, and one identical one for Ubuntu Core 22 that remodels to 24.

The tests are implemented with the assumption that the Ubuntu Core images used by certifications use the official models sourced from either cdimage (which use models from https://github.com/canonical/models) or they are built by certifications themself from the mentioned models.

There are currently a lot of limitations on how remodel works, which means that the models must match brand / model if done offline or the device must have a serial assertion (as offline remodels cannot be done from model to a new model, only upgrades and we do not have official models for that currently). 

If we end in a situation where the remodeling has to be done offline, we must discuss how we solve this for certification testing. Because if things don't line up currently, then we simply cannot test remodelling in certifications without either a new set of models specifically for this, or we have to lax some of the requirements for remodeling (i.e. implement/support some missing cases).

It's important to be aware of the fact that these test cause the device to reboot *multiple times*.

## Resolved issues

I don't know if there is a issue for covering this specific area of testing.

## Documentation

Depending on the test-plan they get added to, we may have to update the coverage in https://certification.canonical.com/docs/programmes/iot/ ?

## Tests

These tests have been tested in qemu for amd64 platform and on a Raspberry Pi4 for pi-arm64 platform, by installing my own custom checkbox frontend containing the two added tests, then run with the following commands:

```
checkbox-remodel.checkbox-cli run com.canonical.qa.remodel::remodel-20-to-22
```
and
```
checkbox-remodel.checkbox-cli run com.canonical.qa.remodel::remodel-22-to-24
```

The python script was tested before it was tested in a snapped checkbox context by running it from the users home directory with the parameters in the tests.