### PR TITLE
Launcher support provider (new)

### DIFF
--- a/checkbox-ng/checkbox_ng/config.py
+++ b/checkbox-ng/checkbox_ng/config.py
@@ -106,10 +106,10 @@ def resolve_configs(launcher_config, session_assistant):
     config = Configuration()
     if launcher_config:
         global_config_name = launcher_config.get_value(
-            "config", "config_filename"
+            "config", "import_override"
         )
     else:
-        global_config_name = config.get_value("config", "config_filename")
+        global_config_name = config.get_value("config", "import_override")
 
     to_load_conf_names = _search_configs_by_name(
         global_config_name, session_assistant
@@ -118,13 +118,13 @@ def resolve_configs(launcher_config, session_assistant):
     loaded_confs_sources = []
 
     # used to avoid "loops"
-    # Note: checkbox.conf is always the default "config_filename"
+    # Note: checkbox.conf is always the default "import_override"
     #       so we *always* have a loop eventually
     loaded_confs_sources = []
     while to_load_conf_names:
         to_load = to_load_conf_names.pop(0)
         curr_cfg = load_config(to_load, session_assistant)
-        imported_cfg_name = curr_cfg.get_value("config", "config_filename")
+        imported_cfg_name = curr_cfg.get_value("config", "import_override")
         if (
             imported_cfg_name
             and imported_cfg_name not in already_loaded_conf_names

--- a/checkbox-ng/checkbox_ng/config.py
+++ b/checkbox-ng/checkbox_ng/config.py
@@ -81,6 +81,8 @@ def load_config(config_name: str, session_assistant):
         return Configuration.from_path(config_name)
 
 
+# WARNING: dont call this function on the controller side! It only makes sense
+#          on the DUT
 def resolve_configs(launcher_config, session_assistant):
     """
     Resolves imports and overrides in a chain of configs applying also the
@@ -147,7 +149,8 @@ def resolve_configs(launcher_config, session_assistant):
         # read the config_filename
         config.update_from_another(
             launcher_config,
-            "Launcher file: {}".format(launcher_config.sources[0]),
+            # launcher may be default therefore sources is empty
+            next(iter(launcher_config.sources), ""),
         )
 
     return config

--- a/checkbox-ng/checkbox_ng/config.py
+++ b/checkbox-ng/checkbox_ng/config.py
@@ -75,7 +75,7 @@ def load_config(config_name: str, session_assistant):
         config_text = session_assistant.get_provider_launcher_by_id(
             config_name
         )
-        # the source will be overwritten futther down anyway
+        # the source will be overwritten further down anyway
         return Configuration.from_text(config_text, config_name)
     except FileNotFoundError:
         return Configuration.from_path(config_name)

--- a/checkbox-ng/checkbox_ng/config.py
+++ b/checkbox-ng/checkbox_ng/config.py
@@ -47,13 +47,16 @@ def expand_all(path):
     return os.path.expandvars(os.path.expanduser(path))
 
 
-def _search_configs_by_name(name: str) -> "list[str]":
+def _search_configs_by_name(name: str, session_assistant) -> "list[str]":
     """
     Returns all well known config locations that have a `name` file
     in them
     """
-    if os.path.isabs(expand_all(name)):
+    if os.path.isabs(
+        expand_all(name)
+    ) or session_assistant.is_provider_launcher_id(name):
         return [name]
+
     to_r = []
     _logger.debug("Searching for %s files...", name)
     for sdir in SEARCH_DIRS:
@@ -65,7 +68,88 @@ def _search_configs_by_name(name: str) -> "list[str]":
     return to_r
 
 
-def load_configs(launcher_file=None, cfg=None):
+def load_config(config_name: str, session_assistant):
+    try:
+        config_text = session_assistant.get_provider_launcher_by_id(
+            config_name
+        )
+        # the source will be overwritten futther down anyway
+        return Configuration.from_text(config_text, config_name)
+    except FileNotFoundError:
+        return Configuration.from_path(config_name)
+
+
+def resolve_configs(launcher_config, session_assistant):
+    """
+    Resolves imports and overrides in a chain of configs applying also the
+    global config
+
+    In theory there can be a very long list of configs that are linked by
+    specifying config_filename in each. Each config that defines a
+    config_filename imports the values that are defined in the path/name
+    provided. The imported are overwritten by the importee and whoever has
+    an higher priority.
+
+    Ex: If ~/.config/checkbox.conf has config_filename A and we have both
+        ~/.config/A and /etc/xdg/A:
+
+        - ~/.config/A has an higher priority than /etc/xdg/A
+        - anything that ~/.config/A imports has a higher priority
+            than /etc/xdg/A but lower than ~/.config/A itself
+        - anything that /etc/xdg/A imports has the lowest possible
+            priority
+    """
+    config = Configuration()
+    if launcher_config:
+        global_config_name = config.get_value("config", "config_filename")
+    else:
+        global_config_name = config.get_value("config", "config_filename")
+
+    to_load_conf_names = _search_configs_by_name(
+        global_config_name, session_assistant
+    )
+    already_loaded_conf_names = {global_config_name}
+    loaded_confs_sources = []
+
+    # used to avoid "loops"
+    # Note: checkbox.conf is always the default "config_filename"
+    #       so we *always* have a loop eventually
+    loaded_confs_sources = []
+    while to_load_conf_names:
+        to_load = to_load_conf_names.pop(0)
+        curr_cfg = load_config(to_load, session_assistant)
+        imported_cfg_name = curr_cfg.get_value("config", "config_filename")
+        if (
+            imported_cfg_name
+            and imported_cfg_name not in already_loaded_conf_names
+        ):
+            # next load what this conf imports
+            to_load_conf_names = (
+                _search_configs_by_name(imported_cfg_name, session_assistant)
+                + to_load_conf_names
+            )
+            already_loaded_conf_names.add(imported_cfg_name)
+        loaded_confs_sources.append((curr_cfg, to_load))
+
+    # here if A -> B -> C in loaded_confs_sources we have [A_conf, B_conf, C_conf]
+    #  but A -> B means A overrides B so we reverse order
+    _logger.debug("Applying conf, latest applied has the highest priority")
+    for conf, source in reversed(loaded_confs_sources):
+        _logger.debug("Applying %s", source)
+        config.update_from_another(conf, "config file: {}".format(source))
+
+    if launcher_config:
+        # Launcher files always have priority, we've loaded it before just to
+        # read the config_filename
+        config.update_from_another(
+            launcher_config,
+            "Launcher file: {}".format(launcher_config.sources[0]),
+        )
+
+    return config
+
+
+def load_configs(launcher_file=None, cfg=None, sa=None):
     """
     Read a chain of configs/launchers.
 
@@ -125,6 +209,8 @@ def load_configs(launcher_file=None, cfg=None):
         cfg.update_from_another(conf, "config file: {}".format(source))
 
     if launcher_file:
+        # Launcher files always have priority, we've loaded it before just to
+        # read the config_filename
         cfg.update_from_another(
             launcher_file_conf,
             "Launcher file: {}".format(launcher_file),

--- a/checkbox-ng/checkbox_ng/launcher/config.py
+++ b/checkbox-ng/checkbox_ng/launcher/config.py
@@ -19,8 +19,13 @@
 """This module contains the implementation of the `check-config` subcmd."""
 
 from argparse import ArgumentParser
-from plainbox.impl.config import CONFIG_SPEC, DynamicSection, ParametricSection
-from checkbox_ng.config import load_configs
+from plainbox.impl.config import (
+    CONFIG_SPEC,
+    DynamicSection,
+    ParametricSection,
+    Configuration,
+)
+from checkbox_ng.config import resolve_configs, load_launcher_text
 
 
 class Config:
@@ -97,7 +102,11 @@ class CheckConfig:
     @staticmethod
     def invoked(context):
         """Function that's run with `check-config` invocation."""
-        config = load_configs(context.args.launcher)
+        config = Configuration.from_text(
+            load_launcher_text(context.args.launcher, context.sa),
+            context.args.launcher,
+        )
+        config = resolve_configs(config, context.sa)
         print("Configuration files:")
         for source in config.sources:
             print(" - {}".format(source))

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -61,7 +61,7 @@ from plainbox.impl.transport import SECURE_ID_PATTERN
 from plainbox.impl.unit.testplan import TestPlanUnitSupport
 from plainbox.impl.config import Configuration
 
-from checkbox_ng.config import resolve_configs
+from checkbox_ng.config import resolve_configs, load_launcher_or_default
 from checkbox_ng.launcher.stages import MainLoopStage, ReportsStage
 from checkbox_ng.launcher.startprovider import (
     EmptyProviderSkeleton,
@@ -242,25 +242,7 @@ class Launcher(MainLoopStage, ReportsStage):
             # exited by now, so validation passed
             print(_("Launcher seems valid."))
             return
-        launcher_config = None
-        from pathlib import Path
-
-        if ctx.args.launcher and Path(ctx.args.launcher).exists():
-            launcher_config = Configuration.from_path(ctx.args.launcher)
-        elif ctx.args.launcher:
-            try:
-                launcher_text = ctx.sa.get_provider_launcher_by_id(
-                    ctx.args.launcher
-                )
-                launcher_config = Configuration.from_text(
-                    launcher_text, ctx.args.launcher
-                )
-            except FileNotFoundError:
-                # launcher was requested but it is neither a provider launcher
-                # nor a local file
-                raise SystemExit(
-                    'Launcher "{}" not found'.format(ctx.args.launcher)
-                )
+        launcher_config = load_launcher_or_default(ctx.args.launcher, ctx.sa)
         self.configuration = resolve_configs(launcher_config, ctx.sa)
         logging_level = {
             "normal": logging.WARNING,

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -61,7 +61,7 @@ from plainbox.impl.transport import SECURE_ID_PATTERN
 from plainbox.impl.unit.testplan import TestPlanUnitSupport
 from plainbox.impl.config import Configuration
 
-from checkbox_ng.config import resolve_configs, load_launcher_or_default
+from checkbox_ng.config import resolve_configs, load_launcher_text
 from checkbox_ng.launcher.stages import MainLoopStage, ReportsStage
 from checkbox_ng.launcher.startprovider import (
     EmptyProviderSkeleton,
@@ -242,7 +242,10 @@ class Launcher(MainLoopStage, ReportsStage):
             # exited by now, so validation passed
             print(_("Launcher seems valid."))
             return
-        launcher_config = load_launcher_or_default(ctx.args.launcher, ctx.sa)
+        launcher_config = Configuration.from_text(
+            load_launcher_text(ctx.args.launcher, ctx.sa),
+            "Launcher {}".format(ctx.args.launcher),
+        )
         self.configuration = resolve_configs(launcher_config, ctx.sa)
         logging_level = {
             "normal": logging.WARNING,

--- a/checkbox-ng/checkbox_ng/launcher/test_config.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_config.py
@@ -57,12 +57,17 @@ class DefaultsTests(TestCase):
 
 class CheckConfigTests(TestCase):
     @mock.patch("builtins.print")
-    @mock.patch("checkbox_ng.launcher.config.load_configs")
-    def test_invoked_ok(self, mock_load_configs, mock_print):
+    @mock.patch(
+        "checkbox_ng.launcher.config.load_launcher_text",
+        new=MagicMock(return_value=""),
+    )
+    @mock.patch(
+        "checkbox_ng.launcher.config.resolve_configs",
+        new=MagicMock(side_effect=lambda conf, sa: conf),
+    )
+    def test_invoked_ok(self, mock_print):
         args_mock = MagicMock()
         args_mock.args.launcher = None
-        # this is the default configuration
-        mock_load_configs.return_value = Configuration()
 
         ret_val = CheckConfig.invoked(args_mock)
 
@@ -71,14 +76,20 @@ class CheckConfigTests(TestCase):
         self.assertEqual(ret_val, 0)
 
     @mock.patch("builtins.print")
-    @mock.patch("checkbox_ng.launcher.config.load_configs")
-    def test_invoked_has_problems(self, mock_load_configs, mock_print):
+    @mock.patch(
+        "checkbox_ng.launcher.config.load_launcher_text",
+        new=MagicMock(return_value=""),
+    )
+    @mock.patch(
+        "checkbox_ng.launcher.config.resolve_configs",
+    )
+    def test_invoked_has_problems(self, resolve_configs_mock, mock_print):
         args_mock = MagicMock()
         args_mock.args.launcher = None
         # this is the default configuration
         conf = Configuration()
         conf.notice_problem("Test problem")
-        mock_load_configs.return_value = conf
+        resolve_configs_mock.return_value = conf
 
         ret_val = CheckConfig.invoked(args_mock)
 

--- a/checkbox-ng/checkbox_ng/test_config.py
+++ b/checkbox-ng/checkbox_ng/test_config.py
@@ -136,7 +136,7 @@ class ResolveConfigsTests(TestCase):
 
         result = resolve_configs(None, session_assistant)
 
-        search_mock.assert_called_once()
+        self.assertEqual(search_mock.call_count, 1)
         self.assertIsNotNone(result)
 
     def test_launcher_config_overrides_all(self, search_mock, load_mock):

--- a/checkbox-ng/checkbox_ng/test_config.py
+++ b/checkbox-ng/checkbox_ng/test_config.py
@@ -1,0 +1,432 @@
+# This file is part of Checkbox.
+#
+# Copyright 2025 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for config module."""
+
+import textwrap
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from plainbox.impl.config import Configuration
+
+from checkbox_ng.config import (
+    _search_configs_by_name,
+    load_config,
+    load_launcher_text,
+    resolve_configs,
+)
+
+
+@patch("checkbox_ng.config.os.path.exists")
+@patch("checkbox_ng.config.expand_all")
+class SearchConfigsByNameTests(TestCase):
+
+    @patch("os.path.isabs", return_value=True)
+    def test_absolute_path_returns_as_is(
+        self, isabs_mock, expand_mock, exists_mock
+    ):
+        expand_mock.return_value = "/absolute/path/to/config"
+
+        result = _search_configs_by_name("/absolute/path/to/config", None)
+
+        self.assertEqual(result, ["/absolute/path/to/config"])
+
+    @patch("os.path.isabs", return_value=False)
+    def test_provider_launcher_id_returns_as_is(
+        self, isabs_mock, expand_mock, exists_mock
+    ):
+        expand_mock.return_value = "com.canonical.certification::launcher_id"
+        session_assistant = MagicMock()
+        session_assistant.is_provider_launcher_id.return_value = True
+
+        result = _search_configs_by_name(
+            "com.canonical.certification::launcher_id", session_assistant
+        )
+
+        self.assertEqual(result, ["com.canonical.certification::launcher_id"])
+
+    @patch("os.path.isabs", return_value=False)
+    def test_searches_all_dirs_returns_existing(
+        self, isabs_mock, expand_mock, exists_mock
+    ):
+        session_assistant = MagicMock()
+        session_assistant.is_provider_launcher_id.return_value = False
+
+        expand_mock.side_effect = lambda x: x
+        exists_mock.side_effect = lambda p: p in [
+            "~/.config/config.conf",
+        ]
+
+        result = _search_configs_by_name("config.conf", session_assistant)
+
+        self.assertEqual(
+            result,
+            ["~/.config/config.conf"],
+        )
+
+    @patch("os.path.isabs", return_value=False)
+    def test_no_configs_found_returns_empty(
+        self, isabs_mock, expand_mock, exists_mock
+    ):
+        session_assistant = MagicMock()
+        session_assistant.is_provider_launcher_id.return_value = False
+        expand_mock.side_effect = lambda p: p
+        exists_mock.return_value = False
+
+        result = _search_configs_by_name("nonexistent.conf", session_assistant)
+
+        self.assertEqual(result, [])
+
+
+@patch("checkbox_ng.config.Configuration")
+class LoadConfigTests(TestCase):
+
+    def test_load_from_provider_launcher(self, config_mock):
+        session_assistant = MagicMock()
+        session_assistant.get_provider_launcher_by_id.return_value = (
+            "config_text"
+        )
+        config_mock.from_text.return_value = "config_object"
+
+        result = load_config(
+            "com.canonical.certification::config_id", session_assistant
+        )
+
+        session_assistant.get_provider_launcher_by_id.assert_called_once_with(
+            "com.canonical.certification::config_id"
+        )
+        self.assertTrue(config_mock.from_text.called)
+        self.assertEqual(result, "config_object")
+
+    def test_load_from_path_when_provider_not_found(self, config_mock):
+        session_assistant = MagicMock()
+        session_assistant.get_provider_launcher_by_id.side_effect = (
+            FileNotFoundError
+        )
+        config_mock.from_path.return_value = "config_from_path"
+
+        result = load_config("/path/to/config", session_assistant)
+
+        self.assertTrue(config_mock.from_path.called)
+        self.assertEqual(result, "config_from_path")
+
+
+@patch("checkbox_ng.config.load_config")
+@patch("checkbox_ng.config._search_configs_by_name")
+class ResolveConfigsTests(TestCase):
+
+    def test_no_launcher_config_uses_default(self, search_mock, load_mock):
+        session_assistant = MagicMock()
+        search_mock.return_value = []
+
+        result = resolve_configs(None, session_assistant)
+
+        search_mock.assert_called_once()
+        self.assertIsNotNone(result)
+
+    def test_launcher_config_overrides_all(self, search_mock, load_mock):
+        session_assistant = MagicMock()
+
+        launcher_text = textwrap.dedent(
+            """
+            [config]
+            config_filename=global.conf
+            [environment]
+            FROM_LAUNCHER = yes
+            SHARED_VAR = launcher
+            """
+        ).strip()
+        launcher_config = Configuration.from_text(
+            launcher_text, "launcher_source"
+        )
+
+        global_text = textwrap.dedent(
+            """
+            [environment]
+            FROM_GLOBAL = yes
+            SHARED_VAR = global
+            """
+        ).strip()
+        global_config = Configuration.from_text(
+            global_text, "/etc/xdg/global.conf"
+        )
+
+        search_mock.return_value = ["/etc/xdg/global.conf"]
+        load_mock.return_value = global_config
+
+        result = resolve_configs(launcher_config, session_assistant)
+
+        self.assertEqual(
+            result.get_value("environment", "FROM_LAUNCHER"), "yes"
+        )
+        self.assertEqual(result.get_value("environment", "FROM_GLOBAL"), "yes")
+        self.assertEqual(
+            result.get_value("environment", "SHARED_VAR"), "launcher"
+        )
+
+    def test_config_chain_resolution(self, search_mock, load_mock):
+        session_assistant = MagicMock()
+
+        launcher_text = textwrap.dedent(
+            """
+            [config]
+            config_filename = A
+            [environment]
+            FROM_LAUNCHER = yes
+            SHARED_VAR = launcher
+            """
+        ).strip()
+        launcher_config = Configuration.from_text(
+            launcher_text, "launcher_source"
+        )
+
+        config_a_text = textwrap.dedent(
+            """
+            [config]
+            config_filename = B
+            [environment]
+            FROM_A = yes
+            SHARED_VAR = a
+            # a should win this as it is in home and imports B
+            A_PRIO_VARIABLE = a
+            """
+        ).strip()
+        config_a = Configuration.from_text(
+            config_a_text, "/home/user/.config/A"
+        )
+
+        config_b_text = textwrap.dedent(
+            """
+            [config]
+            config_filename = C
+            [environment]
+            FROM_B = yes
+            SHARED_VAR = b
+            A_PRIO_VARIABLE = b
+            # b should win this as it is in home and imports C
+            B_PRIO_VARIABLE = b
+            """
+        ).strip()
+        config_b = Configuration.from_text(
+            config_b_text, "/home/user/.config/B"
+        )
+
+        config_c_text = textwrap.dedent(
+            """
+            [environment]
+            FROM_C = yes
+            SHARED_VAR = c
+            A_PRIO_VARIABLE = c
+            B_PRIO_VARIABLE = c
+            """
+        ).strip()
+        config_c = Configuration.from_text(config_c_text, "/etc/xdg/C")
+
+        def search_side_effect(name, sa):
+            if name == "A":
+                return ["/home/user/.config/A"]
+            elif name == "B":
+                return ["/home/user/.config/B"]
+            elif name == "C":
+                return ["/etc/xdg/C"]
+            return []
+
+        def load_side_effect(path, sa):
+            if path == "/home/user/.config/A":
+                return config_a
+            elif path == "/home/user/.config/B":
+                return config_b
+            elif path == "/etc/xdg/C":
+                return config_c
+            return Configuration()
+
+        search_mock.side_effect = search_side_effect
+        load_mock.side_effect = load_side_effect
+
+        result = resolve_configs(launcher_config, session_assistant)
+
+        self.assertEqual(
+            result.get_value("environment", "FROM_LAUNCHER"), "yes"
+        )
+        self.assertEqual(result.get_value("environment", "FROM_A"), "yes")
+        self.assertEqual(result.get_value("environment", "FROM_B"), "yes")
+        self.assertEqual(result.get_value("environment", "FROM_C"), "yes")
+        self.assertEqual(
+            result.get_value("environment", "SHARED_VAR"), "launcher"
+        )
+        self.assertEqual(
+            result.get_value("environment", "A_PRIO_VARIABLE"), "a"
+        )
+        self.assertEqual(
+            result.get_value("environment", "B_PRIO_VARIABLE"), "b"
+        )
+
+    def test_prevents_config_loops(self, search_mock, load_mock):
+        session_assistant = MagicMock()
+
+        launcher_text = textwrap.dedent(
+            """
+            [config]
+            config_filename = A
+            """
+        ).strip()
+        launcher_config = Configuration.from_text(
+            launcher_text, "launcher_source"
+        )
+
+        config_a_text = textwrap.dedent(
+            """
+            [config]
+            config_filename = B
+            [environment]
+            FROM_A = yes
+            """
+        ).strip()
+        config_a = Configuration.from_text(config_a_text, "/config/A")
+
+        config_b_text = textwrap.dedent(
+            """
+            [config]
+            config_filename = A
+            [environment]
+            FROM_B = yes
+            """
+        ).strip()
+        config_b = Configuration.from_text(config_b_text, "/config/B")
+
+        def search_side_effect(name, sa):
+            return ["/config/{}".format(name)]
+
+        def load_side_effect(path, sa):
+            if path == "/config/A":
+                return config_a
+            elif path == "/config/B":
+                return config_b
+            return Configuration()
+
+        search_mock.side_effect = search_side_effect
+        load_mock.side_effect = load_side_effect
+
+        result = resolve_configs(launcher_config, session_assistant)
+
+        self.assertEqual(result.get_value("environment", "FROM_A"), "yes")
+        self.assertEqual(result.get_value("environment", "FROM_B"), "yes")
+        self.assertEqual(load_mock.call_count, 2)
+
+    def test_multiple_config_locations_priority(self, search_mock, load_mock):
+        session_assistant = MagicMock()
+
+        launcher_text = textwrap.dedent(
+            """
+            [config]
+            config_filename = test.conf
+            [environment]
+            FROM_LAUNCHER = yes
+            SHARED_VAR = launcher
+            """
+        ).strip()
+        launcher_config = Configuration.from_text(
+            launcher_text, "launcher_source"
+        )
+
+        config_home_text = textwrap.dedent(
+            """
+            [environment]
+            FROM_HOME = yes
+            SHARED_VAR = home
+            """
+        ).strip()
+        config_home = Configuration.from_text(
+            config_home_text, "/home/user/.config/test.conf"
+        )
+
+        config_etc_text = textwrap.dedent(
+            """
+            [environment]
+            FROM_ETC = yes
+            SHARED_VAR = etc
+            """
+        ).strip()
+        config_etc = Configuration.from_text(
+            config_etc_text, "/etc/xdg/test.conf"
+        )
+
+        search_mock.return_value = [
+            "/home/user/.config/test.conf",
+            "/etc/xdg/test.conf",
+        ]
+
+        def load_side_effect(path, sa):
+            if path == "/home/user/.config/test.conf":
+                return config_home
+            elif path == "/etc/xdg/test.conf":
+                return config_etc
+            return Configuration()
+
+        load_mock.side_effect = load_side_effect
+
+        result = resolve_configs(launcher_config, session_assistant)
+
+        self.assertEqual(
+            result.get_value("environment", "FROM_LAUNCHER"), "yes"
+        )
+        self.assertEqual(result.get_value("environment", "FROM_HOME"), "yes")
+        self.assertEqual(result.get_value("environment", "FROM_ETC"), "yes")
+        self.assertEqual(
+            result.get_value("environment", "SHARED_VAR"), "launcher"
+        )
+
+
+@patch("checkbox_ng.config.Path")
+class LoadLauncherTextTests(TestCase):
+
+    def test_launcher_text_None(self, _):
+        self.assertEqual(load_launcher_text(None, None), "")
+
+    def test_launcher_text_file(self, path_mock):
+        path_mock().open().__enter__().read.return_value = "launcher_text"
+        # tests that local files are read but also that they have precedence
+        # over anything else. Clashing occasions are rare as launcher ids are
+        # namespaced
+        self.assertEqual(
+            load_launcher_text("path_that_exists", None), "launcher_text"
+        )
+
+    def test_launcher_by_id(self, path_mock):
+        path_mock().open.side_effect = FileNotFoundError
+        session_assistant = MagicMock()
+        session_assistant.get_provider_launcher_by_id.return_value = (
+            "launcher_text"
+        )
+        self.assertEqual(
+            load_launcher_text(
+                "com.canonical.certification::launcher_id", session_assistant
+            ),
+            "launcher_text",
+        )
+
+    def test_launcher_doesnt_exist(self, path_mock):
+        path_mock().open.side_effect = FileNotFoundError
+        session_assistant = MagicMock()
+        session_assistant.get_provider_launcher_by_id.side_effect = (
+            FileNotFoundError
+        )
+        # This function is called in "presentation" code, so it should crash
+        # the whole app if the provided launcher id/path doesn't exist
+        with self.assertRaises(SystemExit):
+            load_launcher_text("doesn't exist", session_assistant)

--- a/checkbox-ng/plainbox/impl/config.py
+++ b/checkbox-ng/plainbox/impl/config.py
@@ -26,6 +26,7 @@ import io
 import logging
 import os
 import shlex
+import json
 
 from configparser import ConfigParser
 from collections import namedtuple, OrderedDict
@@ -297,6 +298,28 @@ class Configuration:
                     cfg.notice_problem(problem)
                     continue
                 cfg.set_value(sect_name, var_name, var, origin)
+        return cfg
+
+    def to_json(self):
+        """
+        Encodes the Configuration in a json object with sections and origins
+        """
+        to_encode = {
+            "origins": self._origins,
+            "sections": self.sections,
+            "problems": self._problems,
+            "sources": self.sources,
+        }
+        return json.dumps(to_encode)
+
+    @classmethod
+    def from_json(cls, config_json: str):
+        config_dict = json.loads(config_json)
+        cfg = cls()
+        cfg._origins = config_dict["origins"]
+        cfg._problems = config_dict["problems"]
+        cfg._sources = config_dict["sources"]
+        cfg.sections = config_dict["sections"]
         return cfg
 
     _DYNAMIC_SECTIONS = ("environment", "manifest")

--- a/checkbox-ng/plainbox/impl/highlevel.py
+++ b/checkbox-ng/plainbox/impl/highlevel.py
@@ -147,6 +147,7 @@ class Explorer:
         "category",
         "exporter",
         "job",
+        "launcher",
         "manifest entry",
         "packaging meta-data",
         "template",
@@ -253,6 +254,8 @@ class Explorer:
             return self._packaging_meta_data_to_obj(unit)
         elif unit.Meta.name == "exporter":
             return self._exporter_entry_to_obj(unit)
+        elif unit.Meta.name == "launcher":
+            return self._launcher_to_obj(unit)
         else:
             raise NotImplementedError(unit.Meta.name)
 
@@ -410,6 +413,21 @@ class Explorer:
                     ("id", unit.id),
                     ("summary", unit.summary),
                     ("tr_summary", unit.tr_summary()),
+                )
+            ),
+        )
+
+    def _launcher_to_obj(self, unit):
+        return PlainBoxObject(
+            unit,
+            group=unit.Meta.name,
+            name=unit.name,
+            attrs=OrderedDict(
+                (
+                    ("id", unit.id),
+                    ("name", unit.name),
+                    ("path", unit.path),
+                    ("origin", str(unit.origin)),
                 )
             ),
         )

--- a/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
@@ -458,6 +458,7 @@ class Provider1PlugInTests(TestCase):
         "data_dir = /some/directory/data\n"
         "bin_dir = /some/directory/bin\n"
         "locale_dir = /some/directory/locale\n"
+        "launchers_dir = /some/directory/launchers\n"
     )
 
     LOAD_TIME = 42
@@ -658,6 +659,7 @@ class Provider1Tests(TestCase):
     BIN_DIR = "bin-dir"
     LOCALE_DIR = "locale-dir"
     BASE_DIR = "base-dir"
+    LAUNCHERS_DIR = "launchers-dir"
 
     LOAD_TIME = 42
 
@@ -674,6 +676,7 @@ class Provider1Tests(TestCase):
             self.DATA_DIR,
             self.BIN_DIR,
             self.LOCALE_DIR,
+            self.LAUNCHERS_DIR,
             self.BASE_DIR,
             # We are using dummy job definitions so let's not shout about those
             # being invalid in each test
@@ -886,6 +889,7 @@ class Provider1Tests(TestCase):
             self.DATA_DIR,
             self.BIN_DIR,
             self.LOCALE_DIR,
+            self.LAUNCHERS_DIR,
             self.BASE_DIR,
         )
         mock_gettext.bindtextdomain.assert_called_once_with(
@@ -910,6 +914,7 @@ class Provider1Tests(TestCase):
             self.DATA_DIR,
             self.BIN_DIR,
             locale_dir=None,
+            launchers_dir=self.LAUNCHERS_DIR,
             base_dir=self.BASE_DIR,
         )
         self.assertEqual(mock_gettext.bindtextdomain.call_args_list, [])
@@ -932,6 +937,7 @@ class Provider1Tests(TestCase):
             self.DATA_DIR,
             self.BIN_DIR,
             locale_dir=None,
+            launchers_dir=self.LAUNCHERS_DIR,
             base_dir="/snap/checkbox24/current/providers/some-provider",
         )
         self.assertFalse(provider.custom_frontend_provider)
@@ -950,6 +956,7 @@ class Provider1Tests(TestCase):
             self.DATA_DIR,
             self.BIN_DIR,
             locale_dir=None,
+            launchers_dir=self.LAUNCHERS_DIR,
             base_dir="/snap/checkbox24/x1/custom_frontends/custom_frontend2",
         )
         self.assertTrue(provider.custom_frontend_provider)
