### PR TITLE
Add checkbox-gfx opengl tests (New)

### DIFF
--- a/contrib/checkbox-gfx/.github/workflows/build-installers.yaml
+++ b/contrib/checkbox-gfx/.github/workflows/build-installers.yaml
@@ -46,7 +46,7 @@ jobs:
             opencl:
               - 'bin/install-opencl'
             opengl:
-	      - 'bin/install-opengl'
+              - 'bin/install-opengl'
 
   manual-build:
     if: github.event_name == 'workflow_dispatch'

--- a/contrib/checkbox-gfx/.github/workflows/build-installers.yaml
+++ b/contrib/checkbox-gfx/.github/workflows/build-installers.yaml
@@ -34,6 +34,7 @@ jobs:
     outputs:
       vulkan: ${{ steps.changes.outputs.vulkan }}
       opencl: ${{ steps.changes.outputs.opencl }}
+      opengl: ${{ steps.changes.outputs.opengl }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -44,12 +45,14 @@ jobs:
               - 'bin/install-vulkan'
             opencl:
               - 'bin/install-opencl'
+            opengl:
+	      - 'bin/install-opengl'
 
   manual-build:
     if: github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
-        test_name: [vulkan, opencl]
+        test_name: [vulkan, opencl, opengl]
     name: "Manual Build - ${{ matrix.test_name }}"
     runs-on: [self-hosted, linux, "${{ inputs.arch }}", "${{ inputs.version }}"]
 
@@ -122,4 +125,31 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: output-opencl-${{ matrix.arch }}
+          path: /usr/local/checkbox-gfx/*
+
+  pr-build-opengl:
+    needs: changes
+    # needs.changes only runs if the event is a PR
+    if: needs.changes.outputs.opengl == 'true'
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    name: "Installer testing - OpenGL CTS"
+    runs-on: [self-hosted, linux, "${{ matrix.arch }}", noble]
+
+    steps:
+      - name: "Installers - OpenGL - ${{ matrix.arch }}"
+        run: echo "Running OpenGL ${{ matrix.arch }} install"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run install-opengl
+        shell: bash
+        run: bin/install-opengl
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: output-opengl-${{ matrix.arch }}
           path: /usr/local/checkbox-gfx/*

--- a/contrib/checkbox-gfx/README.md
+++ b/contrib/checkbox-gfx/README.md
@@ -39,9 +39,6 @@ systemctl status snap.checkbox-gfx.run-agent.service
 Most tests need dependencies, and a helper script is available to install each category of tests:
 
 ```shell
-checkbox-gfx.install-lvl-zero
-checkbox-gfx.install-lvl-zero-rt
-checkbox-gfx.install-crucible
 checkbox-gfx.install-vulkan
 checkbox-gfx.install-opengl
 checkbox-gfx.install-opencl
@@ -52,9 +49,10 @@ checkbox-gfx.install-opencl
 Each category of tests is run separately:
 
 ```shell
-checkbox-gfx.test-lvl-zero
-checkbox-gfx.test-lvl-zero-rt
 checkbox-gfx.test-opencl
+checkbox-gfx.test-opengl
+checkbox-gfx.test-opengl-short
+checkbox-gfx.test-vulkan
 ```
 
 Due to some tests causing dropped SSH connections, running the tests remotely should be done like this:

--- a/contrib/checkbox-gfx/bin/install-opengl
+++ b/contrib/checkbox-gfx/bin/install-opengl
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+source $(dirname "$0")/setup-env.sh
+
+sudo apt update -y
+sudo apt install -y build-essential cmake libpng-dev clang python3-pip meson glslang-tools pkg-config cmake libgl1 mesa-common-dev libglfw3-dev libgles2-mesa-dev wayland-protocols
+pip3 install lxml --break-system-packages
+
+echo "Installing VK-GL-CTS for OpenGL"
+cd $WORKING_DIR
+git clone https://github.com/KhronosGroup/VK-GL-CTS
+cd VK-GL-CTS
+git checkout opengl-cts-4.6.6.0
+python3 external/fetch_sources.py
+mkdir build && cd build
+cmake .. -DDEQP_TARGET=default
+# 64GB RAM wasn't enough for -j. Add nproc
+make -j`nproc`
+sudo mv $WORKING_DIR/VK-GL-CTS $INSTALL_DIR/GL-CTS

--- a/contrib/checkbox-gfx/bin/test-opengl
+++ b/contrib/checkbox-gfx/bin/test-opengl
@@ -1,0 +1,18 @@
+#!/usr/bin/env -S checkbox-cli-wrapper
+[launcher]
+app_id = com.canonical.qa.gfx:checkbox
+launcher_version = 1
+stock_reports = text, submission_files
+
+[test plan]
+unit = com.canonical.certification::opengl-test-plan
+forced = yes
+
+[test selection]
+forced = yes
+
+[ui]
+type = silent
+auto_retry = yes
+max_attempts = 3
+delay_before_retry = 15

--- a/contrib/checkbox-gfx/bin/test-opengl-short
+++ b/contrib/checkbox-gfx/bin/test-opengl-short
@@ -1,0 +1,17 @@
+#!/usr/bin/env -S checkbox-cli-wrapper
+[launcher]
+app_id = com.canonical.qa.gfx:checkbox
+launcher_version = 1
+stock_reports = text
+
+[test plan]
+unit = com.canonical.certification::opengl-test-plan-sru
+forced = yes
+
+[test selection]
+forced = yes
+
+[ui]
+type = silent
+auto_retry = no
+max_attempts = 3

--- a/contrib/checkbox-gfx/checkbox-provider-gfx/units/category.pxu
+++ b/contrib/checkbox-gfx/checkbox-provider-gfx/units/category.pxu
@@ -4,4 +4,8 @@ _name: Category for Mesa tests
 
 unit: category
 id: opencl
-_name: A shorter test suit for opencl
+_name: A test suite for opencl
+
+unit: category
+id: opengl
+_name: A test suite for opengl

--- a/contrib/checkbox-gfx/checkbox-provider-gfx/units/opencl/jobs.pxu
+++ b/contrib/checkbox-gfx/checkbox-provider-gfx/units/opencl/jobs.pxu
@@ -11,12 +11,12 @@ environ:
   XDG_RUNTIME_DIR
 estimated_duration: 1
 command:
-if clinfo --prop CL_DEVICE_TYPE | grep -q CL_DEVICE_TYPE_GPU; then
-  echo "PASS: Found a GPU for OpenCL"
-else
-  echo "FAIL: No GPU available in clinfo"
-  exit 1
-fi
+ if clinfo --prop CL_DEVICE_TYPE | grep -q CL_DEVICE_TYPE_GPU; then
+   echo "PASS: Found a GPU for OpenCL"
+ else
+   echo "FAIL: No GPU available in clinfo"
+   exit 1
+ fi
 
 id: gfx_cl_basic
 depends: gfx_cl_gpu_avail

--- a/contrib/checkbox-gfx/checkbox-provider-gfx/units/opengl/jobs.pxu
+++ b/contrib/checkbox-gfx/checkbox-provider-gfx/units/opengl/jobs.pxu
@@ -17,7 +17,6 @@ command:
     exit 1
   fi
   echo "PASS: Using HW rendering"
-  exit 0
 
 id: gfx_mesa_gl_sru_info
 category_id: mesa

--- a/contrib/checkbox-gfx/checkbox-provider-gfx/units/opengl/jobs.pxu
+++ b/contrib/checkbox-gfx/checkbox-provider-gfx/units/opengl/jobs.pxu
@@ -1,0 +1,275 @@
+plugin: resource
+id: gfx_mesa_gl_hw_render
+category_id: mesa
+user: root
+requires:
+  package.name == 'mesa-utils'
+_summary: Checks for HW render for OpenGL
+environ:
+  # necessary for local mode
+  XDG_SESSION_TYPE
+  XDG_RUNTIME_DIR
+estimated_duration: 1
+command:
+  RENDERER=$(glxinfo | grep "OpenGL renderer string" | grep "Mesa Intel")
+  if [ -z "$RENDERER" ]; then
+    echo "FAIL: Renderer appears to be software based"
+    exit 1
+  fi
+  echo "PASS: Using HW rendering"
+  exit 0
+
+id: gfx_mesa_gl_sru_info
+category_id: mesa
+depends: gfx_mesa_gl_hw_render
+flags: simple
+user: root
+_summary: Run the info tests from VK-GL-CTS
+environ:
+  # necessary for local mode
+  XDG_SESSION_TYPE
+  XDG_RUNTIME_DIR
+estimated_duration: 1m
+command:
+  cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.info.*
+_siblings: [
+  { "id": "gfx_mesa_gl_sru_shaders",
+    "_summary": "Run the shaders tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.shaders.*"
+  },
+  { "id": "gfx_mesa_gl_sru_geometry_shader",
+    "_summary": "Run the geometry_shader tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.geometry_shader.*"
+  },
+  { "id": "gfx_mesa_gl_sru_gpu_shader5",
+    "_summary": "Run the gpu_shader5 tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.gpu_shader5.*"
+  },
+  { "id": "gfx_mesa_gl_sru_tessellation_shader",
+    "_summary": "Run the tessellation_shader tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.tessellation_shader.*"
+  },
+  { "id": "gfx_mesa_gl_sru_texture_cube_map_array",
+    "_summary": "Run the texture_cube_map_array tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.texture_cube_map_array.*"
+  },
+  { "id": "gfx_mesa_gl_sru_texture_border_clamp",
+    "_summary": "Run the texture_border_clamp tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.texture_border_clamp.*"
+  },
+  { "id": "gfx_mesa_gl_sru_texture_buffer",
+    "_summary": "Run the texture_buffer tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.texture_buffer.*"
+  },
+  { "id": "gfx_mesa_gl_sru_draw_buffers_indexed",
+    "_summary": "Run the draw_buffers_indexed tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.draw_buffers_indexed.*"
+  },
+  { "id": "gfx_mesa_gl_sru_constant_expressions",
+    "_summary": "Run the constant_expressions tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.constant_expressions.*"
+  },
+  { "id": "gfx_mesa_gl_sru_shader_macros",
+    "_summary": "Run the shader_macros tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.shader_macros.*"
+  },
+  { "id": "gfx_mesa_gl_sru_separable_programs_tf",
+    "_summary": "Run the separable_programs_tf tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.separable_programs_tf.*"
+  },
+  { "id": "gfx_mesa_gl_sru_copy_image",
+    "_summary": "Run the copy_image tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.copy_image.*"
+  },
+  { "id": "gfx_mesa_gl_sru_texture2d",
+    "_summary": "Run the texture2d tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.internalformat.texture2d.*"
+  },
+  { "id": "gfx_mesa_gl_sru_copy_tex_image",
+    "_summary": "Run the copy_tex_image tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.internalformat.copy_tex_image.*"
+  },
+  { "id": "gfx_mesa_gl_sru_renderbuffer",
+    "_summary": "Run the renderbuffer tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.internalformat.renderbuffer.rgb5_a1"
+  },
+  { "id": "gfx_mesa_gl_sru_renderbuffer_depth_component32f",
+    "_summary": "Run the renderbuffer_depth_component32f tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.internalformat.renderbuffer.depth_component32f"
+  },
+  { "id": "gfx_mesa_gl_sru_renderbuffer_depth32f_stencil8",
+    "_summary": "Run the renderbuffer_depth32f_stencil8 tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.internalformat.renderbuffer.depth32f_stencil8"
+  },
+  { "id": "gfx_mesa_gl_sru_sampler2darrayshadow_fragment",
+    "_summary": "Run the sampler2darrayshadow_fragment tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texture.sampler2darrayshadow_fragment"
+  },
+  { "id": "gfx_mesa_gl_sru_sampler2darrayshadow_bias_fragment",
+    "_summary": "Run the sampler2darrayshadow_bias_fragment tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texture.sampler2darrayshadow_bias_fragment"
+  },
+  { "id": "gfx_mesa_gl_sru_samplercubearrayshadow_vertex",
+    "_summary": "Run the samplercubearrayshadow_vertex tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texture.samplercubearrayshadow_vertex"
+  },
+  { "id": "gfx_mesa_gl_sru_samplercubearrayshadow_fragment",
+    "_summary": "Run the samplercubearrayshadow_fragment tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texture.samplercubearrayshadow_fragment"
+  },
+  { "id": "gfx_mesa_gl_sru_samplercubearrayshadow_bias_fragment",
+    "_summary": "Run the samplercubearrayshadow_bias_fragment tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texture.samplercubearrayshadow_bias_fragment"
+  },
+  { "id": "gfx_mesa_gl_sru_textureoffset_sampler2darrayshadow_vertex",
+    "_summary": "Run the textureoffset_sampler2darrayshadow_vertex tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.textureoffset.sampler2darrayshadow_vertex"
+  },
+  { "id": "gfx_mesa_gl_sru_textureoffset_sampler2darrayshadow_fragment",
+    "_summary": "Run the textureoffset_sampler2darrayshadow_fragment tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.textureoffset.sampler2darrayshadow_fragment"
+  },
+  { "id": "gfx_mesa_gl_sru_textureoffset_sampler2darrayshadow_bias_fragment",
+    "_summary": "Run the textureoffset_sampler2darrayshadow_bias_fragment tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.textureoffset.sampler2darrayshadow_bias_fragment"
+  },
+  { "id": "gfx_mesa_gl_sru_texturelod_sampler2darrayshadow_vertex",
+    "_summary": "Run the texturelod_sampler2darrayshadow_vertex tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texturelod.sampler2darrayshadow_vertex"
+  },
+  { "id": "gfx_mesa_gl_sru_texturelod_sampler2darrayshadow_fragment",
+    "_summary": "Run the texturelod_sampler2darrayshadow_fragment tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texturelod.sampler2darrayshadow_fragment"
+  },
+  { "id": "gfx_mesa_gl_sru_texturelod_samplercubeshadow_vertex",
+    "_summary": "Run the texturelod_samplercubeshadow_vertex tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texturelod.samplercubeshadow_vertex"
+  },
+  { "id": "gfx_mesa_gl_sru_texturelod_samplercubeshadow_fragment",
+    "_summary": "Run the texturelod_samplercubeshadow_fragment tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texturelod.samplercubeshadow_fragment"
+  },
+  { "id": "gfx_mesa_gl_sru_texturelod_samplercubearrayshadow_fragment",
+    "_summary": "Run the texturelod_samplercubearrayshadow_fragment tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texturelod.samplercubearrayshadow_fragment"
+  },
+  { "id": "gfx_mesa_gl_sru_texturelodoffset_sampler2darrayshadow_vertex",
+    "_summary": "Run the texturelodoffset_sampler2darrayshadow_vertex tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texturelodoffset.sampler2darrayshadow_vertex"
+  },
+  { "id": "gfx_mesa_gl_sru_texturelodoffset_sampler2darrayshadow_fragment",
+    "_summary": "Run the texturelodoffset_sampler2darrayshadow_fragment tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texturelodoffset.sampler2darrayshadow_fragment"
+  },
+  {"id": "gfx_mesa_gl_sru_nearest_edge",
+    "_summary": "Run the nearest_edge tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.nearest_edge.*"
+  },
+  { "id": "gfx_mesa_gl_sru_framebuffer_completeness",
+    "_summary": "Run the framebuffer_completeness tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.framebuffer_completeness.*"
+  },
+  { "id": "gfx_mesa_gl_sru_texture_compatibility",
+    "_summary": "Run the texture_compatibility tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.texture_compatibility.*"
+  },
+  { "id": "gfx_mesa_gl_sru_compressed_format",
+    "_summary": "Run the compressed_format tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.compressed_format.*"
+  }]
+
+id: gfx_mesa_gl_info
+category_id: mesa
+depends: gfx_mesa_gl_hw_render
+flags: simple
+user: root
+_summary: Run the info tests from VK-GL-CTS
+environ:
+  # necessary for local mode
+  XDG_SESSION_TYPE
+  XDG_RUNTIME_DIR
+estimated_duration: 1m
+command:
+  cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.info.*
+_siblings:
+  [{ "id": "gfx_mesa_gl_shaders",
+    "_summary": "Run the shaders tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.shaders.*"
+  },
+  { "id": "gfx_mesa_gl_geometry_shader",
+    "_summary": "Run the geometry_shader tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.geometry_shader.*"
+  },
+  { "id": "gfx_mesa_gl_gpu_shader5",
+    "_summary": "Run the gpu_shader5 tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.gpu_shader5.*"
+  },
+  { "id": "gfx_mesa_gl_tessellation_shader",
+    "_summary": "Run the tessellation_shader tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.tessellation_shader.*"
+  },
+  { "id": "gfx_mesa_gl_texture_cube_map_array",
+    "_summary": "Run the texture_cube_map_array tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.texture_cube_map_array.*"
+  },
+  { "id": "gfx_mesa_gl_texture_border_clamp",
+    "_summary": "Run the texture_border_clamp tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.texture_border_clamp.*"
+  },
+  { "id": "gfx_mesa_gl_texture_buffer",
+    "_summary": "Run the texture_buffer tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.texture_buffer.*"
+  },
+  { "id": "gfx_mesa_gl_draw_buffers_indexed",
+    "_summary": "Run the draw_buffers_indexed tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.draw_buffers_indexed.*"
+  },
+  { "id": "gfx_mesa_gl_constant_expressions",
+    "_summary": "Run the constant_expressions tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.constant_expressions.*"
+  },
+  { "id": "gfx_mesa_gl_shader_macros",
+    "_summary": "Run the shader_macros tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.shader_macros.*"
+  },
+  { "id": "gfx_mesa_gl_separable_programs_tf",
+    "_summary": "Run the separable_programs_tf tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.separable_programs_tf.*"
+  },
+  { "id": "gfx_mesa_gl_copy_image",
+    "_summary": "Run the copy_image tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.copy_image.*"
+  },
+  { "id": "gfx_mesa_gl_texture2d",
+    "_summary": "Run the texture2d tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.internalformat.texture2d.*"
+  },
+  { "id": "gfx_mesa_gl_copy_tex_image",
+    "_summary": "Run the copy_tex_image tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.internalformat.copy_tex_image.*"
+  },
+  { "id": "gfx_mesa_gl_renderbuffer",
+    "_summary": "Run the renderbuffer tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.internalformat.renderbuffer.*"
+  },
+  { "id": "gfx_mesa_gl_ext_texture_shadow_lod",
+    "_summary": "Run the ext_texture_shadow_lod tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.*"
+  },
+  { "id": "gfx_mesa_gl_nearest_edge",
+    "_summary": "Run the nearest_edge tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.nearest_edge.*"
+  },
+  { "id": "gfx_mesa_gl_framebuffer_completeness",
+    "_summary": "Run the framebuffer_completeness tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.framebuffer_completeness.*"
+  },
+  { "id": "gfx_mesa_gl_texture_compatibility",
+    "_summary": "Run the texture_compatibility tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.texture_compatibility.*"
+  },
+  { "id": "gfx_mesa_gl_compressed_format",
+    "_summary": "Run the compressed_format tests from VK-GL-CTS",
+    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.compressed_format.*"
+  }]
+

--- a/contrib/checkbox-gfx/checkbox-provider-gfx/units/opengl/jobs.pxu
+++ b/contrib/checkbox-gfx/checkbox-provider-gfx/units/opengl/jobs.pxu
@@ -101,63 +101,63 @@ _siblings: [
     "_summary": "Run the renderbuffer_depth32f_stencil8 tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.internalformat.renderbuffer.depth32f_stencil8"
   },
-  { "id": "gfx_mesa_gl_sru_sampler2darrayshadow_fragment",
+  { "id": "gfx_mesa_gl_extra_sru_sampler2darrayshadow_fragment",
     "_summary": "Run the sampler2darrayshadow_fragment tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texture.sampler2darrayshadow_fragment"
   },
-  { "id": "gfx_mesa_gl_sru_sampler2darrayshadow_bias_fragment",
+  { "id": "gfx_mesa_gl_extra_sru_sampler2darrayshadow_bias_fragment",
     "_summary": "Run the sampler2darrayshadow_bias_fragment tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texture.sampler2darrayshadow_bias_fragment"
   },
-  { "id": "gfx_mesa_gl_sru_samplercubearrayshadow_vertex",
+  { "id": "gfx_mesa_gl_extra_sru_samplercubearrayshadow_vertex",
     "_summary": "Run the samplercubearrayshadow_vertex tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texture.samplercubearrayshadow_vertex"
   },
-  { "id": "gfx_mesa_gl_sru_samplercubearrayshadow_fragment",
+  { "id": "gfx_mesa_gl_extra_sru_samplercubearrayshadow_fragment",
     "_summary": "Run the samplercubearrayshadow_fragment tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texture.samplercubearrayshadow_fragment"
   },
-  { "id": "gfx_mesa_gl_sru_samplercubearrayshadow_bias_fragment",
+  { "id": "gfx_mesa_gl_extra_sru_samplercubearrayshadow_bias_fragment",
     "_summary": "Run the samplercubearrayshadow_bias_fragment tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texture.samplercubearrayshadow_bias_fragment"
   },
-  { "id": "gfx_mesa_gl_sru_textureoffset_sampler2darrayshadow_vertex",
+  { "id": "gfx_mesa_gl_extra_sru_textureoffset_sampler2darrayshadow_vertex",
     "_summary": "Run the textureoffset_sampler2darrayshadow_vertex tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.textureoffset.sampler2darrayshadow_vertex"
   },
-  { "id": "gfx_mesa_gl_sru_textureoffset_sampler2darrayshadow_fragment",
+  { "id": "gfx_mesa_gl_extra_sru_textureoffset_sampler2darrayshadow_fragment",
     "_summary": "Run the textureoffset_sampler2darrayshadow_fragment tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.textureoffset.sampler2darrayshadow_fragment"
   },
-  { "id": "gfx_mesa_gl_sru_textureoffset_sampler2darrayshadow_bias_fragment",
+  { "id": "gfx_mesa_gl_extra_sru_textureoffset_sampler2darrayshadow_bias_fragment",
     "_summary": "Run the textureoffset_sampler2darrayshadow_bias_fragment tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.textureoffset.sampler2darrayshadow_bias_fragment"
   },
-  { "id": "gfx_mesa_gl_sru_texturelod_sampler2darrayshadow_vertex",
+  { "id": "gfx_mesa_gl_extra_sru_texturelod_sampler2darrayshadow_vertex",
     "_summary": "Run the texturelod_sampler2darrayshadow_vertex tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texturelod.sampler2darrayshadow_vertex"
   },
-  { "id": "gfx_mesa_gl_sru_texturelod_sampler2darrayshadow_fragment",
+  { "id": "gfx_mesa_gl_extra_sru_texturelod_sampler2darrayshadow_fragment",
     "_summary": "Run the texturelod_sampler2darrayshadow_fragment tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texturelod.sampler2darrayshadow_fragment"
   },
-  { "id": "gfx_mesa_gl_sru_texturelod_samplercubeshadow_vertex",
+  { "id": "gfx_mesa_gl_extra_sru_texturelod_samplercubeshadow_vertex",
     "_summary": "Run the texturelod_samplercubeshadow_vertex tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texturelod.samplercubeshadow_vertex"
   },
-  { "id": "gfx_mesa_gl_sru_texturelod_samplercubeshadow_fragment",
+  { "id": "gfx_mesa_gl_extra_sru_texturelod_samplercubeshadow_fragment",
     "_summary": "Run the texturelod_samplercubeshadow_fragment tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texturelod.samplercubeshadow_fragment"
   },
-  { "id": "gfx_mesa_gl_sru_texturelod_samplercubearrayshadow_fragment",
+  { "id": "gfx_mesa_gl_extra_sru_texturelod_samplercubearrayshadow_fragment",
     "_summary": "Run the texturelod_samplercubearrayshadow_fragment tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texturelod.samplercubearrayshadow_fragment"
   },
-  { "id": "gfx_mesa_gl_sru_texturelodoffset_sampler2darrayshadow_vertex",
+  { "id": "gfx_mesa_gl_extra_sru_texturelodoffset_sampler2darrayshadow_vertex",
     "_summary": "Run the texturelodoffset_sampler2darrayshadow_vertex tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texturelodoffset.sampler2darrayshadow_vertex"
   },
-  { "id": "gfx_mesa_gl_sru_texturelodoffset_sampler2darrayshadow_fragment",
+  { "id": "gfx_mesa_gl_extra_sru_texturelodoffset_sampler2darrayshadow_fragment",
     "_summary": "Run the texturelodoffset_sampler2darrayshadow_fragment tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.texturelodoffset.sampler2darrayshadow_fragment"
   },
@@ -178,98 +178,22 @@ _siblings: [
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.compressed_format.*"
   }]
 
-id: gfx_mesa_gl_info
+id: gfx_mesa_gl_longrun_renderbuffer
 category_id: mesa
 depends: gfx_mesa_gl_hw_render
 flags: simple
 user: root
-_summary: Run the info tests from VK-GL-CTS
+_summary: Run the renderbuffer tests from VK-GL-CTS
 environ:
   # necessary for local mode
   XDG_SESSION_TYPE
   XDG_RUNTIME_DIR
 estimated_duration: 1m
 command:
-  cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.info.*
+  cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.internalformat.renderbuffer.*
 _siblings:
-  [{ "id": "gfx_mesa_gl_shaders",
-    "_summary": "Run the shaders tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.shaders.*"
-  },
-  { "id": "gfx_mesa_gl_geometry_shader",
-    "_summary": "Run the geometry_shader tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.geometry_shader.*"
-  },
-  { "id": "gfx_mesa_gl_gpu_shader5",
-    "_summary": "Run the gpu_shader5 tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.gpu_shader5.*"
-  },
-  { "id": "gfx_mesa_gl_tessellation_shader",
-    "_summary": "Run the tessellation_shader tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.tessellation_shader.*"
-  },
-  { "id": "gfx_mesa_gl_texture_cube_map_array",
-    "_summary": "Run the texture_cube_map_array tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.texture_cube_map_array.*"
-  },
-  { "id": "gfx_mesa_gl_texture_border_clamp",
-    "_summary": "Run the texture_border_clamp tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.texture_border_clamp.*"
-  },
-  { "id": "gfx_mesa_gl_texture_buffer",
-    "_summary": "Run the texture_buffer tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.texture_buffer.*"
-  },
-  { "id": "gfx_mesa_gl_draw_buffers_indexed",
-    "_summary": "Run the draw_buffers_indexed tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.draw_buffers_indexed.*"
-  },
-  { "id": "gfx_mesa_gl_constant_expressions",
-    "_summary": "Run the constant_expressions tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.constant_expressions.*"
-  },
-  { "id": "gfx_mesa_gl_shader_macros",
-    "_summary": "Run the shader_macros tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.shader_macros.*"
-  },
-  { "id": "gfx_mesa_gl_separable_programs_tf",
-    "_summary": "Run the separable_programs_tf tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.separable_programs_tf.*"
-  },
-  { "id": "gfx_mesa_gl_copy_image",
-    "_summary": "Run the copy_image tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.copy_image.*"
-  },
-  { "id": "gfx_mesa_gl_texture2d",
-    "_summary": "Run the texture2d tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.internalformat.texture2d.*"
-  },
-  { "id": "gfx_mesa_gl_copy_tex_image",
-    "_summary": "Run the copy_tex_image tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.internalformat.copy_tex_image.*"
-  },
-  { "id": "gfx_mesa_gl_renderbuffer",
-    "_summary": "Run the renderbuffer tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.internalformat.renderbuffer.*"
-  },
-  { "id": "gfx_mesa_gl_ext_texture_shadow_lod",
+  [{ "id": "gfx_mesa_gl_longrun_ext_texture_shadow_lod",
     "_summary": "Run the ext_texture_shadow_lod tests from VK-GL-CTS",
     "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.ext_texture_shadow_lod.*"
-  },
-  { "id": "gfx_mesa_gl_nearest_edge",
-    "_summary": "Run the nearest_edge tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.nearest_edge.*"
-  },
-  { "id": "gfx_mesa_gl_framebuffer_completeness",
-    "_summary": "Run the framebuffer_completeness tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.framebuffer_completeness.*"
-  },
-  { "id": "gfx_mesa_gl_texture_compatibility",
-    "_summary": "Run the texture_compatibility tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.texture_compatibility.*"
-  },
-  { "id": "gfx_mesa_gl_compressed_format",
-    "_summary": "Run the compressed_format tests from VK-GL-CTS",
-    "command": "cd /usr/local/checkbox-gfx/GL-CTS/build/external/openglcts/modules; ./glcts --deqp-surface-type=fbo --deqp-case=KHR-GLES32.core.compressed_format.*"
   }]
 

--- a/contrib/checkbox-gfx/checkbox-provider-gfx/units/test-plan.pxu
+++ b/contrib/checkbox-gfx/checkbox-provider-gfx/units/test-plan.pxu
@@ -13,3 +13,23 @@ include:
     gfx_cl_.*
 bootstrap_include:
     com.canonical.certification::executable
+
+id: opengl-test-plan
+unit: test plan
+_name: GFX test plan for verifying OpenGL
+include:
+  gfx_mesa_gl.*
+bootstrap_include:
+    com.canonical.certification::executable
+    com.canonical.certification::snap
+    graphics_card
+
+id: opengl-test-plan-sru
+unit: test plan
+_name: Shorter GFX test plan for verifying OpenGL
+include:
+  gfx_mesa_gl_sru_.*
+bootstrap_include:
+    com.canonical.certification::executable
+    com.canonical.certification::snap
+    graphics_card

--- a/contrib/checkbox-gfx/checkbox-provider-gfx/units/test-plan.pxu
+++ b/contrib/checkbox-gfx/checkbox-provider-gfx/units/test-plan.pxu
@@ -18,7 +18,8 @@ id: opengl-test-plan
 unit: test plan
 _name: GFX test plan for verifying OpenGL
 include:
-  gfx_mesa_gl.*
+  gfx_mesa_gl_sru.*
+  gfx_mesa_gl_longrun.*
 bootstrap_include:
     com.canonical.certification::executable
     com.canonical.certification::snap
@@ -29,6 +30,7 @@ unit: test plan
 _name: Shorter GFX test plan for verifying OpenGL
 include:
   gfx_mesa_gl_sru_.*
+  gfx_mesa_gl_extra_sru.*
 bootstrap_include:
     com.canonical.certification::executable
     com.canonical.certification::snap

--- a/contrib/checkbox-gfx/snap/snapcraft.yaml
+++ b/contrib/checkbox-gfx/snap/snapcraft.yaml
@@ -29,6 +29,12 @@ apps:
   test-vulkan:
     command-chain: [bin/wrapper_local]
     command: bin/test-vulkan
+  test-opengl:
+    command-chain: [bin/wrapper_local]
+    command: bin/test-opengl
+  test-opengl-short:
+    command-chain: [bin/wrapper_local]
+    command: bin/test-opengl-short
   test-opencl:
     command-chain: [bin/wrapper_local]
     command: bin/test-opencl
@@ -42,6 +48,8 @@ apps:
     command: bin/shell-wrapper
   install-vulkan:
     command: bin/install-vulkan
+  install-opengl:
+    command: bin/install-opengl
   install-opencl:
     command: bin/install-opencl
   remove:


### PR DESCRIPTION
# Description
This provider contains tests for the graphics stack. Testing currently checks OpenGL by running Khronos's VK-GL-CTS, a conformance test suite. These checks ensure that our graphics stacks are conforming to Khronos's expected functionality for OpenGL.

Since the normal test suite can run upwards of 24h, a shorter test suite has been defined for SRUs and lower-power devices

# Resolved issues
N/A

# Documentation
See README

# Tests
Tests have been run on Intel Tiger Lake, Alder Lake, and Raptor Lake