### PR TITLE
Fixes a timeout on properties access (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/agent.py
+++ b/checkbox-ng/checkbox_ng/launcher/agent.py
@@ -145,7 +145,8 @@ class RemoteAgent:
             protocol_config={
                 "allow_all_attrs": True,
                 "allow_setattr": True,
-                "sync_request_timeout": 1,
+                # this is the max server to client attr accessing speed,
+                "sync_request_timeout": 30,
                 "propagate_SystemExit_locally": True,
             },
         )

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -227,7 +227,11 @@ class RemoteController(ReportsStage, MainLoopStage):
     def connect_and_run(self, host, port=18871):
         config = rpyc.core.protocol.DEFAULT_CONFIG.copy()
         config["allow_all_attrs"] = True
-        config["sync_request_timeout"] = 120
+        # this is the max client to server attr accessing speed, unbounded (-1)
+        # to avoid timing out on any attr request on an enstablished call. This
+        # way even particularly slow @properties won't fail
+        config["sync_request_timeout"] = -1
+
         keep_running = False
         server_msg = None
         self._prepare_transports()

--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -762,16 +762,16 @@ class ReportsStage(CheckboxUiStage):
                     _logger.error(
                         _(
                             "Problem with a '%s' report using '%s' exporter "
-                            "sent to '%s' transport. Reason %s"
+                            "sent to '%s' transport. Reason: %s"
                         ),
                         name,
                         exporter_id,
                         transport.url,
-                        exc,
+                        repr(exc),
                     )
                     import traceback
 
-                    traceback.print_tb(exc)
+                    traceback.print_exception(exc)
 
                 self._reset_auto_submission_retries()
                 done_sending = True


### PR DESCRIPTION
This disables the attribute access timeout from client to server and bumps the server to client one. This is to avoid that slow properties (like system infomation) make the connection timeout and the run void

Minor: this also fixes a very old bug where print_tb was used instead of print_exception

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

On very slow devices, the tar exporter fails because the access to `system_information` triggers the (very generous imo) timeout of 2m. Regardless, the timeout is pointless, Checkbox should wait for a result on property access regardless of how much time it takes, as the controller has no way to recover either way if the agent is stuck on a task and failing would just make the problem worse.

