### PR TITLE
Add "Main Server Chassis" to not-portable sane_product for Nvidia DGX Spark (BugFix)

### DIFF
--- a/providers/resource/bin/dmi_resource.py
+++ b/providers/resource/bin/dmi_resource.py
@@ -44,6 +44,7 @@ def sane_product(og_product: str) -> str:
         "space-saving",
         "all-in-one",
         "aio",
+        "main-server-chassis",
     ]:
         return "non-portable"
     elif cleaned in [


### PR DESCRIPTION
Add "Main Server Chassis" to not-portable sane_product, to handle Nvidia DGX Spark
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

Add "Main Server Chassis" to not-portable sane_product, to handle Nvidia DGX Spark

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

I tested on one of the device, without and with the PR. 
Without it the test `graphics/auto_glxgears_fullscreen` and skipped because 

```
----[ Test that glxgears works in full screen mode for current video card ]-----
ID: com.canonical.certification::graphics/auto_glxgears_fullscreen
Category: com.canonical.plainbox::graphics
Job cannot be started because:
 - resource expression 'dmi.sane_product == "non-portable"' evaluates to false
Outcome: job cannot be started
```

with the PR, it passes.
