### PR TITLE
Add v4l2-compliance tests back to `client-cert-desktop-24-04-automated` (New)

### DIFF
--- a/checkbox-support/checkbox_support/parsers/v4l2_compliance.py
+++ b/checkbox-support/checkbox_support/parsers/v4l2_compliance.py
@@ -18,7 +18,7 @@ TEST_NAME_TO_IOCTL_MAP = {
     "VIDIOC_G/S_TUNER/ENUM_FREQ_BANDS": [
         "VIDIOC_G_TUNER",
         "VIDIOC_S_TUNER",
-        "VIDIO_ENUM_FREQ_BANDS",
+        "VIDIOC_ENUM_FREQ_BANDS",
     ],
     "VIDIOC_S_HW_FREQ_SEEK": ["VIDIOC_S_HW_FREQ_SEEK"],
     "VIDIOC_ENUMAUDIO": ["VIDIOC_ENUMAUDIO"],
@@ -145,12 +145,14 @@ def parse_v4l2_compliance(
     """
 
     if device is not None:
+        # since any failure => return code 1
+        # can't really depend on the return code or use check_output here
         out = sp.run(
             ["v4l2-compliance", "-d", str(device)],
             universal_newlines=True,
             stdout=sp.PIPE,
             stderr=sp.PIPE,
-        )  # can't really depend on the return code here
+        )  
     else:
         out = sp.run(
             ["v4l2-compliance"],
@@ -158,7 +160,7 @@ def parse_v4l2_compliance(
             stdout=sp.PIPE,
             stderr=sp.PIPE,
         )
-    # since any failure => return code 1
+    
 
     error_prefixes = ("Failed to open", "Cannot open device")
     if any(out.stderr.startswith(prefix) for prefix in error_prefixes):

--- a/checkbox-support/checkbox_support/parsers/v4l2_compliance.py
+++ b/checkbox-support/checkbox_support/parsers/v4l2_compliance.py
@@ -144,12 +144,20 @@ def parse_v4l2_compliance(
     :rtype: T.Tuple[Summary, Details]
     """
 
-    out = sp.run(
-        ["v4l2-compliance", *(["-d", str(device)] if device else [])],
-        universal_newlines=True,
-        stdout=sp.PIPE,
-        stderr=sp.PIPE,
-    )  # can't really depend on the return code here
+    if device is not None:
+        out = sp.run(
+            ["v4l2-compliance", "-d", str(device)],
+            universal_newlines=True,
+            stdout=sp.PIPE,
+            stderr=sp.PIPE,
+        )  # can't really depend on the return code here
+    else:
+        out = sp.run(
+            ["v4l2-compliance"],
+            universal_newlines=True,
+            stdout=sp.PIPE,
+            stderr=sp.PIPE,
+        )
     # since any failure => return code 1
 
     error_prefixes = ("Failed to open", "Cannot open device")

--- a/checkbox-support/checkbox_support/parsers/v4l2_compliance.py
+++ b/checkbox-support/checkbox_support/parsers/v4l2_compliance.py
@@ -152,7 +152,7 @@ def parse_v4l2_compliance(
             universal_newlines=True,
             stdout=sp.PIPE,
             stderr=sp.PIPE,
-        )  
+        )
     else:
         out = sp.run(
             ["v4l2-compliance"],
@@ -160,7 +160,6 @@ def parse_v4l2_compliance(
             stdout=sp.PIPE,
             stderr=sp.PIPE,
         )
-    
 
     error_prefixes = ("Failed to open", "Cannot open device")
     if any(out.stderr.startswith(prefix) for prefix in error_prefixes):

--- a/providers/base/units/camera/jobs.pxu
+++ b/providers/base/units/camera/jobs.pxu
@@ -28,6 +28,7 @@ template-resource: device
 template-filter: device.category == 'CAPTURE' and device.name != ''
 template-unit: job
 template-id: camera/v4l2-compliance-blockers_name
+requires: lsb.release >= "24.04"
 flags: also-after-suspend
 _template-summary: To check if the ioctl request works on a v4l2 device
 id: camera/v4l2-compliance-blockers_{name}
@@ -42,6 +43,7 @@ template-resource: device
 template-filter: device.category == 'CAPTURE' and device.name != ''
 template-unit: job
 template-id: camera/v4l2-compliance-non-blockers_name
+requires: lsb.release >= "24.04"
 flags: also-after-suspend
 _template-summary: To check if the ioctl request works on a v4l2 device
 id: camera/v4l2-compliance-non-blockers_{name}

--- a/providers/base/units/camera/jobs.pxu
+++ b/providers/base/units/camera/jobs.pxu
@@ -28,7 +28,9 @@ template-resource: device
 template-filter: device.category == 'CAPTURE' and device.name != ''
 template-unit: job
 template-id: camera/v4l2-compliance-blockers_name
-requires: lsb.release >= "24.04"
+requires:
+  lsb.release >= "24.04"
+  manifest.has_rpi_camera == 'False'
 flags: also-after-suspend
 _template-summary: To check if the ioctl request works on a v4l2 device
 id: camera/v4l2-compliance-blockers_{name}
@@ -43,7 +45,9 @@ template-resource: device
 template-filter: device.category == 'CAPTURE' and device.name != ''
 template-unit: job
 template-id: camera/v4l2-compliance-non-blockers_name
-requires: lsb.release >= "24.04"
+requires:
+  lsb.release >= "24.04"
+  manifest.has_rpi_camera == 'False'
 flags: also-after-suspend
 _template-summary: To check if the ioctl request works on a v4l2 device
 id: camera/v4l2-compliance-non-blockers_{name}

--- a/providers/certification-client/units/client-cert-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-24-04.pxu
@@ -91,6 +91,7 @@ nested_part:
     audio-cert-automated
     bluetooth-cert-automated
     camera-cert-automated
+    camera-v4l2-compliance
     thunderbolt-cert-automated
     monitor-gpu-cert-automated
     graphics-gpu-cert-automated


### PR DESCRIPTION
## Description

This PR adds v4l2-compliance to the client-cert-desktop-24-04-automated plan and restricts the test to run only on non-raspberry pi cameras.  

## Resolved issues

## Documentation

The changes in `v4l2_compliance.py` are just for improving readability and fixing a spelling error. No logic changes were made

## Tests

Original unit tests

C3 submissions:
TODO