### PR TITLE
Add testing DSS on Canonical K8s (New)

### DIFF
--- a/.github/workflows/testflinger-contrib-dss-regression.yaml
+++ b/.github/workflows/testflinger-contrib-dss-regression.yaml
@@ -1,5 +1,5 @@
 name: Data Science Stack (DSS) Regression Testing
-run-name: Testing DSS ${{ inputs.dss_channel }} on microk8s ${{ inputs.microk8s_channel }}
+run-name: Testing DSS ${{ inputs.dss_channel }} on ${{ inputs.k8s_type }} ${{ inputs.k8s_channel }}
 permissions:
   contents: read
 on:
@@ -7,34 +7,31 @@ on:
     inputs:
       dss_channel:
         description: "Channel of the DSS snap to test"
-        default: 1.0/stable
+        default: 1.1/stable
         required: false
         type: choice
         options:
           - 1.0/stable
           - 1.0/edge
-      # XXX:@motjuste: enable after we can test on Canonical K8s
-      #
-      #     - 1.1/stable
-      #     - 1.1/edge
-      #     - latest/stable
-      #     - latest/edge
-      # k8s_type:
-      #   description: "The type of K8s to deploy"
-      #   default: "microk8s"
-      #   required: false
-      #   type: choice
-      #   options:
-      #     - microk8s
-      #     - canonical-k8s
-      #
-      microk8s_channel:
-        description: "Channel of the microk8s snap to deploy"
-        default: "1.28/stable"
+          - 1.1/stable
+          - 1.1/edge
+          - latest/stable
+          - latest/edge
+      k8s_type:
+        description: "The type of K8s to deploy"
+        default: "canonical-k8s"
+        required: false
+        type: choice
+        options:
+          - microk8s
+          - canonical-k8s
+      k8s_channel:
+        description: "Channel of the appropriate k8s snap to deploy"
+        default: "1.32-classic/stable"
         type: string
       kubectl_channel:
         description: "Channel of kubectl snap to use"
-        default: "1.29/stable"
+        default: "1.31/stable"
         type: string
       nvidia_gpu_operator_version:
         description: "Version of the NVIDIA GPU Operator to install"
@@ -105,7 +102,8 @@ jobs:
           ENV_QUEUE: "${{ matrix.queue.name }}"
           ENV_PROVISION_DATA: "${{ matrix.queue.provision_data }}"
           ENV_DSS_CHANNEL: "${{ inputs.dss_channel }}"
-          ENV_MICROK8S_CHANNEL: "${{ inputs.microk8s_channel }}"
+          ENV_K8S_TYPE: "${{ inputs.k8s_type }}"
+          ENV_K8S_CHANNEL: "${{ inputs.k8s_channel }}"
           ENV_CB_DSS_SNAP: "${{ steps.built-snap.outputs.local_path }}"
           ENV_LAUNCHER: "launchers/checkbox-dss.conf"
           ENV_KUBECTL_CHANNEL: "${{ inputs.kubectl_channel }}"
@@ -118,7 +116,7 @@ jobs:
           cat default_manifest.conf
           echo "::endgroup::"
 
-          envsubst '$ENV_DSS_CHANNEL $ENV_KUBECTL_CHANNEL $ENV_MICROK8S_CHANNEL $ENV_NVIDIA_OPERATOR_VERSION $ENV_INTEL_PLUGIN_VERSION' \
+          envsubst '$ENV_DSS_CHANNEL $ENV_KUBECTL_CHANNEL $ENV_K8S_CHANNEL $ENV_K8S_TYPE $ENV_NVIDIA_OPERATOR_VERSION $ENV_INTEL_PLUGIN_VERSION' \
             < testflinger/setup-def.conf > setup.conf
           echo "::group::Built setup launcher"
           cat setup.conf

--- a/contrib/checkbox-dss-validation/README.md
+++ b/contrib/checkbox-dss-validation/README.md
@@ -36,13 +36,21 @@ systemctl status snap.checkbox-dss.remote-slave.service
 > We are migrating to using `setup_include` from Checkbox.
 > While it is not available, installing dependencies is currently done in a separate test plan.
 
-Run Checkbox CLI with the setup launcher:
+DSS 1.0/stable works on Microk8s, whereas DSS 1.1/stable onwards
+DSS will work on Canonical K8s.
+There are accordingly the following launchers available:
+
+- `launchers/setup-microk8s.conf`
+- `launchers/setup-canonical-k8s.conf`
+
+Run Checkbox CLI with the Microk8s setup launcher as below
+substituting the appropriate launcher to setup Canonical K8s:
 
 ```shell
-checkbox-dss.checkbox-cli control 127.0.0.1 launchers/setup.conf
+checkbox-dss.checkbox-cli control 127.0.0.1 launchers/setup-microk8s.conf
 ```
 
