### PR TITLE
Api to read the machine manifest (New)

### DIFF
--- a/checkbox-support/checkbox_support/manifest.py
+++ b/checkbox-support/checkbox_support/manifest.py
@@ -1,0 +1,31 @@
+"""
+Support interfaces related manifest.json
+
+Copyright (C) 2025 Canonical Ltd.
+
+Authors: Massimiliano Girardi <massimiliano.girardi@canonical.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 3,
+as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import json
+from contextlib import suppress
+from collections import defaultdict
+
+
+def get_manifest() -> defaultdict:
+    to_r = defaultdict(bool)
+    with suppress(FileNotFoundError):
+        with open("/var/tmp/checkbox-ng/machine-manifest.json") as f:
+            to_r.update(json.load(f))
+    return to_r

--- a/checkbox-support/checkbox_support/tests/test_manifest.py
+++ b/checkbox-support/checkbox_support/tests/test_manifest.py
@@ -1,0 +1,40 @@
+# This file is part of Checkbox.
+#
+# Copyright 2025 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.giardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+from unittest.mock import patch, mock_open, MagicMock
+
+from checkbox_support.manifest import get_manifest
+
+
+class TestManifest(TestCase):
+    def test_manifest_present(self):
+        mock_file = mock_open(
+            read_data='{"com.canonical.certification::some": true}'
+        )
+        with patch("builtins.open", mock_file) as _:
+            manifest = get_manifest()
+        self.assertTrue(manifest["com.canonical.certification::some"])
+        self.assertFalse(manifest["com.canonical.certification::other"])
+
+    @patch("builtins.open", new=MagicMock(side_effect=FileNotFoundError))
+    def test_manifest_not_present(self):
+        manifest = get_manifest()
+
+        self.assertFalse(manifest["com.canonical.certification::some"])
+        self.assertFalse(manifest["com.canonical.certification::other"])


### PR DESCRIPTION
## Description

It may be increasingly important to be able to take actions in tests depending on the state of manifests. This is true both while testing (for example, nvidia vs amd tests, we may have a "shared" smoke) and in setup (we can use the same code to install drivers for different cards.  Additionally, at launch setup jobs will not have the manfiest reading functionality, this allows the users to still rely on manifests inside their jobs.

## Resolved issues

Fixes: 

## Documentation

N/A

## Tests

Added tests for the functionality.
