### PR TITLE
Bump fwts to the newest version (infra)

### DIFF
--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -75,12 +75,14 @@ parts:
     stage:
       - version.txt
 ################################################################################
-# Upstream: https://kernel.ubuntu.com/git/hwe/fwts.git/plain/snapcraft.yaml
+# Upstream: https://github.com/fwts/fwts/blob/master/snapcraft.yaml
   fwts:
-    source-tag: "V23.09.00"
+    source-tag: "V25.03.00"
     source-depth: 1
     plugin: autotools
     source: https://github.com/fwts/fwts.git
+    autotools-configure-parameters:
+      - --prefix=/
     stage-packages:
       - libfdt1
       - libbsd0
@@ -91,7 +93,6 @@ parts:
       - autoconf
       - automake
       - libtool
-      - libjson-c-dev
       - flex
       - bison
       - dh-autoreconf

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -81,8 +81,6 @@ parts:
     source-depth: 1
     plugin: autotools
     source: https://github.com/fwts/fwts.git
-    autotools-configure-parameters:
-      - --prefix=/
     stage-packages:
       - libfdt1
       - libbsd0

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -75,9 +75,9 @@ parts:
     stage:
       - version.txt
 ################################################################################
-# Upstream: https://kernel.ubuntu.com/git/hwe/fwts.git/plain/snapcraft.yaml
+# Upstream: https://github.com/fwts/fwts/blob/master/snapcraft.yaml
   fwts:
-    source-tag: "V23.09.00"
+    source-tag: "V25.03.00"
     source-depth: 1
     plugin: autotools
     source: https://github.com/fwts/fwts.git
@@ -93,7 +93,6 @@ parts:
       - autoconf
       - automake
       - libtool
-      - libjson-c-dev
       - flex
       - bison
       - dh-autoreconf

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -81,8 +81,6 @@ parts:
     source-depth: 1
     plugin: autotools
     source: https://github.com/fwts/fwts.git
-    autotools-configure-parameters:
-      - --prefix=/
     stage-packages:
       - libfdt1
       - libbsd0

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -79,9 +79,9 @@ parts:
     stage:
       - version.txt
 ################################################################################
-# Upstream: https://kernel.ubuntu.com/git/hwe/fwts.git/plain/snapcraft.yaml
+# Upstream: https://github.com/fwts/fwts/blob/master/snapcraft.yaml
   fwts:
-    source-tag: "V23.09.00"
+    source-tag: "V25.03.00"
     source-depth: 1
     plugin: autotools
     source: https://github.com/fwts/fwts.git
@@ -97,7 +97,6 @@ parts:
       - autoconf
       - automake
       - libtool
-      - libjson-c-dev
       - flex
       - bison
       - dh-autoreconf

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -85,8 +85,6 @@ parts:
     source-depth: 1
     plugin: autotools
     source: https://github.com/fwts/fwts.git
-    autotools-configure-parameters:
-      - --prefix=/
     stage-packages:
       - libfdt1
       - libbsd0

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -82,8 +82,6 @@ parts:
     source-depth: 1
     plugin: autotools
     source: https://github.com/fwts/fwts.git
-    autotools-configure-parameters:
-      - --prefix=/
     stage-packages:
       - libfdt1
       - libbsd0

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -78,9 +78,28 @@ parts:
       - version.txt
 ################################################################################
   fwts:
-    plugin: nil
+    source-tag: "V25.03.00"
+    source-depth: 1
+    plugin: autotools
+    source: https://github.com/fwts/fwts.git
+    autotools-configure-parameters:
+      - --prefix=/
     stage-packages:
-      - fwts
+      - libfdt1
+      - libbsd0
+      - libpci3
+    build-packages:
+      - gcc
+      - make
+      - autoconf
+      - automake
+      - libtool
+      - flex
+      - bison
+      - dh-autoreconf
+      - libglib2.0-dev
+      - libfdt-dev
+      - libbsd-dev
     after: [version-calculator]
 ################################################################################
   stress-ng:


### PR DESCRIPTION
## Description

As per request, we need the newest version of ftws as that brings a few new bugfixes. Additionally, given our newfound build stability, we can now affort to build fwts as well without breaking a sweat

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/1849
Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1859

## Documentation

Upsteam link updated

## Tests

Built all for all archs here:
- https://github.com/canonical/checkbox/actions/runs/14513502314
- https://github.com/canonical/checkbox/actions/runs/14513103192
