### PR TITLE
Add smartcard test (New)

### DIFF
--- a/.github/workflows/tox-checkbox.yaml
+++ b/.github/workflows/tox-checkbox.yaml
@@ -141,7 +141,7 @@ jobs:
           # we pushed them to the Checkbox PPA instead
           sudo add-apt-repository ppa:checkbox-dev/edge
           sudo apt-get update
-          sudo apt-get install -y -qq libgl1 gcc python$PYTHON_VERSION-dev shellcheck
+          sudo apt-get install -y -qq libgl1 gcc python$PYTHON_VERSION-dev shellcheck libpcsclite-dev swig
           pip install tox
       - name: Run tox
         run: tox -e${{ matrix.tox_env_name }}

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -324,6 +324,7 @@ parts:
       - obexftp
       - parted
       - pciutils
+      - python3-pyscard
       - pulseaudio-utils
       - qml-module-qtquick-controls
       - qml-module-qtquick-layouts

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -314,6 +314,7 @@ parts:
       - python3-psutil
       - python3-serial
       - python3-yaml
+      - python3-pyscard
       - qml-module-qtquick-controls
       - qml-module-qtquick-layouts
       - qmlscene

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -339,6 +339,7 @@ parts:
       - python3-pyqrcode
       - python3-serial
       - python3-yaml
+      - python3-pyscard
       - python3-zbar
       - qml-module-qtquick-controls
       - qml-module-qtquick-layouts

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -345,6 +345,7 @@ parts:
       - python3-pyqrcode
       - python3-serial
       - python3-yaml
+      - python3-pyscard
       - python3-zbar
       - qml-module-qtquick-controls
       - qml-module-qtquick-layouts

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -346,6 +346,7 @@ parts:
       - python3-pyqrcode
       - python3-serial
       - python3-yaml
+      - python3-pyscard
       - python3-zbar
       - qml-module-qtquick-controls
       - qml-module-qtquick-layouts

--- a/providers/base/bin/smartcard_test.py
+++ b/providers/base/bin/smartcard_test.py
@@ -1,9 +1,21 @@
 #!/usr/bin/env python3
