### PR TITLE
Log run command (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/secure/rfc822.py
+++ b/checkbox-ng/plainbox/impl/secure/rfc822.py
@@ -322,7 +322,6 @@ def gen_rfc822_records(stream, data_cls=dict, source=None):
             normalized_value = normalize_rfc822_value(raw_value)
             record.raw_data[key] = raw_value
             record.data[key] = normalized_value
-            logger.debug(_("Committed key/value %r=%r"), key, normalized_value)
             key = None
 
     def _set_start_lineno_if_needed():
@@ -347,7 +346,6 @@ def gen_rfc822_records(stream, data_cls=dict, source=None):
         stream = iter(stream.splitlines(True))
     # Iterate over subsequent lines of the stream
     for lineno, line in enumerate(stream, start=1):
-        logger.debug(_("Looking at line %d:%r"), lineno, line)
         # Treat # as comments
         if line.startswith("#"):
             pass
@@ -359,7 +357,6 @@ def gen_rfc822_records(stream, data_cls=dict, source=None):
             # If data is non-empty, yield the record, this allows us to safely
             # use newlines for formatting
             if record.data:
-                logger.debug(_("yielding record: %r"), record)
                 yield record
             # Reset local state so that we can build a new record
             _new_record()
@@ -430,5 +427,4 @@ def gen_rfc822_records(stream, data_cls=dict, source=None):
     _commit_key_value_if_needed()
     # Once we've seen the whole file return the last record, if any
     if record.data:
-        logger.debug(_("yielding record: %r"), record)
         yield record


### PR DESCRIPTION
## Description

It is often useful to have a reproducer command to re-try a job while debugging as it is not always trivially apparent what goes wrong and if its due to the environment or the job itself. We did already log the command in the debug log (which is basically unusable due to the spam), but I think this information is valueable enough to actually get "promoted" to info. This way we will always have it for all checkbox remote runs for all jobs.

Minor: this adds also a info log to state exactly when a job is done, this could come handy to debug in the future
Minor: this drops debug printing every read and parsed line for every single pxu we read, hope its clear why

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-1855

## Documentation

N/A

## Tests

Manually tested this offline. Test this by running smoke on remote, you will see the commands in the log

example.conf: 
```
#!/usr/bin/env checkbox-cli
[launcher]
stock_reports = text
[test plan]
unit = com.canonical.certification::smoke
forced=True
[test selection]
forced=True
```

T1
```
ALLOW_CHECKBOX_AGENT_NONROOT=1 checkbox-cli run-agent
[...]
INFO:plainbox.unified:Starting job [com.canonical.certification::cpuinfo] executing: "sudo --prompt '' --reset-timestamp --stdin --user root env CHECKBOX_SHARE=/home/h25/prj/canonical/checkbox/providers/resource DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus DISPLAY=:0 'PATH=/tmp/nest-vqbo9jvm.f5e31b448fa446bfc0e4594bc18a886314229f0a3c203aaf44df2664143faa49:/home/h25/prj/canonical/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:~/.local/bin:~/mspgcc-20120406:~/gcc-arm-none-eabi-9-2019-q4-major/bin:~/prj/contiki:~/prj/msp430-libc:~/prj/nuxmv:/var/lib/snapd/snap/bin:/home/h25/.platformio/penv/bin' PLAINBOX_PROVIDER_DATA=/home/h25/prj/canonical/checkbox/providers/resource/data PLAINBOX_PROVIDER_GETTEXT_DOMAIN=checkbox-provider-resource PLAINBOX_SESSION_SHARE=/var/tmp/checkbox-ng/sessions/session_title-2025-10-08T16.00.25.session/session-share TEXTDOMAIN=checkbox-provider-resource WAYLAND_DISPLAY=wayland-1 XAUTHORITY=/run/pressure-vessel/Xauthority XDG_RUNTIME_DIR=/run/user/1000 XDG_SESSION_TYPE=wayland bash -c cpuinfo_resource.py"
INFO:plainbox.unified:Finished job [com.canonical.certification::cpuinfo]
```
T2
```
checkbox-cli control 127.1.2.3 example.conf
-----------------------------[ Running job 1 / 20 ]-----------------------------
---------------------[ Collect information about the CPU ]----------------------
ID: com.canonical.certification::cpuinfo
Category: Gathers information about the DUT
--------------------------------------------------------------------------------
[...]
```
