### PR TITLE
Add ppa for missing library version (infra)

### DIFF
--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -63,6 +63,8 @@ slots:
 package-repositories:
   - type: apt
     ppa: colin-king/stress-ng
+  - type: apt
+    ppa: colin-king/ppa
 
 parts:
   version-calculator:


### PR DESCRIPTION
## Description

Currently the build on amd64 fails with a missing dependency, the reason is that stress-ng depends on `libipsec-mb-dev [amd64]` and apt tries to pull `libipsec-mb2 (>= 2.0) ` which is not available in noble universe. The library is backported (and this is how stress-ng gets to build on its own ppa) in another ppa, this adds it to the recipe.

## Resolved issues

Fixes: CHECKBOX-1930

## Documentation

N/A

## Tests

Build ongoing here: https://github.com/canonical/checkbox/actions/runs/15461400887