-# Copyright 2015-2025 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # All rights reserved.
 #
 # Written by:
 #   Hanhsuan Lee <hanhsuan.lee@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
 from smartcard.Exceptions import (
     NoCardException,

--- a/providers/base/bin/smartcard_test.py
+++ b/providers/base/bin/smartcard_test.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+# Copyright 2015-2020 Canonical Ltd.
+# All rights reserved.
+#
+# Written by:
+#   Hanhsuan Lee <hanhsuan.lee@canonical.com>
+
+from smartcard.Exceptions import (
+    NoCardException,
+    CardConnectionException,
+)
+from checkbox_support.helpers.timeout import timeout
+from smartcard.CardRequest import CardRequest
+from smartcard.util import toHexString
+from smartcard.System import readers
+import argparse
+import logging
+import sys
+import re
+
+
+class SmartcardTest:
+    """
+    A class used to test smartcard reader
+
+    :attr logger: console logger
+    :type logger: RootLogger
+
+    :attr readers:
+        Store the smart card readers detected in this system
+    :type readers: list
+    """
+
+    logger = logging.getLogger()
+
+    readers = None
+
+    # https://www.eftlab.com/knowledge-base/complete-list-of-apdu-responses
+    sw1_list = [
+        0x61,
+        0x62,
+        0x63,
+        0x64,
+        0x65,
+        0x66,
+        0x67,
+        0x68,
+        0x69,
+        0x6A,
+        0x6B,
+        0x6C,
+        0x6D,
+        0x6E,
+        0x6F,
+        0x90,
+        0x91,
+        0x92,
+        0x93,
+        0x94,
+        0x95,
+        0x96,
+        0x97,
+        0x98,
+        0x99,
+        0x9A,
+        0x9D,
+        0x9E,
+        0x9F,
+    ]
+
+    def __init__(self):
+        """
+        Store the smart card reader object in a private variable
+        """
+        self.readers = readers()
+
+    def stringify_reader_name(self, name: str) -> str:
+        """
+        Replacing the illegal character with "-"
+
+        :param name: real name of smartcard reader
+        """
+        pattern = r"[^a-zA-Z0-9]+"
+        return re.sub(pattern, "-", name[:40])
+
+    def reader_filter(self, list_type: str, name: str) -> str:
+        """
+        Filter the smart card reader as contact, contactless, or unfiltered
+
+        :param list_type: contact/contactless/ALL
+
+        :param name: real name of smartcard reader
+        """
+        lt = list_type.lower()
+        ln = name.name.lower()
+        if lt == "contact":
+            if "contactless" not in ln and "-cl" not in ln:
+                return name
+        elif lt == "contactless":
+            if "contactless" in ln or "-cl" in ln:
+                return name
+        else:
+            return name
+
+    def list_readers(self, list_type: str):
+        """
+        List smart card readers in stringified format for the resource job
+
+        :param list_type: contact/contactless/ALL
+
+        """
+        for r in self.readers:
+            if self.reader_filter(list_type, r):
+                print(
+                    "smartcard_reader: {}".format(
+                        self.stringify_reader_name(r.name)
+                    )
+                )
+
+    def detect_reader(self, list_type: str):
+        """
+        Detect smart card readers
+
+        :param list_type: contact/contactless/ALL
+
+        """
+        count = 0
+        for r in self.readers:
+            if self.reader_filter(list_type, r):
+                self.logger.info(r.name)
+                count = count + 1
+        if count < 1:
+            raise SystemExit("There is no smartcard reader in this system")
+
+    def get_real_reader_instance(self, reader: str):
+        """
+        Using the stringified smartcard reader name
+        to get the actual reader instance
+
+        :param reader: Stringified smart card reader name
+        """
+        for r in self.readers:
+            if self.stringify_reader_name(r.name) == reader:
+                return r
+
+    def get_connection(self, reader: str):
+        """
+        Connect to the smartcard reader
+
+        :param reader: Stringified smart card reader name
+        """
+        sc_reader = self.get_real_reader_instance(reader)
+        if sc_reader:
+            try:
+                connection = sc_reader.createConnection()
+                connection.connect()
+                self.logger.info("[{}] connected".format(sc_reader))
+                return connection
+            except (NoCardException, CardConnectionException):
+                raise SystemExit("no card inserted or card is unsupported")
+        raise SystemExit("no smartcard reader")
+
+    @timeout(30)
+    def detect_smartcard(self, reader: str):
+        """
+        Detect smartcard insertion and removal in the smartcard reader
+
+        :param reader: Stringified smart card reader name
+        """
+        real_reader = self.get_real_reader_instance(reader)
+
+        self.logger.info(
+            "Smartcard insertion and removal detection test is starting"
+        )
+        self.logger.info(
+            "Please insert and remove the smartcard within 30 seconds.\n"
+        )
+
+        cardrequest = CardRequest(timeout=30, newcardonly=True)
+        cards = []
+        while len(cards) == 0:
+            currentcards = cardrequest.waitforcardevent()
+            for card in currentcards:
+                if (
+                    not cards.__contains__(card)
+                    and real_reader.name == card.reader
+                ):
+                    cards.append(card)
+                    self.logger.info("Smart card insertion detected:")
+                    self.logger.info(card)
+                    self.logger.info(
+                        "\nPlease remove it to test the removal detection\n"
+                    )
+                    break
+
+        cardrequest = CardRequest(timeout=30, newcardonly=False)
+        while True:
+            currentcards = cardrequest.waitforcardevent()
+            for card in cards:
+                if not currentcards.__contains__(card):
+                    cards.remove(card)
+                    self.logger.info("Smart card removal detected:")
+                    self.logger.info(card)
+                    return
+
+    def send_apdu_test(self, reader: str):
+        """
+        Send the APDU command to the smart card and verify the response.
+
+        :param reader: Stringified smart card reader name
+        """
+        sc_conn = self.get_connection(reader)
+        if sc_conn:
+            self.logger.info("ATR from smartcard:")
+            self.logger.info(toHexString(sc_conn.getATR()))
+            # This is a sample APDU command
+            SELECT = [0xA0, 0xA4, 0x00, 0x00, 0x02]
+            DF_TELECOM = [0x7F, 0x10]
+            data, sw1, sw2 = sc_conn.transmit(SELECT + DF_TELECOM)
+            if sw1 in self.sw1_list:
+                self.logger.info("Send/Receive APDU command is working")
+                return
+        raise SystemExit("Could not working for this smartcard reader")
+
+    def _args_parsing(self, args=sys.argv[1:]):
+        """
+        command line arguments parsing
+
+        :param args: arguments from sys
+        :type args: sys.argv
+        """
+        parser = argparse.ArgumentParser(
+            prog="Smartcard validator",
+            description="use to test smartcard reader could work",
+        )
+
+        subparsers = parser.add_subparsers(dest="test_type")
+        subparsers.required = True
+
+        # Add parser for listing smartcard readers for resource job
+        parser_resources = subparsers.add_parser(
+            "resources",
+            help="list smartcard readers on this system to resources",
+        )
+        parser_resources.add_argument(
+            "-t",
+            "--type",
+            type=str,
+            default="All",
+            help="""
+                  List All/contact/contactless smartcard reader for testing
+                  (default: %(default)s)
+                 """,
+        )
+
+        # Add parser for listing smartcard readers for resource job
+        parser_detect_reader = subparsers.add_parser(
+            "detect_reader",
+            help="count smartcard readers on this system",
+        )
+        parser_detect_reader.add_argument(
+            "-t",
+            "--type",
+            type=str,
+            default="All",
+            help="""
+                  List All/contact/contactless smartcard reader for testing
+                  (default: %(default)s)
+                 """,
+        )
+
+        # Add parser for detecting smartcard insert/remove
+        parser_detect = subparsers.add_parser(
+            "detect_card", help="Detecting smartcard insert/remove"
+        )
+        parser_detect.add_argument(
+            "-r",
+            "--reader",
+            type=str,
+            help="smartcard reader for testing",
+        )
+
+        # Add parser for sending/receiving APDU command to/from smartcard
+        parser_send = subparsers.add_parser(
+            "send", help="Sending/receiving APDU command to/from smartcard"
+        )
+        parser_send.add_argument(
+            "-r",
+            "--reader",
+            type=str,
+            help="smartcard reader for testing",
+        )
+        return parser.parse_args(args)
+
+    def function_select(self, args):
+        if args.test_type == "resources":
+            # list_readers("All")
+            return self.list_readers(args.type)
+        elif args.test_type == "detect_reader":
+            # detect_reader("Broadcom 58200")
+            return self.detect_reader(args.type)
+        elif args.test_type == "detect_card":
+            # detect_smartcard("Broadcom 58200")
+            return self.detect_smartcard(args.reader)
+        elif args.test_type == "send":
+            # send_apdu_test("Broadcom 58200")
+            return self.send_apdu_test(args.reader)
+
+
+def main():
+    sc = SmartcardTest()
+
+    # create logger formatter
+    log_formatter = logging.Formatter(fmt="%(message)s")
+
+    # set log level
+    sc.logger.setLevel(logging.INFO)
+
+    # create console handler
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(log_formatter)
+
+    # Add console handler to logger
+    sc.logger.addHandler(console_handler)
+    sys.exit(sc.function_select(sc._args_parsing()))
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/base/bin/smartcard_test.py
+++ b/providers/base/bin/smartcard_test.py
@@ -315,7 +315,7 @@ class SmartcardTest:
             # send_apdu_test("Broadcom 58200")
             return self.send_apdu_test(args.reader)
         else:
-            raise SystemExit("Unknown test type: {}".format(args.test_type)) 
+            raise SystemExit("Unknown test type: {}".format(args.test_type))
 
 
 def main():

--- a/providers/base/bin/smartcard_test.py
+++ b/providers/base/bin/smartcard_test.py
@@ -314,6 +314,8 @@ class SmartcardTest:
         elif args.test_type == "send":
             # send_apdu_test("Broadcom 58200")
             return self.send_apdu_test(args.reader)
+        else:
+            raise SystemExit("Unknown test type: {}".format(args.test_type)) 
 
 
 def main():

--- a/providers/base/bin/smartcard_test.py
+++ b/providers/base/bin/smartcard_test.py
@@ -182,7 +182,7 @@ class SmartcardTest:
         )
 
         cardrequest = CardRequest(timeout=30, newcardonly=True)
