### PR TITLE
Run hotspot test with root (Bugfix)

### DIFF
--- a/providers/base/units/wireless/nm-hotspot.pxu
+++ b/providers/base/units/wireless/nm-hotspot.pxu
@@ -5,6 +5,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/nmcli_wifi_ap_bg_{{ interface }}
 template-id: wireless/nmcli_wifi_ap_bg_interface
+user: root
 _summary: Create 802.11b/g Wi-Fi AP on {{ interface }} using NetworkManager
 _purpose: Create an 802.11b/g Wi-Fi access point on a specified interface using NetworkManager command-line tools.
 command:
@@ -30,6 +31,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/nmcli_wifi_ap_a_{{ interface }}
 template-id: wireless/nmcli_wifi_ap_a_interface
+user: root
 _summary: Create 802.11a Wi-Fi AP on {{ interface }} using NetworkManager
 command:
   net_driver_info.py "$NET_DRIVER_INFO"


### PR DESCRIPTION


## Description

nmcli require authorization to run under a non GUI session. Other wireless testing relying on nmcli is already running with root. So this commit only align the setup as the other wireless/nmcli based tests

## Resolved issues

This PR fix #1873 

## Documentation

## Tests

Running wireless/nmcli_wifi_ap_bg and wireless/nmcli_wifi_ap_a tests under non GUI session (SSH) no longer failed due to authorisation error

