### PR TITLE
Add IoT image url check in collector (New)

### DIFF
--- a/checkbox-ng/plainbox/vendor/image_info.py
+++ b/checkbox-ng/plainbox/vendor/image_info.py
@@ -149,9 +149,9 @@ def dcd_string_to_info_iot(dcd_string):
     }
 
     image_name = f"{project_name}-{series}-{build_id}.tar.xz"
-    info["url"] = (
-        f"{BASE_URL}/{project_name}/share/{series}/{build_id}/{image_name}"
-    )
+    info[
+        "url"
+    ] = f"{BASE_URL}/{project_name}/share/{series}/{build_id}/{image_name}"
 
     return info
 
@@ -159,7 +159,7 @@ def dcd_string_to_info_iot(dcd_string):
 def dcd_info():
     try:
         if DCD_FILE_IOT.is_file():
-            with DCD_FILE_IOT.open("r", encoding="utf-8") as f:
+            with open(str(DCD_FILE_IOT), "r", encoding="utf-8") as f:
                 dcd_string = f.read().strip()
             print("Found IoT dcd string: {}".format(dcd_string), file=sys.stderr)
             return dcd_string_to_info_iot(dcd_string)

--- a/checkbox-ng/plainbox/vendor/image_info.py
+++ b/checkbox-ng/plainbox/vendor/image_info.py
@@ -3,8 +3,11 @@ import sys
 import json
 import argparse
 import subprocess
+import re
+from pathlib import Path
 
 BASE_URL = "https://oem-share.canonical.com/partners"
+DCD_FILE_IOT = Path("/run/mnt/ubuntu-seed/.disk/info")
 VERSION = 1
 
 
