### PR TITLE
Add machine manifest to submission JSON (New)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/system_information.py
+++ b/checkbox-ng/plainbox/impl/session/system_information.py
@@ -308,6 +308,19 @@ class JournalctlCollector(Collector):
         )
 
 
+class ManifestCollector(Collector):
+    COLLECTOR_NAME = "machine_manifest"
+
+    def __init__(self):
+        super().__init__(
+            collection_cmd=[
+                "cat",
+                "/var/tmp/checkbox-ng/machine-manifest.json",
+            ],
+            version_cmd=["checkbox-cli", "--version"],
+        )
+
+
 if __name__ == "__main__":
     collection = collect()
     print(collection.to_json())


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

Add the content of `/var/tmp/checkbox-ng/machine-manifest.json` (aka the machine manifest) to the submission JSON as part of the system_information gathering mechanism.

This information was already present as part of the submission, but in a very awkward format (Checkbox job output). The following PR adds a `machine_manifest` section to the `system_information` section with the JSON information about each manifest defined.

## Resolved issues

https://warthogs.atlassian.net/browse/CHECKBOX-2001

## Documentation

N/A

## Tests

Tested in a venv in the 3 different scenarios:

1. no manifest file is present, and the test plan run does not require one (for example, the smoke test plan).
2. no manifest file is present, but it's populated using Checkbox manifest screen (I wanted to make sure the system_information was kicked in after the creation of the `machine-manifest.json` file and not before!)
3. a manifest file is already there (I made sure to use a different manifest file from case 2 above to compare the outcome)


In case 1, the `machine_manifest` section of the `system_information` section in `submission.json` looks like this:

```json
    "machine_manifest": {
        "tool_version": "$PROVIDERPATH is defined, so following provider sources are ignored ['/usr/local/share/plainbox-providers-1', '/usr/share/plainbox-providers-1', '/home/pieq/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] \n4.2.1.dev44+ga23306767\n",
        "success": false,
        "outputs": {
            "stdout": "",
            "stderr": "cat: /var/tmp/checkbox-ng/machine-manifest.json: No such file or directory\n",
            "return_code": 1
        }
```

(note the garbage in `tool_version` before the actual tool version, this is because I'm working from a venv, but it would be worth considering removing from the usual output)

In cases 2 and 3, it looks something like that:

```json
    "machine_manifest": {
        "tool_version": "$PROVIDERPATH is defined, so following provider sources are ignored ['/usr/local/share/plainbox-providers-1', '/usr/share/plainbox-providers-1', '/home/pieq/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] \n4.2.1.dev44+ga23306767\n",
        "success": true,
        "outputs": {
            "payload": {
                "com.canonical.certification::has_audio_capture": true,
                "com.canonical.certification::has_audio_playback": true,
                "com.canonical.certification::has_bt_obex_support": true,
                "com.canonical.certification::has_camera": true,
                "com.canonical.certification::has_ethernet_adapter": true,
                "com.canonical.certification::has_md_raid": true,
                "com.canonical.certification::has_secure_boot": true,
                "com.canonical.certification::has_touchpad": false,
                "com.canonical.certification::has_usb_dwc3_controller": false,
                "com.canonical.certification::has_usb_storage": false,
                "com.canonical.certification::has_wlan_adapter": true,
                "com.canonical.certification::has_wwan_module": false,
                "com.canonical.certification::need_snapd_snap_update_test": false
            },
            "stderr": ""
        }
```
