### PR TITLE
Ignore nmcli failing to rescan if it is already rescanning (bugfix)

### DIFF
--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -113,6 +113,8 @@ def delete_test_ap_ssid_connection():
 @retry(max_attempts=5, delay=60)
 def device_rescan():
     print_head("Calling a rescan")
+    # Note: once we don't need xenial support anymore, we can use --rescan on
+    #       list_aps and completely remove this function!
     cmd = "nmcli d wifi rescan"
     print_cmd(cmd)
     try:

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -115,7 +115,22 @@ def device_rescan():
     print_head("Calling a rescan")
     cmd = "nmcli d wifi rescan"
     print_cmd(cmd)
-    sp.check_call(shlex.split(cmd))
+    try:
+        sp.check_output(
+            shlex.split(cmd), stderr=sp.STDOUT, universal_newlines=True
+        )
+    except sp.CalledProcessError as e:
+        error = e.output
+        # the objective here is to trigger a rescan, so if one is already
+        # started or was just triggered, we can continue
+        print(error)
+        if "Scanning not allowed immediately following previous scan" in error:
+            pass
+        elif "Scanning not allowed while already scanning" in error:
+            pass
+        else:
+            raise
+
     print()
 
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

nmcli returns an error when trying to trigger a rescan if the rescan is already ongoing or was just triggered. This is a problem because there are several things outside of Checkbox that may trigger a rescan, but also, we want to trigger a rescan, if it is already ongoing, mission accomplished, no need to re-trigger it. 

Minor: this also adds a comment for a future upgrade that we will be able to do once we drop xenial support

## Resolved issues

Fixes: CHECKBOX-1816

## Documentation

N/A

## Tests

Tested via unittests and tested it locally by running the script while triggering a rescan from another terminal (fails before, doesn't now)
