### PR TITLE
Clear up duplicated test plan names that lead to confusion when displayed by checkbox-cli (BugFix)

### DIFF
--- a/providers/base/units/audio/test-plan.pxu
+++ b/providers/base/units/audio/test-plan.pxu
@@ -1,6 +1,6 @@
 id: audio-cert-full
 unit: test plan
-_name: Audio tests
+_name: Audio test (Full)
 _description:
  Audio tests
  See Monitor / Graphic test plans for hybrid-graphic monitor audio tests
@@ -94,7 +94,7 @@ include:
 
 id: audio-full
 unit: test plan
-_name: Audio tests
+_name: Audio tests (QA test for Core devices)
 _description: QA audio tests for Snappy Ubuntu Core devices
 include:
 nested_part:
@@ -130,7 +130,7 @@ include:
 
 id: after-suspend-audio-full
 unit: test plan
-_name: Audio tests (after suspend)
+_name: Audio tests (after suspend, automated and manual)
 _description: QA audio tests for Snappy Ubuntu Core devices
 include:
 nested_part:
@@ -139,7 +139,7 @@ nested_part:
 
 id: after-suspend-audio-manual
 unit: test plan
-_name: Manual audio tests (after suspend)
+_name: Manual audio tests (after suspend, manual)
 _description: Manual audio tests for Snappy Ubuntu Core devices
 include:
     after-suspend-audio/alsa-playback
@@ -157,7 +157,7 @@ include:
 
 id: after-suspend-audio-automated
 unit: test plan
-_name: Automated audio tests
+_name: Automated audio tests (after suspend)
 _description: Automated audio tests for Snappy Ubuntu Core devices
 include:
     after-suspend-audio/detect-playback-devices

--- a/providers/base/units/bluetooth/test-plan.pxu
+++ b/providers/base/units/bluetooth/test-plan.pxu
@@ -1,6 +1,6 @@
 id: bluetooth-cert-full
 unit: test plan
-_name: Bluetooth tests
+_name: Bluetooth tests (Full Cert tests)
 _description:
  Bluetooth tests
 include:
@@ -42,7 +42,7 @@ include:
 
 id: bluetooth-full
 unit: test plan
-_name: Bluetooth tests
+_name: Bluetooth tests (QA tests)
 _description: QA tests for Bluetooth
 estimated_duration: 6m
 include:
@@ -112,7 +112,7 @@ nested_part:
 
 id: after-suspend-bluetooth-manual
 unit: test plan
-_name: Manual Bluetooth tests
+_name: Manual Bluetooth tests (after suspend)
 _description: Manual QA tests for Bluetooth
 estimated_duration: 5m
 include:
@@ -120,7 +120,7 @@ include:
 
 id: after-suspend-bluez-automated
 unit: test plan
-_name: Automated tests for bluez
+_name: Automated tests for bluez (after suspend)
 _description:
  Automated tests for bluez
 estimated_duration: 1m

--- a/providers/base/units/camera/test-plan.pxu
+++ b/providers/base/units/camera/test-plan.pxu
@@ -89,7 +89,7 @@ bootstrap_include:
 
 id: camera-full
 unit: test plan
-_name: Camera tests
+_name: Camera tests (Full test plan for Core devices)
 _description: Camera tests for Ubuntu Core devices
 include:
 nested_part:

--- a/providers/base/units/cpu/test-plan.pxu
+++ b/providers/base/units/cpu/test-plan.pxu
@@ -1,6 +1,6 @@
 id: cpu-cert-full
 unit: test plan
-_name: CPU tests
+_name: CPU tests (Cert full)
 _description:
  CPU tests
 include:

--- a/providers/base/units/dock/test-plan.pxu
+++ b/providers/base/units/dock/test-plan.pxu
@@ -128,7 +128,7 @@ include:
 
 id: after-suspend-dock-cert-full
 unit: test plan
-_name: Dock Cert tests after suspend
+_name: Dock Cert tests after suspend (cert full)
 _description:
  Cert tests for dock devices.
 include:

--- a/providers/base/units/ethernet/test-plan.pxu
+++ b/providers/base/units/ethernet/test-plan.pxu
@@ -53,7 +53,7 @@ bootstrap_include:
 
 id: ethernet-full
 unit: test plan
-_name: QA tests for ethernet
+_name: QA tests for ethernet (Core devices)
 _description: Ethernet tests for Ubuntu Core devices
 estimated_duration: 1m
 include:

