### PR TITLE
Remove pulseaudio-utils for Noble (BugFix)

### DIFF
--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -78,7 +78,7 @@ parts:
       craftctl set version=$version
     stage:
       - version.txt
-################################################################################
+  ################################################################################
   fwts:
     source-tag: "V25.03.00"
     source-depth: 1
@@ -105,19 +105,19 @@ parts:
       - libfdt-dev
       - libbsd-dev
     after: [version-calculator]
-################################################################################
+  ################################################################################
   stress-ng:
     plugin: nil
     stage-packages:
       - stress-ng
     after: [fwts]
-################################################################################
+  ################################################################################
   acpi-tools:
     plugin: nil
     stage-packages:
       - acpica-tools
     after: [stress-ng]
-################################################################################
+  ################################################################################
   checkbox-support:
     plugin: python
     source: checkbox-support
@@ -157,7 +157,7 @@ parts:
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $CRAFT_STAGE/version.txt)"
     override-build: |
       craftctl default
-################################################################################
+  ################################################################################
   checkbox-ng:
     plugin: python
     source: checkbox-ng
@@ -197,11 +197,11 @@ parts:
       - -debian
     build-environment:
       - PYTHONPATH: $CRAFT_PART_INSTALL/usr/lib/python3/dist-packages:${PYTHONPATH:-}
-      - READTHEDOCS: 'True' # simplifies picamera install
+      - READTHEDOCS: "True" # simplifies picamera install
       - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $CRAFT_STAGE/version.txt)"
     override-build: |
       craftctl default
-################################################################################
+  ################################################################################
   checkbox-provider-resource:
     plugin: dump
     source: providers/resource
@@ -229,7 +229,7 @@ parts:
       - libnl-genl-3-dev
       - pkg-config
     after: [checkbox-ng]
-################################################################################
+  ################################################################################
   checkbox-provider-base:
     plugin: dump
     source: providers/base
@@ -302,7 +302,6 @@ parts:
       - obexftp
       - parted
       - pciutils
-      - pulseaudio-utils
       - pyotherside-doc
       - pyotherside-tests
       - qml-module-io-thp-pyotherside
@@ -330,9 +329,9 @@ parts:
       - rt-tests # For realtime performance test
       - mdadm
       - on armhf:
-        - python3-rpi.gpio # only in focal
+          - python3-rpi.gpio # only in focal
       - on arm64:
-        - python3-rpi.gpio # only in focal
+          - python3-rpi.gpio # only in focal
     build-packages:
       - execstack # needed to clear the execstack
       - libasound2-dev
@@ -340,7 +339,7 @@ parts:
     organize:
       usr/lib/lib*.so*: usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/
     after: [checkbox-provider-resource]
-################################################################################
+  ################################################################################
   checkbox-provider-docker:
     plugin: dump
     source: providers/docker
@@ -356,7 +355,7 @@ parts:
     stage-packages:
       - apache2-utils
     after: [checkbox-provider-base]
-################################################################################
+  ################################################################################
   checkbox-provider-tpm2:
     plugin: dump
     source: providers/tpm2
@@ -372,7 +371,7 @@ parts:
     stage-packages:
       - clevis-tpm2
     after: [checkbox-provider-docker]
-################################################################################
+  ################################################################################
   checkbox-provider-iiotg:
     plugin: dump
     source: providers/iiotg
@@ -386,7 +385,7 @@ parts:
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-iiotg --root="$CRAFT_PART_INSTALL"
     after: [checkbox-provider-tpm2]
-################################################################################
+  ################################################################################
   checkbox-provider-sru:
     plugin: dump
     source: providers/sru
@@ -400,7 +399,7 @@ parts:
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-sru --root="$CRAFT_PART_INSTALL"
     after: [checkbox-provider-iiotg]
-################################################################################
+  ################################################################################
   checkbox-provider-gpgpu:
     plugin: dump
     source: providers/gpgpu
@@ -414,7 +413,7 @@ parts:
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-gpgpu --root="$CRAFT_PART_INSTALL"
     after: [checkbox-provider-sru]
-################################################################################
+  ################################################################################
   checkbox-provider-certification-client:
     plugin: dump
     source: providers/certification-client
@@ -428,7 +427,7 @@ parts:
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-certification-client --root="$CRAFT_PART_INSTALL"
     after: [checkbox-provider-gpgpu]
