### PR TITLE
Use text mode to capture subprocess outputs to avoid buffering issues (bugfix)

### DIFF
--- a/providers/base/bin/eth_hotplugging.py
+++ b/providers/base/bin/eth_hotplugging.py
@@ -74,8 +74,8 @@ def get_interface_info(interface, renderer):
 def _get_cmd_info(cmd, key_map, renderer):
     info = {}
     try:
-        output = sp.check_output(cmd, shell=True)
-        for line in output.decode(sys.stdout.encoding).splitlines():
+        output = sp.check_output(cmd, shell=True, universal_newlines=True)
+        for line in output.splitlines():
             # Skip lines that don't have a "key: value" format
             if ":" not in line:
                 continue

--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -21,7 +21,6 @@ import subprocess as sp
 import textwrap
 import time
 import shutil
-import sys
 import ipaddress
 import yaml
 

--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -258,8 +258,8 @@ def get_interface_info(interface, renderer):
 def _get_cmd_info(cmd, key_map, renderer):
     info = {}
     try:
-        output = sp.check_output(cmd, shell=True)
-        for line in output.decode(sys.stdout.encoding).splitlines():
+        output = sp.check_output(cmd, shell=True, universal_newlines=True)
+        for line in output.splitlines():
             # Skip lines that don't have a "key: value" format
             if ":" not in line:
                 continue

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -30,8 +30,8 @@ print = functools.partial(print, flush=True)
 
 def legacy_nmcli():
     cmd = "nmcli -v"
-    output = sp.check_output(shlex.split(cmd))
-    version = version_parser.parse(output.strip().split()[-1].decode())
+    output = sp.check_output(shlex.split(cmd), universal_newlines=True)
+    version = version_parser.parse(output.strip().split()[-1])
     # check if using the 16.04 nmcli because of this bug
     # https://bugs.launchpad.net/plano/+bug/1896806
     return version < version_parser.parse("1.9.9")
@@ -48,9 +48,9 @@ def print_cmd(cmd):
 def _get_nm_wireless_connections():
     cmd = "nmcli -t -f TYPE,UUID,NAME,STATE connection"
     print_cmd(cmd)
-    output = sp.check_output(shlex.split(cmd))
+    output = sp.check_output(shlex.split(cmd), universal_newlines=True)
     connections = {}
-    for line in output.decode(sys.stdout.encoding).splitlines():
+    for line in output.splitlines():
         type, uuid, name, state = line.strip().split(":", 3)
         if type == "802-11-wireless":
             connections[name] = {"uuid": uuid, "state": state}
@@ -144,8 +144,9 @@ def list_aps(ifname, essid=None):
     aps_dict = {}
     fields = "SSID,CHAN,FREQ,SIGNAL"
     cmd = "nmcli -t -f {} d wifi list ifname {}".format(fields, ifname)
-    output = sp.check_output(shlex.split(cmd))
-    for line in output.decode(sys.stdout.encoding).splitlines():
+    output = sp.check_output(shlex.split(cmd), universal_newlines=True)
+    for line in output.splitlines():
+    # for line in output.decode(sys.stdout.encoding).splitlines():
         # lp bug #1723372 - extra line in output on zesty
         if line.strip() == ifname:  # Skip device name line
             continue
@@ -184,8 +185,8 @@ def perform_ping_test(interface):
     target = None
     cmd = "nmcli --mode tabular --terse --fields IP4.GATEWAY c show TEST_CON"
     print_cmd(cmd)
-    output = sp.check_output(shlex.split(cmd))
-    target = output.decode(sys.stdout.encoding).strip()
+    output = sp.check_output(shlex.split(cmd), universal_newlines=True)
+    target = output.strip()
     print("Got gateway address: {}".format(target))
 
     if target:

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -146,7 +146,6 @@ def list_aps(ifname, essid=None):
     cmd = "nmcli -t -f {} d wifi list ifname {}".format(fields, ifname)
     output = sp.check_output(shlex.split(cmd), universal_newlines=True)
     for line in output.splitlines():