@@ -974,6 +981,7 @@ class Provider1Tests(TestCase):
             self.DATA_DIR,
             self.BIN_DIR,
             locale_dir=None,
+            launchers_dir=self.LAUNCHERS_DIR,
             base_dir="/snap/checkbox24/x1/custom_frontends/custom_frontend2",
         )
         self.assertGreater(len(provider.extra_PYTHONPATH), 0)
@@ -998,6 +1006,7 @@ class Provider1Tests(TestCase):
             self.DATA_DIR,
             self.BIN_DIR,
             locale_dir=None,
+            launchers_dir=self.LAUNCHERS_DIR,
             base_dir="/snap/checkbox24/x1/custom_frontends/custom_frontend2",
         )
         self.assertGreater(len(provider.extra_PATH), 0)
@@ -1026,6 +1035,7 @@ class Provider1Tests(TestCase):
             self.DATA_DIR,
             self.BIN_DIR,
             locale_dir=None,
+            launchers_dir=self.LAUNCHERS_DIR,
             base_dir="/snap/checkbox24/x1/custom_frontends/custom_frontend2",
         )
         self.assertGreater(len(provider.extra_LD_LIBRARY_PATH), 0)

--- a/checkbox-ng/plainbox/impl/secure/providers/v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/v1.py
@@ -1298,9 +1298,7 @@ class Provider1(IProvider1):
         List of all the launchers
         """
         return [
-            Path(unit.path)
-            for unit in self.unit_list
-            if unit.Meta.name == "launcher"
+            unit for unit in self.unit_list if unit.Meta.name == "launcher"
         ]
 
     @property

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -1166,6 +1166,33 @@ class SessionAssistant:
         )
         self._context.state.update_desired_job_list(desired_job_list)
 
+    def is_provider_launcher_id(self, launcher_id: str):
+        try:
+            _ = self.get_provider_launcher_by_id(launcher_id)
+            return True
+        except FileNotFoundError:
+            return False
+
+    def get_provider_launcher_by_id(self, launcher_id: str):
+        namespace, *_ = launcher_id.split("::", maxsplit=1)
+        selected_providers = self.get_selected_providers()
+        relevant_providers = filter(
+            lambda x: x.namespace == namespace, selected_providers
+        )
+        try:
+            return str(
+                next(
+                    launcher
+                    for provider in relevant_providers
+                    for launcher in provider.launcher_list
+                    if launcher.id == launcher_id
+                ).text
+            )
+        except StopIteration:
+            raise FileNotFoundError(
+                "Unkown launcher id: {}".format(launcher_id)
+            )
+
     @raises(KeyError, UnexpectedMethodCall)
     def get_job_state(self, job_id: str) -> "JobState":
         """

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -930,7 +930,6 @@ class RemoteSessionAssistant:
 
     def resume_by_id(self, session_id=None, result_interactively_decided={}):
         _logger.info("resume_by_id: %r", session_id)
