### PR TITLE
Fix the regression issue where suspend stress log increments incorrectly (Bugfix)

### DIFF
--- a/providers/base/bin/suspend_trigger.py
+++ b/providers/base/bin/suspend_trigger.py
@@ -5,6 +5,7 @@ import platform
 import subprocess
 import sys
 import time
+import os
 
 from checkbox_support.scripts import fwts_test
 
@@ -72,6 +73,11 @@ def main(args=sys.argv[1:]):
             "Running: {} to suspend the system".format(" ".join(suspend_cmd))
         )
         subprocess.check_call(suspend_cmd)
+
+    log_path = "/tmp/fwts_results.log"
+    if os.path.exists(log_path):
+        print(f"Removing {log_path}...")
+        os.remove(log_path)
 
 
 if __name__ == "__main__":

--- a/providers/base/bin/suspend_trigger.py
+++ b/providers/base/bin/suspend_trigger.py
@@ -74,6 +74,7 @@ def main(args=sys.argv[1:]):
         )
         subprocess.check_call(suspend_cmd)
 
+    # Clean up the FWTS log file from its default path.
     log_path = "/tmp/fwts_results.log"
     if os.path.exists(log_path):
         print("Removing {}...".format(log_path))

--- a/providers/base/bin/suspend_trigger.py
+++ b/providers/base/bin/suspend_trigger.py
@@ -76,7 +76,7 @@ def main(args=sys.argv[1:]):
 
     log_path = "/tmp/fwts_results.log"
     if os.path.exists(log_path):
-        print(f"Removing {log_path}...")
+        print("Removing {}...".format(log_path))
         os.remove(log_path)
 
 

--- a/providers/base/tests/test_suspend_trigger.py
+++ b/providers/base/tests/test_suspend_trigger.py
@@ -80,8 +80,12 @@ class TestSuspendTriggerFWTS(unittest.TestCase):
 @patch("os.path.exists")
 class TestSuspendTriggerRTCWake(unittest.TestCase):
     def test_rtcwake_path_success_with_args(
-        self, mock_exists, mock_remove, mock_machine, mock_check_call,
-        mock_fwts_test
+        self,
+        mock_exists,
+        mock_remove,
+        mock_machine,
+        mock_check_call,
+        mock_fwts_test,
     ):
         """
         Tests the rtcwake/systemctl path on aarch64 with custom arguments.
@@ -112,8 +116,12 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         self.assertEqual(mock_check_call.call_count, 2)
 
     def test_rtcwake_path_with_defaults(
-        self, mock_exists, mock_remove, mock_machine, mock_check_call,
-        mock_fwts_test
+        self,
+        mock_exists,
+        mock_remove,
+        mock_machine,
+        mock_check_call,
+        mock_fwts_test,
     ):
         """
         Tests the rtcwake/systemctl path without any argument.
@@ -140,8 +148,12 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         mock_check_call.assert_has_calls(subprocess_calls)
 
     def test_rtcwake_command_failure(
-        self, mock_exists, mock_remove, mock_machine, mock_check_call,
-        mock_fwts_test
+        self,
+        mock_exists,
+        mock_remove,
+        mock_machine,
+        mock_check_call,
+        mock_fwts_test,
     ):
         """
         Tests the case where the rtcwake command fails.
@@ -162,8 +174,12 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         self.assertIn("rtcwake", mock_check_call.call_args[0][0])
 
     def test_suspend_command_failure(
-        self, mock_exists, mock_remove, mock_machine, mock_check_call,
-        mock_fwts_test
+        self,
+        mock_exists,
+        mock_remove,
+        mock_machine,
+        mock_check_call,
+        mock_fwts_test,
     ):
         """
         Tests the case where the systemctl suspend command fails.
@@ -184,15 +200,19 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         self.assertIn("systemctl", mock_check_call.call_args_list[1][0][0])
 
     def test_log_file_removed_if_exists(
-        self, mock_exists, mock_remove, mock_machine, mock_check_call,
-        mock_fwts_test
+        self,
+        mock_exists,
+        mock_remove,
+        mock_machine,
+        mock_check_call,
+        mock_fwts_test,
     ):
         """
         Tests that /tmp/fwts_results.log is removed if it exists
         after suspend command runs.
         """
         mock_machine.return_value = "aarch64"
-        mock_exists.return_value = True # Simulate file exists
+        mock_exists.return_value = True  # Simulate file exists
         mock_check_call.side_effect = [None, None]
 
         suspend_trigger.main([])
@@ -209,24 +229,30 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
             "30",
         ]
         expected_suspend_cmd = ["systemctl", "suspend"]
-        mock_check_call.assert_has_calls([
-            call(expected_rtcwake_cmd),
-            call(expected_suspend_cmd),
-        ])
+        mock_check_call.assert_has_calls(
+            [
+                call(expected_rtcwake_cmd),
+                call(expected_suspend_cmd),
+            ]
+        )
 
         # Verify log file existence check and removal
         mock_exists.assert_any_call("/tmp/fwts_results.log")
         mock_remove.assert_called_once_with("/tmp/fwts_results.log")
 
     def test_log_file_not_removed_if_missing(
-        self, mock_exists, mock_remove, mock_machine, mock_check_call,
-        mock_fwts_test
+        self,
+        mock_exists,
+        mock_remove,
+        mock_machine,
+        mock_check_call,
+        mock_fwts_test,
     ):
         """
         Tests that /tmp/fwts_results.log is not removed if it does not exist.
         """
         mock_machine.return_value = "aarch64"
