### PR TITLE
Change the default logging level of agent to INFO (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/agent.py
+++ b/checkbox-ng/checkbox_ng/launcher/agent.py
@@ -24,7 +24,10 @@ import logging
 import os
 import socket
 import sys
+
 from checkbox_ng import app_context
+from checkbox_ng.utils import set_all_loggers_level
+
 from plainbox.impl.config import Configuration
 from plainbox.impl.secure.sudo_broker import is_passwordless_sudo
 from plainbox.impl.session.assistant import ResumeCandidate
@@ -106,6 +109,13 @@ class RemoteAgent:
             raise SystemExit(
                 _("System is not configured to run sudo without a password!")
             )
+        # This sets INFO as the default logging level if debug wasn't requested
+        # the hasattr is because debug is a top level flag and may not be
+        # present if not specified
+        if not hasattr(ctx.args, "debug") or not ctx.args.debug:
+            # default log level of the agent is INFO
+            logging.basicConfig(level=logging.INFO)
+            set_all_loggers_level(logging.INFO)
         if ctx.args.resume:
             msg = (
                 "--resume is deprecated and will be removed soon. "

--- a/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
+++ b/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
@@ -139,7 +139,7 @@ def main():
         "-v",
         "--verbose",
         action="store_true",
-        help=_("print more logging from checkbox"),
+        help=_("print more logging from checkbox (default for the agent)"),
     )
     top_parser.add_argument(
         "--debug",


### PR DESCRIPTION
This is done only if debug is not requested

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

With INFO level logging, the Checkbox agent outputs a little bit more information about the test run. This is useful because, given that the agent runs as a systemd unit, this information contains some contextual clues as to what the machine is doing, greatly simplifying reading the debug logs.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1971

## Documentation

N/A

## Tests

Tested it offline, it works
