### PR TITLE
Allow non-exact matching for ids in cli subcommands (New)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -184,7 +184,7 @@ class StartProvider:
         parser.add_argument(
             "name",
             metavar=_("name"),
-            type=str,
+            type=IQN,
             # TRANSLATORS: please keep the YYYY.example... text unchanged or at
             # the very least translate only YYYY and some-name. In either case
             # some-name must be a reasonably-ASCII string (should be safe for a
@@ -1132,8 +1132,9 @@ class Run(MainLoopStage):
             )
             tps = self.sa.get_test_plans()
             self._configure_report()
-            selection = ctx.args.PATTERN
-            selection = self._get_relevant_units(selection, ctx.args.exact)
+            selection = self._get_relevant_units(
+                ctx.args.PATTERN, ctx.args.exact
+            )
             submission_message = self.ctx.args.message
             if len(selection) == 1 and selection[0] in tps:
                 self.ctx.sa.update_app_blob(

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -1078,7 +1078,7 @@ class Run(MainLoopStage):
         parser.add_argument(
             "--exact",
             action="store_true",
-            help="only expand the test-plan FQID that exactly matches",
+            help="only expand the test-plan fully qualified ID that exactly matches",
         )
 
     @property
@@ -1350,7 +1350,7 @@ class Expand:
             "'list-bootstrapped' command instead."
         )
         parser.add_argument(
-            "TEST_PLAN", help=_("test-plan ID or FQID to expand")
+            "TEST_PLAN", help=_("test-plan ID or fully qualified ID to expand")
         )
         parser.add_argument(
             "-f",
@@ -1362,7 +1362,7 @@ class Expand:
         parser.add_argument(
             "--exact",
             action="store_true",
-            help="only expand the test-plan that exactly matches the FQID",
+            help="only expand the test-plan that exactly matches the fully qualified ID",
         )
 
     def _get_relevant_manifest_units(self, jobs_and_templates_list):
@@ -1484,7 +1484,7 @@ class ListBootstrapped:
         parser.add_argument(
             "--exact",
             action="store_true",
-            help="only bootstrap test-plan that exactly match FQID",
+            help="only bootstrap test-plan that exactly match fully qualified ID",
         )
         parser.add_argument("TEST_PLAN", help=_("test-plan id to bootstrap"))
         parser.add_argument(
@@ -1684,7 +1684,9 @@ class Show:
         parser.add_argument(
             "--exact",
             action="store_true",
-            help=_("Only show units that exactly match the FQID"),
+            help=_(
+                "Only show units that exactly match the fully qualified ID"
+            ),
         )
 
     def invoked(self, ctx):

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -184,7 +184,7 @@ class StartProvider:
         parser.add_argument(
             "name",
             metavar=_("name"),
-            type=IQN,
+            type=str,
             # TRANSLATORS: please keep the YYYY.example... text unchanged or at
             # the very least translate only YYYY and some-name. In either case
             # some-name must be a reasonably-ASCII string (should be safe for a
@@ -1075,6 +1075,11 @@ class Run(MainLoopStage):
         parser.add_argument(
             "-m", "--message", help=_("submission description")
         )
+        parser.add_argument(
+            "--exact",
+            action="store_true",
+            help="only expand the test-plan that exactly matches",
+        )
 
     @property
     def C(self):
@@ -1097,6 +1102,23 @@ class Run(MainLoopStage):
             and not self.ctx.args.non_interactive
         )
 
+    def _get_relevant_units(self, patterns, exact=False):
+        if exact:
+            return patterns
+        providers = self.sa.get_selected_providers()
+        root = Explorer(providers).get_object_tree()
+        # here handle the patterns one by one to not change the order
+        matching_units = [
+            root.find_children_by_name([pattern]) for pattern in patterns
+        ]
+        all_ids = [
+            [pattern] if not matches else [match.name for match in matches]
+            for matching_unit in matching_units
+            for (pattern, matches) in matching_unit.items()
+        ]
+        all_ids = [id for all_id in all_ids for id in all_id]
+        return all_ids
+
     def invoked(self, ctx):
         try:
             self._C = Colorizer()
@@ -1111,6 +1133,7 @@ class Run(MainLoopStage):
             tps = self.sa.get_test_plans()
             self._configure_report()
             selection = ctx.args.PATTERN
+            selection = self._get_relevant_units(selection, ctx.args.exact)
             submission_message = self.ctx.args.message
             if len(selection) == 1 and selection[0] in tps:
                 self.ctx.sa.update_app_blob(
@@ -1133,7 +1156,7 @@ class Run(MainLoopStage):
                 self._run_jobs(self.sa.get_dynamic_todo_list())
                 # there might have been new jobs instantiated
                 while True:
-                    self.sa.hand_pick_jobs(ctx.args.PATTERN)
+                    self.sa.hand_pick_jobs(selection)
                     todos = self.sa.get_dynamic_todo_list()
                     if not todos:
                         break
@@ -1333,6 +1356,11 @@ class Expand:
             default="text",
             help=_("output format: 'text' or 'json' (default: %(default)s)"),
         )
+        parser.add_argument(
+            "--exact",
+            action="store_true",
+            help="only expand the test-plan that exactly matches",
+        )
 
     def _get_relevant_manifest_units(self, jobs_and_templates_list):
         """
@@ -1372,9 +1400,12 @@ class Expand:
         session_title = "checkbox-expand-{}".format(ctx.args.TEST_PLAN)
         self.sa.start_new_session(session_title)
         tps = self.sa.get_test_plans()
-        if ctx.args.TEST_PLAN not in tps:
+        testplan_id = get_testplan_id_by_id(
+            tps, ctx.args.TEST_PLAN, self.sa, ctx.args.exact
+        )
+        if testplan_id not in tps:
             raise SystemExit("Test plan not found")
-        self.sa.select_test_plan(ctx.args.TEST_PLAN)
+        self.sa.select_test_plan(testplan_id)
         all_jobs_and_templates = [
             unit
             for unit in self.sa._context.state.unit_list
@@ -1447,6 +1478,11 @@ class ListBootstrapped:
         return self.ctx.sa
 
     def register_arguments(self, parser):
+        parser.add_argument(
+            "--exact",
+            action="store_true",
+            help="only bootstrap test-plan that exactly match",
+        )
         parser.add_argument("TEST_PLAN", help=_("test-plan id to bootstrap"))
         parser.add_argument(
             "-f",
@@ -1464,10 +1500,14 @@ class ListBootstrapped:
     def invoked(self, ctx):
         self.ctx = ctx
         self.sa.start_new_session("checkbox-listing-ephemeral")
+
         tps = self.sa.get_test_plans()
-        if ctx.args.TEST_PLAN not in tps:
+        testplan_id = get_testplan_id_by_id(
+            tps, ctx.args.TEST_PLAN, self.sa, ctx.args.exact
+        )
+        if testplan_id not in tps:
             raise SystemExit("Test plan not found")
-        self.sa.select_test_plan(ctx.args.TEST_PLAN)
+        self.sa.select_test_plan(testplan_id)
         self.sa.bootstrap()
         jobs = []
         for job in self.sa.get_static_todo_list():
@@ -1537,6 +1577,29 @@ class TestPlanExport:
             slugify(self.sa._manager.test_plans[0].name),
         )
         print(path)
+
+
+def get_testplan_id_by_id(tps, testplan_id, sa, exact=False):
+    """
+    Searches for a testplan that matches the given testplan_id
+
+    The input id may not match the testplan id because it is missing the
+    namespace. When the search is not exact, this searches any test plan that
+    has the same id ignoring the namespace.
+    """
+    if exact:
+        return testplan_id
+    if testplan_id in tps:
+        # no need to search for the testplan id
+        return testplan_id
+    providers = sa.get_selected_providers()
+    root = Explorer(providers).get_object_tree()
+
+    relevant = root.find_children_by_name([testplan_id], exact).values()
+    relevant = [unit for units in relevant for unit in units]
+    if relevant:
+        return relevant[0].name
+    return testplan_id  # parent will fail
 
 
 def get_all_jobs(sa):
@@ -1609,18 +1672,26 @@ class Show:
         parser.add_argument(
             "IDs", nargs="+", help=_("Show the definitions of objects")
         )
+        parser.add_argument(
+            "--exact",
+            action="store_true",
+            help=_("Only show units that exactly match the id"),
+        )
 
     def invoked(self, ctx):
         providers = ctx.sa.get_selected_providers()
         self._searched_names = ctx.args.IDs
         root = Explorer(providers).get_object_tree()
-        self._traverse_obj_tree(root)
+        relevant = root.find_children_by_name(ctx.args.IDs, ctx.args.exact)
 
-    def _traverse_obj_tree(self, obj):
-        if obj.name in self._searched_names:
-            self._print_obj(obj)
-        for child in obj.children:
-            self._traverse_obj_tree(child)
+        failed = [id for id, founds in relevant.items() if not founds]
+        to_prints = [unit for units in relevant.values() for unit in units]
+
+        for to_print in to_prints:
+            self._print_obj(to_print)
+
+        if failed:
+            raise SystemExit("Failed to find: {}".format(", ".join(failed)))
 
     def _print_obj(self, obj):
         if "origin" in obj.attrs:

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -1078,7 +1078,7 @@ class Run(MainLoopStage):
         parser.add_argument(
             "--exact",
             action="store_true",
-            help="only expand the test-plan that exactly matches",
+            help="only expand the test-plan FQID that exactly matches",
         )
 
     @property
@@ -1349,7 +1349,9 @@ class Expand:
             "order. To see the execution order, please use the "
             "'list-bootstrapped' command instead."
         )
-        parser.add_argument("TEST_PLAN", help=_("test-plan id to expand"))
+        parser.add_argument(
+            "TEST_PLAN", help=_("test-plan ID or FQID to expand")
+        )
         parser.add_argument(
             "-f",
             "--format",
@@ -1360,7 +1362,7 @@ class Expand:
         parser.add_argument(
             "--exact",
             action="store_true",
-            help="only expand the test-plan that exactly matches",
+            help="only expand the test-plan that exactly matches the FQID",
         )
 
     def _get_relevant_manifest_units(self, jobs_and_templates_list):
@@ -1482,7 +1484,7 @@ class ListBootstrapped:
         parser.add_argument(
             "--exact",
             action="store_true",
-            help="only bootstrap test-plan that exactly match",
+            help="only bootstrap test-plan that exactly match FQID",
         )
         parser.add_argument("TEST_PLAN", help=_("test-plan id to bootstrap"))
         parser.add_argument(
@@ -1682,7 +1684,7 @@ class Show:
         parser.add_argument(
             "--exact",
             action="store_true",
-            help=_("Only show units that exactly match the id"),
+            help=_("Only show units that exactly match the FQID"),
         )
 
     def invoked(self, ctx):

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -1598,6 +1598,12 @@ def get_testplan_id_by_id(tps, testplan_id, sa, exact=False):
 
     relevant = root.find_children_by_name([testplan_id], exact).values()
     relevant = [unit for units in relevant for unit in units]
+    if len(relevant) > 1:
+        raise SystemExit(
+            "More than one testplan match the id {}. Use either:\n- {}".format(
+                testplan_id, "\n- ".join(unit.name for unit in relevant)
+            )
+        )
     if relevant:
         return relevant[0].name
     return testplan_id  # parent will fail

--- a/checkbox-ng/plainbox/impl/highlevel.py
+++ b/checkbox-ng/plainbox/impl/highlevel.py
@@ -23,6 +23,7 @@
 """
 
 from collections import OrderedDict
+import operator
 import logging
 
 from plainbox.impl.session.storage import WellKnownDirsHelper

--- a/checkbox-ng/plainbox/impl/highlevel.py
+++ b/checkbox-ng/plainbox/impl/highlevel.py
@@ -119,7 +119,7 @@ class PlainBoxObject:
 
     def find_children_by_name(self, names: list, exact=False):
         to_explore = [self]
-        name_founds = {name: [] for name in names}
+        name_matches = {name: [] for name in names}
 
         def match_f(a, b):
             # a is namespace::id, b may not contain namespace
@@ -132,10 +132,10 @@ class PlainBoxObject:
             node = to_explore.pop()
             matching = [name for name in names if match_f(node.name, name)]
             for match in matching:
-                name_founds[match].append(node)
+                name_matches[match].append(node)
             to_explore += node.children
 
-        return name_founds
+        return name_matches
 
 
 class Explorer:

--- a/checkbox-ng/plainbox/impl/highlevel.py
+++ b/checkbox-ng/plainbox/impl/highlevel.py
@@ -116,6 +116,26 @@ class PlainBoxObject:
         """
         return self._attrs
 
+    def find_children_by_name(self, names: list, exact=False):
+        to_explore = [self]
+        name_founds = {name: [] for name in names}
+
+        def match_f(a, b):
+            # a is namespace::id, b may not contain namespace
+            return a == b or a.split("::", 1)[-1] == b
+
+        if exact:
+            match_f = operator.eq
+
+        while to_explore:
+            node = to_explore.pop()
+            matching = [name for name in names if match_f(node.name, name)]
+            for match in matching:
+                name_founds[match].append(node)
+            to_explore += node.children
+
+        return name_founds
+
 
 class Explorer:
     """

--- a/docs/tutorial/using-checkbox/advanced-commands.rst
+++ b/docs/tutorial/using-checkbox/advanced-commands.rst
@@ -174,7 +174,7 @@ it contains:
     You can omit the namespace (that would be ``com.canonical.certification``
     in this case from any of the following commands). When doing so, Checkbox
     will do its best to find what you are asking for, disregarding the
-    namespace. If it the match is not unique (there is more than one unit
+    namespace. If the match is not unique (there is more than one unit
     matching), the command may either fail (if it wouldn't make sense to apply
     the same action to all matches) or run the action for all matches. If this
     is undesirable, you can use ``--exact`` to fail if nothing exactly matches

--- a/docs/tutorial/using-checkbox/advanced-commands.rst
+++ b/docs/tutorial/using-checkbox/advanced-commands.rst
@@ -90,7 +90,7 @@ Or let's list all the available jobs (test cases):
 .. code-block:: none
 
     checkbox.checkbox-cli list all-jobs
-    
+
     id: com.canonical.certification::6lowpan/kconfig
     kernel config options for 6LoWPAN
     id: com.canonical.certification::IEEE_80211
@@ -107,7 +107,7 @@ fields available from the jobs. To see what fields are available, run:
 .. code-block:: none
 
     checkbox.checkbox-cli list all-jobs --format ?
-    
+
     Available fields are:
     _description, _purpose, _siblings, _steps, _summary, _verification, after,
     category_id, command, depends, environ, estimated_duration, flags, full_id,
@@ -156,7 +156,7 @@ it contains:
 
 .. code-block:: none
 
-    checkbox.checkbox-cli list-bootstrapped com.canonical.certification::audio-cert-automated
+    checkbox.checkbox-cli list-bootstrapped audio-cert-automated
 
     com.canonical.plainbox::manifest
     com.canonical.certification::package
@@ -168,6 +168,17 @@ it contains:
     com.canonical.certification::audio/alsa_info_attachment
     com.canonical.certification::audio/list_devices
     com.canonical.certification::audio/valid-sof-firmware-sig
+
+.. note::
+
+    You can omit the namespace (that would be ``com.canonical.certification``
+    in this case from any of the following commands). When doing so, Checkbox
+    will do its best to find what you are asking for, disregarding the
+    namespace. If it the match is not unique (there is more than one unit
+    matching), the command may either fail (if it wouldn't make sense to apply
+    the same action to all matches) or run the action for all matches. If this
+    is undesirable, you can use ``--exact`` to fail if nothing exactly matches
+    your query.
 
 If you were to run this test plan with Checkbox, it would run these jobs in
 the order shown above.


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

It is often bothersome, and rarely useful, to include the namespace for all ids in the checkbox-cli subcommands.

This changes them all so that any id provided will be searched both as a `namespace::id` and a `?::id` input. This doesn't affect the user that provides the namespace, but makes it way more accessible for all users to use these tools.

Whenever this behaviour is not desirable, for whatever reason, `--exact` can be provided to all changed subcommands to have the old behaviour back. 

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1951

## Documentation

Documents the new `--exact` option

## Tests

Tested new functions added (most)
Launched manually the commands with the new and old behaviour, ie.
```
checkbox-cli show sru
checkbox-cli show com.canonical.certification::sru
checkbox-cli show com.canonical.certification::sru --exact
```
should all yield the same result
