### PR TITLE
Use json encoding to avoid spamming remote API (breaking)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -916,14 +916,13 @@ class RemoteController(ReportsStage, MainLoopStage):
             next_job = False
             while next_job is False:
                 for interaction in self.sa.run_job(job["id"]):
-                    if interaction.kind == "purpose":
-                        SimpleUI.description(
-                            _("Purpose:"), interaction.message
-                        )
-                    elif interaction.kind == "description":
-                        SimpleUI.description(
-                            _("Description:"), interaction.message
-                        )
+                    # interaction is a netref, cache attributes here
+                    kind = interaction.kind
+                    message = interaction.message
+                    if kind == "purpose":
+                        SimpleUI.description(_("Purpose:"), message)
+                    elif kind == "description":
+                        SimpleUI.description(_("Description:"), message)
                         if job["command"] is None:
                             cmd = "run"
                         else:
@@ -937,8 +936,8 @@ class RemoteController(ReportsStage, MainLoopStage):
                             raise SystemExit("Session paused by the user")
                         self.sa.remember_users_response(cmd)
                         self.wait_for_job(dont_finish=True)
-                    elif interaction.kind in "steps":
-                        SimpleUI.description(_("Steps:"), interaction.message)
+                    elif kind in "steps":
+                        SimpleUI.description(_("Steps:"), message)
                         if job["command"] is None:
                             cmd = "run"
                         else:
@@ -951,12 +950,10 @@ class RemoteController(ReportsStage, MainLoopStage):
                             self.sa.remember_users_response(cmd)
                             raise SystemExit("Session paused by the user")
                         self.sa.remember_users_response(cmd)
-                    elif interaction.kind == "verification":
+                    elif kind == "verification":
                         self.wait_for_job(dont_finish=True)
-                        if interaction.message:
-                            SimpleUI.description(
-                                _("Verification:"), interaction.message
-                            )
+                        if message:
+                            SimpleUI.description(_("Verification:"), message)
                         JobAdapter = namedtuple("job_adapter", ["command"])
                         job_lite = JobAdapter(job["command"])
                         try:
@@ -976,14 +973,14 @@ class RemoteController(ReportsStage, MainLoopStage):
                                 interaction.extra._builder.get_result(),
                             )
                             break
-                    elif interaction.kind == "comment":
+                    elif kind == "comment":
                         new_comment = input(
                             SimpleUI.C.BLUE(
                                 _("Please enter your comments:") + "\n"
                             )
                         )
                         self.sa.remember_users_response(new_comment + "\n")
