### PR TITLE
Skip camera/roundtrip-qrcode test on arm64 (bugfix)

### DIFF
--- a/providers/base/units/camera/jobs.pxu
+++ b/providers/base/units/camera/jobs.pxu
@@ -165,7 +165,7 @@ flags: also-after-suspend
 _summary: Webcam BRISQUE score for {product_slug}
 estimated_duration: 20s
 depends: camera/detect
-requires: lsb.release >= '22.04'
+requires: os.release >= '22.04'
 command:
   camera_quality_test.py -d {name} -o "$PLAINBOX_SESSION_SHARE"
 _purpose:
@@ -184,7 +184,7 @@ flags: also-after-suspend
 _summary: Attach the image used for the BRISQUE score for {product_slug}
 estimated_duration: 1s
 after: camera/camera-quality_{name}
-requires: lsb.release >= '22.04'
+requires: os.release >= '22.04'
 command:
   [ -f "$PLAINBOX_SESSION_SHARE"/quality_image_{name}.jpg ] &&
   cat "$PLAINBOX_SESSION_SHARE"/quality_image_{name}.jpg
@@ -247,10 +247,16 @@ depends:
   camera/detect
   {% endif -%}
 requires:
+  {#
+    If the device that generated this test is MMAL, check that we are on armhf
+    (libmmal doesn't exist for amd64 or arm64).
+    See: https://github.com/waveform80/picamera/issues/716#issuecomment-1063878114
+  #}
+  (device.name == '{{name}}' and device.category == 'MMAL' and dpkg.architecture == 'armhf') or (device.name == '{{ name}}' and device.category == 'CAPTURE')
   {%- if __on_ubuntucore__ %}
-  lsb.release >= '19.1'
+  os.release >= '19.1'
   {%- else %}
-  lsb.release >= '19.1'
+  os.release >= '19.1'
   package.name == 'python3-zbar'
   package.name == 'python3-pyqrcode'
   package.name == 'python3-pil'


### PR DESCRIPTION
## WARNING: This modifies com.canonical.certification::sru-server

## Description

This test relies on libmmal that doesn't exist for arm64. It should therefore be skipped in this context (else it will fail, see linked issue)

Minor: this also replaces lsb with os given that we have soft deprecated lsb

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1739
Fixes: https://github.com/canonical/checkbox/issues/1720

## Documentation

Documented in a jinja comment (I'm sorry, but its already a jinja template so...) why this is done

## Tests

Tested it in the lab on rpi3 both:
- [amd64 (to see that it is skipped)](https://certification.canonical.com/hardware/202311-32356/submission/435955/)
- [armhf (to see that it still runs)](https://certification.canonical.com/hardware/202311-32356/submission/435966/)
