### PR TITLE
Install fwts globally in the snap instead of in /usr (bugfix)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -77,6 +77,10 @@ parts:
     source-depth: 1
     plugin: autotools
     source: https://github.com/fwts/fwts.git
+    # needed because default is /usr/local
+    # if you change this update LD_LIBRARY_PATH
+    configflags:
+      - --prefix=/
     stage-packages:
       - libfdt1
       - libbsd0

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -81,6 +81,10 @@ parts:
     source-depth: 1
     plugin: autotools
     source: https://github.com/fwts/fwts.git
+    # needed because default is /usr/local
+    # if you change this update LD_LIBRARY_PATH
+    configflags:
+      - --prefix=/
     stage-packages:
       - libfdt1
       - libbsd0

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -81,6 +81,10 @@ parts:
     source-depth: 1
     plugin: autotools
     source: https://github.com/fwts/fwts.git
+    # needed because default is /usr/local
+    # if you change this update LD_LIBRARY_PATH
+    autotools-configure-parameters:
+      - --prefix=/
     stage-packages:
       - libfdt1
       - libbsd0

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -85,6 +85,10 @@ parts:
     source-depth: 1
     plugin: autotools
     source: https://github.com/fwts/fwts.git
+    # needed because default is /usr/local
+    # if you change this update LD_LIBRARY_PATH
+    autotools-configure-parameters:
+      - --prefix=/
     stage-packages:
       - libfdt1
       - libbsd0

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -82,6 +82,10 @@ parts:
     source-depth: 1
     plugin: autotools
     source: https://github.com/fwts/fwts.git
+    # needed because default is /usr/local
+    # if you change this update LD_LIBRARY_PATH
+    autotools-configure-parameters:
+      - --prefix=/
     stage-packages:
       - libfdt1
       - libbsd0


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The upgrade of fwts broke the snap in a few situations because by default the autotools recipe installs fwts and its libray in /usr and in the snap /usr/lib/* is not always in LD_LIBRARY_PATH. This makes Checkbox canary fail! 

It is unclear to me how it works on core16 right now, but better safe than sorry, I'm moving all installtion to be global, as I see no downside to it.

See: https://certification.canonical.com/hardware/202302-31257/submission/425313/test/58147/result/48590487/

## Resolved issues

Fixes: CHECKBOX-1884

## Documentation

Documented why this is actually needed, as I'm pretty sure it was there on *some* platforms but it wasn't documented

## Tests

Built and tested the failing test on core24 and it now works as expected. 
Building here: https://github.com/canonical/checkbox/actions/runs/14709968840
And here: https://github.com/canonical/checkbox/actions/runs/14709966174
To be sure I didnt bork the builds
