### PR TITLE
Much needed QOL for manage.py (new)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,11 +112,10 @@ Under the hood, this command will
 You can run each part separately. See `./manage.py test -h` for more
 information.
 
-If you only want to run one test script from the test suite, you have to
-point the `PYTHONPATH` environment variable to the provider's `bin/` directory,
-then go to the `tests/` directory and run the unit tests for your test file:
+If you only want to run one test script from the test suite, you can use the
+`-k` selector, similarly to what you would do with pytest:
 
-    (venv) $ PYTHONPATH=~/checkbox/providers/base/bin python -m unittest <your_test_file.py>
+    (venv) $ ./manage.py -k <your_test_name>
 
 ### Coverage
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ information.
 If you only want to run one test script from the test suite, you can use the
 `-k` selector, similarly to what you would do with pytest:
 
-    (venv) $ ./manage.py -k <your_test_name>
+    (venv) $ ./manage.py test -k <your_test_name>
 
 ### Coverage
 

--- a/checkbox-ng/plainbox/provider_manager.py
+++ b/checkbox-ng/plainbox/provider_manager.py
@@ -1566,12 +1566,21 @@ def create_inline_shellcheck_test(command):
     """Creates the target for the monkey patched methods in ShellcheckTests"""
 
     def run_inline_shellcheck(self):
-        result = subprocess.run(
-            ["shellcheck", "-", "--shell=bash"],
-            input=command,
-            universal_newlines=True,
-        )
-        self.assertEqual(result.returncode, 0)
+        try:
+            _ = subprocess.check_output(
+                ["shellcheck", "-", "--shell=bash"],
+                input=command,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+            )
+            failed = False
+        except subprocess.CalledProcessError as e:
+            failed = True
+            failure_reason = e.output
+
+        # this is to avoid having an ugly error traceback
+        if failed:
+            self.fail(failure_reason)
 
     return run_inline_shellcheck
 
@@ -1592,8 +1601,20 @@ def create_shellcheck_test(shellfile):
     """Creates the target for the monkey patched methods in ShellcheckTests"""
 
     def run_shellcheck(self):
-        result = subprocess.run(["shellcheck", shellfile])
-        self.assertEqual(result.returncode, 0)
+        try:
+            _ = subprocess.check_output(
+                ["shellcheck", shellfile],
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+            )
+            failed = False
+        except subprocess.CalledProcessError as e:
+            failed = True
+            failure_reason = e.output
+
+        # this is to avoid having an ugly error traceback
+        if failed:
+            self.fail(failure_reason)
 
     return run_shellcheck
 

--- a/checkbox-ng/plainbox/provider_manager.py
+++ b/checkbox-ng/plainbox/provider_manager.py
@@ -1669,11 +1669,18 @@ class TestCommand(ManageCommand):
             action="store_true",
             help=_("Only unittest from tests/ dir"),
         )
+        group.add_argument(
+            "-k",
+            help=_("Only tests/test class with name matching the glob"),
+            default="*",
+        )
 
     def invoked(self, ns):
         sys.path.insert(0, self.scripts_dir)
         runner = TextTestRunner(verbosity=2)
         provider = self.get_provider()
+
+        defaultTestLoader.testNamePatterns = [ns.k]
 
         # create unittest for each bin/*.sh file
         for file in glob.glob(self.scripts_dir + "/*.sh"):

