### PR TITLE
Fixed boolean in wwan tests (BugFix)

### DIFF
--- a/providers/base/bin/wwan_tests.py
+++ b/providers/base/bin/wwan_tests.py
@@ -326,7 +326,7 @@ def _delete_all_bearers(mm_id: str):
                 ["mmcli", "-m", mm_id, "--delete-bearer={}".format(path)]
             )
         print()
-    except subprocess.CalledProcessError as e:
+    except subprocess.CalledProcessError:
         print("No bearers found")
         return
 

--- a/providers/base/bin/wwan_tests.py
+++ b/providers/base/bin/wwan_tests.py
@@ -316,7 +316,7 @@ def _allow_roaming(mm_id: str, apn: str):
         apn (str): The APN (Access Point Name) to use.
     """
     print_head("Set bearer to enable roaming")
-    bearer = "apn={},allow-roaming=yes".format(apn)
+    bearer = "apn={},allow-roaming=true".format(apn)
     cmd = ["mmcli", "-m", mm_id, "--create-bearer={}".format(bearer)]
     print_cmd(cmd)
     subprocess.check_call(cmd)

--- a/providers/base/tests/test_wwan_tests.py
+++ b/providers/base/tests/test_wwan_tests.py
@@ -379,7 +379,7 @@ class TestAllowRoaming(unittest.TestCase):
 
         _allow_roaming(test_mm_id, test_apn)
 
-        expected_bearer = "apn={},allow-roaming=yes".format(test_apn)
+        expected_bearer = "apn={},allow-roaming=true".format(test_apn)
         expected_cmd = [
             "mmcli",
             "-m",

--- a/providers/base/tests/test_wwan_tests.py
+++ b/providers/base/tests/test_wwan_tests.py
@@ -38,7 +38,9 @@ class TestMMDbus(unittest.TestCase):
 
         self.assertEqual(obj_mmdbus.__init__.call_count, 1)
         obj_mmdbus._modem_props_iface.assert_called_with(1)
-        mock_get.assert_called_with(wwan_tests.DBUS_MM1_IF_MODEM, "HardwareRevision")
+        mock_get.assert_called_with(
+            wwan_tests.DBUS_MM1_IF_MODEM, "HardwareRevision"
+        )
         self.assertEqual(resp, hw_revision_pattern)
 
 
@@ -53,7 +55,9 @@ class TestMMCli(unittest.TestCase):
         resp = obj_mmcli.get_firmware_revision(1)
 
         self.assertEqual(obj_mmcli.__init__.call_count, 1)
-        mock_value_from_table.assert_called_with("modem", 1, "firmware revision")
+        mock_value_from_table.assert_called_with(
+            "modem", 1, "firmware revision"
+        )
         self.assertEqual(resp, fw_revision_pattern)
 
     @patch("wwan_tests.MMCLI.__init__", Mock(return_value=None))

--- a/providers/base/tests/test_wwan_tests.py
+++ b/providers/base/tests/test_wwan_tests.py
@@ -38,9 +38,7 @@ class TestMMDbus(unittest.TestCase):
 
         self.assertEqual(obj_mmdbus.__init__.call_count, 1)
         obj_mmdbus._modem_props_iface.assert_called_with(1)
-        mock_get.assert_called_with(
-            wwan_tests.DBUS_MM1_IF_MODEM, "HardwareRevision"
-        )
+        mock_get.assert_called_with(wwan_tests.DBUS_MM1_IF_MODEM, "HardwareRevision")
         self.assertEqual(resp, hw_revision_pattern)
 
 
@@ -55,9 +53,7 @@ class TestMMCli(unittest.TestCase):
         resp = obj_mmcli.get_firmware_revision(1)
 
         self.assertEqual(obj_mmcli.__init__.call_count, 1)
-        mock_value_from_table.assert_called_with(
-            "modem", 1, "firmware revision"
-        )
+        mock_value_from_table.assert_called_with("modem", 1, "firmware revision")
         self.assertEqual(resp, fw_revision_pattern)
 
     @patch("wwan_tests.MMCLI.__init__", Mock(return_value=None))
@@ -72,6 +68,40 @@ class TestMMCli(unittest.TestCase):
         self.assertEqual(obj_mmcli.__init__.call_count, 1)
         mock_value_from_table.assert_called_with("modem", 1, "h/w revision")
         self.assertEqual(resp, hw_revision_pattern)
+
+    @patch("subprocess.check_output")
+    @patch("subprocess.run")
+    def test_delete_all_bearers(self, mock_run, mock_check_output):
+        bearer_list_pattern = (
+            "/org/freedesktop/ModemManager1/Bearer/0\n"
+            "/org/freedesktop/ModemManager1/Bearer/1\n"
+        )
+        mock_check_output.return_value = bearer_list_pattern
+        wwan_tests._delete_all_bearers("0")
+        mock_check_output.assert_called_with(
+            ["mmcli", "-m", "0", "--list-bearers"],
+            universal_newlines=True,
+            stderr=subprocess.STDOUT,
+        )
+        expected_calls = [
+            unittest.mock.call(
+                [
+                    "mmcli",
+                    "-m",
+                    "0",
+                    "--delete-bearer=/org/freedesktop/ModemManager1/Bearer/0",
+                ]
+            ),
+            unittest.mock.call(
+                [
+                    "mmcli",
+                    "-m",
+                    "0",
+                    "--delete-bearer=/org/freedesktop/ModemManager1/Bearer/1",
+                ]
+            ),
+        ]
+        mock_run.assert_has_calls(expected_calls, any_order=True)
 
 
 class TestResources(unittest.TestCase):
@@ -174,7 +204,6 @@ class TestWWANTestCtx(unittest.TestCase):
 
 class TestThreeGppScanTest(unittest.TestCase):
     def test_register_argument(self):
-
         sys.argv = ["wwan_tests.py", "3gpp-scan", "2", "--timeout", "600"]
         obj_3gppscan = wwan_tests.ThreeGppScanTest()
         ret_args = obj_3gppscan.register_argument()
@@ -262,7 +291,6 @@ class TestThreeGppScanTest(unittest.TestCase):
 
 class TestThreeGppConnectionTest(unittest.TestCase):
     def test_register_argument(self):
-
         sys.argv = [
             "wwan_tests.py",
             "3gpp-connection",


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

The wwan tests were failing on caracalla wwan devices because of a parsing error
`Error parsing properties string: 'Cannot get boolean from string 'yes''`

Replacing the "yes" string for a "true" fixed the issue

I've also added a function to delete all the bearers before running the tests, because there where cases in which they were interfering with the tests
## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->


## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Caracalla transport:
https://certification.canonical.com/hardware/201702-25399/submission/463885/

HP - Elite x360:
https://certification.canonical.com/hardware/202202-29969/submission/463889/

Dell - Pro 14 Plus:
https://certification.canonical.com/hardware/202501-36199/submission/463898/