### PR TITLE
Allow agent to run as non-root for debugging (infra)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,9 +75,11 @@ you have to activate the `checkbox-cli run-agent` on the Machine under test:
 
 > Note: Keep in mind that run-agent has to be run as root and needs the
 > virtual env, you may have to re-enable/activate it after a `sudo -s`
-> you can circumvent this constraint if you are developing for Checkbox by
-> exporting ALLOW_CHECKBOX_AGENT_NONROOT to `true`. This only makes sense if
-> you are debugging Checkbox internals. The agent will not work as normal user.
+>
+> You can circumvent this constraint if you are developing for Checkbox by
+> setting the `ALLOW_CHECKBOX_AGENT_NONROOT` environment variable to `true`.
+> This only makes sense if you are debugging Checkbox internals.
+> The agent will not work as normal user.
 
 Now you can run the control command to connect to it:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,9 @@ you have to activate the `checkbox-cli run-agent` on the Machine under test:
 
 > Note: Keep in mind that run-agent has to be run as root and needs the
 > virtual env, you may have to re-enable/activate it after a `sudo -s`
+> you can circumvent this constraint if you are developing for Checkbox by
+> exporting ALLOW_CHECKBOX_AGENT_NONROOT to `true`. This only makes sense if
+> you are debugging Checkbox internals. The agent will not work as normal user.
 
 Now you can run the control command to connect to it:
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This makes debugging locally much easier because running the agent as root while iterating locally is quite bothersome and has quite a few undesired side effects.

## Resolved issues

N/A

## Documentation

N/A

I don't know if/where we would want to document this, we don't really have checkbox developer documentation

## Tests

Start a non-priviledged container, enable the Checkbox venv
```
$ checkbox-cli run-agent
Checkbox agent must be run by root!
```

Now try with the envvar exported:
```
$ ALLOW_CHECKBOX_AGENT_NONROOT=1 checkbox-cli run-agent
WARNING:agent:Forcing the agent to allow running as non-root
WARNING:agent:Note: this is a debugging tool, THE AGENT DOESN'T ACTUALLY WORK AS NON-ROOT
```