-        self._launcher = load_configs()
         resume_candidates = list(self._sa.get_resumable_sessions())
         if not session_id:
             if not resume_candidates:
@@ -950,14 +949,11 @@ class RemoteSessionAssistant:
             session_id, runner_kwargs=runner_kwargs
         )
         app_blob = json.loads(meta.app_blob.decode("UTF-8"))
-        if "launcher" in app_blob:
-            launcher_from_controller = Configuration.from_text(
-                app_blob["launcher"], "Remote launcher"
-            )
-        else:
-            launcher_from_controller = Configuration()
-        self._launcher.update_from_another(
-            launcher_from_controller, "Remote launcher"
+        self._launcher = resolve_configs(
+            Configuration.from_text(
+                app_blob.get("launcher", ""), origin="Remote launcher"
+            ),
+            self._sa,
         )
         self._sa.use_alternate_configuration(self._launcher)
 

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -185,6 +185,10 @@ class RemoteAssistantTests(TestCase):
             tps = RemoteSessionAssistant.start_session(rsa, extra_cfg)
             self.assertEqual(tps[0][0][1], "tp")
 
+    @mock.patch(
+        "plainbox.impl.session.remote_assistant.resolve_configs",
+        new=mock.Mock(side_effect=lambda conf, sa: conf),
+    )
     def test_resume_by_id_with_session_id(self):
         rsa = mock.Mock()
         resumable_session = mock.Mock()
@@ -213,6 +217,10 @@ class RemoteAssistantTests(TestCase):
         RemoteSessionAssistant.resume_by_id(rsa, "bad_id")
         self.assertEqual(rsa.state, RemoteSessionStates.Idle)
 
+    @mock.patch(
+        "plainbox.impl.session.remote_assistant.resolve_configs",
+        new=mock.Mock(side_effect=lambda conf, sa: conf),
+    )
     def test_resume_by_id_without_session_id(self):
         rsa = mock.Mock()
         resumable_session = mock.Mock()
@@ -227,8 +235,11 @@ class RemoteAssistantTests(TestCase):
         RemoteSessionAssistant.resume_by_id(rsa)
         self.assertEqual(rsa.state, RemoteSessionStates.TestsSelected)
 
-    @mock.patch("plainbox.impl.session.remote_assistant.load_configs")
-    def test_resume_by_id_with_result_file_ok(self, mock_load_configs):
+    @mock.patch(
+        "plainbox.impl.session.remote_assistant.resolve_configs",
+        new=mock.Mock(side_effect=lambda conf, sa: conf),
+    )
+    def test_resume_by_id_with_result_file_ok(self):
         rsa = mock.Mock()
         resumable_session = mock.Mock()
         resumable_session.id = "session_id"
@@ -269,10 +280,11 @@ class RemoteAssistantTests(TestCase):
         )
         rsa._sa.use_job_result.assert_called_with(rsa._last_job, mjr, True)
 
