### PR TITLE
Fix edid test case that can not find edid on A+N platforms (OEX86-680) (bugfix)

### DIFF
--- a/contrib/pc-sanity/bin/edid_continuous_frequency_check.py
+++ b/contrib/pc-sanity/bin/edid_continuous_frequency_check.py
@@ -16,14 +16,23 @@ def is_laptop():
 
 
 def find_internal_panel_edid():
-    """Find internal panel edid"""
-    drmdir = "/sys/class/drm/"
-    for i in "card0-eDP-1", "card1-eDP-1", "card0-LVDS-1", "card1-LVDS-1":
-        for edid_file_path in glob.glob(drmdir + i):
-            edid_file = edid_file_path + "/edid"
-            if os.path.isfile(edid_file):
-                print(edid_file)
-                return edid_file
+    root_dir = "/sys/class/drm"
+    max_depth = 1
+    lcd_interface_list = ["eDP-1", "LVDS-1"]
+    root_depth = root_dir.rstrip(os.path.sep).count(os.path.sep)
+    for dirpath, dirnames, filenames in os.walk(root_dir, followlinks=True):
+        current_depth = (
+            dirpath.rstrip(os.path.sep).count(os.path.sep) - root_depth
+        )
+        if current_depth >= max_depth:
+            dirnames[:] = []
+        if (
+            any(interface in dirpath for interface in lcd_interface_list)
+            and "edid" in filenames
+        ):
+            edid_file = f"{dirpath}/edid"
+            print(edid_file)
+            return edid_file
     raise SystemExit("Can not find edid from sysfs !")
 
 
@@ -129,7 +138,7 @@ def main():
                         read_edid(fobj, 0x36, 18)
                     ),
                 ):  # noqa: E501
-                    print("EDID Display Range Limits Descriptor checke: pass")
+                    print("EDID Display Range Limits Descriptor check: pass")
                 else:
                     raise SystemExit(
                         "EDID Display Range Limits Descriptor check failed!"


### PR DESCRIPTION
edid_continuous_frequency_check.py:
  * Change the way to find the internal panel edid

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
For the new A+N platform the first graphic card begins from card1 instead card0 (first graphic card is card1 and second graphic card is card2). 
The fix is to find edid file by searching the postfix string of the directory name instead of enumerating the directories.
## Resolved issues
https://warthogs.atlassian.net/browse/OEX86-680
https://warthogs.atlassian.net/browse/SOMERVILLE-2077

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
None
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
Test output on GRD6-EVT-C4	(202504-36595)
$ ./edid_continuous_frequency_check.py
/sys/class/drm/card2-eDP-1/edid
0xFD is an optional field in EDID 1.4
https://glenwing.github.io/docs/VESA-EEDID-A2.pdf page 38
EDID Display Range Limits Descriptor check: pass

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->