### PR TITLE
Fix Docker export permission denied error in snap environments (#1514)

### DIFF
--- a/providers/docker/units/docker.pxu
+++ b/providers/docker/units/docker.pxu
@@ -204,7 +204,7 @@ command:
  set -e
  ID=$(docker run -dit ubuntu bash)
  tarball_file={root_dir}/ubuntu.tar
- docker export $ID > $tarball_file
+ docker export -o $tarball_file $ID
  cat $tarball_file | sudo docker import - plainbox/ubuntu:v1.0
  docker images -a | grep 'plainbox/ubuntu'
  docker rm -f $ID


### PR DESCRIPTION
## Problem
Docker tests `docker/export-and-import_{arch}` and `docker/save-and-load_{arch}` fail with "write /dev/stdout: permission denied" error when running with checkbox snap and Docker snap due to snap confinement restrictions.

The issue occurs specifically when:
- Docker snap is installed (not deb packages)
- Tests are run via checkbox snap
- Snap confinement prevents stdout redirection operations

## Solution
Replace stdout redirection (`>`) with Docker's native `-o` flag in the export command:

```bash
# Before (problematic):
docker export $ID > $tarball_file

# After (fixed):
docker export -o $tarball_file $ID
```

## Why This Fix Works
1. **Avoids snap confinement issues**: The `-o` flag writes directly to files without stdout redirection
2. **Consistency**: Makes export command consistent with save command (which already uses `-o`)
3. **Precedent**: Follows the same pattern as previous fix in commit ff16599b5816cf973373df29b4111ba1a4443d00

## Testing
- All Docker automated tests pass
- Both `docker/export-and-import` and `docker/save-and-load` tests work correctly
- No regressions introduced

## Files Changed
- `providers/docker/units/docker.pxu`: Updated docker export command to use `-o` flag

Fixes #1514