### PR TITLE
system_information from submission json (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/merge_reports.py
+++ b/checkbox-ng/checkbox_ng/launcher/merge_reports.py
@@ -25,14 +25,18 @@ import os
 import tarfile
 from tempfile import TemporaryDirectory
 
-from plainbox.impl.ctrl import gen_rfc822_records_from_io_log
-from plainbox.impl.providers.special import get_exporters
 from plainbox.impl.resource import Resource
 from plainbox.impl.result import IOLogRecord
+from plainbox.impl.unit.job import JobDefinition
 from plainbox.impl.result import MemoryJobResult
 from plainbox.impl.session import SessionManager
 from plainbox.impl.unit.category import CategoryUnit
-from plainbox.impl.unit.job import JobDefinition
+from plainbox.impl.providers.special import get_exporters
+from plainbox.impl.ctrl import gen_rfc822_records_from_io_log
+from plainbox.impl.session.system_information import (
+    CollectionOutput,
+    CollectorOutputs,
+)
 
 
 #: Name-space prefix for Canonical Certification
@@ -103,6 +107,19 @@ class MergeReports:
                     self.category_dict[cat_id] = CategoryUnit(
                         {"id": cat_id, "name": cat_name}
                     )
+            if mode == "list":
+                self.system_information["version"].append(
+                    data["system_information"].pop("version")
+                )
+                for collector_id, collection in data[
+                    "system_information"
+                ].items():
+                    collection = CollectionOutput.from_dict(collection)
+                    self.system_information[collector_id].append(collection)
+            elif mode == "dict":
+                self.system_information = CollectorOutputs.from_dict(
+                    data["system_information"]
+                )
         except OSError as e:
             raise SystemExit(e)
         except KeyError as e:
@@ -143,6 +160,7 @@ class MergeReports:
         job_state.effective_certification_status = job.get_record_value(
             "certification_status", "non-blocker"
         )
+        state.system_information = self.system_information
 
     def _create_exporter(self, exporter_id):
         exporter_map = {}
@@ -177,6 +195,7 @@ class MergeReports:
             tmpdir = TemporaryDirectory()
             self.job_list = []
             self.category_list = []
+            self.system_information = []
             session_title = self._parse_submission(submission, tmpdir)
             manager = SessionManager.create_with_unit_list(
                 self.job_list + self.category_list

--- a/checkbox-ng/checkbox_ng/launcher/merge_reports.py
+++ b/checkbox-ng/checkbox_ng/launcher/merge_reports.py
@@ -108,14 +108,9 @@ class MergeReports:
                         {"id": cat_id, "name": cat_name}
                     )
             if mode == "list":
-                self.system_information["version"].append(
-                    data["system_information"].pop("version")
+                self.system_information.append(
+                    CollectorOutputs.from_dict(data["system_information"])
                 )
-                for collector_id, collection in data[
-                    "system_information"
-                ].items():
-                    collection = CollectionOutput.from_dict(collection)
-                    self.system_information[collector_id].append(collection)
             elif mode == "dict":
                 self.system_information = CollectorOutputs.from_dict(
                     data["system_information"]

--- a/checkbox-ng/checkbox_ng/launcher/merge_submissions.py
+++ b/checkbox-ng/checkbox_ng/launcher/merge_submissions.py
@@ -55,6 +55,7 @@ class MergeSubmissions(MergeReports):
         tmpdir = TemporaryDirectory()
         self.job_dict = {}
         self.category_dict = {}
+        self.system_information = {}
         for submission in ctx.args.submission:
             session_title = self._parse_submission(
                 submission, tmpdir, mode="dict"

--- a/checkbox-ng/checkbox_ng/launcher/test_merge_reports.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_merge_reports.py
@@ -63,6 +63,7 @@ class MergeReportsTests(TestCase):
             "resource-results": [basic_job_info],
             "attachment-results": [basic_job_info],
             "category_map": {"test_category": "test_name"},
+            "system_information": {"version": 0},
         }
         json_mock.return_value = sub_to_read
 

--- a/checkbox-ng/checkbox_ng/launcher/test_merge_submissions.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_merge_submissions.py
@@ -39,6 +39,8 @@ class MergeSubmissionsTests(TestCase):
         session_manager_mock,
         temporary_directory_mock,
     ):
+        temporary_directory_mock().name = "not_existing"
+
         ctx_mock = mock.MagicMock()
         ctx_mock.args.submission = ["submission"]
         ctx_mock.args.output_file = "file_location"
@@ -50,3 +52,14 @@ class MergeSubmissionsTests(TestCase):
 
         # output path was printed
         print_mock.assert_any_call(ctx_mock.args.output_file)
+
+    def test_export(self):
+        self_mock = mock.MagicMock()
+        temp_location = mock.MagicMock()
+
+        MergeSubmissions.export(
+            self_mock, mock.MagicMock(), temp_location, "json"
+        )
+
+        expected_creates = temp_location / "submission.json"
+        self.assertTrue(expected_creates.open.called)

--- a/checkbox-ng/plainbox/impl/session/system_information.py
+++ b/checkbox-ng/plainbox/impl/session/system_information.py
@@ -27,6 +27,13 @@ class CollectorOutputs(dict):
 
     @classmethod
     def from_dict(cls, dct):
+        """
+        This loads the class from a dct
+        Note: this ignores the version the CollectionOutputs was generated from
+              as we have no good way of using it for now
+        """
+        # ignore the version, this shouldn't matter as this is only used in
+        # merge-reports and merge-submissions
         _ = dct.pop("version")
         to_load = {
             name: CollectionOutput.from_dict(value)

--- a/checkbox-ng/plainbox/impl/session/system_information.py
+++ b/checkbox-ng/plainbox/impl/session/system_information.py
@@ -25,6 +25,15 @@ class CollectorOutputs(dict):
         to_dump["version"] = self.COLLECTOR_OUTPUTS_VERSION
         return json.dumps(to_dump, indent=4)
 
+    @classmethod
+    def from_dict(cls, dct):
+        _ = dct.pop("version")
+        to_load = {
+            name: CollectionOutput.from_dict(value)
+            for (name, value) in dct.items()
+        }
+        return cls(to_load)
+
 
 class CollectorMeta(type):
     """


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

`system_information` was not taken into account in merge reports. This made it so, when creating the exported tar, Checkbox would re-calculate it instead of taking it from the submissions, slowing down the process significantly (as it has to do it once per submission) but most importantly, making it wrong, as the merge process is usually done on a random machine.

Note: This also makes the process about 20% faster, as it avoids unpacking and repacking the xz twice.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1887
Fixes: https://github.com/canonical/checkbox/issues/1905

## Documentation

Documented why the tar change was done
The rest of the change adheres to the code around it

## Tests

Submission.json now generates correctly without querying the `system_information` collector

Exported before and after the multi export change. With the same subs diff reports only one change (date now)
```
(venv)  z >  diff -r *
diff -r before/submission.html after/submission.html
6132c6132
<                 <p>This report was created using Checkbox 4.2.1.dev38+gc9201b347.d20250107 on 2025-05-06T13:03:08</p>
---
>                 <p>This report was created using Checkbox 4.2.1.dev38+gc9201b347.d20250107 on 2025-05-06T13:57:48</p>
```
