### PR TITLE
Fix the Invalid class code from lspci (BugFix)

### DIFF
--- a/contrib/pc-sanity/bin/gpu-driver-checker.sh
+++ b/contrib/pc-sanity/bin/gpu-driver-checker.sh
@@ -5,9 +5,9 @@ set -e
 result=0
 
 # Available driver check in each GPU
-for gpu in $(lspci -n -d ::0x0300| awk '{print $1}') \
-           $(lspci -n -d ::0x0302| awk '{print $1}') \
-           $(lspci -n -d ::0x0380| awk '{print $1}'); do
+for gpu in $(lspci -n -d ::0300| awk '{print $1}') \
+           $(lspci -n -d ::0302| awk '{print $1}') \
+           $(lspci -n -d ::0380| awk '{print $1}'); do
     if [[ ${gpu} != "0000"* ]]; then
         gpu="0000:${gpu}"
     fi


### PR DESCRIPTION
## Description
We found the lspci errors when run
```
$ checkbox-cli run com.canonical.certification::miscellanea/check-gpu-driver

----------------------[ Check drivers on each gpu cards. ]----------------------
ID: com.canonical.certification::miscellanea/check-gpu-driver
Category: com.canonical.plainbox::miscellanea
... 8< -------------------------------------------------------------------------
lspci: -d: Invalid class code
lspci: -d: Invalid class code
lspci: -d: Invalid class code
------------------------------------------------------------------------- >8 ---
Outcome: job passed

```
Fixed the usage of lspci.

## Resolved issues

Don't show the error logs.

## Tests

```
$ checkbox-cli run com.canonical.certification::miscellanea/check-gpu-driver

===========================[ Running Selected Jobs ]============================
=========[ Running job 1 / 1. Estimated time left (at least): 0:00:00 ]=========
----------------------[ Check drivers on each gpu cards. ]----------------------
ID: com.canonical.certification::miscellanea/check-gpu-driver
Category: com.canonical.plainbox::miscellanea
... 8< -------------------------------------------------------------------------
Your GPU 0000:07:00.0 is using amdgpu.
------------------------------------------------------------------------- >8 ---
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2025-06-27T10.50.32
```
