### PR TITLE
Tox develop all providers to validate (infra)

### DIFF
--- a/providers/base/tox.ini
+++ b/providers/base/tox.ini
@@ -4,18 +4,16 @@ skip_missing_interpreters = true
 skipsdist=True
 
 [testenv]
-allowlist_externals = rm
+allowlist_externals = bash
 commands =
     {envpython} -m pip -q install ../../checkbox-ng
-    # Required because this provider depends on checkbox-support parsers & scripts
     {envpython} -m pip -q install ../../checkbox-support
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
-    # Required because this provider depends on the resource provider
-    {envpython} ../resource/manage.py develop
+    bash -c "for provider in ../*; do {envpython} $provider/manage.py develop -f; done"
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
     {envpython} -m coverage xml
+setenv = PROVIDERPATH = {envdir}
 
 [testenv:py35]
 deps =
@@ -38,6 +36,7 @@ setenv=
 # we do not care about the package version in tox
 #  but it breaks some old python3.5 builds
     SETUPTOOLS_SCM_PRETEND_VERSION=0.0
+    PROVIDERPATH = {envdir}
 
 [testenv:py36]
 deps =

--- a/providers/certification-client/tox.ini
+++ b/providers/certification-client/tox.ini
@@ -4,18 +4,16 @@ skip_missing_interpreters = true
 skipsdist=True
 
 [testenv]
-allowlist_externals = rm
+allowlist_externals = bash
 commands =
-    pip -q install ../../checkbox-ng
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
-    # Required because this provider depends on the resource and base providers
-    {envpython} ../resource/manage.py develop
-    {envpython} ../base/manage.py develop
+    {envpython} -m pip -q install ../../checkbox-ng
+    {envpython} -m pip -q install ../../checkbox-support
+    bash -c "for provider in ../*; do {envpython} $provider/manage.py develop -f; done"
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
     {envpython} -m coverage xml
+setenv = PROVIDERPATH = {envdir}
 
 [testenv:py35]
 deps =
@@ -35,6 +33,7 @@ setenv=
 # we do not care about the package version in tox
 #  but it breaks some old python3.5 builds
     SETUPTOOLS_SCM_PRETEND_VERSION=0.0
+    PROVIDERPATH = {envdir}
 
 [testenv:py36]
 deps =

--- a/providers/certification-server/tox.ini
+++ b/providers/certification-server/tox.ini
@@ -4,18 +4,16 @@ skip_missing_interpreters = true
 skipsdist=True
 
 [testenv]
-allowlist_externals = rm
+allowlist_externals = bash
 commands =
-    pip -q install ../../checkbox-ng
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
-    # Required because this provider depends on the resource and base providers
-    {envpython} ../resource/manage.py develop
-    {envpython} ../base/manage.py develop
+    {envpython} -m pip -q install ../../checkbox-ng
+    {envpython} -m pip -q install ../../checkbox-support
+    bash -c "for provider in ../*; do {envpython} $provider/manage.py develop -f; done"
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
     {envpython} -m coverage xml
+setenv = PROVIDERPATH = {envdir}
 
 [testenv:py35]
 deps =
@@ -35,6 +33,7 @@ setenv=
 # we do not care about the package version in tox
 #  but it breaks some old python3.5 builds
     SETUPTOOLS_SCM_PRETEND_VERSION=0.0
+    PROVIDERPATH = {envdir}
 
 [testenv:py36]
 deps =

--- a/providers/docker/tox.ini
+++ b/providers/docker/tox.ini
@@ -4,15 +4,13 @@ skip_missing_interpreters = true
 skipsdist=True
 
 [testenv]
-allowlist_externals = rm
+allowlist_externals = bash
 commands =
-    pip -q install ../../checkbox-ng
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
-    # Required because this provider depends on the resource and base providers
-    {envpython} ../resource/manage.py develop
-    {envpython} ../base/manage.py develop
+    {envpython} -m pip -q install ../../checkbox-ng
+    {envpython} -m pip -q install ../../checkbox-support
+    bash -c "for provider in ../*; do {envpython} $provider/manage.py develop -f; done"
     {envpython} manage.py validate
+setenv = PROVIDERPATH = {envdir}
 
 [testenv:py35]
 deps =
