### PR TITLE
Fix permission for checking journalctl log (BugFix)

### DIFF
--- a/contrib/pc-sanity/units/pc-sanity/pc-sanity-check-devices.pxu
+++ b/contrib/pc-sanity/units/pc-sanity/pc-sanity-check-devices.pxu
@@ -1,16 +1,14 @@
 plugin: shell
 category_id: com.canonical.plainbox::miscellanea
-id: miscellanea/check_i2c_hid
+id: miscellanea/check-i2c-hid-existence
+estimated_duration: 2.0
+requires:
+ dmi.product in ['Notebook','Laptop']
 command:
- set -x
- if sudo dmidecode -t 3 | grep -i "Notebook\|Laptop"; then
-    journalctl -b -k | grep i2c | grep input || exit 1
- else
-    echo "this machine is not laptop, no need to check i2c touchpad"
- fi
-_summary: check if i2c device exists
+ cat /sys/class/input/input*/phys | grep -q i2c || exit 1
+_summary: Check if there is input device on i2c bus
 _description:
- check if i2c device exists
+ Touchpad is mandatory on notebook and laptop, which works as input device on i2c bus generally.
 
 unit: template
 template-resource: cpuinfo

--- a/contrib/pc-sanity/units/pc-sanity/pc-sanity.pxu
+++ b/contrib/pc-sanity/units/pc-sanity/pc-sanity.pxu
@@ -38,7 +38,7 @@ include:
     com.canonical.certification::miscellanea/check-thermald-unknown-cond
     com.canonical.certification::miscellanea/dump_libsmbios_tokens
     com.canonical.certification::miscellanea/dump_libsmbios_tokens_attachment
-    com.canonical.certification::miscellanea/check_i2c_hid
+    com.canonical.certification::miscellanea/check-i2c-hid-existence
     com.canonical.certification::miscellanea/tgp-rid-check_.*
     com.canonical.certification::miscellanea/touchpad-firmware-version_.*
     com.canonical.certification::miscellanea/check_oem_recovery_version


### PR DESCRIPTION
## Description

User not in the adm group has no permission to check journal log. Change the implementation by reading the sysfs node.

## Resolved issues

Fixes: Somerville-2260