### PR TITLE
Use _ignore_disconnected_ethernet_interfaces for Ipv6 tests as well (bugfix)

### DIFF
--- a/providers/base/units/canary/test-plan.pxu
+++ b/providers/base/units/canary/test-plan.pxu
@@ -75,6 +75,7 @@ include:
  com.canonical.certification::memory/info
  com.canonical.certification::ipv6_detect
  com.canonical.certification::ipv6_link_local_address_.*
+ com.canonical.certification::ipv6_link_local_address_any_if
  com.canonical.certification::networking/predictable_names
  com.canonical.certification::power-management/warm-reboot
  com.canonical.certification::power-management/post-warm-reboot

--- a/providers/base/units/networking/ipv6.pxu
+++ b/providers/base/units/networking/ipv6.pxu
@@ -9,7 +9,7 @@ command:
   fi
   echo "/proc/net/if_inet6 not present"
   echo "Running kernel does not appear to be IPv6 ready"
-  exit 1  
+  exit 1
 flags: simple also-after-suspend
 
 unit: template
@@ -22,6 +22,42 @@ template-id: ipv6_link_local_address_interface
 _summary: Test that {interface} has an IPv6 link local address
 plugin: shell
 category_id: com.canonical.plainbox::networking
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest._ignore_disconnected_ethernet_interfaces == 'False'
 command:
-  [ "$(ip -6 -o addr show dev {interface} scope link | wc -l)" -eq 1 ]
+  IPV6_ADDR="$(ip -6 -o addr show dev {interface} scope link)"
+  echo ip -6 -o addr show dev {interface} scope link
+  echo "$IPV6_ADDR"
+  echo
+  COUNT=$(echo -n "$IPV6_ADDR" | grep -cve '^\s*$') # count non-empty lines
+  if [ "$COUNT" -gt 0 ]; then
+    echo PASS: At least one IPv6 address reported for interface {interface}
+  else
+    echo FAIL: No IPv6 address reported for the interface {interface}
+    exit 1
+  fi
+flags: also-after-suspend
+
+unit: job
+depends: ipv6_detect
+id: ipv6_link_local_address_any_if
+_summary: Test that any interface has an IPv6 address
+plugin: shell
+category_id: com.canonical.plainbox::networking
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest._ignore_disconnected_ethernet_interfaces == 'True'
+command:
+  IPV6_ADDR="$(ip -6 -o addr show scope link)"
+  echo ip -6 -o addr show scope link
+  echo "$IPV6_ADDR"
+  echo
+  COUNT=$(echo -n "$IPV6_ADDR" | grep -cve '^\s*$') # count non-empty lines
+  if [ "$COUNT" -gt 0 ]; then
+    echo PASS: At least 1 IPv6 reported
+  else
+    echo FAIL: No IPv6 address reported
+    exit 1
+  fi
 flags: also-after-suspend

--- a/providers/base/units/networking/test-plan.pxu
+++ b/providers/base/units/networking/test-plan.pxu
@@ -72,6 +72,7 @@ _description: Automated networking tests for devices
 include:
   ipv6_detect
   ipv6_link_local_address_.*
+  ipv6_link_local_address_any_if
   networking/predictable_names
 bootstrap_include:
   device
@@ -102,6 +103,7 @@ _description: Automated networking tests for devices (after suspend)
 include:
   after-suspend-ipv6_detect
   after-suspend-ipv6_link_local_address_.*
+  after-suspend-ipv6_link_local_address_any_if
 bootstrap_include:
   device
 
@@ -112,4 +114,3 @@ _description: Networking tests for Server Cert
 include:
     networking/predictable_names    certification-status=blocker
     networking/ntp                  certification-status=non-blocker
-


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This hidden manifest was introduced for this purpose but not adopted for this test. This creates a new test (that has the same effect but for any interface instead of for just 1) and introduces the manifest entry check for both

Note: this also fixes a small bug: if the interface was assigned 2 ips for whatever reason, this counted as a failure, which is wrong

Note2: now regardless if the tests passes or fails, it prints what it is doing and why. This is a significant QoL change for reviewers.

## Resolved issues

Fixes: CHECKBOX-1885
Fixes: https://github.com/canonical/checkbox/issues/1481

## Documentation

N/A

## Tests

