### PR TITLE
Exclude v4l2-compliance to not break existing certs (BugFix)

### DIFF
--- a/providers/base/units/camera/test-plan.pxu
+++ b/providers/base/units/camera/test-plan.pxu
@@ -36,11 +36,9 @@ _description: Camera tests (automated)
 include:
  camera/detect                                     certification-status=blocker
  camera/multiple-resolution-images_.*              certification-status=blocker
- camera/v4l2-compliance-blockers_.*                certification-status=blocker
  camera/multiple-resolution-images-attachment_.*   certification-status=non-blocker
  camera/camera-quality_.*                          certification-status=non-blocker
  camera/camera-quality-image_.*                    certification-status=non-blocker
- camera/v4l2-compliance-non-blockers_.*            certification-status=non-blocker
 bootstrap_include:
  device
 
@@ -53,7 +51,16 @@ include:
  camera/still_.*                                   certification-status=blocker
  camera/display_.*                                 certification-status=blocker
  camera/multiple-resolution-images_.*              certification-status=blocker
+bootstrap_include:
+ device
+
+id: camera-v4l2-compliance
+unit: test plan
+_name: V4L2 Compliance Tests
+_description: Tests whether all the cameras on this device are V4L2 compliant
+include:
  camera/v4l2-compliance-blockers_.*                certification-status=blocker
+ camera/v4l2-compliance-non-blockers_.*            certification-status=non-blocker
 bootstrap_include:
  device
 
@@ -64,7 +71,6 @@ _description: Camera tests (after suspend, certification blockers only)
 include:
  after-suspend-camera/still_.*                     certification-status=blocker
  after-suspend-camera/display_.*                   certification-status=blocker
- after-suspend-camera/v4l2-compliance-blockers_.*  certification-status=blocker
 bootstrap_include:
  device
 
@@ -75,11 +81,9 @@ _description: Camera tests After Suspend (automated)
 include:
  after-suspend-camera/detect                                     certification-status=blocker
  after-suspend-camera/multiple-resolution-images_.*              certification-status=blocker
- after-suspend-camera/v4l2-compliance-blockers_.*                certification-status=blocker
  after-suspend-camera/multiple-resolution-images-attachment_.*   certification-status=non-blocker
  after-suspend-camera/camera-quality_.*                          certification-status=non-blocker
  after-suspend-camera/camera-quality-image_.*                    certification-status=non-blocker 
- after-suspend-camera/v4l2-compliance-non-blockers_.*            certification-status=non-blocker
 bootstrap_include:
  device
 

--- a/providers/certification-client/units/client-cert-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-24-04.pxu
@@ -90,6 +90,7 @@ nested_part:
     audio-cert-automated
     bluetooth-cert-automated
     camera-cert-automated
+    camera-v4l2-compliance
     thunderbolt-cert-automated
     monitor-gpu-cert-automated
     graphics-gpu-cert-automated

--- a/providers/certification-client/units/client-cert-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-24-04.pxu
@@ -90,7 +90,6 @@ nested_part:
     audio-cert-automated
     bluetooth-cert-automated
     camera-cert-automated
-    camera-v4l2-compliance
     thunderbolt-cert-automated
     monitor-gpu-cert-automated
     graphics-gpu-cert-automated


### PR DESCRIPTION
## WARNING: This modifies com.canonical.certification::sru-server

## Description

This PR is a short workaround for v4l2-compliance tests that was breaking on older ubuntu versions. It moves the v4l2-compliance tests to it's own test plan and is not included anywhere for now.

## Resolved issues



## Documentation

v4l2-compliance tests now lives in its own test plan `camera-v4l2-compliance`


## Tests