-    @mock.patch("plainbox.impl.session.remote_assistant.load_configs")
-    def test_resume_by_id_with_result_file_garbage_outcome(
-        self, mock_load_configs
-    ):
+    @mock.patch(
+        "plainbox.impl.session.remote_assistant.resolve_configs",
+        new=mock.Mock(side_effect=lambda conf, sa: conf),
+    )
+    def test_resume_by_id_with_result_file_garbage_outcome(self):
         rsa = mock.Mock()
         resumable_session = mock.Mock()
         resumable_session.id = "session_id"
@@ -316,10 +328,11 @@ class RemoteAssistantTests(TestCase):
         rsa._sa.use_job_result.assert_called_with(rsa._last_job, mjr, True)
 
     @mock.patch("plainbox.impl.session.remote_assistant.open")
-    @mock.patch("plainbox.impl.session.remote_assistant.load_configs")
-    def test_resume_by_id_with_result_no_file_noreturn(
-        self, mock_load_configs, mock_open
-    ):
+    @mock.patch(
+        "plainbox.impl.session.remote_assistant.resolve_configs",
+        new=mock.Mock(side_effect=lambda conf, sa: conf),
+    )
+    def test_resume_by_id_with_result_no_file_noreturn(self, mock_open):
         rsa = mock.Mock()
         resumable_session = mock.Mock()
         resumable_session.id = "session_id"
