### PR TITLE
Add bluetooth 6.0's HCI version in beacontools (New)

### DIFF
--- a/checkbox-support/checkbox_support/vendor/beacontools/scanner.py
+++ b/checkbox-support/checkbox_support/vendor/beacontools/scanner.py
@@ -47,6 +47,7 @@ class HCIVersion(IntEnum):
     BT_CORE_SPEC_5_2 = 11
     BT_CORE_SPEC_5_3 = 12
     BT_CORE_SPEC_5_4 = 13
+    BT_CORE_SPEC_6_0 = 14
 
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
## Description

Super simple 1 line change for BT6.0

## Resolved issues

The eddystone test will immediately crash on BT6.0 devices because it's trying to construct a `HCIVersion` enum from an unknown member (14). This PR adds 14 in the enum and fixes it.

## Documentation

https://www.bluetoothandusb3.com/what-versions-of-bluetooth-are-there
HCI version number can also be found with `hciconfig -a | grep HCI` (this shows the hexadecimal version, for example 14 = 0xe is bt6.0, 13 = 0xd is bt5.4)

## Tests

https://certification.canonical.com/hardware/202511-38076/submission/460156/