### PR TITLE
Fix the issue where 'cool' and 'balanced' do not match (BugFix)

### DIFF
--- a/providers/base/bin/switch_power_mode.py
+++ b/providers/base/bin/switch_power_mode.py
@@ -24,6 +24,18 @@ from pathlib import Path
 import subprocess
 import contextlib
 
+# In sys file the modes are quiet, low-power, cool, balanced or performance
+# but powerprofilesctl only accepts power-saver, balanced or performance
+profile_mappings = {
+    "low-power": "power-saver",
+    "power-saver": "power-saver",
+    "quiet": "power-saver",
+    "balanced": "balanced",
+    "balanced_performance": "balanced",
+    "cool": "balanced",
+    "performance": "performance",
+}
+
 
 def get_sysfs_content(path):
     """
@@ -48,17 +60,6 @@ def set_power_profile(profile):
     Raises:
         SystemExit: If the power profile could not be set.
     """
-    # In sys file the modes are quiet, low-power, cool, balanced or performance
-    # but powerprofilesctl only accepts power-saver, balanced or performance
-    profile_mappings = {
-        "low-power": "power-saver",
-        "power-saver": "power-saver",
-        "quiet": "power-saver",
-        "balanced": "balanced",
-        "balanced_performance": "balanced",
-        "cool": "balanced",
-        "performance": "performance",
-    }
 
     if profile not in profile_mappings:
         raise SystemExit("Unhandled ACPI platform profile: {}".format(profile))
@@ -101,7 +102,10 @@ def main():
         print("Power mode choices: {}".format(choices))
         for choice in choices:
             set_power_profile(choice)
-            if get_sysfs_content(profile_path) == choice:
+            if (
+                profile_mappings[get_sysfs_content(profile_path)]
+                == profile_mappings[choice]
+            ):
                 print("Switch to {} successfully.".format(choice))
             else:
                 raise SystemExit(


### PR DESCRIPTION
Fix the issue where 'cool' and 'balanced' do not match.
Credit to KaiChuan Hsieh.


## Description
When user see cool platform profile it will set balanced, but the script expect to get cool but balanced.

## Resolved issues
'cool' and 'balanced' could match.

## Tests
```
$ checkbox-cli run com.canonical.certification::power-management/switch_power_mode
==============[ Running job 4 / 4. Estimated time left: 0:00:10 ]===============
---------------------[ power-management/switch_power_mode ]---------------------
ID: com.canonical.certification::power-management/switch_power_mode
Category: com.canonical.plainbox::power-management
... 8< -------------------------------------------------------------------------
Power mode choices: ['cool', 'quiet', 'balanced', 'performance']
Switch to cool successfully.
Switch to quiet successfully.
Switch to balanced successfully.
Switch to performance successfully.
------------------------------------------------------------------------- >8 ---
Outcome: job passed
```