### PR TITLE
Fix `checkbox-dss` snap build on irrelevant PRs (Infra)

### DIFF
--- a/.github/workflows/checkbox-dss-build.yaml
+++ b/.github/workflows/checkbox-dss-build.yaml
@@ -7,11 +7,9 @@ on:
     paths:
       - contrib/checkbox-dss-validation/checkbox-provider-dss/**
       - .github/workflows/checkbox-dss-build.yaml
-  pull_request:
+  pull_request_review:
     branches: [ main ]
-    paths:
-      - contrib/checkbox-dss-validation/checkbox-provider-dss/**
-      - .github/workflows/checkbox-dss-build.yaml
+    types: [submitted]
   workflow_dispatch:
   workflow_call:
     outputs:
@@ -19,10 +17,33 @@ on:
         value: ${{ jobs.snap_frontend_native.outputs.artifact-url }}
 
 jobs:
+  dss_snap_build_required:
+    runs-on: ubuntu-latest
+    name: Check for changes in checkbox-dss dirs
+    outputs:
+      build_required: ${{ steps.check_diff.outputs.build_required }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Use git diff to see if there are any changes in the checkbox-dss directories
+        id: check_diff
+        run: |
+          DIFF_LENGTH=`git diff HEAD origin/main -- contrib/checkbox-dss-validation .github/workflows/checkbox-dss-build.yaml | wc -l`
+          if [[ $DIFF_LENGTH -eq 0 ]]
+            then
+              echo "No checkbox-dss snap build required."
+              echo "build_required=false" >> $GITHUB_OUTPUT
+            else
+              echo "checkbox-dss snap build required!"
+              echo "build_required=true" >> $GITHUB_OUTPUT
+          fi
 
   snap_frontend_native:
+    needs: dss_snap_build_required
     # When running for a PR, run only after approval
-    if: github.event_name != 'pull_request' || github.event.review.state == 'approved'
+    if: github.event_name != 'pull_request_review' || (github.event.review.state == 'approved' && true == fromJSON(needs.dss_snap_build_required.outputs.build_required))
     outputs:
       artifact-url: ${{ steps.upload_artifact.outputs.artifact-url }}
     runs-on:

--- a/.github/workflows/checkbox-dss-build.yaml
+++ b/.github/workflows/checkbox-dss-build.yaml
@@ -7,9 +7,11 @@ on:
     paths:
       - contrib/checkbox-dss-validation/checkbox-provider-dss/**
       - .github/workflows/checkbox-dss-build.yaml
-  pull_request_review:
+  pull_request:
     branches: [ main ]
-    types: [submitted]
+    paths:
+      - contrib/checkbox-dss-validation/checkbox-provider-dss/**
+      - .github/workflows/checkbox-dss-build.yaml
   workflow_dispatch:
   workflow_call:
     outputs:
@@ -17,33 +19,10 @@ on:
         value: ${{ jobs.snap_frontend_native.outputs.artifact-url }}
 
 jobs:
-  dss_snap_build_required:
-    runs-on: ubuntu-latest
-    name: Check for changes in checkbox-dss dirs
-    outputs:
-      build_required: ${{ steps.check_diff.outputs.build_required }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Use git diff to see if there are any changes in the checkbox-dss directories
-        id: check_diff
-        run: |
-          DIFF_LENGTH=`git diff HEAD origin/main -- contrib/checkbox-dss-validation .github/workflows/checkbox-dss-build.yaml | wc -l`
-          if [[ $DIFF_LENGTH -eq 0 ]]
-            then
-              echo "No checkbox-dss snap build required."
-              echo "build_required=false" >> $GITHUB_OUTPUT
-            else
-              echo "checkbox-dss snap build required!"
-              echo "build_required=true" >> $GITHUB_OUTPUT
-          fi
 
   snap_frontend_native:
-    needs: dss_snap_build_required
     # When running for a PR, run only after approval
-    if: (github.event.review.state == 'approved' && true == fromJSON(needs.dss_snap_build_required.outputs.build_required)) || github.event_name != 'pull_request_review'
+    if: github.event_name != 'pull_request' || github.event.review.state == 'APPROVED'
     outputs:
       artifact-url: ${{ steps.upload_artifact.outputs.artifact-url }}
     runs-on:

--- a/.github/workflows/checkbox-dss-build.yaml
+++ b/.github/workflows/checkbox-dss-build.yaml
@@ -43,7 +43,7 @@ jobs:
   snap_frontend_native:
     needs: dss_snap_build_required
     # When running for a PR, run only after approval
-    if: true == fromJSON(needs.dss_snap_build_required.outputs.build_required) && (github.event_name != 'pull_request_review' || github.event.review.state == 'approved')
+    if: (github.event.review.state == 'approved' && true == fromJSON(needs.dss_snap_build_required.outputs.build_required)) || github.event_name != 'pull_request_review'
     outputs:
       artifact-url: ${{ steps.upload_artifact.outputs.artifact-url }}
     runs-on:

--- a/.github/workflows/checkbox-dss-build.yaml
+++ b/.github/workflows/checkbox-dss-build.yaml
@@ -20,9 +20,32 @@ on:
         value: ${{ jobs.snap_frontend_native.outputs.artifact-url }}
 
 jobs:
+  dss_snap_build_required:
+    runs-on: ubuntu-latest
+    name: Check for changes in checkbox-dss dirs
+    outputs:
+      build_required: ${{ steps.check_diff.outputs.build_required }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Use git diff to see if there are any changes in the checkbox-dss directories
+        id: check_diff
+        run: |
+          DIFF_LENGTH=`git diff HEAD origin/main -- contrib/checkbox-dss-validation .github/workflows/checkbox-dss-build.yaml | wc -l`
+          if [[ $DIFF_LENGTH -eq 0 ]]
+            then
+              echo "No checkbox-dss snap build required."
+              echo "build_required=false" >> $GITHUB_OUTPUT
+            else
+              echo "checkbox-dss snap build required!"
+              echo "build_required=true" >> $GITHUB_OUTPUT
+          fi
+
   snap_frontend_native:
     # When running for a PR, run only after approval
-    if: ${{ github.event_name != 'pull_request_review' || github.event.review.state == 'approved' }}
+    if: true == fromJSON(needs.dss_snap_build_required.outputs.build_required)) && (github.event_name != 'pull_request_review' || github.event.review.state == 'approved')
     outputs:
       artifact-url: ${{ steps.upload_artifact.outputs.artifact-url }}
     runs-on:

--- a/.github/workflows/checkbox-dss-build.yaml
+++ b/.github/workflows/checkbox-dss-build.yaml
@@ -22,7 +22,7 @@ jobs:
 
   snap_frontend_native:
     # When running for a PR, run only after approval
-    if: github.event_name != 'pull_request' || github.event.review.state == 'APPROVED'
+    if: github.event_name != 'pull_request' || github.event.review.state == 'approved'
     outputs:
       artifact-url: ${{ steps.upload_artifact.outputs.artifact-url }}
     runs-on:

--- a/.github/workflows/checkbox-dss-build.yaml
+++ b/.github/workflows/checkbox-dss-build.yaml
@@ -41,6 +41,7 @@ jobs:
           fi
 
   snap_frontend_native:
+    needs: dss_snap_build_required
     # When running for a PR, run only after approval
     if: true == fromJSON(needs.dss_snap_build_required.outputs.build_required) && (github.event_name != 'pull_request_review' || github.event.review.state == 'approved')
     outputs:

--- a/.github/workflows/checkbox-dss-build.yaml
+++ b/.github/workflows/checkbox-dss-build.yaml
@@ -45,7 +45,7 @@ jobs:
 
   snap_frontend_native:
     # When running for a PR, run only after approval
-    if: true == fromJSON(needs.dss_snap_build_required.outputs.build_required)) && (github.event_name != 'pull_request_review' || github.event.review.state == 'approved')
+    if: true == fromJSON(needs.dss_snap_build_required.outputs.build_required) && (github.event_name != 'pull_request_review' || github.event.review.state == 'approved')
     outputs:
       artifact-url: ${{ steps.upload_artifact.outputs.artifact-url }}
     runs-on:

--- a/.github/workflows/checkbox-dss-build.yaml
+++ b/.github/workflows/checkbox-dss-build.yaml
@@ -10,9 +10,6 @@ on:
   pull_request_review:
     branches: [ main ]
     types: [submitted]
-    paths:
-      - contrib/checkbox-dss-validation/checkbox-provider-dss/**
-      - .github/workflows/checkbox-dss-build.yaml
   workflow_dispatch:
   workflow_call:
     outputs:


### PR DESCRIPTION
## Description

#1936 did not sufficiently restrict when the `checkbox-dss` snap's build was triggered on PR approvals. `paths` is not supported in the trigger `pull_request_review` and was unfortunately not caught by any validations.

This PR follows the approach from `metabox.yaml` where the workflow gets triggered on approval of all PRs, but we explicitly check if the changes are relevant before actually running the build.

### What did not work

- Having `paths` in the `pull_request_review` trigger.
- Having `paths` in the `pull_request` trigger, but checking if PR is `approved`.  This does not trigger the workflow on PRs' approval.

## Resolved issues

Part of [CHECKBOX-1905](https://warthogs.atlassian.net/browse/CHECKBOX-1905).

## Documentation

No changes to documentation.

## Tests

Relevant runs of this workflow:

- [This](https://github.com/canonical/checkbox/actions/runs/15304439788) was run manually, showing that it is still possible to dispatch the workflow.
- [x] Check that the workflow runs after this PR is approved.


[CHECKBOX-1905]: https://warthogs.atlassian.net/browse/CHECKBOX-1905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