-        mock_exists.return_value = False # Simulate file missing
+        mock_exists.return_value = False  # Simulate file missing
         mock_check_call.side_effect = [None, None]
 
         suspend_trigger.main([])

--- a/providers/base/tests/test_suspend_trigger.py
+++ b/providers/base/tests/test_suspend_trigger.py
@@ -76,9 +76,12 @@ class TestSuspendTriggerFWTS(unittest.TestCase):
 @patch("suspend_trigger.fwts_test")
 @patch("suspend_trigger.subprocess.check_call")
 @patch("suspend_trigger.platform.machine")
+@patch("os.remove")
+@patch("os.path.exists")
 class TestSuspendTriggerRTCWake(unittest.TestCase):
     def test_rtcwake_path_success_with_args(
-        self, mock_machine, mock_check_call, mock_fwts_test
+        self, mock_exists, mock_remove, mock_machine, mock_check_call,
+        mock_fwts_test
     ):
         """
         Tests the rtcwake/systemctl path on aarch64 with custom arguments.
@@ -109,7 +112,8 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         self.assertEqual(mock_check_call.call_count, 2)
 
     def test_rtcwake_path_with_defaults(
-        self, mock_machine, mock_check_call, mock_fwts_test
+        self, mock_exists, mock_remove, mock_machine, mock_check_call,
+        mock_fwts_test
     ):
         """
         Tests the rtcwake/systemctl path without any argument.
@@ -136,7 +140,8 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         mock_check_call.assert_has_calls(subprocess_calls)
 
     def test_rtcwake_command_failure(
-        self, mock_machine, mock_check_call, mock_fwts_test
+        self, mock_exists, mock_remove, mock_machine, mock_check_call,
+        mock_fwts_test
     ):
         """
         Tests the case where the rtcwake command fails.
@@ -157,7 +162,8 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         self.assertIn("rtcwake", mock_check_call.call_args[0][0])
 
     def test_suspend_command_failure(
-        self, mock_machine, mock_check_call, mock_fwts_test
+        self, mock_exists, mock_remove, mock_machine, mock_check_call,
+        mock_fwts_test
     ):
         """
         Tests the case where the systemctl suspend command fails.
@@ -176,3 +182,53 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         self.assertEqual(mock_check_call.call_count, 2)
         self.assertIn("rtcwake", mock_check_call.call_args_list[0][0][0])
         self.assertIn("systemctl", mock_check_call.call_args_list[1][0][0])
+
+    def test_log_file_removed_if_exists(
+        self, mock_exists, mock_remove, mock_machine, mock_check_call,
+        mock_fwts_test
+    ):
+        """
+        Tests that /tmp/fwts_results.log is removed if it exists
+        after suspend command runs.
+        """
+        mock_machine.return_value = "aarch64"
+        mock_exists.return_value = True # Simulate file exists
+        mock_check_call.side_effect = [None, None]
+
+        suspend_trigger.main([])
+
+        # Verify commands were called
+        expected_rtcwake_cmd = [
+            "rtcwake",
+            "--verbose",
+            "--device",
+            "/dev/rtc0",
+            "--mode",
+            "no",
+            "--seconds",
+            "30",
+        ]
+        expected_suspend_cmd = ["systemctl", "suspend"]
+        mock_check_call.assert_has_calls([
+            call(expected_rtcwake_cmd),
+            call(expected_suspend_cmd),
+        ])
+
+        # Verify log file existence check and removal
+        mock_exists.assert_any_call("/tmp/fwts_results.log")
+        mock_remove.assert_called_once_with("/tmp/fwts_results.log")
+
+    def test_log_file_not_removed_if_missing(
+        self, mock_exists, mock_remove, mock_machine, mock_check_call,
+        mock_fwts_test
+    ):
+        """
+        Tests that /tmp/fwts_results.log is not removed if it does not exist.
+        """
+        mock_machine.return_value = "aarch64"
+        mock_exists.return_value = False # Simulate file missing
+        mock_check_call.side_effect = [None, None]
+
+        suspend_trigger.main([])
+        # Verify remove was never called
+        mock_remove.assert_not_called()

--- a/providers/base/units/stress/suspend_cycles_reboot.pxu
+++ b/providers/base/units/stress/suspend_cycles_reboot.pxu
@@ -81,6 +81,7 @@ user: root
 command:
    echo "Current boot ID is: $(tr -d - < /proc/sys/kernel/random/boot_id)"
    suspend_trigger.py --wait "${STRESS_S3_INIT_DELAY:-120}" --check-delay "${STRESS_S3_WAIT_DELAY:-45}" --sleep-delay "${STRESS_S3_SLEEP_DELAY:-30}" --rtc-device "${RTC_DEVICE_FILE:-/dev/rtc0}" 2>&1 | tee -a "$PLAINBOX_SESSION_SHARE"/suspend_cycles_with_reboot_total.log