-################################################################################
+  ################################################################################
   checkbox-provider-certification-server:
     plugin: dump
     source: providers/certification-server
@@ -442,7 +441,7 @@ parts:
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-certification-server --root="$CRAFT_PART_INSTALL"
     after: [checkbox-provider-certification-client]
-################################################################################
+  ################################################################################
   checkbox-provider-tutorial:
     plugin: dump
     source: providers/tutorial
@@ -456,24 +455,24 @@ parts:
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-tutorial --root="$CRAFT_PART_INSTALL"
     after: [checkbox-provider-base]
-################################################################################
+  ################################################################################
   gnome-randr:
     source: https://github.com/maxwellainatchi/gnome-randr-rust.git
     plugin: rust
     rust-channel: nightly
     build-packages:
       - libdbus-1-dev
-################################################################################
+  ################################################################################
   rpi-support-binaries:
     plugin: nil
     stage-packages:
       - on armhf:
-        - libraspberrypi0
+          - libraspberrypi0
       - on arm64:
-        - libraspberrypi0
+          - libraspberrypi0
     organize:
       usr/lib/lib*.so: usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/
-################################################################################
+  ################################################################################
   lk-boot-env:
     plugin: nil
     source: .
@@ -485,9 +484,9 @@ parts:
     build-packages:
       - wget
       - on amd64 to armhf:
-        - gcc-arm-linux-gnueabihf:amd64
+          - gcc-arm-linux-gnueabihf:amd64
       - on amd64 to arm64:
-        - gcc-aarch64-linux-gnu:amd64
+          - gcc-aarch64-linux-gnu:amd64
     override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/bin
       if [ "${CRAFT_ARCH_TRIPLET_BUILD_FOR}" = "arm-linux-gnueabihf" ]; then
@@ -498,7 +497,7 @@ parts:
           # native build
           gcc lk-boot-env.c -I/usr/include/ -Iapp/aboot -o ${CRAFT_PART_INSTALL}/bin/lk-boot-env
       fi
-################################################################################
+  ################################################################################
   parts-meta-info:
     plugin: nil
     build-environment:
@@ -508,7 +507,7 @@ parts:
       echo "checkbox-runtime:" >> $CRAFT_PART_INSTALL/parts_meta_info
       echo "$RUNTIME_VERSION" >> $CRAFT_PART_INSTALL/parts_meta_info
     after: [checkbox-provider-certification-server]
-################################################################################
+  ################################################################################
   common-config:
     plugin: dump
     source: config/


### PR DESCRIPTION
Remove pulseaudio-utils for Noble, since pipewire is the default sound server for Noble. And the command provided by checkbox could be trobulesome. This change will only affect desktop image, since none of server and core use pactl at all.

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
https://github.com/canonical/checkbox/issues/2003
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
We are facing [
$XDG_RUNTIME_DIR is not set in checkbox control session](https://github.com/canonical/checkbox/issues/2058) here. However, we can make sure it able to run test after remove `pulseaudio-utils` from checkbox stage-package.
```
-----------------------------[ Running job 3 / 9 ]------------------------------                                                                       
--------------[ Ensure audio sinks are available for detection. ]---------------                                                                       
ID: com.canonical.certification::audio/detect_sinks                                                                                                    
Category: Audio tests                                                                                                                                  
--------------------------------------------------------------------------------                                                                       
Daemon is pipewire, use pipewire function                                                                                                              
ubuntu                                                                                                                                                 
1000                                                                                                                                                   
                                                                                                                                                       
device id:[33] media.class:[Audio/Sink] node.name:[auto_null]                                                                                          
--------------------------------------------------------------------------------                                                                       
Outcome: job passed                                                                                                                                    
-----------------------------[ Running job 4 / 9 ]------------------------------                                                                       
---------------[ Test to ensure audio sources can be detected. ]----------------                                                                       
ID: com.canonical.certification::audio/detect_sources                                                                                                  
Category: Audio tests                                                                                                                                  
--------------------------------------------------------------------------------                                                                       
Daemon is pipewire, use pipewire function                                                                                                              
ubuntu                                                                                                                                                 
1000                                                                                                                                                   
                                                                                                                                                       
media.class:[Audio/Source] couldn't find                                                                                                               
--------------------------------------------------------------------------------                                                                       
Outcome: job failed  
```
https://certification.canonical.com/hardware/202503-36377/submission/442445/

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
