### PR TITLE
Migrate to new randr cycle script (New)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -308,6 +308,9 @@ class RemoteSessionAssistant:
                 "XDG_CURRENT_DESKTOP"
             ),
             "XDG_SESSION_TYPE": self._set_envvar_from_proc("XDG_SESSION_TYPE"),
+            "XDG_CURRENT_DESKTOP": self._set_envvar_from_proc(
+                "XDG_CURRENT_DESKTOP"
+            ),
             "XDG_RUNTIME_DIR": "/run/user/{}".format(uid),
             "DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/{}/bus".format(
                 uid
@@ -325,6 +328,7 @@ class RemoteSessionAssistant:
             "XAUTHORITY",
             "XDG_CURRENT_DESKTOP",
             "XDG_SESSION_TYPE",
+            "XDG_CURRENT_DESKTOP",
             "XDG_RUNTIME_DIR",
             "DBUS_SESSION_BUS_ADDRESS",
             "WAYLAND_DISPLAY",

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -308,9 +308,6 @@ class RemoteSessionAssistant:
                 "XDG_CURRENT_DESKTOP"
             ),
             "XDG_SESSION_TYPE": self._set_envvar_from_proc("XDG_SESSION_TYPE"),
-            "XDG_CURRENT_DESKTOP": self._set_envvar_from_proc(
-                "XDG_CURRENT_DESKTOP"
-            ),
             "XDG_RUNTIME_DIR": "/run/user/{}".format(uid),
             "DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/{}/bus".format(
                 uid
@@ -328,7 +325,6 @@ class RemoteSessionAssistant:
             "XAUTHORITY",
             "XDG_CURRENT_DESKTOP",
             "XDG_SESSION_TYPE",
-            "XDG_CURRENT_DESKTOP",
             "XDG_RUNTIME_DIR",
             "DBUS_SESSION_BUS_ADDRESS",
             "WAYLAND_DISPLAY",

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -223,12 +223,13 @@ template-id: graphics/index_cycle_resolution_product_slug
 flags: also-after-suspend
 requires: package.name == 'xorg'
 depends: graphics/VESA_drivers_not_in_use
+environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 command:
  # shellcheck disable=SC1091
  source graphics_env.sh {driver} {index}
- if [[ $XDG_SESSION_TYPE == "wayland" ]]
+ if [[ $XDG_CURRENT_DESKTOP == *"GNOME"* ]]
  then
-   gnome_randr_cycle.py --screenshot-dir="$PLAINBOX_SESSION_SHARE"
+   randr_cycle.py -c resolution --prefix {index} --screenshot_dir="$PLAINBOX_SESSION_SHARE"
  else
    xrandr_cycle.py --screenshot-dir="$PLAINBOX_SESSION_SHARE"
  fi
@@ -250,10 +251,16 @@ category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_rotation_{product_slug}
 template-id: graphics/index_rotation_product_slug
 flags: also-after-suspend
+environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 command:
  # shellcheck disable=SC1091
  source graphics_env.sh {driver} {index}
- rotation_test.py
+ if [[ $XDG_CURRENT_DESKTOP == *"GNOME"* ]]
+ then
+   randr_cycle.py -c transform --prefix {index} --screenshot_dir="$PLAINBOX_SESSION_SHARE"
+ else
+   rotation_test.py
+ fi
 estimated_duration: 20.000
 _summary: Test rotation for {vendor} {product}
 _purpose:

--- a/providers/base/units/suspend/suspend-graphics.pxu
+++ b/providers/base/units/suspend/suspend-graphics.pxu
@@ -97,12 +97,13 @@ depends:
   suspend/suspend_advanced_auto
  {%- endif %}
 estimated_duration: 120.0
+environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 command:
- # shellcheck disable=SC1091
+ # shellcheck disable=SC1091,SC1083
  source graphics_env.sh {{ driver }} {{ index }}
- if [[ $XDG_SESSION_TYPE == "wayland" ]]
+ if [[ $XDG_CURRENT_DESKTOP == *"GNOME"* ]]
  then
-   gnome_randr_cycle.py --keyword={{ index }}_after_suspend --screenshot-dir="$PLAINBOX_SESSION_SHARE"
+   randr_cycle.py -c resolution --prefix {index} --screenshot_dir="$PLAINBOX_SESSION_SHARE"
  else
    xrandr_cycle.py --keyword={{ index }}_after_suspend --screenshot-dir="$PLAINBOX_SESSION_SHARE"
  fi
@@ -122,7 +123,7 @@ category_id: com.canonical.plainbox::suspend
 id: suspend/{index}_xrandr_screens_after_suspend.tar.gz_auto
 template-id: suspend/index_xrandr_screens_after_suspend.tar.gz_auto
 depends: after-suspend-graphics/{index}_cycle_resolution_{product_slug}
-command: [ -f "$PLAINBOX_SESSION_SHARE"/xrandr_screens_{index}_after_suspend.tgz ] && cat "$PLAINBOX_SESSION_SHARE"/xrandr_screens_{index}_after_suspend.tgz
+command: [ -f "$PLAINBOX_SESSION_SHARE"/{index}_xrandr_screens_after_suspend.tgz ] && cat "$PLAINBOX_SESSION_SHARE"/{index}_xrandr_screens_after_suspend.tgz
 _purpose: This attaches screenshots from the suspend/cycle_resolutions_after_suspend test to the results submission.
 _summary: Attach screenshots from suspend/cycle resolutions after suspend test to results.
 

--- a/providers/base/units/suspend/suspend.pxu
+++ b/providers/base/units/suspend/suspend.pxu
@@ -1151,10 +1151,11 @@ id: suspend/cycle_resolutions_after_suspend
 estimated_duration: 120.0
 requires: package.name == 'xorg'
 depends: suspend/suspend_advanced_auto
+environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 command:
- if [[ $XDG_SESSION_TYPE == "wayland" ]]
+ if [[ $XDG_CURRENT_DESKTOP == *"GNOME"* ]]
  then
-   gnome_randr_cycle.py --keyword=after_suspend --screenshot-dir="$PLAINBOX_SESSION_SHARE"
+   randr_cycle.py -c resolution --screenshot_dir="$PLAINBOX_SESSION_SHARE"
  else
    xrandr_cycle.py --keyword=after_suspend --screenshot-dir="$PLAINBOX_SESSION_SHARE"
  fi
@@ -1175,11 +1176,12 @@ id: suspend/{index}_cycle_resolutions_after_suspend_{product_slug}
 template-id: suspend/index_cycle_resolutions_after_suspend_product_slug
 requires: package.name == 'xorg'
 depends: suspend/{index}_suspend_after_switch_to_card_{product_slug}
+environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 estimated_duration: 120.0
 command:
- if [[ $XDG_SESSION_TYPE == "wayland" ]]
+ if [[ $XDG_CURRENT_DESKTOP == *"GNOME"* ]]
  then
-   gnome_randr_cycle.py --keyword={index}_after_suspend --screenshot-dir="$PLAINBOX_SESSION_SHARE"
+   randr_cycle.py -c resolution --prefix {index} --screenshot_dir="$PLAINBOX_SESSION_SHARE"
  else
    xrandr_cycle.py --keyword={index}_after_suspend --screenshot-dir="$PLAINBOX_SESSION_SHARE"
  fi
@@ -1197,13 +1199,14 @@ id: suspend/cycle_resolutions_after_suspend_auto
 estimated_duration: 1.2
 requires: package.name == 'xorg'
 depends: suspend/suspend_advanced_auto
+environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 _purpose:
  This test will check to make sure supported video modes work after a suspend and resume.
  This is done automatically by taking screenshots and uploading them as an attachment.
 command:
- if [[ $XDG_SESSION_TYPE == "wayland" ]]
+ if [[ $XDG_CURRENT_DESKTOP == *"GNOME"* ]]
  then
-   gnome_randr_cycle.py --keyword=after_suspend --screenshot-dir="$PLAINBOX_SESSION_SHARE"
+   randr_cycle.py -c resolution --screenshot_dir="$PLAINBOX_SESSION_SHARE"
  else
    xrandr_cycle.py --keyword=after_suspend --screenshot-dir="$PLAINBOX_SESSION_SHARE"
  fi
@@ -1213,7 +1216,9 @@ plugin: attachment
 category_id: com.canonical.plainbox::suspend
 id: suspend/xrandr_screens_after_suspend.tar.gz
 depends: suspend/cycle_resolutions_after_suspend
-command: [ -f "$PLAINBOX_SESSION_SHARE"/xrandr_screens_after_suspend.tgz ] && cat "$PLAINBOX_SESSION_SHARE"/xrandr_screens_after_suspend.tgz
+command:
+    # shellcheck disable=SC1091,SC1083
+    [ -f "$PLAINBOX_SESSION_SHARE"/{index}_xrandr_screens_after_suspend.tgz ] && cat "$PLAINBOX_SESSION_SHARE"/{index}_xrandr_screens_after_suspend.tgz
 _purpose: This attaches screenshots from the suspend/cycle_resolutions_after_suspend test to the results submission.
 _summary: Attach screenshots from the suspend/cycle_resolutions_after_suspend test to results.
 
@@ -1225,7 +1230,9 @@ category_id: com.canonical.plainbox::suspend
 id: suspend/{index}_xrandr_screens_after_suspend.tar.gz
 template-id: suspend/index_xrandr_screens_after_suspend.tar.gz
 depends: suspend/{index}_cycle_resolutions_after_suspend_{product_slug}
-command: [ -f "$PLAINBOX_SESSION_SHARE"/{index}_xrandr_screens_after_suspend.tgz ] && cat "$PLAINBOX_SESSION_SHARE"/{index}_xrandr_screens_after_suspend.tgz
+command:
+    # shellcheck disable=SC1091,SC1083
+    [ -f "$PLAINBOX_SESSION_SHARE"/{index}_xrandr_screens_after_suspend.tgz ] && cat "$PLAINBOX_SESSION_SHARE"/{index}_xrandr_screens_after_suspend.tgz
 _purpose: This attaches screenshots from the suspend/cycle_resolutions_after_suspend test to the results submission.
 _summary: Attach screenshots from suspend/cycle_resolutions_after_suspend test to the results.
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

This is the following PR of #1843 to replace the old `gnome_randr_cycle.py` and following changes:
1. add `XDG_CURRENT_DESKTOP` environment variable to [remote_assistant.py](https://github.com/canonical/checkbox/blob/79c7c03d68990e1f2f6a303eb7b29d60e9af2798/checkbox-ng/plainbox/impl/session/remote_assistant.py#L301) to ensure the remote testing could have this variable.
2. Using `XDG_CURRENT_DESKTOP` instead of `XDG_SESSION_TYPE` in the `command` field to align the same behavior of [display_info.py](https://github.com/canonical/checkbox/blob/79c7c03d68990e1f2f6a303eb7b29d60e9af2798/checkbox-support/checkbox_support/helpers/display_info.py#L32)

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
- #855 
- #370: If the `XDG_CURRENT_DESKTOP` is not GNOME, the old `xrandr_cycle.py` should be integrated into `randr_cycle.py` and implement the same [cycle method](https://github.com/canonical/checkbox/blob/79c7c03d68990e1f2f6a303eb7b29d60e9af2798/checkbox-support/checkbox_support/dbus/gnome_monitor.py#L339) for it in [xrandr.py](https://github.com/canonical/checkbox/blob/main/checkbox-support/checkbox_support/parsers/xrandr.py) 

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->
N/A

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
client-cert-desktop-24-04-manual with `wayland`: https://certification.canonical.com/hardware/202303-31324/submission/455043/
client-cert-desktop-24-04-manual with `X11`: https://certification.canonical.com/hardware/202303-31324/submission/455044/
client-cert-desktop-hwe-sru with `wayland`: https://certification.canonical.com/hardware/202303-31324/submission/455046/
