### PR TITLE
Extend minimum timeout for the command (Bugfix)

### DIFF
--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -337,7 +337,7 @@ class HardwareRendererTester:
                     ],
                     stdout=sp.DEVNULL,
                     stderr=sp.DEVNULL,
-                    timeout=min(5, max_wait_seconds),
+                    timeout=min(10, max_wait_seconds),
                 )
                 if out.returncode == 0:
                     return True


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
For some IoT devices, running the command `systemd-analyze critical-chain` may takes longer than 5 seconds. For instance, Xilinx KD240 took 4.8 seconds to finish the command. Hence, it will take longer if it executes in checkbox environment.

```
ubuntu@kria:~$ time systemd-analyze critical-chain 
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

graphical.target @53.968s
└─multi-user.target @53.967s
  └─docker.service @43.296s +10.668s
    └─containerd.service @36.436s +6.824s
      └─network.target @36.397s
        └─NetworkManager.service @26.087s +10.307s
          └─dbus.service @25.233s +820ms
            └─basic.target @25.211s
              └─sockets.target @25.210s
                └─snapd.socket @25.191s +18ms
                  └─sysinit.target @25.148s
                    └─cloud-init.service @22.607s +2.536s
                      └─cloud-init-local.service @11.803s +10.777s
                        └─systemd-remount-fs.service @4.381s +138ms
                          └─systemd-fsck-root.service @3.864s +499ms
                            └─systemd-journald.socket @3.506s
                              └─-.mount @3.206s
                                └─-.slice @3.206s

real	0m4.841s
user	0m1.091s
sys	0m0.133s
```
Overall, increasing it to 10 seconds could fix the problem. However, this is open to discussion here if 10 seconds enough or if we just use the max_wait_seconds 120 seconds.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
N/A
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
N/A
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
