### PR TITLE
Add while loop to check if restartCount is expected in 30 sec (Bugfix)

### DIFF
--- a/providers/docker/units/docker.pxu
+++ b/providers/docker/units/docker.pxu
@@ -372,8 +372,13 @@ command:
  [ $restartPolicy = on-failure ] || exit 1
  maximumRetryCount=$(docker inspect  -f {maximumRetryCount} $ID)
  [ $maximumRetryCount = 3 ] || exit 1
- sleep 10
- restartCount=$(docker inspect -f {restartCount} $ID)
+ count=0
+ while [ $count -lt 10 ]; do
+   restartCount=$(docker inspect -f {restartCount} $ID)
+   [ $restartCount = 3 ] && break
+   sleep 3
+   count=$((count + 1))
+ done
  [ $restartCount = 3 ] || exit 1
  docker rm -f $ID
 _summary: Test container restart policy with on_failure applied


### PR DESCRIPTION
Add while loop to check if restartCount is expected in 30 sec since we found on some low power machines, restartCount is not expected if sleep only 10 sec

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
The original logic was to sleep 10 sec before checking restartCount. And we found some low power machine could take longer to get expected restartCount.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
https://github.com/canonical/checkbox/issues/2194
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
https://certification.canonical.com/hardware/202508-37028/submission/458595/test-results/
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