This fixes both of the issues in this log:
- This makes the timeout infinite from controller to agent (for the above described reason, controller has no way to recover either way)
- This also fixes that dumb double exception at the bottom, the wrong traceback api was used to print the exception :(

Log reported by @LiaoU3 
```
80.0kB [00:00, 1.76MB/s, file=/home/ubuntu/.local/share/checkbox-ng/submission_2025-04-24T11.38.56.460490.junit.xml]
[junit_file]: file:///home/ubuntu/.local/share/checkbox-ng/submission_2025-04-24T11.38.56.460490.junit.xml (URL added to: /home/ubuntu/.local/share/checkbox-ng/submission_2025-04-24T11.38.56.460490.submission.log)
Problem with a '2_tar_file' report using 'com.canonical.plainbox::tar' exporter sent to '/home/ubuntu/.local/share/checkbox-ng/submission_2025-04-24T11.38.56.460490.tar.xz' transport. Reason result expired
Traceback (most recent call last):
  File "/snap/checkbox22/current/lib/python3.10/site-packages/checkbox_ng/launcher/stages.py", line 708, in _export_results
    result = self._export_fn(exporter_id, transport)
  File "/snap/checkbox22/current/lib/python3.10/site-packages/checkbox_ng/launcher/controller.py", line 834, in local_export
    rf = self.sa.cache_report(exporter_id, options)
  File "/snap/checkbox22/current/lib/python3.10/site-packages/plainbox/vendor/rpyc/core/netref.py", line 240, in __call__
    return syncreq(_self, consts.HANDLE_CALL, args, kwargs)
  File "/snap/checkbox22/current/lib/python3.10/site-packages/plainbox/vendor/rpyc/core/netref.py", line 63, in syncreq
    return conn.sync_request(handler, proxy, *args)
  File "/snap/checkbox22/current/lib/python3.10/site-packages/plainbox/vendor/rpyc/core/protocol.py", line 718, in sync_request
    return _async_res.value
  File "/snap/checkbox22/current/lib/python3.10/site-packages/plainbox/vendor/rpyc/core/async_.py", line 106, in value
    self.wait()
  File "/snap/checkbox22/current/lib/python3.10/site-packages/plainbox/vendor/rpyc/core/async_.py", line 55, in wait
    raise AsyncResultTimeout("result expired")
TimeoutError: result expired

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/snap/checkbox22/current/bin/checkbox-cli", line 8, in <module>
    sys.exit(main())
  File "/snap/checkbox22/current/lib/python3.10/site-packages/checkbox_ng/launcher/checkbox_cli.py", line 182, in main
    return subcmd.invoked(ctx)
  File "/snap/checkbox22/current/lib/python3.10/site-packages/checkbox_ng/launcher/controller.py", line 178, in invoked
    return self.connect_and_run(ctx.args.host, port)
  File "/snap/checkbox22/current/lib/python3.10/site-packages/checkbox_ng/launcher/controller.py", line 306, in connect_and_run
    keep_running = {
  File "/snap/checkbox22/current/lib/python3.10/site-packages/checkbox_ng/launcher/controller.py", line 781, in run_jobs
    self.finish_session()
  File "/snap/checkbox22/current/lib/python3.10/site-packages/checkbox_ng/launcher/controller.py", line 707, in finish_session
    self._export_results()
  File "/snap/checkbox22/current/lib/python3.10/site-packages/checkbox_ng/launcher/stages.py", line 774, in _export_results
    traceback.print_tb(exc)
  File "/snap/checkbox22/current/usr/lib/python3.10/traceback.py", line 53, in print_tb
    print_list(extract_tb(tb, limit=limit), file=file)
  File "/snap/checkbox22/current/usr/lib/python3.10/traceback.py", line 72, in extract_tb
    return StackSummary.extract(walk_tb(tb), limit=limit)
  File "/snap/checkbox22/current/usr/lib/python3.10/traceback.py", line 364, in extract
    for f, lineno in frame_gen:
  File "/snap/checkbox22/current/usr/lib/python3.10/traceback.py", line 329, in walk_tb
    yield tb.tb_frame, tb.tb_lineno
AttributeError: 'TimeoutError' object has no attribute 'tb_frame'
```

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1877

## Documentation

Documented the rationale above it.

## Tests

Tested this interactively by using this launcher:
```
        #!/usr/bin/env checkbox-cli
        [launcher]
        launcher_version = 1
        stock_reports = submission_json
        [test plan]
        # filtering to avoid the test being out of bound
        forced = yes
        unit = 2021.com.canonical.certification::pass-and-fail
        [ui]
        type=silent
        [manifest]
        2021.com.canonical.certification::manifest_location = 0

```
First, I set the controller to agent timeout to 1 and added a breakpoint to the system_information property. When this is done the same exception as above is triggered after 1 second (at the end of the run when the agent tries to create the submission files).

I've modified the traceback call to the correct one and the following was printed: (Not crashing the controller this time!)
```
Problem with a '2_json_file' report using 'com.canonical.plainbox::json' exporter sent to '/home/h25/.local/share/checkbox-ng/submission_2025-04-24T12.31.32.274737.json' transport. Reason: TimeoutError('result expired')
Traceback (most recent call last):
  File "/home/h25/prj/canonical/checkbox/checkbox-ng/checkbox_ng/launcher/stages.py", line 708, in _export_results
    result = self._export_fn(exporter_id, transport)
  File "/home/h25/prj/canonical/checkbox/checkbox-ng/checkbox_ng/launcher/controller.py", line 836, in local_export
    rf = self.sa.cache_report(exporter_id, options)
  File "/home/h25/prj/canonical/checkbox/checkbox-ng/plainbox/vendor/rpyc/core/netref.py", line 240, in __call__
    return syncreq(_self, consts.HANDLE_CALL, args, kwargs)
  File "/home/h25/prj/canonical/checkbox/checkbox-ng/plainbox/vendor/rpyc/core/netref.py", line 63, in syncreq
    return conn.sync_request(handler, proxy, *args)
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/h25/prj/canonical/checkbox/checkbox-ng/plainbox/vendor/rpyc/core/protocol.py", line 718, in sync_request
    return _async_res.value
           ^^^^^^^^^^^^^^^^
  File "/home/h25/prj/canonical/checkbox/checkbox-ng/plainbox/vendor/rpyc/core/async_.py", line 106, in value
    self.wait()
    ~~~~~~~~~^^
  File "/home/h25/prj/canonical/checkbox/checkbox-ng/plainbox/vendor/rpyc/core/async_.py", line 55, in wait
    raise AsyncResultTimeout("result expired")
TimeoutError: result expired
```

Good, now that we have the correct exception and not some broken mess, I changed the timeout to `-1`, doing so the controller is blocked forever on the breakpoint (tested 15m which is less than forever but more than 120s)
