### PR TITLE
Add tests based on nvidia-container-toolkit (New)

### DIFF
--- a/providers/certification-client/units/client-cert-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-24-04.pxu
@@ -94,6 +94,7 @@ nested_part:
     monitor-gpu-cert-automated
     graphics-gpu-cert-automated
     cpu-cert-automated
+    gpgpu-nvidia-cert-automated
     input-cert-automated
     disk-cert-automated
     misc-client-cert-automated

--- a/providers/gpgpu/units/category.pxu
+++ b/providers/gpgpu/units/category.pxu
@@ -1,3 +1,7 @@
 unit: category
 id: gpgpu
 _name: GPGPU Compute Tests
+
+unit: category
+id: nvgpgpu
+_name: GPGPU Compute Tests (NVIDIA)

--- a/providers/gpgpu/units/cuda.pxu
+++ b/providers/gpgpu/units/cuda.pxu
@@ -1,5 +1,6 @@
 id: gpgpu/cuda-samples-0-int
-category_id: gpgpu
+imports: from com.canonical.plainbox import manifest
+category_id: nvgpgpu
 environ:
     CUDA_SAMPLES_VERSION
     CUDA_IGNORE_TESTS
@@ -8,7 +9,7 @@ environ:
 plugin: shell
 estimated_duration: 4
 requires:
-    graphics_card.vendor == 'NVIDIA Corporation'
+    manifest.has_nvidia_gpu == 'True'
 _summary: NVIDIA CUDA 0 - introduction
 command: run_cuda_sample_set.py introduction
 _siblings: [
@@ -37,6 +38,31 @@ _siblings: [
     "_summary": "NVIDIA CUDA 8 - platform specific",
     "command": "run_cuda_sample_set.py platform"}
     ]
+
+id: gpgpu/nv-container-smi
+_summary: NVIDIA container toolkit
+category_id: nvgpgpu
+plugin: shell
+estimated_duration: 5
+imports: from com.canonical.plainbox import manifest
+requires:
+    executable.name == 'docker'
+    executable.name == 'nvidia-ctk'
+    manifest.has_nvidia_gpu == 'True'
+command:
+    sudo docker run --gpus all ubuntu:24.04 nvidia-smi
+
+id: gpgpu/nvidia-detect
+_summary: Check that the nvidia graphic card is detected
+category_id: nvgpgpu
+plugin: shell
+estimated_duration: 1
+imports: from com.canonical.plainbox import manifest
+requires:
+    manifest.has_nvidia_gpu == 'True'
+command:
+    echo "Searching for a graphics card in graphics_card_resource with vendor: NVIDIA Corporation"
+    graphics_card_resource.py | grep -o "vendor: NVIDIA Corporation"
 
 unit: packaging meta-data
 os-id: debian

--- a/providers/gpgpu/units/manifest.pxu
+++ b/providers/gpgpu/units/manifest.pxu
@@ -1,0 +1,4 @@
+unit: manifest entry
+id: has_nvidia_gpu
+_name: a NVIDIA GPU
+value-type: bool

--- a/providers/gpgpu/units/test-plan.pxu
+++ b/providers/gpgpu/units/test-plan.pxu
@@ -46,22 +46,22 @@ bootstrap_include:
     package
     snap
 
-id: gpgpu-cuda-features
+id: gpgpu-nvidia-cert-automated
 unit: test plan
-_name: NVIDIA CUDA Feature testing
-_description: Feature testing for various CUDA versions
+_name: NVIDIA Feature testing
+_description: Feature testing for various NVIDIA-specific features
 include:
-    gpgpu/cuda-samples-0-int        certification-status=non-blocker
-    gpgpu/cuda-samples-1-utils      certification-status=non-blocker
-    gpgpu/cuda-samples-2-conc       certification-status=non-blocker
-    gpgpu/cuda-samples-3-feat       certification-status=non-blocker
-    gpgpu/cuda-samples-4-libs       certification-status=non-blocker
-    gpgpu/cuda-samples-5-dom        certification-status=non-blocker
-    gpgpu/cuda-samples-6-perf       certification-status=non-blocker
-    gpgpu/cuda-samples-7-nvvm       certification-status=non-blocker
-    gpgpu/cuda-samples-8-plat       certification-status=non-blocker
+    gpgpu/nvidia-detect
+    gpgpu/nv-container-smi
+    gpgpu/cuda-samples-0-int
+    gpgpu/cuda-samples-1-utils
+    gpgpu/cuda-samples-2-conc
+    gpgpu/cuda-samples-3-feat
+    gpgpu/cuda-samples-4-libs
+    gpgpu/cuda-samples-5-dom 
+    gpgpu/cuda-samples-6-perf
+    gpgpu/cuda-samples-7-nvvm
+    gpgpu/cuda-samples-8-plat
 bootstrap_include:
-    graphics_card
     executable
-    package
-    snap
+    graphics_card


### PR DESCRIPTION
## Description

Implement new nvidia-specific tests.
This first test of this category runs nvidia-smi within a container, to verify that the nvidia-container-toolkit is correctly setup and that the GPU passthrough works as expected.

A passed test: https://certification.canonical.com/hardware/202502-36337/submission/424289/
