### PR TITLE
Keepalive rpyc connection (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -291,7 +291,7 @@ class RemoteController(ReportsStage, MainLoopStage):
                     keep_running = self._handle_interrupt()
                     if not keep_running:
                         break
-                conn = rpyc.connect(host, port, config=config)
+                conn = rpyc.connect(host, port, config=config, keepalive=True)
                 keep_running = True
 
                 def quitter(msg):


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Whenever the agent fails to close the connection (currently happening on one device, that fails to do so during the watchdog reset test), the session may hang forever. This wasn't an issue when we had a global attribute access timeout but now that we removed it, it is blocking at least one execution. 

This modifies the rpyc connection so that it also implements keepalive. This way the keepalive messages are also used to probe the connection and detect if it was closed. 

Additionally, this should also fix a very rare bug. When asking for interactions, the connection is not kept alive, so it may be unexpectedly closed by an intermidiary.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1995 

## Documentation

N/A

## Tests

Tested on the machine, it now 100% works, before it worked very rarely.