### PR TITLE
Add reusable workflow to build `checkbox-dss` Snap (Infra)

### DIFF
--- a/.github/workflows/checkbox-dss-build.yaml
+++ b/.github/workflows/checkbox-dss-build.yaml
@@ -7,8 +7,9 @@ on:
     paths:
       - contrib/checkbox-dss-validation/checkbox-provider-dss/**
       - .github/workflows/checkbox-dss-build.yaml
-  pull_request:
+  pull_request_review:
     branches: [ main ]
+    types: [submitted]
     paths:
       - contrib/checkbox-dss-validation/checkbox-provider-dss/**
       - .github/workflows/checkbox-dss-build.yaml
@@ -20,6 +21,8 @@ on:
 
 jobs:
   snap_frontend_native:
+    # When running for a PR, run only after approval
+    if: ${{ github.event_name != 'pull_request_review' || github.event.review.state == 'approved' }}
     outputs:
       artifact-url: ${{ steps.upload_artifact.outputs.artifact-url }}
     runs-on:


### PR DESCRIPTION
## Description

This adds re-usable workflow for building the Snap with the Checkbox provider for testing DSS.  While this PR only adds this workflow, a subsequent PR will call it to build the Snap in GH before using it to test DSS.

The workflow to build the `checkbox-ce-oem` Snaps was used as a reference, except that the `checkbox-dss` Snap produced by this workflow is currently not published in the store.  This is why the workflow produces the built Snap's artifact URI when it is triggered by a `workflow_call` event.

Finally, since the provider is validated as part of the Snap's build process, this is also a good check to be triggered on PRs and changes related to the DSS provider.  However, the build will be triggered only on Approval of the PR and not on every commit to the PR.

## Resolved issues

Part of [CHECKBOX-1905](https://warthogs.atlassian.net/browse/CHECKBOX-1905)

## Documentation

No changes to documentation.

## Tests

No changes to source code, but see run of workflow in the checks below!

- [x] Verify that the workflow is triggered on approval of this PR.


[CHECKBOX-1905]: https://warthogs.atlassian.net/browse/CHECKBOX-1905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