### PR TITLE
Implement textual fallback parser if json fails to read (bugfix)

### DIFF
--- a/providers/base/bin/check_iwlwifi_microcode_errors.py
+++ b/providers/base/bin/check_iwlwifi_microcode_errors.py
@@ -26,6 +26,7 @@ def get_boot_ids():
         boots = json.loads(boots_txt)
     except json.decoder.JSONDecodeError:
         # some ancient versions of journalctl ignore the --output flag
+        # See: https://github.com/canonical/checkbox/issues/1875
         boots = text_fallback_boots_parser(boots_txt)
     boot_ids = [boot["boot_id"] for boot in boots]
     return boot_ids

--- a/providers/base/bin/check_iwlwifi_microcode_errors.py
+++ b/providers/base/bin/check_iwlwifi_microcode_errors.py
@@ -1,12 +1,32 @@
 #!/usr/bin/env python3
 
 import json
+import itertools
 import subprocess
+
+
+def text_fallback_boots_parser(boots_txt):
+    boots_lines = boots_txt.splitlines()
+    boots_lines_items = map(str.split, boots_lines)
+    # for malformed lines with just one item, lets set the boot id to none
+    boots_lines_items = (
+        itertools.chain(x, [None, None]) for x in boots_lines_items
+    )
+    return [
+        {"boot_id": boot_id}
+        for (boot_number, boot_id, *_) in boots_lines_items
+        if boot_id
+    ]
 
 
 def get_boot_ids():
     cmd = ["journalctl", "--list-boots", "--output", "json"]
-    boots = json.loads(subprocess.check_output(cmd, universal_newlines=True))
+    boots_txt = subprocess.check_output(cmd, universal_newlines=True)
+    try:
+        boots = json.loads(boots_txt)
+    except json.decoder.JSONDecodeError:
+        # some ancient versions of journalctl ignore the --output flag
+        boots = text_fallback_boots_parser(boots_txt)
     boot_ids = [boot["boot_id"] for boot in boots]
     return boot_ids
 

--- a/providers/base/tests/test_check_iwlwifi_microcode_errors.py
+++ b/providers/base/tests/test_check_iwlwifi_microcode_errors.py
@@ -1,5 +1,5 @@
 import unittest
-import os
+import textwrap
 import json
 from unittest.mock import patch
 from check_iwlwifi_microcode_errors import (
@@ -109,4 +109,22 @@ class TestCheckIwlwifi(unittest.TestCase):
         mock_ce.assert_not_called()
         mock_print.assert_called_once_with(
             "No microcode software errors detected."
+        )
+
+    @patch("subprocess.check_output")
+    def test_text_fallback_list_boots(self, mock_sp_check_output):
+        mock_sp_check_output.return_value = textwrap.dedent(
+            """
+            -5 99493f Thu 2025-04-17 07:15:53 EDT—Thu 2025-04-17 07:16:17 EDT
+            -4 663433 Thu 2025-04-17 07:17:49 EDT—Thu 2025-04-17 07:30:46 EDT
+            -3 402991 Thu 2025-04-17 07:31:48 EDT—Thu 2025-04-17 07:33:43 EDT
+            -2 3e1a21 Thu 2025-04-17 07:38:02 EDT—Thu 2025-04-17 08:09:19 EDT
+            -1 350a81 Thu 2025-04-17 08:10:07 EDT—Thu 2025-04-17 08:10:34 EDT
+             0 335e02 Thu 2025-04-17 08:12:49 EDT—Thu 2025-04-17 10:30:01 EDT
+            """
+        ).strip()
+
+        res = get_boot_ids()
+        self.assertEqual(
+            res, ["99493f", "663433", "402991", "3e1a21", "350a81", "335e02"]
         )


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Sometimes journalctl fails to output json when asked to list boots (nice). This provides a fallback to the script

## Resolved issues

Fixes: CHECKBOX-1873

## Documentation

N/A

## Tests

Added a test
