### PR TITLE
Fix crash in ManifestBrowser when only hidden manifests are present (BugFix)

### DIFF
--- a/checkbox-ng/checkbox_ng/test_urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/test_urwid_ui.py
@@ -1,0 +1,58 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import urwid
+from checkbox_ng.urwid_ui import ManifestBrowser
+
+
+class ManifestBrowserTest(unittest.TestCase):
+
+    @patch("checkbox_ng.urwid_ui.urwid.MainLoop")
+    def test_handle_focused_question_input_empty_pile(self, mock_mainloop):
+        browser = ManifestBrowser("Test", {})
+        # No items in the pile ⟶ nothing happens
+        browser.handle_focused_question_input("Any key")
+
+    @patch("checkbox_ng.urwid_ui.urwid.MainLoop")
+    def test_handle_focused_question_input(self, mock_mainloop):
+        cases = [
+            ("bool", "y", ["left", " ", "down"]),
+            ("bool", "n", ["right", " ", "down"]),
+            ("natural", "enter", ["down"]),
+        ]
+
+        for value_type, key, expected_calls in cases:
+            with self.subTest(key=key):
+                browser = ManifestBrowser("Test", {})
+                browser._pile = MagicMock()
+                bool_question = MagicMock()
+                bool_question._value_type = value_type
+                browser._pile.focus = bool_question
+                browser.loop = MagicMock()
+                browser.handle_focused_question_input(key)
+                browser.loop.process_input.assert_called_with(expected_calls)
+
+    def test_handle_submit_key_not_all_answered(self):
+        browser = ManifestBrowser("Test", {})
+        q1 = MagicMock()
+        q1.value = None  # Unanswered question
+        q2 = MagicMock()
+        q2.value = 42
+        browser._question_store = [q1, q2]
+
+        # Should not raise
+        browser.handle_submit_key()
+
+    def test_handle_submit_key_all_answered(self):
+        browser = ManifestBrowser("Test", {})
+        q1 = MagicMock()
+        q1.value = 1
+        q2 = MagicMock()
+        q2.value = 42
+        browser._question_store = [q1, q2]
+
+        with self.assertRaises(urwid.ExitMainLoop):
+            browser.handle_submit_key()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/checkbox-ng/checkbox_ng/urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/urwid_ui.py
@@ -1109,11 +1109,20 @@ class ManifestBrowser:
 
     def unhandled_input(self, key):
         if key in ("t", "T"):
-            for w in self._question_store:
-                if w.value is None:
-                    break
-            else:
-                raise urwid.ExitMainLoop()
+            self.handle_submit_key(self)
+        else:
+            self.handle_focused_question_input(key)
+
+    def handle_submit_key(self):
+        for w in self._question_store:
+            if w.value is None:
+                break
+        else:
+            raise urwid.ExitMainLoop()
+
+    def handle_focused_question_input(self, key):
+        if self._pile.focus is None:
+            return
         if self._pile.focus._value_type == "bool":
             if key in ("y", "Y"):
                 self.loop.process_input(["left", " ", "down"])


### PR DESCRIPTION
## Description
- Prevents crashing of the application when test plan uses only hidden manifests.
- For better unit testing and readability logic of `ManifestBrowser.unhandled_input` is extracted into `handle_submit_key` & `handle_focused_question_input`.
- Adds first unit tests for ManifestBrowser.

## Resolved issues
Fixes: [CHECKBOX-1963](https://warthogs.atlassian.net/browse/CHECKBOX-1963)