--- a/checkbox-ng/plainbox/test_provider_manager.py
+++ b/checkbox-ng/plainbox/test_provider_manager.py
@@ -24,24 +24,118 @@ plainbox.test_provider_manager
 Test definitions for plainbox.provider_manager module
 """
 
-from unittest import TestCase
 import os
 import shutil
 import tarfile
 import tempfile
 import textwrap
 
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
 from plainbox.impl.secure.providers.v1 import Provider1Definition
-from plainbox.provider_manager import InstallCommand
-from plainbox.provider_manager import ManageCommand
-from plainbox.provider_manager import ProviderManagerTool
-from plainbox.provider_manager import manage_py_extension
+from plainbox.provider_manager import (
+    InstallCommand,
+    ManageCommand,
+    ProviderManagerTool,
+    manage_py_extension,
+    TestCommand,
+)
 from plainbox.testing_utils.io import TestIO
-from plainbox.vendor import mock
 
 
 def inline_output(text):
     return textwrap.dedent(text).lstrip("\n")
+
+
+class TestCommandTests(TestCase):
+    @patch("glob.glob")
+    @patch("plainbox.provider_manager.ShellcheckTests")
+    @patch("plainbox.provider_manager.create_shellcheck_test")
+    def test_get_sh_tests(
+        self, mock_create_shellcheck_test, mock_ShellcheckTests, mock_glob
+    ):
+        mock_self = MagicMock()
+        mock_glob.return_value = (str(x) for x in range(10))
+
+        TestCommand.get_sh_tests(mock_self)
+
+        self.assertEqual(mock_create_shellcheck_test.call_count, 10)
+
+    @patch("glob.glob")
+    @patch("plainbox.provider_manager.Flake8Tests")
+    @patch("plainbox.provider_manager.create_flake8_test")
+    def test_get_flake8_tests(
+        self, mock_create_flake8_test, mock_ShellcheckTests, mock_glob
+    ):
+        mock_self = MagicMock()
+        mock_glob.return_value = (str(x) for x in range(10))
+
+        TestCommand.get_flake8_tests(mock_self)
+
+        self.assertEqual(mock_create_flake8_test.call_count, 10)
+
+    def create_unit(self, meta_name, **kwargs):
+        to_r = MagicMock(**kwargs)
+        to_r.Meta.name = meta_name
+        return to_r
+
+    @patch("plainbox.provider_manager.create_inline_shellcheck_test")
+    @patch("plainbox.provider_manager.InlineShellcheckTests", new=MagicMock())
+    def test_get_inline_shellcheck_tests_jobs(
+        self, mock_create_inline_shellcheck_test
+    ):
+        mock_self = MagicMock()
+        mock_self.get_provider().unit_list = [
+            self.create_unit("job", command="true"),
+            self.create_unit("file"),
+        ]
+
+        TestCommand.get_inline_shellcheck_tests(mock_self)
+
+        self.assertEqual(mock_create_inline_shellcheck_test.call_count, 1)
+
+    @patch("plainbox.provider_manager.create_inline_shellcheck_test")
+    @patch("plainbox.provider_manager.InlineShellcheckTests", new=MagicMock())
+    def test_get_inline_shellcheck_tests_templates(
+        self, mock_create_inline_shellcheck_test
+    ):
+        mock_self = MagicMock()
+        mock_self.get_provider().unit_list = [
+            self.create_unit("template", command="true"),
+            self.create_unit("file"),
+        ]
+
+        TestCommand.get_inline_shellcheck_tests(mock_self)
+
+        self.assertEqual(mock_create_inline_shellcheck_test.call_count, 1)
+
+    @patch("sys.path", new=MagicMock())
+    @patch("os.path")
+    @patch("plainbox.provider_manager.TextTestRunner")
+    def test_invoked(self, mock_TextTestRunner, mock_path):
+        mock_path.exists.return_value = False
+        # run all tests with default verbosity and k matcher
+        mock_ns = MagicMock(
+            v=False,
+            k="*",
+            inline=False,
+            flake8=False,
+            unittest=False,
+            shellcheck=False,
+        )
+        # tests_dir would make this unittest discover, we don't want to do it
+        mock_self = MagicMock(tests_dir=None)
+        mock_self.get_sh_tests.return_value = (
+            mock_self.get_flake8_tests.return_value
+        ) = mock_self.get_inline_shellcheck_tests.return_value = TestCase
+
+        result = TestCommand.invoked(mock_self, mock_ns)
+
+        test_runner = mock_TextTestRunner()
+        test_runner.run.return_value.wasSuccessful.return_value = True
+        self.assertTrue(test_runner.run.called)
+        self.assertEqual(result, None)
 
 
 class ProviderManagerToolTests(TestCase):
@@ -272,7 +366,7 @@ class ProviderManagerToolTests(TestCase):
         """
         verify that ``sdist`` creates a proper tarball
         """
-        with mock.patch("subprocess.call"):
+        with patch("subprocess.call"):
             self.tool.main(["sdist"])
         tarball = os.path.join(
             self.tmpdir, "dist", "com.example.test-1.0.tar.gz"
@@ -294,7 +388,7 @@ class ProviderManagerToolTests(TestCase):
         even if some files are missing
         """
         shutil.rmtree(os.path.join(self.tmpdir, "jobs"))
