### PR TITLE
Fix not-portable -> non-portable typo (bugfix)

### DIFF
--- a/providers/resource/bin/dmi_resource.py
+++ b/providers/resource/bin/dmi_resource.py
@@ -45,7 +45,7 @@ def sane_product(og_product: str) -> str:
         "all-in-one",
         "aio",
     ]:
-        return "not-portable"
+        return "non-portable"
     elif cleaned in [
         "notebook",
         "laptop",

--- a/providers/resource/tests/test_dmi_resource.py
+++ b/providers/resource/tests/test_dmi_resource.py
@@ -48,7 +48,7 @@ class TestDmiResource(TestCase):
             "aio",
         ]
         category = set(map(dmi_resource.sane_product, products))
-        self.assertEqual(category, {"not-portable"})
+        self.assertEqual(category, {"non-portable"})
 
     def test_sane_product_unknown(self):
         products = ["strange-iot-product"]


### PR DESCRIPTION


## Description

There is a typo in the resource. It was supposed to be non-portable, but it was actually typod to not-portable

## Resolved issues

Fix: CHECKBOX-2017

## Documentation

N/A (comment was correct)

## Tests

Unittest updated