@@ -358,10 +371,11 @@ class RemoteAssistantTests(TestCase):
         rsa._sa.use_job_result.assert_called_with(rsa._last_job, mjr, True)
 
     @mock.patch("plainbox.impl.session.remote_assistant.open")
-    @mock.patch("plainbox.impl.session.remote_assistant.load_configs")
-    def test_resume_by_id_with_result_no_file_normal(
-        self, mock_load_configs, mock_open
-    ):
+    @mock.patch(
+        "plainbox.impl.session.remote_assistant.resolve_configs",
+        new=mock.Mock(side_effect=lambda conf, sa: conf),
+    )
+    def test_resume_by_id_with_result_no_file_normal(self, mock_open):
         rsa = mock.Mock()
         resumable_session = mock.Mock()
         resumable_session.id = "session_id"
@@ -403,10 +417,11 @@ class RemoteAssistantTests(TestCase):
         rsa._sa.use_job_result.assert_called_with(rsa._last_job, mjr, True)
 
     @mock.patch("plainbox.impl.session.remote_assistant.open")
-    @mock.patch("plainbox.impl.session.remote_assistant.load_configs")
-    def test_resume_by_id_with_result_no_file_already_set(
-        self, mock_load_configs, mock_open
-    ):
+    @mock.patch(
+        "plainbox.impl.session.remote_assistant.resolve_configs",
+        new=mock.Mock(side_effect=lambda conf, sa: conf),
+    )
+    def test_resume_by_id_with_result_no_file_already_set(self, mock_open):
         rsa = mock.Mock()
         resumable_session = mock.Mock()
         resumable_session.id = "session_id"
