### PR TITLE
Add level zero raytracing testing (New)

### DIFF
--- a/contrib/checkbox-gfx/.github/workflows/build-installers.yaml
+++ b/contrib/checkbox-gfx/.github/workflows/build-installers.yaml
@@ -37,6 +37,7 @@ jobs:
       opengl: ${{ steps.changes.outputs.opengl }}
       crucible: ${{ steps.changes.outputs.crucible }}
       lvl-zero: ${{ steps.changes.outputs.lvl-zero }}
+      lvl-zero-rt: ${{ steps.changes.outputs.lvl-zero-rt }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -53,12 +54,14 @@ jobs:
               - 'bin/install-crucible'
             lvl-zero:
               - 'bin/install-lvl-zero'
+            lvl-zero-rt:
+              - 'bin/install-lvl-zero-rt'
 
   manual-build:
     if: github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
-        test_name: [vulkan, opencl, opengl, crucible, lvl-zero]
+        test_name: [vulkan, opencl, opengl, crucible, lvl-zero, lvl-zero-rt]
     name: "Manual Build - ${{ matrix.test_name }}"
     runs-on: [self-hosted, linux, "${{ inputs.arch }}", "${{ inputs.version }}"]
 
@@ -212,4 +215,31 @@ pr-build-lvl-zero:
         uses: actions/upload-artifact@v4
         with:
           name: output-lvl-zero-${{ matrix.arch }}
+          path: /usr/local/checkbox-gfx/*
+
+pr-build-lvl-zero-rt:
+    needs: changes
+    # needs.changes only runs if the event is a PR
+    if: needs.changes.outputs.lvl-zero-rt == 'true'
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    name: "Installer testing - Level Zero Raytracing"
+    runs-on: [self-hosted, linux, "${{ matrix.arch }}", noble]
+
+    steps:
+      - name: "Installers - Level Zero Raytracing - ${{ matrix.arch }}"
+        run: echo "Running Level Zero Raytracing ${{ matrix.arch }} install"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run install-lvl-zero-rt
+        shell: bash
+        run: bin/install-lvl-zero-rt
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: output-lvl-zero-rt-${{ matrix.arch }}
           path: /usr/local/checkbox-gfx/*

--- a/contrib/checkbox-gfx/README.md
+++ b/contrib/checkbox-gfx/README.md
@@ -44,6 +44,7 @@ checkbox-gfx.install-opengl
 checkbox-gfx.install-opencl
 checkbox-gfx.install-crucible
 checkbox-gfx.install-lvl-zero
+checkbox-gfx.install-lvl-zero-rt
 ```
 
 # Automated Run
@@ -57,6 +58,7 @@ checkbox-gfx.test-opengl
 checkbox-gfx.test-opengl-short
 checkbox-gfx.test-vulkan
 checkbox-gfx.test-lvl-zero
+checkbox-gfx.test-lvl-zero-rt
 ```
 
 Due to some tests causing dropped SSH connections, running the tests remotely should be done like this:

--- a/contrib/checkbox-gfx/bin/install-lvl-zero-rt
+++ b/contrib/checkbox-gfx/bin/install-lvl-zero-rt
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e
+
+source $(dirname "$0")/setup-env.sh
+
+package_is_installed() {
+  pkg_name=$1
+  return $(dpkg -s $pkg_name >/dev/null 2>&1 && echo 0 || echo 1)
+}
+
+prepare_for_build() {
+    sudo apt update -y
+    sudo apt install -y build-essential cmake ocl-icd-libopencl1 libva2 libva-drm2 libze-dev libze-intel-gpu-dev libpng-dev libboost-all-dev libmfx-gen1.2 ninja-build clang ocl-icd-opencl-dev clinfo python3-pip meson glslang-tools pkg-config cmake libvulkan-dev libgl1 mesa-common-dev libglfw3-dev libgles2-mesa-dev
+pip3 install opencv-python lxml --break-system-packages
+
+    sudo apt install -y libze-intel-gpu-raytracing
+
+    echo "Installing Level Zero Raytracing tests"
+    # install level-zero-raytracing-support testing
+    if package_is_installed intel-level-zero-gpu-raytracing; then
+        RT_VERSION=$(dpkg -s intel-level-zero-gpu-raytracing | grep '^Version:' | awk '{print $2}' | cut -d'-' -f1)
+    else
+        RT_VERSION=$(dpkg -s libze-intel-gpu-raytracing | grep '^Version:' | awk '{print $2}' | cut -d'-' -f1)
+    fi
+    cd $WORKING_DIR
+    mkdir sycl_linux && cd sycl_linux
+    wget https://github.com/intel/llvm/releases/download/nightly-2024-06-10/sycl_linux.tar.gz
+    tar xf sycl_linux.tar.gz
+    sudo mv $WORKING_DIR/sycl_linux $INSTALL_DIR/sycl_linux
+}
+
+if [ "$VENDOR" = "Intel" ]; then
+    prepare_for_build
+
+    cd $INSTALL_DIR/sycl_linux
+    # Set up the expected paths
+    export SYCL_BUNDLE_ROOT=$(pwd)
+    export PATH=$SYCL_BUNDLE_ROOT/bin:$PATH
+    export CPATH=$SYCL_BUNDLE_ROOT/include:$CPATH
+    export LIBRARY_PATH=$SYCL_BUNDLE_ROOT/lib:$LIBRARY_PATH
+    export LD_LIBRARY_PATH=$SYCL_BUNDLE_ROOT/lib:$LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH=$SYCL_BUNDLE_ROOT/linux/lib/x64:$LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH=$SYCL_BUNDLE_ROOT/lib/oclgpu:$LD_LIBRARY_PATH
+
+    cd $WORKING_DIR
+    if [ ! -d "level-zero-raytracing-support" ]; then
+      echo "Cloning v${RT_VERSION}"
+      git clone -b v${RT_VERSION} https://github.com/intel/level-zero-raytracing-support
+    fi
+    cd level-zero-raytracing-support
+    mkdir -p build
+    cd build/
+    cmake -G Ninja -D CMAKE_CXX_COMPILER=clang++ -D CMAKE_C_COMPILER=clang -D CMAKE_BUILD_TYPE=Release -D ZE_RAYTRACING_SYCL_TESTS=LEVEL_ZERO_RTAS_BUILDER ..
+    cmake --build . --target package && echo "Level zero raytracing build complete" || exit 1
+    sudo mv $WORKING_DIR/level-zero-raytracing-support $INSTALL_DIR
+else
+    echo "Not installing Level Zero testing because it is Intel-specific"
+fi

--- a/contrib/checkbox-gfx/bin/test-lvl-zero-rt
+++ b/contrib/checkbox-gfx/bin/test-lvl-zero-rt
@@ -1,0 +1,18 @@
+#!/usr/bin/env -S checkbox-cli-wrapper control 127.0.0.1
+[launcher]
+app_id = com.canonical.qa.gfx:checkbox
+launcher_version = 1
+stock_reports = text, submission_files
+
+[test plan]
+unit = com.canonical.certification::lvl-zero-rt-plan
+forced = yes
+
+[test selection]
+forced = yes
+
+[ui]
+type = silent
+auto_retry = yes
+max_attempts = 3
+delay_before_retry = 15

--- a/contrib/checkbox-gfx/checkbox-provider-gfx/data/env_lvlzerort
+++ b/contrib/checkbox-gfx/checkbox-provider-gfx/data/env_lvlzerort
@@ -1,0 +1,4 @@
+SYCL_BUNDLE_ROOT=/usr/local/checkbox-gfx/sycl_linux/
+LVL_ZERO_BUILD_DIR=$SYCL_BUNDLE_ROOT/../level-zero-raytracing-support/build/
+PATH=$LVL_ZERO_BUILD_DIR:$PATH
+LD_LIBRARY_PATH=$SYCL_BUNDLE_ROOT/lib/oclgpu:$SYCL_BUNDLE_ROOT/lib:$SYCL_BUNDLE_ROOT/linux/lib/x64:$LD_LIBRARY_PATH

--- a/contrib/checkbox-gfx/checkbox-provider-gfx/units/category.pxu
+++ b/contrib/checkbox-gfx/checkbox-provider-gfx/units/category.pxu
@@ -13,3 +13,7 @@ _name: A test suite for opengl
 unit: category
 id: level-zero
 _name: Category for Intel level zero tests
+
+unit: category
+id: level-zero-raytracing
+_name: Category for Intel level zero raytracing tests

--- a/contrib/checkbox-gfx/checkbox-provider-gfx/units/level-zero-rt/jobs.pxu
+++ b/contrib/checkbox-gfx/checkbox-provider-gfx/units/level-zero-rt/jobs.pxu
@@ -1,0 +1,88 @@
+id: gfx_level_zero_rt_embree_rthwif_cornell_box
+category_id: level-zero-raytracing
+flags: simple
+user: root
+_summary: Run the embree_rthwif_cornell_box test from level zero tests
+requires: cpuinfo.type == 'GenuineIntel'
+environ:
+  # necessary for local mode
+  XDG_SESSION_TYPE
+  XDG_RUNTIME_DIR
+  NORMAL_USER
+estimated_duration: 1m
+command:
+  . $PLAINBOX_PROVIDER_DATA/env_lvlzerort
+  cd $LVL_ZERO_BUILD_DIR
+  embree_rthwif_cornell_box --compare cornell_box_reference.tga
+_siblings: [{ "id": "gfx_level_zero_rt_rthwif_test_builder_triangles_expected",
+    "_summary": "Run the rthwif_test_builder_triangles_expected tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --build_test_triangles --build_mode_expected" },
+  { "id": "gfx_level_zero_rt_rthwif_test_builder_procedurals_expected",
+    "_summary": "Run the rthwif_test_builder_procedurals_expected tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --build_test_procedurals --build_mode_expected" },
+  { "id": "gfx_level_zero_rt_rthwif_test_builder_instances_expected",
+    "_summary": "Run the rthwif_test_builder_instances_expected tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --build_test_instances --build_mode_expected" },
+  { "id": "gfx_level_zero_rt_rthwif_test_builder_mixed_expected",
+    "_summary": "Run the rthwif_test_builder_mixed_expected tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --build_test_mixed --build_mode_expected" },
+  { "id": "gfx_level_zero_rt_rthwif_test_benchmark_triangles",
+    "_summary": "Run the rthwif_test_benchmark_triangles tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --benchmark_triangles" },
+  { "id": "gfx_level_zero_rt_rthwif_test_benchmark_procedurals",
+    "_summary": "Run the rthwif_test_benchmark_procedurals tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --benchmark_procedurals" },
+  { "id": "gfx_level_zero_rt_rthwif_test_builder_triangles_worst_case",
+    "_summary": "Run the rthwif_test_builder_triangles_worst_case tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --build_test_triangles --build_mode_worst_case" },
+  { "id": "gfx_level_zero_rt_rthwif_test_builder_procedurals_worst_case",
+    "_summary": "Run the rthwif_test_builder_procedurals_worst_case tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --build_test_procedurals --build_mode_worst_case" },
+  { "id": "gfx_level_zero_rt_rthwif_test_builder_instances_worst_case",
+    "_summary": "Run the rthwif_test_builder_instances_worst_case tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --build_test_instances --build_mode_worst_case" },
+  { "id": "gfx_level_zero_rt_rthwif_test_builder_mixed_worst_case",
+    "_summary": "Run the rthwif_test_builder_mixed_worst_case tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --build_test_mixed --build_mode_worst_case" },
+  { "id": "gfx_level_zero_rt_rthwif_test_triangles_committed_hit",
+    "_summary": "Run the rthwif_test_triangles_committed_hit tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --no-instancing --triangles-committed-hit" },
+  { "id": "gfx_level_zero_rt_rthwif_test_triangles_potential_hit",
+    "_summary": "Run the rthwif_test_triangles_potential_hit tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --no-instancing --triangles-potential-hit" },
+  { "id": "gfx_level_zero_rt_rthwif_test_triangles_anyhit_shader_commit",
+    "_summary": "Run the rthwif_test_triangles_anyhit_shader_commit tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --no-instancing --triangles-anyhit-shader-commit" },
+  { "id": "gfx_level_zero_rt_rthwif_test_triangles_anyhit_shader_reject",
+    "_summary": "Run the rthwif_test_triangles_anyhit_shader_reject tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --no-instancing --triangles-anyhit-shader-reject" },
+  { "id": "gfx_level_zero_rt_rthwif_test_procedurals_committed_hit",
+    "_summary": "Run the rthwif_test_procedurals_committed_hit tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --no-instancing --procedurals-committed-hit" },
+  { "id": "gfx_level_zero_rt_rthwif_test_hwinstancing_triangles_committed_hit",
+    "_summary": "Run the rthwif_test_hwinstancing_triangles_committed_hit tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --hw-instancing --triangles-committed-hit" },
+  { "id": "gfx_level_zero_rt_rthwif_test_hwinstancing_triangles_potential_hit",
+    "_summary": "Run the rthwif_test_hwinstancing_triangles_potential_hit tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --hw-instancing --triangles-potential-hit" },
+  { "id": "gfx_level_zero_rt_rthwif_test_hwinstancing_triangles_anyhit_shader_commit",
+    "_summary": "Run the rthwif_test_hwinstancing_triangles_anyhit_shader_commit tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --hw-instancing --triangles-anyhit-shader-commit" },
+  { "id": "gfx_level_zero_rt_rthwif_test_hwinstancing_procedurals_committed_hit",
+    "_summary": "Run the rthwif_test_hwinstancing_procedurals_committed_hit tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --hw-instancing --procedurals-committed-hit" },
+  { "id": "gfx_level_zero_rt_rthwif_test_swinstancing_triangles_committed_hit",
+    "_summary": "Run the rthwif_test_swinstancing_triangles_committed_hit tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --sw-instancing --triangles-committed-hit" },
+  { "id": "gfx_level_zero_rt_rthwif_test_swinstancing_triangles_potential_hit",
+    "_summary": "Run the rthwif_test_swinstancing_triangles_potential_hit tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --sw-instancing --triangles-potential-hit" },
+  { "id": "gfx_level_zero_rt_rthwif_test_swinstancing_triangles_anyhit_shader_commit",
+    "_summary": "Run the rthwif_test_swinstancing_triangles_anyhit_shader_commit tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --sw-instancing --triangles-anyhit-shader-commit" },
+  { "id": "gfx_level_zero_rt_rthwif_test_swinstancing_triangles_anyhit_shader_reject",
+    "_summary": "Run the rthwif_test_swinstancing_triangles_anyhit_shader_reject tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --sw-instancing --triangles-anyhit-shader-reject" },
+  { "id": "gfx_level_zero_rt_rthwif_test_swinstancing_procedurals_committed_hit",
+    "_summary": "Run the rthwif_test_swinstancing_procedurals_committed_hit tests from Level Zero Raytracing",
+    "command": ". $PLAINBOX_PROVIDER_DATA/env_lvlzerort; cd $LVL_ZERO_BUILD_DIR; embree_rthwif_test --sw-instancing --procedurals-committed-hit" }]

--- a/contrib/checkbox-gfx/checkbox-provider-gfx/units/test-plan.pxu
+++ b/contrib/checkbox-gfx/checkbox-provider-gfx/units/test-plan.pxu
@@ -55,3 +55,13 @@ bootstrap_include:
     com.canonical.certification::executable
     com.canonical.certification::snap
     graphics_card
+
+id: lvl-zero-rt-plan
+unit: test plan
+_name: GFX test plan for hardware encode and decode
+include:
+  gfx_level_zero_rt.*
+bootstrap_include:
+    com.canonical.certification::executable
+    com.canonical.certification::snap
+    graphics_card

--- a/contrib/checkbox-gfx/snap/snapcraft.yaml
+++ b/contrib/checkbox-gfx/snap/snapcraft.yaml
@@ -29,6 +29,9 @@ apps:
   test-lvl-zero:
     command-chain: [bin/wrapper_local]
     command: bin/test-lvl-zero
+  test-lvl-zero-rt:
+    command-chain: [bin/wrapper_local]
+    command: bin/test-lvl-zero-rt
   test-vulkan:
     command-chain: [bin/wrapper_local]
     command: bin/test-vulkan
@@ -54,6 +57,8 @@ apps:
     command: bin/shell-wrapper
   install-lvl-zero:
     command: bin/install-lvl-zero
+  install-lvl-zero-rt:
+    command: bin/install-lvl-zero-rt
   install-vulkan:
     command: bin/install-vulkan
   install-opengl:


### PR DESCRIPTION
# Description
This provider contains tests for the graphics stack. This runs Intel's level zero raytracing testing

# Resolved issues
N/A

# Documentation
See README

# Tests
Tests have been run on Arrow Lake (We do not have many devices capable of running this test suite at this time, since it only runs on newer hardware)