### PR TITLE
Add groups to jobs (New)

### DIFF
--- a/checkbox-ng/plainbox/impl/ctrl.py
+++ b/checkbox-ng/plainbox/impl/ctrl.py
@@ -615,8 +615,3 @@ class SymLinkNest:
                 dest,
                 exc,
             )
-
-        raise SystemExit(
-            "Failed: Cannot have encode and decode mode enabled at the same "
-            "time"
-        )

--- a/checkbox-ng/plainbox/impl/ctrl.py
+++ b/checkbox-ng/plainbox/impl/ctrl.py
@@ -615,3 +615,8 @@ class SymLinkNest:
                 dest,
                 exc,
             )
+
+        raise SystemExit(
+            "Failed: Cannot have encode and decode mode enabled at the same "
+            "time"
+        )

--- a/checkbox-ng/plainbox/impl/depmgr.py
+++ b/checkbox-ng/plainbox/impl/depmgr.py
@@ -401,15 +401,6 @@ class DependencySolver:
             )
         self._clear_state_map()
 
-        # # Create a dict of groups referenced in the pulled jobs
-        # for job in self._pull_solution:
-        #     if hasattr(job, "group") and job.group is not None:
-        #         # Check if the group is already in the map
-        #         if job.group in self._groups:
-        #         self._groups[job.group] = self._groups.get(job.group, []) + [
-        #             job
-        #         ]
-        #         self._jobs_in_groups[job.id] = job.group
         self.create_groups()
         # Print the groups
         if self._groups:
@@ -419,9 +410,7 @@ class DependencySolver:
 
         # Replace the jobs in the pulled map with the group job
         group_solution = self.replace_jobs_by_groups(self._pull_solution)
-        print(
-            "Pulled map after group replacement: {}".format(group_solution)
-        )
+        print("Pulled map after group replacement: {}".format(group_solution))
 
         # Solve again for order dependencies, using the pulled jobs as the
         # new visit list
@@ -594,16 +583,10 @@ class DependencySolver:
         ):
 
             if self._current_group is None:
-                # If the dependency is pointing to a job inside a group, we replace
-                # it with the group job.
+                # If the dependency is pointing to a job inside a group, we
+                # replace it with the group job.
                 if job_id in self._jobs_in_groups:
                     group_name = self._jobs_in_groups[job_id]
-                    # We are in the general phase
-                    # print(
-                    #     "Job {} is inside a group, rpl w group {}".format(
-                    #         job_id, group_name
-                    #     )
-                    # )
                     job_id = "{}{}".format(self.GROUP_PREFIX, group_name)
                     print("---> Analyzing job group {}".format(job_id))
                     deps = job.controller.get_dependency_set(
@@ -615,15 +598,8 @@ class DependencySolver:
                 # If we are in a group, we only care about the dependencies
                 # inside the group
                 if job_id not in self._groups[self._current_group]:
-                    # If the job is not in the current group, we skip it
-                    # print(
-                    #     "Job {} is not in the current group {}".format(
-                    #         job_id, self._current_group
-                    #     )
-                    # )
                     continue
 
-            # print("Continuing with job id: {}".format(job_id))
             try:
                 # We look up the job only in the map of pulled jobs
                 print("**> next job will be {}".format(job_id))
@@ -719,7 +695,11 @@ class DependencySolver:
                     )
                     self._pulled_map[group_job_id] = group_job
                     self._job_state_map[group_job_id] = State.NOT_VISITED
-                    print("*-*adding the job to the state map: {}".format(group_job_id))
+                    print(
+                        "*-*adding the job to the state map: {}".format(
+                            group_job_id
+                        )
+                    )
                     print(self._job_state_map[group_job_id])
                     replaced_solution.append(group_job)
                     added_groups.append(group_name)

--- a/checkbox-ng/plainbox/impl/depmgr.py
+++ b/checkbox-ng/plainbox/impl/depmgr.py
@@ -416,9 +416,10 @@ class DependencySolver:
         # new visit list
         self._clear_state_map()
         self._order_solution = []
-        for job in self._pull_solution:
+        for job in group_solution:
             self._visit(job)
         group_solution = self._order_solution