@@ -437,8 +452,11 @@ class RemoteAssistantTests(TestCase):
         # the job already has an outcome, don't re-adopt it
         self.assertFalse(rsa._sa.use_job_result.called)
 
-    @mock.patch("plainbox.impl.session.remote_assistant.load_configs")
-    def test_resume_by_id_with_result_file_not_json(self, mock_load_configs):
+    @mock.patch(
+        "plainbox.impl.session.remote_assistant.resolve_configs",
+        new=mock.Mock(side_effect=lambda conf, sa: conf),
+    )
+    def test_resume_by_id_with_result_file_not_json(self):
         rsa = mock.Mock()
         resumable_session = mock.Mock()
         resumable_session.id = "session_id"

--- a/checkbox-ng/plainbox/impl/unit/file.py
+++ b/checkbox-ng/plainbox/impl/unit/file.py
@@ -57,6 +57,7 @@ class FileRole(SymbolDef):
     manage_py = "manage.py"  # management script
     legal = "legal"  # license & copyright
     docs = "docs"  # documentation
+    launcher = "launcher"  # launcher configuration file
     unknown = "unknown"  # unknown / unclassified
     build = "build"  # build artefact
     invalid = "invalid"  # invalid file that will never be used

--- a/checkbox-ng/plainbox/impl/unit/launcher.py
+++ b/checkbox-ng/plainbox/impl/unit/launcher.py
@@ -52,7 +52,7 @@ class LauncherUnit(UnitWithId):
         """
         Calculating checksums of launchers is not supported
         """