-    # for line in output.decode(sys.stdout.encoding).splitlines():
         # lp bug #1723372 - extra line in output on zesty
         if line.strip() == ifname:  # Skip device name line
             continue

--- a/providers/base/tests/test_eth_hotplugging.py
+++ b/providers/base/tests/test_eth_hotplugging.py
@@ -85,7 +85,7 @@ class EthHotpluggingTests(TestCase):
     @patch("subprocess.check_output")
     def test_get_interface_info_networkd(self, mock_check_output):
         mock_check_output.return_value = (
-            b"State: routable\nGateway: 192.168.1.1\nPath: pci-0000:02:00.0"
+            "State: routable\nGateway: 192.168.1.1\nPath: pci-0000:02:00.0"
         )
         interface = "eth0"
         renderer = "networkd"
@@ -96,8 +96,8 @@ class EthHotpluggingTests(TestCase):
     @patch("subprocess.check_output")
     def test_get_interface_info_networkd_any_name(self, mock_check_output):
         mock_check_output.return_value = (
-            b"State: routable\nGateway: 192.168.1.1 (ABC 123)\n"
-            b"Path: pci-0000:02:00.0"
+            "State: routable\nGateway: 192.168.1.1 (ABC 123)\n"
+            "Path: pci-0000:02:00.0"
         )
         interface = "eth0"
         renderer = "networkd"
@@ -108,7 +108,7 @@ class EthHotpluggingTests(TestCase):
     @patch("subprocess.check_output")
     def test_get_interface_info_networkd_no_state(self, mock_check_output):
         mock_check_output.return_value = (
-            b"Some other info: value\nsome more info"
+            "Some other info: value\nsome more info"
         )
         interface = "eth0"
         renderer = "networkd"
@@ -118,7 +118,7 @@ class EthHotpluggingTests(TestCase):
 
     @patch("subprocess.check_output")
     def test_get_interface_info_networkd_empty_output(self, mock_check_output):
-        mock_check_output.return_value = b" "
+        mock_check_output.return_value = " "
         interface = "eth0"
         renderer = "networkd"
         info = get_interface_info(interface, renderer)
@@ -145,9 +145,9 @@ class EthHotpluggingTests(TestCase):
     @patch("subprocess.check_output")
     def test_get_interface_info_networkmanager(self, mock_check_output):
         mock_check_output.return_value = (
-            b"GENERAL.MTU:                            1500\n"
-            b"GENERAL.STATE:                          100 (connected)\n"
-            b"IP4.GATEWAY:                            192.168.1.1"
+            "GENERAL.MTU:                            1500\n"
+            "GENERAL.STATE:                          100 (connected)\n"
+            "IP4.GATEWAY:                            192.168.1.1"
         )
         interface = "eth0"
         renderer = "NetworkManager"
@@ -159,7 +159,7 @@ class EthHotpluggingTests(TestCase):
     def test_get_interface_info_networkmanager_unexpected_output(
         self, mock_check_output
     ):
-        mock_check_output.return_value = b"some unexpected output"
+        mock_check_output.return_value = "some unexpected output"
         interface = "eth0"
         renderer = "NetworkManager"
         info = get_interface_info(interface, renderer)

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -450,28 +450,28 @@ class WifiClientTestNetplanTests(TestCase):
 
     @patch("subprocess.check_output")
     def test_networkd_routable(self, mock_check_output):
-        mock_check_output.return_value = b"State: routable"
+        mock_check_output.return_value = "State: routable"
         routable, state = _check_routable_state("wlan0", "networkd")
         self.assertTrue(routable)
         self.assertIn("routable", state)
 
     @patch("subprocess.check_output")
     def test_networkd_not_routable(self, mock_check_output):
