### PR TITLE
Skip journal collection in `merge-submissions` (Bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/merge_reports.py
+++ b/checkbox-ng/checkbox_ng/launcher/merge_reports.py
@@ -24,6 +24,7 @@ import json
 import os
 import tarfile
 from tempfile import TemporaryDirectory
+from typing import List, Any
 
 from plainbox.impl.ctrl import gen_rfc822_records_from_io_log
 from plainbox.impl.providers.special import get_exporters
@@ -55,12 +56,14 @@ class MergeReports:
             help="save combined test results to the specified FILE",
         )
 
-    def _parse_submission(self, submission, tmpdir, mode="list"):
+    def _parse_submission(
+        self, submission: str, tmpdir: TemporaryDirectory, mode="list"
+    ):
         try:
             with tarfile.open(submission) as tar:
                 tar.extractall(tmpdir.name)
                 with open(os.path.join(tmpdir.name, "submission.json")) as f:
-                    data = json.load(f)
+                    data = json.load(f)  # type: dict[str, Any]
             for result in data["results"]:
                 result["plugin"] = "shell"  # Required so default to shell
                 result["summary"] = result["name"]
@@ -144,7 +147,9 @@ class MergeReports:
             "certification_status", "non-blocker"
         )
 
-    def _create_exporter(self, exporter_id):
+    def _create_exporter(
+        self, exporter_id: str, exporter_options: List[str] = []
+    ):
         exporter_map = {}
         exporter_units = get_exporters().unit_list
         for unit in exporter_units:
@@ -154,7 +159,7 @@ class MergeReports:
                     exporter_map[unit.id] = support
         exporter_support = exporter_map[exporter_id]
         return exporter_support.exporter_cls(
-            [], exporter_unit=exporter_support
+            exporter_options, exporter_unit=exporter_support
         )
 
     def _output_potential_action(self, message):

--- a/checkbox-ng/checkbox_ng/launcher/merge_submissions.py
+++ b/checkbox-ng/checkbox_ng/launcher/merge_submissions.py
@@ -65,7 +65,9 @@ class MergeSubmissions(MergeReports):
         manager.state.metadata.title = ctx.args.title or session_title
         for job in self.job_dict.values():
             self._populate_session_state(job, manager.state)