+        print("*!*!*!Order solution before group replacement: {}".format(group_solution))
 
         # Solve internally for each group
         for group, jobs in self._groups.items():
@@ -459,6 +460,7 @@ class DependencySolver:
         print("********Done solving**********")
 
         # Return the final solution
+        # print("Final solution: {}".format(self._final_solution))
         return self._final_solution
 
     def _visit(self, job, trail=None, pull=False):
@@ -588,11 +590,11 @@ class DependencySolver:
                 if job_id in self._jobs_in_groups:
                     group_name = self._jobs_in_groups[job_id]
                     job_id = "{}{}".format(self.GROUP_PREFIX, group_name)
-                    print("---> Analyzing job group {}".format(job_id))
+                    # print("---> Analyzing job group {}".format(job_id))
                     deps = job.controller.get_dependency_set(
                         job, self._pull_solution
                     )
-                    print("the deps of the group: {}".format(deps))
+                    # print("the deps of the group: {}".format(deps))
                     # We are ordering a group
             else:
                 # If we are in a group, we only care about the dependencies
@@ -602,7 +604,7 @@ class DependencySolver:
 
             try:
                 # We look up the job only in the map of pulled jobs
-                print("**> next job will be {}".format(job_id))
+                # print("**> next job will be {}".format(job_id))
                 next_job = self._pulled_map[job_id]
             except KeyError:
                 # Since this is an order operation, we don't care if the dep
@@ -722,16 +724,16 @@ class DependencySolver:
                 # Replace the group job with the jobs inside the group in the
                 # same position
                 replaced_solution.extend(self._group_solutions[group_name])
-                print(
-                    "---->>> REPLACING group job {} with jobs: {}".format(
-                        job.id, self._group_solutions[group_name]
-                    )
-                )
+                # print(
+                #     "---->>> REPLACING group job {} with jobs: {}".format(
+                #         job.id, self._group_solutions[group_name]
+                #     )
+                # )
             else:
                 # If the job is not a group job, just add it to the solution
                 replaced_solution.append(job)
 
-        print("---->>>Replaced solution: {}".format(replaced_solution))
+        # print("---->>>Replaced solution: {}".format(replaced_solution))
 
         return replaced_solution
 

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -1161,21 +1161,19 @@ class SessionState:
             data["flags"] = data["flags"].replace(Suspend.AUTO_FLAG, "")
             data["flags"] = data["flags"].replace(Suspend.MANUAL_FLAG, "")
             data["id"] = "after-suspend-{}".format(new_job.partial_id)
-            if new_job.after:
-                print(new_job.get_after_dependencies())
-                after_job_list = ["after-suspend-{}".format(x.split("::")[1] ) for x in new_job.get_after_dependencies()]
-                data["after"] = " ".join(after_job_list)
-            if new_job.before:
-                before_job_list = ["after-suspend-{}".format(x.split("::")[1] ) for x in new_job.get_before_dependencies()]
-                data["before"] = " ".join(before_job_list)
-            if new_job.group:
-                data["group"] = "after-suspend-{}".format(new_job.group)
+
             data["_summary"] = "{} after suspend (S3)".format(new_job.summary)
             if new_job.depends:
                 data["depends"] += " {}".format(new_job.id)
             else:
                 data["depends"] = "{}".format(new_job.id)
             data["depends"] += " {}".format(Suspend.AUTO_JOB_ID)
