### PR TITLE
Allow all users to write to temp cwd (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -402,6 +402,9 @@ class UnifiedRunner(IJobRunner):
         suffix = ".{}".format(job.checksum)
         try:
             with tempfile.TemporaryDirectory(suffix, prefix) as cwd_dir:
+                # most of the times, Checkbox is running as root and the job
+                # is running as user, it needs permission to cwd
+                os.chmod(cwd_dir, 0o777)
                 logger.debug(
                     _("Job temporary current working directory: %s"), cwd_dir
                 )


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

When running a test (not in snaps), checkbox will create a cwd in tmp so that it can check if the test leaves over any file. This mechanism is sadly broken right now when runnign a user job with checkbox remote or local (ran as root). The reason is that whover creates the directory doesn't give the permission to other viewers to read/write to it, so anything that does try will fail

I've discovered this while developing the plz-run runner, as that will fail to start any process given that the child process tree there will 100% be undert he correct slice/user (with the current runner, only the child shell is under the correct user, the parent is still root), and that is why it doesn't fail to start but just to do any file operation.

## Resolved issues

Fixes: CHECKBOX-2009

## Documentation

N/A

## Tests

Create a unit that write to cwd as normal user, run it as root. It will print permission denied and fail to do so.