### PR TITLE
Add screen-private-ppa test (New)

### DIFF
--- a/contrib/pc-sanity/units/pc-sanity/pc-sanity-screen-oem-gaps.pxu
+++ b/contrib/pc-sanity/units/pc-sanity/pc-sanity-screen-oem-gaps.pxu
@@ -16,3 +16,16 @@ _summary: check if pkgs are not supported by Canonical
 _description:
  This lists the packages which is not coming from main or restricted component.
 
+plugin: shell
+category_id: com.canonical.plainbox::miscellanea
+id: miscellanea/screen-private-ppa
+user: root
+command:
+  if grep -qrE 'private-ppa\.launchpad(|content)\.net' "/etc/apt/sources.list"* ; then
+      >&2 printf 'The following files have private PPA access:\n'
+      >&2 grep -lrE 'private-ppa\.launchpad(|content)\.net' "/etc/apt/sources.list"*
+      exit 1
+  fi
+_summary: check if any private ppas are added
+_description:
+ This checks if any private ppas are added to the system, fails if any found.

--- a/contrib/pc-sanity/units/pc-sanity/pc-sanity.pxu
+++ b/contrib/pc-sanity/units/pc-sanity/pc-sanity.pxu
@@ -44,6 +44,7 @@ include:
     com.canonical.certification::miscellanea/gate_rste_raid
     com.canonical.certification::miscellanea/screen-pkg-not-public
     com.canonical.certification::miscellanea/screen-pkg-not-supported-by-canonical
+    com.canonical.certification::miscellanea/screen-private-ppa
     com.canonical.certification::miscellanea/edid-continuous-frequency
     com.canonical.certification::miscellanea/bluetooth-on-off-rfkill_.*
     com.canonical.certification::miscellanea/csme-detection-tool


### PR DESCRIPTION
## Description

This test is to avoid any leak of private PPA credentials in the release image.
This checks if any private PPAs are present in the system, fails if present. 

adds `miscellanea/screen-private-ppa` test to contrib/pc-sanity

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/PECA-1148

## Documentation

## Tests

Tested on Qualcomm RB3Gen2 Lite, should work on any system.