-        mock_check_output.return_value = b"State: degraded"
+        mock_check_output.return_value = "State: degraded"
         routable, state = _check_routable_state("wlan0", "networkd")
         self.assertFalse(routable)
         self.assertIn("degraded", state)
 
     @patch("subprocess.check_output")
     def test_networkmanager_connected(self, mock_check_output):
-        mock_check_output.return_value = b"GENERAL.STATE: 100 (connected)"
+        mock_check_output.return_value = "GENERAL.STATE: 100 (connected)"
         routable, state = _check_routable_state("wlan0", "NetworkManager")
         self.assertTrue(routable)
         self.assertIn("connected", state)
 
     @patch("subprocess.check_output")
     def test_networkmanager_not_connected(self, mock_check_output):
-        mock_check_output.return_value = b"GENERAL.STATE: 30 (disconnected)"
+        mock_check_output.return_value = "GENERAL.STATE: 30 (disconnected)"
         routable, state = _check_routable_state("wlan0", "NetworkManager")
         self.assertFalse(routable)
         self.assertIn("disconnected", state)
@@ -483,7 +483,7 @@ class WifiClientTestNetplanTests(TestCase):
     @patch("subprocess.check_output")
     def test_get_interface_info_networkd(self, mock_check_output):
         mock_check_output.return_value = (
-            b"State: routable\nGateway: 192.168.1.1\nPath: pci-0000:02:00.0"
+            "State: routable\nGateway: 192.168.1.1\nPath: pci-0000:02:00.0"
         )
         interface = "wlan0"
         renderer = "networkd"
@@ -494,8 +494,8 @@ class WifiClientTestNetplanTests(TestCase):
     @patch("subprocess.check_output")
     def test_get_interface_info_networkd_any_name(self, mock_check_output):
         mock_check_output.return_value = (
-            b"State: routable\nGateway: 192.168.1.1 (TP-Link 123)\n"
-            b"Path: pci-0000:02:00.0"
+            "State: routable\nGateway: 192.168.1.1 (TP-Link 123)\n"
+            "Path: pci-0000:02:00.0"
         )
         interface = "wlan0"
         renderer = "networkd"
@@ -506,7 +506,7 @@ class WifiClientTestNetplanTests(TestCase):
     @patch("subprocess.check_output")
     def test_get_interface_info_networkd_no_state(self, mock_check_output):
         mock_check_output.return_value = (
-            b"Some other info: value\nsome more info"
+            "Some other info: value\nsome more info"
         )
         interface = "wlan0"
         renderer = "networkd"
@@ -516,7 +516,7 @@ class WifiClientTestNetplanTests(TestCase):
 
     @patch("subprocess.check_output")
     def test_get_interface_info_networkd_empty_output(self, mock_check_output):
-        mock_check_output.return_value = b""
+        mock_check_output.return_value = ""
         interface = "wlan0"
         renderer = "networkd"
         info = get_interface_info(interface, renderer)
@@ -537,9 +537,9 @@ class WifiClientTestNetplanTests(TestCase):
     @patch("subprocess.check_output")
     def test_get_interface_info_networkmanager(self, mock_check_output):
         mock_check_output.return_value = (
-            b"GENERAL.MTU:                            1500\n"
-            b"GENERAL.STATE:                          100 (connected)\n"
-            b"IP4.GATEWAY:                            192.168.1.1"
+            "GENERAL.MTU:                            1500\n"
+            "GENERAL.STATE:                          100 (connected)\n"
+            "IP4.GATEWAY:                            192.168.1.1"
         )
         interface = "wlan0"
         renderer = "NetworkManager"
@@ -551,7 +551,7 @@ class WifiClientTestNetplanTests(TestCase):
     def test_get_interface_info_networkmanager_unexpected_output(
         self, mock_check_output
     ):
