### PR TITLE
Fix net_driver_info crash when dumping parameters (Bugfix)

### DIFF
--- a/providers/base/bin/net_driver_info.py
+++ b/providers/base/bin/net_driver_info.py
@@ -42,7 +42,7 @@ for interface, driver in driver_list:
             if path.is_file():
                 # Path.read_text is new in python 3.5 but we want to support
                 # trusty as well, which uses python 3.4 by default.
-                with open(str(path), "r") as f:
+                with open(str(path), "r", errors="backslashreplace") as f:
                     print("    {}: {}".format(path.name, f.read().strip()))
     print()
     print("Checking kernel ring buffer for {} messages:".format(driver))


### PR DESCRIPTION
## Description

When the net_driver_info script encounters a parameter that is not valid utf-8 text, it crashes and doesn't produce more information.
Some drivers (for instance rtl8822ce) have such parameters and thus shortens available information when there is an issue to investigate.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
