### PR TITLE
exclude existing stress tests from regression plan for server (New)

### DIFF
--- a/providers/certification-server/units/server-regression.pxu
+++ b/providers/certification-server/units/server-regression.pxu
@@ -20,7 +20,6 @@ include:
     benchmarks/disk/hdparm-read_.*             certification-status=blocker
     benchmarks/disk/hdparm-cache-read_.*       certification-status=blocker
     power-management/rtc                       certification-status=blocker
-    stress/cpu_stress_ng_test                  certification-status=blocker
     usb/detect                                 certification-status=non-blocker
     virtualization/verify_lxd                  certification-status=blocker
     virtualization/verify_lxd_vm               certification-status=blocker
@@ -31,6 +30,10 @@ include:
     miscellanea/olog_results.log
     miscellanea/klog                           certification-status=blocker
     miscellanea/klog_results.log
+exclude:
+    stress/memory_stress_ng
+    disk/disk_stress_ng_.*
+    disk/disk_cpu_load_.*
 bootstrap_include:
     device
     fwts


### PR DESCRIPTION
Remove the existing long-running stress from the server regression plan

## Description

In preparation for #1985 this excludes the full length stress tests from the server so we can run SRU without spending days in stress testing. 

## Documentation

NA

## Tests
NA
