### PR TITLE
Move from deprecated ntpdate to ntpsec-ntpdate (infra)

### DIFF
--- a/providers/base/units/dock/jobs.pxu
+++ b/providers/base/units/dock/jobs.pxu
@@ -652,7 +652,8 @@ id: dock/networking-ntp
 category_id: dock-network
 plugin: user-interact-verify
 depends: dock/cold-plug
-requires: package.name == 'ntpdate'
+requires:
+    (package.name == 'ntpdate' or package.name == 'ntpsec-ntpdate')
 user: root
 command: network_ntp_test.py
 estimated_duration: 10.00
@@ -2680,7 +2681,7 @@ plugin: user-interact-verify
 imports: from com.canonical.plainbox import manifest
 requires:
     manifest.has_dock_ethernet_adapter == 'True'
-    package.name == 'ntpdate'
+    (package.name == 'ntpdate' or package.name == 'ntpsec-ntpdate')
 user: root
 command: network_ntp_test.py
 estimated_duration: 10.00

--- a/providers/base/units/networking/jobs.pxu
+++ b/providers/base/units/networking/jobs.pxu
@@ -70,7 +70,8 @@ plugin: shell
 category_id: com.canonical.plainbox::networking
 id: networking/ntp
 flags: also-after-suspend
-requires: package.name == 'ntpdate'
+requires:
+    (package.name == 'ntpdate' or package.name == 'ntpsec-ntpdate')
 user: root
 command: network_ntp_test.py
 _purpose: Test to see if we can sync local clock to an NTP server

--- a/providers/base/units/networking/packaging.pxu
+++ b/providers/base/units/networking/packaging.pxu
@@ -1,6 +1,16 @@
 unit: packaging meta-data
 os-id: debian
-Depends: ntpdate, net-tools, ethtool
+Depends: net-tools, ethtool
+
+unit: packaging meta-data
+os-id: ubuntu
+os-version-id: < 22.04
+Depends: ntpdate
+
+unit: packaging meta-data
+os-id: ubuntu
+os-version-id: >= 22.04
+Depends: ntpsec-ntpdate
 
 unit: packaging meta-data
 os-id: debian


### PR DESCRIPTION
## WARNING: This modifies com.canonical.certification::sru-server

## Description

Package has been deprecated in jammy and we've been installing the transitional package for years. Removed now. Time to migrate!

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-2025

## Documentation

N/A

## Tests

CI will validate this
See: https://packages.ubuntu.com/search?section=all&arch=any&keywords=ntpdate&searchon=names