-        cards = []  # type: list[smartcard.Card]
+        cards = []  # list[smartcard.Card]
         while len(cards) == 0:
             currentcards = cardrequest.waitforcardevent()
             for card in currentcards:

--- a/providers/base/bin/smartcard_test.py
+++ b/providers/base/bin/smartcard_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2015-2020 Canonical Ltd.
+# Copyright 2015-2025 Canonical Ltd.
 # All rights reserved.
 #
 # Written by:

--- a/providers/base/bin/smartcard_test.py
+++ b/providers/base/bin/smartcard_test.py
@@ -286,7 +286,6 @@ class SmartcardTest:
         parser_detect.add_argument(
             "-r",
             "--reader",
-            type=str,
             help="smartcard reader for testing",
         )
 

--- a/providers/base/debian/control
+++ b/providers/base/debian/control
@@ -39,6 +39,7 @@ Recommends: bonnie++,
             python3-dbus,
             python3-evdev,
             python3-gi,
+            python3-pyscard,
             smartmontools,
             sysstat,
             ${plainbox:Recommends}

--- a/providers/base/tests/test_smartcard_test.py
+++ b/providers/base/tests/test_smartcard_test.py
@@ -1,0 +1,506 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import logging
+
+from checkbox_support.helpers.timeout import mock_timeout
+
+# Import the class to be tested
+# Assuming smartcard_test.py is in the same directory or accessible via PYTHONPATH
+from smartcard_test import (
+    SmartcardTest,
+    NoCardException,
+    CardConnectionException,
+)
+
+
+@mock_timeout()
+class TestSmartcardTest(unittest.TestCase):
+    def setUp(self):
+        """
+        Set up for each test case.
+        We'll patch `smartcard.System.readers` globally for most tests
+        since it's accessed in the constructor.
+        """
+        # Patch smartcard.System.readers to return a mock list of readers
+        self.mock_reader_class = MagicMock()
+        self.mock_reader_class.name = "Mock Reader 1"
+        self.mock_reader_class_contactless = MagicMock()
+        self.mock_reader_class_contactless.name = "Mock Reader 2 - Contactless"
+        self.mock_reader_class_cl = MagicMock()
+        self.mock_reader_class_cl.name = "Mock Reader 3 -CL"
+
+        self.mock_readers_list = [
+            self.mock_reader_class,
+            self.mock_reader_class_contactless,
+            self.mock_reader_class_cl,
+        ]
+
+        self.patcher_readers = patch(
+            "smartcard_test.readers", return_value=self.mock_readers_list
+        )
+        self.mock_readers = self.patcher_readers.start()
+
+        # Initialize SmartcardTest instance
+        self.sc = SmartcardTest()
+
+        self.sc.readers = self.mock_readers_list
+
+        # Suppress logging output during tests unless explicitly needed
+        self.sc.logger.setLevel(logging.CRITICAL)
+
+    def tearDown(self):
+        """
+        Clean up after each test case.
+        Stop all patches.
+        """
+        self.patcher_readers.stop()
+
+    def test_stringify_reader_name(self):
+        """
+        Test stringify_reader_name method.
+        """
+        self.assertEqual(
+            self.sc.stringify_reader_name("My Reader Name 123!@#"),
+            "My-Reader-Name-123-",
+        )
+        self.assertEqual(
+            self.sc.stringify_reader_name("Another_Reader-Name.V2"),
+            "Another-Reader-Name-V2",
+        )
+        self.assertEqual(self.sc.stringify_reader_name("Short"), "Short")
+        self.assertEqual(
+            self.sc.stringify_reader_name("A" * 50), "A" * 40
+        )  # Test truncation
+
+    def test_reader_filter_all(self):
+        """
+        Test reader_filter with 'All' type.
+        """
+        self.assertEqual(
+            self.sc.reader_filter("All", self.mock_reader_class),
+            self.mock_reader_class,
+        )
+        self.assertEqual(
+            self.sc.reader_filter("ALL", self.mock_reader_class_contactless),
+            self.mock_reader_class_contactless,
+        )
+
+    def test_reader_filter_contact(self):
+        """
+        Test reader_filter with 'contact' type.
+        """
+        self.assertEqual(
+            self.sc.reader_filter("contact", self.mock_reader_class),
+            self.mock_reader_class,
+        )
+        self.assertIsNone(
+            self.sc.reader_filter(
+                "contact", self.mock_reader_class_contactless
+            )
+        )
+        self.assertIsNone(
+            self.sc.reader_filter("contact", self.mock_reader_class_cl)
+        )
+
+    def test_reader_filter_contactless(self):
+        """
+        Test reader_filter with 'contactless' type.
+        """
+        self.assertIsNone(
+            self.sc.reader_filter("contactless", self.mock_reader_class)
+        )
+        self.assertEqual(
+            self.sc.reader_filter(
+                "contactless", self.mock_reader_class_contactless
+            ),
+            self.mock_reader_class_contactless,
+        )
+        self.assertEqual(
+            self.sc.reader_filter("contactless", self.mock_reader_class_cl),
+            self.mock_reader_class_cl,
+        )
+
+    @patch("builtins.print")
+    def test_list_readers(self, mock_print):
+        """
+        Test list_readers method.
+        """
+        # Test with 'All'
+        self.sc.list_readers("All")
+        expected_calls = [
+            unittest.mock.call("smartcard_reader: Mock-Reader-1"),
+            unittest.mock.call("smartcard_reader: Mock-Reader-2-Contactless"),
+            unittest.mock.call("smartcard_reader: Mock-Reader-3-CL"),
+        ]
+        mock_print.assert_has_calls(expected_calls, any_order=True)
+        mock_print.reset_mock()
+
+        # Test with 'contact'
+        self.sc.list_readers("contact")
+        mock_print.assert_called_once_with("smartcard_reader: Mock-Reader-1")
+        mock_print.reset_mock()
+
+        # Test with 'contactless'
+        self.sc.list_readers("contactless")
+        expected_calls = [
+            unittest.mock.call("smartcard_reader: Mock-Reader-2-Contactless"),
+            unittest.mock.call("smartcard_reader: Mock-Reader-3-CL"),
+        ]
+        mock_print.assert_has_calls(expected_calls, any_order=True)
+        self.assertEqual(mock_print.call_count, 2)
+        mock_print.reset_mock()
+
+    @patch("smartcard_test.SmartcardTest.logger.info")
+    def test_detect_reader_success(self, mock_logger_info):
+        """
+        Test detect_reader method when readers are found.
+        """
+        # Test with 'All'
+        self.sc.detect_reader("All")
+        expected_calls = [
+            unittest.mock.call("Mock Reader 1"),
+            unittest.mock.call("Mock Reader 2 - Contactless"),
+            unittest.mock.call("Mock Reader 3 -CL"),
+        ]
+        mock_logger_info.assert_has_calls(expected_calls, any_order=True)
+        self.assertEqual(mock_logger_info.call_count, 3)
+
+    @patch("smartcard_test.SmartcardTest.logger.info")
+    def test_detect_reader_no_reader(self, mock_logger_info):
+        """
+        Test detect_reader method when no readers are found.
+        """
+        # Mock readers to be empty
+        sc_no_readers = SmartcardTest()
+        sc_no_readers.readers = []
+        with self.assertRaises(SystemExit) as cm:
+            sc_no_readers.detect_reader("All")
+        self.assertEqual(
+            cm.exception.code,
+            "There is no smartcard reader in this system",
+        )
+        mock_logger_info.assert_not_called()
+
+    def test_get_real_reader_instance(self):
+        """
+        Test get_real_reader_instance method.
+        """
+        # Assuming stringify_reader_name works correctly
+        reader_name = self.sc.stringify_reader_name(
+            self.mock_reader_class.name
+        )
+        found_reader = self.sc.get_real_reader_instance(reader_name)
+        self.assertEqual(found_reader, self.mock_reader_class)
+
+        # Test with a non-existent reader
+        self.assertIsNone(
+            self.sc.get_real_reader_instance("NonExistentReader")
+        )
+
+    @patch("smartcard_test.SmartcardTest.get_real_reader_instance")
+    @patch("smartcard_test.SmartcardTest.logger.info")
+    def test_get_connection_success(
+        self, mock_logger_info, mock_get_real_reader_instance
+    ):
+        """
+        Test get_connection method on successful connection.
+        """
+        mock_connection = MagicMock()
+        mock_reader = MagicMock()
+        mock_reader.createConnection.return_value = mock_connection
+        mock_reader.name = "Test Reader"
+
+        mock_get_real_reader_instance.return_value = mock_reader
+
+        connection = self.sc.get_connection("Test Reader Stringified")
+
+        mock_get_real_reader_instance.assert_called_once_with(
+            "Test Reader Stringified"
+        )
+        self.assertEqual(connection, mock_connection)
+
+    @patch("smartcard_test.SmartcardTest.get_real_reader_instance")
+    @patch("sys.exit")
+    @patch("smartcard_test.SmartcardTest.logger.info")
+    def test_get_connection_no_card_exception(
+        self, mock_logger_info, mock_sys_exit, mock_get_real_reader_instance
+    ):
+        """
+        Test get_connection method when NoCardException occurs.
+        """
+        mock_reader = MagicMock()
+        mock_reader.createConnection.side_effect = NoCardException(
+            "No card", hresult=-1
+        )
+        mock_get_real_reader_instance.return_value = mock_reader
+
+        with self.assertRaises(SystemExit) as cm:
+            self.sc.get_connection("Test Reader Stringified")
+        self.assertEqual(
+            cm.exception.code, "no card inserted or card is unsupported"
+        )
+        mock_logger_info.assert_not_called()  # Should not log success if exception occurs
+
+        mock_get_real_reader_instance.return_value = None
+        with self.assertRaises(SystemExit) as cm:
+            self.sc.get_connection("Test Reader Stringified")
+        self.assertEqual(cm.exception.code, "no smartcard reader")
+
+    @patch("smartcard_test.SmartcardTest.get_real_reader_instance")
+    @patch("sys.exit")
+    @patch("smartcard_test.SmartcardTest.logger.info")
+    def test_get_connection_card_connection_exception(
+        self, mock_logger_info, mock_sys_exit, mock_get_real_reader_instance
+    ):
+        """
+        Test get_connection method when CardConnectionException occurs.
+        """
+        mock_reader = MagicMock()
+        mock_reader.createConnection.side_effect = CardConnectionException(
+            "Connection error"
+        )
+        mock_get_real_reader_instance.return_value = mock_reader
+
+        with self.assertRaises(SystemExit) as cm:
+            self.sc.get_connection("Test Reader Stringified")
+        self.assertEqual(
+            cm.exception.code, "no card inserted or card is unsupported"
+        )
+        mock_logger_info.assert_not_called()  # Should not log success if exception occurs
+
+    @patch("smartcard_test.SmartcardTest.get_real_reader_instance")
+    @patch("smartcard_test.SmartcardTest.logger.info")
+    @patch("smartcard_test.CardRequest")
+    def test_detect_smartcard_success(
+        self, MockCardRequest, mock_logger_info, mock_get_real_reader_instance
+    ):
+        """
+        Test detect_smartcard method for successful insertion and removal.
+        """
+        mock_real_reader = MagicMock()
+        mock_real_reader.name = "Mock Reader 1"
+        mock_get_real_reader_instance.return_value = mock_real_reader
+
+        mock_card_insert = MagicMock()
+        mock_card_insert.reader = "Mock Reader 1"
+        mock_card_insert.atr = [0x3B, 0x00]  # Example ATR
+
+        mock_card_request_instance_new = MagicMock()
+        mock_card_request_instance_new.waitforcardevent.side_effect = [
+            [mock_card_insert],
+        ]
+        mock_card_request_instance_old = MagicMock()
+        mock_card_request_instance_old.waitforcardevent.side_effect = [
+            [],
+        ]
+
+        MockCardRequest.side_effect = [
+            mock_card_request_instance_new,
+            mock_card_request_instance_old,
+        ]
+        self.sc.detect_smartcard("Mock-Reader-1")
+
+        mock_get_real_reader_instance.assert_called_once_with("Mock-Reader-1")
+        self.assertEqual(MockCardRequest.call_count, 2)
+        MockCardRequest.assert_has_calls(
+            [
+                unittest.mock.call(timeout=30, newcardonly=True),
+                unittest.mock.call(timeout=30, newcardonly=False),
+            ]
+        )
+
+        expected_logger_calls = [
+            unittest.mock.call(
+                "Smartcard insertion and removal detection test is starting"
+            ),
+            unittest.mock.call(
+                "Please insert and remove the smartcard within 30 seconds.\n"
+            ),
+            unittest.mock.call("Smart card insertion detected:"),
+            unittest.mock.call(mock_card_insert),
+            unittest.mock.call(
+                "\nPlease remove it to test the removal detection\n"
+            ),
+            unittest.mock.call("Smart card removal detected:"),
+            unittest.mock.call(mock_card_insert),
+        ]
+        mock_logger_info.assert_has_calls(expected_logger_calls)
+
+    @patch("smartcard_test.SmartcardTest.get_connection")
+    @patch("smartcard_test.SmartcardTest.logger.info")
+    @patch("smartcard.util.toHexString", return_value="3B00")
+    def test_send_apdu_test_success(
+        self, mock_toHexString, mock_logger_info, mock_get_connection
+    ):
+        """
+        Test send_apdu_test method on successful APDU transmission.
+        """
+        mock_connection = MagicMock()
+        mock_connection.getATR.return_value = [0x3B, 0x00]
+        mock_connection.transmit.return_value = (
+            [],
+            self.sc.sw1_list[0],
+            0x00,
+        )  # Simulate success SW1
+        mock_get_connection.return_value = mock_connection
+
+        self.sc.send_apdu_test("Test Reader Stringified")
+
+        mock_get_connection.assert_called_once_with("Test Reader Stringified")
+
+        expected_logger_calls = [
+            unittest.mock.call("ATR from smartcard:"),
+            unittest.mock.call("3B 00"),
+            unittest.mock.call("Send/Receive APDU command is working"),
+        ]
+        mock_logger_info.assert_has_calls(expected_logger_calls)
+
+    @patch("smartcard_test.SmartcardTest.get_connection")
+    @patch("sys.exit")
+    @patch("smartcard_test.SmartcardTest.logger.info")
+    @patch("smartcard.util.toHexString")
+    def test_send_apdu_test_failure(
+        self,
+        mock_toHexString,
+        mock_logger_info,
+        mock_sys_exit,
+        mock_get_connection,
+    ):
+        """
+        Test send_apdu_test method when APDU transmission fails (SW1 not in list).
+        """
+        mock_connection = MagicMock()
+        mock_connection.getATR.return_value = [0x3B, 0x00]
+        mock_connection.transmit.return_value = (
+            [],
+            0x11,
+            0x00,
+        )  # Simulate failure SW1
+        mock_get_connection.return_value = mock_connection
+
+        with self.assertRaises(SystemExit) as cm:
+            self.sc.send_apdu_test("Test Reader Stringified")
+        self.assertEqual(
+            cm.exception.code, "Could not working for this smartcard reader"
+        )
+
+        mock_get_connection.assert_called_once_with("Test Reader Stringified")
+        mock_logger_info.assert_has_calls(
+            [
+                unittest.mock.call("ATR from smartcard:"),
+                unittest.mock.call("3B 00"),
+            ]
+        )
+        # Ensure success message is NOT logged
+        self.assertNotIn(
+            unittest.mock.call("Send/Receive APDU command is working"),
+            mock_logger_info.call_args_list,
+        )
+
+        mock_get_connection.return_value = (
+            None  # No return value from connection
+        )
+        with self.assertRaises(SystemExit) as cm:
+            self.sc.send_apdu_test("Test Reader Stringified")
+        self.assertEqual(
+            cm.exception.code, "Could not working for this smartcard reader"
+        )
+
+    def test_args_parsing_resources(self):
+        """
+        Test _args_parsing for 'resources' command.
+        """
+        args = self.sc._args_parsing(["resources", "-t", "contact"])
+        self.assertEqual(args.test_type, "resources")
+        self.assertEqual(args.type, "contact")
+
+        args = self.sc._args_parsing(["resources"])  # Default type
+        self.assertEqual(args.test_type, "resources")
+        self.assertEqual(args.type, "All")
+
+    def test_args_parsing_detect_reader(self):
+        """
+        Test _args_parsing for 'detect_reader' command.
+        """
+        args = self.sc._args_parsing(
+            ["detect_reader", "--type", "contactless"]
+        )
+        self.assertEqual(args.test_type, "detect_reader")
+        self.assertEqual(args.type, "contactless")
+
+        args = self.sc._args_parsing(["detect_reader"])  # Default type
+        self.assertEqual(args.test_type, "detect_reader")
+        self.assertEqual(args.type, "All")
+
+    def test_args_parsing_detect_card(self):
+        """
+        Test _args_parsing for 'detect_card' command.
+        """
+        args = self.sc._args_parsing(["detect_card", "-r", "MyReader"])
+        self.assertEqual(args.test_type, "detect_card")
+        self.assertEqual(args.reader, "MyReader")
+
+    def test_args_parsing_send(self):
+        """
+        Test _args_parsing for 'send' command.
+        """
+        args = self.sc._args_parsing(["send", "-r", "AnotherReader"])
+        self.assertEqual(args.test_type, "send")
+        self.assertEqual(args.reader, "AnotherReader")
+
+    def test_args_parsing_no_subcommand(self):
+        """
+        Test _args_parsing when no subcommand is provided.
+        """
+        with self.assertRaises(
+            SystemExit
+        ):  # argparse will exit if required subcommand is missing
+            self.sc._args_parsing([])
+
+    @patch("smartcard_test.SmartcardTest.list_readers")
+    def test_function_select_resources(self, mock_list_readers):
+        """
+        Test function_select for 'resources' type.
+        """
+        mock_args = MagicMock()
+        mock_args.test_type = "resources"
+        mock_args.type = "All"
+        self.sc.function_select(mock_args)
+        mock_list_readers.assert_called_once_with("All")
+
+    @patch("smartcard_test.SmartcardTest.detect_reader")
+    def test_function_select_detect_reader(self, mock_detect_reader):
+        """
+        Test function_select for 'detect_reader' type.
+        """
+        mock_args = MagicMock()
+        mock_args.test_type = "detect_reader"
+        mock_args.type = "contact"
+        self.sc.function_select(mock_args)
+        mock_detect_reader.assert_called_once_with("contact")
+
+    @patch("smartcard_test.SmartcardTest.detect_smartcard")
+    def test_function_select_detect_card(self, mock_detect_smartcard):
+        """
+        Test function_select for 'detect_card' type.
+        """
+        mock_args = MagicMock()
+        mock_args.test_type = "detect_card"
+        mock_args.reader = "MyReader"
+        self.sc.function_select(mock_args)
+        mock_detect_smartcard.assert_called_once_with("MyReader")
+
+    @patch("smartcard_test.SmartcardTest.send_apdu_test")
+    def test_function_select_send(self, mock_send_apdu_test):
+        """
+        Test function_select for 'send' type.
+        """
+        mock_args = MagicMock()
+        mock_args.test_type = "send"
+        mock_args.reader = "AnotherReader"
+        self.sc.function_select(mock_args)
+        mock_send_apdu_test.assert_called_once_with("AnotherReader")
+
+
+if __name__ == "__main__":
+    unittest.main(argv=["first-arg-is-ignored"], exit=False)

