### PR TITLE
Support quiet, cool and balanced_performance (BugFix)

### DIFF
--- a/providers/base/bin/switch_power_mode.py
+++ b/providers/base/bin/switch_power_mode.py
@@ -50,21 +50,23 @@ def set_power_profile(profile):
     """
     # In sys file the modes are quiet, low-power, cool, balanced or performance
     # but powerprofilesctl only accepts power-saver, balanced or performance
-    profile = (
-        "power-saver"
-        if profile in ["low-power", "quiet"]
-        else (
-            "balanced"
-            if profile in ["cool", "balanced_performance"]
-            else profile
-        )
-    )
+    profile_mappings = {
+        "low-power": "power-saver",
+        "power-saver": "power-saver",
+        "quiet": "power-saver",
+        "balanced": "balanced",
+        "balanced_performance": "balanced",
+        "cool": "balanced",
+        "performance": "performance",
+    }
+    if profile not in profile_mappings:
+        raise SystemExit(f"Unhandled ACPI platform profile: {profile}")
+    profile = profile_mappings[profile]
+
     try:
         subprocess.check_call(["powerprofilesctl", "set", profile])
     except subprocess.CalledProcessError as e:
-        raise SystemExit(
-            "Failed to set power mode to {}.".format(profile)
-        ) from e
+        raise SystemExit(f"Failed to set power mode to {profile}.") from e
 
 
 @contextlib.contextmanager

--- a/providers/base/bin/switch_power_mode.py
+++ b/providers/base/bin/switch_power_mode.py
@@ -59,14 +59,18 @@ def set_power_profile(profile):
         "cool": "balanced",
         "performance": "performance",
     }
+
     if profile not in profile_mappings:
-        raise SystemExit(f"Unhandled ACPI platform profile: {profile}")
+        raise SystemExit("Unhandled ACPI platform profile: {}".format(profile))
+
     profile = profile_mappings[profile]
 
     try:
         subprocess.check_call(["powerprofilesctl", "set", profile])
     except subprocess.CalledProcessError as e:
-        raise SystemExit(f"Failed to set power mode to {profile}.") from e
+        raise SystemExit(
+            "Failed to set power mode to {}.".format(profile)
+        ) from e
 
 
 @contextlib.contextmanager

--- a/providers/base/bin/switch_power_mode.py
+++ b/providers/base/bin/switch_power_mode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+# !/usr/bin/env python3
 #
 # This file is part of Checkbox.
 #
@@ -48,9 +48,17 @@ def set_power_profile(profile):
     Raises:
         SystemExit: If the power profile could not be set.
     """
-    # In sys file the modes are low-power, balanced, or performance
+    # In sys file the modes are quiet, low-power, cool, balanced or performance
     # but powerprofilesctl only accepts power-saver, balanced or performance
-    profile = "power-saver" if profile == "low-power" else profile
+    profile = (
+        "power-saver"
+        if profile in ["low-power", "quiet"]
+        else (
+            "balanced"
+            if profile in ["cool", "balanced_performance"]
+            else profile
+        )
+    )
     try:
         subprocess.check_call(["powerprofilesctl", "set", profile])
     except subprocess.CalledProcessError as e:

--- a/providers/base/tests/test_switch_power_mode.py
+++ b/providers/base/tests/test_switch_power_mode.py
@@ -107,6 +107,23 @@ class TestSwitchPowerMode(unittest.TestCase):
             ["powerprofilesctl", "set", "performance"]
         )
 
+    @patch("subprocess.check_call")  # Mock the subprocess.check_call function
+    def test_set_power_profile_unhandled(self, mock_check_call):
+        """
+        Tests handling of a unhandled power profile setting.
+        """
+        mock_check_call.side_effect = subprocess.CalledProcessError(
+            1, "powerprofilesctl"
+        )
+
+        with self.assertRaises(SystemExit) as cm:
+            set_power_profile("unexpected-profile")
+
+        self.assertEqual(
+            str(cm.exception),
+            "Unhandled ACPI platform profile: unexpected-profile",
+        )
+
     @patch("sys.stdout", new_callable=io.StringIO)
     def test_main_success(self, mock_stdout):
         """


### PR DESCRIPTION
The new power-profile-daemon support some new value from platform_profile in the commit below.
https://gitlab.freedesktop.org/upower/power-profiles-daemon/-/commit/6b565b0b05a2bc92e3c546a567b394f415937265

## Description
We found the testcase will be failed on Dell platform.

power-management/switch_power_mode failed
certification_status: non-blocker

[I/O log]
Failed to communicate with power-profiles-daemon: g-dbus-error-quark: GDBus.Error:org.freedesktop.DBus.Error.Failed: Invalid profile name 'quiet' (0)
Power mode choices: ['quiet', 'balanced', 'performance']
Failed to set power mode to quiet.

## Resolved issues

JIRA: SOMERVILLE-2363

## Tests

$ checkbox-cli run com.canonical.certification::power-management/switch_power_mode

==============[ Running job 4 / 4. Estimated time left: 0:00:10 ]===============                                                                               
---------------------[ power-management/switch_power_mode ]---------------------                                                                               
ID: com.canonical.certification::power-management/switch_power_mode            
Category: com.canonical.plainbox::power-management                             
... 8< -------------------------------------------------------------------------                                                                               
Power mode choices: ['quiet', 'balanced', 'performance']                       
Switch to quiet successfully.                                                  
Switch to balanced successfully.                                               
Switch to performance successfully.                                            
------------------------------------------------------------------------- >8 ---                                                                               
Outcome: job passed                                                            
Finalizing session that hasn't been submitted anywhere: checkbox-run-2025-06-13T05.56.50                                                                       
==================================[ Results ]===================================                                                                               
 ☑ : Collect information about kernel modules                                  
 ☑ : Discover if the system supports power modes via acpi                      
 ☑ : Collect information about installed software packages                     
 ☑ : power-management/switch_power_mode     