+   rm /tmp/fwts_results.log
 summary:
     Suspend and resume device (suspend cycle 1, reboot cycle 1)
 _purpose: Suspend and resume device (suspend cycle 1, reboot cycle 1)
@@ -107,6 +108,7 @@ user: root
 command:
  echo "Current boot ID is: $(tr -d - < /proc/sys/kernel/random/boot_id)"
  suspend_trigger.py --wait "${STRESS_S3_INIT_DELAY:-120}" --check-delay "${STRESS_S3_WAIT_DELAY:-45}" --sleep-delay "${STRESS_S3_SLEEP_DELAY:-30}" --rtc-device "${RTC_DEVICE_FILE:-/dev/rtc0}" 2>&1 | tee -a "$PLAINBOX_SESSION_SHARE"/suspend_cycles_with_reboot_total.log
+ rm /tmp/fwts_results.log
 summary:
     Suspend and resume device (suspend cycle 1, reboot cycle {{suspend_reboot_id}})
 
@@ -131,6 +133,7 @@ user: root
 command:
  echo "Current boot ID is: $(tr -d - < /proc/sys/kernel/random/boot_id)"
  suspend_trigger.py --check-delay "${STRESS_S3_WAIT_DELAY:-45}" --sleep-delay "${STRESS_S3_SLEEP_DELAY:-30}" --rtc-device "${RTC_DEVICE_FILE:-/dev/rtc0}" 2>&1 | tee -a "$PLAINBOX_SESSION_SHARE"/suspend_cycles_with_reboot_total.log
+ rm /tmp/fwts_results.log
 summary:
     Suspend and resume device (suspend cycle {{suspend_id}}, reboot cycle {{suspend_reboot_id}})
 _summary:

--- a/providers/base/units/stress/suspend_cycles_reboot.pxu
+++ b/providers/base/units/stress/suspend_cycles_reboot.pxu
@@ -81,7 +81,6 @@ user: root
 command:
    echo "Current boot ID is: $(tr -d - < /proc/sys/kernel/random/boot_id)"
    suspend_trigger.py --wait "${STRESS_S3_INIT_DELAY:-120}" --check-delay "${STRESS_S3_WAIT_DELAY:-45}" --sleep-delay "${STRESS_S3_SLEEP_DELAY:-30}" --rtc-device "${RTC_DEVICE_FILE:-/dev/rtc0}" 2>&1 | tee -a "$PLAINBOX_SESSION_SHARE"/suspend_cycles_with_reboot_total.log
-   rm /tmp/fwts_results.log
 summary:
     Suspend and resume device (suspend cycle 1, reboot cycle 1)
 _purpose: Suspend and resume device (suspend cycle 1, reboot cycle 1)
@@ -108,7 +107,6 @@ user: root
 command:
  echo "Current boot ID is: $(tr -d - < /proc/sys/kernel/random/boot_id)"
  suspend_trigger.py --wait "${STRESS_S3_INIT_DELAY:-120}" --check-delay "${STRESS_S3_WAIT_DELAY:-45}" --sleep-delay "${STRESS_S3_SLEEP_DELAY:-30}" --rtc-device "${RTC_DEVICE_FILE:-/dev/rtc0}" 2>&1 | tee -a "$PLAINBOX_SESSION_SHARE"/suspend_cycles_with_reboot_total.log
- rm /tmp/fwts_results.log
 summary:
     Suspend and resume device (suspend cycle 1, reboot cycle {{suspend_reboot_id}})
 
@@ -133,7 +131,6 @@ user: root
 command:
  echo "Current boot ID is: $(tr -d - < /proc/sys/kernel/random/boot_id)"
  suspend_trigger.py --check-delay "${STRESS_S3_WAIT_DELAY:-45}" --sleep-delay "${STRESS_S3_SLEEP_DELAY:-30}" --rtc-device "${RTC_DEVICE_FILE:-/dev/rtc0}" 2>&1 | tee -a "$PLAINBOX_SESSION_SHARE"/suspend_cycles_with_reboot_total.log
- rm /tmp/fwts_results.log
 summary:
     Suspend and resume device (suspend cycle {{suspend_id}}, reboot cycle {{suspend_reboot_id}})
 _summary:


### PR DESCRIPTION
Due to PR #1981, the suspend.sh file was removed.
As the result, the suspend log is counting cumulatively as (1+2+3)*3,
but it should count individually as (1+1+1)*3 to save the log correctly each time.

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
https://warthogs.atlassian.net/browse/OEMQA-6362
The log counted 1395 times.
((1+30)*30/2)*3=1395

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
checkbox.conf
STRESS_S3_ITERATIONS = 3
STRESS_SUSPEND_REBOOT_ITERATIONS = 3

Before(fail) - (1+2+3)*3 =18 iterations
https://certification.canonical.com/hardware/202508-37804/submission/444584/
After(pass) - (1+1+1)*3 = 9 iterations
https://certification.canonical.com/hardware/202508-37804/submission/444906/
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
