### PR TITLE
Add system debian pakcages status attachment (New)

### DIFF
--- a/contrib/pc-sanity/units/pc-sanity/pc-sanity-misc.pxu
+++ b/contrib/pc-sanity/units/pc-sanity/pc-sanity-misc.pxu
@@ -102,14 +102,6 @@ _description: Check the result of the installation, from oem-qa-checkbox 6596762
 
 plugin: attachment
 category_id: com.canonical.plainbox::miscellanea
-id: miscellanea/dpkg-l
-estimated_duration: 1.0
-command: dpkg -l
-_description:
- attache log from dpkg -l
-
-plugin: attachment
-category_id: com.canonical.plainbox::miscellanea
 id: miscellanea/bootstrap-pc-sanity-smoke-test
 estimated_duration: 1.0
 command:

--- a/contrib/pc-sanity/units/pc-sanity/pc-sanity.pxu
+++ b/contrib/pc-sanity/units/pc-sanity/pc-sanity.pxu
@@ -6,7 +6,6 @@ _description:
     devices check, GPU check and thermal check. It will be used to qualify OEM image before
     release the image to QA team.
 include:
-    com.canonical.certification::miscellanea/dpkg-l
     com.canonical.certification::miscellanea/bootstrap-pc-sanity-smoke-test
     com.canonical.certification::miscellanea/side-load-changes
     com.canonical.certification::somerville-installation

--- a/providers/base/units/info/jobs.pxu
+++ b/providers/base/units/info/jobs.pxu
@@ -52,6 +52,16 @@ estimated_duration: 0.030
 _description: Attaches dmidecode output
 _summary: Attach output of dmidecode
 
+id: dpkg_attachment
+plugin: attachment
+category_id: com.canonical.plainbox::info
+requires:
+  executable.name == 'dpkg'
+command: dpkg -l
+estimated_duration: 2.0
+_summary: Attach dpkg -l output
+_purpose: Attach system debian packages status
+
 id: lshw_attachment
 plugin: attachment
 category_id: com.canonical.plainbox::info

--- a/providers/base/units/info/test-plan.pxu
+++ b/providers/base/units/info/test-plan.pxu
@@ -32,6 +32,7 @@ include:
  dmesg_attachment
  dmi_attachment
  dmidecode_attachment
+ dpkg_attachment
  efi_attachment
  info/buildstamp
  info/disk_partitions
@@ -69,6 +70,7 @@ include:
  dmesg_attachment
  dmi_attachment
  dmidecode_attachment
+ dpkg_attachment
  efi_attachment
  info/buildstamp
  info/disk_partitions


### PR DESCRIPTION
Add dpkg attachment for knowing system's debian packages status.

## WARNING: This modifies com.canonical.certification::sru-server

https://certification.canonical.com/hardware/202504-36589/submission/428888/