-By default it will attempt to install the following:
+By default, the Microk8s setup will attempt to install the following:
 
 - `microk8s` snap from channel `1.28/stable` in `--classic` mode
 - `data-science-stack` snap from channel `1.0/stable`
@@ -53,7 +61,12 @@ By default it will attempt to install the following:
 - Setup the Intel GPU Plugin `v0.30.0` in `microk8s`
   - Only if there's a manifest entry with `com.canonical.contrib::has_intel_gpus = true`
 
-Please edit the environment section in the setup launcher to customize the versions.
+The difference in the Canonical K8s launcher will be:
+
+- Instead of `microk8s`, `k8s` snap from channel `1.32-classic/stable` in `--classic` mode.
+- `data-science-stack` snap from channel `1.1/stable`
+
+Please edit the environment section in the appropriate setup launcher to customize the versions.
 You can add a `[manifest]` section too with the appropriate entries to setup appropriate GPUs.
 
 # Automated Run

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/setup.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/setup.pxu
@@ -28,7 +28,15 @@ flags: simple
 _summary: Install Snap microk8s with classic confinement (classic for GPU support)
 estimated_duration: 2m
 command:
-  sudo snap install microk8s --classic --channel="${SETUP_MICROK8S_CHANNEL}"
+  sudo snap install microk8s --classic --channel="${SETUP_K8S_CHANNEL}"
+
+id: setup_dss/install_snap_k8s
+category_id: setup-dss-regress
+flags: simple
+_summary: Install Snap k8s with classic confinement (classic for GPU support)
+estimated_duration: 2m
+command:
+  sudo snap install k8s --classic --channel="${SETUP_K8S_CHANNEL}"
 
 id: setup_dss/install_package_intel-gpu-tools
 category_id: setup-dss-regress
@@ -61,9 +69,8 @@ command:
 
 id: setup_dss/create_kube_config_directory
 category_id: setup-dss-regress
-depends: setup_dss/enable_microk8s_addons
 flags: simple
-_summary: Write out the kubeconfig for the microk8s cluster
+_summary: Create directory to store the kubeconfig of cluster
 estimated_duration: 2s
 command: mkdir -p "${HOME}/.kube"
 
@@ -112,5 +119,62 @@ estimated_duration: 45m
 command:
   timeout 45m k8s_gpu_setup.py \
     --microk8s \
+    intel \
+    "${SETUP_INTEL_GPU_PLUGIN_VERSION}"
+
+id: setup_dss/bootstrap_and_enable_canonical_k8s
+category_id: setup-dss-regress
+depends: setup_dss/install_snap_k8s
+flags: simple
+_summary: Bootstrap Canonical K8s and enable features
+estimated_duration: 10m
+command:
+  set -e
+  timeout 5m sudo k8s bootstrap
+  timeout 5m sudo k8s enable local-storage
+
+id: setup_dss/write_canonical_k8s_kube_config
+category_id: setup-dss-regress
+depends:
+  setup_dss/bootstrap_and_enable_canonical_k8s
+  setup_dss/create_kube_config_directory
+flags: simple
+_summary: Write out the kubeconfig for the Canonical K8s cluster
+estimated_duration: 2s
+command:
+  set -e
+  # hack as redirecting stdout anywhere but /dev/null throws a permission denied error
+  # see: https://forum.snapcraft.io/t/eksctl-cannot-write-to-stdout/17254/4
+  sudo k8s config | tee "${HOME}/.kube/config" >/dev/null
+
+id: setup_dss/canonical_k8s_nvidia_gpu_setup
+category_id: setup-dss-regress
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_nvidia_gpus == 'True'
+depends:
+  setup_dss/install_snap_kubectl
+  setup_dss/install_snap_helm
+  setup_dss/write_canonical_k8s_kube_config
+flags: simple
+_summary: Setup Canonical K8s cluster to use any NVIDIA GPUs
+estimated_duration: 45m
+command:
+  timeout 45m k8s_gpu_setup.py \
+    nvidia \
+    "${SETUP_NVIDIA_GPU_OPERATOR_VERSION}"
+
+id: setup_dss/canonical_k8s_intel_gpu_setup
+category_id: setup-dss-regress
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_intel_gpus == 'True'
+depends:
+  setup_dss/install_snap_kubectl
+  setup_dss/install_snap_helm
+  setup_dss/write_canonical_k8s_kube_config
+flags: simple
+_summary: Setup Canonical K8s cluster to use any Intel GPUs
+estimated_duration: 45m
+command:
+  timeout 45m k8s_gpu_setup.py \
     intel \
     "${SETUP_INTEL_GPU_PLUGIN_VERSION}"

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/setup.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/setup.pxu
@@ -59,22 +59,29 @@ command:
   timeout 2m sudo microk8s.kubectl -n kube-system rollout status ds/calico-node
   timeout 5m sudo microk8s status --wait-ready
 
