### PR TITLE
update server cert launchers to prompt for manifest entries (BugFix)

### DIFF
--- a/providers/certification-server/launcher/certify-22.04
+++ b/providers/certification-server/launcher/certify-22.04
@@ -10,7 +10,7 @@ unit = com.canonical.certification::22.04-server-full
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/certify-soc-22.04
+++ b/providers/certification-server/launcher/certify-soc-22.04
@@ -10,7 +10,7 @@ unit = com.canonical.certification::22.04-server-soc-cert
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/certify-ubuntu-server
+++ b/providers/certification-server/launcher/certify-ubuntu-server
@@ -10,7 +10,7 @@ unit = com.canonical.certification::server-full
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/certify-ubuntu-server-soc
+++ b/providers/certification-server/launcher/certify-ubuntu-server-soc
@@ -10,7 +10,7 @@ unit = com.canonical.certification::server-soc-cert
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/certify-ubuntu-server-vm
+++ b/providers/certification-server/launcher/certify-ubuntu-server-vm
@@ -10,7 +10,7 @@ unit = com.canonical.certification::virtual-machine-full
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/certify-vm-22.04
+++ b/providers/certification-server/launcher/certify-vm-22.04
@@ -10,7 +10,7 @@ unit = com.canonical.certification::22.04-virtual-machine-full
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/test-cpu
+++ b/providers/certification-server/launcher/test-cpu
@@ -10,7 +10,7 @@ unit = com.canonical.certification::cpu-only
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/test-firmware
+++ b/providers/certification-server/launcher/test-firmware
@@ -10,10 +10,11 @@ unit = com.canonical.certification::firmware-tests
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment
+type=interactive
 
 [config]
 config_filename = canonical-certification.conf

--- a/providers/certification-server/launcher/test-functional
+++ b/providers/certification-server/launcher/test-functional
@@ -10,7 +10,7 @@ unit = com.canonical.certification::server-functional
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/test-functional-22.04
+++ b/providers/certification-server/launcher/test-functional-22.04
@@ -10,7 +10,7 @@ unit = com.canonical.certification::22.04-server-functional
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/test-iso-install
+++ b/providers/certification-server/launcher/test-iso-install
@@ -10,7 +10,7 @@ unit = com.canonical.certification::iso-install
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/test-memory
+++ b/providers/certification-server/launcher/test-memory
@@ -10,7 +10,7 @@ unit = com.canonical.certification::memory-only
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/test-network-underspeed
+++ b/providers/certification-server/launcher/test-network-underspeed
@@ -10,7 +10,7 @@ unit = com.canonical.certification::underspeed-network-only
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/test-nvdimm
+++ b/providers/certification-server/launcher/test-nvdimm
@@ -10,7 +10,7 @@ unit = com.canonical.certification::nvdimm-only
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/test-regression
+++ b/providers/certification-server/launcher/test-regression
@@ -10,7 +10,7 @@ unit = com.canonical.certification::server-regression
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/test-stress
+++ b/providers/certification-server/launcher/test-stress
@@ -10,7 +10,7 @@ unit = com.canonical.certification::stress-only
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/test-usb
+++ b/providers/certification-server/launcher/test-usb
@@ -10,7 +10,7 @@ unit = com.canonical.certification::usb-only
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment

--- a/providers/certification-server/launcher/test-virtualization
+++ b/providers/certification-server/launcher/test-virtualization
@@ -10,7 +10,7 @@ unit = com.canonical.certification::virtualization-only
 forced = yes
 
 [test selection]
-forced = yes
+forced = no
 
 [ui]
 output = hide-resource-and-attachment


### PR DESCRIPTION
## Description

Changes launchers in the server provider from forcing test selection to not forcing test selection so that the Manifest entry prompts appear.

Previously this was set to force test selection on most launchers to prevent users from de-selecting tests, which we found was happening occasionally, rather than users using the smaller focused launchers like test-network for instance.

Until checkbox launchers have a separate manifest section and the manifest prompts are disconnected from the test selection (so that we can force test selection again while also prompting for current and future manifest questions)

For now, rather than removing the [test selection] section, I changed them all to 

```
[test selection]
forced = no
```
with the plan to change these back to yes once we are at a place where we can prevent users from de-selecting test cases and still be prompted for any detected manifest dependent items.

## Resolved issues
fixes #1978
resolves CHECKBOX-1962


## Documentation

Documentation will be handed separately by Rod as part of the work to split the server self-test guide into diataxis modules.  During that work he'll update screen shots and instructions around the newly exposed manifest menu.

## Tests
Updated the launchers and ran each one manually long enough to see that it presented the test selection screen and after hitting T presented the manifest screen.

Also using the test-firmware launcher I tried saying Yes and No to the SecureBoot manifest entry and verified that the SB test was either executed or skipped (respectively).
