### PR TITLE
Add WWAN modem count in wwan/detect (bugfix)

### DIFF
--- a/providers/base/units/wwan/jobs.pxu
+++ b/providers/base/units/wwan/jobs.pxu
@@ -16,7 +16,9 @@ plugin: shell
 user: root
 command:
   COUNT=$(wwan_tests.py count)
+  echo "Number of WWAN modems found: $COUNT"
   if [ "$COUNT" -eq 0 ]; then
+    echo "This device should have at least one WWAN modem, none found!"
     exit 1
   fi
 estimated_duration: 2.0


### PR DESCRIPTION
## WARNING: This modifies com.canonical.certification::sru-server

wwan/detect job does not print anything when it fails. Add a little bit more information for reviewers.

This PR comes after reviewing a card in TO where the wwan/detect job failed without providing any information. At least now the reviewer could go check in the archive attachments to see if there is anything wrong in dmesg or ModemManager.

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Running on a device with no WWAN modem (but with the `has_wwan_module` set to `true`):

```
---------------------[ Identify if WWAN module is missing ]---------------------
ID: com.canonical.certification::wwan/detect
Category: com.canonical.certification::wwan
... 8< -------------------------------------------------------------------------
Enter sudo password:

Number of WWAN modems found: 0
This device should have at least one WWAN modem, none found!
------------------------------------------------------------------------- >8 ---
Outcome: job failed
```