### PR TITLE
Add vscode env for better dev experience working with checkbox using VSCode + gitignore venv folder (Infra)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+
+venv

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+   "version": "0.2.0",
+   "configurations": [
+       {
+           "name": "Debug checkbox-cli",
+           "type": "python",
+           "request": "launch",
+           "program": "${workspaceFolder}/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py",
+           "args": ["--clear-cache", "--clear-old-sessions"],
+           "console": "integratedTerminal"
+       }
+   ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,14 @@
 {
-    "[markdown]": {
-        "editor.formatOnSave": false
-    }
+   "[markdown]": {
+       "editor.formatOnSave": false
+   },
+   "python.testing.unittestArgs": [
+       "-v",
+       "-s",
+       "./checkbox-ng",
+       "-p",
+       "test_*.py"
+   ],
+   "python.testing.pytestEnabled": false,
+   "python.testing.unittestEnabled": true
 }


### PR DESCRIPTION
## Description

- Adds possibility to debug checkbox directly from VSCode.
- Adds possibility to run/debug tests directly from VSCode.
- 'Gitingores'  virtual env `venv`.

## Resolved issues
N/A

## Documentation
N/A

## Tests
- F5 from VS Code runs checkbox under debug.
- Tests tab shows all unit tests available.
