### PR TITLE
Make run_watcher print every line it reads from journal (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -75,7 +75,6 @@ class StorageInterface(ABC):
     these methods
     """
 
-    @abstractmethod
     def _parse_journal_line(self, line_str):
         """
         Parse the journal line and update the attributes based on the line
@@ -83,7 +82,8 @@ class StorageInterface(ABC):
 
         :param line_str: str of the scanned log lines.
         """
-        pass
+
+        print(line_str)
 
     @abstractmethod
     def _validate_insertion(self):
@@ -265,6 +265,8 @@ class USBStorage(StorageWatcher):
         if match:
             self.mounted_partition = match.group("part_name")
 
+        return super()._parse_journal_line(line_str)
+
 
 class MediacardStorage(StorageWatcher):
     """
@@ -322,6 +324,8 @@ class MediacardStorage(StorageWatcher):
         removal_re = re.compile(r"card ([0-9a-fA-F]+) removed")
         if re.search(removal_re, line_str):
             self.action = "removal"
+
+        return super()._parse_journal_line(line_str)
 
 
 class MediacardComboStorage(StorageWatcher):
@@ -410,6 +414,8 @@ class ThunderboltStorage(StorageWatcher):
         removal_re = re.compile(r"{} device disconnected".format(RE_PREFIX))
         if re.search(removal_re, line_str):
             self.action = "removal"
+
+        return super()._parse_journal_line(line_str)
 
 
 def parse_args():

--- a/checkbox-support/checkbox_support/tests/test_run_watcher.py
+++ b/checkbox-support/checkbox_support/tests/test_run_watcher.py
@@ -225,6 +225,12 @@ class TestRunWatcher(unittest.TestCase):
         mock_usb_storage.action = ""
         USBStorage._validate_removal(mock_usb_storage)
 
+    @patch("builtins.print")
+    def test_parse_journal_line(self, mock_print):
+        mock_storage = MagicMock()
+        StorageWatcher._parse_journal_line(mock_storage, "hello")
+        mock_print.assert_called_once_with("hello")
+
     @patch("checkbox_support.scripts.run_watcher.super")
     def test_usb_storage_parse_journal_line(self, mock_super):
         line_str = "new high-speed USB device"

--- a/checkbox-support/checkbox_support/tests/test_run_watcher.py
+++ b/checkbox-support/checkbox_support/tests/test_run_watcher.py
@@ -225,11 +225,14 @@ class TestRunWatcher(unittest.TestCase):
         mock_usb_storage.action = ""
         USBStorage._validate_removal(mock_usb_storage)
 
-    def test_usb_storage_parse_journal_line(self):
+    @patch("checkbox_support.scripts.run_watcher.super")
+    def test_usb_storage_parse_journal_line(self, mock_super):
         line_str = "new high-speed USB device"
         mock_usb_storage = MagicMock()
         USBStorage._parse_journal_line(mock_usb_storage, line_str)
         self.assertEqual(mock_usb_storage.device, "high_speed_usb")
+        super_method = mock_super.return_value._parse_journal_line
+        super_method.assert_called_once_with(line_str)
 
         line_str = "new SuperSpeed USB device"
         mock_usb_storage = MagicMock()
@@ -312,11 +315,14 @@ class TestRunWatcher(unittest.TestCase):
         mock_mediacard_storage.action = ""
         MediacardStorage._validate_removal(mock_mediacard_storage)
 
-    def test_mediacard_storage_parse_journal_line(self):
+    @patch("checkbox_support.scripts.run_watcher.super")
+    def test_mediacard_storage_parse_journal_line(self, mock_super):
         line_str = "mmcblk0: p1"
         mock_mediacard_storage = MagicMock()
         MediacardStorage._parse_journal_line(mock_mediacard_storage, line_str)
         self.assertEqual(mock_mediacard_storage.mounted_partition, "mmcblk0p1")
+        super_method = mock_super.return_value._parse_journal_line
+        super_method.assert_called_once_with(line_str)
 
         line_str = "new SD card at address 123456"
         mock_mediacard_storage = MagicMock()
@@ -382,7 +388,8 @@ class TestRunWatcher(unittest.TestCase):
         mock_mediacard_combo_storage.action = ""
         MediacardComboStorage._validate_removal(mock_mediacard_combo_storage)
 
-    def test_mediacard_combo_storage_parse_journal_line(self):
+    @patch("checkbox_support.scripts.run_watcher.super")
+    def test_mediacard_combo_storage_parse_journal_line(self, mock_super):
         line_str = "mmcblk0: p1"
         mock_mediacard_combo_storage = MagicMock()
         MediacardComboStorage._parse_journal_line(
@@ -391,6 +398,8 @@ class TestRunWatcher(unittest.TestCase):
         self.assertEqual(
             mock_mediacard_combo_storage.mounted_partition, "mmcblk0p1"
         )
+        super_method = mock_super.return_value._parse_journal_line
+        super_method.assert_called_with(line_str)
 
         line_str = "new SD card at address 123456"
         mock_mediacard_combo_storage = MagicMock()
@@ -448,7 +457,8 @@ class TestRunWatcher(unittest.TestCase):
         mock_thunderbolt_storage.action = ""
         ThunderboltStorage._validate_removal(mock_thunderbolt_storage)
 
-    def test_thunderbolt_storage_parse_journal_line(self):
+    @patch("checkbox_support.scripts.run_watcher.super")
+    def test_thunderbolt_storage_parse_journal_line(self, mock_super):
         line_str = "nvme0n1: p1"
         mock_thunderbolt_storage = MagicMock()
         ThunderboltStorage._parse_journal_line(
@@ -457,6 +467,8 @@ class TestRunWatcher(unittest.TestCase):
         self.assertEqual(
             mock_thunderbolt_storage.mounted_partition, "nvme0n1p1"
         )
+        super_method = mock_super.return_value._parse_journal_line
+        super_method.assert_called_once_with(line_str)
 
         line_str = "thunderbolt 1-1: new device found"
         mock_thunderbolt_storage = MagicMock()


### PR DESCRIPTION
## Description

The error you get from any storage watcher job is quite useless, it's just a timeout error:

```
Traceback (most recent call last):
    <...>
    raise TimeoutError(""Task unable to finish in {}s"".format(timeout_s))
TimeoutError: Task unable to finish in 30s
```

This change makes it print every line it reads from journal, making it easier to understand what was going on in case of failure. I don't expect this log to get big enough in 30s to be a concern in terms of size.


## Resolved issues

N/A

## Documentation

N/A

## Tests

- Added unit test and updated the rest of them