@@ -38,7 +41,7 @@ def parse_ubuntu_report():
 def dcd_string_to_info(dcd_string):
     """
     Creates a dict with all available information that can be extracted from
-    the dcd string, at the very least:
+    the PC's dcd string, at the very least:
     - project
     - series
     - kernel type
@@ -117,7 +120,48 @@ def dcd_string_to_info(dcd_string):
     return info
 
 
+def dcd_string_to_info_iot(dcd_string):
+    """
+    Convert IoT's dcd string to a URL based on specified rules.
+
+    # Regex pattern:
+    ^canonical-oem- : Must start with "canonical-oem-"
+    ([a-zA-Z0-9]+) : Project name (alphanumeric, mandatory)
+    :([a-zA-Z0-9-]+) : Series (alphanumeric and dash, mandatory)
+    :([0-9.-]+) : Build ID (numbers, dot, dash, mandatory)
+    (:(.*))? : Additional info (anything, optional) - currently unused
+    """
+    pattern = (
+        r"^canonical-oem-([a-zA-Z0-9]+):([a-zA-Z0-9-]+):([0-9.-]+)(:(.*))?$"
+    )
+
+    match = re.match(pattern, dcd_string)
+    if not match:
+        raise ValueError(f"Invalid DCD format: {dcd_string}")
+
+    project_name, series, build_id, _, additional_info = match.groups()
+
+    info = {
+        "base_url": BASE_URL,
+        "project": project_name,
+        "series": series,
+        "build_id": build_id,
+    }
+
+    image_name = f"{project_name}-{series}-{build_id}.tar.xz"
+    info["url"] = (
+        f"{BASE_URL}/{project_name}/share/{series}/{build_id}/{image_name}"
+    )
+
+    return info
+
+
 def dcd_info():
+    if DCD_FILE_IOT.is_file():
+        dcd_string = DCD_FILE_IOT.read_text().strip()
+        print(f"Found IoT dcd string: {dcd_string}", file=sys.stderr)
+        return dcd_string_to_info_iot(dcd_string)
+
     ubuntu_report = parse_ubuntu_report()
     print(
         "Parsed report: {}".format(json.dumps(ubuntu_report)), file=sys.stderr

--- a/checkbox-ng/plainbox/vendor/image_info.py
+++ b/checkbox-ng/plainbox/vendor/image_info.py
@@ -163,14 +163,13 @@ def dcd_string_to_info_iot(dcd_string):
 
 def dcd_info():
     try:
-        if DCD_FILE_IOT.is_file():
-            with open(str(DCD_FILE_IOT), "r", encoding="utf-8") as f:
-                dcd_string = f.read().strip()
-            print(
-                "Found IoT dcd string: {}".format(dcd_string), file=sys.stderr
-            )
-            return dcd_string_to_info_iot(dcd_string)
-    except (IOError, OSError):
+        with DCD_FILE_IOT.open("r", encoding="utf-8") as f:
+            dcd_string = f.read().strip()
+        print(
+            "Found IoT dcd string: {}".format(dcd_string), file=sys.stderr
+        )
+        return dcd_string_to_info_iot(dcd_string)
+    except (IOError, OSError, FileNotFoundError):
         print("IoT dcd file not found. Assuming PC platform", file=sys.stderr)
 
     ubuntu_report = parse_ubuntu_report()

--- a/checkbox-ng/plainbox/vendor/image_info.py
+++ b/checkbox-ng/plainbox/vendor/image_info.py
@@ -163,13 +163,14 @@ def dcd_string_to_info_iot(dcd_string):
 
 def dcd_info():
     try:
-        with DCD_FILE_IOT.open("r", encoding="utf-8") as f:
-            dcd_string = f.read().strip()
-        print(
-            "Found IoT dcd string: {}".format(dcd_string), file=sys.stderr
-        )
-        return dcd_string_to_info_iot(dcd_string)
-    except (IOError, OSError, FileNotFoundError):
+        if DCD_FILE_IOT.is_file():
+            with open(str(DCD_FILE_IOT), "r", encoding="utf-8") as f:
+                dcd_string = f.read().strip()
+            print(
+                "Found IoT dcd string: {}".format(dcd_string), file=sys.stderr
+            )
+            return dcd_string_to_info_iot(dcd_string)
+    except (IOError, OSError):
         print("IoT dcd file not found. Assuming PC platform", file=sys.stderr)
 
     ubuntu_report = parse_ubuntu_report()

--- a/checkbox-ng/plainbox/vendor/image_info.py
+++ b/checkbox-ng/plainbox/vendor/image_info.py
@@ -157,10 +157,14 @@ def dcd_string_to_info_iot(dcd_string):
 
 
 def dcd_info():
-    if DCD_FILE_IOT.is_file():
-        dcd_string = DCD_FILE_IOT.read_text().strip()
-        print(f"Found IoT dcd string: {dcd_string}", file=sys.stderr)
-        return dcd_string_to_info_iot(dcd_string)
+    try:
+        if DCD_FILE_IOT.is_file():
+            with DCD_FILE_IOT.open("r", encoding="utf-8") as f:
+                dcd_string = f.read().strip()
+            print("Found IoT dcd string: {}".format(dcd_string), file=sys.stderr)
+            return dcd_string_to_info_iot(dcd_string)
+    except (IOError, OSError):
+        print("IoT dcd file not found. Assuming PC platform", file=sys.stderr)
 
     ubuntu_report = parse_ubuntu_report()
     print(

--- a/checkbox-ng/plainbox/vendor/image_info.py
+++ b/checkbox-ng/plainbox/vendor/image_info.py
@@ -137,7 +137,7 @@ def dcd_string_to_info_iot(dcd_string):
 
     match = re.match(pattern, dcd_string)
     if not match:
-        raise ValueError(f"Invalid DCD format: {dcd_string}")
+        raise ValueError("Invalid DCD format: {}".format(dcd_string))
 
     project_name, series, build_id, _, additional_info = match.groups()
 
@@ -147,11 +147,16 @@ def dcd_string_to_info_iot(dcd_string):
         "series": series,
         "build_id": build_id,
     }
-
-    image_name = f"{project_name}-{series}-{build_id}.tar.xz"
-    info[
-        "url"
-    ] = f"{BASE_URL}/{project_name}/share/{series}/{build_id}/{image_name}"
+    image_name = "{}-{}-{}.tar.xz".format(project_name, series, build_id)
+    info["url"] = (
+        "{base_url}/{project}/share/{series}/{build_id}/{image_name}"
+    ).format(
+        base_url=BASE_URL,
+        project=project_name,
+        series=series,
+        build_id=build_id,
+        image_name=image_name,
+    )
 
     return info
 
@@ -161,7 +166,9 @@ def dcd_info():
         if DCD_FILE_IOT.is_file():
             with open(str(DCD_FILE_IOT), "r", encoding="utf-8") as f:
                 dcd_string = f.read().strip()
-            print("Found IoT dcd string: {}".format(dcd_string), file=sys.stderr)
+            print(
+                "Found IoT dcd string: {}".format(dcd_string), file=sys.stderr
+            )
             return dcd_string_to_info_iot(dcd_string)
     except (IOError, OSError):
         print("IoT dcd file not found. Assuming PC platform", file=sys.stderr)

--- a/checkbox-ng/plainbox/vendor/test_image_info.py
+++ b/checkbox-ng/plainbox/vendor/test_image_info.py
@@ -185,11 +185,12 @@ class TestDCDStringToInfoIoT(TestCase):
 
 
 class TestDCDStringE2EIoT(TestCase):
+    @patch("builtins.open")
     @patch("pathlib.Path.is_file")
-    @patch("pathlib.Path.read_text")
-    def test_dcd_info_iot_path_all_fields(self, mock_read_text, mock_is_file):
+    def test_dcd_info_iot_path_all_fields(self, mock_is_file, mock_open):
         mock_is_file.return_value = True
-        mock_read_text.return_value = (
+        mock_file = mock_open.return_value.__enter__.return_value
+        mock_file.read.return_value = (
             "canonical-oem-carlsbad:element-v2-uc24:20241205.15:v2-uc24-x01"
         )
 
@@ -203,13 +204,14 @@ class TestDCDStringE2EIoT(TestCase):
             "https://oem-share.canonical.com/partners/carlsbad/share/element-v2-uc24/20241205.15/carlsbad-element-v2-uc24-20241205.15.tar.xz",
         )
 
+    @patch("builtins.open")
     @patch("pathlib.Path.is_file")
-    @patch("pathlib.Path.read_text")
     def test_dcd_info_iot_path_no_additional_info(
-        self, mock_read_text, mock_is_file
+        self, mock_is_file, mock_open
     ):
         mock_is_file.return_value = True
-        mock_read_text.return_value = (
+        mock_file = mock_open.return_value.__enter__.return_value
+        mock_file.read.return_value = (
             "canonical-oem-shiner:x8high35-som-pdk:20250507-1170:"
         )
 
@@ -243,7 +245,3 @@ class TestDCDStringE2EIoT(TestCase):
         # Since iot dcd file is missing, this must be pc platform
         self.assertEqual(info["project"], "pinktiger")
         self.assertEqual(info["series"], "noble")
-        self.assertEqual(
-            info["url"],
-            "https://oem-share.canonical.com/partners/pinktiger/share/releases/noble/oem-24.04a/20240823-74/",
-        )

--- a/checkbox-ng/plainbox/vendor/test_image_info.py
+++ b/checkbox-ng/plainbox/vendor/test_image_info.py
@@ -126,3 +126,124 @@ class TestDCDStringE2E(TestCase):
         }"""
         with self.assertRaises(SystemExit):
             image_info.main([])
