### PR TITLE
Hotfix max size of journalctl collector (infra)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/system_information.py
+++ b/checkbox-ng/plainbox/impl/session/system_information.py
@@ -285,6 +285,8 @@ class JournalctlCollector(Collector):
                 "json",
                 "--since",
                 "-3 days",
+                "-n",
+                "80000",  # limit the lines to 80k, ~80Mb of memory
             ],
             version_cmd=["journalctl", "--version"],
         )


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Seems like the apparmor smap is crashing some iot devices with hundreds of megabytes of submissions. This limits the size of the journal collected to about 80Mb

## Resolved issues

Fixes: CHECKBOX-1874

## Documentation

Added a comment to document why this is done

## Tests

N/A
