### PR TITLE
Add chassis type to support new type of device  (Bugfix)

### DIFF
--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -306,7 +306,7 @@ id: graphics/{index}_auto_glxgears_{product_slug}
 flags: also-after-suspend
 requires:
     executable.name == 'glxgears'
-    dmi.product in ['Notebook','Laptop','Portable','All In One','All-In-One','AIO','Convertible']
+    dmi.product in ['Notebook','Laptop','Portable','All In One','All-In-One','AIO','Convertible', 'Tablet', 'Detachable']
 user: root
 command:
  # shellcheck disable=SC1091
@@ -327,7 +327,7 @@ id: graphics/{index}_valid_glxgears_{product_slug}
 flags: also-after-suspend
 requires:
     executable.name == 'glxgears'
-    dmi.product in ['Notebook','Laptop','Portable','All In One','All-In-One','AIO','Convertible']
+    dmi.product in ['Notebook','Laptop','Portable','All In One','All-In-One','AIO','Convertible', 'Tablet', 'Detachable']
 user: root
 command:
  # shellcheck disable=SC1091
@@ -356,7 +356,7 @@ id: graphics/{index}_auto_glxgears_fullscreen_{product_slug}
 flags: also-after-suspend
 requires:
     executable.name == 'glxgears'
-    dmi.product in ['Notebook','Laptop','Portable','All In One','All-In-One','AIO','Convertible']
+    dmi.product in ['Notebook','Laptop','Portable','All In One','All-In-One','AIO','Convertible','Tablet', 'Detachable']
 user: root
 command:
  # shellcheck disable=SC1091
@@ -377,7 +377,7 @@ id: graphics/{index}_valid_glxgears_fullscreen_{product_slug}
 flags: also-after-suspend
 requires:
     executable.name == 'glxgears'
-    dmi.product in ['Notebook','Laptop','Portable','All In One','All-In-One','AIO','Convertible']
+    dmi.product in ['Notebook','Laptop','Portable','All In One','All-In-One','AIO','Convertible','Tablet', 'Detachable']
 user: root
 command:
  # shellcheck disable=SC1091

--- a/providers/base/units/monitor/jobs.pxu
+++ b/providers/base/units/monitor/jobs.pxu
@@ -187,7 +187,7 @@ template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'
 id: monitor/{index}_dim_brightness_{product_slug}
 template-id: monitor/index_dim_brightness_product_slug
-requires: dmi.product in ['Notebook','Laptop','Portable','All In One','All-In-One','AIO','Convertible']
+requires: dmi.product in ['Notebook','Laptop','Portable','All In One','All-In-One','AIO','Convertible', 'Tablet', 'Detachable']
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::monitor
 user: root

--- a/providers/base/units/power-management/jobs.pxu
+++ b/providers/base/units/power-management/jobs.pxu
@@ -106,7 +106,7 @@ plugin: manual
 category_id: com.canonical.plainbox::power-management
 id: power-management/lid
 estimated_duration: 120.0
-requires: dmi.product in ['Notebook','Laptop','Portable','Convertible']
+requires: dmi.product in ['Notebook','Laptop','Portable','Convertible', 'Detachable']
 _description:
 _purpose:
     This test will check your lid sensors.
@@ -180,7 +180,7 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::power-management
 id: power-management/lid_close_suspend_open
 estimated_duration: 20.0
-requires: device.product == 'Lid Switch'
+requires: dmi.product in ['Notebook','Laptop','Portable','Convertible', 'Detachable']
 _purpose:
     This test will check your lid sensor can detect lid close/open, and the DUT (Device Under Test) will suspend when the lid is closed
 _steps:
@@ -545,7 +545,7 @@ category_id: com.canonical.plainbox::power-management
 id: power-management/light_sensor
 estimated_duration: 10.0
 requires:
-  dmi.product in ['Notebook','Laptop','Portable','Convertible']
+  dmi.product in ['Notebook','Laptop','Portable','Convertible', 'Tablet', 'Detachable']
   executable.name == 'monitor-sensor'
 flags: also-after-suspend
 command: light_sensor_test.sh


### PR DESCRIPTION

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
There is one [new type of device](https://warthogs.atlassian.net/browse/OEMQA-6304) has to be enabled and we notice that some test cases could not be executed on it.
- id: graphics/{index}_auto_glxgears_{product_slug}
  add `Tablet` and  `Detachable` to require chassis
- id: graphics/{index}_valid_glxgears_{product_slug}
  add `Tablet` and  `Detachable` to require chassis
- id: graphics/{index}_auto_glxgears_fullscreen_{product_slug}
  add `Tablet` and  `Detachable` to require chassis
- id: graphics/{index}_valid_glxgears_fullscreen_{product_slug}
  add `Tablet` and  `Detachable` to require chassis
- id: monitor/{index}_dim_brightness_{product_slug}
  add `Tablet` and  `Detachable` to require chassis
- id: power-management/lid
  add `Detachable` to require chassis
- id: power-management/lid_close_suspend_open
  Change to align the same requirement to `id: power-management/lid`
- id: power-management/light_sensor
  add `Tablet` and  `Detachable` to require chassis


## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
- auto test: https://certification.canonical.com/hardware/202507-36998/submission/439824/
- manual test: https://certification.canonical.com/hardware/202507-36998/submission/439831/