### PR TITLE
Add v4l2 compliance tests to client-cert-24-04-automated (New)

### DIFF
--- a/providers/certification-client/units/client-cert-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-24-04.pxu
@@ -85,6 +85,7 @@ _description:
 include:
     recovery_info_attachment
 nested_part:
+    camera-v4l2-compliance
     submission-cert-automated
     info-attachment-cert-automated
     acpi-automated


### PR DESCRIPTION
## Description

This PR adds the v4l2 compliance tests to just the 24-04 automated test plan

## Resolved issues

## Documentation

## Tests

Sideloaded the test plan and v4l2-compliance is correctly picked up