### PR TITLE
Fully typed version of gnome-monitors.py (New)

### DIFF
--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -35,7 +35,6 @@ from typing import (
     Set,
     override,
 )
-import time
 
 from checkbox_support.monitor_config import MonitorConfig
 from gi.repository import Gio, GLib  # type: ignore
@@ -395,7 +394,6 @@ class MonitorConfigGnome(MonitorConfig):
                 # Get the state before applying to avoid this issue.
                 state = self.get_current_state()
                 self._apply_monitors_config(state.serial, logical_monitors)
-                time.sleep(5)  # wait before calling apply() again
 
                 if post_cycle_action is not None:
                     post_cycle_action(uni_string, **kwargs)

--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -386,15 +386,3 @@ class MonitorConfigGnome(MonitorConfig):
             cancellable=None,
         )
 
-
-if __name__ == "__main__":
-    s = MonitorConfigGnome().get_current_state_raw()
-    for i, m in enumerate(s.physical_monitors):
-        print("monitor", m.info.connector)
-        for mode in m.modes:
-            if mode.is_current:
-                print(mode, "is current")
-            if mode.is_preferred:
-                print(mode, "is preferred")
-    print(s.properties)
-    print("physical", s.layout_mode == 2)

--- a/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
@@ -12,7 +12,6 @@ from gi.repository import GLib, Gio  # type: ignore
 from checkbox_support.dbus.gnome_monitor import MonitorConfigGnome
 
 
-@patch("time.sleep")
 class MonitorConfigGnomeTests(unittest.TestCase):
     """This class provides test cases for the MonitorConfig DBus class."""
 
@@ -33,7 +32,7 @@ class MonitorConfigGnomeTests(unittest.TestCase):
             return self.MockGLibType()
 
     @patch("checkbox_support.dbus.gnome_monitor.Gio.DBusProxy")
-    def test_get_connected_monitors(self, mock_dbus_proxy, mock_sleep):
+    def test_get_connected_monitors(self, mock_dbus_proxy):
         """
         Test whether the function returns a list of connected
         monitors, even if inactive.
@@ -99,7 +98,7 @@ class MonitorConfigGnomeTests(unittest.TestCase):
         self.assertSetEqual(monitors, {"eDP-1", "HDMI-1"})
 
     @patch("checkbox_support.dbus.gnome_monitor.Gio.DBusProxy")
-    def test_get_current_resolution(self, mock_dbus_proxy ,mock_sleep):
+    def test_get_current_resolution(self, mock_dbus_proxy):
         """
         Test whether the function returns a dictionary of
         monitor-id:resolution for any active monitors.
@@ -168,7 +167,7 @@ class MonitorConfigGnomeTests(unittest.TestCase):
         )
 
     @patch("checkbox_support.dbus.gnome_monitor.Gio.DBusProxy")
-    def test_set_extended_mode(self, mock_dbus_proxy, mock_sleep):
+    def test_set_extended_mode(self, mock_dbus_proxy):
         """
         Test whether the function set the logical display
         configuration to two screens at preferred resolution
@@ -260,7 +259,7 @@ class MonitorConfigGnomeTests(unittest.TestCase):
         self.assertDictEqual(configuration, expected)
 
     @patch("checkbox_support.dbus.gnome_monitor.Gio.DBusProxy")
-    def test_cycle(self, mock_dbus_proxy, mock_sleep):
+    def test_cycle(self, mock_dbus_proxy):
         """
         Test the cycle could get the right monitors configuration
         and send to ApplyMonitorsConfig.
@@ -349,7 +348,10 @@ class MonitorConfigGnomeTests(unittest.TestCase):
         )
 
     @patch("checkbox_support.dbus.gnome_monitor.Gio.DBusProxy")
-    def test_cycle_no_cycling(self, mock_dbus_proxy,mock_sleep):
+    def test_cycle_no_cycling(
+        self,
+        mock_dbus_proxy,
+    ):
         """
         Test the cycle could get the right monitors configuration
         (without res and transform change) and send to ApplyMonitorsConfig.


### PR DESCRIPTION
## Description

This PR adds complete type annotations and named properties to the original gnome-monitors script. 

## Resolved issues

No real issue here but accessing deeply nested properties from the `GetCurrentState`'s return value was a bit awkward. If I need to get the 1st refresh rate of the 1st monitor, I need to write `state[1][1][0][1][0][3]` which looks like magic numbers without looking at the original [dbus xml](https://gitlab.gnome.org/GNOME/mutter/-/blob/main/data/dbus-interfaces/org.gnome.Mutter.DisplayConfig.xml#L414). This PR circumvents this situation by providing named attribute access for the return value of `GetCurrentState`, so now we can write `state.physical_monitors[0].modes[0].refresh_rate` and only use indices in places where there's an actual array.

## Documentation

The main reference point is [this xml](https://gitlab.gnome.org/GNOME/mutter/-/blob/main/data/dbus-interfaces/org.gnome.Mutter.DisplayConfig.xml#L414)
and [gnome-randr](https://github.com/maxwellainatchi/gnome-randr-rust)

**None of the new classes (MutterDisplayConfig, PhysicalMonitor, LogicalMonitor, MonitorInfo) should be directly constructed** because they assume that the input GLib.Variant has the correct type. Use `MonitorConfigGnome.get_current_state()` as the entry point.

## Tests

Original unit tests