-id: setup_dss/write_microk8s_kube_config
+id: setup_dss/create_kube_config_directory
 category_id: setup-dss-regress
 depends: setup_dss/enable_microk8s_addons
 flags: simple
 _summary: Write out the kubeconfig for the microk8s cluster
 estimated_duration: 2s
+command: mkdir -p "${HOME}/.kube"
+
+id: setup_dss/write_microk8s_kube_config
+category_id: setup-dss-regress
+depends:
+  setup_dss/enable_microk8s_addons
+  setup_dss/create_kube_config_directory
+flags: simple
+_summary: Write out the kubeconfig for the microk8s cluster
+estimated_duration: 2s
 command:
   set -e
-  destination_dir="${HOME}/.kube"
-  mkdir -p "${destination_dir}"
-  destination="${destination_dir}/config"
   # hack as redirecting stdout anywhere but /dev/null throws a permission denied error
   # see: https://forum.snapcraft.io/t/eksctl-cannot-write-to-stdout/17254/4
-  sudo microk8s.kubectl config view --raw | tee "$destination" >/dev/null
+  sudo microk8s.kubectl config view --raw | tee "${HOME}/.kube/config" >/dev/null
 
-id: setup_dss/k8s_nvidia_gpu_setup
+id: setup_dss/microk8s_nvidia_gpu_setup
 category_id: setup-dss-regress
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_nvidia_gpus == 'True'
@@ -83,7 +90,7 @@ depends:
   setup_dss/install_snap_helm
   setup_dss/write_microk8s_kube_config
 flags: simple
-_summary: Setup K8s cluster to use any NVIDIA GPUs
+_summary: Setup microk8s cluster to use any NVIDIA GPUs
 estimated_duration: 45m
 command:
   timeout 45m k8s_gpu_setup.py \
@@ -91,7 +98,7 @@ command:
     nvidia \
     "${SETUP_NVIDIA_GPU_OPERATOR_VERSION}"
 
-id: setup_dss/k8s_intel_gpu_setup
+id: setup_dss/microk8s_intel_gpu_setup
 category_id: setup-dss-regress
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_intel_gpus == 'True'
@@ -100,7 +107,7 @@ depends:
   setup_dss/install_snap_helm
   setup_dss/write_microk8s_kube_config
 flags: simple
-_summary: Setup K8s cluster to use any Intel GPUs
+_summary: Setup microk8s cluster to use any Intel GPUs
 estimated_duration: 45m
 command:
   timeout 45m k8s_gpu_setup.py \

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/setup.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/setup.pxu
@@ -113,6 +113,7 @@ depends:
   setup_dss/install_snap_kubectl
   setup_dss/install_snap_helm
   setup_dss/write_microk8s_kube_config
+  setup_dss/install_package_intel-gpu-tools
 flags: simple
 _summary: Setup microk8s cluster to use any Intel GPUs
 estimated_duration: 45m
@@ -171,6 +172,7 @@ depends:
   setup_dss/install_snap_kubectl
   setup_dss/install_snap_helm
   setup_dss/write_canonical_k8s_kube_config
+  setup_dss/install_package_intel-gpu-tools
 flags: simple
 _summary: Setup Canonical K8s cluster to use any Intel GPUs
 estimated_duration: 45m

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/setup.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/setup.pxu
@@ -135,6 +135,19 @@ command:
   sudo k8s enable local-storage --timeout 5m
   sudo k8s status --wait-ready --timeout 10m
 
+id: setup_dss/restart_k8s_snap_as_workaround
+category_id: setup-dss-regress
+after: setup_dss/bootstrap_and_enable_canonical_k8s
+flags: simple
+_summary: Work around <https://github.com/canonical/k8s-snap/issues/1789>
+estimated_duration: 10m
+command:
+  set -e
+  echo "[WARNING] restarting k8s snap; see <https://github.com/canonical/k8s-snap/issues/1789>"
+  sudo snap restart k8s
+  sudo k8s status --wait-ready --timeout 10m
+
+
 id: setup_dss/write_canonical_k8s_kube_config
 category_id: setup-dss-regress
 depends:

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/setup.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/setup.pxu
@@ -131,8 +131,9 @@ _summary: Bootstrap Canonical K8s and enable features
 estimated_duration: 10m
 command:
   set -e
