### PR TITLE
Allow `rocm-validation-suite` deb in AMD GPGPU test `requires` (Bugfix)

### DIFF
--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -40,7 +40,7 @@ plugin: shell
 estimated_duration: 4
 requires:
     graphics_card.vendor == 'Advanced Micro Devices, Inc. [AMD/ATI]'
-    snap.name == 'rocm-validation-suite'
+    package.name == 'rocm-validation-suite' or snap.name == 'rocm-validation-suite'
     uname.machine == 'x86_64'
 _summary: AMD GPGPU properties query
 command: rvs.py gpup


### PR DESCRIPTION
## Description

This PR allows the AMD GPGPU jobs to execute if the `rocm-validation-suite` deb package is found (this might be used instead of the snap in some edge cases where the snap is not functioning as expected).

## Resolved issues

## Documentation

## Tests

