### PR TITLE
Run Secure Boot test on all UEFI servers. (Bugfix)

### DIFF
--- a/providers/certification-server/configs/canonical-certification.conf
+++ b/providers/certification-server/configs/canonical-certification.conf
@@ -85,3 +85,9 @@ STRESS_NG_MIN_SWAP_SIZE = 16
 # UNCOMMENT THE FOLLOWING LINE and set the IP/Hostname of your iperf target
 # system as necessary:
 #TEST_TARGET_IPERF =  your-iperf-server.example.com
+
+[manifest]
+# We need to run the miscellanea/secure_boot_mode test on all UEFI servers,
+# but this test runs only if the following manifest option is set to True.
+# Other conditions prevent it from running on non-UEFI systems.
+com.canonical.certification::has_secure_boot = True


### PR DESCRIPTION
Title: The miscellanea/secure_boot_mode test should always run on UEFI-based servers (Bugfix)

## Description

This PR adds a `[manifest]` section to the Server Certification `/etc/xdg/canonical-certification.conf` configuration file and sets the `has_secure_boot` variable to `True`. This causes the `miscellanea/secure_boot_mode` test to run on all UEFI servers. (Other conditions prevent it from running on non-UEFI servers.)

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/1978

## Documentation

No documentation changes are required.

## Tests

I installed the modified file on servers running both UEFI and non-UEFI firmware. The test ran on the former but not on the latter, both as in the past.