-  timeout 5m sudo k8s bootstrap
-  timeout 5m sudo k8s enable local-storage
+  sudo k8s bootstrap --timeout 5m
+  sudo k8s enable local-storage --timeout 5m
+  timeout 10m sudo k8s status --wait-ready
 
 id: setup_dss/write_canonical_k8s_kube_config
 category_id: setup-dss-regress

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/setup.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/setup.pxu
@@ -133,7 +133,7 @@ command:
   set -e
   sudo k8s bootstrap --timeout 5m
   sudo k8s enable local-storage --timeout 5m
-  timeout 10m sudo k8s status --wait-ready
+  sudo k8s status --wait-ready --timeout 10m
 
 id: setup_dss/write_canonical_k8s_kube_config
 category_id: setup-dss-regress

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
@@ -6,6 +6,14 @@ include:
     setup_dss/microk8s_nvidia_gpu_setup
     setup_dss/microk8s_intel_gpu_setup
 
+id: setup-dss-validation-on-canonical-k8s
+unit: test plan
+_name: Setup to run DSS validations on Canonical K8s
+include:
+    setup_dss/write_canonical_k8s_kube_config
+    setup_dss/canonical_k8s_nvidia_gpu_setup
+    setup_dss/canonical_k8s_intel_gpu_setup
+
 id: dss-validation
 unit: test plan
 _name: DSS validations with Intel and NVIDIA GPUs if available

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
@@ -1,13 +1,10 @@
-id: setup-dss-validation
+id: setup-dss-validation-on-microk8s
 unit: test plan
-_name: Setup to run DSS validations
+_name: Setup to run DSS validations on microk8s
 include:
-    setup_dss/install_snap_.*
-    setup_dss/install_package_.*
-    setup_dss/enable_microk8s_addons
     setup_dss/write_microk8s_kube_config
-    setup_dss/k8s_nvidia_gpu_setup
-    setup_dss/k8s_intel_gpu_setup
+    setup_dss/microk8s_nvidia_gpu_setup
+    setup_dss/microk8s_intel_gpu_setup
 
 id: dss-validation
 unit: test plan

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
@@ -2,6 +2,7 @@ id: setup-dss-validation-on-microk8s
 unit: test plan
 _name: Setup to run DSS validations on microk8s
 include:
+    setup_dss/install_snap_data-science-stack
     setup_dss/write_microk8s_kube_config
     setup_dss/microk8s_nvidia_gpu_setup
     setup_dss/microk8s_intel_gpu_setup
@@ -10,6 +11,7 @@ id: setup-dss-validation-on-canonical-k8s
 unit: test plan
 _name: Setup to run DSS validations on Canonical K8s
 include:
+    setup_dss/install_snap_data-science-stack
     setup_dss/write_canonical_k8s_kube_config
     setup_dss/canonical_k8s_nvidia_gpu_setup
     setup_dss/canonical_k8s_intel_gpu_setup

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/units/test-plan.pxu
@@ -12,6 +12,8 @@ unit: test plan
 _name: Setup to run DSS validations on Canonical K8s
 include:
     setup_dss/install_snap_data-science-stack
+    setup_dss/bootstrap_and_enable_canonical_k8s
+    setup_dss/restart_k8s_snap_as_workaround
     setup_dss/write_canonical_k8s_kube_config
     setup_dss/canonical_k8s_nvidia_gpu_setup
     setup_dss/canonical_k8s_intel_gpu_setup

--- a/contrib/checkbox-dss-validation/launchers/setup-canonical-k8s.conf
+++ b/contrib/checkbox-dss-validation/launchers/setup-canonical-k8s.conf
@@ -1,0 +1,22 @@
+[launcher]
+app_id = com.canonical.contrib.dss-validation:checkbox
+launcher_version = 1
+stock_reports = text, submission_files
+
+[test plan]
+unit = com.canonical.contrib::setup-dss-validation-on-canonical-k8s
+forced = yes
+
+[test selection]
+forced = yes
+
+[ui]
+type = silent
+auto_retry = no
+
+[environment]
+SETUP_KUBECTL_CHANNEL="1.31/stable"
+SETUP_DSS_CHANNEL="1.1/stable"
+SETUP_K8S_CHANNEL="1.32-classic/stable"
+SETUP_NVIDIA_GPU_OPERATOR_VERSION="v24.6.2"
+SETUP_INTEL_GPU_PLUGIN_VERSION="v0.30.0"

