### PR TITLE
Bootstrap refactor (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -201,7 +201,7 @@ class SessionAssistant:
         self._load_providers()
         UsageExpectation.of(self).allowed_calls = {
             self.start_new_session: "create a new session from scratch",
-            self.resume_session: "resume a resume candidate",
+            self.prepare_resume_session: "resume a resume candidate",
             self.get_resumable_sessions: "get resume candidates",
             self.use_alternate_configuration: (
                 "use an alternate configuration system"
@@ -543,11 +543,11 @@ class SessionAssistant:
         }
 
     @raises(KeyError, UnexpectedMethodCall, IncompatibleJobError)
-    def resume_session(
+    def prepare_resume_session(
         self, session_id: str, runner_cls=UnifiedRunner, runner_kwargs=dict()
     ) -> "SessionMetaData":
         """
-        Resume a session.
+        Prepares the session to a state where it is able to continue.
 
         :param session_id:
             The identifier of the session to resume.
@@ -562,10 +562,13 @@ class SessionAssistant:
             It is a bug in your program. The error message will indicate what
             is the likely cause.
 
-        This method restores internal state of the plainbox runtime as it was
-        the last time session assistant did a checkpoint, i.e. session
+        This method restores internal state of the Checkbox session close to what
+        it was the last time session assistant did a checkpoint, i.e. session
         assistant's clients commited any information (e.g. saves job result,
-        runs bootstrapping, updates app blob, etc.)
+        runs bootstrapping, updates app blob, etc.). This is called
+        prepares_resume_session and doesn't resume_session because to fully
+        resume a session with a test plan, the test plan must be selected and
+        the bootstrap process must be re-executed.
         """
         UsageExpectation.of(self).enforce()
         all_units = list(
@@ -667,7 +670,7 @@ class SessionAssistant:
                         InternalResumeCandidate(storage, metadata)
                     )
                     UsageExpectation.of(self).allowed_calls[
-                        self.resume_session
+                        self.prepare_resume_session
                     ] = "resume session"
                     yield ResumeCandidate(storage.id, metadata)
 
@@ -1783,7 +1786,7 @@ class SessionAssistant:
             self.export_to_stream: "to export the results to a stream",
             self.get_resumable_sessions: "to get resume candidates",
             self.start_new_session: "to create a new session",
-            self.resume_session: "to resume a session",
+            self.prepare_resume_session: "to resume a session",
             self.get_old_sessions: ("get previously created sessions"),
             self.delete_sessions: ("delete previously created sessions"),
         }

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -167,7 +167,7 @@ class RemoteSessionAssistant:
         self.terminate_cb = None
         self._pipe_from_controller = open(self._input_piping[1], "w")
         self._pipe_to_subproc = open(self._input_piping[0])
-        self._sa = SessionAssistant()
+        self._sa: SessionAssistant = None
         self._reset_sa()
         self._currently_running_job = None
 
@@ -396,11 +396,11 @@ class RemoteSessionAssistant:
         return False
 
     @allowed_when(Started)
-    def get_bootstrapping_todo_list_json(self):
-        return json.dumps(self.get_bootstrapping_todo_list())
+    def start_bootstrap_json(self):
+        return json.dumps(self.start_bootstrap())
 
     @allowed_when(Started)
-    def get_bootstrapping_todo_list(self):
+    def start_bootstrap(self):
         return self._sa.start_bootstrap()
 
     def finish_bootstrap_json(self):

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -400,7 +400,7 @@ class RemoteSessionAssistant:
 
     @allowed_when(Started)
     def get_bootstrapping_todo_list(self):
-        return self._sa.get_bootstrap_todo_list()
+        return self._sa.start_bootstrap()
 
     def finish_bootstrap_json(self):
         return json.dumps(self.finish_bootstrap())

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -167,6 +167,7 @@ class RemoteSessionAssistant:
         self.terminate_cb = None
         self._pipe_from_controller = open(self._input_piping[1], "w")
         self._pipe_to_subproc = open(self._input_piping[0])
+        self._sa = SessionAssistant()
         self._reset_sa()
         self._currently_running_job = None
 
@@ -756,7 +757,9 @@ class RemoteSessionAssistant:
         return self._sa.get_resumable_sessions()
 
     def resume_session(self, session_id, runner_kwargs={}):
-        return self._sa.resume_session(session_id, runner_kwargs=runner_kwargs)
+        return self._sa.prepare_resume_session(
+            session_id, runner_kwargs=runner_kwargs
+        )
 
     def bootstrap(self):
         return self._sa.bootstrap()

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -26,6 +26,8 @@ import json
 import logging
 import re
 
+from contextlib import suppress
+
 from plainbox.abc import IJobResult
 from plainbox.i18n import gettext as _
 from plainbox.impl import deprecated
@@ -107,6 +109,18 @@ class SessionMetaData:
             self.flags,
             self.running_job_name,
         )
+
+    @property
+    def bootstrapping(self) -> bool:
+        return self.FLAG_BOOTSTRAPPING in self.flags
+
+    @bootstrapping.setter
+    def bootstrapping(self, value: bool):
+        if value:
+            self.flags.add(self.FLAG_BOOTSTRAPPING)
+        else:
+            with suppress(KeyError):
+                self.flags.remove(self.FLAG_BOOTSTRAPPING)
 
     @property
     def title(self):

--- a/checkbox-ng/plainbox/impl/session/test_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_assistant.py
@@ -171,7 +171,7 @@ class SessionAssistantTests(morris.SignalTestCase):
         self_mock.get_resumable_sessions.return_value = []
 
         with self.assertRaises(KeyError):
-            SessionAssistant.resume_session(self_mock, "session_id")
+            SessionAssistant.prepare_resume_session(self_mock, "session_id")
 
     @mock.patch("plainbox.impl.session.assistant.SessionManager")
     @mock.patch("plainbox.impl.session.assistant.JobRunnerUIDelegate")
@@ -195,7 +195,7 @@ class SessionAssistantTests(morris.SignalTestCase):
 
         self_mock.get_resumable_sessions.return_value = [session_mock]
 
-        _ = SessionAssistant.resume_session(self_mock, "session_id")
+        _ = SessionAssistant.prepare_resume_session(self_mock, "session_id")
 
     @mock.patch("plainbox.impl.session.state.select_units")
     @mock.patch("plainbox.impl.unit.testplan.TestPlanUnit")

--- a/checkbox-ng/plainbox/impl/session/test_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_assistant.py
@@ -223,7 +223,7 @@ class SessionAssistantTests(morris.SignalTestCase):
         self, mock_tpu, mock_su, mock_get_providers
     ):
         self_mock = mock.MagicMock()
