### PR TITLE
Fix package plainbox-provider-pc-sanity build fail (bugfix)

### DIFF
--- a/contrib/pc-sanity/bin/edid_continuous_frequency_check.py
+++ b/contrib/pc-sanity/bin/edid_continuous_frequency_check.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import glob
 import argparse
 
 
@@ -28,7 +27,7 @@ def find_internal_panel_edid():
             dirnames[:] = []
         if (
             any(interface in dirpath for interface in lcd_interface_list)
-            and "edid" in filenames
+            and "edid" in filenames  # noqa: W503
         ):
             edid_file = f"{dirpath}/edid"
             print(edid_file)
@@ -92,7 +91,7 @@ def check_display_range_limits_descriptor(
             ):  # noqa: E501
                 if (
                     horizontal_address_video_in_pixels
-                    == maximum_horizontal_active_pixels(
+                    == maximum_horizontal_active_pixels(  # noqa: W503
                         data_block_of_DRLD[12], data_block_of_DRLD[13]
                     )
                 ):  # noqa: E501


### PR DESCRIPTION
edid_continuous_frequency_check.py:
  * Remove unused glob module

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
plainbox-provider-pc-sanity build failed due to flake8 found unused module glob in edid_continuous_frequency_check.py.
Build log:
```
python3 contrib/pc-sanity/manage.py test
.....................................................................................................F..
======================================================================
FAIL: test_flake8_/<<PKGBUILDDIR>>/contrib/pc-sanity/bin/edid_continuous_frequency_check.py (plainbox.provider_manager.Flake8Tests.test_flake8_/<<PKGBUILDDIR>>/contrib/pc-sanity/bin/edid_continuous_frequency_check.py)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/plainbox/provider_manager.py", line 1605, in _test
    self.fail(failure_reason)
AssertionError: /<<PKGBUILDDIR>>/contrib/pc-sanity/bin/edid_continuous_frequency_check.py:5:1: F401 'glob' imported but unused
```
## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
https://warthogs.atlassian.net/browse/SOMERVILLE-2215

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->
None
## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
```
$ flake8 --count contrib/pc-sanity/bin/edid_continuous_frequency_check.py 
0
```