### PR TITLE
Hardcode SYSTEMD_IGNORE_CHROOT forced to 1 (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -784,11 +784,12 @@ def get_execution_command_systemd_unit(
     env = get_differential_execution_environment(
         job, environ, session_id, nest_dir, extra_env
     )
-    env_cmds = []
-    env_cmds += [
+    env_cmds = [
         "{key}={value}".format(key=key, value=value)
         for key, value in sorted(env.items())
-    ]
+    ] + ["SYSTEMD_IGNORE_CHROOT=1"]
+    # SYSTEMD_IGNORE_CHROOT intentionally at the end because without this
+    # any systemd command will not work
     if on_ubuntucore():
         # when in a core snap, we need the snap mount namespace to use anything
         # that was shared via a content interface


### PR DESCRIPTION
## Description

Calling systemd in jobs with the new runner doesn't work because systemd detects it is running in a chroot (the namespace of the snap). This was true also before but the variable was forced on the outer level shell, now the outer level is not propagated inward anymore.

## Resolved issues

N/A

## Documentation

Added a comment to explain why this is done

## Tests

N/A