-        SessionAssistant.get_bootstrap_todo_list(self_mock)
+        SessionAssistant.start_bootstrap(self_mock)
         self.assertEqual(
             self_mock._context.state.update_desired_job_list.call_count, 1
         )

--- a/checkbox-ng/plainbox/impl/session/test_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_assistant.py
@@ -201,6 +201,12 @@ class SessionAssistantTests(morris.SignalTestCase):
     @mock.patch("plainbox.impl.unit.testplan.TestPlanUnit")
     def test_bootstrap(self, mock_tpu, mock_su, mock_get_providers):
         self_mock = mock.MagicMock()
+        self_mock.start_bootstrap = partial(
+            SessionAssistant.start_bootstrap, self_mock
+        )
+        self_mock.finish_bootstrap = partial(
+            SessionAssistant.finish_bootstrap, self_mock
+        )
         SessionAssistant.bootstrap(self_mock)
         # Bootstrapping involves updating the list of desired jobs twice:
         # - one time to get the resource jobs

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -431,22 +431,20 @@ class RemoteAssistantTests(TestCase):
         conf_type = RemoteSessionAssistant.configuration_type(mock.MagicMock())
         self.assertEqual(conf_type, remote_assistant.Configuration)
 
-    def test_bootstrapping_todo_list(self):
+    def test_start_bootstrap_json(self):
         self_mock = mock.MagicMock()
         self_mock._state = remote_assistant.Started
-        self_mock.get_bootstrapping_todo_list = partial(
-            RemoteSessionAssistant.get_bootstrapping_todo_list, self_mock
+        self_mock.start_bootstrap = partial(
+            RemoteSessionAssistant.start_bootstrap, self_mock
         )
-        self_mock._sa.get_bootstrap_todo_list.return_value = [
+        self_mock._sa.start_bootstrap.return_value = [
             "job1",
             "job2",
         ]
 
-        job_list_str = RemoteSessionAssistant.get_bootstrapping_todo_list_json(
-            self_mock
-        )
+        job_list_str = RemoteSessionAssistant.start_bootstrap_json(self_mock)
 
-        self.assertTrue(self_mock._sa.get_bootstrap_todo_list.called)
+        self.assertTrue(self_mock._sa.start_bootstrap.called)
         self.assertEqual(["job1", "job2"], json.loads(job_list_str))
 
     def test_finish_bootstrap_json(self):


### PR DESCRIPTION
## Description

While implementing `setup_include`, I noted a similarity between this feature and `bootstrap_include`. I also note that the bootstrap process api is very messy and hard to comprehend, this is mainly due to the following:
1. To know if a session is bootstrapping, the metadata flags are accessed manually to check if they contain the bootstrapping flag
2. To bootstrap, one can either use the `bootstrap` function or the  `get_bootstrap_todo_list` + `run_job` + `finish_bootstrap`. `get_bootstrap_todo_list` doesn't just get the bootstrap todo list, it also allows the application to run job, notes that bootstrap is starting and updates the desired_job_list
3. `bootstrap` contains (almost verbatim) `get_bootstrap_todo_list` and `finish_bootstrap`
4. `resume_session` doesn't actually resume the session 

This refactors the functions to have better naming, docstrings and to remove code duplication. 

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1982

## Documentation

This improves all docstrings that needed a better documentation (more accurate in some cases, in some other more precise)

## Tests

This also updates unit tests, note that nothing should change in the actual implementation