--- a/providers/base/units/input/test-plan.pxu
+++ b/providers/base/units/input/test-plan.pxu
@@ -31,7 +31,7 @@ bootstrap_include:
 
 id: after-suspend-input-cert-automated
 unit: test plan
-_name: Input tests (Automated)
+_name: Input tests (Automated after suspend)
 _description:
  Input tests (Automated)
 include:

--- a/providers/base/units/mediacard/test-plan.pxu
+++ b/providers/base/units/mediacard/test-plan.pxu
@@ -1,6 +1,6 @@
 id: mediacard-cert-full
 unit: test plan
-_name: Mediacard tests
+_name: Mediacard tests (Cert Full)
 _description:
  Mediacard tests
 include:

--- a/providers/base/units/memory/test-plan.pxu
+++ b/providers/base/units/memory/test-plan.pxu
@@ -14,14 +14,14 @@ include:
 
 id: memory-automated
 unit: test plan
-_name: Automated memory tests
+_name: Automated memory tests (Core)
 _description: Automated memory tests for Ubuntu Core devices
 include:
     memory/info    certification-status=blocker
 
 id: server-memory
 unit: test plan
-_name: Automated memory tests
+_name: Automated memory tests (Server)
 _desctiption: Automated memory tests for Server Cert
 include:
     memory/info                 certification-status=blocker

--- a/providers/base/units/miscellanea/test-plan.pxu
+++ b/providers/base/units/miscellanea/test-plan.pxu
@@ -86,7 +86,7 @@ include:
 
 id: server-miscellaneous-regression
 unit: test plan
-_name: Miscellaneous server cert tests
+_name: Miscellaneous server tests for SRU
 _description:
  Miscellaneous server tests (log checks, dmi data, etc)
 mandatory_include:

--- a/providers/base/units/monitor/test-plan.pxu
+++ b/providers/base/units/monitor/test-plan.pxu
@@ -214,8 +214,8 @@ bootstrap_include:
 
 id: after-suspend-monitor-discrete-gpu-cert-full
 unit: test plan
-_name: Monitor tests (after suspend, integrated GPU)
-_description: Monitor tests (after suspend, integrated GPU)
+_name: Monitor tests (after suspend, discrete GPU)
+_description: Monitor tests (after suspend, discrete GPU)
 include:
 nested_part:
     after-suspend-monitor-discrete-gpu-cert-manual
@@ -348,7 +348,7 @@ bootstrap_include:
 
 id: monitor-full
 unit: test plan
-_name: Monitor tests
+_name: Monitor tests (QA manual)
 _description: QA monitor tests for Snappy Ubuntu Core devices
 include:
 nested_part:

--- a/providers/base/units/optical/test-plan.pxu
+++ b/providers/base/units/optical/test-plan.pxu
@@ -65,8 +65,8 @@ bootstrap_include:
 
 id: after-suspend-optical-cert-blockers
 unit: test plan
-_name: Optical drive tests (certification blockers only)
-_description: Optical drive tests (certification blockers only)
+_name: Optical drive tests (certification blockers only after suspend)
+_description: Optical drive tests (certification blockers only after suspend)
 include:
     optical/detect                                                      certification-status=blocker
     after-suspend-optical/read_.*                                       certification-status=blocker

--- a/providers/base/units/snapd/test-plan.pxu
+++ b/providers/base/units/snapd/test-plan.pxu
@@ -12,7 +12,7 @@ nested_part:
 
 id: snappy-snap-full-with-refresh-control
 unit: test plan
-_name: Tests for snap command
+_name: Tests for snap command (with refresh control)
 _description:
  QA test plan that includes generic tests for the snap command for Snappy
  Ubuntu Core devices.

--- a/providers/base/units/stress/test-plan.pxu
+++ b/providers/base/units/stress/test-plan.pxu
@@ -1,6 +1,6 @@
 id: stress-cert-full
 unit: test plan
-_name: Stress tests
+_name: Stress tests (Cert Full)
 _description:
  Stress tests
 include:

--- a/providers/base/units/thunderbolt/test-plan.pxu
+++ b/providers/base/units/thunderbolt/test-plan.pxu
@@ -10,9 +10,9 @@ nested_part:
 
 id: after-suspend-thunderbolt-cert-full
 unit: test plan
-_name: Thunderbolt tests
+_name: Thunderbolt tests (after suspend)
 _description:
