### PR TITLE
wifi test: fix checking of ping results (#2116) (BugFix)

### DIFF
--- a/providers/base/bin/wifi_client_test_netplan.py
+++ b/providers/base/bin/wifi_client_test_netplan.py
@@ -354,7 +354,7 @@ def perform_ping_test(interface, renderer):
         count = 5
         result = ping(target, interface, count, 10)
         print("Ping result: {}".format(result))
-        if result["received"] == count:
+        if result["received"] == result["transmitted"]:
             return True
 
     return False

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -196,7 +196,7 @@ def perform_ping_test(interface):
     if target:
         count = 5
         result = ping(target, interface, count, 10)
-        if result["received"] != count:
+        if result["received"] != result["transmitted"]:
             raise ValueError(
                 "{} packets expected but only {} received".format(
                     count, result["received"]

--- a/providers/base/tests/test_wifi_client_test_netplan.py
+++ b/providers/base/tests/test_wifi_client_test_netplan.py
@@ -780,6 +780,33 @@ class WifiClientTestNetplanTests(TestCase):
         self.assertIn("Got gateway address: ", captured_output.getvalue())
 
 
+@patch("wifi_client_test_netplan.ping")
+@patch("wifi_client_test_netplan.get_gateway")
+@patch("wifi_client_test_netplan.sp.check_output")
+class TestPerformPingTest(TestCase):
+    def test_perform_ping_test_success(
+        self, mock_check_output, mock_gateway, mock_ping
+    ):
+        mock_gateway.return_value = "127.1"
+        mock_ping.return_value = {
+            "transmitted": 5,
+            "received": 5,
+            "pct_loss": 0,
+        }
+        self.assertTrue(perform_ping_test("wlan0", "networkd"))
+
+    def test_perform_ping_test_failure(
+        self, mock_check_output, mock_gateway, mock_ping
+    ):
+        mock_gateway.return_value = "127.1"
+        mock_ping.return_value = {
+            "transmitted": 5,
+            "received": 0,
+            "pct_loss": 0,
+        }
+        self.assertFalse(perform_ping_test("wlan0", "networkd"))
+
+
 class TestMain(TestCase):
 
     @patch("wifi_client_test_netplan.parse_args")


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Fix the tests relying on gateway_ping_test::ping to properly handle network latency above 1s, thus ping having more than `count` packets

## Resolved issues

Fixes #2116

