### PR TITLE
Fix missing docstring (bugfix)

### DIFF
--- a/providers/base/bin/pulse_active_port_change.py
+++ b/providers/base/bin/pulse_active_port_change.py
@@ -105,21 +105,21 @@ class AudioPlugDetection:
     @classmethod
     def main(cls):
         """
-        This script checks if the active port on either sinks (speakers or headphones)
-        or sources (microphones, webcams) is changed after an appropriate device is
-        plugged into the DUT. The script is fully automatic and either times out after
-        30 seconds or returns as soon as the change is detected.
+        This script checks if the active port on either sinks (speakers or
+        headphones) or sources (microphones, webcams) is changed after an
+        appropriate device is plugged into the DUT. The script is fully
+        automatic and either times out after 30 seconds or returns as soon as
+        the change is detected.
 
 
-        The script monitors pulse audio events with `pactl subscribe`. Any changes to
-        sinks (or sources, depending on the mode) are treated as a possible match. A
-        match is verified by running `pactl list sinks` (or `pactl list sources`) and
-        constructing a set of tuples (sink-source-name, sink-source-active-port,
-        sink-source-availability). Any change to the computed set, as compared to the
-        initially computed set, is considered a match.
-
-        Due to the algorithm used, it will also detect things like USB headsets, HDMI
-        monitors/speakers, webcams, etc.
+        The script monitors pulse audio events with `pactl subscribe`. Any
+        changes to sinks (or sources, depending on the mode) are treated as a
+        possible match. A match is verified by running `pactl list sinks` (or
+        `pactl list sources`) and constructing a set of tuples
+        (sink-source-name, sink-source-active-port, sink-source-availability).
+        Any change to the computed set, as compared to the initially computed
+        set, is considered a match. Due to the algorithm used, it will also
+        detect things like USB headsets, HDMI monitors/speakers, webcams, etc.
         """
         parser = argparse.ArgumentParser(
             description=cls.main.__doc__.split("\n\n", 1)[0],

--- a/providers/base/bin/pulse_active_port_change.py
+++ b/providers/base/bin/pulse_active_port_change.py
@@ -104,9 +104,26 @@ class AudioPlugDetection:
 
     @classmethod
     def main(cls):
+        """
+        This script checks if the active port on either sinks (speakers or headphones)
+        or sources (microphones, webcams) is changed after an appropriate device is
+        plugged into the DUT. The script is fully automatic and either times out after
+        30 seconds or returns as soon as the change is detected.
+
+
+        The script monitors pulse audio events with `pactl subscribe`. Any changes to
+        sinks (or sources, depending on the mode) are treated as a possible match. A
+        match is verified by running `pactl list sinks` (or `pactl list sources`) and
+        constructing a set of tuples (sink-source-name, sink-source-active-port,
+        sink-source-availability). Any change to the computed set, as compared to the
+        initially computed set, is considered a match.
+
+        Due to the algorithm used, it will also detect things like USB headsets, HDMI
+        monitors/speakers, webcams, etc.
+        """
         parser = argparse.ArgumentParser(
-            description=__doc__.split("")[0],
-            epilog=__doc__.split("")[1],
+            description=cls.main.__doc__.split("\n\n", 1)[0],
+            epilog=cls.main.__doc__.split("\n\n", 1)[1],
             formatter_class=argparse.RawDescriptionHelpFormatter,
         )
         parser.add_argument(


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Missing docstring, for some reason

## Resolved issues

Fixes: CHECKBOX-1959
Fixes: https://github.com/canonical/checkbox/issues/1971

## Documentation

N/A

## Tests

Tested locally, doesn't crash anymore.
```
(venv) $ python pulse_active_port_change.py --help
```