--- a/providers/base/tests/test_smartcard_test.py
+++ b/providers/base/tests/test_smartcard_test.py
@@ -531,7 +531,6 @@ class TestSmartcardTest(unittest.TestCase):
         mock_logger.setLevel.assert_called_once_with(logging.INFO)
         mock_logger.addHandler.assert_called_once_with(mock_handler_instance)
 
-        mock_instance._args_parsing.assert_called_once()
         mock_instance.function_select.assert_called_once_with(["dummy_arg"])
 
         mock_sys_exit.assert_called_once_with(0)

--- a/providers/base/tox.ini
+++ b/providers/base/tox.ini
@@ -19,6 +19,7 @@ setenv = PROVIDERPATH = {envdir}
 deps =
     flake8
     evdev
+    pyscard == 1.9.9
     coverage == 5.5
     distro == 1.0.1
     Jinja2 == 2.8
@@ -43,6 +44,7 @@ setenv=
 deps =
     flake8
     evdev
+    pyscard == 2.1.1
     coverage == 5.5
     distro == 1.0.1
     Jinja2 == 2.10
@@ -62,6 +64,7 @@ deps =
 deps =
     flake8
     evdev
+    pyscard == 2.1.1
     coverage == 7.3.0
     distro == 1.4.0
     Jinja2 == 2.10.1
