### PR TITLE
exclude existing stress tests from regression plan for server

### DIFF
--- a/providers/certification-server/units/server-regression.pxu
+++ b/providers/certification-server/units/server-regression.pxu
@@ -20,7 +20,6 @@ include:
     benchmarks/disk/hdparm-read_.*             certification-status=blocker
     benchmarks/disk/hdparm-cache-read_.*       certification-status=blocker
     power-management/rtc                       certification-status=blocker
-    stress/cpu_stress_ng_test                  certification-status=blocker
     usb/detect                                 certification-status=non-blocker
     virtualization/verify_lxd                  certification-status=blocker
     virtualization/verify_lxd_vm               certification-status=blocker
@@ -31,6 +30,10 @@ include:
     miscellanea/olog_results.log
     miscellanea/klog                           certification-status=blocker
     miscellanea/klog_results.log
+exclude:
+    stress/memory_stress_ng
+    disk/disk_stress_ng_.*
+    disk/disk_cpu_load_.*
 bootstrap_include:
     device
     fwts


### PR DESCRIPTION
## Description
Just explicitly excludes the existing long-running test plans from the server-regression testplan in certification-server.

These will eventually be replaced when the PR for the abbreviated stress tests is completed.

## Resolved issues

Unblocks running server-regression in an automated way for testing the scheduler and starting to automatically test SRU artifacts.

## Documentation

N/A

## Tests

N/A
