### PR TITLE
mod regex check for valid pci_bdf_format detection (BugFix)

### DIFF
--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -83,7 +83,7 @@ class PrimeOffloader:
 
         :returns: card id
         """
-        pci_bdf_format = "[0-9]{4}:[0-9,a-f]{2}:[0-9,a-f]{2}.[0-9]"
+        pci_bdf_format = "[0-9]{2}[0-9,a-f]{2}:[0-9,a-f]{2}:[0-9,a-f]{2}.[0-9]"
         if not re.match(pci_bdf_format, pci_bdf.lower()):
             raise SystemExit("pci BDF format error")
 


### PR DESCRIPTION
## Description

Allows the pci domain to now be hexadecimal. In theory a maximum of 255 domains should be addressable. The change adjusts the regular expression domain part to check for two '0' and two hexvals.

## Resolved issues

This fixes https://github.com/canonical/checkbox/issues/1821.
