### PR TITLE
Typo in the arch name (infra)

### DIFF
--- a/.github/workflows/checkbox-daily-cross-builds.yaml
+++ b/.github/workflows/checkbox-daily-cross-builds.yaml
@@ -33,9 +33,9 @@ jobs:
           - release: 16
             arch: arm64
           - release: 22
-            arch: riscv
+            arch: riscv64
           - release: 24
-            arch: riscv
+            arch: riscv64
     # uc16 needs ubuntu20 because we need cgroup v1 to build it
     runs-on: ${{ matrix.release == 16 && fromJson('["self-hosted", "focal"]') || 'ubuntu-latest' }}
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
@@ -117,10 +117,10 @@ jobs:
             arch: arm64
         include:
           - release: 22
-            arch: riscv
+            arch: riscv64
             type: uc
           - release: 24
-            arch: riscv
+            arch: riscv64
             type: uc
     # uc16 needs ubuntu20 because we need cgroup v1 to build it
     runs-on: ${{ matrix.release == 16 && fromJson('["self-hosted", "focal"]') || 'ubuntu-latest' }}


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

There is typo, `riscv` doesn't exist, it should be `riscv64`

## Resolved issues

N/A

## Documentation

N/A

## Tests

see: https://github.com/canonical/checkbox/actions/runs/17828238973/job/50687668856

silly of me not to notice, the uc frontend cant build till we push the riscv runtime to the store, because it needs it to be installed while building. soo... this validates this is actually correct.

The reason it "worked" before is that there was a bug in the snapcraft multiarch action that I also fixed today. See: https://github.com/canonical/snapcraft-multiarch-action/pull/6
