### PR TITLE
Remove "stress-10-reboot-poweroff-automated" from SRU (Bugfix)

### DIFF
--- a/providers/sru/units/sru.pxu
+++ b/providers/sru/units/sru.pxu
@@ -78,7 +78,6 @@ nested_part:
     power-automated
     tpm-cert-automated
     stress-ng-cert-automated
-    stress-10-reboot-poweroff-automated
 bootstrap_include:
     device
     graphics_card


### PR DESCRIPTION
## WARNING: This modifies com.canonical.certification::sru-server
## Description

While running the NV SRU testing from lab-ci-job, I found that `poweroff_10` and `reboot_10` rely on `pm_test.py` are still being executed.
These tests were excluded in jenkins job very long time ago, and we has switched to using `warmboot` and `coldboot` already. 
Therefore, the pm_test.py based test should be removed from the SRU test plan.

## Resolved issues

https://certification.canonical.com/hardware/202202-29948/submission/435717/test-results/fail/

## Tests

Only test plan was modified.