@@ -80,6 +83,7 @@ deps =
 deps =
     flake8
     evdev
+    pyscard == 2.2.2
     coverage == 7.3.0
     distro == 1.7.0
     Jinja2 == 3.0.3
@@ -99,6 +103,7 @@ deps =
 deps =
     flake8
     evdev
+    pyscard == 2.2.2
     coverage == 7.4.4
     distro == 1.9.0
     Jinja2 == 3.1.2

--- a/providers/base/tox.ini
+++ b/providers/base/tox.ini
@@ -64,7 +64,7 @@ deps =
 deps =
     flake8
     evdev
-    pyscard == 2.1.1
+    pyscard == 1.9.9
     coverage == 7.3.0
     distro == 1.4.0
     Jinja2 == 2.10.1

--- a/providers/base/tox.ini
+++ b/providers/base/tox.ini
@@ -9,7 +9,6 @@ commands =
     {envpython} -m pip -q install ../../checkbox-ng
     {envpython} -m pip -q install ../../checkbox-support
     bash -c "for provider in ../*; do {envpython} $provider/manage.py develop -f; done"
-    bash -c "swig -version"
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report
@@ -79,10 +78,6 @@ deps =
     pyparsing == 2.4.6
     PyYAML == 5.3.1
     XlsxWriter == 1.1.2