@@ -32,6 +30,7 @@ setenv=
 # we do not care about the package version in tox
 #  but it breaks some old python3.5 builds
     SETUPTOOLS_SCM_PRETEND_VERSION=0.0
+    PROVIDERPATH = {envdir}
 
 [testenv:py36]
 deps =

--- a/providers/genio/tox.ini
+++ b/providers/genio/tox.ini
@@ -4,19 +4,16 @@ skip_missing_interpreters = true
 skipsdist=True
 
 [testenv]
-allowlist_externals = rm
+allowlist_externals = bash
 commands =
     {envpython} -m pip -q install ../../checkbox-ng
-    # Required because this provider depends on checkbox-support parsers & scripts
     {envpython} -m pip -q install ../../checkbox-support
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
-    # Required because this provider depends on the resource provider
-    {envpython} ../../providers/resource/manage.py develop
-    {envpython} manage.py develop
+    bash -c "for provider in ../*; do {envpython} $provider/manage.py develop -f; done"
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
     {envpython} -m coverage xml
+setenv = PROVIDERPATH = {envdir}
 
 [testenv:py35]
 deps =
@@ -34,6 +31,7 @@ setenv=
 # we do not care about the package version in tox
 #  but it breaks some old python3.5 builds
     SETUPTOOLS_SCM_PRETEND_VERSION=0.0
+    PROVIDERPATH = {envdir}
 
 [testenv:py36]
 deps =

--- a/providers/gpgpu/tox.ini
+++ b/providers/gpgpu/tox.ini
@@ -4,20 +4,16 @@ skip_missing_interpreters = true
 skipsdist=True
 
 [testenv]
-allowlist_externals = rm
+allowlist_externals = bash
 commands =
     {envpython} -m pip -q install ../../checkbox-ng
-    # Required because this provider depends on checkbox-support scripts
     {envpython} -m pip -q install ../../checkbox-support
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
-    # Required because this provider depends on the resource and base providers
-    {envpython} ../resource/manage.py develop
-    {envpython} ../base/manage.py develop
+    bash -c "for provider in ../*; do {envpython} $provider/manage.py develop -f; done"
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
     {envpython} -m coverage xml
+setenv = PROVIDERPATH = {envdir}
 
 [testenv:py35]
 deps =
@@ -37,6 +33,7 @@ setenv=
 # we do not care about the package version in tox
 #  but it breaks some old python3.5 builds
     SETUPTOOLS_SCM_PRETEND_VERSION=0.0
+    PROVIDERPATH = {envdir}
 
 [testenv:py36]
 deps =

--- a/providers/iiotg/tox.ini
+++ b/providers/iiotg/tox.ini
@@ -4,18 +4,16 @@ skip_missing_interpreters = true
 skipsdist=True
 
 [testenv]
-allowlist_externals = rm
+allowlist_externals = bash
 commands =
-    pip -q install ../../checkbox-ng
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
-    # Required because this provider depends on the resource and base providers
-    {envpython} ../resource/manage.py develop
-    {envpython} ../base/manage.py develop
+    {envpython} -m pip -q install ../../checkbox-ng
+    {envpython} -m pip -q install ../../checkbox-support
+    bash -c "for provider in ../*; do {envpython} $provider/manage.py develop -f; done"
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
     {envpython} -m coverage xml
+setenv = PROVIDERPATH = {envdir}
 
 [testenv:py35]
 deps =
@@ -35,6 +33,8 @@ setenv=
 # we do not care about the package version in tox
 #  but it breaks some old python3.5 builds
     SETUPTOOLS_SCM_PRETEND_VERSION=0.0
+    PROVIDERPATH = {envdir}
+
 
 [testenv:py36]
 deps =

--- a/providers/resource/tox.ini
+++ b/providers/resource/tox.ini
@@ -4,14 +4,16 @@ skip_missing_interpreters = true
 skipsdist=True
 
 [testenv]
+allowlist_externals = bash
 commands =
-    pip -q install ../../checkbox-ng
-    # Required because this provider depends on checkbox-support parsers & scripts
-    pip -q install ../../checkbox-support
+    {envpython} -m pip -q install ../../checkbox-ng
+    {envpython} -m pip -q install ../../checkbox-support
+    bash -c "for provider in ../*; do {envpython} $provider/manage.py develop -f; done"
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
     {envpython} -m coverage xml