-                    elif interaction.kind == "skip":
+                    elif kind == "skip":
                         if (
                             job_state.effective_certification_status
                             == "blocker"

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -836,7 +836,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         _logger.info("controller: Exporting locally'")
         rf = self.sa.cache_report(exporter_id, options)
         exported_stream = SpooledTemporaryFile(max_size=102400, mode="w+b")
-        chunk_size = 16384
+        chunk_size = 160 * 1024
         with tqdm(
             total=rf.tell(),
             unit="B",

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -800,7 +800,7 @@ class RemoteController(ReportsStage, MainLoopStage):
                         SimpleUI.black_text(line[6:])
             if state == "running":
                 time.sleep(polling_backoff[polling_i])
-                polling_i = min(polling_i + 1, len(polling_backoff))
+                polling_i = min(polling_i + 1, len(polling_backoff) - 1)
                 while True:
                     res = select.select([sys.stdin], [], [], 0)
                     if not res[0]:

--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -454,6 +454,11 @@ class ReportsStage(CheckboxUiStage):
 
     def _prepare_stock_report(self, report):
         try:
+            # This function is called by both remote and local. Local sa
+            # doesn't have this API so it will fallback to the "normal"
+            # Configuration type. In remote we get the agent Configuration type
+            # because the object is passed and mostly used by the agent, so
+            # creating this object as a netref saves a lot of rpyc calls
             ConfigurationType = self.sa.configuration_type()
         except AttributeError:
             ConfigurationType = Configuration

--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -453,9 +453,13 @@ class ReportsStage(CheckboxUiStage):
         self._export_fn = export_fn
 
     def _prepare_stock_report(self, report):
+        try:
+            ConfigurationType = self.sa.configuration_type()
+        except AttributeError:
+            ConfigurationType = Configuration
         new_origin = "stock_reports"
         if report == "text":
-            additional_config = Configuration.from_text(
+            additional_config = ConfigurationType.from_text(
                 textwrap.dedent(
                     """
                     [exporter:text]
@@ -473,7 +477,7 @@ class ReportsStage(CheckboxUiStage):
             )
             self.sa.config.update_from_another(additional_config, new_origin)
         elif report == "certification":
-            additional_config = Configuration.from_text(
+            additional_config = ConfigurationType.from_text(
                 textwrap.dedent(
                     """
                     [exporter:tar]
@@ -489,7 +493,7 @@ class ReportsStage(CheckboxUiStage):
             )
             self.sa.config.update_from_another(additional_config, new_origin)
         elif report == "certification-staging":
-            additional_config = Configuration.from_text(
+            additional_config = ConfigurationType.from_text(
                 textwrap.dedent(
                     """
                     [exporter:tar]
@@ -526,7 +530,7 @@ class ReportsStage(CheckboxUiStage):
                     transport = {exporter}_file
                     """
                 )
-                additional_config = Configuration.from_text(
+                additional_config = ConfigurationType.from_text(
                     template.format(exporter=exporter, path=path), new_origin
                 )
                 self.sa.config.update_from_another(
@@ -550,7 +554,7 @@ class ReportsStage(CheckboxUiStage):
                 transport = {exporter}_file
                 """
             )
-            additional_config = Configuration.from_text(
+            additional_config = ConfigurationType.from_text(
                 template.format(exporter=exporter, path=path), new_origin
             )
             self.sa.config.update_from_another(additional_config, new_origin)

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -18,6 +18,7 @@
 
 
 import socket
+import json
 
 from unittest import TestCase, mock
 from functools import partial
@@ -180,13 +181,8 @@ class ControllerTests(TestCase):
         """
         self_mock = mock.MagicMock()
 
-        mock_job_state_map = {
-            "job1": mock.MagicMock(result=mock.MagicMock(outcome="pass")),
-            "job2": mock.MagicMock(result=mock.MagicMock(outcome="pass")),
-        }
-        self_mock.manager.default_device_context._state._job_state_map = (
-            mock_job_state_map
-        )
+        self_mock.sa.has_any_job_failed.return_value = False
+
         RemoteController.finish_session(self_mock)
 
         self.assertFalse(self_mock._has_anything_failed)
@@ -1037,14 +1033,14 @@ class ControllerTests(TestCase):
             "normal_user": True,
         }
 
-        self_mock.sa.start_session.return_value = "session_started"
+        self_mock.sa.start_session_json.return_value = '["testplan1"]'
 
         tps = RemoteController.start_session(self_mock)
 
-        self_mock.sa.start_session.assert_called_once_with(
-            expected_configuration
+        self_mock.sa.start_session_json.assert_called_once_with(
+            json.dumps(expected_configuration)
         )
-        self.assertEqual(tps, "session_started")
+        self.assertEqual(tps, ["testplan1"])
 
     def test_start_session_with_sideloaded_providers(self):
         self_mock = mock.MagicMock()
@@ -1052,7 +1048,7 @@ class ControllerTests(TestCase):
         self_mock._normal_user = True
         self_mock.sa.sideloaded_providers = True
 
-        self_mock.sa.start_session.return_value = "session_started"
+        self_mock.sa.start_session_json.return_value = '["testplan1"]'
 
         RemoteController.start_session(self_mock)
 
@@ -1060,7 +1056,7 @@ class ControllerTests(TestCase):
         self_mock = mock.MagicMock()
         self_mock._launcher_text = "launcher_example"
         self_mock._normal_user = True
-        self_mock.sa.start_session.side_effect = RuntimeError(
+        self_mock.sa.start_session_json.side_effect = RuntimeError(
             "Failed to start session"
         )
 

--- a/checkbox-ng/checkbox_ng/launcher/test_stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_stages.py
@@ -161,6 +161,7 @@ class TestReportsStage(TestCase):
     @mock.patch("os.makedirs")
     def test__prepare_stock_report_submission_json(self, makedirs):
         self_mock = mock.MagicMock()
+        self_mock.sa.configuration_type.side_effect = AttributeError
         self_mock._get_submission_file_path = partial(
             ReportsStage._get_submission_file_path, self_mock
         )

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -154,7 +154,7 @@ class RemoteSessionAssistant:
     object but JSON encoded.
     """
 
-    REMOTE_API_VERSION = 14
+    REMOTE_API_VERSION = 15
 
     def __init__(self, cmd_callback):
         _logger.debug("__init__()")

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -154,7 +154,7 @@ class RemoteSessionAssistant:
     object but JSON encoded.
     """
 
-    REMOTE_API_VERSION = 15
+    REMOTE_API_VERSION = 14
 
     def __init__(self, cmd_callback):
         _logger.debug("__init__()")

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -205,9 +205,6 @@ class RemoteSessionAssistant:
     def configuration_type(self):
         return Configuration
 
-    def get_config_json(self):
-        return json.dumps(self._sa.config.sections)
-
     def update_app_blob(self, app_blob):
         self._sa.update_app_blob(app_blob)
 
@@ -433,7 +430,7 @@ class RemoteSessionAssistant:
         return self._sa.save_manifest(manifest_answers)
 
     def modify_todo_list_json(self, chosen_jobs):
-        self._sa.use_alternate_selection(json.loads(chosen_jobs))
+        self.modify_todo_list(json.loads(chosen_jobs))
 
     def modify_todo_list(self, chosen_jobs):
         self._sa.use_alternate_selection(chosen_jobs)
@@ -642,12 +639,14 @@ class RemoteSessionAssistant:
         if result:
             result = json.loads(result)
         result = self.finish_job(result)
-        return json.dumps(
-            {
-                "tr_outcome": result.tr_outcome(),
-                "outcome_color": result.outcome_color_ansi(),
-            }
-        )
+        if result is not None:
+            return json.dumps(
+                {
+                    "tr_outcome": result.tr_outcome(),
+                    "outcome_color": result.outcome_color_ansi(),
+                }
+            )
+        return
 
     def finish_job(self, result=None):
         # assert the thread completed

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -17,7 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
+import json
 from os.path import exists
+from functools import partial
 
 from unittest import TestCase, mock
 
@@ -31,13 +33,14 @@ from plainbox.impl.result import MemoryJobResult
 from plainbox.impl.secure.sudo_broker import is_passwordless_sudo
 
 from plainbox.impl.session import remote_assistant
+from plainbox.impl.session.remote_assistant import RemoteSessionAssistant
 from plainbox.impl.session.assistant import SessionAssistant
 
 
 class RemoteAssistantTests(TestCase):
     def test_allowed_when_ok(self):
         self_mock = mock.MagicMock()
-        allowed_when = remote_assistant.RemoteSessionAssistant.allowed_when
+        allowed_when = RemoteSessionAssistant.allowed_when
 
         @allowed_when(remote_assistant.Idle)
         def allowed(self, *args): ...
@@ -47,7 +50,7 @@ class RemoteAssistantTests(TestCase):
 
     def test_allowed_when_fail(self):
         self_mock = mock.MagicMock()
-        allowed_when = remote_assistant.RemoteSessionAssistant.allowed_when
+        allowed_when = RemoteSessionAssistant.allowed_when
 
         @allowed_when(remote_assistant.Idle)
         def not_allowed(self, *args): ...
@@ -61,7 +64,7 @@ class RemoteAssistantTests(TestCase):
     def test__reset_sa(self, is_passwordless_sudo_mock, init_mock):
         init_mock.return_value = None
         # RSA constructor calls _reset_sa, which in turns creates a new SA
-        rsa = remote_assistant.RemoteSessionAssistant(lambda: None)
+        rsa = RemoteSessionAssistant(lambda: None)
         self.assertEqual(init_mock.call_count, 1)
 
     @mock.patch("plainbox.impl.session.remote_assistant.guess_normal_user")
@@ -75,11 +78,20 @@ class RemoteAssistantTests(TestCase):
         rsa = mock.Mock()
         rsa.get_test_plans.return_value = [mock.Mock()]
         rsa._state = remote_assistant.Idle
+
+        def get_test_plan_mock(name):
+            to_r = mock.Mock()
+            to_r.name = name
+            return to_r
+
+        rsa._sa.get_test_plan.side_effect = get_test_plan_mock
+        rsa.start_session = partial(RemoteSessionAssistant.start_session, rsa)
         with mock.patch("plainbox.impl.config.Configuration.from_text") as cm:
             cm.return_value = Configuration()
-            tps = remote_assistant.RemoteSessionAssistant.start_session(
-                rsa, extra_cfg
+            tps = RemoteSessionAssistant.start_session_json(
+                rsa, json.dumps(extra_cfg)
             )
+            tps = json.loads(tps)
             self.assertEqual(tps[0][0][1], "tp")
 
     @mock.patch("plainbox.impl.session.remote_assistant.guess_normal_user")
@@ -95,9 +107,7 @@ class RemoteAssistantTests(TestCase):
         rsa._state = remote_assistant.Idle
         with mock.patch("plainbox.impl.config.Configuration.from_text") as cm:
             cm.return_value = Configuration()
-            tps = remote_assistant.RemoteSessionAssistant.start_session(
-                rsa, extra_cfg
-            )
+            tps = RemoteSessionAssistant.start_session(rsa, extra_cfg)
             self.assertEqual(tps[0][0][1], "tp")
 
     def test_resume_by_id_with_session_id(self):
@@ -110,7 +120,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
         rsa.resume_session.return_value = mock_meta
-        remote_assistant.RemoteSessionAssistant.resume_by_id(rsa, "session_id")
+        RemoteSessionAssistant.resume_by_id(rsa, "session_id")
         self.assertEqual(rsa._state, "testsselected")
 
     def test_resume_by_id_bad_session_id(self):
@@ -123,7 +133,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
         rsa.resume_session.return_value = mock_meta
-        remote_assistant.RemoteSessionAssistant.resume_by_id(rsa, "bad_id")
+        RemoteSessionAssistant.resume_by_id(rsa, "bad_id")
         self.assertEqual(rsa._state, "idle")
 
     def test_resume_by_id_without_session_id(self):
@@ -136,7 +146,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
         rsa.resume_session.return_value = mock_meta
-        remote_assistant.RemoteSessionAssistant.resume_by_id(rsa)
+        RemoteSessionAssistant.resume_by_id(rsa)
         self.assertEqual(rsa._state, "testsselected")
 
     @mock.patch("plainbox.impl.session.remote_assistant.load_configs")
@@ -167,7 +177,7 @@ class RemoteAssistantTests(TestCase):
                     ),
                 ):
                     os_path_exists_mock.return_value = True
-                    remote_assistant.RemoteSessionAssistant.resume_by_id(rsa)
+                    RemoteSessionAssistant.resume_by_id(rsa)
 
         mjr = MemoryJobResult(
             {
@@ -207,7 +217,7 @@ class RemoteAssistantTests(TestCase):
                     ),
                 ):
                     os_path_exists_mock.return_value = True
-                    remote_assistant.RemoteSessionAssistant.resume_by_id(rsa)
+                    RemoteSessionAssistant.resume_by_id(rsa)
 
         mjr = MemoryJobResult(
             {
@@ -244,7 +254,7 @@ class RemoteAssistantTests(TestCase):
                 "noreturn"
             }
 
-            remote_assistant.RemoteSessionAssistant.resume_by_id(rsa)
+            RemoteSessionAssistant.resume_by_id(rsa)
 
         mjr = MemoryJobResult(
             {
@@ -282,7 +292,7 @@ class RemoteAssistantTests(TestCase):
             os_path_exists_mock.return_value = False
             rsa._sa.get_job.return_value.get_flag_set.return_value = {}
 
-            remote_assistant.RemoteSessionAssistant.resume_by_id(rsa)
+            RemoteSessionAssistant.resume_by_id(rsa)
 
         mjr = MemoryJobResult(
             {
@@ -322,7 +332,7 @@ class RemoteAssistantTests(TestCase):
             os_path_exists_mock.return_value = False
             rsa._sa.get_job.return_value.get_flag_set.return_value = {}
 
-            remote_assistant.RemoteSessionAssistant.resume_by_id(rsa)
+            RemoteSessionAssistant.resume_by_id(rsa)
 
         mjr = MemoryJobResult(
             {
@@ -354,7 +364,7 @@ class RemoteAssistantTests(TestCase):
             with mock.patch("builtins.open", mock.mock_open(read_data="!@!")):
                 with mock.patch("os.path.exists", os_path_exists_mock):
                     os_path_exists_mock.return_value = True
-                    remote_assistant.RemoteSessionAssistant.resume_by_id(rsa)
+                    RemoteSessionAssistant.resume_by_id(rsa)
 
         mjr = MemoryJobResult(
             {
@@ -369,9 +379,7 @@ class RemoteAssistantTests(TestCase):
         self_mock = mock.MagicMock()
         self_mock._state = remote_assistant.Interacting
 
-        remote_assistant.RemoteSessionAssistant.remember_users_response(
-            self_mock, "quit"
-        )
+        RemoteSessionAssistant.remember_users_response(self_mock, "quit")
 
         self.assertTrue(self_mock.abandon_session.called)
 
@@ -379,9 +387,7 @@ class RemoteAssistantTests(TestCase):
         self_mock = mock.MagicMock()
         self_mock._state = remote_assistant.Interacting
 
-        remote_assistant.RemoteSessionAssistant.remember_users_response(
-            self_mock, "rollback"
-        )
+        RemoteSessionAssistant.remember_users_response(self_mock, "rollback")
 
         self.assertEqual(self_mock._state, remote_assistant.TestsSelected)
 
@@ -389,35 +395,224 @@ class RemoteAssistantTests(TestCase):
         self_mock = mock.MagicMock()
         self_mock._state = remote_assistant.Interacting
 
-        remote_assistant.RemoteSessionAssistant.remember_users_response(
-            self_mock, "run"
-        )
+        RemoteSessionAssistant.remember_users_response(self_mock, "run")
 
         self.assertEqual(self_mock._state, remote_assistant.Running)
 
     def test_note_metadata_starting_job(self):
         self_mock = mock.MagicMock()
-        remote_assistant.RemoteSessionAssistant.note_metadata_starting_job(
-            self_mock, mock.MagicMock(), mock.MagicMock()
+        note_metadata_starting_job = partial(
+            RemoteSessionAssistant.note_metadata_starting_job,
+            self_mock,
+        )
+        self_mock.note_metadata_starting_job = note_metadata_starting_job
+        RemoteSessionAssistant.note_metadata_starting_job_json(
+            self_mock, "{}", mock.MagicMock()
         )
         self.assertTrue(self_mock._sa.note_metadata_starting_job.called)
 
     def test_abandon_session(self):
         self_mock = mock.MagicMock()
-        remote_assistant.RemoteSessionAssistant.abandon_session(self_mock)
+        RemoteSessionAssistant.abandon_session(self_mock)
         self.assertTrue(self_mock._reset_sa.called)
 
     def test_delete_sessions(self):
         self_mock = mock.MagicMock()
-        remote_assistant.RemoteSessionAssistant.delete_sessions(self_mock, [])
+        RemoteSessionAssistant.delete_sessions(self_mock, [])
         self.assertTrue(self_mock._sa.delete_sessions.called)
 
     def test_get_resumable_sessions(self):
         self_mock = mock.MagicMock()
-        remote_assistant.RemoteSessionAssistant.get_resumable_sessions(
+        RemoteSessionAssistant.get_resumable_sessions(self_mock)
+        self.assertTrue(self_mock._sa.get_resumable_sessions.called)
+
+    def test_configuration_type(self):
+        # This is used to allow the controller to create netref configurations.
+        conf_type = RemoteSessionAssistant.configuration_type(mock.MagicMock())
+        self.assertEqual(conf_type, remote_assistant.Configuration)
+
+    def test_bootstrapping_todo_list(self):
+        self_mock = mock.MagicMock()
+        self_mock._state = remote_assistant.Started
+        self_mock.get_bootstrapping_todo_list = partial(
+            RemoteSessionAssistant.get_bootstrapping_todo_list, self_mock
+        )
+        self_mock._sa.get_bootstrap_todo_list.return_value = [
+            "job1",
+            "job2",
+        ]
+
+        job_list_str = RemoteSessionAssistant.get_bootstrapping_todo_list_json(
             self_mock
         )
-        self.assertTrue(self_mock._sa.get_resumable_sessions.called)
+
+        self.assertTrue(self_mock._sa.get_bootstrap_todo_list.called)
+        self.assertEqual(["job1", "job2"], json.loads(job_list_str))
+
+    def test_finish_bootstrap_json(self):
+        self_mock = mock.MagicMock()
+        self_mock.finish_bootstrap = partial(
+            RemoteSessionAssistant.finish_bootstrap, self_mock
+        )
+        self_mock._sa.get_static_todo_list.return_value = static_todo_list = [
+            "test_{}".format(x) for x in range(10)
+        ]
+        to_r = {x: mock.MagicMock() for x in static_todo_list}
+
+        def get_job_state(id):
+            return to_r[id]
+
+        self_mock._sa.get_job_state = get_job_state
+
+        def get_value(top, key):
+            assert top == "ui"
+            if key == "auto_retry":
+                return True
+            elif key == "max_attempts":
+                return 10
+            assert False, "Undefined key"
+
+        self_mock._launcher.get_value = get_value
+
+        bootstrapped_todo = json.loads(
+            RemoteSessionAssistant.finish_bootstrap_json(self_mock)
+        )
+
+        self.assertEqual(self_mock._state, remote_assistant.Bootstrapped)
+        self.assertEqual(bootstrapped_todo, static_todo_list)
+        self.assertTrue(
+            all(
+                to_r[x].attempts == get_value("ui", "max_attempts")
+                for x in bootstrapped_todo
+            )
+        )
+
+    def test_get_manifest_repr_json(self):
+        self_mock = mock.MagicMock()
+        self_mock.get_manifest_repr = partial(
+            RemoteSessionAssistant.get_manifest_repr, self_mock
+        )
+        self_mock._sa.get_manifest_repr.return_value = {"manifest1": True}
+
+        manifest = RemoteSessionAssistant.get_manifest_repr_json(self_mock)
+
+        self.assertEqual(json.loads(manifest), {"manifest1": True})
+
+    def test_modify_todo_list_json(self):
+        self_mock = mock.MagicMock()
+        self_mock.modify_todo_list = partial(
+            RemoteSessionAssistant.modify_todo_list, self_mock
+        )
+        chosen_jobs_list = ["job1", "job2", "job3"]
+        chosen_jobs_json = json.dumps(chosen_jobs_list)
+
+        RemoteSessionAssistant.modify_todo_list_json(
+            self_mock, chosen_jobs_json
+        )
+
+        self.assertTrue(self_mock._sa.use_alternate_selection.assert_called)
+
+    def test_finish_job_json_with_result(self):
+        self_mock = mock.MagicMock()
+        mock_result_obj = mock.MagicMock()
+        mock_result_obj.tr_outcome.return_value = "PASS"
+        mock_result_obj.outcome_color_ansi.return_value = "[green]PASS[/green]"
+        self_mock.finish_job.return_value = mock_result_obj
+
+        input_result_data = {
+            "outcome": "PASS",
+            "comments": "Completed successfully",
+        }
+        input_result_json = json.dumps(input_result_data)
+
+        response_json = RemoteSessionAssistant.finish_job_json(
+            self_mock, input_result_json
+        )
+
+        self_mock.finish_job.assert_called_once_with(input_result_data)
+        expected_response = {
+            "tr_outcome": "PASS",
+            "outcome_color": "[green]PASS[/green]",
+        }
+        self.assertEqual(json.loads(response_json), expected_response)
+
+    def test_finish_job_json_without_result(self):
+        self_mock = mock.MagicMock()
+        mock_result_obj = mock.MagicMock()
+        mock_result_obj.tr_outcome.return_value = "FAIL"
+        mock_result_obj.outcome_color_ansi.return_value = "[red]FAIL[/red]"
+        self_mock.finish_job.return_value = mock_result_obj
+
+        response_json = RemoteSessionAssistant.finish_job_json(self_mock)
+
+        self_mock.finish_job.assert_called_once_with(None)
+        expected_response = {
+            "tr_outcome": "FAIL",
+            "outcome_color": "[red]FAIL[/red]",
+        }
+        self.assertEqual(json.loads(response_json), expected_response)
+
+    def test_finish_job_json_handles_none_result_from_finish_job(self):
+        self_mock = mock.MagicMock()
+        self_mock.finish_job.return_value = None
+
+        response = RemoteSessionAssistant.finish_job_json(self_mock)
+
+        self_mock.finish_job.assert_called_once_with(None)
+        self.assertIsNone(response)
+
+    def test_has_any_job_failed_is_true_if_a_job_failed(self):
+        self_mock = mock.MagicMock()
+
+        passing_job = mock.MagicMock()
+        passing_job.result.outcome = IJobResult.OUTCOME_PASS
+
+        failing_job = mock.MagicMock()
+        failing_job.result.outcome = IJobResult.OUTCOME_FAIL
+
+        self_mock.manager.default_device_context._state._job_state_map = {
+            "job1": passing_job,
+            "job2": failing_job,
+        }
+
+        self.assertTrue(RemoteSessionAssistant.has_any_job_failed(self_mock))
+
+    def test_has_any_job_failed_is_true_if_a_job_crashed(self):
+        self_mock = mock.MagicMock()
+
+        passing_job = mock.MagicMock()
+        passing_job.result.outcome = IJobResult.OUTCOME_PASS
+
+        crashing_job = mock.MagicMock()
+        crashing_job.result.outcome = IJobResult.OUTCOME_CRASH
+
+        self_mock.manager.default_device_context._state._job_state_map = {
+            "job1": passing_job,
+            "job2": crashing_job,
+        }
+
+        self.assertTrue(RemoteSessionAssistant.has_any_job_failed(self_mock))
+
+    def test_has_any_job_failed_is_false_if_no_jobs_failed(self):
+        self_mock = mock.MagicMock()
+
+        passing_job_1 = mock.MagicMock()
+        passing_job_1.result.outcome = IJobResult.OUTCOME_PASS
+
+        passing_job_2 = mock.MagicMock()
+        passing_job_2.result.outcome = IJobResult.OUTCOME_PASS
+
+        self_mock.manager.default_device_context._state._job_state_map = {
+            "job1": passing_job_1,
+            "job2": passing_job_2,
+        }
+
+        self.assertFalse(RemoteSessionAssistant.has_any_job_failed(self_mock))
+
+    def test_has_any_job_failed_is_false_for_empty_job_map(self):
+        self_mock = mock.MagicMock()
+        self_mock.manager.default_device_context._state._job_state_map = {}
+        self.assertFalse(RemoteSessionAssistant.has_any_job_failed(self_mock))
 
 
 class RemoteAssistantFinishJobTests(TestCase):
@@ -433,7 +628,7 @@ class RemoteAssistantFinishJobTests(TestCase):
         mock_builder = MockJobResultBuilder.return_value
         mock_builder.get_result.return_value = IJobResult.OUTCOME_PASS
 
-        result = remote_assistant.RemoteSessionAssistant.finish_job(self.rsa)
+        result = RemoteSessionAssistant.finish_job(self.rsa)
 
         self.rsa._sa.use_job_result.assert_called_with("job_id", "pass")
         self.assertEqual(result, IJobResult.OUTCOME_PASS)
@@ -451,7 +646,7 @@ class RemoteAssistantFinishJobTests(TestCase):
         self.rsa._be.wait().get_result = wait_get_result_res
         wait_get_result_res.return_value = IJobResult.OUTCOME_PASS
 
-        result = remote_assistant.RemoteSessionAssistant.finish_job(self.rsa)
+        result = RemoteSessionAssistant.finish_job(self.rsa)
 
         self.assertTrue(self.rsa._be.wait.called)
         self.assertTrue(self.rsa._be.wait().get_result)
@@ -467,7 +662,7 @@ class RemoteAssistantFinishJobTests(TestCase):
         mock_builder = MockJobResultBuilder.return_value
         mock_builder.get_result.return_value = IJobResult.OUTCOME_PASS
 
-        result = remote_assistant.RemoteSessionAssistant.finish_job(self.rsa)
+        result = RemoteSessionAssistant.finish_job(self.rsa)
 
         self.rsa._sa.use_job_result.assert_called_with("job_id", "pass")
         self.assertEqual(result, IJobResult.OUTCOME_PASS)

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -510,7 +510,7 @@ class RemoteAssistantTests(TestCase):
             self_mock, chosen_jobs_json
         )
 
-        self.assertTrue(self_mock._sa.use_alternate_selection.assert_called)
+        self.assertTrue(self_mock._sa.use_alternate_selection.called)
 
     def test_finish_job_json_with_result(self):
         self_mock = mock.MagicMock()


### PR DESCRIPTION

## Description

Checkbox Remote is very, very slow when used over a slow connection. This is mostly due to a reason: When returning a mutable objects over an rpyc function, any further query on that object is a rpyc call. This is most evident in the following situations:
- Test plan selection (iterating over the testplan list takes ~600 (number of testplans) rpyc calls
- Test selection (modifying the desired list takes one call per test that will be selected, so deselecting just one test could lead to hundreds of rpyc calls)
- Calculating the return code of a test run (This iterated over the whole job_state_map, leading to ~10k rpyc calls as undesired jobs are present when no reboots are done)
- Exporting (Additional Configurations that were created client side lead to hundreds of rpyc remote calls when used afterward)

Additionally (this is a bit of a bonus), every test on a medium to high latency will always pay 0.5s to "wait" for the test to be completed + the latency. This adds a backoff mechanism that starts from 0 and goes to .5s

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1956
Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1955

## Documentation

Documented this in the class docstring

## Tests

Added unit tests for /most/ of the api changed.

To try this change and simulate this issue locally modify `checkbox-ng/plainbox/vendor/rpyc/core/protocol.py` add to the serve function of the Connection class the following
```python
    def serve(self, timeout=1, wait_for_lock=True):  # serving
        import time
        time.sleep(.1)
```

This will simulate a 100ms latency (less than what it is Europe to Taiwan). Add the following test units to the metabox provider:
```
id: tons_of_jobs
_summary: Generates a lot of ids to fill the job_state_map
plugin: resource
shell: python
command:
  for i in range(100):
    print(f"id: stress_{i}")
    print()

unit: template
template-resource: tons_of_jobs
template-unit: job
id: {id}
template-id: template_tons_of_jobs
command:
  echo "Test {id}"
_summary: Test that stresses rpyc calls
flags: simple

unit: test plan
id: stress_remote_tps
_name: Stress test of the checkbox remote-api
bootstrap_include:
  tons_of_jobs
include:
  template_tons_of_jobs
```

A test run at 100ms latency of this testplan takes about 35minutes on main, 5m on this branch

Additionally, I've used this very ugly decorator to log all the calls made to the server to be able to track them down
```python
if os.getuid() == 0:
    log = open("/tmp/root_agent.log", "w+")
else:
    log = open("/tmp/usr_control.log", "w+")


def _log_call(f):

    # return f

    def _f(self, *args, **kwargs):
        global total
        total += 1
        import json

        log.write(json.dumps([str(x) for x in [total, *args, kwargs]]))
        log.write("\n")
        print(total, *args, kwargs)
        to_r = f(self, *args, **kwargs)
        if (
            not any(isinstance(to_r, x) for x in [str, int, float, bool])
        ) and to_r is not None:
            # breakpoint()
            ...
        return to_r

    return _f
```
Decorate all _handle_[...] functions in the Connection class to use this.