-        with mock.patch("subprocess.call"):
+        with patch("subprocess.call"):
             self.tool.main(["sdist"])
         tarball = os.path.join(
             self.tmpdir, "dist", "com.example.test-1.0.tar.gz"
@@ -304,8 +398,8 @@ class ProviderManagerToolTests(TestCase):
         )
         self.assert_common_sdist(tarball)
 
-    @mock.patch("plainbox.impl.providers.v1.get_universal_PROVIDERPATH_entry")
-    @mock.patch("os.getenv")
+    @patch("plainbox.impl.providers.v1.get_universal_PROVIDERPATH_entry")
+    @patch("os.getenv")
     def test_develop(self, mock_getenv, mock_path_entry):
         """
         verify that ``develop`` creates a provider file
@@ -327,9 +421,9 @@ class ProviderManagerToolTests(TestCase):
         self.tool.main(["develop"])
         self.assertFileContent(filename, content)
 
-    @mock.patch("plainbox.impl.providers.v1.get_universal_PROVIDERPATH_entry")
-    @mock.patch("os.getenv")
-    @mock.patch("os.path.samefile")
+    @patch("plainbox.impl.providers.v1.get_universal_PROVIDERPATH_entry")
+    @patch("os.getenv")
+    @patch("os.path.samefile")
     def test_develop_provider_path(
         self, mock_samefile, mock_getenv, mock_path_entry
     ):
@@ -359,8 +453,8 @@ class ProviderManagerToolTests(TestCase):
         self.tool.main(["develop"])
         self.assertFileContent(filename, content)
 
-    @mock.patch("plainbox.impl.providers.v1.get_universal_PROVIDERPATH_entry")
-    @mock.patch("os.getenv")
+    @patch("plainbox.impl.providers.v1.get_universal_PROVIDERPATH_entry")
+    @patch("os.getenv")
     def test_develop__force(self, mock_getenv, mock_path_entry):
         """
         verify that ``develop --force`` overwrites existing .provider
@@ -386,8 +480,8 @@ class ProviderManagerToolTests(TestCase):
         self.tool.main(["develop", "--force"])
         self.assertFileContent(filename, content)
 
-    @mock.patch("plainbox.impl.providers.v1.get_universal_PROVIDERPATH_entry")
-    @mock.patch("os.getenv")
+    @patch("plainbox.impl.providers.v1.get_universal_PROVIDERPATH_entry")
+    @patch("os.getenv")
     def test_develop__uninstall(self, mock_getenv, mock_path_entry):
         """
         verify that ``develop --uninstall`` works

--- a/checkbox-ng/plainbox/test_provider_manager.py
+++ b/checkbox-ng/plainbox/test_provider_manager.py
@@ -162,6 +162,13 @@ class TestCommandTests(TestCase):
 
         self.assertFalse(self_mock.fail.called)
 
+    def test_starwrap(self):
+        self.assertEqual(TestCommand._starwrap("test_a"), "*test_a*")
+        self.assertEqual(TestCommand._starwrap("test_a*"), "*test_a*")
+        self.assertEqual(TestCommand._starwrap("*test_a"), "*test_a*")
+        self.assertEqual(TestCommand._starwrap("*test_a*"), "*test_a*")
+        self.assertEqual(TestCommand._starwrap("*"), "*")
+
 
 class ProviderManagerToolTests(TestCase):
     """


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Executing a subset of tests that manage.py exposes is a recurrent need and, although there are workarounds like setting the pythonpath and using pytest, these are not quite all that we need because they don't work for non-unit tests and, quite frankly, we have a builtin testing feature that would work fine enough.

This PR exposes a feature I would have loved to have, and now I do, the `-k` selector, similar to the one pytest exposes.

This also a `-v` switch that works similarly to pytest, and decreases the default verboseness to the same level as pytest.

Additionally, now the test output is buffered (meaning, the test output will be shown only when the test fails and in the test report, not outside of it), making it way easier to debug a problem and know where they come from. In the same spirit, output of linting tests, like shellcheck and flake8, is now buffered and shown in the test report like the rest of the outputs, instead of being in a random spot in the test log. 

Finally, this refactors the test command slightly, to make it easier to read and test.

## Resolved issues

Fixes: CHECKBOX-1868

## Documentation

N/A

## Tests

Used it interactively