-        exporter = self._create_exporter("com.canonical.plainbox::tar")
+        exporter = self._create_exporter(
+            "com.canonical.plainbox::tar", ["skip-sysinfo-in-json"]
+        )
         with open(ctx.args.output_file, "wb") as stream:
             exporter.dump_from_session_manager(manager, stream)
         with tarfile.open(ctx.args.output_file) as tar:

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox-nosysinfo.json
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox-nosysinfo.json
@@ -1,0 +1,194 @@
+{%- set ns = 'com.canonical.certification::' -%}
+{%- set state = manager.default_device_context.state -%}
+{%- set resource_map = state.resource_map -%}
+{%- set job_state_map = state.job_state_map -%}
+{%- set category_map = state.category_map -%}
+{
+    "title": {{ state.metadata.title | jsonify | safe }},
+    "origin": {{ origin | jsonify | safe }},
+{%- if "testplan_id" in app_blob %}
+{%- if app_blob['testplan_id'] %}
+    "testplan_id": {{ app_blob['testplan_id'] | jsonify | safe }},
+{%- endif %}
+{%- endif %}
+    "custom_joblist": {{ state.metadata.custom_joblist | jsonify | safe }},
+{%- if "description" in app_blob %}
+{%- if app_blob['description'] %}
+    "description": {{ app_blob['description'] | jsonify | safe }},
+{%- endif %}
+{%- endif %}
+{%- if ns ~ 'package' in state.resource_map %}
+    "packages": [
+    {%- set package_resource_list = state.resource_map[ns ~ 'package'] %}
+    {%- for package_resource in package_resource_list if package_resource.name %}
+        {
+            "name": "{{ package_resource.name }}",
+            "version": "{{ package_resource.version }}"
+        }{%- if not loop.last -%},{%- endif %}
+    {%- endfor %}
+    ],
+{%- endif %}
+{%- if ns ~ 'snap' in state.resource_map %}
+    "snap-packages": [
+    {%- set snap_package_resource_list = state.resource_map[ns ~ 'snap'] %}
+    {%- for snap_package_resource in snap_package_resource_list if snap_package_resource.name %}
+        {
+            "name": "{{ snap_package_resource.name }}",
+            {%- for key in snap_package_resource|reject('is_name')|sort %}
+            "{{ key }}": "{{ snap_package_resource[key] }}"{%- if not loop.last -%},{%- endif %}
+            {%- endfor %}
+        }{%- if not loop.last -%},{%- endif %}
+    {%- endfor %}
+    ],
+{%- endif %}
+{%- if ns ~ 'lsb' in state.resource_map and state.resource_map[ns ~ 'lsb'][0] %}
+{%- set lsb_resource = state.resource_map[ns ~ 'lsb'][0] %}
+    "distribution": {
+        {%- for key in lsb_resource|sort %}
+        "{{ key }}": "{{ lsb_resource[key] }}"{%- if not loop.last -%},{%- endif %}
+        {%- endfor %}
+    },
+{%- endif %}
+    "results": [
+    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.job.plugin not in ("resource", "attachment") %}
+        {
+            "id": "{{ job_id|strip_ns }}",
+            "full_id": "{{ job_id }}",
+            "name": "{{ job_state.job.tr_summary() }}",
+            "certification_status": "{{ job_state.effective_certification_status }}",
+            "category": "{{ category_map[job_state.effective_category_id] }}",
+            "category_id": "{{ job_state.effective_category_id }}",
+            "status": "{{ job_state.result.outcome_meta().hexr_mapping }}",
+            "outcome": "{{ job_state.result.outcome }}",
+            "comments": {{ job_state.result.comments | jsonify | safe }},
+            "io_log": {{ job_state.result.io_log_as_flat_text | jsonify | safe }},
+            "type": "test",
+            "project": "certification",
+            "duration": {{ job_state.result.execution_duration if job_state.result.execution_duration else 0 }},
+            "plugin": {{ job_state.job.plugin | jsonify | safe }},
+            "template_id": {{ job_state.job.template_id | jsonify | safe }}
+        }{%- if not loop.last -%},{%- endif %}
+    {%- endfor %}
+    ],
+    "resource-results": [
+    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.job.plugin == "resource" %}
+        {
+            "id": "{{ job_id|strip_ns }}",
+            "full_id": "{{ job_id }}",
+            "name": "{{ job_state.job.tr_summary() }}",
+            "certification_status": "{{ job_state.effective_certification_status }}",
+            "category": "{{ category_map[job_state.effective_category_id] }}",
+            "category_id": "{{ job_state.effective_category_id }}",
+            "status": "{{ job_state.result.outcome_meta().hexr_mapping }}",
+            "outcome": "{{ job_state.result.outcome }}",
+            "comments": {{ job_state.result.comments | jsonify | safe }},
+            "io_log": {{ job_state.result.io_log_as_flat_text | jsonify | safe }},
+            "type": "test",
+            "project": "certification",
+            "duration": {{ job_state.result.execution_duration if job_state.result.execution_duration else 0 }},
+            "plugin": {{ job_state.job.plugin | jsonify | safe }},
+            "template_id": {{ job_state.job.template_id | jsonify | safe }}
+        }{%- if not loop.last -%},{%- endif %}
+    {%- endfor %}
+    ],
+    "attachment-results": [
+    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.job.plugin == "attachment" %}
+        {
+            "id": "{{ job_id|strip_ns }}",
+            "full_id": "{{ job_id }}",
+            "name": "{{ job_state.job.tr_summary() }}",
+            "certification_status": "{{ job_state.effective_certification_status }}",
+            "category": "{{ category_map[job_state.effective_category_id] }}",
+            "category_id": "{{ job_state.effective_category_id }}",
+            "status": "{{ job_state.result.outcome_meta().hexr_mapping }}",
+            "outcome": "{{ job_state.result.outcome }}",
+            "comments": {{ job_state.result.comments | jsonify | safe }},
+            "io_log": {{ job_state.result.io_log_as_text_attachment | jsonify | safe }},
+            "duration": {{ job_state.result.execution_duration if job_state.result.execution_duration else 0 }},
+            "plugin": {{ job_state.job.plugin | jsonify | safe }},
+            "template_id": {{ job_state.job.template_id | jsonify | safe }}
+        }{%- if not loop.last -%},{%- endif %}
+    {%- endfor %}
+    ],
+    "rejected-jobs": [
+    {%- for job_id in state.metadata.rejected_jobs %}
+        {
+            "id": "{{ job_id|strip_ns }}",
+            "full_id": "{{ job_id }}",
+            "name": "{{ job_state_map[job_id].job.tr_summary() }}",
+            "plugin": "{{ job_state_map[job_id].job.plugin }}",
+            "certification_status": "{{ job_state_map[job_id].effective_certification_status }}",
+            "category": "{{ category_map[job_state_map[job_id].effective_category_id] }}",
+            "category_id": "{{ job_state_map[job_id].effective_category_id }}",
+            "template_id": {{ job_state_map[job_id].job.template_id | jsonify | safe }}
+        }{%- if not loop.last -%},{%- endif %}
+    {%- endfor %}
+    ],
+    "category_map": {
+        {%- for cat_id, cat_name in category_map|dictsort %}
+        "{{ cat_id }}": "{{ cat_name }}"{%- if not loop.last -%},{%- endif %}
+        {%- endfor %}
+    },
+    "launcher" : {{ launcher | jsonify | safe}}
+{%- if ns ~ 'dkms_info_json' in state.job_state_map and state.job_state_map[ns ~ 'dkms_info_json'].result.outcome == 'pass' %},
+{%- set dkms_info_json = '{' + state.job_state_map[ns ~ 'dkms_info_json'].result.io_log_as_text_attachment.split('{', 1)[-1] %}
+    "dkms_info": {{ dkms_info_json | indent(4, false) | safe }}
+{%- endif %}
+{%- if ns ~ 'udev_json' in state.job_state_map and state.job_state_map[ns ~ 'udev_json'].result.outcome == 'pass' %}
+{%- set udev_json = state.job_state_map[ns ~ 'udev_json'].result.io_log_as_text_attachment %}
+{%- if udev_json %},
+    "devices": {{ udev_json | indent(4, false) | safe }}
+{%- endif %}
+{%- endif %}
+{%- if ns ~ 'raw_devices_dmi_json' in state.job_state_map and state.job_state_map[ns ~ 'raw_devices_dmi_json'].result.outcome == 'pass' %},
+{%- set raw_devices_dmi_json = state.job_state_map[ns ~ 'raw_devices_dmi_json'].result.io_log_as_text_attachment %}
+    "raw-devices-dmi": {{ raw_devices_dmi_json | indent(4, false) | safe }}
+{%- endif %}
+{%- if ns ~ 'modprobe_json' in state.job_state_map and state.job_state_map[ns ~ 'modprobe_json'].result.outcome == 'pass' %},
+{%- set modprobe_json = state.job_state_map[ns ~ 'modprobe_json'].result.io_log_as_text_attachment %}
+    "modprobe-info": {{ modprobe_json | indent(4, false) | safe }}
+{%- endif %}
+{%- if ns ~ 'lspci_standard_config_json' in state.job_state_map and state.job_state_map[ns ~ 'lspci_standard_config_json'].result.outcome == 'pass' %},
+{%- set lspci_standard_config_json = state.job_state_map[ns ~ 'lspci_standard_config_json'].result.io_log_as_text_attachment %}
+    "pci_subsystem_id": {{ lspci_standard_config_json | indent(4, false) | safe }}
+{%- endif %}
+{%- if ns ~ 'uname' in state.resource_map and state.resource_map[ns ~ 'uname'][0] %},
+{%- set uname_resource = state.resource_map[ns ~ 'uname'][0] %}
+    "kernel": "{{ uname_resource.release }}"
+{%- endif %}
+{%- if ns ~ 'dpkg' in state.resource_map and state.resource_map[ns ~ 'dpkg'][0] %},
+{%- set dpkg_resource = state.resource_map[ns ~ 'dpkg'][0] %}
+    "architecture": "{{ dpkg_resource.architecture }}"
+{%- endif %}
+{%- if ns ~ 'meminfo' in state.resource_map and state.resource_map[ns ~ 'meminfo'][0] %},
+{%- set meminfo = state.resource_map[ns ~ 'meminfo'][0] %}
+    "memory": {
+        "swap": {{ meminfo.swap }},
+        "total": {{ meminfo.total }}
+    }
+{%- endif %}
+{%- if ns ~ 'cpuinfo' in state.resource_map and state.resource_map[ns ~ 'cpuinfo'][0] %},
+{%- set processor_resource = state.resource_map[ns ~ 'cpuinfo'][0] %}
+    "processor": {
+    {%- for key in processor_resource|sort %}
+        "{{ key }}": "{{ processor_resource[key] }}"{%- if not loop.last -%},{%- endif %}
+    {%- endfor %}
+    }
+{%- endif %}
+{%- if ns ~ 'kernel_cmdline_attachment' in state.job_state_map and state.job_state_map[ns ~ 'kernel_cmdline_attachment'].result.outcome == 'pass' %},
+{%- set kernel_cmdline = state.job_state_map[ns ~ 'kernel_cmdline_attachment'].result.io_log_as_text_attachment %}
+    "kernel-cmdline": {{ kernel_cmdline.strip() | jsonify | safe }}
+{%- endif %}
+{%- if ns ~ 'dell_bto_xml_attachment_json' in state.job_state_map and state.job_state_map[ns ~ 'dell_bto_xml_attachment_json'].result.outcome == 'pass' %},
+{%- set bto = state.job_state_map[ns ~ 'dell_bto_xml_attachment_json'].result.io_log_as_text_attachment %}
+    "bto-info": {{ bto | indent(8, false) | safe }}
+{%- endif %}
+{%- if ns ~ 'recovery_info_attachment_json' in state.job_state_map and state.job_state_map[ns ~ 'recovery_info_attachment_json'].result.outcome == 'pass' %},
+{%- set recovery = state.job_state_map[ns ~ 'recovery_info_attachment_json'].result.io_log_as_text_attachment %}
+    "image-version": {{ recovery | indent(8, false) | safe }}
+{%- endif %}
+{%- if ns ~ 'info/buildstamp' in state.job_state_map and state.job_state_map[ns ~ 'info/buildstamp'].result.outcome == 'pass' %},
+{%- set buildstamp = state.job_state_map[ns ~ 'info/buildstamp'].result.io_log_as_text_attachment.rstrip().splitlines() or ['Unknown'] %}
+    "buildstamp": {{ buildstamp[-1] | jsonify | safe }}
+{%- endif %}
+}

