### PR TITLE
revised serial test function call for rpmsg-tty test (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpmsg_tests.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rpmsg_tests.py
@@ -336,10 +336,9 @@ def serial_tty_test(cpu_type, data_size):
     path_obj = Path("/dev")
     rpmsg_devs = check_rpmsg_tty_devices(path_obj, check_pattern, probe_cmd)
     if rpmsg_devs:
-        serial_dev = serial_test.Serial(
+        serial_test.client_mode(
             str(rpmsg_devs[0]), "rpmsg-tty", [], 115200, 8, "N", 1, 3, 1024
         )
-        serial_test.client_mode(serial_dev, data_size)
     else:
         raise SystemExit("No RPMSG TTY devices found.")
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_rpmsg_tests.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_rpmsg_tests.py
@@ -143,26 +143,22 @@ class TestRpmsgPingPong(unittest.TestCase):
 class TestRpmsgSerialTty(unittest.TestCase):
 
     @patch("serial_test.client_mode")
-    @patch("serial_test.Serial")
     @patch("rpmsg_tests.check_rpmsg_tty_devices")
     def test_no_rpmsg_devices(
-        self, mock_check_rpmsg_tty_devices, mock_serial, mock_client_mode
+        self, mock_check_rpmsg_tty_devices, mock_client_mode
     ):
         """
         No RPMSG TTY devices found and raise SystemExit
         """
-        mock_serial.return_value = []
         mock_check_rpmsg_tty_devices.return_value = []
         with self.assertRaisesRegex(SystemExit, "No RPMSG TTY devices found."):
             rpmsg_tests.serial_tty_test("imx", 64)
-            mock_serial.assert_not_called()
             mock_client_mode.assert_not_called()
 
     @patch("serial_test.client_mode")
-    @patch("serial_test.Serial")
     @patch("rpmsg_tests.check_rpmsg_tty_devices")
     def test_rpmsg_tty_test_passed(
-        self, mock_check_rpmsg_tty_devices, mock_serial, mock_client_mode
+        self, mock_check_rpmsg_tty_devices, mock_client_mode
     ):
         """
         String-ECHO test passed through RPMSG TTY device
@@ -170,13 +166,11 @@ class TestRpmsgSerialTty(unittest.TestCase):
         serial_dev = "serial-dev"
         tty_device = "/dev/ttyRPMSG30"
         mock_check_rpmsg_tty_devices.return_value = [tty_device]
-        mock_serial.return_value = serial_dev
 
         rpmsg_tests.serial_tty_test("imx", 64)
-        mock_serial.assert_called_with(
+        mock_client_mode.assert_called_with(
             tty_device, "rpmsg-tty", [], 115200, 8, "N", 1, 3, 1024
         )
-        mock_client_mode.assert_called_with(serial_dev, 64)
 
     @patch("rpmsg_tests.serial_tty_test")
     @patch("rpmsg_tests.pingpong_test")


### PR DESCRIPTION


<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
the `client_mode` method in the `serial_test.py` has been updated, so we need to revised `serial test` function in rpmsg-serial-tty test as well
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
appllied this fixed into the python script directly and tested it on real platform.
```
iotuc@ubuntu:~$ sudo checkbox-ce-oem.shell 
checkbox-ce-oem runtime shell, type 'exit' to quit the session
root@ubuntu:/home/iotuc# python3 rpmsg_tests.py --type serial-tty
2025-04-17 01:19:22 INFO     SoC family is Freescale i.MX
2025-04-17 01:19:22 INFO     SoC machine is Honeywell i.MX8MM X8Med35 PDK
2025-04-17 01:19:22 INFO     SoC family is Freescale i.MX, machine is Honeywell i.MX8MM X8Med35 PDK
2025-04-17 01:19:22 INFO     # Start string-echo test for RPMSG TTY device
2025-04-17 01:19:25 INFO     Sent: 4EB}TOyduQ-Iw2myj|/7+&$N32~*5kI(:@0^uV.(1|.o82yK\+Ra$Bnj[^1c%v/hN]QVl)mC}ec5^/^.MG*x-Ax_h[+c*(.CLO_8D4uySsG3}\^t=hD"NGtuq+jn8PzS]Jh!})j=BCu}jx@xP,f5~K\86k3wjZJU!Zj[:E!3wG\ZPN/Z;xp&|i92ZDWeWYUOwa<[F|vl#iZ)fv@EE>I)`kiaZ.p`m&xkcVE?uCef'jwv,}oE:Lcyr**bhl&eNnZC&(_~yZ?Y\[&TZcf-%mcDh@(~k'C|Wa64rZA[%69^!d1:0;I@TbFA.a,Ui'MdPsyf"<Vf]HzqoXkr?&G*%St?:t#Lc=k}",6w5SOeCn|K2?g$QWDdBoxVaU]r(@hAFNu>MQKy+-T`vZX/7~Scb%&TcS6(~>MGTc*HLK/6W3oaJsl&T/E&AQ^|Z/eg#x5zJ^>(v%d"ng#Pm-+ttj2uHFUAo`rW`s"f;CK7Fc~{_p*PtRwatk[/"?HMY-^6OZ!I".@l$60AIF)a.BSX*f4R??)`cg#CF[~5lGum\3&A`:};VcS=I40K%Pi5U=.h`oE0y${ctOJPDGeHN-nf=7=r1wq*_1:J{Xn]lK&tvmrTls$esVst*`5x7pMKi+~'q`p+rYhWyTsXI!v=(JXfh0k!>7KLO9XI=6+khrPXy.56L$7BAH+<A?V}X@@Y47~RBb}7&2=Yj^@p0|S}BR[Gb'@hNU[/^du+rxfxqzli=^|NRW>4,(ho_LgD'aRSaP8i6~]6"]g{O^vLlVtB-QHD+if2$)yqJ(lv)Db4d~C_`d9]NbS7p+eL8<LGa<W;`i&\*w"&\f-mYRUp!;\;6HT%4r\=LtQ{]5k'~,i|OK8u(^,5#<cA9>h3+zieTIF4h(gp<LtFrJ'TK#ILs2T4hI3vr\(zl3Eqnqq$x}P`.p*MO)9hNIF[(,~I{1r%Pe~AnzZ'UE2j<<+<A]|BfVZFRd<k/_ugDfvz`y<`Zl"V.jS}m@h={!.A'5_WG2KP9$&3)$4t'J5LO{"&
2025-04-17 01:19:25 INFO     Attempting receive string... 1 time
2025-04-17 01:19:25 INFO     Received: 4EB}TOyduQ-Iw2myj|/7+&$N32~*5kI(:@0^uV.(1|.o82yK\+Ra$Bnj[^1c%v/hN]QVl)mC}ec5^/^.MG*x-Ax_h[+c*(.CLO_8D4uySsG3}\^t=hD"NGtuq+jn8PzS]Jh!})j=BCu}jx@xP,f5~K\86k3wjZJU!Zj[:E!3wG\ZPN/Z;xp&|i92ZDWeWYUOwa<[F|vl#iZ)fv@EE>I)`kiaZ.p`m&xkcVE?uCef'jwv,}oE:Lcyr**bhl&eNnZC&(_~yZ?Y\[&TZcf-%mcDh@(~k'C|Wa64rZA[%69^!d1:0;I@TbFA.a,Ui'MdPsyf"<Vf]HzqoXkr?&G*%St?:t#Lc=k}",6w5SOeCn|K2?g$QWDdBoxVaU]r(@hAFNu>MQKy+-T`vZX/7~Scb%&TcS6(~>MGTc*HLK/6W3oaJsl&T/E&AQ^|Z/eg#x5zJ^>(v%d"ng#Pm-+ttj2uHFUAo`rW`s"f;CK7Fc~{_p*PtRwatk[/"?HMY-^6OZ!I".@l$60AIF)a.BSX*f4R??)`cg#CF[~5lGum\3&A`:};VcS=I40K%Pi5U=.h`oE0y${ctOJPDGeHN-nf=7=r1wq*_1:J{Xn]lK&tvmrTls$esVst*`5x7pMKi+~'q`p+rYhWyTsXI!v=(JXfh0k!>7KLO9XI=6+khrPXy.56L$7BAH+<A?V}X@@Y47~RBb}7&2=Yj^@p0|S}BR[Gb'@hNU[/^du+rxfxqzli=^|NRW>4,(ho_LgD'aRSaP8i6~]6"]g{O^vLlVtB-QHD+if2$)yqJ(lv)Db4d~C_`d9]NbS7p+eL8<LGa<W;`i&\*w"&\f-mYRUp!;\;6HT%4r\=LtQ{]5k'~,i|OK8u(^,5#<cA9>h3+zieTIF4h(gp<LtFrJ'TK#ILs2T4hI3vr\(zl3Eqnqq$x}P`.p*MO)9hNIF[(,~I{1r%Pe~AnzZ'UE2j<<+<A]|BfVZFRd<k/_ugDfvz`y<`Zl"V.jS}m@h={!.A'5_WG2KP9$&3)$4t'J5LO{"&
2025-04-17 01:19:28 INFO     [PASS] Received string is correct!
root@ubuntu:/home/iotuc# exit
exit

```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
