### PR TITLE
Use Python3.5 and 3.6 from the Checkbox-dev PPA (infra)

### DIFF
--- a/.github/workflows/tox-checkbox.yaml
+++ b/.github/workflows/tox-checkbox.yaml
@@ -137,6 +137,9 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python }}
         run: |
           sudo add-apt-repository ppa:deadsnakes/ppa
+          # python3.5 and python3.6 are no longer in deadsnakes for focal
+          # we pushed them to the Checkbox PPA instead
+          sudo add-apt-repository ppa:checkbox-dev/edge
           sudo apt-get update
           sudo apt-get install -y -qq libgl1 gcc python$PYTHON_VERSION-dev shellcheck
           pip install tox

--- a/.github/workflows/tox-contrib-provider-ce-oem.yaml
+++ b/.github/workflows/tox-contrib-provider-ce-oem.yaml
@@ -57,6 +57,9 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python }}
         run: |
           sudo add-apt-repository ppa:deadsnakes/ppa
+          # python3.5 and python3.6 are no longer in deadsnakes for focal
+          # we pushed them to the Checkbox PPA instead
+          sudo add-apt-repository ppa:checkbox-dev/edge
           sudo apt-get update
           sudo apt-get install -y -qq libgl1 gcc python$PYTHON_VERSION-dev
           pip install tox

--- a/.github/workflows/tox-contrib-provider-dss.yaml
+++ b/.github/workflows/tox-contrib-provider-dss.yaml
@@ -42,6 +42,9 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python }}
         run: |
           sudo add-apt-repository ppa:deadsnakes/ppa
+          # python3.5 and python3.6 are no longer in deadsnakes for focal
+          # we pushed them to the Checkbox PPA instead
+          sudo add-apt-repository ppa:checkbox-dev/edge
           sudo apt-get update
           sudo apt-get install -y -qq libgl1 gcc python$PYTHON_VERSION-dev
           pip install tox

--- a/.github/workflows/tox-provider-docker.yaml
+++ b/.github/workflows/tox-provider-docker.yaml
@@ -57,6 +57,9 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python }}
         run: |
           sudo add-apt-repository ppa:deadsnakes/ppa
+          # python3.5 and python3.6 are no longer in deadsnakes for focal
+          # we pushed them to the Checkbox PPA instead
+          sudo add-apt-repository ppa:checkbox-dev/edge
           sudo apt-get update
           sudo apt-get install -y -qq libgl1 gcc python$PYTHON_VERSION-dev
           pip install tox

--- a/.github/workflows/tox-provider-tpm2.yaml
+++ b/.github/workflows/tox-provider-tpm2.yaml
@@ -57,6 +57,9 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python }}
         run: |
           sudo add-apt-repository ppa:deadsnakes/ppa
+          # python3.5 and python3.6 are no longer in deadsnakes for focal
+          # we pushed them to the Checkbox PPA instead
+          sudo add-apt-repository ppa:checkbox-dev/edge
           sudo apt-get update
           sudo apt-get install -y -qq libgl1 gcc python$PYTHON_VERSION-dev
           pip install tox

--- a/.github/workflows/tox-provider-tutorial.yaml
+++ b/.github/workflows/tox-provider-tutorial.yaml
@@ -57,6 +57,9 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python }}
         run: |
           sudo add-apt-repository ppa:deadsnakes/ppa
+          # python3.5 and python3.6 are no longer in deadsnakes for focal
+          # we pushed them to the Checkbox PPA instead
+          sudo add-apt-repository ppa:checkbox-dev/edge
           sudo apt-get update
           sudo apt-get install -y -qq libgl1 gcc python$PYTHON_VERSION-dev
           pip install tox

--- a/docs/how-to/ancient-python.rst
+++ b/docs/how-to/ancient-python.rst
@@ -14,7 +14,7 @@ Save the following ``cloud-init`` file in ``python35_cloud_init.yaml``:
 
   #cloud-config
   runcmd:
-    - add-apt-repository --yes ppa:deadsnakes/ppa
+    - add-apt-repository --yes ppa:checkbox-dev/edge
     - apt update -q -y
     - apt install -q -y "python3.5" "python3.5-venv" "python3.5-dev" gcc "flake8" "shellcheck"
     - python3.5 -m ensurepip
@@ -41,3 +41,8 @@ The ``cloud-init`` file has prepared you a fresh clone of the Checkbox repo in
 ``/root/checkbox``, it has created a venv you can use in ``/root/venv`` with
 Python3.5 and it has developed the ``resource`` and ``base`` provider. You
 should now be able to iterate on your tests!
+
+.. note::
+
+  Python 3.5 and Python 3.6 are no longer in the deadsnakes PPA. We have added
+  them to the checkbox-dev PPA to still be able to run the tests.


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Deadsnakes dropped python3.5 and 3.6 for focal. To still be able to do the testing we have backported it to our PPA.
Note: deadsnakes is still used for python3.8+ on ubuntu:latest, so this is why I left it there.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-2030

## Documentation

Updated the tutorial on how to test python3.5 so that it also uses the PPA

## Tests

Tested this locally by:
```shell
$ lxc launch ubuntu:focal focal
$ lxc shell focal
root@focal > add-apt-repository --yes ppa:deadsnakes/ppa
root@focal > apt update
root@focal > apt install python3.6-dev
# [...] this fails, as the package is no longer in deadsnakes
root@focal > add-apt-repository --yes ppa:checkbox-dev/edge
root@focal > apt update
root@focal > apt install python3.6-dev
[...] this works, the package is in the checkbox-dev ppa
```
