### PR TITLE
Fix network.py crash on unexpected NUMA node listing data (BugFix)

### DIFF
--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -210,9 +210,13 @@ class IPerfPerformanceTest(object):
         """Extract a list of CPU cores from a line of the form:
         NUMA node# CPU(s):    a-b[,c-d[,...]]"""
         colon = line.find(":")
-        cpu_list = line[colon + 1 :]
+        cpu_list = line[colon + 1:]
         core_list = []
         for core_range in cpu_list.split(","):
+            # Skip it if the CPU list for the NUMA node is empty....
+            core_range = core_range.strip()
+            if not core_range:
+                continue
             # core_range should be of the form "a-b" or "a"
             range_list = core_range.split("-")
             if len(range_list) > 1:


### PR DESCRIPTION
Title: Fix network.py crash on unexpected NUMA node listing data (BugFix)

## Description

The `extract_core_list()` function in `network.py` loops through the NUMA node list data presented by `lscpu`, looking for lines of the form:

`NUMA node0 CPU(s):      0-15`

When one of these lines is empty, the code crashed with a Python traceback. This bug fix skips lines with empty CPU lists.

In addition, one minor formatting change (removing a space from the `cpu_list = line[colon + 1 :]` line) was made to fix a flake8 complaint.

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/2027

## Documentation

No documentation changes are needed.

## Tests

The partner who encountered this bug provided the fix and tested it to their satisfaction. I've tested it on three other systems that have not exhibited the bug, and have seen no problems on these systems, so it seems to have no effect on these systems.
