### PR TITLE
Update GPU passthrough tests (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/lxd_support.py
+++ b/checkbox-support/checkbox_support/lxd_support.py
@@ -212,9 +212,14 @@ class LXD:
         self.run("lxc restart {}".format(self.name))
 
     @retry(10, 10)
-    def wait_until_running(self):
+    def wait_until_running(self, allow_degraded: bool = False):
         """Waits for the instance to be up and running."""
-        self.run("systemctl is-system-running --wait", on_guest=True)
+        try:
+            self.run("systemctl is-system-running --wait", on_guest=True)
+        except subprocess.CalledProcessError as e:
+            if allow_degraded and e.stdout == "degraded":
+                return
+            raise
 
     def add_device(
         self,

--- a/checkbox-support/checkbox_support/lxd_support.py
+++ b/checkbox-support/checkbox_support/lxd_support.py
@@ -217,7 +217,7 @@ class LXD:
         try:
             self.run("systemctl is-system-running --wait", on_guest=True)
         except subprocess.CalledProcessError as e:
-            if allow_degraded and e.stdout == "degraded":
+            if allow_degraded and e.stdout.strip() == "degraded":
                 return
             raise
 

--- a/checkbox-support/checkbox_support/tests/test_lxd_support.py
+++ b/checkbox-support/checkbox_support/tests/test_lxd_support.py
@@ -285,6 +285,21 @@ class TestLXD(TestCase):
         self_mock = MagicMock()
         LXD.wait_until_running(self_mock)
 
+    def test_wait_until_running_degraded(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.run = MagicMock(
+            side_effect=subprocess.CalledProcessError(1, "", "degraded")
+        )
+        with self.assertRaises(subprocess.CalledProcessError):
+            LXD.wait_until_running(self_mock, allow_degraded=False)
+
+    def test_wait_until_running_allow_degraded(self, logging_mock):
+        self_mock = MagicMock()
+        self_mock.run = MagicMock(
+            side_effect=subprocess.CalledProcessError(1, "", "degraded")
+        )
+        LXD.wait_until_running(self_mock, allow_degraded=True)
+
     @patch.object(LXD, "cleanup")
     @patch.object(LXD, "init_lxd")
     def test_context_manager(self, init_lxd_mock, cleanup_mock, logging_mock):

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -50,20 +50,6 @@ GPU_VENDORS = {
 }
 """Mapping of supported vendor names to test configuration."""
 
-GPU_RUNS = 20
-"""How many times to run the GPU test.
-
-This can be overwritten by the `--count` option or by setting the environment
-variable `LXD_GPU_RUNS`. With priority in that order.
-"""
-
-GPU_THRESHOLD_SEC = 12.0
-"""The threshold for the GPU test to pass.
-
-This can be overwritten by the `--threshold` option or by setting the
-environment variable `LXD_GPU_THRESHOLD`. With priority in that order.
-"""
-
 QEMU_OPTS = ""
 """Any custom QEMU options required for passthrough on your platform
 
@@ -86,39 +72,22 @@ environment variable `VM_CPUS`. With priority in that order.
 """
 
 
-def run_gpu_test(
-    instance: LXD,
-    cmd: str,
-    run_count: int = GPU_RUNS,
-    threshold_sec: float = GPU_THRESHOLD_SEC,
-):
+def run_gpu_test(instance: LXD, cmd: str):
     """Executes GPU passthrough test."""
-    logging.info("Running GPU passthrough test %d times", run_count)
+    logging.info("Running GPU passthrough test")
     total_runtime_sec = 0.0
-    for i in range(run_count):
-        tic = time.time()
-        instance.run(cmd, on_guest=True)
-        toc = time.time()
-        runtime_sec = toc - tic
-        total_runtime_sec += runtime_sec
-        logging.debug("Runtime #%d (sec): %f", i, runtime_sec)
-
-    avg_runtime_sec = total_runtime_sec / run_count
-    logging.info("Average runtime (sec): %f", avg_runtime_sec)
-    if avg_runtime_sec >= threshold_sec:
-        logging.error(
-            "Average runtime %fs greater than threshold %fs",
-            avg_runtime_sec,
-            threshold_sec,
-        )
-        raise SystemExit(1)
+    tic = time.time()
+    instance.run(cmd, on_guest=True)
+    toc = time.time()
+    runtime_sec = toc - tic
+    total_runtime_sec += runtime_sec
+    logging.debug("Runtime: %f sec", runtime_sec)
 
 
 def test_lxd_gpu(args):
     """Tests GPU passthrough with a LXD container."""
     logging.info("Executing LXD GPU passthrough test")
 
-    instance = LXD(args.template, args.rootfs)
     with LXD(args.template, args.rootfs) as instance:
         logging.info("Launching container: %s", instance.name)
         instance.launch(
@@ -134,12 +103,7 @@ def test_lxd_gpu(args):
         logging.info("Installing mixbench snap")
         instance.run("snap install mixbench", on_guest=True)
 
-        run_gpu_test(
-            instance,
-            GPU_VENDORS[args.vendor]["test"],
-            args.count,
-            args.threshold,
-        )
+        run_gpu_test(instance, GPU_VENDORS[args.vendor]["test"])
 
 
 def test_lxdvm_gpu(args):
@@ -200,12 +164,7 @@ def test_lxdvm_gpu(args):
         logging.info("Installing mixbench snap")
         instance.run("snap install mixbench", on_guest=True)
 
-        run_gpu_test(
-            instance,
-            GPU_VENDORS[args.vendor]["test"],
-            args.count,
-            args.threshold,
-        )
+        run_gpu_test(instance, GPU_VENDORS[args.vendor]["test"])
 
 
 def parse_args():
@@ -221,20 +180,6 @@ def parse_args():
         default=logging.INFO,
         const=logging.DEBUG,
         help="Increase logging level",
-    )
-
-    test_group = parser.add_argument_group("test")
-    test_group.add_argument(
-        "--threshold",
-        type=float,
-        default=float(os.getenv("LXD_GPU_THRESHOLD") or GPU_THRESHOLD_SEC),
-        help="Threshold (sec) for GPU test",
-    )
-    test_group.add_argument(
-        "--count",
-        type=int,
-        default=int(os.getenv("LXD_GPU_RUNS") or GPU_RUNS),
-        help="Times to run GPU test",
     )
 
     gpu_group = parser.add_argument_group("gpu")

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -28,7 +28,7 @@ from checkbox_support.lxd_support import LXD, LXDVM
 
 GPU_VENDORS = {
     "nvidia": {
-        "test": "sudo mixbench.cuda",
+        "test": "gpu-burn 30",
         "lxd": {
             "launch_options": [
                 "-c",
@@ -100,8 +100,8 @@ def test_lxd_gpu(args):
         logging.info("Waiting for %s to be up", instance.name)
         instance.wait_until_running()
 
-        logging.info("Installing mixbench snap")
-        instance.run("snap install mixbench", on_guest=True)
+        logging.info("Installing gpu-burn snap")
+        instance.run("snap install gpu-burn", on_guest=True)
 
         run_gpu_test(instance, GPU_VENDORS[args.vendor]["test"])
 
@@ -161,8 +161,8 @@ def test_lxdvm_gpu(args):
         logging.info("Waiting for %s to be up", instance.name)
         instance.wait_until_running()
 
-        logging.info("Installing mixbench snap")
-        instance.run("snap install mixbench", on_guest=True)
+        logging.info("Installing gpu-burn snap")
+        instance.run("snap install gpu-burn", on_guest=True)
 
         run_gpu_test(instance, GPU_VENDORS[args.vendor]["test"])
 

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -117,7 +117,7 @@ def test_lxdvm_gpu(args):
         )
 
         logging.info("Waiting for %s to be up", instance.name)
-        instance.wait_until_running()
+        instance.wait_until_running(allow_degraded=True)
 
         instance.stop(force=True)
 

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -28,7 +28,7 @@ from checkbox_support.lxd_support import LXD, LXDVM
 
 GPU_VENDORS = {
     "nvidia": {
-        "test": "gpu-burn 30",
+        "test": "gpu-burn",
         "lxd": {
             "launch_options": [
                 "-c",

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -143,13 +143,13 @@ def test_lxdvm_gpu(args):
 
         instance.start()
 
-        instance.wait_until_running()
+        instance.wait_until_running(allow_degraded=True)
 
         logging.info("Passing GPU %s through to %s", args.pci, instance.name)
         instance.add_device("gpu", "gpu", options=["pci={}".format(args.pci)])
 
         logging.info("Waiting for %s to be up", instance.name)
-        instance.wait_until_running()
+        instance.wait_until_running(allow_degraded=True)
 
         logging.info("Configuring %s", instance.name)
         for cmd in GPU_VENDORS[args.vendor]["lxdvm"].get("config_cmds", []):
@@ -159,7 +159,7 @@ def test_lxdvm_gpu(args):
         instance.restart()
 
         logging.info("Waiting for %s to be up", instance.name)
-        instance.wait_until_running()
+        instance.wait_until_running(allow_degraded=True)
 
         logging.info("Installing gpu-burn snap")
         instance.run("snap install gpu-burn", on_guest=True)

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -104,6 +104,7 @@ def test_lxd_gpu(args):
         instance.run("snap install gpu-burn", on_guest=True)
 
         run_gpu_test(instance, GPU_VENDORS[args.vendor]["test"])
+        instance.stop(force=True)
 
 
 def test_lxdvm_gpu(args):
@@ -165,6 +166,7 @@ def test_lxdvm_gpu(args):
         instance.run("snap install gpu-burn", on_guest=True)
 
         run_gpu_test(instance, GPU_VENDORS[args.vendor]["test"])
+        instance.stop(force=True)
 
 
 def parse_args():

--- a/providers/gpgpu/tests/test_gpu_passthrough.py
+++ b/providers/gpgpu/tests/test_gpu_passthrough.py
@@ -19,6 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+from subprocess import CalledProcessError
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -37,15 +38,16 @@ class TestMain(TestCase):
     def test_run_gpu_test_success(self, time_mock, logging_mock):
         instance = MagicMock()
         try:
-            run_gpu_test(instance, "test", run_count=1, threshold_sec=2)
+            run_gpu_test(instance, "test")
         except SystemExit:
             self.fail("run_gpu_test raised SystemExit")
 
     @patch("time.time", side_effect=[0, 2])
     def test_run_gpu_test_failure(self, time_mock, logging_mock):
         instance = MagicMock()
-        with self.assertRaises(SystemExit):
-            run_gpu_test(instance, "test", run_count=1, threshold_sec=1)
+        instance.run.side_effect = CalledProcessError(1, "gpu-burn 30")
+        with self.assertRaises(CalledProcessError):
+            run_gpu_test(instance, "test")
 
     @patch("gpu_passthrough.run_gpu_test")
     @patch("gpu_passthrough.LXD")

--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -84,8 +84,6 @@ category_id: gpgpu
 plugin: shell
 estimated_duration: 1m 45s
 environ:
-    LXD_GPU_THRESHOLD
-    LXD_GPU_RUNS
     QEMU_OPTS
     VM_RAM_MB
     VM_CPUS
@@ -105,6 +103,10 @@ requires:
 category_id: gpgpu
 plugin: shell
 estimated_duration: 12m
+environ:
+    QEMU_OPTS
+    VM_RAM_MB
+    VM_CPUS
 command: gpu_passthrough.py -v --vendor=nvidia --pci={pci_device_name} lxdvm
 _purpose: Creates a LXD virtual machine and passes {pci_device_name} GPU through
 _summary: Test LXD VM GPU passthrough on NVIDIA GPU {pci_device_name}

--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -83,10 +83,6 @@ requires:
 category_id: gpgpu
 plugin: shell
 estimated_duration: 1m 45s
-environ:
-    QEMU_OPTS
-    VM_RAM_MB
-    VM_CPUS
 command: gpu_passthrough.py -v --vendor=nvidia --pci={pci_device_name} lxd
 _purpose: Creates a LXD container and passes {pci_device_name} GPU through
 _summary: Test LXD GPU passthrough on NVIDIA GPU {pci_device_name}

--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -83,6 +83,9 @@ requires:
 category_id: gpgpu
 plugin: shell
 estimated_duration: 1m 45s
+environ:
+    LXD_TEMPLATE
+    LXD_ROOTFS
 command: gpu_passthrough.py -v --vendor=nvidia --pci={pci_device_name} lxd
 _purpose: Creates a LXD container and passes {pci_device_name} GPU through
 _summary: Test LXD GPU passthrough on NVIDIA GPU {pci_device_name}
@@ -100,6 +103,8 @@ category_id: gpgpu
 plugin: shell
 estimated_duration: 12m
 environ:
+    LXD_TEMPLATE
+    KVM_IMAGE
     QEMU_OPTS
     VM_RAM_MB
     VM_CPUS


### PR DESCRIPTION
## Description

- Replaces `mixbench` with `gpu-burn`
  - `mixbench` is not building for newer versions of CUDA or newer architectures
  - Since the test is just for NVIDIA GPUs at the moment, we can use `gpu-burn`, which we already use to test the GPU without passthrough
- Runs test once instead of re-running and taking average time
- Added missing `environ` section for LXDVM passthrough job (see #2007)

## Resolved issues

- ~~Related to CHECKBOX-2020~~

## Documentation

## Tests

- Updated unit tests
- Run checkbox on lab device and add submission
  - VM tests passing: https://testflinger.canonical.com/jobs/9d102692-c872-4f2e-8686-ac55eb85b90c (container tests failing due to wrong host driver installed)
  - All tests pass: https://testflinger.canonical.com/jobs/b7dbd054-ba55-48dd-a832-34b575396920
