### PR TITLE
Remote assistant refactoring (new)

### DIFF
--- a/.github/workflows/tox-checkbox.yaml
+++ b/.github/workflows/tox-checkbox.yaml
@@ -93,6 +93,7 @@ jobs:
   tox_test_checkbox_component:
     needs: get_path_matrix
     strategy:
+      fail-fast: false
       matrix:
         path_flag: ${{ fromJson(needs.get_path_matrix.outputs.path_flag) }}
         python: ["3.5", "3.6", "3.8", "3.10", "3.12"]

--- a/.github/workflows/tox-checkbox.yaml
+++ b/.github/workflows/tox-checkbox.yaml
@@ -3,7 +3,6 @@ permissions:
   contents: read
 on:
   push:
-    branches: [ main ]
     paths:
       - checkbox-ng/**
       - checkbox-support/**
@@ -18,7 +17,6 @@ on:
       - providers/iiotg/**
       - .github/workflows/tox-checkbox.yaml
   pull_request:
-    branches: [ main ]
     paths:
       - checkbox-ng/**
       - checkbox-support/**

--- a/checkbox-ng/checkbox_ng/launcher/agent.py
+++ b/checkbox-ng/checkbox_ng/launcher/agent.py
@@ -146,19 +146,6 @@ class RemoteAgent:
             lambda x: None
         )
 
-        # the agent is meant to be run only as a service,
-        # and we always resume if the session was automated,
-        # so we don't need to encode check whether we should resume
-
-        sessions = list(ctx.sa.get_resumable_sessions())
-        if sessions:
-            # the sessions are ordered by time, so the first one is the most
-            # recent one
-            if is_the_session_noninteractive(sessions[0]):
-                SessionAssistantAgent.session_assistant.resume_by_id(
-                    sessions[0].id
-                )
-
         self._server = ThreadedServer(
             SessionAssistantAgent,
             port=agent_port,
@@ -182,25 +169,6 @@ class RemoteAgent:
         parser.add_argument(
             "--port", type=int, default=18871, help=_("port to listen on")
         )
-
-
-def is_the_session_noninteractive(
-    resumable_session: "ResumeCandidate",
-) -> bool:
-    """
-    Check if given session is non-interactive.
-
-    To determine that we need to take the original launcher that had been used
-    when the session was started, recreate it as a proper Launcher object, and
-    check if it's in fact non-interactive.
-    """
-    # app blob is a bytes string with a utf-8 encoded json
-    # let's decode it and parse it as json
-    app_blob = json.loads(resumable_session.metadata.app_blob.decode("utf-8"))
-    launcher = Configuration.from_text(
-        app_blob.get("launcher", ""), "resumed session"
-    )
-    return launcher.sections["ui"].get("type") == "silent"
 
 
 def exit_if_port_unavailable(port: int) -> None:

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -493,7 +493,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         # this should be unreachable, innter functions must exit!
         raise SystemExit("Invalid session flow, failed to terminate")
 
-    def resume_by_id(self, session_id, result_dict=None):
+    def resume_by_id(self, session_id, result_dict={}):
         self.sa.resume_by_id(session_id, result_dict)
         # resume_by_id will get us to a resumable state, lets see how to
         # continue

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -457,7 +457,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         _ = self.start_session()
         test_plan_unit = self.launcher.get_value("test plan", "unit")
         self.select_test_plan(test_plan_unit)
-        self.select_jobs(self.jobs)
+        self.bootstrap_and_continue()
 
     def automatically_resume_last_session(self):
         last_abandoned_session = next(self.sa.get_resumable_sessions())
@@ -507,6 +507,8 @@ class RemoteController(ReportsStage, MainLoopStage):
             print(_("Nothing selected"))
             raise SystemExit(0)
         self.select_test_plan(selected_tp)
+        # TODO: This isn't using bootstrap_and_continue but it should
+        self.bootstrap()
         if not self.jobs:
             _logger.error(self.C.RED(_("There were no tests to select from!")))
             self.sa.finalize_session()

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -41,11 +41,15 @@ from plainbox.abc import IJobResult
 from plainbox.impl.result import MemoryJobResult
 from plainbox.impl.color import Colorizer
 from plainbox.impl.config import Configuration
+from plainbox.impl.session.state import SessionMetaData
 from plainbox.impl.session.resume import (
     IncompatibleJobError,
     CorruptedSessionError,
 )
-from plainbox.impl.session.remote_assistant import RemoteSessionAssistant
+from plainbox.impl.session.remote_assistant import (
+    RemoteSessionAssistant,
+    RemoteSessionStates,
+)
 from plainbox.vendor import rpyc
 from checkbox_ng.resume_menu import ResumeMenu
 from checkbox_ng.urwid_ui import (
@@ -125,6 +129,27 @@ class RemoteController(ReportsStage, MainLoopStage):
 
     name = "remote-control"
 
+    @classmethod
+    def connection_strategy(cls):
+        """
+        This is the action the controller takes when connecting to an agent.
+
+        Given that the session may be on-going, the state will not always be
+        RemoteSessionStates.Idle but may vary. All functions declared here
+        must take two parameters, self + payload. Both state and payload are
+        returned from the agent
+        """
+        return {
+            RemoteSessionStates.Idle: cls.resume_or_start_new_session,
+            RemoteSessionStates.Started: cls.restart,
+            RemoteSessionStates.Bootstrapping: cls.restart,
+            RemoteSessionStates.Bootstrapped: cls.select_jobs,
+            RemoteSessionStates.TestsSelected: cls.run_interactable_jobs,
+            RemoteSessionStates.Running: cls.wait_and_continue,
+            RemoteSessionStates.Interacting: cls.resume_interacting,
+            RemoteSessionStates.Finalizing: cls.finish_session,
+        }
+
     @property
     def is_interactive(self):
         return (
@@ -138,7 +163,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         return self._C
 
     @property
-    def sa(self):
+    def sa(self) -> RemoteSessionAssistant:
         return self._sa
 
     def invoked(self, ctx):
@@ -146,7 +171,6 @@ class RemoteController(ReportsStage, MainLoopStage):
         self._override_exporting(self.local_export)
         self._launcher_text = ""
         self._has_anything_failed = False
-        self._is_bootstrapping = False
         self._target_host = ctx.args.host
         self._normal_user = ""
         self.launcher = Configuration()
@@ -187,7 +211,16 @@ class RemoteController(ReportsStage, MainLoopStage):
         Check that agent and controller are running on the same
         REMOTE_API_VERSION else exit checkbox with an error
         """
-        agent_api_version = self.sa.get_remote_api_version()
+        try:
+            agent_api_version = self.sa.get_remote_api_version()
+        except AttributeError:
+            raise SystemExit(
+                _(
+                    "Agent doesn't declare Remote API"
+                    " version. Update Checkbox on the"
+                    " DUT!"
+                )
+            )
         controller_api_version = RemoteSessionAssistant.REMOTE_API_VERSION
 
         if agent_api_version == controller_api_version:
@@ -245,6 +278,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         spinner = itertools.cycle("-\\|/")
         #  this tracks the disconnection time
         disconnection_time = 0
+        connection_strategy = self.connection_strategy()
         while True:
             try:
                 if interrupted:
@@ -285,16 +319,6 @@ class RemoteController(ReportsStage, MainLoopStage):
                             " to be run as root"
                         )
                     )
-                try:
-                    agent_api_version = self.sa.get_remote_api_version()
-                except AttributeError:
-                    raise SystemExit(
-                        _(
-                            "Agent doesn't declare Remote API"
-                            " version. Update Checkbox on the"
-                            " SUT!"
-                        )
-                    )
 
                 self.check_remote_api_match()
 
@@ -307,22 +331,8 @@ class RemoteController(ReportsStage, MainLoopStage):
                         )
                     )
                     printed_reconnecting = False
-                keep_running = {
-                    "idle": self.resume_or_start_new_session,
-                    "running": self.wait_and_continue,
-                    "finalizing": self.finish_session,
-                    "testsselected": partial(
-                        self.run_jobs, resumed_ongoing_session_info=payload
-                    ),
-                    "bootstrapping": self.restart,
-                    "bootstrapped": partial(
-                        self.select_jobs, all_jobs=payload
-                    ),
-                    "started": self.restart,
-                    "interacting": partial(
-                        self.resume_interacting, interaction=payload
-                    ),
-                }[state]()
+                state = RemoteSessionStates(state)
+                keep_running = connection_strategy[state](self, payload)
             except EOFError as exc:
                 if keep_running:
                     print("Connection lost!")
@@ -384,7 +394,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         before exiting the context
         """
         try:
-            yield self.sa.resume_session(session_id)
+            yield self.sa.prepare_resume_session(session_id)
         except rpyc.core.vinegar.GenericException as e:
             # cast back the (custom) remote exception for IncompatibleJobError
             # (that is of type GenericException due to rpyc)
@@ -438,10 +448,15 @@ class RemoteController(ReportsStage, MainLoopStage):
         # last resumable session is incompatible
         return False
 
+    def bootstrap_and_continue(self, resume_payload=None):
+        self.bootstrap(resume_payload=resume_payload)
+        self.select_jobs(self.jobs)
+        self.run_interactable_jobs()
+
     def automatically_start_via_launcher(self):
         _ = self.start_session()
-        tp_unit = self.launcher.get_value("test plan", "unit")
-        self.select_tp(tp_unit)
+        test_plan_unit = self.launcher.get_value("test plan", "unit")
+        self.select_test_plan(test_plan_unit)
         self.select_jobs(self.jobs)
 
     def automatically_resume_last_session(self):
@@ -463,7 +478,7 @@ class RemoteController(ReportsStage, MainLoopStage):
             raise SystemExit(exc.args[0]) from exc
         return tps
 
-    def resume_or_start_new_session(self):
+    def resume_or_start_new_session(self, *args):
         if self.should_start_via_autoresume():
             self.automatically_resume_last_session()
         elif self.should_start_via_launcher():
@@ -471,7 +486,11 @@ class RemoteController(ReportsStage, MainLoopStage):
         else:
             self.interactively_choose_tp()
 
-        self.run_jobs()
+        # here depending on where we got, lets continue the session
+        state, payload = self.sa.whats_up()
+        state = RemoteSessionStates(state)
+        connection_strategy = self.connection_strategy()
+        return connection_strategy[state](self, payload)
 
     def _new_session_flow(self, tps, resumable_sessions):
         tp_info_list = [{"id": tp[0], "name": tp[1]} for tp in tps]
@@ -487,7 +506,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         if selected_tp is None:
             print(_("Nothing selected"))
             raise SystemExit(0)
-        self.select_tp(selected_tp)
+        self.select_test_plan(selected_tp)
         if not self.jobs:
             _logger.error(self.C.RED(_("There were no tests to select from!")))
             self.sa.finalize_session()
@@ -536,7 +555,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         return False
 
     def _resume_session(self, resume_params):
-        metadata = self.sa.resume_session(resume_params.session_id)
+        metadata = self.sa.prepare_resume_session(resume_params.session_id)
         if "testplanless" not in metadata.flags:
             app_blob = json.loads(metadata.app_blob.decode("UTF-8"))
             test_plan_id = app_blob["testplan_id"]
@@ -597,27 +616,29 @@ class RemoteController(ReportsStage, MainLoopStage):
                     resumable_sessions
                 )
 
-    def select_tp(self, tp):
-        _logger.info("controller: Selected test plan: %s", tp)
-        try:
-            self.sa.prepare_bootstrapping(tp)
-        except KeyError as e:
-            _logger.error('The test plan "%s" is not available!', tp)
-            raise SystemExit(1)
-        self._is_bootstrapping = True
-        bs_todo = json.loads(self.sa.get_bootstrapping_todo_list_json())
-        for job_no, job_id in enumerate(bs_todo, start=1):
-            print(
-                self.C.header(
-                    _("Bootstrap {} ({}/{})").format(
-                        job_id, job_no, len(bs_todo), fill="-"
-                    )
-                )
-            )
-            self.sa.run_bootstrapping_job(job_id)
-            self.wait_for_job()
-        self._is_bootstrapping = False
+    def bootstrap(self, resume_payload=None):
+        """
+        This is the bootstrap job-running UI
+
+        This is different from calling self.sa.bootstrap because this shows
+        progress (currently running job and result) while that is silent
+        """
+        if resume_payload is not None:
+            raise SystemExit("not supported")
+        bs_todo = json.loads(self.sa.start_bootstrap_json())
+        self.run_uninteractable_jobs(
+            bs_todo, "Bootstrap", starting_index=0, suppress_output=True
+        )
         self.jobs = json.loads(self.sa.finish_bootstrap_json())
+        return self.jobs
+
+    def select_test_plan(self, testplan_id):
+        _logger.info("controller: Selected test plan: %s", testplan_id)
+        try:
+            self.sa.select_test_plan(testplan_id)
+        except KeyError as e:
+            _logger.error('The test plan "%s" is not available!', testplan_id)
+            raise SystemExit(1)
 
     def _strtobool(self, val):
         return val.lower() in ("y", "yes", "t", "true", "on", "1")
@@ -701,7 +722,7 @@ class RemoteController(ReportsStage, MainLoopStage):
             self._sa.send_signal(signal.SIGKILL.value)
             return True
 
-    def finish_session(self):
+    def finish_session(self, *args):
         print(self.C.header("Results"))
         if self.launcher.get_value("launcher", "local_submission"):
             # Disable SIGINT while we save local results
@@ -714,8 +735,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         self.sa.finalize_session()
         return False
 
-    def wait_and_continue(self):
-        progress = self.sa.whats_up()[1]
+    def wait_and_continue(self, progress):
         print("Rejoined session.")
         print(
             "In progress: {} ({}/{})".format(
@@ -723,7 +743,7 @@ class RemoteController(ReportsStage, MainLoopStage):
             )
         )
         self.wait_for_job()
-        self.run_jobs()
+        self.run_interactable_jobs()
 
     def _handle_last_job_after_resume(self, resumed_session_info):
         if self.launcher.get_value("ui", "type") != "silent":
@@ -742,7 +762,33 @@ class RemoteController(ReportsStage, MainLoopStage):
             + SimpleUI.C.result(self.sa.get_job_result(job["id"]))
         )
 
-    def run_jobs(self, resumed_ongoing_session_info=None):
+    def run_uninteractable_jobs(
+        self, job_ids, step_name, starting_index=0, suppress_output=False
+    ):
+        """
+        Runs the jobs in order and prints a UI that tracks the progression.
+
+        This assumes all jobs are non-interactive jobs like during
+        bootstrap
+        """
+        # we may start not from 0 because we are resuming
+        total_jobs = len(job_ids)
+        job_ids = job_ids[starting_index:]
+        for job_no, job_id in enumerate(job_ids, start=starting_index):
+            print(
+                self.C.header(
+                    _("{} {} ({}/{})").format(
+                        step_name, job_id, job_no + 1, total_jobs, fill="-"
+                    )
+                )
+            )
+            self.sa.run_uninteractable_job(job_id)
+            self.wait_for_job(suppress_output=suppress_output)
+
+    def run_interactable_jobs(self, resumed_ongoing_session_info=None):
+        """
+        Runs the desired job list in normal mode (post bootstrap).
+        """
         if (
             resumed_ongoing_session_info
             and resumed_ongoing_session_info["last_job"]
@@ -762,7 +808,7 @@ class RemoteController(ReportsStage, MainLoopStage):
             )
         )
 
-        self._run_jobs(jobs_repr, total_num)
+        self._run_interactable_jobs(jobs_repr, total_num)
         rerun_candidates = self.sa.get_rerun_candidates("manual")
         if rerun_candidates:
             if self.launcher.get_value("ui", "type") == "interactive":
@@ -777,15 +823,15 @@ class RemoteController(ReportsStage, MainLoopStage):
 
     def resume_interacting(self, interaction):
         self.sa.remember_users_response("rollback")
-        self.run_jobs()
+        self.run_interactable_jobs()
 
-    def wait_for_job(self, dont_finish=False):
+    def wait_for_job(self, dont_finish=False, suppress_output=False):
         _logger.info("controller: Waiting for job to finish.")
         polling_backoff = [0, 0.1, 0.2, 0.5]
         polling_i = 0
         while True:
             state, payload = self.sa.monitor_job()
-            if payload and not self._is_bootstrapping:
+            if payload and not suppress_output:
                 polling_i = 0
                 for line in payload.splitlines():
                     if line.startswith("stderr"):
@@ -815,15 +861,14 @@ class RemoteController(ReportsStage, MainLoopStage):
     def finish_job(self, result=None):
         _logger.info("controller: Finishing job with a result: %s", result)
         job_result = self.sa.finish_job(result)
-        if not self._is_bootstrapping:
-            SimpleUI.horiz_line()
-            print(_("Outcome") + ": " + SimpleUI.C.result(job_result))
+        SimpleUI.horiz_line()
+        print(_("Outcome") + ": " + SimpleUI.C.result(job_result))
 
     def abandon(self):
         _logger.info("controller: Abandoning session.")
         self.sa.finalize_session()
 
-    def restart(self):
+    def restart(self, *args):
         _logger.info("controller: Restarting session.")
         self.abandon()
         self.resume_or_start_new_session()
@@ -870,7 +915,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         # include resource jobs that jobs to retry depend on
 
         candidates = self.sa.prepare_rerun_candidates(rerun_candidates)
-        self._run_jobs(
+        self._run_interactable_jobs(
             json.loads(self.sa.get_jobs_repr(candidates)), len(candidates)
         )
         return True
@@ -890,12 +935,12 @@ class RemoteController(ReportsStage, MainLoopStage):
         candidates = self.sa.prepare_rerun_candidates(
             [job for job in rerun_candidates if job.id in wanted_set]
         )
-        self._run_jobs(
+        self._run_interactable_jobs(
             json.loads(self.sa.get_jobs_repr(candidates)), len(candidates)
         )
         return True
 
-    def _run_jobs(self, jobs_repr, total_num=0):
+    def _run_interactable_jobs(self, jobs_repr, total_num=0):
         for job in jobs_repr:
             job_state = self.sa.get_job_state(job["id"])
             # Note: job_state is a remote object, no need to json encode it

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -489,7 +489,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         else:
             return self.interactively_choose_test_plan_and_continue()
 
-        # this should be unreachable, innter functions must exit!
+        # this should be unreachable, inner functions must exit!
         raise SystemExit("Invalid session flow, failed to terminate")
 
     def resume_by_id(self, session_id, result_dict={}):

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -332,8 +332,7 @@ class RemoteController(ReportsStage, MainLoopStage):
                         )
                     )
                     printed_reconnecting = False
-                state = RemoteSessionStates(state)
-                keep_running = connection_strategy[state](self, payload)
+                keep_running = self.continue_session()
             except EOFError as exc:
                 if keep_running:
                     print("Connection lost!")

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -50,7 +50,7 @@ from plainbox.impl.result import MemoryJobResult
 from plainbox.impl.runner import slugify
 from plainbox.impl.secure.sudo_broker import sudo_password_provider
 from plainbox.impl.secure.qualifiers import select_units
-from plainbox.impl.session.assistant import SA_RESTARTABLE
+from plainbox.impl.session.assistant import SA_RESTARTABLE, SessionAssistant
 from plainbox.impl.session.restart import detect_restart_strategy
 from plainbox.impl.session.storage import WellKnownDirsHelper
 from plainbox.impl.transport import TransportError
@@ -210,7 +210,7 @@ class StartProvider:
 
 class Launcher(MainLoopStage, ReportsStage):
     @property
-    def sa(self):
+    def sa(self) -> SessionAssistant:
         return self.ctx.sa
 
     @property
@@ -271,20 +271,20 @@ class Launcher(MainLoopStage, ReportsStage):
                             self.resume_candidates
                         )
 
-            if not self.ctx.sa.get_static_todo_list():
+            if not self.sa.get_static_todo_list():
                 return 0
             if "submission_files" in self.configuration.get_value(
                 "launcher", "stock_reports"
             ):
                 print("Reports will be saved to: {}".format(self.base_dir))
             # we initialize the nb of attempts for all the selected jobs...
-            for job_id in self.ctx.sa.get_dynamic_todo_list():
-                job_state = self.ctx.sa.get_job_state(job_id)
+            for job_id in self.sa.get_dynamic_todo_list():
+                job_state = self.sa.get_job_state(job_id)
                 job_state.attempts = self.configuration.get_value(
                     "ui", "max_attempts"
                 )
             # ... before running them
-            self._run_jobs(self.ctx.sa.get_dynamic_todo_list())
+            self._run_jobs(self.sa.get_dynamic_todo_list())
             if self.is_interactive and not self.configuration.get_value(
                 "ui", "auto_retry"
             ):
@@ -355,7 +355,7 @@ class Launcher(MainLoopStage, ReportsStage):
         """
         try:
             # reload the list of resumable_session in SA
-            yield self.sa.resume_session(session_id)
+            yield self.sa.prepare_resume_session(session_id)
         finally:
             self.ctx.reset_sa()
 
@@ -450,11 +450,9 @@ class Launcher(MainLoopStage, ReportsStage):
 
             resume_params = ResumeMenu(entries).run()
             if resume_params.action == "delete":
-                self.ctx.sa.finalize_session()
-                self.ctx.sa.delete_sessions([resume_params.session_id])
-                self.resume_candidates = list(
-                    self.ctx.sa.get_resumable_sessions()
-                )
+                self.sa.finalize_session()
+                self.sa.delete_sessions([resume_params.session_id])
+                self.resume_candidates = list(self.sa.get_resumable_sessions())
 
                 # the entries list is just a copy of the resume_candidates,
                 # and it's not updated when we delete a session, so we need
@@ -540,7 +538,7 @@ class Launcher(MainLoopStage, ReportsStage):
         else:
             resumed_launcher = Configuration()
         config = load_configs(cfg=resumed_launcher)
-        self.ctx.sa.use_alternate_configuration(config)
+        self.sa.use_alternate_configuration(config)
 
     def _resume_session(
         self, session_id: str, outcome: "IJobResult|None", comments=[]
@@ -550,19 +548,19 @@ class Launcher(MainLoopStage, ReportsStage):
         running job the given outcome. If outcome is not provided it will be
         calculated from the function _get_autoresume_outcome_last_job
         """
-        metadata = self.ctx.sa.resume_session(session_id)
+        metadata = self.sa.prepare_resume_session(session_id)
         if "testplanless" not in metadata.flags:
             app_blob = json.loads(metadata.app_blob.decode("UTF-8"))
             test_plan_id = app_blob["testplan_id"]
             self.load_configs_from_app_blob(app_blob)
-            self.ctx.sa.select_test_plan(test_plan_id)
-            self.ctx.sa.bootstrap()
+            self.sa.select_test_plan(test_plan_id)
+            self.sa.bootstrap()
             if outcome is None:
                 outcome = self._get_autoresume_outcome_last_job(metadata)
 
         last_job = metadata.running_job_name
         is_cert_blocker = (
-            self.ctx.sa.get_job_state(last_job).effective_certification_status
+            self.sa.get_job_state(last_job).effective_certification_status
             == "blocker"
         )
         # If we resumed maybe not rerun the same, probably broken job
@@ -603,7 +601,7 @@ class Launcher(MainLoopStage, ReportsStage):
                 "Unsupported outcome for resume {}".format(outcome)
             )
         result = MemoryJobResult(result_dict)
-        self.ctx.sa.use_job_result(last_job, result)
+        self.sa.use_job_result(last_job, result)
 
     def _start_new_session(self):
         print(_("Preparing..."))
@@ -621,7 +619,7 @@ class Launcher(MainLoopStage, ReportsStage):
             "password_provider": sudo_password_provider.get_sudo_password,
             "stdin": None,
         }
-        self.ctx.sa.start_new_session(title, UnifiedRunner, runner_kwargs)
+        self.sa.start_new_session(title, UnifiedRunner, runner_kwargs)
         if self.configuration.get_value("test plan", "forced"):
             tp_id = self.configuration.get_value("test plan", "unit")
             if not tp_id:
@@ -631,7 +629,7 @@ class Launcher(MainLoopStage, ReportsStage):
                     )
                 )
                 raise SystemExit(1)
-            if tp_id not in self.ctx.sa.get_test_plans():
+            if tp_id not in self.sa.get_test_plans():
                 _logger.error(_('The test plan "%s" is not available!'), tp_id)
                 raise SystemExit(1)
         elif not self.is_interactive:
@@ -647,7 +645,7 @@ class Launcher(MainLoopStage, ReportsStage):
             tp_id = self._interactively_pick_test_plan()
             if tp_id is None:
                 raise SystemExit(_("No test plan selected."))
-        self.ctx.sa.select_test_plan(tp_id)
+        self.sa.select_test_plan(tp_id)
         description = self.ctx.args.message or self.configuration.get_value(
             "launcher", "session_desc"
         )
@@ -658,17 +656,17 @@ class Launcher(MainLoopStage, ReportsStage):
                     app_blob["launcher"] = f.read()
             except FileNotFoundError:
                 pass
-        self.ctx.sa.update_app_blob(json.dumps(app_blob).encode("UTF-8"))
+        self.sa.update_app_blob(json.dumps(app_blob).encode("UTF-8"))
         bs_jobs = self.sa.start_bootstrap()
         self._run_bootstrap_jobs(bs_jobs)
-        self.ctx.sa.finish_bootstrap()
+        self.sa.finish_bootstrap()
 
     def _delete_old_sessions(self, ids):
-        completed_ids = [s[0] for s in self.ctx.sa.get_old_sessions()]
-        self.ctx.sa.delete_sessions(completed_ids + ids)
+        completed_ids = [s[0] for s in self.sa.get_old_sessions()]
+        self.sa.delete_sessions(completed_ids + ids)
 
     def _interactively_pick_test_plan(self):
-        test_plan_ids = self.ctx.sa.get_test_plans()
+        test_plan_ids = self.sa.get_test_plans()
         filtered_tp_ids = set()
         for filter in self.configuration.get_value("test plan", "filter"):
             filtered_tp_ids.update(fnmatch.filter(test_plan_ids, filter))
@@ -688,7 +686,7 @@ class Launcher(MainLoopStage, ReportsStage):
         return val.lower() in ("y", "yes", "t", "true", "on", "1")
 
     def _save_manifest(self, interactive):
-        manifest_repr = self.ctx.sa.get_manifest_repr()
+        manifest_repr = self.sa.get_manifest_repr()
         if not manifest_repr:
             _logger.info("Skipping saving of the manifest")
             return
@@ -706,7 +704,7 @@ class Launcher(MainLoopStage, ReportsStage):
                 manifest_repr
             )
 
-        self.ctx.sa.save_manifest(to_save_manifest)
+        self.sa.save_manifest(to_save_manifest)
 
     def _pick_jobs_to_run(self):
         if self.configuration.get_value("test selection", "forced"):
@@ -715,8 +713,8 @@ class Launcher(MainLoopStage, ReportsStage):
             # by default all tests are selected; so we're done here
             return
         job_list = [
-            self.ctx.sa.get_job(job_id)
-            for job_id in self.ctx.sa.get_static_todo_list()
+            self.sa.get_job(job_id)
+            for job_id in self.sa.get_static_todo_list()
         ]
         if not job_list:
             print(self.C.RED(_("There were no tests to select from!")))
@@ -734,10 +732,10 @@ class Launcher(MainLoopStage, ReportsStage):
         # use it to filter jobs from get_static_todo_list.
         job_id_list = [
             job_id
-            for job_id in self.ctx.sa.get_static_todo_list()
+            for job_id in self.sa.get_static_todo_list()
             if job_id in wanted_set
         ]
-        self.ctx.sa.use_alternate_selection(job_id_list)
+        self.sa.use_alternate_selection(job_id_list)
 
     def _handle_last_job_after_resume(self, last_job):
         if last_job is None:
@@ -749,7 +747,7 @@ class Launcher(MainLoopStage, ReportsStage):
                 "comments": _("Automatically passed after resuming execution"),
             }
             session_share = WellKnownDirsHelper.session_share(
-                self.ctx.sa.get_session_id()
+                self.sa.get_session_id()
             )
             result_path = os.path.join(session_share, "__result")
             if os.path.exists(result_path):
@@ -776,13 +774,13 @@ class Launcher(MainLoopStage, ReportsStage):
                 )
             )
             result = MemoryJobResult(result_dict)
-            self.ctx.sa.use_job_result(last_job, result)
+            self.sa.use_job_result(last_job, result)
             return
 
         print(
             _("Previous session run tried to execute job: {}").format(last_job)
         )
-        last_job_cert_status = self.ctx.sa.get_job_state(
+        last_job_cert_status = self.sa.get_job_state(
             last_job
         ).effective_certification_status
         result_dict = {"outcome": IJobResult.OUTCOME_NONE, "comments": ""}
@@ -870,10 +868,10 @@ class Launcher(MainLoopStage, ReportsStage):
                 result = None
                 break
         if result:
-            self.ctx.sa.use_job_result(last_job, result)
+            self.sa.use_job_result(last_job, result)
 
     def _maybe_auto_rerun_jobs(self):
-        rerun_candidates = self.ctx.sa.get_rerun_candidates("auto")
+        rerun_candidates = self.sa.get_rerun_candidates("auto")
         # bail-out early if no job qualifies for rerunning
         if not rerun_candidates:
             return False
@@ -886,13 +884,13 @@ class Launcher(MainLoopStage, ReportsStage):
             )
         )
         time.sleep(delay)
-        candidates = self.ctx.sa.prepare_rerun_candidates(rerun_candidates)
+        candidates = self.sa.prepare_rerun_candidates(rerun_candidates)
         self._run_jobs(candidates)
         return True
 
     def _maybe_rerun_jobs(self):
         # create a list of jobs that qualify for rerunning
-        rerun_candidates = self.ctx.sa.get_rerun_candidates("manual")
+        rerun_candidates = self.sa.get_rerun_candidates("manual")
         # bail-out early if no job qualifies for rerunning
         if not rerun_candidates:
             return False
@@ -903,12 +901,8 @@ class Launcher(MainLoopStage, ReportsStage):
         if not wanted_set:
             # nothing selected - nothing to run
             return False
-        rerun_candidates = [
-            self.ctx.sa.get_job(job_id) for job_id in wanted_set
-        ]
-        rerun_candidates = self.ctx.sa.prepare_rerun_candidates(
-            rerun_candidates
-        )
+        rerun_candidates = [self.sa.get_job(job_id) for job_id in wanted_set]
+        rerun_candidates = self.sa.prepare_rerun_candidates(rerun_candidates)
         # include resource jobs that selected jobs depend on
         self._run_jobs(rerun_candidates)
         return True

--- a/checkbox-ng/checkbox_ng/launcher/test_agent.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_agent.py
@@ -117,7 +117,6 @@ class AgentTests(TestCase):
 
         geteuid_mock.return_value = 0
 
-
         RemoteAgent.invoked(self_mock, ctx_mock)
         self.assertFalse(
             remote_assistant_mock.return_value.resume_by_id.called

--- a/checkbox-ng/checkbox_ng/launcher/test_agent.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_agent.py
@@ -19,7 +19,6 @@
 import json
 from unittest import TestCase, mock
 
-from checkbox_ng.launcher.agent import is_the_session_noninteractive
 from checkbox_ng.launcher.agent import exit_if_port_unavailable
 from checkbox_ng.launcher.agent import RemoteAgent
 from plainbox.impl.session.assistant import ResumeCandidate
@@ -118,61 +117,11 @@ class AgentTests(TestCase):
 
         geteuid_mock.return_value = 0
 
-        ctx_mock.sa.get_resumable_sessions.return_value = [
-            ResumeCandidate("an_id", SessionMetaData())
-        ]
-        with mock.patch(
-            "checkbox_ng.launcher.agent.is_the_session_noninteractive"
-        ) as itni:
-            itni.return_value = True
 
-            RemoteAgent.invoked(self_mock, ctx_mock)
-            self.assertTrue(
-                remote_assistant_mock.return_value.resume_by_id.called
-            )
-
-        remote_assistant_mock.reset_mock()
-
-        with mock.patch(
-            "checkbox_ng.launcher.agent.is_the_session_noninteractive"
-        ) as itni:
-            itni.return_value = False
-
-            RemoteAgent.invoked(self_mock, ctx_mock)
-            self.assertFalse(
-                remote_assistant_mock.return_value.resume_by_id.called
-            )
-
-
-class IsTheSessionNonInteractiveTests(TestCase):
-    def test_a_non_interactive_one(self):
-        a_non_interactive_launcher = """
-            [ui]
-            type = silent
-        """
-        app_blob = json.dumps({"launcher": a_non_interactive_launcher})
-        metadata = SessionMetaData(app_blob=app_blob.encode("utf-8"))
-
-        candidate = ResumeCandidate("an_id", metadata)
-        self.assertTrue(is_the_session_noninteractive(candidate))
-
-    def test_an_interactive(self):
-        an_interactive_launcher = """
-            [ui]
-            type = interactive
-        """
-        app_blob = json.dumps({"launcher": an_interactive_launcher})
-        metadata = SessionMetaData(app_blob=app_blob.encode("utf-8"))
-
-        candidate = ResumeCandidate("an_id", metadata)
-        self.assertFalse(is_the_session_noninteractive(candidate))
-
-    def test_no_launcher_in_app_blob(self):
-        app_blob = json.dumps({})
-        metadata = SessionMetaData(app_blob=app_blob.encode("utf-8"))
-
-        candidate = ResumeCandidate("an_id", metadata)
-        self.assertFalse(is_the_session_noninteractive(candidate))
+        RemoteAgent.invoked(self_mock, ctx_mock)
+        self.assertFalse(
+            remote_assistant_mock.return_value.resume_by_id.called
+        )
 
 
 class ExitIfPortUnavilableTests(TestCase):

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -506,7 +506,7 @@ class ControllerTests(TestCase):
             1:
         ]
 
-        resumed = RemoteController._resume_session_menu(
+        resumed = RemoteController.resume_session_via_menu_and_continue(
             self_mock, resumable_sessions
         )
 
@@ -541,7 +541,7 @@ class ControllerTests(TestCase):
 
         self_mock.sa.get_resumable_sessions.return_value = []
 
-        resumed = RemoteController._resume_session_menu(
+        resumed = RemoteController.resume_session_via_menu_and_continue(
             self_mock, [resumable_sessions[0]]
         )
 
@@ -564,7 +564,7 @@ class ControllerTests(TestCase):
             action="resume", session_id=None
         )
 
-        resumed = RemoteController._resume_session_menu(
+        resumed = RemoteController.resume_session_via_menu_and_continue(
             self_mock, resumable_sessions
         )
 
@@ -588,7 +588,7 @@ class ControllerTests(TestCase):
             action="resume", session_id=2
         )
 
-        resumed = RemoteController._resume_session_menu(
+        resumed = RemoteController.resume_session_via_menu_and_continue(
             self_mock, resumable_sessions
         )
 
@@ -909,7 +909,7 @@ class ControllerTests(TestCase):
         self_mock = mock.MagicMock()
 
         # by default always try to start a new session and not resuming
-        RemoteController.interactively_choose_tp(self_mock)
+        RemoteController.interactively_choose_test_plan_and_continue(self_mock)
 
         self.assertTrue(self_mock._new_session_flow.called)
         self.assertFalse(self_mock._resume_session_menu.called)
@@ -919,7 +919,7 @@ class ControllerTests(TestCase):
         self_mock._new_session_flow.side_effect = ResumeInstead
         self_mock._resume_session_menu.return_value = True
 
-        RemoteController.interactively_choose_tp(self_mock)
+        RemoteController.interactively_choose_test_plan_and_continue(self_mock)
 
         self.assertTrue(self_mock._new_session_flow.called)
         self.assertTrue(self_mock._resume_session_menu.called)
@@ -929,7 +929,7 @@ class ControllerTests(TestCase):
         self_mock._new_session_flow.side_effect = [ResumeInstead, True]
         self_mock._resume_session_menu.return_value = True
 
-        RemoteController.interactively_choose_tp(self_mock)
+        RemoteController.interactively_choose_test_plan_and_continue(self_mock)
 
         self.assertTrue(self_mock._new_session_flow.called)
         self.assertTrue(self_mock._resume_session_menu.called)
@@ -1044,7 +1044,7 @@ class ControllerTests(TestCase):
     def test_automatically_start_via_launcher(self):
         self_mock = mock.MagicMock()
 
-        RemoteController.automatically_start_via_launcher(self_mock)
+        RemoteController.auto_start_via_launcher_and_continue(self_mock)
 
         self.assertTrue(self_mock.select_test_plan.called)
         self.assertTrue(self_mock.bootstrap_and_continue.called)
@@ -1052,7 +1052,7 @@ class ControllerTests(TestCase):
     def test_automatically_resume_last_session(self):
         self_mock = mock.MagicMock()
 
-        RemoteController.automatically_resume_last_session(self_mock)
+        RemoteController.resume_last_session_and_continue(self_mock)
 
         self.assertTrue(self_mock.sa.get_resumable_sessions.called)
         self.assertTrue(self_mock.sa.resume_by_id.called)

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -31,7 +31,12 @@ from checkbox_ng.launcher.controller import (
 from checkbox_ng.launcher.controller import is_hostname_a_loopback
 
 
-class TestRemoteController(TestCase):
+class ControllerTests(TestCase):
+    def test_connection_strategy_comprehensive(self):
+        connection_strategy = RemoteController.connection_strategy()
+        for state in RemoteSessionStates:
+            connection_strategy[state]
+
     @mock.patch("checkbox_ng.launcher.controller.is_hostname_a_loopback")
     @mock.patch("time.time")
     @mock.patch("builtins.print")
@@ -1042,7 +1047,7 @@ class TestRemoteController(TestCase):
         RemoteController.automatically_start_via_launcher(self_mock)
 
         self.assertTrue(self_mock.select_test_plan.called)
-        self.assertTrue(self_mock.select_jobs.called)
+        self.assertTrue(self_mock.bootstrap_and_continue.called)
 
     def test_automatically_resume_last_session(self):
         self_mock = mock.MagicMock()

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -899,6 +899,27 @@ class TestLauncher(TestCase):
             {"manifest1": False, "manifest2": 7}
         )
 
+    def test__select_test_plan_and_continue_automated_ok(self):
+        self_mock = MagicMock()
+
+        def get_value(*args):
+            if args == ("test plan", "forced"):
+                return True
+            elif args == ("test plan", "unit"):
+                return "test_plan_id"
+            elif args == ("launcher", "session_desc"):
+                return "description"
+            raise AssertionError("Unknown config")
+
+        self_mock.configuration.get_value = get_value
+        self_mock.ctx.args.launcher = None
+        self_mock.ctx.args.message = None
+        self_mock.sa.get_test_plans.return_value = ["test_plan_id"]
+
+        Launcher._select_test_plan_and_continue(self_mock)
+
+        self.assertTrue(self_mock.sa.select_test_plan.called)
+
 
 @patch("os.makedirs", new=MagicMock())
 class TestLauncherReturnCodes(TestCase):

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -294,7 +294,7 @@ class TestLauncher(TestCase):
 
         self.assertTrue(configuration_mock.from_text.called)
         self.assertTrue(load_config_mock.called)
-        self.assertTrue(self_mock.ctx.sa.use_alternate_configuration.called)
+        self.assertTrue(self_mock.sa.use_alternate_configuration.called)
 
     @patch("checkbox_ng.launcher.subcommands.Configuration")
     @patch("checkbox_ng.launcher.subcommands.load_configs")
@@ -308,7 +308,7 @@ class TestLauncher(TestCase):
 
         self.assertFalse(configuration_mock.from_text.called)
         self.assertTrue(load_config_mock.called)
-        self.assertTrue(self_mock.ctx.sa.use_alternate_configuration.called)
+        self.assertTrue(self_mock.sa.use_alternate_configuration.called)
 
     @patch("checkbox_ng.launcher.subcommands.MemoryJobResult")
     @patch("checkbox_ng.launcher.subcommands.newline_join", new=MagicMock())
@@ -317,7 +317,9 @@ class TestLauncher(TestCase):
         self_mock._resume_session = partial(
             Launcher._resume_session, self_mock
         )
-        session_metadata_mock = self_mock.ctx.sa.resume_session.return_value
+        session_metadata_mock = (
+            self_mock.sa.prepare_resume_session.return_value
+        )
         session_metadata_mock.flags = ["testplanless"]
 
         resume_params_mock = MagicMock()
@@ -341,11 +343,13 @@ class TestLauncher(TestCase):
         self_mock._resume_session = partial(
             Launcher._resume_session, self_mock
         )
-        self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
+        self_mock.sa.get_job_state.return_value.effective_certification_status = (
             "blocker"
         )
 
-        session_metadata_mock = self_mock.ctx.sa.resume_session.return_value
+        session_metadata_mock = (
+            self_mock.sa.prepare_resume_session.return_value
+        )
         session_metadata_mock.flags = ["testplanless"]
 
         resume_params_mock = MagicMock()
@@ -369,11 +373,13 @@ class TestLauncher(TestCase):
         self_mock._resume_session = partial(
             Launcher._resume_session, self_mock
         )
-        self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
+        self_mock.sa.get_job_state.return_value.effective_certification_status = (
             "non-blocker"
         )
 
-        session_metadata_mock = self_mock.ctx.sa.resume_session.return_value
+        session_metadata_mock = (
+            self_mock.sa.prepare_resume_session.return_value
+        )
         session_metadata_mock.flags = ["testplanless"]
 
         resume_params_mock = MagicMock()
@@ -394,11 +400,13 @@ class TestLauncher(TestCase):
         self, request_comment_mock, memory_job_result_mock
     ):
         self_mock = MagicMock()
-        self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
+        self_mock.sa.get_job_state.return_value.effective_certification_status = (
             "blocker"
         )
 
-        session_metadata_mock = self_mock.ctx.sa.resume_session.return_value
+        session_metadata_mock = (
+            self_mock.sa.prepare_resume_session.return_value
+        )
         session_metadata_mock.flags = ["testplanless"]
 
         Launcher._resume_session(
@@ -415,11 +423,13 @@ class TestLauncher(TestCase):
     @patch("checkbox_ng.launcher.subcommands.newline_join", new=MagicMock())
     def test__resume_session_crash_non_blocker(self, memory_job_result_mock):
         self_mock = MagicMock()
-        self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
+        self_mock.sa.get_job_state.return_value.effective_certification_status = (
             "non-blocker"
         )
 
-        session_metadata_mock = self_mock.ctx.sa.resume_session.return_value
+        session_metadata_mock = (
+            self_mock.sa.prepare_resume_session.return_value
+        )
         session_metadata_mock.flags = ["testplanless"]
 
         Launcher._resume_session(
@@ -440,11 +450,13 @@ class TestLauncher(TestCase):
         self_mock._resume_session = partial(
             Launcher._resume_session, self_mock
         )
-        self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
+        self_mock.sa.get_job_state.return_value.effective_certification_status = (
             "blocker"
         )
 
-        session_metadata_mock = self_mock.ctx.sa.resume_session.return_value
+        session_metadata_mock = (
+            self_mock.sa.prepare_resume_session.return_value
+        )
         session_metadata_mock.flags = ["testplanless"]
 
         resume_params_mock = MagicMock()
@@ -468,11 +480,13 @@ class TestLauncher(TestCase):
         self_mock._resume_session = partial(
             Launcher._resume_session, self_mock
         )
-        self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
+        self_mock.sa.get_job_state.return_value.effective_certification_status = (
             "non-blocker"
         )
 
-        session_metadata_mock = self_mock.ctx.sa.resume_session.return_value
+        session_metadata_mock = (
+            self_mock.sa.prepare_resume_session.return_value
+        )
         session_metadata_mock.flags = ["testplanless"]
 
         resume_params_mock = MagicMock()
@@ -493,11 +507,13 @@ class TestLauncher(TestCase):
         self_mock._resume_session = partial(
             Launcher._resume_session, self_mock
         )
-        self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
+        self_mock.sa.get_job_state.return_value.effective_certification_status = (
             "non-blocker"
         )
 
-        session_metadata_mock = self_mock.ctx.sa.resume_session.return_value
+        session_metadata_mock = (
+            self_mock.sa.prepare_resume_session.return_value
+        )
         session_metadata_mock.flags = ["testplanless"]
 
         resume_params_mock = MagicMock()
@@ -508,7 +524,7 @@ class TestLauncher(TestCase):
         )
 
         # we don't use job result of rerun jobs
-        self.assertFalse(self_mock.ctx.sa.use_job_result.called)
+        self.assertFalse(self_mock.sa.use_job_result.called)
 
     @patch("checkbox_ng.launcher.subcommands.MemoryJobResult")
     @patch("checkbox_ng.launcher.subcommands.newline_join", new=MagicMock())
@@ -516,14 +532,16 @@ class TestLauncher(TestCase):
         self, memory_job_result_mock
     ):
         self_mock = MagicMock()
-        self_mock.ctx.sa.get_job_state.return_value.effective_certification_status = (
+        self_mock.sa.get_job_state.return_value.effective_certification_status = (
             "non-blocker"
         )
         self_mock._get_autoresume_outcome_last_job.return_value = (
             IJobResult.OUTCOME_CRASH
         )
 
-        session_metadata_mock = self_mock.ctx.sa.resume_session.return_value
+        session_metadata_mock = (
+            self_mock.sa.prepare_resume_session.return_value
+        )
         session_metadata_mock.flags = []
         session_metadata_mock.app_blob = b'{"testplan_id" : "testplan_id"}'
 
@@ -585,7 +603,7 @@ class TestLauncher(TestCase):
         self_mock = MagicMock()
 
         with Launcher._resumed_session(self_mock, "session_id"):
-            self.assertTrue(self_mock.sa.resume_session.called)
+            self.assertTrue(self_mock.sa.prepare_resume_session.called)
             self.assertFalse(self_mock.ctx.reset_sa.called)
         self.assertTrue(self_mock.ctx.reset_sa.called)
 
@@ -606,7 +624,7 @@ class TestLauncher(TestCase):
         )
         session_mock = MagicMock(id="session_id")
 
-        self_mock.sa.resume_session.side_effect = IncompatibleJobError
+        self_mock.sa.prepare_resume_session.side_effect = IncompatibleJobError
 
         self.assertFalse(
             Launcher._should_autoresume_last_run(self_mock, [session_mock])
@@ -628,7 +646,7 @@ class TestLauncher(TestCase):
         )
         session_mock = MagicMock(id="session_id")
 
-        self_mock.sa.resume_session.side_effect = IncompatibleJobError
+        self_mock.sa.prepare_resume_session.side_effect = IncompatibleJobError
 
         self.assertFalse(
             Launcher._should_autoresume_last_run(self_mock, [session_mock])
@@ -645,7 +663,7 @@ class TestLauncher(TestCase):
         )
         session_mock = MagicMock(id="session_id")
         metadata_mock = MagicMock(app_blob=b"{}")
-        self_mock.sa.resume_session.return_value = metadata_mock
+        self_mock.sa.prepare_resume_session.return_value = metadata_mock
 
         self.assertFalse(
             Launcher._should_autoresume_last_run(self_mock, [session_mock])
@@ -660,7 +678,7 @@ class TestLauncher(TestCase):
         metadata_mock = MagicMock(
             app_blob=b'{"testplan_id" : "testplan_id"}', running_job_name=None
         )
-        self_mock.sa.resume_session.return_value = metadata_mock
+        self_mock.sa.prepare_resume_session.return_value = metadata_mock
 
         self.assertFalse(
             Launcher._should_autoresume_last_run(self_mock, [session_mock])
@@ -676,7 +694,7 @@ class TestLauncher(TestCase):
             app_blob=b'{"testplan_id" : "testplan_id"}',
             running_job_name="running_job_name",
         )
-        self_mock.sa.resume_session.return_value = metadata_mock
+        self_mock.sa.prepare_resume_session.return_value = metadata_mock
         job_state_mock = self_mock.sa.get_job_state()
         job_state_mock.job.plugin = "user-interact"
 
@@ -694,7 +712,7 @@ class TestLauncher(TestCase):
             app_blob=b'{"testplan_id" : "testplan_id"}',
             running_job_name="running_job_name",
         )
-        self_mock.sa.resume_session.return_value = metadata_mock
+        self_mock.sa.prepare_resume_session.return_value = metadata_mock
         job_state_mock = self_mock.sa.get_job_state()
         job_state_mock.job.plugin = "shell"
 
@@ -766,8 +784,10 @@ class TestLauncher(TestCase):
     @patch("checkbox_ng.launcher.subcommands.Colorizer", new=MagicMock())
     def test_invoked_resume(self, load_config_mock):
         self_mock = MagicMock()
-        self_mock._maybe_auto_resume_session.side_effect = [False, True]
+        self_mock._auto_resume_session.return_value = False
+        self_mock._manually_resume_session.side_effect = [False, True]
         self_mock._pick_jobs_to_run.side_effect = ResumeInstead()
+        self_mock._maybe_auto_rerun_jobs.return_value = False
 
         ctx_mock = MagicMock()
         ctx_mock.args.verify = False
@@ -890,6 +910,7 @@ class TestLauncherReturnCodes(TestCase):
             return_value=False
         )
         self.launcher._start_new_session = Mock()
+        self.launcher._select_test_plan_and_continue = Mock()
         self.launcher._pick_jobs_to_run = Mock()
         self.launcher._export_results = Mock()
         self.ctx = Mock()
@@ -898,6 +919,7 @@ class TestLauncherReturnCodes(TestCase):
             get_resumable_sessions=Mock(return_value=[]),
             get_dynamic_todo_list=Mock(return_value=[]),
         )
+        self.sa = self.ctx.sa
 
     def test_invoke_returns_0_on_no_fails(self):
         mock_results = {"fail": 0, "crash": 0, "pass": 1}

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -782,6 +782,13 @@ class SessionAssistant:
         """
         UsageExpectation.of(self).enforce()
         test_plan = self._context.get_unit(test_plan_id, "test plan")
+        self.update_app_blob(
+            json.dumps(
+                {
+                    "testplan_id": test_plan_id,
+                }
+            ).encode("UTF-8")
+        )
         self._manager.test_plans = (test_plan,)
         self._manager.checkpoint()
         UsageExpectation.of(self).allowed_calls = {

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -1770,22 +1770,21 @@ class SessionAssistant:
                 "finalize_session called for already finalized session: %s",
                 self._manager.storage.id,
             )
-            # leave the same usage expectations
-            return
-        ignored_flags = {
-            SessionMetaData.FLAG_SUBMITTED,
-            SessionMetaData.FLAG_BOOTSTRAPPING,
-        }
-        if not (ignored_flags & set(self._metadata.flags)):
-            _logger.warning(
-                "Finalizing session that hasn't been submitted "
-                "anywhere: %s",
-                self._manager.storage.id,
-            )
-        for flag in finalizable_flags:
-            if flag in self._metadata.flags:
-                self._metadata.flags.remove(flag)
-        self._manager.checkpoint()
+        else:
+            ignored_flags = {
+                SessionMetaData.FLAG_SUBMITTED,
+                SessionMetaData.FLAG_BOOTSTRAPPING,
+            }
+            if not (ignored_flags & set(self._metadata.flags)):
+                _logger.warning(
+                    "Finalizing session that hasn't been submitted "
+                    "anywhere: %s",
+                    self._manager.storage.id,
+                )
+            for flag in finalizable_flags:
+                if flag in self._metadata.flags:
+                    self._metadata.flags.remove(flag)
+            self._manager.checkpoint()
         UsageExpectation.of(self).allowed_calls = {
             self.finalize_session: "to finalize session",
             self.export_to_transport: "to export the results and send them",

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -89,9 +89,9 @@ def allowed_when(*states: RemoteSessionStates):
         def fun(self, *args):
             if self.state not in states:
                 raise RuntimeError(
-                    "Uh, Oh... Function '{}' can only be called in {} "
-                    "but was called an current state is: {}".format(
-                        f.__name__, states, self._state
+                    "Uh, Oh... Function '{}' can only be called in states: {} \n"
+                    "but was called now and current state is: {}".format(
+                        f.__name__, states, self.state
                     )
                 )
             return f(self, *args)

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -410,24 +410,6 @@ class RemoteSessionAssistant:
         return self._sa.select_test_plan(test_plan_id)
 
     @allowed_when(RemoteSessionStates.Started)
-    def prepare_bootstrapping(self, test_plan_id):
-        """Save picked test plan to the app blob."""
-        _logger.debug("prepare_bootstrapping: %r", test_plan_id)
-        self._sa.update_app_blob(
-            json.dumps(
-                {
-                    "testplan_id": test_plan_id,
-                }
-            ).encode("UTF-8")
-        )
-        self._sa.select_test_plan(test_plan_id)
-        # TODO: REMOTE API RAPI: Change this API on the next RAPI bump
-        # previously the function returned bool signifying the need for sudo
-        # password. With agent being guaranteed to never need it anymor
-        # we can make this funciton return nothing
-        return False
-
-    @allowed_when(RemoteSessionStates.Started)
     def start_bootstrap_json(self):
         return json.dumps(self.start_bootstrap())
 
@@ -604,12 +586,9 @@ class RemoteSessionAssistant:
                 Interaction("verification", job.verification, self._be)
             )
 
-    @allowed_when(
-        RemoteSessionStates.Started, RemoteSessionStates.Bootstrapping
-    )
-    def run_bootstrapping_job(self, job_id):
+    @allowed_when(RemoteSessionStates.Bootstrapping)
+    def run_uninteractable_job(self, job_id):
         self._currently_running_job = job_id
-        self.state = RemoteSessionStates.Bootstrapping
         self._be = BackgroundExecutor(self, job_id, self._sa.run_job)
 
     @allowed_when(

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -412,7 +412,7 @@ class RemoteSessionAssistant:
         self._available_testplans = list(self._available_testplans)
         return self._available_testplans
 
-    @allowed_when(RemoteSessionStates.Started)
+    @allowed_when(RemoteSessionStates.Started, RemoteSessionStates.Idle)
     def select_test_plan(self, test_plan_id):
         return self._sa.select_test_plan(test_plan_id)
 

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -23,6 +23,7 @@ import logging
 import os
 import pwd
 import time
+from functools import wraps
 from collections import namedtuple
 from contextlib import suppress
 from tempfile import SpooledTemporaryFile
@@ -55,21 +56,49 @@ _logger = logging.getLogger("plainbox.session.remote_assistant")
 Interaction = namedtuple("Interaction", ["kind", "message", "extra"])
 
 
-class Interaction(namedtuple("Interaction", ["kind", "message", "extra"])):
-    __slots__ = ()
+class RemoteSessionStates(Enum):
+    """
+    These are the state the RemoteSessionAssistant handles.
 
-    def __new__(cls, kind, message="", extra=None):
-        return super(Interaction, cls).__new__(cls, kind, message, extra)
+    We need a second state machine (In addition to the SessionAssistant
+    UsageExpectation) to allow the controller to gracefully know how to
+    continue or start a new session on connection.
+    """
+
+    # nothing has connected yet
+    Idle = "idle"
+    # session has started, test plan was selected
+    Started = "started"
+    # bootstrap phase is ongoing
+    Bootstrapping = "bootstrapping"
+    # done bootstrapping, ready to select tests
+    Bootstrapped = "bootstrapped"
+    # tests were selected, ready to run them
+    TestsSelected = "testsselected"
+    # running a non-interactive test
+    Running = "running"
+    # waiting for an user interaction (like a comment)
+    Interacting = "interacting"
+    # finalizing the session (generating reports)
+    Finalizing = "finalizing"
 
 
-Idle = "idle"
-Started = "started"
-Bootstrapping = "bootstrapping"
-Bootstrapped = "bootstrapped"
-TestsSelected = "testsselected"
-Running = "running"
-Interacting = "interacting"
-Finalizing = "finalizing"
+def allowed_when(*states: RemoteSessionStates):
+    def wrap(f):
+        @wraps(f)
+        def fun(self, *args):
+            if self.state not in states:
+                raise RuntimeError(
+                    "Uh, Oh... Function '{}' can only be called in {} "
+                    "but was called an current state is: {}".format(
+                        f.__name__, states, self._state
+                    )
+                )
+            return f(self, *args)
+
+        return fun
+
+    return wrap
 
 
 class BufferedUI(SilentUI):
@@ -168,12 +197,13 @@ class RemoteSessionAssistant:
         self._pipe_from_controller = open(self._input_piping[1], "w")
         self._pipe_to_subproc = open(self._input_piping[0])
         self._sa = None  # type: SessionAssistant
+        self._state = None  # type: RemoteSessionStates
         self._reset_sa()
         self._currently_running_job = None
 
     def _reset_sa(self):
         _logger.info("Resetting RSA")
-        self._state = Idle
+        self._state = RemoteSessionStates.Idle
         self._sa = SessionAssistant()
         self._be = None
         self._session_id = ""
@@ -192,6 +222,20 @@ class RemoteSessionAssistant:
         job = json.loads(job)
         return self.note_metadata_starting_job(job, job_state)
 
+    @property
+    def state(self):
+        return self._state
+
+    @state.setter
+    def state(self, new_state):
+        if self._state != new_state:
+            _logger.info(
+                "Transitioning from {} to {}".format(
+                    self._state.value, new_state.value
+                )
+            )
+        self._state = new_state
+
     def note_metadata_starting_job(self, job, job_state):
         self._sa.note_metadata_starting_job(job, job_state)
 
@@ -209,38 +253,25 @@ class RemoteSessionAssistant:
     def update_app_blob(self, app_blob):
         self._sa.update_app_blob(app_blob)
 
-    def allowed_when(*states):
-        def wrap(f):
-            def fun(self, *args):
-                if self._state not in states:
-                    raise AssertionError(
-                        "expected %s, is %s" % (states, self._state)
-                    )
-                return f(self, *args)
-
-            return fun
-
-        return wrap
-
     def interact(self, interaction):
-        self._state = Interacting
+        self.state = RemoteSessionStates.Interacting
         self._current_interaction = interaction
         yield self._current_interaction
 
-    @allowed_when(Interacting)
+    @allowed_when(RemoteSessionStates.Interacting)
     def remember_users_response(self, response):
         if response == "rollback":
             self._currently_running_job = None
             self.session_change_lock.acquire(blocking=False)
             self.session_change_lock.release()
             self._current_comments = ""
-            self._state = TestsSelected
+            self.state = RemoteSessionStates.TestsSelected
             return
         elif response == "quit":
             self.abandon_session()
             return
         self._last_response = response
-        self._state = Running
+        self.state = RemoteSessionStates.Running
 
     def _set_envvar_from_proc(self, name):
         for path in os.listdir("/proc/"):
@@ -304,11 +335,11 @@ class RemoteSessionAssistant:
 
         return extra_env
 
-    @allowed_when(Idle)
+    @allowed_when(RemoteSessionStates.Idle)
     def start_session_json(self, configuration):
         return json.dumps(self.start_session(json.loads(configuration)))
 
-    @allowed_when(Idle)
+    @allowed_when(RemoteSessionStates.Idle)
     def start_session(self, configuration):
         self._reset_sa()
         _logger.info("start_session: %r", configuration)
@@ -367,17 +398,18 @@ class RemoteSessionAssistant:
             filtered_tps,
             [self._sa.get_test_plan(tp).name for tp in filtered_tps],
         )
-        self._state = Started
+        self.state = RemoteSessionStates.Started
         self._available_testplans = sorted(
             response, key=lambda x: x[1]
         )  # sorted by name
         self._available_testplans = list(self._available_testplans)
         return self._available_testplans
 
+    @allowed_when(RemoteSessionStates.Started)
     def select_test_plan(self, test_plan_id):
         return self._sa.select_test_plan(test_plan_id)
 
-    @allowed_when(Started)
+    @allowed_when(RemoteSessionStates.Started)
     def prepare_bootstrapping(self, test_plan_id):
         """Save picked test plan to the app blob."""
         _logger.debug("prepare_bootstrapping: %r", test_plan_id)
@@ -395,12 +427,13 @@ class RemoteSessionAssistant:
         # we can make this funciton return nothing
         return False
 
-    @allowed_when(Started)
+    @allowed_when(RemoteSessionStates.Started)
     def start_bootstrap_json(self):
         return json.dumps(self.start_bootstrap())
 
-    @allowed_when(Started)
+    @allowed_when(RemoteSessionStates.Started)
     def start_bootstrap(self):
+        self.state = RemoteSessionStates.Bootstrapping
         return self._sa.start_bootstrap()
 
     def finish_bootstrap_json(self):
@@ -408,7 +441,7 @@ class RemoteSessionAssistant:
 
     def finish_bootstrap(self):
         self._sa.finish_bootstrap()
-        self._state = Bootstrapped
+        self.state = RemoteSessionStates.Bootstrapped
         if self._launcher.get_value("ui", "auto_retry"):
             for job_id in self._sa.get_static_todo_list():
                 job_state = self._sa.get_job_state(job_id)
@@ -438,14 +471,16 @@ class RemoteSessionAssistant:
 
     def finish_job_selection(self):
         self._jobs_count = len(self._sa.get_dynamic_todo_list())
-        self._state = TestsSelected
+        self.state = RemoteSessionStates.TestsSelected
 
-    @allowed_when(Interacting, TestsSelected)
+    @allowed_when(
+        RemoteSessionStates.Interacting, RemoteSessionStates.TestsSelected
+    )
     def rerun_job(self, job_id, result):
         self._sa.use_job_result(job_id, result)
         self.session_change_lock.acquire(blocking=False)
         self.session_change_lock.release()
-        self._state = TestsSelected
+        self.state = RemoteSessionStates.TestsSelected
 
     def _get_ui_for_job(self, job):
         show_out = True
@@ -469,7 +504,7 @@ class RemoteSessionAssistant:
             self._ui = RemoteSilentUI()
         return self._ui
 
-    @allowed_when(TestsSelected)
+    @allowed_when(RemoteSessionStates.TestsSelected)
     def run_job(self, job_id):
         """
         Depending on the type of the job, run_job can yield different number
@@ -552,7 +587,7 @@ class RemoteSessionAssistant:
                     Interaction("skip", job.verification, self._be)
                 )
         if job.command:
-            self._state = Running
+            self.state = RemoteSessionStates.Running
             ui = self._get_ui_for_job(job)
             self._be = BackgroundExecutor(self, job_id, self._sa.run_job, ui)
         else:
@@ -569,13 +604,20 @@ class RemoteSessionAssistant:
                 Interaction("verification", job.verification, self._be)
             )
 
-    @allowed_when(Started, Bootstrapping)
+    @allowed_when(
+        RemoteSessionStates.Started, RemoteSessionStates.Bootstrapping
+    )
     def run_bootstrapping_job(self, job_id):
         self._currently_running_job = job_id
-        self._state = Bootstrapping
+        self.state = RemoteSessionStates.Bootstrapping
         self._be = BackgroundExecutor(self, job_id, self._sa.run_job)
 
-    @allowed_when(Running, Bootstrapping, Interacting, TestsSelected)
+    @allowed_when(
+        RemoteSessionStates.Running,
+        RemoteSessionStates.Bootstrapping,
+        RemoteSessionStates.Interacting,
+        RemoteSessionStates.TestsSelected,
+    )
     def monitor_job(self):
         """
         Check the state of the currently running job.
@@ -598,27 +640,28 @@ class RemoteSessionAssistant:
 
     def whats_up(self):
         """
-        Check what is remote-service up to
-        :returns:
-            (state, payload) tuple.
+        Returns the current agent state along with useful information to
+        allow the controller to start or recover the current session
         """
-        _logger.debug("whats_up() -> %r", self._state)
         payload = None
-        if self._state == Running:
+        if self.state == RemoteSessionStates.Running:
             payload = (
                 self._job_index,
                 self._jobs_count,
                 self._currently_running_job,
             )
-        if self._state == TestsSelected and not self._currently_running_job:
+        if (
+            self.state == RemoteSessionStates.TestsSelected
+            and not self._currently_running_job
+        ):
             payload = {"last_job": self._last_job}
-        elif self._state == Started:
+        elif self.state == RemoteSessionStates.Started:
             payload = self._available_testplans
-        elif self._state == Interacting:
+        elif self.state == RemoteSessionStates.Interacting:
             payload = self._current_interaction
-        elif self._state == Bootstrapped:
+        elif self.state == RemoteSessionStates.Bootstrapped:
             payload = self._sa.get_static_todo_list()
-        return self._state, payload
+        return self.state.value, payload
 
     def terminate(self):
         if self.terminate_cb:
@@ -673,16 +716,16 @@ class RemoteSessionAssistant:
             else:
                 result = self._be.wait().get_result()
         self._sa.use_job_result(self._currently_running_job, result)
-        if self._state != Bootstrapping:
+        if self.state != RemoteSessionStates.Bootstrapping:
             if not self._sa.get_dynamic_todo_list():
                 if self._launcher.get_value(
                     "ui", "auto_retry"
                 ) and self.get_rerun_candidates("auto"):
-                    self._state = TestsSelected
+                    self.state = RemoteSessionStates.TestsSelected
                 else:
-                    self._state = Idle
+                    self.state = RemoteSessionStates.Idle
             else:
-                self._state = TestsSelected
+                self.state = RemoteSessionStates.TestsSelected
         return result
 
     def get_rerun_candidates(self, session_type="manual"):
@@ -690,7 +733,7 @@ class RemoteSessionAssistant:
 
     def prepare_rerun_candidates(self, rerun_candidates):
         candidates = self._sa.prepare_rerun_candidates(rerun_candidates)
-        self._state = TestsSelected
+        self.state = RemoteSessionStates.TestsSelected
         return candidates
 
     def get_job_result(self, job_id):
@@ -756,7 +799,7 @@ class RemoteSessionAssistant:
     def get_resumable_sessions(self):
         return self._sa.get_resumable_sessions()
 
-    def resume_session(self, session_id, runner_kwargs={}):
+    def prepare_resume_session(self, session_id, runner_kwargs={}):
         return self._sa.prepare_resume_session(
             session_id, runner_kwargs=runner_kwargs
         )
@@ -782,7 +825,9 @@ class RemoteSessionAssistant:
             "stdin": self._pipe_to_subproc,
             "extra_env": self.prepare_extra_env,
         }
-        meta = self.resume_session(session_id, runner_kwargs=runner_kwargs)
+        meta = self.prepare_resume_session(
+            session_id, runner_kwargs=runner_kwargs
+        )
         app_blob = json.loads(meta.app_blob.decode("UTF-8"))
         if "launcher" in app_blob:
             launcher_from_controller = Configuration.from_text(
@@ -869,7 +914,7 @@ class RemoteSessionAssistant:
                     "ui", "max_attempts"
                 ) - len(job_state.result_history)
 
-        self._state = TestsSelected
+        self.state = RemoteSessionStates.TestsSelected
 
     def has_any_job_failed(self):
         job_state_map = (

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -53,7 +53,14 @@ _ = gettext.gettext
 
 _logger = logging.getLogger("plainbox.session.remote_assistant")
 
-Interaction = namedtuple("Interaction", ["kind", "message", "extra"])
+
+class Interaction(namedtuple("Interaction", ["kind", "message", "extra"])):
+    """
+    This is a named tuple with optional parameters
+    """
+
+    def __new__(cls, kind, message="", extra=None):
+        return super().__new__(cls, kind, message, extra)
 
 
 class RemoteSessionStates(Enum):

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -120,9 +120,9 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa.resume_session.return_value = mock_meta
+        rsa.prepare_resume_session.return_value = mock_meta
         RemoteSessionAssistant.resume_by_id(rsa, "session_id")
-        self.assertEqual(rsa.state, "testsselected")
+        self.assertEqual(rsa.state, RemoteSessionStates.TestsSelected)
 
     def test_resume_by_id_bad_session_id(self):
         rsa = mock.Mock()
@@ -133,7 +133,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa.resume_session.return_value = mock_meta
+        rsa.prepare_resume_session.return_value = mock_meta
         RemoteSessionAssistant.resume_by_id(rsa, "bad_id")
         self.assertEqual(rsa.state, RemoteSessionStates.Idle)
 
@@ -146,9 +146,9 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa.resume_session.return_value = mock_meta
+        rsa.prepare_resume_session.return_value = mock_meta
         RemoteSessionAssistant.resume_by_id(rsa)
-        self.assertEqual(rsa.state, "testsselected")
+        self.assertEqual(rsa.state, RemoteSessionStates.TestsSelected)
 
     @mock.patch("plainbox.impl.session.remote_assistant.load_configs")
     def test_resume_by_id_with_result_file_ok(self, mock_load_configs):
@@ -162,7 +162,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa.resume_session.return_value = mock_meta
+        rsa.prepare_resume_session.return_value = mock_meta
         os_path_exists_mock = mock.Mock()
 
         with mock.patch("plainbox.impl.session.remote_assistant._") as mock__:
@@ -202,7 +202,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa.resume_session.return_value = mock_meta
+        rsa.prepare_resume_session.return_value = mock_meta
         os_path_exists_mock = mock.Mock()
 
         with mock.patch("plainbox.impl.session.remote_assistant._") as mock__:
@@ -244,7 +244,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"testplan_id": "tp_id"}'
 
-        rsa.resume_session.return_value = mock_meta
+        rsa.prepare_resume_session.return_value = mock_meta
         os_path_exists_mock = mock.Mock()
 
         rsa._sa.get_job.return_value.plugin = "shell"
@@ -284,7 +284,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa.resume_session.return_value = mock_meta
+        rsa.prepare_resume_session.return_value = mock_meta
         os_path_exists_mock = mock.Mock()
 
         rsa._sa.get_job.return_value.plugin = "shell"
@@ -324,7 +324,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa.resume_session.return_value = mock_meta
+        rsa.prepare_resume_session.return_value = mock_meta
         os_path_exists_mock = mock.Mock()
 
         rsa._sa.get_job.return_value.plugin = "shell"
@@ -358,7 +358,7 @@ class RemoteAssistantTests(TestCase):
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
-        rsa.resume_session.return_value = mock_meta
+        rsa.prepare_resume_session.return_value = mock_meta
         os_path_exists_mock = mock.Mock()
         with mock.patch("plainbox.impl.session.remote_assistant._") as mock__:
             mock__.side_effect = lambda x: x

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -32,31 +32,32 @@ from plainbox.impl.result import MemoryJobResult
 
 from plainbox.impl.secure.sudo_broker import is_passwordless_sudo
 
-from plainbox.impl.session import remote_assistant
-from plainbox.impl.session.remote_assistant import RemoteSessionAssistant
+from plainbox.impl.session.remote_assistant import (
+    RemoteSessionAssistant,
+    RemoteSessionStates,
+    allowed_when,
+)
 from plainbox.impl.session.assistant import SessionAssistant
 
 
 class RemoteAssistantTests(TestCase):
     def test_allowed_when_ok(self):
         self_mock = mock.MagicMock()
-        allowed_when = RemoteSessionAssistant.allowed_when
 
-        @allowed_when(remote_assistant.Idle)
+        @allowed_when(RemoteSessionStates.Idle)
         def allowed(self, *args): ...
 
-        self_mock._state = remote_assistant.Idle
+        self_mock.state = RemoteSessionStates.Idle
         allowed(self_mock)
 
     def test_allowed_when_fail(self):
         self_mock = mock.MagicMock()
-        allowed_when = RemoteSessionAssistant.allowed_when
 
-        @allowed_when(remote_assistant.Idle)
+        @allowed_when(RemoteSessionStates.Idle)
         def not_allowed(self, *args): ...
 
-        self_mock._state = remote_assistant.Started
-        with self.assertRaises(AssertionError):
+        self_mock.state = RemoteSessionStates.Started
+        with self.assertRaises(RuntimeError):
             not_allowed(self_mock)
 
     @mock.patch.object(SessionAssistant, "__init__")
@@ -77,7 +78,7 @@ class RemoteAssistantTests(TestCase):
         extra_cfg["launcher"] = "test_launcher"
         rsa = mock.Mock()
         rsa.get_test_plans.return_value = [mock.Mock()]
-        rsa._state = remote_assistant.Idle
+        rsa.state = RemoteSessionStates.Idle
 
         def get_test_plan_mock(name):
             to_r = mock.Mock()
@@ -104,7 +105,7 @@ class RemoteAssistantTests(TestCase):
         extra_cfg["launcher"] = "test_launcher"
         rsa = mock.Mock()
         rsa.get_test_plans.return_value = [mock.Mock()]
-        rsa._state = remote_assistant.Idle
+        rsa.state = RemoteSessionStates.Idle
         with mock.patch("plainbox.impl.config.Configuration.from_text") as cm:
             cm.return_value = Configuration()
             tps = RemoteSessionAssistant.start_session(rsa, extra_cfg)
@@ -115,39 +116,39 @@ class RemoteAssistantTests(TestCase):
         resumable_session = mock.Mock()
         resumable_session.id = "session_id"
         rsa._sa.get_resumable_sessions.return_value = [resumable_session]
-        rsa._state = remote_assistant.Idle
+        rsa.state = RemoteSessionStates.Idle
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
         rsa.resume_session.return_value = mock_meta
         RemoteSessionAssistant.resume_by_id(rsa, "session_id")
-        self.assertEqual(rsa._state, "testsselected")
+        self.assertEqual(rsa.state, "testsselected")
 
     def test_resume_by_id_bad_session_id(self):
         rsa = mock.Mock()
         resumable_session = mock.Mock()
         resumable_session.id = "session_id"
         rsa._sa.get_resumable_sessions.return_value = [resumable_session]
-        rsa._state = remote_assistant.Idle
+        rsa.state = RemoteSessionStates.Idle
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
         rsa.resume_session.return_value = mock_meta
         RemoteSessionAssistant.resume_by_id(rsa, "bad_id")
-        self.assertEqual(rsa._state, "idle")
+        self.assertEqual(rsa.state, RemoteSessionStates.Idle)
 
     def test_resume_by_id_without_session_id(self):
         rsa = mock.Mock()
         resumable_session = mock.Mock()
         resumable_session.id = "session_id"
         rsa._sa.get_resumable_sessions.return_value = [resumable_session]
-        rsa._state = remote_assistant.Idle
+        rsa.state = RemoteSessionStates.Idle
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
 
         rsa.resume_session.return_value = mock_meta
         RemoteSessionAssistant.resume_by_id(rsa)
-        self.assertEqual(rsa._state, "testsselected")
+        self.assertEqual(rsa.state, "testsselected")
 
     @mock.patch("plainbox.impl.session.remote_assistant.load_configs")
     def test_resume_by_id_with_result_file_ok(self, mock_load_configs):
@@ -156,7 +157,7 @@ class RemoteAssistantTests(TestCase):
         resumable_session.id = "session_id"
         rsa._sa.get_resumable_sessions.return_value = [resumable_session]
         rsa.get_rerun_candidates.return_value = []
-        rsa._state = remote_assistant.Idle
+        rsa.state = RemoteSessionStates.Idle
 
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
@@ -196,7 +197,7 @@ class RemoteAssistantTests(TestCase):
         resumable_session.id = "session_id"
         rsa._sa.get_resumable_sessions.return_value = [resumable_session]
         rsa.get_rerun_candidates.return_value = []
-        rsa._state = remote_assistant.Idle
+        rsa.state = RemoteSessionStates.Idle
 
         mock_meta = mock.Mock()
         mock_meta.app_blob = b'{"launcher": "", "testplan_id": "tp_id"}'
@@ -236,7 +237,7 @@ class RemoteAssistantTests(TestCase):
         resumable_session.id = "session_id"
         rsa._sa.get_resumable_sessions.return_value = [resumable_session]
         rsa.get_rerun_candidates.return_value = []
-        rsa._state = remote_assistant.Idle
+        rsa.state = RemoteSessionStates.Idle
         job_state = rsa._sa.get_job_state.return_value
         job_state.result.outcome = None
 
@@ -276,7 +277,7 @@ class RemoteAssistantTests(TestCase):
         resumable_session.id = "session_id"
         rsa._sa.get_resumable_sessions.return_value = [resumable_session]
         rsa.get_rerun_candidates.return_value = []
-        rsa._state = remote_assistant.Idle
+        rsa.state = RemoteSessionStates.Idle
         job_state = rsa._sa.get_job_state.return_value
         job_state.result.outcome = None
 
@@ -315,7 +316,7 @@ class RemoteAssistantTests(TestCase):
         resumable_session.id = "session_id"
         rsa._sa.get_resumable_sessions.return_value = [resumable_session]
         rsa.get_rerun_candidates.return_value = []
-        rsa._state = remote_assistant.Idle
+        rsa.state = RemoteSessionStates.Idle
         job_state = rsa._sa.get_job_state.return_value
         job_state.result.outcome = IJobResult.OUTCOME_PASS
         job_state.result.comments = None
@@ -350,7 +351,7 @@ class RemoteAssistantTests(TestCase):
         resumable_session.id = "session_id"
         rsa._sa.get_resumable_sessions.return_value = [resumable_session]
         rsa.get_rerun_candidates.return_value = []
-        rsa._state = remote_assistant.Idle
+        rsa.state = RemoteSessionStates.Idle
         job_state = rsa._sa.get_job_state.return_value
         job_state.result.outcome = None
 
@@ -377,7 +378,7 @@ class RemoteAssistantTests(TestCase):
 
     def test_remember_users_response_quit(self):
         self_mock = mock.MagicMock()
-        self_mock._state = remote_assistant.Interacting
+        self_mock.state = RemoteSessionStates.Interacting
 
         RemoteSessionAssistant.remember_users_response(self_mock, "quit")
 
@@ -385,19 +386,19 @@ class RemoteAssistantTests(TestCase):
 
     def test_remember_users_response_rollback(self):
         self_mock = mock.MagicMock()
-        self_mock._state = remote_assistant.Interacting
+        self_mock.state = RemoteSessionStates.Interacting
 
         RemoteSessionAssistant.remember_users_response(self_mock, "rollback")
 
-        self.assertEqual(self_mock._state, remote_assistant.TestsSelected)
+        self.assertEqual(self_mock.state, RemoteSessionStates.TestsSelected)
 
     def test_remember_users_response_run(self):
         self_mock = mock.MagicMock()
-        self_mock._state = remote_assistant.Interacting
+        self_mock.state = RemoteSessionStates.Interacting
 
         RemoteSessionAssistant.remember_users_response(self_mock, "run")
 
-        self.assertEqual(self_mock._state, remote_assistant.Running)
+        self.assertEqual(self_mock.state, RemoteSessionStates.Running)
 
     def test_note_metadata_starting_job(self):
         self_mock = mock.MagicMock()
@@ -429,11 +430,11 @@ class RemoteAssistantTests(TestCase):
     def test_configuration_type(self):
         # This is used to allow the controller to create netref configurations.
         conf_type = RemoteSessionAssistant.configuration_type(mock.MagicMock())
-        self.assertEqual(conf_type, remote_assistant.Configuration)
+        self.assertEqual(conf_type, Configuration)
 
     def test_start_bootstrap_json(self):
         self_mock = mock.MagicMock()
-        self_mock._state = remote_assistant.Started
+        self_mock.state = RemoteSessionStates.Started
         self_mock.start_bootstrap = partial(
             RemoteSessionAssistant.start_bootstrap, self_mock
         )
@@ -476,7 +477,7 @@ class RemoteAssistantTests(TestCase):
             RemoteSessionAssistant.finish_bootstrap_json(self_mock)
         )
 
-        self.assertEqual(self_mock._state, remote_assistant.Bootstrapped)
+        self.assertEqual(self_mock.state, RemoteSessionStates.Bootstrapped)
         self.assertEqual(bootstrapped_todo, static_todo_list)
         self.assertTrue(
             all(


### PR DESCRIPTION
## Description

Currently:
- The remote api relies on an obscure dict to re-connect to the agent depending on its state which is basically not documented or tested + weird partial usage that is unnecessary to pass arguments to functions
- bootstrapping (with or without a ui) uses duplicated code in two functions
- bootstrappping relies on a pointlessly duplicated api
- bootstrapping uses a flag in self to suppress resource jobs output (sigh)
- run_jobs is not used (and can't be used) to run any job, only normal jobs (post bootstrap)
- remote api stores states as string, not an enum
- there is a class local decorator in the remote api (which doesn't use the class and its args inferred wrong by the lsp)
- the decorator also raises an AssertionError for a runtime error with an obscure error message
- state transitions are done by setting a private variable and not logged
- bootstrap transition is not done when starting the bootstrap process but when running the first bootstrap job
- `whats_up` is poorly documented
- similarly to the other pr, resume session is called resume session but doesn't resume the session!

This refactor fixes all the above issues

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1983

## Documentation

Added documentation for many APIs

## Tests

Metabox tests, nothing should change about the behaviour
