### PR TITLE
Nested info-attachment-cert-automated plan for ubuntu core plan(New)

### DIFF
--- a/providers/certification-client/units/client-cert-iot-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-iot-desktop-24-04.pxu
@@ -162,6 +162,7 @@ nested_part:
   socketcan-auto-local
   socketcan-auto-remote
   submission-cert-automated
+  info-attachment-cert-automated
   thunderbolt-cert-automated
   tpm-cert-automated
   usb-automated

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-16.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-16.pxu
@@ -106,6 +106,7 @@ bootstrap_include:
   net_if_management
 nested_part:
   submission-cert-automated
+  info-attachment-cert-automated
   self-automated
   iot-fwts-automated
   acpi-automated

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-18.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-18.pxu
@@ -108,6 +108,7 @@ bootstrap_include:
   net_if_management
 nested_part:
   submission-cert-automated
+  info-attachment-cert-automated
   self-automated
   iot-fwts-automated
   acpi-automated

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-20.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-20.pxu
@@ -109,6 +109,7 @@ bootstrap_include:
   net_if_management
 nested_part:
   submission-cert-automated
+  info-attachment-cert-automated
   self-automated
   ubuntucore-automated
   iot-fwts-automated

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-22.pxu
@@ -110,6 +110,7 @@ bootstrap_include:
   net_if_management
 nested_part:
   submission-cert-automated
+  info-attachment-cert-automated
   self-automated
   ubuntucore-automated
   iot-fwts-automated

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-24.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-24.pxu
@@ -151,6 +151,7 @@ nested_part:
   socketcan-auto-local
   socketcan-auto-remote
   submission-cert-automated
