### PR TITLE
Close stale issues automatically (infra)

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -6,7 +6,7 @@ on:
       - .github/workflows/stale.yaml
   workflow_dispatch:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: '7 1 * * *'
 
 permissions:
   contents: read
@@ -22,7 +22,9 @@ jobs:
         with:
           stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in a week.'
           close-pr-message: 'This PR was closed because of inactivity. Feel free to re-open this once you want to work on it again!'
+          stale-issue-message: 'This issue is stale because it has been open for one year with no activity. Remove the stale label or comment or this will be closed in a week.'
+          close-issue-message: 'This issue was closed because of inactivity. Feel free to re-open this if you are still encountering this!'
           days-before-stale: 60
           days-before-close: 7
-          days-before-issue-stale: -1
-          days-before-issue-close: -1
+          days-before-issue-stale: 360
+          days-before-issue-close: 7


### PR DESCRIPTION
## Description

As agreed during the sprint, to actually allow us to use the issue tab we have to start grooming it and keeping it organized. To bootstrap this process (given the huge size of the backlog) we start from a clean slate.

## Resolved issues

N/A

## Documentation

N/A

## Tests

N/A
