### PR TITLE
- Add an option to use a value other than 10% for  --oom-avoid-bytes

### DIFF
--- a/providers/base/bin/stress_ng_test.py
+++ b/providers/base/bin/stress_ng_test.py
@@ -59,6 +59,7 @@ class StressNg:
         sng_timeout,
         thread_count=0,
         extra_options="",
+        oom_avoid_bytes="10%",
     ):
 
         self.stressors = stressors
@@ -66,6 +67,7 @@ class StressNg:
         self.sng_timeout = sng_timeout
         self.extra_options = extra_options
         self.thread_count = thread_count
+        self.oom_avoid_bytes = oom_avoid_bytes
         self.results = ""
         self.returncode = 0
 
@@ -79,9 +81,9 @@ class StressNg:
         stressor_list = stressor_list + " {}".format(self.thread_count)
 
         command = (
-            "stress-ng --aggressive --verify --oom-avoid-bytes 10% "
+            "stress-ng --aggressive --verify --oom-avoid-bytes {} "
             "--timeout {} {} {}"
-        ).format(self.sng_timeout, self.extra_options, stressor_list)
+        ).format(self.oom_avoid_bytes, self.sng_timeout, self.extra_options, stressor_list)
         print("Running command: {}".format(command))
         time_str = time.strftime("%d %b %H:%M", time.gmtime())
         if len(self.stressors) == 1:
@@ -245,6 +247,13 @@ def stress_memory(args):
 
     ram = psutil.virtual_memory()
     total_mem_in_gb = ram.total / (1024**3)
+    
+    if args.oom_avoid_bytes is not None:
+        oom_avoid_bytes = args.oom_avoid_bytes
+    elif total_mem_in_gb > 255:
+        oom_avoid_bytes = "5%"
+    else:
+        oom_avoid_bytes = "10%"
     vrt = args.base_time + total_mem_in_gb * args.time_per_gig
     print("Total memory is {:.1f} GiB".format(total_mem_in_gb))
     print(
@@ -299,6 +308,7 @@ def stress_memory(args):
             sng_timeout=args.base_time,
             wrapper_timeout=args.base_time * 2,
             thread_count=0,
+            oom_avoid_bytes=oom_avoid_bytes,
         )
         retval = retval | test_object.run()
         print(test_object.results)
@@ -308,6 +318,7 @@ def stress_memory(args):
             sng_timeout=vrt,
             wrapper_timeout=vrt * 2,
             thread_count=0,
+            oom_avoid_bytes=oom_avoid_bytes,
         )
         retval = retval | test_object.run()
         print(test_object.results)
@@ -317,6 +328,7 @@ def stress_memory(args):
             sng_timeout=vrt,
             wrapper_timeout=vrt * 2,
             thread_count=8,
+            oom_avoid_bytes=oom_avoid_bytes,
         )  # throttle to 8 threads
         retval = retval | test_object.run()
         print(test_object.results)
@@ -450,6 +462,12 @@ def main():
         "--keep-swap",
         action="store_true",
         help="Keep swap file, if added by test",
+    )
+    memory_parser.add_argument(
+        "--oom-avoid-bytes",
+        type=str,
+        help="OOM avoidance memory (default=10%%, 5%% for >255GB)",
+        default=None,
     )
 
     # Disk parameters


### PR DESCRIPTION
The OOM killer is a kernel feature that automatically terminates processes when the system runs out of memory.  The oom-avoid-bytes parameter reserves a certain amount of memory that stress-ng will not use. By default, this is set to 10% of the system's total memory in this script. If a system has more than 255 GB of RAM, this value is reduced to 5%. 

- Added the check to set --oom-avoid-bytes 5% for RAM over 255GB

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:
On some system with a large amount of memory, memory_stress_ng was failing
One hardware provider was seeing this error.
Stress_ng is failing with the oom-avoid-bytes stressor

Running command: stress-ng --aggressive --verify --oom-avoid-bytes 10% --timeout 15409.311904907227 --vm 0
02 May 10:53: Running stress-ng vm stressor for 15409 seconds...
** stress-ng exited with code 3
https://bugs.launchpad.net/dellserver/+bug/2111510

Another hardware vendor was seeing this with a different stressor.
Running command: stress-ng --aggressive --verify --oom-avoid-bytes 10% --timeout 300 --shm-sysv 0
19 Jul 07:09: Running stress-ng shm-sysv stressor for 300 seconds...
** stress-ng exited with code 2


- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
This fix seems to have resolved the issue.
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
