### PR TITLE
Fixed snap confinement issue with rocm-validation-suite (BugFix)

### DIFF
--- a/providers/gpgpu/bin/rvs.py
+++ b/providers/gpgpu/bin/rvs.py
@@ -42,8 +42,16 @@ class ModuleRunner:
 
     def __init__(self, rvs: Path, config: Path) -> None:
         """Initializes the module runner."""
-        self.rvs = rvs
         self.config = config
+
+        # CHECKBOX-2021: Snap confinement prevents access to /usr/share
+        snap_bins = ["/snap/bin/rvs", "/snap/bin/rocm-validation-suite"]
+        if any(rvs.match(p) for p in snap_bins):
+            # To avoid confinement issues we run the binary directly
+            snap_current = Path("/snap/rocm-validation-suite/current")
+            self.rvs = list(snap_current.glob("opt/rocm-*/bin/rvs"))[0]
+        else:
+            self.rvs = rvs
 
     def run(self, module: str):
         """Runs and validates the RVS module.


### PR DESCRIPTION
## Description

- When running the AMD GPGPU tests, the ROCm Validation Suite is installed as a snap, but the snap confinement does not allow RVS to access `/usr/share/checkbox-provider-gpgpu/data/*`.
- The `rvs.py` wrapper for the ROCm Validation Suite will detect if the snap is being used and run the unconfined binary instead.

## Resolved issues

- Fixes #2132

## Documentation

## Tests

- Added unit tests
- Tested locally:

```console
λ pavalos@hephaestus:gpgpu(CHECKOX-2021-rvs-file-not-found) which rvs
/snap/bin/rvs
λ pavalos@hephaestus:gpgpu(CHECKOX-2021-rvs-file-not-found) ./bin/rvs.py -v --rvs /snap/bin/rvs -c /usr/share/checkbox-provider-gpgpu/data/rvs-gpup.conf gpup
DEBUG:root:Module to run: gpup
DEBUG:root:gpup: RUNNING
INFO:root:[RESULT] [ 22804.904776] Action name :query
[RESULT] [ 22804.905217] Module name :gpup
[RESULT] [ 22804.905274] [query] gpup 33281 cpu_cores_count 0
[RESULT] [ 22804.905275] [query] gpup 33281 simd_count 80
[RESULT] [ 22804.905276] [query] gpup 33281 mem_banks_count 1
[RESULT] [ 22804.905276] [query] gpup 33281 caches_count 86
[RESULT] [ 22804.905277] [query] gpup 33281 io_links_count 1
[RESULT] [ 22804.905277] [query] gpup 33281 p2p_links_count 0
[RESULT] [ 22804.905278] [query] gpup 33281 cpu_core_id_base 0
[RESULT] [ 22804.905278] [query] gpup 33281 simd_id_base 2147487744
[RESULT] [ 22804.905279] [query] gpup 33281 max_waves_per_simd 16
[RESULT] [ 22804.905279] [query] gpup 33281 lds_size_in_kb 64
[RESULT] [ 22804.905280] [query] gpup 33281 gds_size_in_kb 0
[RESULT] [ 22804.905280] [query] gpup 33281 num_gws 64
[RESULT] [ 22804.905281] [query] gpup 33281 wave_front_size 32
[RESULT] [ 22804.905281] [query] gpup 33281 array_count 4
[RESULT] [ 22804.905282] [query] gpup 33281 simd_arrays_per_engine 2
[RESULT] [ 22804.905282] [query] gpup 33281 cu_per_simd_array 10
[RESULT] [ 22804.905282] [query] gpup 33281 simd_per_cu 2
[RESULT] [ 22804.905283] [query] gpup 33281 max_slots_scratch_cu 32
[RESULT] [ 22804.905283] [query] gpup 33281 gfx_target_version 100301
[RESULT] [ 22804.905284] [query] gpup 33281 vendor_id 4098
[RESULT] [ 22804.905284] [query] gpup 33281 device_id 29663
[RESULT] [ 22804.905285] [query] gpup 33281 location_id 2560
[RESULT] [ 22804.905285] [query] gpup 33281 domain 0
[RESULT] [ 22804.905286] [query] gpup 33281 drm_render_minor 128
[RESULT] [ 22804.905286] [query] gpup 33281 hive_id 0
[RESULT] [ 22804.905287] [query] gpup 33281 num_sdma_engines 2
[RESULT] [ 22804.905287] [query] gpup 33281 num_sdma_xgmi_engines 0
[RESULT] [ 22804.905287] [query] gpup 33281 num_sdma_queues_per_engine 8
[RESULT] [ 22804.905288] [query] gpup 33281 num_cp_queues 8
[RESULT] [ 22804.905288] [query] gpup 33281 max_engine_clk_fcompute 2880
[RESULT] [ 22804.905289] [query] gpup 33281 local_mem_size 0
[RESULT] [ 22804.905289] [query] gpup 33281 fw_version 116
[RESULT] [ 22804.905290] [query] gpup 33281 capability 671326848
[RESULT] [ 22804.905290] [query] gpup 33281 debug_prop 1495
[RESULT] [ 22804.905291] [query] gpup 33281 sdma_fw_version 80
[RESULT] [ 22804.905291] [query] gpup 33281 unique_id 0
[RESULT] [ 22804.905291] [query] gpup 33281 num_xcc 1
[RESULT] [ 22804.905292] [query] gpup 33281 max_engine_clk_ccompute 4954
[RESULT] [ 22804.905316] [query] gpup 33281 0 type 2
[RESULT] [ 22804.905317] [query] gpup 33281 0 version_major 0
[RESULT] [ 22804.905318] [query] gpup 33281 0 version_minor 0
[RESULT] [ 22804.905318] [query] gpup 33281 0 node_from 1
[RESULT] [ 22804.905318] [query] gpup 33281 0 node_to 0
[RESULT] [ 22804.905319] [query] gpup 33281 0 weight 20
[RESULT] [ 22804.905319] [query] gpup 33281 0 min_latency 0
[RESULT] [ 22804.905320] [query] gpup 33281 0 max_latency 0
[RESULT] [ 22804.905320] [query] gpup 33281 0 min_bandwidth 0
[RESULT] [ 22804.905321] [query] gpup 33281 0 max_bandwidth 32000
[RESULT] [ 22804.905321] [query] gpup 33281 0 recommended_transfer_size 0
[RESULT] [ 22804.905322] [query] gpup 33281 0 recommended_sdma_engine_id_mask 0
[RESULT] [ 22804.905322] [query] gpup 33281 0 flags 1

DEBUG:root:gpup: SUCCESS
INFO:root:Result: PASS
λ pavalos@hephaestus:gpgpu(CHECKOX-2021-rvs-file-not-found) ./bin/rvs.py -v --rvs /snap/bin/rocm-validation-suite -c /usr/share/checkbox-provider-gpgpu/data/rvs-gpup.conf gpup
DEBUG:root:Module to run: gpup
DEBUG:root:gpup: RUNNING
INFO:root:[RESULT] [ 22845.135740] Action name :query
[RESULT] [ 22845.136159] Module name :gpup
[RESULT] [ 22845.136217] [query] gpup 33281 cpu_cores_count 0
[RESULT] [ 22845.136218] [query] gpup 33281 simd_count 80
[RESULT] [ 22845.136219] [query] gpup 33281 mem_banks_count 1
[RESULT] [ 22845.136219] [query] gpup 33281 caches_count 86
[RESULT] [ 22845.136220] [query] gpup 33281 io_links_count 1
[RESULT] [ 22845.136220] [query] gpup 33281 p2p_links_count 0
[RESULT] [ 22845.136221] [query] gpup 33281 cpu_core_id_base 0
[RESULT] [ 22845.136221] [query] gpup 33281 simd_id_base 2147487744
[RESULT] [ 22845.136222] [query] gpup 33281 max_waves_per_simd 16
[RESULT] [ 22845.136222] [query] gpup 33281 lds_size_in_kb 64
[RESULT] [ 22845.136223] [query] gpup 33281 gds_size_in_kb 0
[RESULT] [ 22845.136223] [query] gpup 33281 num_gws 64
[RESULT] [ 22845.136224] [query] gpup 33281 wave_front_size 32
[RESULT] [ 22845.136224] [query] gpup 33281 array_count 4
[RESULT] [ 22845.136224] [query] gpup 33281 simd_arrays_per_engine 2
[RESULT] [ 22845.136225] [query] gpup 33281 cu_per_simd_array 10
[RESULT] [ 22845.136225] [query] gpup 33281 simd_per_cu 2
[RESULT] [ 22845.136226] [query] gpup 33281 max_slots_scratch_cu 32
[RESULT] [ 22845.136226] [query] gpup 33281 gfx_target_version 100301
[RESULT] [ 22845.136227] [query] gpup 33281 vendor_id 4098
[RESULT] [ 22845.136227] [query] gpup 33281 device_id 29663
[RESULT] [ 22845.136228] [query] gpup 33281 location_id 2560
[RESULT] [ 22845.136228] [query] gpup 33281 domain 0
[RESULT] [ 22845.136229] [query] gpup 33281 drm_render_minor 128
[RESULT] [ 22845.136229] [query] gpup 33281 hive_id 0
[RESULT] [ 22845.136229] [query] gpup 33281 num_sdma_engines 2
[RESULT] [ 22845.136230] [query] gpup 33281 num_sdma_xgmi_engines 0
[RESULT] [ 22845.136230] [query] gpup 33281 num_sdma_queues_per_engine 8
[RESULT] [ 22845.136231] [query] gpup 33281 num_cp_queues 8
[RESULT] [ 22845.136231] [query] gpup 33281 max_engine_clk_fcompute 2880
[RESULT] [ 22845.136232] [query] gpup 33281 local_mem_size 0
[RESULT] [ 22845.136232] [query] gpup 33281 fw_version 116
[RESULT] [ 22845.136232] [query] gpup 33281 capability 671326848
[RESULT] [ 22845.136233] [query] gpup 33281 debug_prop 1495
[RESULT] [ 22845.136233] [query] gpup 33281 sdma_fw_version 80
[RESULT] [ 22845.136234] [query] gpup 33281 unique_id 0
[RESULT] [ 22845.136234] [query] gpup 33281 num_xcc 1
[RESULT] [ 22845.136235] [query] gpup 33281 max_engine_clk_ccompute 4954
[RESULT] [ 22845.136260] [query] gpup 33281 0 type 2
[RESULT] [ 22845.136261] [query] gpup 33281 0 version_major 0
[RESULT] [ 22845.136261] [query] gpup 33281 0 version_minor 0
[RESULT] [ 22845.136262] [query] gpup 33281 0 node_from 1
[RESULT] [ 22845.136262] [query] gpup 33281 0 node_to 0
[RESULT] [ 22845.136263] [query] gpup 33281 0 weight 20
[RESULT] [ 22845.136263] [query] gpup 33281 0 min_latency 0
[RESULT] [ 22845.136264] [query] gpup 33281 0 max_latency 0
[RESULT] [ 22845.136264] [query] gpup 33281 0 min_bandwidth 0
[RESULT] [ 22845.136265] [query] gpup 33281 0 max_bandwidth 32000
[RESULT] [ 22845.136265] [query] gpup 33281 0 recommended_transfer_size 0
[RESULT] [ 22845.136265] [query] gpup 33281 0 recommended_sdma_engine_id_mask 0
[RESULT] [ 22845.136266] [query] gpup 33281 0 flags 1

DEBUG:root:gpup: SUCCESS
INFO:root:Result: PASS
```