--- a/contrib/checkbox-dss-validation/launchers/setup-microk8s.conf
+++ b/contrib/checkbox-dss-validation/launchers/setup-microk8s.conf
@@ -4,7 +4,7 @@ launcher_version = 1
 stock_reports = text, submission_files
 
 [test plan]
-unit = com.canonical.contrib::setup-dss-validation
+unit = com.canonical.contrib::setup-dss-validation-on-microk8s
 forced = yes
 
 [test selection]
@@ -17,6 +17,6 @@ auto_retry = no
 [environment]
 SETUP_KUBECTL_CHANNEL="1.29/stable"
 SETUP_DSS_CHANNEL="1.0/stable"
-SETUP_MICROK8S_CHANNEL="1.28/stable"
+SETUP_K8S_CHANNEL="1.28/stable"
 SETUP_NVIDIA_GPU_OPERATOR_VERSION="v24.6.2"
 SETUP_INTEL_GPU_PLUGIN_VERSION="v0.30.0"

--- a/contrib/checkbox-dss-validation/testflinger/setup-def.conf
+++ b/contrib/checkbox-dss-validation/testflinger/setup-def.conf
@@ -4,7 +4,7 @@ launcher_version = 1
 stock_reports = text, submission_files
 
 [test plan]
-unit = com.canonical.contrib::setup-dss-validation
+unit = com.canonical.contrib::setup-dss-validation-on-$ENV_K8S_TYPE
 forced = yes
 
 [test selection]
@@ -17,6 +17,6 @@ auto_retry = no
 [environment]
 SETUP_KUBECTL_CHANNEL="$ENV_KUBECTL_CHANNEL"
 SETUP_DSS_CHANNEL="$ENV_DSS_CHANNEL"
-SETUP_MICROK8S_CHANNEL="$ENV_MICROK8S_CHANNEL"
+SETUP_K8S_CHANNEL="$ENV_K8S_CHANNEL"
 SETUP_NVIDIA_GPU_OPERATOR_VERSION="$ENV_NVIDIA_OPERATOR_VERSION"
 SETUP_INTEL_GPU_PLUGIN_VERSION="$ENV_INTEL_PLUGIN_VERSION"


### PR DESCRIPTION
## Description

This PR adds testing DSS on Canonical K8s in the Checkbox-DSS provider.

### Background

DSS channel `1.0` only supports running on Microk8s, whereas DSS channel `1.1` and onwards (including `latest`) now only support running on Canonical K8s.  Apart from installing a different Snap and doing the appropriate bootstrapping of the K8s cluster, the rest of the jobs and scripts can be re-used.  In particular, the `k8s_gpu_setup.py` added in #2066 is able to setup NVIDIA and Intel GPUs for both Microk8s and Canonical K8s.

### Breakdown

- Setup jobs for Microk8s have been renamed or refactored slightly 
  + The original test plan for setting up Microk8s has been renamed to be more explicit as `setup-dss-validation-on-microk8s`.
- Analogous setup jobs have been added for Canonical K8s to install, bootstrap, extract kube config from, and installing GPU plugins.
  - Analogously, a new test-plan `setup-dss-validation-on-canonical-k8s` has been added.
  
While working on this PR, an issue kept hampering progress on using Canonical K8s in this PR.  This has been reported to the K8s team in [issue canonical/k8s-snap #1789](https://github.com/canonical/k8s-snap/issues/1789).  In the meantime, we need a workaround job `setup_dss/restart_k8s_snap_as_workaround` and restarts the `k8s` Snap.

The main GitHub workflow for testing DSS and the launcher template it uses has been updated, and now enables choosing more version of DSS snap, and of course the type of K8s to test it on.



## Resolved issues

[CHECKBOX-1898](https://warthogs.atlassian.net/browse/CHECKBOX-1898).

## Documentation

No changes to Checkbox documentation.  For the provider, we now have two separate example launchers, one each for setting up Microk8s and Canonical K8s.  There use has been documented in the provider's README.

## Tests

- [Testing DSS 1.1/stable on canonical-k8s 1.32-classic/stable](https://github.com/canonical/checkbox/actions/runs/17260382958) now works.
- [Testing DSS 1.0/stable on microk8s 1.28/stable](https://github.com/canonical/checkbox/actions/runs/17260452524) continues to work.

[CHECKBOX-1898]: https://warthogs.atlassian.net/browse/CHECKBOX-1898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