-setenv=
-#   The new SWIG version deprecated the $function keyword.
-#   It is set to the old version to allow compilation for pyscard 2.1.1.
-    SWIG_VERSION=040020
 
 [testenv:py310]
 deps =

--- a/providers/base/tox.ini
+++ b/providers/base/tox.ini
@@ -9,6 +9,7 @@ commands =
     {envpython} -m pip -q install ../../checkbox-ng
     {envpython} -m pip -q install ../../checkbox-support
     bash -c "for provider in ../*; do {envpython} $provider/manage.py develop -f; done"
+    bash -c "swig -version"
     {envpython} manage.py validate
     {envpython} -m coverage run manage.py test
     {envpython} -m coverage report

--- a/providers/base/tox.ini
+++ b/providers/base/tox.ini
@@ -44,7 +44,7 @@ setenv=
 deps =
     flake8
     evdev
-    pyscard == 2.1.1
+    pyscard == 1.9.9
     coverage == 5.5
     distro == 1.0.1
     Jinja2 == 2.10
@@ -64,7 +64,7 @@ deps =
 deps =
     flake8
     evdev
-    pyscard == 2.1.1
+    pyscard == 2.3.1
     coverage == 7.3.0
     distro == 1.4.0
     Jinja2 == 2.10.1
@@ -83,7 +83,7 @@ deps =
 deps =
     flake8
     evdev
-    pyscard == 2.2.2
+    pyscard == 2.3.1
     coverage == 7.3.0
     distro == 1.7.0
     Jinja2 == 3.0.3
@@ -103,7 +103,7 @@ deps =
 deps =
     flake8
     evdev
-    pyscard == 2.2.2
+    pyscard == 2.3.1
     coverage == 7.4.4
     distro == 1.9.0
     Jinja2 == 3.1.2

--- a/providers/base/tox.ini
+++ b/providers/base/tox.ini
@@ -64,7 +64,7 @@ deps =
 deps =
     flake8
     evdev
-    pyscard == 2.3.1
+    pyscard == 2.1.1
     coverage == 7.3.0
     distro == 1.4.0
     Jinja2 == 2.10.1
@@ -78,6 +78,10 @@ deps =
     pyparsing == 2.4.6
     PyYAML == 5.3.1
     XlsxWriter == 1.1.2