--- a/checkbox-ng/plainbox/impl/providers/exporters/units/exporter.pxu
+++ b/checkbox-ng/plainbox/impl/providers/exporters/units/exporter.pxu
@@ -20,6 +20,13 @@ file_extension: json
 data: {"template": "checkbox.json"}
 
 unit: exporter
+id: json-nosysinfo
+_summary: Generate JSON output without collecting system info (just jobs)
+entry_point: jinja2
+file_extension: json
+data: {"template": "checkbox-nosysinfo.json"}
+
+unit: exporter
 id: text
 _summary: Generate plain text output
 entry_point: text


### PR DESCRIPTION
## Description

This PR fixes #1905 by introducing an option in the tar exporter to use a json template that doesn't have the line `{%- set system_information = state.system_information -%}`

## Resolved issues

#1905 

Also added a few type annotations

## Documentation

The basic idea is to avoid accessing `state.system_information` altogether when using merge-submissions since it has a side effect of collecting journals of the machine that executed the merge. 

This PR implements this solution by adding another exporter unit `json-nosysinfo` and an option `OPTION_SKIP_SYSINFO_IN_JSON` in the `TARSessionStateExporter`. The merge-submissions subcommand would then pass in the option when calling
```py
exporter = self._create_exporter(
    "com.canonical.plainbox::tar", ["skip-sysinfo-in-json"]
)
```
and the tar exporter will use the json template that doesn't have state.system_information

The `checkbox-nosysinfo.json` might look like a lot of changes but it actually only has 2 lines of diffs compared to `checkbox.json`

## Tests

- Original unit tests
- Comparing the merged submission.json without the `system_information` key with current implementation and they produced the same result.