-        return "0"
+        return str(hash(self._data["path"]))
 
     @property
     def text(self):
@@ -61,9 +61,13 @@ class LauncherUnit(UnitWithId):
 
     @classmethod
     def from_path(cls, path: str, text: str, **kwargs):
-        path = Path(path)
         return cls(
-            {"unit": "launcher", "path": path, "id": path.stem, "text": text},
+            {
+                "unit": "launcher",
+                "path": str(path),
+                "id": str(Path(path).stem),
+                "text": text,
+            },
             **kwargs
         )
 

--- a/checkbox-ng/plainbox/impl/unit/launcher.py
+++ b/checkbox-ng/plainbox/impl/unit/launcher.py
@@ -1,0 +1,113 @@
+# This file is part of Checkbox.
+#
+# Copyright 2025 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+"""
+:mod:`plainbox.impl.unit.launcher` -- launcher unit
+====================================================
+
+Launcher units represent launcher configuration files that are shipped with a
+provider.
+"""
+
+import logging
+from pathlib import Path
+
+from plainbox.i18n import gettext as _
+from plainbox.i18n import gettext_noop as N_
+from plainbox.impl.symbol import SymbolDef
+from plainbox.impl.unit.unit_with_id import UnitWithId
+from plainbox.impl.unit.validators import CorrectFieldValueValidator
+from plainbox.impl.validation import Problem, Severity
+
+__all__ = ["LauncherUnit"]
+
+logger = logging.getLogger("plainbox.unit.launcher")
+
+
+class LauncherUnit(UnitWithId):
+    """
+    Launcher Unit
+
+    This unit represents a launcher configuration file that can be used
+    to configure test runs. Launchers are .conf files stored in the
+    launchers/ directory of a provider.
+    """
+
+    @property
+    def checksum(self):
+        """
+        Calculating checksums of launchers is not supported
+        """
+        return "0"
+
+    @property
+    def text(self):
+        # str is necessary because text is lazy loaded
+        return str(self.get_record_value("text"))
+
+    @classmethod
+    def from_path(cls, path: str, text: str, **kwargs):
+        path = Path(path)
+        return cls(
+            {"unit": "launcher", "path": path, "id": path.stem, "text": text},
+            **kwargs
+        )
+
+    def __str__(self):
+        """
+        Same as .name
+        """
+        return self.id
+
+    def __repr__(self):
+        return "<LauncherUnit id:{!r} name:{!r}>".format(self.id, self.name)
+
+    @property
+    def path(self):
+        """
+        Absolute path of the launcher configuration file
+        """
+        return self.get_record_value("path")
+
+    @property
+    def name(self):
+        """
+        Name of the launcher (filename without .conf extension)
+        """
+        return self.id
+
+    class Meta:
+
+        name = N_("launcher")
+
+        class fields(SymbolDef):
+            """
+            Symbols for each field that a LauncherUnit can have
+            """
+
+            path = "path"
+
+        field_validators = {
+            fields.path: [
+                CorrectFieldValueValidator(
+                    lambda path: Path(path).stem != "checkbox",
+                    Problem.wrong,
+                    Severity.error,
+                    message=_("launcher name can not be named 'checkbox'"),
+                )
+            ]
+        }

--- a/checkbox-ng/plainbox/impl/unit/launcher.py
+++ b/checkbox-ng/plainbox/impl/unit/launcher.py
@@ -32,6 +32,7 @@ from plainbox.impl.symbol import SymbolDef
 from plainbox.impl.unit.unit_with_id import UnitWithId
 from plainbox.impl.unit.validators import CorrectFieldValueValidator
 from plainbox.impl.validation import Problem, Severity
+from plainbox.impl.config import Configuration
 
 __all__ = ["LauncherUnit"]
 
@@ -104,6 +105,20 @@ class LauncherUnit(UnitWithId):
             """
 
             path = "path"
