### PR TITLE
Only deactivate activated connections in wifi_nmcli_test.py (BugFix)

### DIFF
--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -92,21 +92,16 @@ def turn_up_connection(uuid):
 
 def turn_down_nm_connections():
     print_head("Turn off NM all connections")
-    while True:
-        connections = _get_nm_wireless_connections()
-        did_down = False
-        for name, value in connections.items():
-            if value["state"] != "activated":
-                continue
-            did_down = True
-            uuid = value["uuid"]
-            print("Turn down connection", name)
-            cmd = "nmcli c down {}".format(uuid)
-            print_cmd(cmd)
-            sp.check_call(shlex.split(cmd))
-            print("{} {} is down now".format(name, uuid))
-        if not did_down:
-            break
+    connections = _get_nm_wireless_connections()
+    for name, value in connections.items():
+        if value["state"] != "activated":
+            continue
+        uuid = value["uuid"]
+        print("Turn down connection", name)
+        cmd = "nmcli c down {}".format(uuid)
+        print_cmd(cmd)
+        sp.check_call(shlex.split(cmd))
+        print("{} {} is down now".format(name, uuid))
     print()
 
 

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -92,14 +92,21 @@ def turn_up_connection(uuid):
 
 def turn_down_nm_connections():
     print_head("Turn off NM all connections")
-    connections = _get_nm_wireless_connections()
-    for name, value in connections.items():
-        uuid = value["uuid"]
-        print("Turn down connection", name)
-        cmd = "nmcli c down {}".format(uuid)
-        print_cmd(cmd)
-        sp.check_call(shlex.split(cmd))
-        print("{} {} is down now".format(name, uuid))
+    while True:
+        connections = _get_nm_wireless_connections()
+        did_down = False
+        for name, value in connections.items():
+            if value["state"] != "activated":
+                continue
+            did_down = True
+            uuid = value["uuid"]
+            print("Turn down connection", name)
+            cmd = "nmcli c down {}".format(uuid)
+            print_cmd(cmd)
+            sp.check_call(shlex.split(cmd))
+            print("{} {} is down now".format(name, uuid))
+        if not did_down:
+            break
     print()
 
 

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -152,7 +152,10 @@ class TestTurnDownNmConnections(unittest.TestCase):
     @patch("wifi_nmcli_test.sp.check_call")
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
-        return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
+        return_value={
+            "Wireless1": {"uuid": "uuid1", "state": "activated"},
+            "Wireless2": {"uuid": "uuid2", "state": "deactivated"},
+        },
     )
     def test_turn_down_single_connection(
         self, get_connections_mock, sp_check_call_mock


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
This PR updates `turn_down_nm_connections()` to deactivate only Wi-Fi connections currently in the activated state. It re-queries NetworkManager connections and repeats until no activated Wi-Fi connection remains.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
When running Wireless networking tests with NetworkManager, `turn_down_nm_connections()` may attempt to deactivate saved Wi-Fi profiles that are not active. In that case, `nmcli connection down <uuid>` fails with:

- `Error: '<uuid>' is not an active connection`
- `Error: no active connection provided`
- `returned non-zero exit status 10`

This change deactivates only activated Wi-Fi connections and loops until none remain, preventing the above failure.

Ref: [WTN-323](https://warthogs.atlassian.net/browse/WTN-323) (oem bug)
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
Environment:

- Ubuntu 24.04
- NetworkManager (nmcli)
- Checkbox 6.0.0.dev90

Steps:

1. Before running Checkbox, ensure the DUT has:


>at least one Wi-Fi connection in "activated" state (connected to an AP), and
 >at least one saved Wi-Fi profile that is not active.

Verify with `nmcli connection show`. For example, SSID `4F-1VC2-A45` is active on `wlp2s0f0`, and SSID `4F-1VC2-A35` is not active:
```
jfy@jfy:~$ nmcli connection show
NAME         UUID                                  TYPE      DEVICE   
4F-1VC2-A45  47e857fd-f5cc-4a2b-ac71-c336cca8251b  wifi      wlp2s0f0 
lo           6a0de5a2-310d-433d-865f-0feaf4bc1bbe  loopback  lo       
4F-1VC2-A35  ba001808-66a7-4392-8f74-bc45d45f1649  wifi      --       
jfy@jfy:~$
```

2. Set up the environment using the Checkbox Ubuntu launcher.
3. Run: `checkbox-cli <Ubuntu_launcher>` (replace with your launcher name if different)
4. Select:
`Desktop Preload Certification Tests for 24.04`
→ `Wireless networking tests`
→ `wireless/wireless_connection_wpa_ax_nm_<interface>` (<interface> is auto-detected, e.g. wlp2s0f0)

Expected result:

- `turn_down_nm_connections()` only deactivates connections in activated state.
- It stops once no activated Wi-Fi connection remains.
- The test no longer fails with exit status 10 due to attempting to deactivate inactive profiles.

Failure example (before this change):

- `nmcli c down <uuid>`
- `Error: '<uuid>' is not an active connection`
- `Error: no active connection provided`
- `returned non-zero exit status 10`

failure reference:
```
======================================
Attempt 1/5 (function 'device_rescan')
======================================
## Calling a rescan
+ nmcli d wifi rescan

## List APs with ESSID: 4F-1VC2-A35
SSID: 4F-1VC2-A35 Chan: 44 Freq: 5220 MHz Signal: 60

## Cleaning up TEST_CON connection
+ nmcli -t -f TYPE,UUID,NAME,STATE connection
No TEST_CON connection found, nothing to delete
## Get NM activate connection name
+ nmcli -t -f TYPE,UUID,NAME,STATE connection
## Turn off NM all connections
+ nmcli -t -f TYPE,UUID,NAME,STATE connection
Turn down connection 4F-1VC2-A35
+ nmcli c down 6a3cc2d6-d581-458d-a291-3edd8240ce73
Error: '6a3cc2d6-d581-458d-a291-3edd8240ce73' is not an active connection.
Error: no active connection provided.
Attempt 4 failed:
Command '['nmcli', 'c', 'down', '6a3cc2d6-d581-458d-a291-3edd8240ce73']' returned non-zero exit status 10.

Waiting 28.99 seconds before retrying...

```
 
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->


[WTN-323]: https://warthogs.atlassian.net/browse/WTN-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