+  info-attachment-cert-automated
   tpm-cert-automated
   thunderbolt-cert-automated
   ubuntucore-automated


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
We found that plan of `info-attachment-cert-automated` does not nested to ubuntu core plan. And that could cause ubuntu core and server test for iot device lack of some informations such like build stamp and so on.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
```
com.canonical.plainbox::manifest
com.canonical.certification::executable
com.canonical.certification::interface
com.canonical.certification::connections
com.canonical.certification::model_assertion
com.canonical.certification::serial_assertion
com.canonical.certification::net_if_management
com.canonical.certification::net_if_management_attachment
com.canonical.certification::lspci_attachment
com.canonical.certification::lsusb_attachment
com.canonical.certification::rtc
com.canonical.certification::sleep
com.canonical.certification::parts_meta_info_attachment
com.canonical.certification::snap
com.canonical.certification::package
com.canonical.certification::module
com.canonical.certification::kernel_cmdline_attachment
com.canonical.certification::lsblk_attachment
com.canonical.certification::dmi_present
com.canonical.certification::dmi
com.canonical.certification::cpuinfo
com.canonical.certification::system_info_json
com.canonical.certification::lspci_standard_config_json
com.canonical.certification::dmi_attachment
com.canonical.certification::efi
com.canonical.certification::requirements
com.canonical.certification::sysfs_attachment
com.canonical.certification::udev_json
com.canonical.certification::meminfo
com.canonical.certification::environment
com.canonical.certification::uname
com.canonical.certification::dkms_info_json
com.canonical.certification::udev_attachment
com.canonical.certification::raw_devices_dmi_json
com.canonical.certification::cdimage
com.canonical.certification::dpkg
com.canonical.certification::modprobe_json
com.canonical.certification::info/kernel_config
com.canonical.certification::kernel_config_attachment
com.canonical.certification::lsb
com.canonical.certification::device
com.canonical.certification::miscellanea/submission-resources
com.canonical.certification::info/systemd-analyze
com.canonical.certification::info/systemd-analyze-critical-chain
com.canonical.certification::info/kernel-config-iommu-flag
com.canonical.certification::disk/encryption/detect
com.canonical.certification::image/model-grade
com.canonical.certification::miscellanea/secure_boot_mode_MISSING_PARAM_1
com.canonical.certification::acpi/oem_osi
com.canonical.certification::audio/detect-playback-devices
com.canonical.certification::audio/detect-capture-devices
com.canonical.certification::audio/alsa-loopback-automated
com.canonical.certification::bluetooth/detect-output
com.canonical.certification::bluetooth/bluetooth_obex_send
com.canonical.certification::bluetooth/detect
com.canonical.certification::bluetooth/bluez-controller-detect
com.canonical.certification::cpu/scaling_test
com.canonical.certification::cpu/scaling_test-log-attach
com.canonical.certification::cpu/maxfreq_test
com.canonical.certification::cpu/maxfreq_test-log-attach
com.canonical.certification::cpu/clocktest
com.canonical.certification::cpu_offlining
com.canonical.certification::cpu/offlining_test
com.canonical.certification::cpu/topology
com.canonical.certification::cpu/cstates
com.canonical.certification::cpu/cstates_results.log
com.canonical.certification::disk/detect
com.canonical.certification::disk/check-software-raid
com.canonical.certification::docker/info
com.canonical.certification::docker/version
com.canonical.certification::docker/run_amd64
com.canonical.certification::docker/interative_amd64
com.canonical.certification::docker/diff_amd64
com.canonical.certification::docker/copy_amd64
com.canonical.certification::docker/inspect_amd64
com.canonical.certification::docker/kill_amd64
com.canonical.certification::docker/build-single_amd64
com.canonical.certification::docker/start-stop_amd64
com.canonical.certification::docker/deploy-registry_amd64
com.canonical.certification::docker/export-and-import_amd64
com.canonical.certification::docker/save-and-load_amd64
com.canonical.certification::docker/commit_amd64
com.canonical.certification::docker/update_amd64
com.canonical.certification::docker/restart-on-failure_amd64
com.canonical.certification::docker/restart-always_amd64
com.canonical.certification::docker/compose-single_amd64
com.canonical.certification::docker/compose-and-basic_amd64
com.canonical.certification::docker/compose-restart_amd64
com.canonical.certification::edac/detect
com.canonical.certification::edac/default-report
com.canonical.certification::eeprom/read-write
com.canonical.certification::ethernet/detect
com.canonical.certification::ethernet/ping-with-any-cable-interface
com.canonical.certification::firmware/fwts_desktop_diagnosis
com.canonical.certification::firmware/fwts_desktop_diagnosis_results.log.gz
com.canonical.certification::i2c/i2c-bus-detect
com.canonical.certification::i2c/i2c-device-detect
com.canonical.certification::ishtp/module-detect
com.canonical.certification::ishtp/device-detect
com.canonical.certification::eclite/module-detect
com.canonical.certification::eclite/temperature-reading-from-thermal-acpitz
com.canonical.certification::ubuntu_core_features
com.canonical.certification::kernel-snap/booted-kernel-matches-current-grub
com.canonical.certification::mei/check-module
com.canonical.certification::mei/check-device
com.canonical.certification::mei/get-firmware-version
com.canonical.certification::memory/info
com.canonical.certification::ipv6_detect
com.canonical.certification::ipv6_link_local_address_any_if
com.canonical.certification::networking/predictable_names
com.canonical.certification::power-management/warm-reboot
com.canonical.certification::power-management/post-warm-reboot
com.canonical.certification::power-management/cold-reboot
com.canonical.certification::power-management/post-cold-reboot
com.canonical.certification::qep/qep-device-driver-for-4bc3
com.canonical.certification::qep/qep-device-driver-for-4b81
com.canonical.certification::qep/qep-device-driver-for-4b82
com.canonical.certification::qep/qep-device-driver-for-4b83
com.canonical.certification::qep/qep-device-node-for-4bc3
com.canonical.certification::qep/qep-device-node-for-4b81
com.canonical.certification::qep/qep-device-node-for-4b82
com.canonical.certification::qep/qep-device-node-for-4b83
com.canonical.certification::rtc/rtc_number
com.canonical.certification::rtc/rtc_alarm_rtc0
com.canonical.certification::rtc/rtc_clock_rtc0
com.canonical.certification::snappy/snap-list
com.canonical.certification::snappy/snap-search
com.canonical.certification::snappy/snap-install
com.canonical.certification::snappy/snap-refresh-automated
com.canonical.certification::snappy/snap-revert-automated
com.canonical.certification::snappy/snap-reupdate-automated
com.canonical.certification::snappy/snap-remove
com.canonical.certification::snappy/test-store-install-beta
com.canonical.certification::snappy/test-store-install-edge
com.canonical.certification::snappy/test-system-confinement
com.canonical.certification::snappy/test-snaps-confinement
com.canonical.certification::snap_revision_info
com.canonical.certification::snapd/snap-refresh-snapd-snapd-to-base-rev
com.canonical.certification::snapd/log-attach-after-snap-refresh-snapd-snapd-to-base-rev
com.canonical.certification::snapd/snap-verify-after-refresh-snapd-snapd-to-base-rev
com.canonical.certification::snapd/snap-revert-snapd-snapd-from-base-rev
com.canonical.certification::snapd/log-attach-after-snap-revert-snapd-snapd-from-base-rev
com.canonical.certification::snapd/snap-verify-after-revert-snapd-snapd-from-base-rev
com.canonical.certification::snapd/snap-refresh-snapd-snapd-to-stable-rev
com.canonical.certification::snapd/log-attach-after-snap-refresh-snapd-snapd-to-stable-rev
com.canonical.certification::snapd/snap-verify-after-refresh-snapd-snapd-to-stable-rev
com.canonical.certification::snapd/snap-revert-snapd-snapd-from-stable-rev
com.canonical.certification::snapd/log-attach-after-snap-revert-snapd-snapd-from-stable-rev
com.canonical.certification::snapd/snap-verify-after-revert-snapd-snapd-from-stable-rev
com.canonical.certification::socketcan/modprobe_vcan
com.canonical.certification::socketcan/send_packet_local_sff_virtual
com.canonical.certification::socketcan/send_packet_local_eff_virtual
com.canonical.certification::socketcan/send_packet_local_fd_virtual
com.canonical.certification::acpi_sleep_attachment
com.canonical.certification::codecs_attachment
com.canonical.certification::cpuinfo_attachment
com.canonical.certification::dkms_info_attachment
com.canonical.certification::dmesg_attachment
com.canonical.certification::dmidecode_attachment
com.canonical.certification::dpkg_attachment
com.canonical.certification::efi_attachment
com.canonical.certification::info/buildstamp
com.canonical.certification::info/disk_partitions
com.canonical.certification::info/touchpad_driver
com.canonical.certification::installer_debug.gz
com.canonical.certification::lsmod_attachment
com.canonical.certification::lspci_standard_config_attachment
com.canonical.certification::lstopo_visual_attachment
com.canonical.certification::meminfo_attachment
com.canonical.certification::modinfo_attachment
com.canonical.certification::modprobe_attachment
com.canonical.certification::modules_attachment
com.canonical.certification::sysctl_attachment
com.canonical.certification::firmware/fwts_dump
com.canonical.certification::firmware/fwts_dump_acpi_attachment.gz
com.canonical.certification::info/secure-boot-check
com.canonical.certification::tpm2/fwts-event-log-dump
com.canonical.certification::clevis-encrypt-tpm2/precheck
com.canonical.certification::clevis-encrypt-tpm2/detect-rsa-capabilities
com.canonical.certification::clevis-encrypt-tpm2/rsa
com.canonical.certification::clevis-encrypt-tpm2/detect-ecc-capabilities
com.canonical.certification::clevis-encrypt-tpm2/ecc
com.canonical.certification::usb/storage-detect
com.canonical.certification::usb-dwc3/driver-detect
com.canonical.certification::usb-dwc3/module-detect
com.canonical.certification::watchdog/detect
com.canonical.certification::watchdog/systemd-config
com.canonical.certification::watchdog/trigger-system-reset-auto
com.canonical.certification::watchdog/post-trigger-system-reset-auto
com.canonical.certification::wireless/detect
com.canonical.certification::wwan/detect
com.canonical.certification::suspend/suspend_advanced_auto
com.canonical.certification::after-suspend-audio/detect-playback-devices
com.canonical.certification::after-suspend-audio/detect-capture-devices
com.canonical.certification::after-suspend-audio/alsa-loopback-automated
com.canonical.certification::after-suspend-bluetooth/bluetooth_obex_send
com.canonical.certification::after-suspend-eeprom/read-write
com.canonical.certification::after-suspend-ethernet/detect
com.canonical.certification::after-suspend-ethernet/ping-with-any-cable-interface
com.canonical.certification::after-suspend-rtc/rtc_number
com.canonical.certification::after-suspend-rtc/rtc_alarm_rtc0
com.canonical.certification::after-suspend-rtc/rtc_clock_rtc0
com.canonical.certification::after-suspend-usb/storage-detect
com.canonical.certification::after-suspend-wwan/detect
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