+setenv = PROVIDERPATH = {envdir}
 
 [testenv:py35]
 deps =
@@ -30,6 +32,7 @@ setenv=
 # we do not care about the package version in tox
 #  but it breaks some old python3.5 builds
     SETUPTOOLS_SCM_PRETEND_VERSION=0.0
+    PROVIDERPATH = {envdir}
 
 [testenv:py36]
 deps =

--- a/providers/sru/tox.ini
+++ b/providers/sru/tox.ini
@@ -4,18 +4,16 @@ skip_missing_interpreters = true
 skipsdist=True
 
 [testenv]
-allowlist_externals = rm
+allowlist_externals = bash
 commands =
-    pip -q install ../../checkbox-ng
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
-    # Required because this provider depends on the resource and base providers
-    {envpython} ../resource/manage.py develop
-    {envpython} ../base/manage.py develop
+    {envpython} -m pip -q install ../../checkbox-ng
+    {envpython} -m pip -q install ../../checkbox-support
+    bash -c "for provider in ../*; do {envpython} $provider/manage.py develop -f; done"
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
     {envpython} -m coverage xml
+setenv = PROVIDERPATH = {envdir}
 
 [testenv:py35]
 deps =
@@ -35,6 +33,7 @@ setenv=
 # we do not care about the package version in tox
 #  but it breaks some old python3.5 builds
     SETUPTOOLS_SCM_PRETEND_VERSION=0.0
+    PROVIDERPATH = {envdir}
 
 [testenv:py36]
 deps =

--- a/providers/tpm2/tox.ini
+++ b/providers/tpm2/tox.ini
@@ -4,13 +4,13 @@ skip_missing_interpreters = true
 skipsdist=True
 
 [testenv]
-allowlist_externals = rm
+allowlist_externals = bash
 commands =
-    pip -q install ../../checkbox-ng
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
-    # Required because this provider depends on the resource provider
-    {envpython} ../resource/manage.py develop
+    {envpython} -m pip -q install ../../checkbox-ng
+    {envpython} -m pip -q install ../../checkbox-support
+    bash -c "for provider in ../*; do {envpython} $provider/manage.py develop -f; done"
     {envpython} manage.py validate
+setenv = PROVIDERPATH = {envdir}
 
 [testenv:py35]
 deps =
@@ -29,6 +29,7 @@ setenv=
 # we do not care about the package version in tox
 #  but it breaks some old python3.5 builds
     SETUPTOOLS_SCM_PRETEND_VERSION=0.0
+    PROVIDERPATH = {envdir}
 
 [testenv:py36]
 deps =

--- a/providers/tutorial/tox.ini
+++ b/providers/tutorial/tox.ini
@@ -4,18 +4,16 @@ skip_missing_interpreters = true
 skipsdist=True
 
 [testenv]
-allowlist_externals = rm
+allowlist_externals = bash
 commands =
     {envpython} -m pip -q install ../../checkbox-ng
-    # Required because this provider depends on checkbox-support parsers & scripts
     {envpython} -m pip -q install ../../checkbox-support
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
-    # Required because this provider depends on the resource provider
-    {envpython} ../resource/manage.py develop
+    bash -c "for provider in ../*; do {envpython} $provider/manage.py develop -f; done"
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
     {envpython} -m coverage xml
+setenv = PROVIDERPATH = {envdir}
 
 [testenv:py35]
 deps =
@@ -38,6 +36,7 @@ setenv=
 # we do not care about the package version in tox
 #  but it breaks some old python3.5 builds
     SETUPTOOLS_SCM_PRETEND_VERSION=0.0
+    PROVIDERPATH = {envdir}
 
 [testenv:py36]
 deps =


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

validating a provider doesn't guarantee the provider is valid if all providers in the same namespace are not developed as well. This caused a regression last pulse where a test was introduced with an id clashing with an id in another provider. This fixes it by developing always all of them

This also fixes the fact that our tox.ini used to develop providers globally (sigh) and `rm -rf` them globally (double sigh). This uses the tox env directory as tmp (as it would do if we were in a checkbox venv created with mk-venv) and the `-f` option to not break on re-development (for local iteration)


## Resolved issues

Fixes: CHECKBOX-1915

## Documentation

N/A

## Tests

Ran thanks to the other pr here!
