### PR TITLE
fix: add more mock time values in test_prime_offload_tester to handle (Bugfix)

### DIFF
--- a/providers/base/tests/test_prime_offload_tester.py
+++ b/providers/base/tests/test_prime_offload_tester.py
@@ -325,7 +325,7 @@ class CheckOffloadTests(unittest.TestCase):
         cmd = ["echo"]
         # get_clients return string that doesn't include cmd
         mock_client.return_value = ""
-        mock_time.side_effect = [0, 0, 1, 2]
+        mock_time.side_effect = [0, 0, 1, 2, 3, 4]
         po = PrimeOffloader()
         self.assertEqual(
             po.check_offload(cmd, "card_id", "card_name", 1), None
@@ -334,7 +334,7 @@ class CheckOffloadTests(unittest.TestCase):
 
         # get_clients return None by CalledProcessError
         mock_client.return_value = None
-        mock_time.side_effect = [0, 0, 1, 2]
+        mock_time.side_effect = [0, 0, 1, 2, 3, 4]
         po = PrimeOffloader()
         self.assertEqual(
             po.check_offload(cmd, "card_id", "card_name", 1), None
@@ -388,7 +388,7 @@ class FindOffloadTests(unittest.TestCase):
         po.find_card_id = MagicMock(return_value="0")
         po.find_card_name = MagicMock(return_value="Intel")
         po.find_file_containing_string = MagicMock(return_value="")
-        mock_time.side_effect = [0, 0, 1, 2]
+        mock_time.side_effect = [0, 0, 1, 2, 3, 4]
         self.assertEqual(po.find_offload(cmd, 1), None)
         po.find_file_containing_string.assert_called_with(
             "/sys/kernel/debug/dri", "clients", cmd


### PR DESCRIPTION
## Description
add more mock time values in test_prime_offload_tester to handle

The check_offload() method makes 5 time.time() calls in the failure scenario:
Call #1: deadline = time.time() + timeout → returns 0, sets deadline to 1
Call #2: while time.time() < deadline: → returns 0, check 0 < 1 = True, enters loop
Call #3: while time.time() < deadline: → returns 1, check 1 < 1 = False, exits loop
Call #4: self.logger.info("Checking fail:") → LogRecord creation calls time.time() → returns 2   (ref: https://docs.python.org/3/library/logging.html#logrecord-attributes)
Call #5: self.logger.info(" Couldn't find process") → LogRecord creation calls time.time() → returns 3


ref: `python3 -c "import logging, inspect; print(inspect.getsource(logging.LogRecord.__init__))"` , https://github.com/python/cpython/blob/main/Lib/logging/__init__.py#L283

## Resolved issues
PR #2162
https://github.com/canonical/checkbox/actions/runs/18641071113/job/53139932346?pr=2162


## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
cherry pick this commit 
https://github.com/canonical/checkbox/actions/runs/18641579136/job/53141487716?pr=2162
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
