### PR TITLE
Stage "libasound2t64" instead of the virtual package "libasound2" (BugFix)

### DIFF
--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -287,7 +287,7 @@ parts:
       - iw
       - jq
       - kmod
-      - libasound2
+      - libasound2t64
       - libcap2-bin
       - libfdt1
       - libsvm3


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
`libasound2` is not a virtual package before noble (e.g. [jammy](https://packages.ubuntu.com/jammy/libasound2)), but it is in [noble](https://packages.ubuntu.com/noble/libasound2). Moreover, it seems like in the build for [arm64](https://github.com/canonical/checkbox/actions/runs/16202677370/job/45745393365) (currently it only happened on arm64 and if you search for "asound", you will find that it installed both packages on arm), snapcraft tried to package both `libasound2t64` and `liboss4-salsa-asound2`, which should no happened (I will create a bug for snapcraft). Since these 2 packages conflict each other, and actually what we want is `libasound2t64`.

Overall, I not only to try to workaround the snapcraft issue, but also think it is better to point out the package we want.

```
$ sudo apt install libasound2
[sudo] password for vincent: 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package libasound2 is a virtual package provided by:
  libasound2t64 1.2.11-1ubuntu0.1 (= 1.2.11-1ubuntu0.1)
  liboss4-salsa-asound2 4.2-build2020-1ubuntu3
You should explicitly select one to install.

E: Package 'libasound2' has no installation candidate
```
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
#1885 
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
I build a checkbox24 with replacing `libasound2` with `libasound2t64`
### Before
```
ubuntu@ubuntu:~$ checkbox.shell 
checkbox runtime shell, type 'exit' to quit the session
(checkbox-shell) ubuntu@ubuntu:~$ amixer 
amixer: error while loading shared libraries: libOSSlib.so: cannot open shared object file: No such file or directory
```
### After
```
ubuntu@ubuntu:~$ checkbox.shell 
checkbox runtime shell, type 'exit' to quit the session
(checkbox-shell) ubuntu@ubuntu:~$ amixer 
ALSA lib conf.c:4579:(snd_config_update_r) Cannot access file /snap/checkbox/15760/usr/share/alsa/alsa.conf
ALSA lib conf.c:4579:(snd_config_update_r) Cannot access file /snap/checkbox/15760/usr/share/alsa/pcm/default.conf
Simple mixer control 'Master',0
  Capabilities: pvolume pswitch pswitch-joined
  Playback channels: Front Left - Front Right
  Limits: Playback 0 - 65536
  Mono:
  Front Left: Playback 65536 [100%] [on]
  Front Right: Playback 65536 [100%] [on]
Simple mixer control 'Capture',0
  Capabilities: cvolume cswitch cswitch-joined
  Capture channels: Front Left - Front Right
  Limits: Capture 0 - 65536
  Front Left: Capture 65536 [100%] [on]
  Front Right: Capture 65536 [100%] [on]
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
