### PR TITLE
Change the user on failed service check (bugfix)

### DIFF
--- a/providers/base/units/power-management/jobs.pxu
+++ b/providers/base/units/power-management/jobs.pxu
@@ -204,7 +204,7 @@ requires:
   cpuinfo.other != 'emulated by qemu'
 user: root
 environ: RTC_DEVICE_FILE
-command: 
+command:
   if [[ -n "$RTC_DEVICE_FILE" ]]; then
     rtc_path="/sys/class/rtc/${RTC_DEVICE_FILE/#\/dev\/}"
   else
@@ -381,6 +381,7 @@ category_id: com.canonical.plainbox::power-management
 _summary: Post warm reboot service check
 _purpose: Check there are no failed services after the warm reboot
 unit: job
+user: root
 plugin: shell
 command: failed_service_check.sh
 estimated_duration: 1.0
@@ -411,6 +412,7 @@ category_id: com.canonical.plainbox::power-management
 _summary: Post cold reboot service check
 _purpose: Check there are no failed services after the cold reboot
 unit: job
+user: root
 plugin: shell
 command: failed_service_check.sh
 estimated_duration: 1.0
@@ -550,13 +552,13 @@ command: light_sensor_test.sh
 _purpose:
     This test will check your Ambient Light Sensor work, if you don't have it, please skip this test.
 _steps:
-    1. Make sure "Automatic brightness" is ON in Power settings. 
+    1. Make sure "Automatic brightness" is ON in Power settings.
     2. Locate the Ambient Light Sensor, which should be around the Camera.
     3. Cover your hand over the Ambient Light Sensor.
     4. When the backlight dims, press Enter to start testing.
     5. Wait until the message "Has ambient light sensor" is printed on the screen and wave your hand slowly during testing.
 _verification:
-    Did the Ambient Light Sensor values change when you _shook_ your hands over the sensor? 
+    Did the Ambient Light Sensor values change when you _shook_ your hands over the sensor?
     Did the Screen backlight also change?
 _summary: Test the functionality of the Ambient Light Sensor by checking if sensor values and screen backlight change when covered.
 

--- a/providers/base/units/watchdog/jobs.pxu
+++ b/providers/base/units/watchdog/jobs.pxu
@@ -37,6 +37,7 @@ category_id: com.canonical.plainbox::power-management
 _summary: Post watchdog reset service check
 _purpose: Check there are no failed services after the watchdog triggered
 unit: job
+user: root
 plugin: shell
 command: failed_service_check.sh
 estimated_duration: 1.0


### PR DESCRIPTION
## WARNING: This modifies com.canonical.certification::sru-server

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The failed_permission check fails to collect logs on *some* platforms because the normal user on those platforms doesn't have the permission to read the journal on *some* services. There is no reason not to run this as root.

See:
```
Found 1 failed units

Failed units:
  UNIT                      LOAD   ACTIVE SUB    DESCRIPTION
● plymouth-show-run.service loaded failed failed Display state on splash

LOAD   = Reflects whether the unit definition was properly loaded.
ACTIVE = The high-level unit activation state, i.e. generalization of SUB.
SUB    = The low-level unit activation state, values depend on unit type.
1 loaded units listed.

Logs for plymouth-show-run.service:
Hint: You are currently not seeing messages from other users and the system.
      Users in groups 'adm', 'systemd-journal' can see all messages.
      Pass -q to turn off this notice.
No journal files were opened due to insufficient permissions.
```

## Resolved issues

Fixes: CHECKBOX-1738

## Documentation

N/A

## Tests

N/A
