### PR TITLE
Make networking/info_device template depend on ethernet/detect (bugfix)

### DIFF
--- a/providers/base/units/networking/jobs.pxu
+++ b/providers/base/units/networking/jobs.pxu
@@ -19,6 +19,7 @@ template-id: networking/info_device__index___interface
 flags: also-after-suspend
 _summary: Network Information of device {__index__} ({interface})
 estimated_duration: 1.0
+depends: ethernet/detect
 requires: executable.name == 'ethtool'
 command:
   network_device_info.py info NETWORK --interface {interface}


### PR DESCRIPTION
networking/info_device__index___interface template should only be run if ethernet/detect passed.

ethernet/detect requires the `has_ethernet_adapter` manifest, so if this manifest entry is set to false, both tests would be skipped.

Before this patch, the following problem could happen:

- on laptop without an onboard Ethernet adapter, testing teams sometimes plug an USB Ethernet adapter to make it easier to hook the device up in our testing lab (to be able to remote access it, etc.)
- when doing so, Checkbox will detect this adapter as if it was an onboard adapter
- testing teams rightfully set the `has_ethernet_adapter` manifest entry to true, yet the networking/info_device__index___interface job is still run for that device.

This can create unnecessary problems down the line to review test reports in order to issue a certificate.

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

Prevent unwanted failures in certificate requests (see [this for example](https://bugs.launchpad.net/certify-planning/+bug/2103972/comments/2))

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