+
+
+class TestDCDStringToInfoIoT(TestCase):
+    def test_valid_dcd_with_all_fields(self):
+        example = (
+            "canonical-oem-carlsbad:element-v2-uc24:20241205.15:v2-uc24-x01"
+        )
+        info = image_info.dcd_string_to_info_iot(example)
+
+        self.assertEqual(info["project"], "carlsbad")
+        self.assertEqual(info["series"], "element-v2-uc24")
+        self.assertEqual(info["build_id"], "20241205.15")
+        self.assertEqual(
+            info["url"],
+            "https://oem-share.canonical.com/partners/carlsbad/share/element-v2-uc24/20241205.15/carlsbad-element-v2-uc24-20241205.15.tar.xz",
+        )
+
+    def test_valid_dcd_no_additional_info(self):
+        example = "canonical-oem-shiner:x8high35-som-pdk:20250507-1170:"
+        info = image_info.dcd_string_to_info_iot(example)
+
+        self.assertEqual(info["project"], "shiner")
+        self.assertEqual(info["series"], "x8high35-som-pdk")
+        self.assertEqual(info["build_id"], "20250507-1170")
+        self.assertEqual(
+            info["url"],
+            "https://oem-share.canonical.com/partners/shiner/share/x8high35-som-pdk/20250507-1170/shiner-x8high35-som-pdk-20250507-1170.tar.xz",
+        )
+
+    def test_invalid_dcd_formats(self):
+        invalid_examples = [
+            # Missing canonical-oem- prefix
+            "projectalpha:series:20241210:",
+            # Missing project name
+            "canonical-oem-:series:20241210:",
+            # Missing series
+            "canonical-oem-project::",
+            # Missing build ID
+            "canonical-oem-project:series::",
+            # Invalid project name (special chars)
+            "canonical-oem-project@123:series:20241210:",
+            # Invalid series (special chars)
+            "canonical-oem-project:series@123:20241210:",
+            # Invalid build ID (letters)
+            "canonical-oem-project:series:abc123:",
+            # Empty string
+            "",
+            # Wrong format
+            "canonical-oem-test-stub-dcd",
+        ]
+
+        for example in invalid_examples:
+            with self.assertRaises(
+                ValueError, msg=f"Should fail for: {example}"
+            ):
+                image_info.dcd_string_to_info_iot(example)
+
+
+class TestDCDStringE2EIoT(TestCase):
+    @patch("pathlib.Path.is_file")
+    @patch("pathlib.Path.read_text")
+    def test_dcd_info_iot_path_all_fields(self, mock_read_text, mock_is_file):
+        mock_is_file.return_value = True
+        mock_read_text.return_value = (
+            "canonical-oem-carlsbad:element-v2-uc24:20241205.15:v2-uc24-x01"
+        )
+
+        info = image_info.dcd_info()
+
+        self.assertEqual(info["project"], "carlsbad")
+        self.assertEqual(info["series"], "element-v2-uc24")
+        self.assertEqual(info["build_id"], "20241205.15")
+        self.assertEqual(
+            info["url"],
+            "https://oem-share.canonical.com/partners/carlsbad/share/element-v2-uc24/20241205.15/carlsbad-element-v2-uc24-20241205.15.tar.xz",
+        )
+
+    @patch("pathlib.Path.is_file")
+    @patch("pathlib.Path.read_text")
+    def test_dcd_info_iot_path_no_additional_info(
+        self, mock_read_text, mock_is_file
+    ):
+        mock_is_file.return_value = True
+        mock_read_text.return_value = (
+            "canonical-oem-shiner:x8high35-som-pdk:20250507-1170:"
+        )
+
+        info = image_info.dcd_info()
+
+        self.assertEqual(info["project"], "shiner")
+        self.assertEqual(info["series"], "x8high35-som-pdk")
+        self.assertEqual(info["build_id"], "20250507-1170")
+        self.assertEqual(
+            info["url"],
+            "https://oem-share.canonical.com/partners/shiner/share/x8high35-som-pdk/20250507-1170/shiner-x8high35-som-pdk-20250507-1170.tar.xz",
+        )
+
+    @patch("pathlib.Path.is_file")
+    @patch("subprocess.check_output")
+    def test_dcd_info_iot_path_not_exists(
+        self, mock_check_output, mock_is_file
+    ):
+        mock_is_file.return_value = False
+        mock_check_output.return_value = """{
+          "Version": "24.04",
+          "OEM": {
+            "Vendor": "Some Inc.",
+            "Product": "13312",
+            "Family": "NOFAMILY",
+            "DCD": "canonical-oem-pinktiger-noble-oem-24.04a-20240823-74"
+          }
+        }"""
+
+        info = image_info.dcd_info()
+        # Since iot dcd file is missing, this must be pc platform
+        self.assertEqual(info["project"], "pinktiger")
+        self.assertEqual(info["series"], "noble")
+        self.assertEqual(
+            info["url"],
+            "https://oem-share.canonical.com/partners/pinktiger/share/releases/noble/oem-24.04a/20240823-74/",
+        )

