### PR TITLE
Create extra-envs with pinned dependencies (infra)

### DIFF
--- a/checkbox-ng/pyproject.toml
+++ b/checkbox-ng/pyproject.toml
@@ -17,6 +17,7 @@
     'Jinja2 >= 2.7',
     'xlsxwriter',
     'tqdm',
+    'pyyaml',
     'importlib_metadata; python_version < "3.8"',
     'filetype; python_version > "3.12"'
   ]
@@ -33,10 +34,14 @@
     'Intended Audience :: Manufacturing',
     'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
     'Natural Language :: English',
-    'Natural Language :: Polish',
     'Operating System :: POSIX',
     'Operating System :: POSIX :: Linux',
-    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Topic :: Software Development :: Quality Assurance',
     'Topic :: Software Development :: Testing',
@@ -44,6 +49,47 @@
     'Topic :: Utilities',
   ]
   dynamic = ["version"]
+[project.optional-dependencies]
+# this is the prod setup for provisioning from source. The versions are
+# pinned to the jammy universe because that is what testflinger agent uses
+jammy_prod = [
+  'certifi==2020.6.20',
+  'chardet==4.0.0',
+  'filetype==1.0.10',
+  'idna==2.10', # universe is 3.3 but it is incompatible with requests
+  'jinja2==3.0.3',
+  'markupsafe==2.0.1',
+  'packaging==21.3',
+  'psutil==5.9.0',
+  'pyparsing==2.4.7',
+  'requests==2.25.1',
+  'tqdm==4.57.0',
+  'urllib3==1.26.5',
+  'urwid==2.1.2',
+  'xlsxwriter==3.0.2',
+  'pyyaml==6.0', # universe is 5.4.1 but it doesn't install anymore (cython issue)
+]
+# useful to get up to date packages and future version of testflinger agent
+noble_prod = [
+  'certifi==2023.11.17',
+  'chardet==5.2.0',
+  'charset-normalizer==3.3.2',
+  'filetype==1.2.0',
+  'idna==3.6',
+  'jinja2==3.1.2',
+  'markupsafe==2.1.5',
+  'packaging==24.0',
+  'psutil==5.9.8',
+  'pyparsing==3.1.1',
+  'requests==2.31.0',
+  'tqdm==4.66.2',
+  'typing-extensions==4.10.0',
+  'urllib3==2.0.7',
+  'urwid==2.6.10',
+  'wcwidth==0.2.5',
+  'xlsxwriter==3.1.9',
+  'pyyaml==6.0.1',
+]
 [tool.black]
   line-length = 79
   # Exclude vendorized code (e.g. the stuff in plainbox/vendor/)

--- a/checkbox-ng/setup.cfg
+++ b/checkbox-ng/setup.cfg
@@ -11,6 +11,7 @@ install_requires=
   Jinja2 >= 2.7
   xlsxwriter
   tqdm
+  pyyaml
   importlib_metadata; python_version < "3.8"
   filetype; python_version > "3.12"
 [upload_docs]

--- a/checkbox-support/pyproject.toml
+++ b/checkbox-support/pyproject.toml
@@ -13,7 +13,6 @@
     'pyparsing>=2.2.0',
     'requests>=1.0',
     'distro>=1.0',
-    'configparser; python_version=="2.7"',
     'requests_unixsocket>=0.1.2; python_version>="3.5" and python_version<="3.11"',
     'requests_unixsocket2; python_version>="3.12"',
     'importlib_metadata; python_version<"3.8"',
@@ -22,6 +21,37 @@
 [metadata]
   long_description={'file' = 'README.md'}
   long_description_content_type='text/x-rst'
+[project.optional-dependencies]
+# this is the prod setup for provisioning from source. The versions are
+# pinned to the jammy universe because that is what testflinger agent uses
+jammy_prod = [ # Note: ancient versions of pip fail to see this section, use pipx!
+  'certifi==2020.6.20',
+  'charset-normalizer==2.0.6',
+  'distro==1.7.0',
+  'idna==2.10', # universe is 3.3 but it is incompatible with requests
+  'pyparsing==2.4.7',
+  'requests==2.25.1',
+  'distro==1.7.0',
+  'requests_unixsocket==0.2.0',
+  'pyyaml==6.0', # universe is 5.4.1 but it doesn't install anymore (cython issue)
+  'urllib3==1.26.5', # called python3-yaml in universe
+  'numpy==1.21.5',
+  'opencv==4.5.4'
+]
+# useful to get up to date packages and future version of testflinger agent
+noble_prod = [
+  'certifi==2023.11.17',
+  'charset-normalizer==3.3.2',
+  'distro==1.9.0',
+  'idna==3.6',
+  'pyparsing==3.1.1',
+  'PyYAML==6.0.1',
+  'requests==2.31.0',
+  'requests-unixsocket==0.3.0',
+  'urllib3==2.0.7',
+  'numpy==1.26.4',
+  'opencv-python==4.6.0.66'
+]
 [tool.black]
   line-length = 79
   # Exclude vendorized code (e.g. the stuff in checkbox_support/vendor)


### PR DESCRIPTION
# Description
Given the recent urwid debacle taking down our infra, its about time we take seriously source installs of Checkbox. Checkbox source IS part of our infra, it is not a development tool anymore. As such, the distribution of it must be fixed.

This is not the principled solution to the issue, [this is](https://github.com/canonical/checkbox/pull/1912), but I'm completely unable to make it work. For some reason, if dependencies are precisely (or loosely for that matter) pinned, snap builds for core18 and core20 stop working, I've tried and failed multiple iterations.

This introduces two new optional environments to install checkbox-ng and checkbox-support so that one can install them on demand with the pinned dependencies.

# Resolved issues
Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1921
# Documentation
Documented each pinning block what it is referring to.
# Tests
Tox 
Metabox run: [link](https://github.com/canonical/checkbox/actions/runs/15612030419)
snaps native: [link](https://github.com/canonical/checkbox/actions/runs/15612183760)
snaps cross: [link](https://github.com/canonical/checkbox/actions/runs/15612404843)

To test this locally
```
$ lxc launch ubuntu:(noble|jammy) tmp
# assuming we are in checkbox/
$ lxc file push -r . tmp/root/
$ lxc shell tmp
(lxc) $ apt update && apt install -qq -y python3 python3-venv
(lxc) $ python3 -m venv venv
(lxc) $ . venv/bin/activate
(lxc) (venv) $ cd checkbox/checkbox-ng
(lxc) (venv) $ pip install .[jammy_prod] # or noble_prod if you are on noble
(lxc) (venv) $ cd ../checkbox-support
(lxc) (venv) $ pip install .[jammy_prod] # or noble_prod if you are on noble
```

You should now have a full venv with all the dependencies as pinned in the `pyproject.toml`