### PR TITLE
Fix network.py crash on unexpected NUMA node data (BugFix)

### DIFF
--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -213,6 +213,11 @@ class IPerfPerformanceTest(object):
         cpu_list = line[colon + 1 :]
         core_list = []
         for core_range in cpu_list.split(","):
+            # Skip it if the CPU list for the NUMA node is empty....
+            core_range = core_range.strip()
+            if not core_range:
+                logging.error("Empty core range in line: %s", line)
+                continue
             # core_range should be of the form "a-b" or "a"
             range_list = core_range.split("-")
             if len(range_list) > 1:

--- a/providers/base/tests/test_network.py
+++ b/providers/base/tests/test_network.py
@@ -25,6 +25,23 @@ import network
 
 
 class IPerfPerfomanceTestTests(unittest.TestCase):
+    def test_extract_core_list_single(self):
+        """Tests parsing a NUMA node CPUs list with a single CPU."""
+        line = "NUMA node0 CPU(s): 0"
+        core_list = network.IPerfPerformanceTest.extract_core_list(None, line)
+        self.assertListEqual(core_list, [0])
+
+    def test_extract_core_list_range(self):
+        """Tests parsing a NUMA node CPUs list."""
+        line = "NUMA node0 CPU(s): 0-2"
+        core_list = network.IPerfPerformanceTest.extract_core_list(None, line)
+        self.assertListEqual(core_list, [0, 1, 2])
+
+    def test_extract_core_list_empty(self):
+        """Tests that parsing an empty NUMA node CPUs does not crash."""
+        line = "NUMA node0 CPU(s):"
+        core_list = network.IPerfPerformanceTest.extract_core_list(None, line)
+        self.assertListEqual(core_list, [])
 
     def test_find_numa_reports_node(self):
         with patch("builtins.open", mock_open(read_data="1")) as mo:


### PR DESCRIPTION
Title: Fix network.py crash on unexpected NUMA node listing data (attempt 2) (BugFix)

## Description

The `extract_core_list()` function in `network.py` loops through the NUMA node list data presented by `lscpu`, looking for lines of the form:

`NUMA node0 CPU(s):      0-15`

When one of these lines is empty, the code crashed with a Python traceback. This bug fix skips lines with empty CPU lists.

This PR replaces #2028, which ran into permissions problems that I and Pedro were unable to resolve.

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/2027

## Documentation

No documentation changes are needed.

## Tests

The partner who encountered this bug provided the fix and tested it to their satisfaction. I've tested it on three other systems that have not exhibited the bug, and have seen no problems on these systems, so it seems to have no effect on these systems.