--- a/checkbox-ng/plainbox/vendor/test_image_info.py
+++ b/checkbox-ng/plainbox/vendor/test_image_info.py
@@ -179,7 +179,7 @@ class TestDCDStringToInfoIoT(TestCase):
 
         for example in invalid_examples:
             with self.assertRaises(
-                ValueError, msg=f"Should fail for: {example}"
+                ValueError, msg="Should fail for: {}".format(example)
             ):
                 image_info.dcd_string_to_info_iot(example)
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
~~Adds a test case to get URL of the image installed on IoT device~~
PC and IOT devices have different DCD strings formats, thus existing PC parser does not support url generation for IoT devices.
This change will add a check in collector to parse the dcd file for IoT devices first. When this file is missing, we assume that platform is PC and use the PC parser instead.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
Closes https://warthogs.atlassian.net/browse/OEX86-682
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
Added unittest for IoT dcd format and url

```
$ python3 -m unittest plainbox/vendor/test_image_info.py  -v
test_fail_no_dcd_output (plainbox.vendor.test_image_info.TestDCDStringE2E) ... Parsed report: {"Version": "24.04", "BIOS": {"Vendor": "Some Inc.", "Version": "0.1.20"}, "Arch": "amd64", "HwCap": "x86-64-v3", "GPU": [{"Vendor": "0000", "Model": "0000"}], "RAM": 16, "Partitions": [477.7, 1.1], "Autologin": true, "LivePatch": false, "Session": {"DE": "", "Name": "", "Type": "tty"}, "Language": "en_US", "Timezone": "Etc/UTC", "Install": {"Type": "Flutter", "OEM": false, "Media": "Ubuntu OEM 24.04.1 LTS", "Stages": {"20": "loading", "218": "done"}}}
ok
test_ok_output (plainbox.vendor.test_image_info.TestDCDStringE2E) ... Parsed report: {"Version": "24.04", "OEM": {"Vendor": "Some Inc.", "Product": "13312", "Family": "NOFAMILY", "DCD": "canonical-oem-pinktiger-noble-oem-24.04a-20240823-74"}, "BIOS": {"Vendor": "Some Inc.", "Version": "0.1.20"}, "Arch": "amd64", "HwCap": "x86-64-v3", "GPU": [{"Vendor": "0000", "Model": "0000"}], "RAM": 16, "Partitions": [477.7, 1.1], "Autologin": true, "LivePatch": false, "Session": {"DE": "", "Name": "", "Type": "tty"}, "Language": "en_US", "Timezone": "Etc/UTC", "Install": {"Type": "Flutter", "OEM": false, "Media": "Ubuntu OEM 24.04.1 LTS", "Stages": {"20": "loading", "218": "done"}}}
ok
test_dcd_info_iot_path_all_fields (plainbox.vendor.test_image_info.TestDCDStringE2EIoT) ... Found IoT dcd string: canonical-oem-carlsbad:element-v2-uc24:20241205.15:v2-uc24-x01
ok
test_dcd_info_iot_path_no_additional_info (plainbox.vendor.test_image_info.TestDCDStringE2EIoT) ... Found IoT dcd string: canonical-oem-shiner:x8high35-som-pdk:20250507-1170:
ok
test_dcd_info_iot_path_not_exists (plainbox.vendor.test_image_info.TestDCDStringE2EIoT) ... Parsed report: {"Version": "24.04", "OEM": {"Vendor": "Some Inc.", "Product": "13312", "Family": "NOFAMILY", "DCD": "canonical-oem-pinktiger-noble-oem-24.04a-20240823-74"}}
ok
test_len_5 (plainbox.vendor.test_image_info.TestDCDStringToInfo) ... ok
test_len_6 (plainbox.vendor.test_image_info.TestDCDStringToInfo) ... ok
test_len_7 (plainbox.vendor.test_image_info.TestDCDStringToInfo) ... ok
test_len_wrong (plainbox.vendor.test_image_info.TestDCDStringToInfo) ... ok
test_invalid_dcd_formats (plainbox.vendor.test_image_info.TestDCDStringToInfoIoT) ... ok
test_valid_dcd_no_additional_info (plainbox.vendor.test_image_info.TestDCDStringToInfoIoT) ... ok
test_valid_dcd_with_all_fields (plainbox.vendor.test_image_info.TestDCDStringToInfoIoT) ... ok

----------------------------------------------------------------------
Ran 12 tests in 0.034s

OK
```

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