+            text = "text"
+
+        def _raise_problems(text, unit):
+            """
+            This allows us to report problems in the unit straight in the
+            validation error
+            """
+            problems = Configuration.from_text(text, unit.path).get_problems()
+            if not problems:
+                return True
+            raise ValueError(
+                "Configuration has the following problems:"
+                + "\n- ".join(problems)
+            )
 
         field_validators = {
             fields.path: [
@@ -113,5 +128,12 @@ class LauncherUnit(UnitWithId):
                     Severity.error,
                     message=_("launcher name can not be named 'checkbox'"),
                 )
-            ]
+            ],
+            fields.text: [
+                CorrectFieldValueValidator(
+                    _raise_problems,
+                    Problem.wrong,
+                    Severity.error,
+                )
+            ],
         }

--- a/checkbox-ng/plainbox/provider_manager.py
+++ b/checkbox-ng/plainbox/provider_manager.py
@@ -197,6 +197,9 @@ class InstallCommand(ManageCommand):
             "units": os.path.join(
                 "{prefix}", "share", "{provider.name}", "units"
             ),
+            "launchers": os.path.join(
+                "{prefix}", "share", "{provider.name}", "launchers"
+            ),
             "po": None,
             "provider": os.path.join(
                 "{prefix}",
@@ -241,6 +244,13 @@ class InstallCommand(ManageCommand):
                 "{provider.name}",
                 "units",
             ),
+            "launchers": os.path.join(
+                "{prefix}",
+                "lib",
+                "plainbox-providers-1",
+                "{provider.name}",
+                "launchers",
+            ),
             "po": None,
             "provider": os.path.join(
                 "{prefix}",
@@ -255,6 +265,7 @@ class InstallCommand(ManageCommand):
             "data": os.path.join("{prefix}", "data"),
             "jobs": os.path.join("{prefix}", "jobs"),
             "units": os.path.join("{prefix}", "units"),
+            "launchers": os.path.join("{prefix}", "launchers"),
             "po": None,
             "provider": os.path.join(
                 "{prefix}", "{provider.name_without_colon}.provider"
@@ -269,6 +280,7 @@ class InstallCommand(ManageCommand):
         "data": "data_dir",
         "jobs": "jobs_dir",
         "units": "units_dir",
+        "launchers": "launchers_dir",
     }
 
     def get_command_epilog(self):

--- a/checkbox-ng/pyproject.toml
+++ b/checkbox-ng/pyproject.toml
@@ -120,6 +120,7 @@ noble_prod = [
   'manifest entry' = "plainbox.impl.unit.manifest:ManifestEntryUnit"
   'packaging meta-data' = "plainbox.impl.unit.packaging_metadata:PackagingMetaDataUnit"
   exporter = "plainbox.impl.unit.exporter:ExporterUnit"
+  launcher = "plainbox.impl.unit.launcher:LauncherUnit"
 [project.entry-points."plainbox.parsers"]
   pxu = "plainbox.impl.secure.rfc822:load_rfc822_records"
   regex = "plainbox.impl.xparsers:Re.parse"

--- a/docs/reference/launcher.rst
+++ b/docs/reference/launcher.rst
@@ -26,8 +26,11 @@ Launcher can specify external file(s) to load values from.
 ``[config]``
     Beginning of the configuration section.
 
-``config_filename``
-    Name of the configuration file to look for. The value may be a file name or an absolute path, and may use environment variables. If no directory is specified, the default directories where the file will be searched for are ``/etc/xdg/`` and ``~/.config/``.
+``include_override``
+    Name, path or ID of the configuration file to include and (potentially)
+    override with the current one. If a name without a directory is specified,
+    the configuration is searched in both ``/etc/xdg/`` and ``~/.config/``.
+    Each matching configuration is loaded.
 
     Default value: ``checkbox.conf``
 
@@ -503,6 +506,15 @@ Example of all three sections working to produce a report:
     transport = out
     forced = yes
 
+Packaging
+=========
+
+Launchers can be packaged in providers in the ``launcher/`` directory.
+Launchers that are included in this directory can be used by their fully
+qualified ID which is composed by
+``namespace.of.the.provider::file_name_without_extension``. All launchers
+included in the ``launcher/`` directory must have a ``.conf`` extension and
+their name must be unique in the namespace.
 
 Launcher examples
 =================


### PR DESCRIPTION
## Description

Sharing launchers is often useful to get less technical users to use the product correctly and to have a easier pre-baked input for projects. There was up until now a mechanism in checkbox to share these files so the two solutions that were employed were:
1. Hack in the manage.py to put these files in local/bin + shebang
2. Snap apps

The first solution doesn't work for snaps and the second solution doesn't work for debs. Both solution can't be used with checkbox remote. Additionally, both will not work with the new `custom-frontend` interface. 

This introduces the concept of Launchers in the whole Checkbox ecosystem, from packaging to units, creating a new location where these provider-specific launchers live (`provider/launchers`), a standard way to use them (via their FQN, more below!), a standard way to list them (`checkbox-cli list launcher`) and a cleaner way (in name, mechanism is unchanged)  to inherit from other configurations.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

WIP

## Tests

Unit tests + try the following 
```shell
# from the checkbox repo
$ mkdir providers/base/launchers
$ cat <<EOF > providers/base/launchers/foo.conf
[test plan]
filter = *smoke*
[environment]
FOO=1
EOF
# now the foo launcher is part of the base provider and you can do the following
$ checkbox-cli list launcher
launcher 'com.canonical.certification::foo'
$ checkbox-cli config check com.canonical.certification::foo
[...] # you should see the filter + the environment variable + no problems hopefully :)
$ checkbox-cli com.canonical.certification::foo
[...] # you should see just the smoke test plan
# now start an agent and use the following
# ALLOW_CHECKBOX_AGENT_NONROOT=1 checkbox-cli run-agent
$ checkbox-cli control 127.0.0.1 com.canonical.certification::foo
[...] # you should see the same
# Now lets try to use this configuration as a part of another configuration
$ cat <<EOF > bar.conf
[config]
import_override = com.canonical.certification::foo
[test plan]
filter = *
[environment]
BAR=1
EOF
$ checkbox-cli config check bar.conf
[...] # here you will see the two got merged, filter of bar has overwritten the filter in c.c.c::foo
$ checkbox-cli control 127.0.0.1 bar.conf
[...] # here no filter will be applied
```