+setenv=
+#   The new SWIG version deprecated the $function keyword.
+#   It is set to the old version to allow compilation for pyscard 2.1.1.
+    SWIG_VERSION=040020
 
 [testenv:py310]
 deps =

--- a/providers/base/units/smartcard/category.pxu
+++ b/providers/base/units/smartcard/category.pxu
@@ -1,0 +1,3 @@
+unit: category
+id: smartcard
+_name: Smartcard

--- a/providers/base/units/smartcard/jobs.pxu
+++ b/providers/base/units/smartcard/jobs.pxu
@@ -1,0 +1,89 @@
+plugin: shell
+category_id: smartcard
+id: smartcard/smartcard-reader-info
+user: root
+estimated_duration: 1.0
+_description:
+ Dump pcscd debug message in to log
+flags: fail-on-resource
+imports: from com.canonical.plainbox import manifest
+requires:
+ (manifest.has_contact_smartcard_reader == 'True' or manifest.has_contactless_smartcard_reader == 'True')
+ package.name == 'pcscd' or snap.name == 'pcscd'
+command:
+ pcscd --debug
+ journalctl --since="5 minutes ago" -t pcscd
+
+plugin: shell
+category_id: smartcard
+id: smartcard/smartcard-reader-detect-contact
+estimated_duration: 1.0
+_description:
+ Check if Smartcard reader exist or not
+flags: also-after-suspend
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_contact_smartcard_reader == 'True'
+command: smartcard_test.py detect_reader -t contact
+
+plugin: shell
+category_id: smartcard
+id: smartcard/smartcard-reader-detect-contactless
+estimated_duration: 1.0
+_description:
+ Check if Smartcard reader exist or not
+flags: also-after-suspend
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_contactless_smartcard_reader == 'True'
+command: smartcard_test.py detect_reader -t contactless
+
+unit: template
+template-resource: smartcard_resource_contact
+template-unit: job
+plugin: shell
+category_id: smartcard
+id: smartcard/{smartcard_reader}-send-apdu-auto
+template-id: smartcard/smartcard-reader-send-apdu-auto
+estimated_duration: 5.0
+_description:
+ Check if Smartcard reader could send/receive APDU command to/from smartcard
+flags: also-after-suspend
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_contact_smartcard_reader == 'True'
+ manifest.has_smartcard == 'True'
+depends: smartcard/smartcard-reader-detect-contact
+command: smartcard_test.py send -r {smartcard_reader}
+
+unit: template
+template-resource: smartcard_resource_contact
+template-unit: job
+plugin: user-interact-verify
+category_id: smartcard
+id: smartcard/{smartcard_reader}-detect-contact-manual
+template-id: smartcard/smartcard-reader-detect-contact-manual
+estimated_duration: 45.0
+_description:
+ Check if a Smartcard reader could detect contact smartcard insert/remove
+flags: also-after-suspend
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_contact_smartcard_reader == 'True'
+command: smartcard_test.py detect_card -r {smartcard_reader}
+
+unit: template
+template-resource: smartcard_resource_contactless
+template-unit: job
+plugin: user-interact-verify
+category_id: smartcard
+id: smartcard/{smartcard_reader}-detect-contactless-manual
+template-id: smartcard/smartcard-reader-detect-contactless-manual
+estimated_duration: 45.0
+_description:
+ Check if a Smartcard reader could detect contactless smartcard touch/remove
+flags: also-after-suspend
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_contactless_smartcard_reader == 'True'
+command: smartcard_test.py detect_card -r {smartcard_reader}

--- a/providers/base/units/smartcard/jobs.pxu
+++ b/providers/base/units/smartcard/jobs.pxu
@@ -17,6 +17,7 @@ command:
 plugin: shell
 category_id: smartcard
 id: smartcard/smartcard-reader-detect-contact
+user: root
 estimated_duration: 1.0
 _description:
  Check if Smartcard reader exist or not
@@ -29,6 +30,7 @@ command: smartcard_test.py detect_reader -t contact
 plugin: shell
 category_id: smartcard
 id: smartcard/smartcard-reader-detect-contactless
+user: root
 estimated_duration: 1.0
 _description:
  Check if Smartcard reader exist or not
@@ -44,6 +46,7 @@ template-unit: job
 plugin: shell
 category_id: smartcard
 id: smartcard/{smartcard_reader}-send-apdu-auto
+user: root
 template-id: smartcard/smartcard-reader-send-apdu-auto
 estimated_duration: 5.0
 _description:
@@ -62,6 +65,7 @@ template-unit: job
 plugin: user-interact-verify
 category_id: smartcard
 id: smartcard/{smartcard_reader}-detect-contact-manual
+user: root
 template-id: smartcard/smartcard-reader-detect-contact-manual
 estimated_duration: 45.0
 _description:
@@ -78,6 +82,7 @@ template-unit: job
 plugin: user-interact-verify
 category_id: smartcard
 id: smartcard/{smartcard_reader}-detect-contactless-manual
+user: root
 template-id: smartcard/smartcard-reader-detect-contactless-manual
 estimated_duration: 45.0
 _description:

--- a/providers/base/units/smartcard/manifest.pxu
+++ b/providers/base/units/smartcard/manifest.pxu
@@ -1,0 +1,20 @@
+# Copyright 2025 Canonical Ltd.
+# All rights reserved.
+#
+# Written by:
+#   Hanhsuan Lee <hanhsuan.lee@canonical.com>
+
+unit: manifest entry
+id: has_contact_smartcard_reader
+_name: Contact Smartcard Reader
+value-type: bool
+
+unit: manifest entry
+id: has_contactless_smartcard_reader
+_name: Contactless Smartcard Reader
+value-type: bool
+
+unit: manifest entry
+id: has_smartcard
+_name: A working Smartcard inserted
+value-type: bool

--- a/providers/base/units/smartcard/packaging.pxu
+++ b/providers/base/units/smartcard/packaging.pxu
@@ -1,0 +1,4 @@
+# For smartcard/*
+unit: packaging meta-data
+os-id: ubuntu
+Depends: python3-pyscard

