### PR TITLE
Restart the session instead of setupping (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -146,7 +146,7 @@ class RemoteController(ReportsStage, MainLoopStage):
             RemoteSessionStates.SettingUp: cls.setup_and_continue,
             RemoteSessionStates.SetupCompleted: cls.restart,
             RemoteSessionStates.Bootstrapping: cls.restart,
-            RemoteSessionStates.Bootstrapped: cls.select_jobs,
+            RemoteSessionStates.Bootstrapped: cls.resume_select_jobs,
             RemoteSessionStates.TestsSelected: cls.run_interactable_jobs,
             RemoteSessionStates.Running: cls.wait_and_continue,
             RemoteSessionStates.Interacting: cls.resume_interacting,
@@ -712,6 +712,9 @@ class RemoteController(ReportsStage, MainLoopStage):
             )
 
         self.sa.save_manifest_json(json.dumps(to_save_manifest))
+
+    def resume_select_jobs(self, all_jobs_json):
+        return self.select_jobs(json.loads(all_jobs_json))
 
     def select_jobs(self, all_jobs):
         if self.launcher.get_value("test selection", "forced"):

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -698,7 +698,7 @@ class RemoteSessionAssistant:
         elif self.state == RemoteSessionStates.Interacting:
             payload = self._current_interaction
         elif self.state == RemoteSessionStates.Bootstrapped:
-            payload = self._sa.get_static_todo_list()
+            payload = json.dumps(self._sa.get_static_todo_list())
         elif self.state == RemoteSessionStates.SettingUp:
             # this is set by the resume_by_id function or None
             payload = {"last_job": self._last_job}


### PR DESCRIPTION
## Description

When a remote session starts, the remote assistant goes from `Idle` (nothing has connected yet) to `Started`. `Started` remains up until either `setup` or `bootstrap` starts. The rationale is that a session where you lost connection before selecting a testplan (so you just started the session and looked at the menu) has basically no (valueable) information stored, so these two states are collapsed into one and treated together. 

A bug was introduced when implementing `setup_include`, wrongfully treating these two states as if they were `TestplanSelected`, while actually, `SessionStarted` is there as well. This leads to Checkbox crashing if one tries to reconnect after starting the session but before selecting a testplan. Given that selecting a test plan almost immediatly leads to starting bootstrap or setup (and therefore changing state), we loose no value by restarting the session on reconnection here.

Lastly, another bug was introduced (in the netref -> json transition) to test selection reconnection, namely it expecting a json serializable job list but the reconnecion still relying on a netref. This also fixes that.

## Resolved issues

Fixes: CHECKBOX-2038
Fixes: https://github.com/canonical/checkbox/issues/2164

## Documentation

N/A

## Tests

Reproduce the issue, apply this patch, you won't see the issue anymore.

First issue:
- Start checkbox agent
- Connect with controller up to test plan selection
- Ctrl+c twice
- Reconnect  (this will fail on main, pass here)

Second issue
- Start checkbox agent
- Connect with controller and select a testplan that has a bootstrap phase (ie sru)
- On the test selection screen Ctrl+C twice
- Reconnect (this will fail on main, pass here)
