### PR TITLE
Add missing dependency filetype for python 3.13+ (infra)

### DIFF
--- a/checkbox-ng/debian/control
+++ b/checkbox-ng/debian/control
@@ -46,6 +46,7 @@ Package: python3-checkbox-ng
 Architecture: all
 Depends: python3-importlib-metadata | python3 (>> 3.8),
          python3-jinja2,
+         python3-filetype | python3 (<< 3.12),
          python3-packaging,
          python3-pkg-resources,
          python3-psutil,

--- a/checkbox-ng/pyproject.toml
+++ b/checkbox-ng/pyproject.toml
@@ -17,7 +17,8 @@
     'Jinja2 >= 2.7',
     'xlsxwriter',
     'tqdm',
-    'importlib_metadata; python_version < "3.8"'
+    'importlib_metadata; python_version < "3.8"',
+    'filetype; python_version > "3.12"'
   ]
   #test_suite='checkbox_ng.tests.test_suite'
   license={"text" = "GPLv3"}

--- a/checkbox-ng/setup.cfg
+++ b/checkbox-ng/setup.cfg
@@ -12,6 +12,7 @@ install_requires=
   xlsxwriter
   tqdm
   importlib_metadata; python_version < "3.8"
+  filetype; python_version > "3.12"
 [upload_docs]
 upload_dir=build/sphinx/html
 [metadata]


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Filetype was added to replace the deprecated imghdr, but it wasn't included in any of the dependencies anywhere. This fixes it. 

Note: I didn't add it to the core24 snap as that uses python3.12, will have to remember to add it to the core26 one.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1888
Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1888

## Documentation

N/A

## Tests

N/A