-        mock_check_output.return_value = b"some unexpected output"
+        mock_check_output.return_value = "some unexpected output"
         interface = "wlan0"
         renderer = "NetworkManager"
         info = get_interface_info(interface, renderer)

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -49,20 +49,20 @@ class WifiNmcliBackupTests(unittest.TestCase):
     @patch("wifi_nmcli_test.sp")
     def test_legacy_nmcli_true(self, subprocess_mock):
         subprocess_mock.check_output.return_value = (
-            b"nmcli tool, version 1.9.8-5"
+            "nmcli tool, version 1.9.8-5"
         )
         self.assertTrue(legacy_nmcli())
 
     @patch("wifi_nmcli_test.sp")
     def test_legacy_nmcli_false(self, subprocess_mock):
         subprocess_mock.check_output.return_value = (
-            b"nmcli tool, version 1.46.0-2"
+            "nmcli tool, version 1.46.0-2"
         )
         self.assertFalse(legacy_nmcli())
 
 
 class TestGetNmWirelessConnections(unittest.TestCase):
-    @patch("wifi_nmcli_test.sp.check_output", return_value=b"")
+    @patch("wifi_nmcli_test.sp.check_output", return_value="")
     def test_no_wireless_connections(self, check_output_mock):
         expected = {}
         self.assertEqual(_get_nm_wireless_connections(), expected)
@@ -70,9 +70,9 @@ class TestGetNmWirelessConnections(unittest.TestCase):
     @patch(
         "wifi_nmcli_test.sp.check_output",
         return_value=(
-            b"802-11-wireless:uuid1:Wireless1:activated\n"
-            b"802-3-ethernet:uuid2:Ethernet1:activated\n"
-            b"802-11-wireless:uuid3:Wireless2:deactivated\n"
+            "802-11-wireless:uuid1:Wireless1:activated\n"
+            "802-3-ethernet:uuid2:Ethernet1:activated\n"
+            "802-11-wireless:uuid3:Wireless2:deactivated\n"
         ),
     )
     def test_multiple_wireless_connections(self, check_output_mock):
@@ -224,7 +224,7 @@ class TestListAps(unittest.TestCase):
     @patch("wifi_nmcli_test.sp.check_output")
     def test_list_aps_no_essid(self, check_output_mock):
         check_output_mock.return_value = (
-            b"wlan0 \nSSID1:1:2412:60\nSSID2:6:2437:70\nSSID3:11:2462:80"
+            "wlan0 \nSSID1:1:2412:60\nSSID2:6:2437:70\nSSID3:11:2462:80"
         )
         expected = {
             "SSID1": {"Chan": "1", "Freq": "2412", "Signal": "60"},
@@ -236,7 +236,7 @@ class TestListAps(unittest.TestCase):
     @patch("wifi_nmcli_test.sp.check_output")
     def test_list_aps_with_essid(self, check_output_mock):
         check_output_mock.return_value = (
-            b"SSID1:1:2412:60\nSSID2:6:2437:70\nSSID3:11:2462:80"
+            "SSID1:1:2412:60\nSSID2:6:2437:70\nSSID3:11:2462:80"
         )
         expected = {
             "SSID2": {"Chan": "6", "Freq": "2437", "Signal": "70"},
@@ -245,7 +245,7 @@ class TestListAps(unittest.TestCase):
 
     @patch("wifi_nmcli_test.sp.check_output")
     def test_list_aps_empty_output(self, check_output_mock):
-        check_output_mock.return_value = b""
+        check_output_mock.return_value = ""
         expected = {}
         self.assertEqual(list_aps("wlan0"), expected)
 


### PR DESCRIPTION
When running unit tests with the buffering option, `sys.stdout.encoding` is set to None during test execution, which leads to problems wherever an output is decoded using it.

Instead, this commit updates all the check_output calls to use `universal_newlines=True`, which captures the output as text. This avoids having to decode it later.

This fixes a problem following implementation of buffering when running unit tests in #1863.

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