--- a/providers/base/units/smartcard/resource.pxu
+++ b/providers/base/units/smartcard/resource.pxu
@@ -8,6 +8,7 @@ unit: job
 id: smartcard_resource_contact
 category_id: smartcard
 plugin: resource
+user: root
 _description:
     Gather device info about smartcard reader
 command: smartcard_test.py resources -t contact
@@ -17,6 +18,7 @@ unit: job
 id: smartcard_resource_contactless
 category_id: smartcard
 plugin: resource
+user: root
 _description:
     Gather device info about smartcard reader
 command: smartcard_test.py resources -t contactless

--- a/providers/base/units/smartcard/resource.pxu
+++ b/providers/base/units/smartcard/resource.pxu
@@ -1,0 +1,23 @@
+# Copyright 2025 Canonical Ltd.
+# All rights reserved.
+#
+# Written by:
+#   Hanhsuan Lee <hanhsuan.lee@canonical.com>
+
+unit: job
+id: smartcard_resource_contact
+category_id: smartcard
+plugin: resource
+_description:
+    Gather device info about smartcard reader
+command: smartcard_test.py resources -t contact
+estimated_duration: 3s
+
+unit: job
+id: smartcard_resource_contactless
+category_id: smartcard
+plugin: resource
+_description:
+    Gather device info about smartcard reader
+command: smartcard_test.py resources -t contactless
+estimated_duration: 3s

--- a/providers/base/units/smartcard/test-plan.pxu
+++ b/providers/base/units/smartcard/test-plan.pxu
@@ -1,0 +1,70 @@
+id: smartcard-cert-full
+unit: test plan
+_name: Full Smartcard tests
+_description:
+ Mediacard tests
+include:
+nested_part:
+ com.canonical.certification::smartcard-cert-manual
+ com.canonical.certification::smartcard-cert-automated
+
+id: smartcard-cert-manual
+unit: test plan
+_name: Smartcard tests (Manual)
+_description:
+ Smartcard tests (Manual)
+bootstrap_include:
+  smartcard_resource_contact
+  smartcard_resource_contactless
+include:
+ smartcard/smartcard-reader-detect-contact-manual
+ smartcard/smartcard-reader-detect-contactless-manual
+
+id: smartcard-cert-automated
+unit: test plan
+_name: Smartcard tests (Automated)
+_description:
+ Smartcard tests (Automated)
+bootstrap_include:
+  smartcard_resource_contact
+  smartcard_resource_contactless
+include:
+ smartcard/smartcard-reader-info
+ smartcard/smartcard-reader-detect-contact
+ smartcard/smartcard-reader-detect-contactless
+ smartcard/smartcard-reader-send-apdu-auto
+
+id: after-suspend-smartcard-cert-full
+unit: test plan
+_name: Full Smartcard tests (After Suspend)
+_description:
+ Smartcard tests (After Suspend)
+include:
+nested_part:
+ com.canonical.certification::after-suspend-smartcard-cert-manual
+ com.canonical.certification::after-suspend-smartcard-cert-automated
+
+id: after-suspend-smartcard-cert-manual
+unit: test plan
+_name: Smartcard tests (After Suspend Manual)
+_description:
+ Smartcard tests (After Suspend Manual)
+bootstrap_include:
+  smartcard_resource_contact
+  smartcard_resource_contactless
+include:
+ after-suspend-smartcard/smartcard-reader-detect-contact-manual
+ after-suspend-smartcard/smartcard-reader-detect-contactless-manual
+
+id: after-suspend-smartcard-cert-automated
+unit: test plan
+_name: Smartcard tests (After Suspend Automated)
+_description:
+ Smartcard tests (After Suspend Automated)
+bootstrap_include:
+  smartcard_resource_contact
+  smartcard_resource_contactless
+include:
+ after-suspend-smartcard/smartcard-reader-detect-contact
+ after-suspend-smartcard/smartcard-reader-detect-contactless
+ after-suspend-smartcard/smartcard-reader-send-apdu-auto


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
This PR is going to add smart card relevant  test cases and test plan. Including
1. add `libpcsclite-dev` and `swig` to tox environment to make `pyscard` could be compiled
2. add `python3-pyscard` under `cehckbox-provider-base` in the `snapcraft.yaml`
3. add new `smartcard` category
4. add `smartcard_resource_contact` resource job to generate contact type smart card reader
5. add `smartcard_resource_contactless` resource job to generate contactless type smart card reader (The contactless smart card reader could not test without moving card manually)
6. add `smartcard/smartcard-reader-info` to dump smart card reader debug information to log
7. add `smartcard/smartcard-reader-detect-contact` to detect contact type smart card reader
8. add `smartcard/smartcard-reader-detect-contactless` to detect contactless type smart card reader
9. add `smartcard/smartcard-reader-send-apdu-auto` to test the APDU command could be sent and processed
10. add `smartcard/smartcard-reader-detect-contact-manual` to test contact type smart card reader could detect smart card insert/remove
11. add `smartcard/smartcard-reader-detect-contactless-manual` to test contactless type smart card reader could detect smart card insert/remove
## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
https://warthogs.atlassian.net/browse/SOMERVILLE-2331

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
Building test:
https://github.com/canonical/checkbox/actions/runs/16443809078

- 24.04 debian
    auto test: https://certification.canonical.com/hardware/202503-36528/submission/438753/
    Manual test: https://certification.canonical.com/hardware/202503-36528/submission/438752/
- 24 snap (host OS is 24.04)
    auto test: https://certification.canonical.com/hardware/202503-36528/submission/439416/
    manual test: https://certification.canonical.com/hardware/202503-36528/submission/439418/
- 22 snap (host OS is 24.04)
    auto test: https://certification.canonical.com/hardware/202503-36528/submission/439423/
    manual test: https://certification.canonical.com/hardware/202503-36528/submission/439425/
- 20 snap (host OS is 24.04)
    auto test: https://certification.canonical.com/hardware/202503-36528/submission/439432/
    manual test: https://certification.canonical.com/hardware/202503-36528/submission/439433/
- 18 snap (host OS is 24.04 and make the journalctl could not work)
    auto test: https://certification.canonical.com/hardware/202503-36528/submission/439550/
    manual test: https://certification.canonical.com/hardware/202503-36528/submission/439546/
