### PR TITLE
Fix clipping in tets report html table (BugFix)

### DIFF
--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.css
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.css
@@ -41,6 +41,10 @@
     src: local("Ubuntu Mono"), local("UbuntuMono-Regular"), url("https://fonts.gstatic.com/s/ubuntumono/v6/ViZhet7Ak-LRXZMXzuAfkYbN6UDyHWBl620a-IRfuBk.woff") format("woff");
 }
 
+.ui-loader{
+    display: none !important;
+}
+
 /* JQM Demos custom CSS */
 
 .ui-collapsible-content,

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
@@ -172,27 +172,23 @@
                     {% set mainloop = loop %}
                     <div data-role="collapsible" data-filter="true" data-input="#filterTable-input1" class="openMe" style="margin: 0;" data-content-theme="false">
                     <h3>{{ cat_name }}<span class="ui-li-count {{ OUTCOME_METADATA_MAP[category_outcome_map[cat_id]].tr_label }}Count">{{ OUTCOME_METADATA_MAP[category_outcome_map[cat_id]].tr_label }}</span></h3>
-                        <table data-role="table" id="{{ cat_id }}" data-filter="true" data-input="#filterTable-input1" class="ui-body-d ui-shadow table-stroke ui-responsive">
-                            <thead>
-                                <tr class="ui-bar-d">
-                                </tr>
-                            </thead>
+                        <table data-role="table" id="{{ cat_id }}" data-filter="true" data-input="#filterTable-input1" class="ui-body-d ui-shadow table-stroke ui-responsive ui-table ui-table-reflow" style="table-layout: fixed;">
                             <tbody>
                             {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
                                 <tr>
-                                    <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%'>{{ job_id|strip_ns }}</td>
-                                    <td style='width:10%; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
+                                    <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%;word-wrap:break-word;'>{{ job_id|strip_ns }}</td>
+                                    <td style='width:min-content; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
                                     {%- if job_state.effective_certification_status != "non-blocker" %}
-                                    <td style='width:10%'>{{ job_state.effective_certification_status }}</td>
+                                    <td style='width:min-content;text-wrap:nowrap;'>{{ job_state.effective_certification_status }}</td>
                                     {%- else %}
-                                    <td style='width:10%'></td>
+                                    <td style='width:min-content;text-wrap:nowrap;'></td>
                                     {%- endif %}
                                     {%- if job_state.result.io_log_as_flat_text != "" %}
-                                    <td style='width:10%'><a href="#{{ mainloop.index }}-{{ loop.index }}-log">I/O log</a></td>
+                                    <td style='width:min-content;text-wrap:nowrap;'><a href="#{{ mainloop.index }}-{{ loop.index }}-log">I/O log</a></td>
                                     {%- else %}
-                                    <td style='width:10%'></td>
+                                    <td style='width:min-content;text-wrap:nowrap;'></td>
                                     {%- endif %}
-                                    <td style='width:35%'>{% autoescape false %}{{ job_state.result.comments if job_state.result.comments != None }}{% endautoescape %}</td>
+                                    <td style='width:35%;word-wrap:break-word;'>{% autoescape false %}{{ job_state.result.comments if job_state.result.comments != None }}{% endautoescape %}</td>
                                 </tr>
                             {%- endfor %}
                             </tbody>

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
@@ -177,16 +177,16 @@
                             {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
                                 <tr>
                                     <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%;word-wrap:break-word;'>{{ job_id|strip_ns }}</td>
-                                    <td style='width:max-content;text-wrap:nowrap; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
+                                    <td style='width:auto;word-break:break-word; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
                                     {%- if job_state.effective_certification_status != "non-blocker" %}
-                                    <td style='width:max-content;text-wrap:nowrap;'>{{ job_state.effective_certification_status }}</td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'>{{ job_state.effective_certification_status }}</td>
                                     {%- else %}
-                                    <td style='width:max-content;text-wrap:nowrap;'></td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'></td>
                                     {%- endif %}
                                     {%- if job_state.result.io_log_as_flat_text != "" %}
-                                    <td style='width:max-content;text-wrap:nowrap;'><a href="#{{ mainloop.index }}-{{ loop.index }}-log">I/O log</a></td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'><a href="#{{ mainloop.index }}-{{ loop.index }}-log">I/O log</a></td>
                                     {%- else %}
-                                    <td style='width:max-content;text-wrap:nowrap;'></td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'></td>
                                     {%- endif %}
                                     <td style='width:35%;word-wrap:break-word;'>{% autoescape false %}{{ job_state.result.comments if job_state.result.comments != None }}{% endautoescape %}</td>
                                 </tr>
@@ -210,32 +210,32 @@
                                 {%- if job_id|strip_ns == "package" %}
                                 <tr>
                                     <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%;word-wrap:break-word;'>{{ job_id|strip_ns }}</td>
-                                    <td style='width:max-content;text-wrap:nowrap; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
+                                    <td style='width:auto;word-break:break-word; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
                                     {%- if job_state.effective_certification_status != "non-blocker" %}
-                                    <td style='width:max-content;text-wrap:nowrap;'>{{ job_state.effective_certification_status }}</td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'>{{ job_state.effective_certification_status }}</td>
                                     {%- else %}
-                                    <td style='width:max-content;text-wrap:nowrap;'></td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'></td>
                                     {%- endif %}
                                     {%- if job_state.result.io_log_as_flat_text != "" %}
-                                    <td style='width:max-content;text-wrap:nowrap;'><a href="#package-log">View</a></td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'><a href="#package-log">View</a></td>
                                     {%- else %}
-                                    <td style='width:max-content;text-wrap:nowrap;'></td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'></td>
                                     {%- endif %}
                                     <td style='width:35%;word-wrap:break-word'>{{ job_state.result.comments if job_state.result.comments != None }}</td>
                                 </tr>
                                 {%- else %}
                                 <tr>
                                     <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%;word-wrap:break-word'>{{ job_id|strip_ns }}</td>
-                                    <td style='width:max-content;text-wrap:nowrap; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
+                                    <td style='width:auto;word-break:break-word; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
                                     {%- if job_state.effective_certification_status != "non-blocker" %}
-                                    <td style='width:max-content;text-wrap:nowrap;'>{{ job_state.effective_certification_status }}</td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'>{{ job_state.effective_certification_status }}</td>
                                     {%- else %}
-                                    <td style='width:max-content;text-wrap:nowrap;'></td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'></td>
                                     {%- endif %}
                                     {%- if job_state.result.io_log_as_flat_text != "" %}
-                                    <td style='width:max-content;text-wrap:nowrap;'><a href="#resource-{{ loop.index }}-log">I/O log</a></td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'><a href="#resource-{{ loop.index }}-log">I/O log</a></td>
                                     {%- else %}
-                                    <td style='width:max-content;text-wrap:nowrap;'></td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'></td>
                                     {%- endif %}
                                     <td style='width:35%;word-wrap:break-word'>{{ job_state.result.comments if job_state.result.comments != None }}</td>
                                 </tr>
@@ -258,17 +258,17 @@
                     {%- endif %}
                                 <tr>
                                     <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%;word-wrap:break-word'>{{ job_id|strip_ns }}</td>
-                                    <td style='width:max-content;text-wrap:nowrap; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
+                                    <td style='width:auto;word-break:break-word; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
                                     {%- if job_state.effective_certification_status != "non-blocker" %}
-                                    <td style='width:max-content;text-wrap:nowrap;'>{{ job_state.effective_certification_status }}</td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'>{{ job_state.effective_certification_status }}</td>
                                     {%- else %}
-                                    <td style='width:max-content;text-wrap:nowrap;'></td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'></td>
                                     {%- endif %}
                                     {%- set img_type = job_state.result.img_type %}
                                     {%- if img_type or job_state.result.io_log_as_text_attachment != "" %}
-                                    <td style='width:max-content;text-wrap:nowrap;'><a href="#attachment-{{ loop.index }}-log">View</a></td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'><a href="#attachment-{{ loop.index }}-log">View</a></td>
                                     {%- else %}
-                                    <td style='width:max-content;text-wrap:nowrap;'></td>
+                                    <td style='width:auto;word-break:break-word;text-align:center'></td>
                                     {%- endif %}
                                     <td style='width:35%;word-wrap:break-word'>{{ job_state.result.comments if job_state.result.comments != None }}</td>
                                 </tr>

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
@@ -177,16 +177,16 @@
                             {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
                                 <tr>
                                     <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%;word-wrap:break-word;'>{{ job_id|strip_ns }}</td>
-                                    <td style='width:min-content; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
+                                    <td style='width:max-content;text-wrap:nowrap; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
                                     {%- if job_state.effective_certification_status != "non-blocker" %}
-                                    <td style='width:min-content;text-wrap:nowrap;'>{{ job_state.effective_certification_status }}</td>
+                                    <td style='width:max-content;text-wrap:nowrap;'>{{ job_state.effective_certification_status }}</td>
                                     {%- else %}
-                                    <td style='width:min-content;text-wrap:nowrap;'></td>
+                                    <td style='width:max-content;text-wrap:nowrap;'></td>
                                     {%- endif %}
                                     {%- if job_state.result.io_log_as_flat_text != "" %}
-                                    <td style='width:min-content;text-wrap:nowrap;'><a href="#{{ mainloop.index }}-{{ loop.index }}-log">I/O log</a></td>
+                                    <td style='width:max-content;text-wrap:nowrap;'><a href="#{{ mainloop.index }}-{{ loop.index }}-log">I/O log</a></td>
                                     {%- else %}
-                                    <td style='width:min-content;text-wrap:nowrap;'></td>
+                                    <td style='width:max-content;text-wrap:nowrap;'></td>
                                     {%- endif %}
                                     <td style='width:35%;word-wrap:break-word;'>{% autoescape false %}{{ job_state.result.comments if job_state.result.comments != None }}{% endautoescape %}</td>
                                 </tr>
@@ -209,35 +209,35 @@
                             {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.job.plugin == "resource" %}
                                 {%- if job_id|strip_ns == "package" %}
                                 <tr>
-                                    <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%'>{{ job_id|strip_ns }}</td>
-                                    <td style='width:10%; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
+                                    <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%;word-wrap:break-word;'>{{ job_id|strip_ns }}</td>
+                                    <td style='width:max-content;text-wrap:nowrap; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
                                     {%- if job_state.effective_certification_status != "non-blocker" %}
-                                    <td style='width:10%'>{{ job_state.effective_certification_status }}</td>
+                                    <td style='width:max-content;text-wrap:nowrap;'>{{ job_state.effective_certification_status }}</td>
                                     {%- else %}
-                                    <td style='width:10%'></td>
+                                    <td style='width:max-content;text-wrap:nowrap;'></td>
                                     {%- endif %}
                                     {%- if job_state.result.io_log_as_flat_text != "" %}
-                                    <td style='width:10%'><a href="#package-log">View</a></td>
+                                    <td style='width:max-content;text-wrap:nowrap;'><a href="#package-log">View</a></td>
                                     {%- else %}
-                                    <td style='width:10%'></td>
+                                    <td style='width:max-content;text-wrap:nowrap;'></td>
                                     {%- endif %}
-                                    <td style='width:35%'>{{ job_state.result.comments if job_state.result.comments != None }}</td>
+                                    <td style='width:35%;word-wrap:break-word'>{{ job_state.result.comments if job_state.result.comments != None }}</td>
                                 </tr>
                                 {%- else %}
                                 <tr>
-                                    <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%'>{{ job_id|strip_ns }}</td>
-                                    <td style='width:10%; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
+                                    <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%;word-wrap:break-word'>{{ job_id|strip_ns }}</td>
+                                    <td style='width:max-content;text-wrap:nowrap; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
                                     {%- if job_state.effective_certification_status != "non-blocker" %}
-                                    <td style='width:10%'>{{ job_state.effective_certification_status }}</td>
+                                    <td style='width:max-content;text-wrap:nowrap;'>{{ job_state.effective_certification_status }}</td>
                                     {%- else %}
-                                    <td style='width:10%'></td>
+                                    <td style='width:max-content;text-wrap:nowrap;'></td>
                                     {%- endif %}
                                     {%- if job_state.result.io_log_as_flat_text != "" %}
-                                    <td style='width:10%'><a href="#resource-{{ loop.index }}-log">I/O log</a></td>
+                                    <td style='width:max-content;text-wrap:nowrap;'><a href="#resource-{{ loop.index }}-log">I/O log</a></td>
                                     {%- else %}
-                                    <td style='width:10%'></td>
+                                    <td style='width:max-content;text-wrap:nowrap;'></td>
                                     {%- endif %}
-                                    <td style='width:35%'>{{ job_state.result.comments if job_state.result.comments != None }}</td>
+                                    <td style='width:35%;word-wrap:break-word'>{{ job_state.result.comments if job_state.result.comments != None }}</td>
                                 </tr>
                                 {%- endif %}
                             {%- endfor %}
@@ -257,20 +257,20 @@
                             <tbody>
                     {%- endif %}
                                 <tr>
-                                    <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%'>{{ job_id|strip_ns }}</td>
-                                    <td style='width:10%; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
+                                    <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%;word-wrap:break-word'>{{ job_id|strip_ns }}</td>
+                                    <td style='width:max-content;text-wrap:nowrap; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
                                     {%- if job_state.effective_certification_status != "non-blocker" %}
-                                    <td style='width:10%'>{{ job_state.effective_certification_status }}</td>
+                                    <td style='width:max-content;text-wrap:nowrap;'>{{ job_state.effective_certification_status }}</td>
                                     {%- else %}
-                                    <td style='width:10%'></td>
+                                    <td style='width:max-content;text-wrap:nowrap;'></td>
                                     {%- endif %}
                                     {%- set img_type = job_state.result.img_type %}
                                     {%- if img_type or job_state.result.io_log_as_text_attachment != "" %}
-                                    <td style='width:10%'><a href="#attachment-{{ loop.index }}-log">View</a></td>
+                                    <td style='width:max-content;text-wrap:nowrap;'><a href="#attachment-{{ loop.index }}-log">View</a></td>
                                     {%- else %}
-                                    <td style='width:10%'></td>
+                                    <td style='width:max-content;text-wrap:nowrap;'></td>
                                     {%- endif %}
-                                    <td style='width:35%'>{{ job_state.result.comments if job_state.result.comments != None }}</td>
+                                    <td style='width:35%;word-wrap:break-word'>{{ job_state.result.comments if job_state.result.comments != None }}</td>
                                 </tr>
                     {%- if loop.last %}
                             </tbody>


### PR DESCRIPTION
## Description

This is a quick CSS fix for the text clipping issue in test report HTMLs. The unsupported cases usually have a long "job cannot be started: resource expression..." string at the end of the table but it gets clipped when the screen isn't big enough. It gets worse if the test case also has a really long name. 

Basically turns this:

![image](https://github.com/user-attachments/assets/7b2031de-ea24-469e-9eb7-60b2c306ac4b)

into this:

![image](https://github.com/user-attachments/assets/e2f98416-acdc-4c6c-b5c5-720dcedc9593)

## Resolved issues

Just CSS fixes

## Documentation

Since the test case names (left most) and the message (right most) cells have a fixed 35% width, the `not-supported` string may wrap in a slightly weird way. This can be tuned by changing 35% to other values. 

## Tests

Chrome and firefox
