### PR TITLE
Add lan.* as a valid wired interface (Bugfix)

### DIFF
--- a/providers/base/bin/gateway_ping_test.py
+++ b/providers/base/bin/gateway_ping_test.py
@@ -484,6 +484,7 @@ def is_cable_interface(interface: str) -> bool:
         interface.startswith("en")
         or interface.startswith("eth")
         or interface.startswith("oob")
+        or interface.startswith("lan")
     )
 
 

--- a/providers/base/tests/test_gateway_ping_test.py
+++ b/providers/base/tests/test_gateway_ping_test.py
@@ -651,6 +651,9 @@ class IsCableInterfaceTests(unittest.TestCase):
     def test_is_cable_interface_nominal_3(self):
         self.assertTrue(is_cable_interface("enp0s25"))
 
+    def test_is_cable_interface_nominal_4(self):
+        self.assertTrue(is_cable_interface("lan1"))
+
     def test_is_cable_interface_nominal_oob(self):
         """Test out-of-band (oob) management are detected as wired interfaces"""
         self.assertTrue(is_cable_interface("oob_mnic0"))


### PR DESCRIPTION
## Description

When working on an IoT device racking, I noticed it kept failing to `ping-with-any-cable-interface` test.
After investigating, I found that its interfaces are named with `lan.*`, as it's using a switch controller.
So this PR simply add `lan.*` as an expected wired interface. 
```
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
0.0.0.0         10.102.164.1    0.0.0.0         UG    100    0        0 lan1
```

## Resolved issues

An [IoT device](https://certification.canonical.com/hardware/202408-34281) keeps failing to run `ping-with-any-cable-interface` test.

## Tests

Tested it locally on the device.
```
python3 gateway_ping_test.py --any-cable-interface
Looking for all cable interfaces...
PING 10.102.164.1 (10.102.164.1) from 10.102.164.123 lan1: 56(84) bytes of data.
64 bytes from 10.102.164.1: icmp_seq=1 ttl=64 time=1.16 ms
64 bytes from 10.102.164.1: icmp_seq=2 ttl=64 time=1.48 ms

```