- Thunderbolt tests
+ Thunderbolt tests after suspend
 include:
 nested_part:
  com.canonical.certification::after-suspend-thunderbolt-cert-manual

--- a/providers/base/units/touchpad/test-plan.pxu
+++ b/providers/base/units/touchpad/test-plan.pxu
@@ -42,7 +42,7 @@ include:
 
 id: after-suspend-touchpad-cert-full
 unit: test plan
-_name: Touchpad tests
+_name: Touchpad tests (after suspend)
 _description: Touchpad tests
 include:
     after-suspend-touchpad/basic                                 certification-status=blocker

--- a/providers/base/units/touchscreen/test-plan.pxu
+++ b/providers/base/units/touchscreen/test-plan.pxu
@@ -33,9 +33,9 @@ include:
 
 id: after-suspend-touchscreen-cert-full
 unit: test plan
-_name: Touchscreen tests
+_name: Touchscreen tests (after suspend)
 _description:
- Touchscreen tests
+ Touchscreen tests after suspend
 include:
 nested_part:
  after-suspend-touchscreen-cert-manual
@@ -43,9 +43,9 @@ nested_part:
 
 id: after-suspend-touchscreen-cert-manual
 unit: test plan
-_name: Touchscreen tests (Manual)
+_name: Touchscreen tests (Manual after suspend)
 _description:
- Touchscreen tests (Manual)
+ Touchscreen tests (Manual after suspend)
 include:
  after-suspend-touchscreen/drag-n-drop                certification-status=blocker
  after-suspend-touchscreen/multitouch-zoom            certification-status=blocker
@@ -59,9 +59,9 @@ bootstrap_include:
 
 id: after-suspend-touchscreen-cert-automated
 unit: test plan
-_name: Touchscreen tests (Automated)
+_name: Touchscreen tests (Automated after suspend)
 _description:
- Touchscreen tests (Automated)
+ Touchscreen tests (Automated after suspend)
 include:
 
 id: touchscreen-cert-blockers

--- a/providers/base/units/usb/test-plan.pxu
+++ b/providers/base/units/usb/test-plan.pxu
@@ -1,6 +1,6 @@
 id: usb-cert-full
 unit: test plan
-_name: USB tests
+_name: USB tests (Cert full)
 _description:
  USB tests
 include:
@@ -27,7 +27,7 @@ include:
 
 id: after-suspend-usb-cert-automated
 unit: test plan
-_name: USB tests (Automated)
+_name: USB tests (Automated after suspend)
 _description:
  USB tests (Automated)
 include:
@@ -35,7 +35,7 @@ include:
 
 id: usb3-cert-full
 unit: test plan
-_name: USB3 tests
+_name: USB3 tests (Cert full)
 _description:
  USB3 tests
 include:
@@ -70,7 +70,7 @@ include:
 
 id: after-suspend-usb-cert-full
 unit: test plan
-_name: USB tests (after suspend)
+_name: USB tests (cert full after suspend)
 _description: USB tests (after suspend)
 include:
  after-suspend-usb/hid                                    certification-status=blocker
@@ -78,7 +78,7 @@ include:
 
 id: after-suspend-usb3-cert-full
 unit: test plan
-_name: USB3 tests (after suspend)
+_name: USB3 tests (cert full after suspend)
 _description: USB3 tests (after suspend)
 include:
  after-suspend-usb3/storage-manual                        certification-status=blocker

--- a/providers/base/units/wireless/test-plan.pxu
+++ b/providers/base/units/wireless/test-plan.pxu
@@ -1,6 +1,6 @@
 id: wireless-cert-full
 unit: test plan
-_name: Wireless tests
+_name: Wireless tests (cert full)
 _description:
  Wireless connection tests
 include:
@@ -17,7 +17,7 @@ include:
 
 id: after-suspend-wireless-cert-full
 unit: test plan
-_name: Wireless tests (after suspend)
+_name: Wireless tests (cert full after suspend)
 _description: Wireless connection tests (after suspend)
 include:
 nested_part:
@@ -25,7 +25,7 @@ nested_part:
 
 id: wireless-cert-automated
 unit: test plan
-_name: Wireless tests
+_name: Wireless tests (cert automated)
 _description: Wireless connection tests
 bootstrap_include:
     device
@@ -257,7 +257,7 @@ bootstrap_include:
 
 id: wireless-wifi-master-mode-manual
 unit: test plan
-_name: QA tests for wifi master mode
+_name: QA tests for wifi master mode (manual)
 _description:
  System as Access Point tests
 include:
@@ -304,7 +304,7 @@ bootstrap_include:
 
 id: after-suspend-wireless-wifi-master-mode-manual
 unit: test plan
-_name: QA tests for wifi master mode (after suspend)
+_name: QA tests for wifi master mode (after suspend, manual mode)
 _description:
  System as Access Point tests
 include:
@@ -320,7 +320,7 @@ bootstrap_include:
 
 id: after-suspend-wireless-wifi-master-mode-auto
 unit: test plan
-_name: QA tests for wifi master mode (after suspend)
+_name: QA tests for wifi master mode (after suspend, auto mode)
 _description:
  System as Access Point tests
 include:

--- a/providers/genio/units/audio/test-plan.pxu
+++ b/providers/genio/units/audio/test-plan.pxu
@@ -33,7 +33,7 @@ include:
 
 id: after-suspend-genio-audio-manual
 unit: test plan
-_name: Genio Manual audio test
+_name: Genio Manual Audio Test (after suspend)
 _description: Manual after suspend audio test for G1200-evk, G700 and G350 platforms
 include:
     after-suspend-genio-audio/earphone-playback
@@ -49,6 +49,6 @@ include:
 
 id: after-suspend-genio-audio-automated
 unit: test plan
-_name: Genio Auto Audio test
+_name: Genio Auto Audio test (after suspend)
 _description: Automated after suspend audio test for G1200-evk, G700 and G350 platforms
 include:

--- a/providers/genio/units/power-management/test-plan.pxu
+++ b/providers/genio/units/power-management/test-plan.pxu
@@ -35,13 +35,13 @@ include:
 
 id: after-suspend-genio-power-management-manual
 unit: test plan
-_name: Genio Manual power management test
+_name: Genio Manual power management test (after suspend)
 _description: Manual after suspend power management test for G1200-evk, G700 and G350 platforms
 include:
 
 id: after-suspend-genio-power-management-automated
 unit: test plan
-_name: Genio Auto Power Management test
+_name: Genio Auto Power Management test (after suspend)
 _description: Automated after suspend power management test for G1200-evk, G700 and G350 platforms
 include:
     after-suspend-genio-power-management/dvfs-gpufreq.*


### PR DESCRIPTION
## Description

After some discussion on MM led me to running checkbox-cli directly to test some thing, I noticed that a few test plans had duplicate names with no context, which become quite confusing when displayed via checkbox.

After working through this I found a lot more than initially seen so I made an effort to fix all of the duplicated test-plan name fields so that when listed in checkbox-cli, all test plan names are unique and any potential duplicates have some sort of context... for example there were many "after suspend" test plans that had the same name as their "before suspend" counterparts.

## Resolved issues

fixes CHECKBOX-1966

## Documentation

No doc changes needed, I believe, the name field is only really used in the list of test plans in the Checkbox UI and CLI (e.g. `checkbox-cli list 'test plan' --format='json' --a | jq -r '.[] | "name: " +.name + " id:" + .id' | sort`)

## Tests

Doublechecked the changes by re-running the analyze_testplans.py script claude created while I was having it analyse the providers directory.

Example before and after:
```
bladernr@galactica:~/development/checkbox/tools$ python3 analyze_duplicates.py                                                                                          
=== DUPLICATE NAME ANALYSIS ===                                                                                                                                         
                                                                                                                                                                        
File: /home/bladernr/development/checkbox/providers/base/units/usb/test-plan.pxu                                                                                        
Duplicates found:                                                                                                                                                       
- Name: "USB tests (Automated)" (case insensitive)                                                                                                                      
  IDs: usb-cert-manual (line 11), usb-cert-automated (line 20)                                                                                                          
                                                                                                                                                                        
File: /home/bladernr/development/checkbox/providers/tpm2/units/test-plan.pxu                                                                                            
Duplicates found:                                                                                                                                                       
- Name: "TPM tests" (case insensitive)                                                                                                                                  
  IDs: tpm-cert-full (line 102), tpm-cert-manual (line 113), tpm-cert-automated (line 121)

bladernr@galactica:~/development/checkbox/tools$ python3 analyze_duplicates.py       
=== DUPLICATE NAME ANALYSIS ===

No duplicate names found in any test-plan.pxu files.
```

Also ran a quick find/grep and visually checked to doublecheck the script as well.

``for x in `find ../providers/ -name test-plan.pxu`; do cat $x |grep "name: " |sort; done |less``