New outcome without setting the manifest entry: (some interfaces on my machine dont have an ipv6 address lol)
```
=========[ Running job 4 / 4. Estimated time left (at least): 0:00:00 ]=========
----------------[ Test that any interface has an IPv6 address ]-----------------
ID: com.canonical.certification::ipv6_link_local_address_any_if
Category: com.canonical.plainbox::networking
Job cannot be started because:
 - resource expression "manifest._ignore_disconnected_ethernet_interfaces == 'True'" evaluates to false
Outcome: job cannot be started
=========[ Running job 1 / 3. Estimated time left (at least): 0:00:00 ]=========
-------------[ Test that enp2s0f0 has an IPv6 link local address ]--------------
ID: com.canonical.certification::ipv6_link_local_address_enp2s0f0
Category: com.canonical.plainbox::networking
Unable to create symlink s/home/h25/prj/canonical/checkbox/providers/genio/bin/brightness_test.py -> /tmp/nest-74dpo450.3cb0677d93ba75e7d45e3705d651f48d550a56229b89dd9b819deb914de856fc/brightness_test.py: FileExistsError(17, 'File exists')
... 8< -------------------------------------------------------------------------
ip -6 -o addr show dev enp2s0f0 scope link


FAIL: No IPv6 address reported for the interface enp2s0f0
------------------------------------------------------------------------- >8 ---
Outcome: job failed
=========[ Running job 2 / 3. Estimated time left (at least): 0:00:00 ]=========
--------------[ Test that enp5s0 has an IPv6 link local address ]---------------
ID: com.canonical.certification::ipv6_link_local_address_enp5s0
Category: com.canonical.plainbox::networking
Unable to create symlink s/home/h25/prj/canonical/checkbox/providers/genio/bin/brightness_test.py -> /tmp/nest-tn4yut4d.8619fbc676a51f1ffe4ad7a5688477a1e67c8104b2914a171039c439ca9e253d/brightness_test.py: FileExistsError(17, 'File exists')
... 8< -------------------------------------------------------------------------
ip -6 -o addr show dev enp5s0 scope link


FAIL: No IPv6 address reported for the interface enp5s0
------------------------------------------------------------------------- >8 ---
Outcome: job failed
=========[ Running job 3 / 3. Estimated time left (at least): 0:00:00 ]=========
-----------[ Test that enp7s0f3u1u2 has an IPv6 link local address ]------------
ID: com.canonical.certification::ipv6_link_local_address_enp7s0f3u1u2
Category: com.canonical.plainbox::networking
Unable to create symlink s/home/h25/prj/canonical/checkbox/providers/genio/bin/brightness_test.py -> /tmp/nest-s3b2dsol.d23d5aa38119f6d1b3a6e9d3c85797c4253bdaba69bcea19f1cc007e7da87176/brightness_test.py: FileExistsError(17, 'File exists')
... 8< -------------------------------------------------------------------------
ip -6 -o addr show dev enp7s0f3u1u2 scope link
45: enp7s0f3u1u2    inet6 fe80::5fcf:daa6:bd1f:ced8/64 scope link noprefixroute \       valid_lft forever preferred_lft forever

PASS: At least one IPv6 address reported for interface enp7s0f3u1u2
------------------------------------------------------------------------- >8 ---
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2025-04-30T13.44.43
==================================[ Results ]===================================
 ☑ : Collect information about hardware devices (udev)
 ☑ : Test if the kernel is IPv6 ready
 ☑ : Hardware Manifest
 ☐ : Test that any interface has an IPv6 address
 ☒ : Test that enp2s0f0 has an IPv6 link local address
 ☒ : Test that enp5s0 has an IPv6 link local address
 ☑ : Test that enp7s0f3u1u2 has an IPv6 link local address
```

With the manifest entry set:
```
========[ Running job 2 / 11. Estimated time left (at least): 0:01:30 ]=========
----------------[ Test that any interface has an IPv6 address ]-----------------
ID: com.canonical.certification::ipv6_link_local_address_any_if
Category: com.canonical.plainbox::networking
ERROR:plainbox.ctrl:Unable to create symlink s/home/h25/prj/canonical/checkbox/providers/genio/bin/brightness_test.py -> /tmp/nest-nb84ugyg.6ee41175040eb0e1715de3196b0b5a6aed3b9b0ca28abaa3a0b49aac333b4852/brightness_test.py: FileExistsError(17, 'File exists')
... 8< -------------------------------------------------------------------------
ip -6 -o addr show scope link
4: wlan0    inet6 fe80::56ed:f16b:4ae8:233f/64 scope link noprefixroute \       valid_lft forever preferred_lft forever
6: lxdbr0    inet6 fe80::216:3eff:fe10:4207/64 scope link proto kernel_ll \       valid_lft forever preferred_lft forever
45: enp7s0f3u1u2    inet6 fe80::5fcf:daa6:bd1f:ced8/64 scope link noprefixroute \       valid_lft forever preferred_lft forever
46: tun0    inet6 fe80::6860:f7f3:86f:c168/64 scope link stable-privacy proto kernel_ll \       valid_lft forever preferred_lft forever

PASS: At least 1 IPv6 reported
------------------------------------------------------------------------- >8 ---
Outcome: job passed
```

To test this you can try with this test plan:
```
unit: test plan
id: check_new_jobs
_name: check_new_jobs
bootstrap_include:
    ipv6_detect
    device
include:
    ipv6_link_local_address_any_if
    ipv6_link_local_address_interface
```
And toggle the test/run the test via this launcher:
```
        #!/usr/bin/env checkbox-cli
        [launcher]
        launcher_version = 1
        stock_reports = submission_json
        [test plan]
        forced = yes
        unit = com.canonical.certification::check_new_jobs
        [test selection]
        forced=yes
        [manifest]
        com.canonical.certification::_ignore_disconnected_ethernet_interfaces = True
```