+            if new_job.after:
+                data["after"] += " {}".format(new_job.id)
+            else:
+                data["after"] = "{}".format(new_job.id)
+            if new_job.group:
+                data["group"] = "after-suspend-{}".format(new_job.group)
             self._add_job_unit(
                 JobDefinition(
                     data,
@@ -1203,6 +1201,12 @@ class SessionState:
             else:
                 data["depends"] = "{}".format(new_job.id)
             data["depends"] += " {}".format(Suspend.MANUAL_JOB_ID)
+            if new_job.after:
+                data["after"] += " {}".format(new_job.id)
+            else:
+                data["after"] = "{}".format(new_job.id)
+            if new_job.group:
+                data["group"] = "after-suspend-{}".format(new_job.group)
             self._add_job_unit(
                 JobDefinition(
                     data,

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -917,51 +917,15 @@ class SessionState:
         self._desired_job_list += list(desired_job_list)
         # Reset run list just in case desired_job_list is empty
         self._run_list = []
-        # Try to solve the dependency graph. This is done in a loop as may need
-        # to remove a problematic job and re-try. The loop provides a stop
-        # condition as we will eventually run out of jobs.
-        problems = []
         # Get a copy of all the jobs as we'll be removing elements from this
         # list to come to a stable set in the loop below.
         job_list = self._job_list[:]
-        while self._desired_job_list:
-            # XXX: it might be more efficient to incorporate this 'recovery
-            # mode' right into the solver, this way we'd probably save some
-            # resources or runtime complexity.
-            # TODO: This may hide unwanted errors, since we are just removing
-            # tests from our testplan arbitrarily. We should probably raise
-            # DependencyError immediately.
-            try:
-                self._run_list = DependencySolver.resolve_dependencies(
-                    job_list, self._desired_job_list
-                )
-            except DependencyError as exc:
-                # When a dependency error is detected remove the affected job
-                # form _desired_job_list and try again.
-                if exc.affected_job in self._desired_job_list:
-                    # The job may have been removed by now:
-                    # https://bugs.launchpad.net/plainbox/+bug/1444126
-                    self._desired_job_list.remove(exc.affected_job)
-                if exc.affected_job in job_list:
-                    # If the affected job is in the job list, remove it from
-                    # the job list we're going to consider in the next run.
-                    # This is done so that if a job depends on a broken but
-                    # existing job, it won't constantly re-add the same broken
-                    # job over and over (so that the algorithm can stop).
-                    job_list.remove(exc.affected_job)
-                # Remember each problem, this can be presented by the UI
-                problems.append(exc)
-                raise exc
-                continue
-            else:
-                # Don't iterate the loop if there was no exception
-                break
+        self._run_list = DependencySolver.resolve_dependencies(
+            job_list, self._desired_job_list
+        )
         # Update all job readiness state
         self._recompute_job_readiness()
-        # Return all dependency problems to the caller
-        for problem in problems:
-            logger.error("Dependency problem: %s", str(problem))
-        return problems
+        return
 
     def get_estimated_duration(self, manual_overhead=30.0):
         """

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -1161,6 +1161,15 @@ class SessionState:
             data["flags"] = data["flags"].replace(Suspend.AUTO_FLAG, "")
             data["flags"] = data["flags"].replace(Suspend.MANUAL_FLAG, "")
             data["id"] = "after-suspend-{}".format(new_job.partial_id)
+            if new_job.after:
+                print(new_job.get_after_dependencies())
+                after_job_list = ["after-suspend-{}".format(x.split("::")[1] ) for x in new_job.get_after_dependencies()]
+                data["after"] = " ".join(after_job_list)
+            if new_job.before:
+                before_job_list = ["after-suspend-{}".format(x.split("::")[1] ) for x in new_job.get_before_dependencies()]
+                data["before"] = " ".join(before_job_list)
+            if new_job.group:
+                data["group"] = "after-suspend-{}".format(new_job.group)
             data["_summary"] = "{} after suspend (S3)".format(new_job.summary)
             if new_job.depends:
                 data["depends"] += " {}".format(new_job.id)

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -951,6 +951,7 @@ class SessionState:
                     job_list.remove(exc.affected_job)
                 # Remember each problem, this can be presented by the UI
                 problems.append(exc)
+                raise exc
                 continue
             else:
                 # Don't iterate the loop if there was no exception

--- a/checkbox-ng/plainbox/impl/test_depmgr.py
+++ b/checkbox-ng/plainbox/impl/test_depmgr.py
@@ -461,7 +461,17 @@ class TestDependencySolver(TestCase):
         observed = DependencySolver.resolve_dependencies(job_list)
         self.assertEqual(expected, observed)
 
-    def test_groups_cycle(self):
+    def test_groups_internal_cycle(self):
+        # This tests grouped jobs with dependencies
+        # [G1_1 <- G2_2] [G1_2 <- G2_1]
+        # G2 <- G1 & G2 <- G1
+        G1_1 = make_job(id="G1_1", group="group1", depends="G1_2")
+        G1_2 = make_job(id="G1_2", group="group1", depends="G1_1")
+        job_list = [G1_1, G1_2]
+        with self.assertRaises(DependencyCycleError):
+            DependencySolver.resolve_dependencies(job_list)
+
+    def test_groups_external_cycle(self):
         # This tests grouped jobs with dependencies
         # [G1_1 <- G2_2] [G1_2 <- G2_1]
         # G2 <- G1 & G2 <- G1

--- a/checkbox-ng/plainbox/impl/unit/job.py
+++ b/checkbox-ng/plainbox/impl/unit/job.py
@@ -344,6 +344,10 @@ class JobDefinition(UnitWithId, IJobDefinition):
         return self.get_record_value("before")
 
     @cached_property
+    def group(self):
+        return self.get_record_value("group")
+
+    @cached_property
     def salvages(self):
         return self.get_record_value("salvages")
 
@@ -800,6 +804,7 @@ class JobDefinition(UnitWithId, IJobDefinition):
             depends = "depends"
             after = "after"
             before = "before"
+            group = "group"
             salvages = "salvages"
             requires = "requires"
             shell = "shell"
@@ -990,6 +995,9 @@ class JobDefinition(UnitWithId, IJobDefinition):
                         )
                     ],
                 ),
+            ],
+            fields.group: [
+                concrete_validators.untranslatable,
             ],
             fields.requires: [
                 concrete_validators.untranslatable,

--- a/metabox/metabox/metabox-provider/units/ordering.pxu
+++ b/metabox/metabox/metabox-provider/units/ordering.pxu
@@ -127,23 +127,142 @@ include:
  ordering_6_B
  ordering_6_C
 
-id: ordering_7_B
-flags: simple, also-after-suspend
-command: true
-
-id: ordering_7_A
+id: groups_1_A
 flags: simple
-before: suspend/suspend_advanced_auto, ordering_7_B
 command: true
 
-id: after-suspend-ordering_7_A
+id: groups_1_B
+after: groups_1_A
 flags: simple
-after: suspend/suspend_advanced_auto
-before: after-suspend-ordering_7_B
 command: true
 
-id: ordering_after_suspend
-name: ordering_after_suspend
+id: groups_1_g1
+flags: simple
+after: groups_1_A
+before: groups_1_g2
+group: group_1
+command: true
+
+id: groups_1_g2
+flags: simple
+before: groups_1_B groups_1_D
+group: group_1
+command: true
+
+id: groups_1_C
+after: groups_1_g1 groups_1_B
+flags: simple
+command: true
+
+id: groups_1_D
+flags: simple
+command: true
+
+id: ordering_groups
+name: ordering_groups
 unit: test plan
+_summary: Group order test
 include:
- .*ordering_7.*
+  groups_1_C
+  groups_1_g2
+  groups_1_B
+  groups_1_g1
+  groups_1_A
+# Expected order:
+# groups_1_A, groups_1_g1, groups_1_g2, groups_1_B, groups_1_C
+
+
+id: groups_2_A1
+after: groups_2_B2
+flags: simple
+group: group_A
+command: true
+
+id: groups_2_A2
+group: group_A
+flags: simple
+command: true
+
+id: groups_2_B1
+flags: simple
+after: groups_2_A1
+group: group_B
+command: true
+
+id: groups_2_B2
+flags: simple
+group: group_B
+command: true
+
+id: ordering_groups_cycle
+name: ordering_groups_cycle
+unit: test plan
+_summary: Group cycle test
+include:
+  groups_2_A1
+  groups_2_A2
+  groups_2_B1
+  groups_2_B2
+# Expected cycle error
+
+id: group_template_resource
+category_id: information_gathering
+plugin: resource
+command:
+    echo 'id: 1'
+    echo ''
+    echo 'id: 2'
+
+unit: template
+template-unit: job
+template-resource: group_template_resource
+id: setup_order_{id}
+group: group_{id}
+flags: simple
+command: True
+
+unit: template
+template-unit: job
+template-resource: group_template_resource
+template-id: test_feature_order_A_id
+id: test_feature_order_A_{id}
+group: group_{id}
+after: setup_order_{id}
+before: teardown_order_{id}
+flags: simple
+command: True
+
+unit: template
+template-unit: job
+template-resource: group_template_resource
+template-id: test_feature_order_B_id
+id: test_feature_order_B_{id}
+group: group_{id}
+after: setup_order_{id} test_feature_order_A_{id}
+before: teardown_order_{id}
+flags: simple
+command: True
+
+unit: template
+template-unit: job
+template-resource: group_template_resource
+template-id: teardown_order_id
+id: teardown_order_{id}
+group: group_{id}
+flags: simple
+command: True
+
+id: ordering_groups_template
+name: ordering_groups_template
+unit: test plan
+_summary: Templated group order test
+include:
+  teardown_order_id
+  test_feature_order_B.*
+  test_feature_order_A.*
+  setup_order_id
+bootstrap_include:
+  group_template_resource
+# Expected order:
+# setup_order_1 test_feature_order_A_1 test_feature_order_B_1 teardown_order_1 
+# setup_order_2 test_feature_order_A_2 test_feature_order_B_2 teardown_order_2

--- a/metabox/metabox/scenarios/basic/ordering.py
+++ b/metabox/metabox/scenarios/basic/ordering.py
@@ -176,3 +176,73 @@ class OrderingAfterSuspend(Scenario):
             r".*after-suspend-ordering_7_A"
         ),
     ]
+
+
+@tag("ordering")
+class OrderingGroups(Scenario):
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::ordering_groups
+        forced = yes
+        [test selection]
+        forced = yes
+        [ui]
+        type = silent
+        """
+    )
+    steps = [
+        Start(),
+        AssertPrinted(
+            r"(?m)"
+            r".*groups_1_A\n"
+            r".*groups_1_g1\n"
+            r".*groups_1_g2\n"
+            r".*groups_1_B\n"
+            r".*groups_1_C\n"
+        ),
+    ]
+
+
+@tag("ordering")
+class OrderingGroupsCycle(Scenario):
+    modes = ["local"]
+    steps = [
+        Start("run 2021.com.canonical.certification::ordering_groups_cycle"),
+        AssertPrinted(r"Dependency problem: dependency cycle detected"),
+    ]
+
+
+@tag("ordering")
+class OrderingGroupsTemplate(Scenario):
+    launcher = textwrap.dedent(
+        """
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::ordering_groups_template
+        forced = yes
+        [test selection]
+        forced = yes
+        [ui]
+        type = silent
+        """
+    )
+    steps = [
+        Start(),
+        AssertPrinted(
+            r"(?m)"
+            r".*setup_order_1\n"
+            r".*test_feature_order_A_1\n"
+            r".*test_feature_order_B_1\n"
+            r".*teardown_order_1\n"
+            r".*setup_order_2\n"
+            r".*test_feature_order_A_2\n"
+            r".*test_feature_order_B_2\n"
+            r".*teardown_order_2\n"
+        ),
+    ]


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

This PR introduces groups in checkbox following the spec detailed here:
https://docs.google.com/document/d/1Uf4tV6bYr_rNG39nQ4-_M7NFkiUZFRbn-LWxrs54i2M/edit?tab=t.0

Here are some of the main changes:
 - A new field "group" has been added
 - The "after" deps are now also added to the "after-suspend" jobs
 - The dependency solver looks for the group field and modifies the order accordingly
   - "group_jobs" are created to substitute the groups while solving the dependencies. 
   - If jobs are inside a group, they will be executed together and with no other jobs in between
   - If jobs inside a group have external dependencies, they will be treated as dependencies of the groups
   - First, the deps outside the group are solved, then the deps inside each group.
 - The ordering job including the "after-suspend" flag has been removed, since it failed provider validation. Jobs that use the "after-suspend" flag or sibling jobs can't be used as fields in the deps, since they are not instantiated at validation time.

 - !!! This PR also includes a change in the `update_desired_job_list` function in the session state. The errors raised by `dpmgr` are no longer ignored and fixed silently; they are raised.
 
## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

The new functions have been documented in the code

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Added unittests and metabox tests for the new functionality