### PR TITLE
Run hotspot test as root (bugfix)

### DIFF
--- a/providers/base/units/wireless/nm-hotspot.pxu
+++ b/providers/base/units/wireless/nm-hotspot.pxu
@@ -5,6 +5,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/nmcli_wifi_ap_bg_{{ interface }}
 template-id: wireless/nmcli_wifi_ap_bg_interface
+user: root
 _summary: Create 802.11b/g Wi-Fi AP on {{ interface }} using NetworkManager
 _purpose: Create an 802.11b/g Wi-Fi access point on a specified interface using NetworkManager command-line tools.
 command:
@@ -30,6 +31,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/nmcli_wifi_ap_a_{{ interface }}
 template-id: wireless/nmcli_wifi_ap_a_interface
+user: root
 _summary: Create 802.11a Wi-Fi AP on {{ interface }} using NetworkManager
 command:
   net_driver_info.py "$NET_DRIVER_INFO"


### PR DESCRIPTION
nmcli require authorization to run under a non GUI session. Other wireless testing relying on nmcli is already running with root. So this commit only align the setup as the other wireless/nmcli based tests

Ported from: https://github.com/canonical/checkbox/pull/1899