### PR TITLE
Unecessary secrets for PPA copy packages (Infra)

### DIFF
--- a/.github/workflows/checkbox-beta-release.yml
+++ b/.github/workflows/checkbox-beta-release.yml
@@ -57,9 +57,7 @@ jobs:
           persist-credentials: false
       - name: Copy deb packages from edge to beta ppa
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LP_CREDENTIALS: ${{ secrets.LP_CREDS }}
-          CHECKBOX_REPO: ${{ github.repository }}
         run: |
           tools/release/lp_copy_packages.py checkbox-dev edge checkbox-dev beta
 


### PR DESCRIPTION
## Description

I've just noticed the `lp_copy_packages.py` doesn't require so many secrets. Keep it simple.

## Resolved issues

N/A

## Documentation

N/A

## Tests

Tested with a private PPA, we'll see next run if it works here.
