### PR TITLE
Replace `"\z"` with `r"\z"` (Bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/test_runner.py
+++ b/checkbox-ng/plainbox/impl/test_runner.py
@@ -45,7 +45,7 @@ class SlugifyTests(TestCase):
         self.assertEqual(slugify("A-"), "A-")
         self.assertEqual(slugify("A_"), "A_")
         self.assertEqual(slugify(".b"), ".b")
-        self.assertEqual(slugify("\z"), "_z")
+        self.assertEqual(slugify(r"\z"), "_z")
         self.assertEqual(slugify("/z"), "_z")
         self.assertEqual(slugify("1k"), "1k")
 


### PR DESCRIPTION
## Description

This PR replaces the invalid escape sequence `"\z"` with `r"\z"`

## Resolved issues

When installing checkbox it was producing a warning about this. This PR fixes it.

## Documentation

Python has been implicitly converting it to a backslash with a z since there's no \z escape sequence.

## Tests

No changes to tests
