### PR TITLE
Make dkms test run as root (bugfix)

### DIFF
--- a/providers/sru/units/sru.pxu
+++ b/providers/sru/units/sru.pxu
@@ -5,6 +5,7 @@ Depends: checkbox-provider-certification-client
 plugin: shell
 category_id: com.canonical.plainbox::miscellanea
 id: miscellanea/dkms_build_validation
+user: root
 requires: package.name == 'dkms'
 command:
  dkms_build_validation.py


### PR DESCRIPTION
## Description

As per sru review, there is no reason why this runs as normal user, on some system this fails due to a lack of permissions (not being added to a specific group.) Lets make this run as root.
## Resolved issues

N/A

## Documentation

N/A

## Tests

N/A
