### PR TITLE
Use --non-interactive instead of -A (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/secure/sudo_broker.py
+++ b/checkbox-ng/plainbox/impl/secure/sudo_broker.py
@@ -33,6 +33,7 @@ import sys
 from plainbox.i18n import gettext as _
 from subprocess import (
     check_output,
+    check_call,
     CalledProcessError,
     STDOUT,
     DEVNULL,

--- a/checkbox-ng/plainbox/impl/secure/test_sudo_broker.py
+++ b/checkbox-ng/plainbox/impl/secure/test_sudo_broker.py
@@ -17,7 +17,10 @@
 from subprocess import CalledProcessError
 from unittest import TestCase, mock
 
-from plainbox.impl.secure.sudo_broker import is_passwordless_sudo
+from plainbox.impl.secure.sudo_broker import (
+    is_passwordless_sudo,
+    validate_pass,
+)
 
 
 class IsPasswordlessSudoTests(TestCase):
@@ -46,3 +49,14 @@ class IsPasswordlessSudoTests(TestCase):
     def test_non_root_raising(self, mock_check_output, mock_getuid):
         mock_check_output.side_effect = CalledProcessError(1, "oops")
         self.assertFalse(is_passwordless_sudo())
+
+
+class ValidatePassTest(TestCase):
+    @mock.patch("plainbox.impl.secure.sudo_broker.check_call")
+    def test_validate_pass_wrong(self, check_output_mock):
+        check_output_mock.side_effect = CalledProcessError(1, "oops")
+        self.assertFalse(validate_pass(b"password"))
+
+    @mock.patch("plainbox.impl.secure.sudo_broker.check_call")
+    def test_validate_pass_ok(self, check_output_mock):
+        self.assertTrue(validate_pass(b"password"))


### PR DESCRIPTION
## Description

Checkbox on Questing is unable to start the service and always prompts for password even if passwordless sudo is configured. The reason is that `sudo-rs` doesn't support `-A` (askpass) option yet. Checkbox is using this option both to detect that we are able to run `sudo` when root (crashing the service, as checkbox thinks something is wrong with sudo itself) and detect if the password is required in local (interpreting the failure due to `-A` is not supported as passwordless sudo is not supported). 

This uses another option `--non-interactive` in combination with `--reset-timestamp` to have the same result as before, namely the command will fail if user interaction is required, which is what we want in this situation.

This also improves the error message for the agent, as before it was very difficoult to know exactly why the process was crashing, now we log the sudo output

See `-A` not supported: https://github.com/trifectatechfoundation/sudo-rs/issues/1249#issuecomment-3274142007

## Resolved issues

Fixes: CHECKBOX-2037
Fixes: https://github.com/canonical/checkbox/issues/2159

## Documentation

Added a comment to explain the logic behind the command and the reason for the switch in case someone will wonder in the future why we don't use `-A`

## Tests

To test this do the following:
```
lxc launch ubuntu:questing questing
lxc shell questing
root@questing: add-apt-repository ppa:checkbox-dev/edge
root@questing: apt update
root@questing: apt install checkbox-ng checkbox-provider-resource checkbox-provider-base
root@questing: sudo -u ubuntu bash
ubuntu@questing: sudo --non-interactive --reset-timestamp true; echo $?
0 
# this confirms that passwordless sudo is enabled! Try it on your machine, it should fail
# if you aren't a cowboy
 # Now try to run the smoke testplan, you will be prompted for a password 
ubuntu@questing: checkbox-cli 
# /smoke <enter>
Enter sudo password: <- this is actually not sudo, this is checkbox!
```
Verify that also the agent is broken
```
root@questing: checkbox-cli run-agent
BOOM
```
Now patch the installation with the sudo_broker from this PR:
```
root@questing: curl https://raw.githubusercontent.com/canonical/checkbox/refs/heads/passwordless_sudo_rs/checkbox-ng/plainbox/impl/secure/sudo_broker.py >  /usr/lib/python3/dist-packages/plainbox/impl/secure/sudo_broker.py
```
Rerun the above, everything should work as intended.