### PR TITLE
Specify fwts data directory for snap checkbox (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -187,7 +187,7 @@ def get_fwts_base_cmd() -> str:
         if not fwts_json_data_dir.exists():
             raise SystemExit(
                 "We are in a snap environment, "
-                + "but {}".format(fwts_json_data_dir)
+                + "but '{}' ".format(fwts_json_data_dir)
                 + "doesn't exist"
             )
         return "fwts -j {}".format(fwts_json_data_dir)

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -186,7 +186,7 @@ def get_fwts_base_cmd() -> str:
             # workaround for issue 2295
             # https://github.com/canonical/checkbox/issues/2295
             # TODO: remove this logic and read CHECKBOX_RUNTIME directly
-            # after 2295 i fixed
+            # after 2295 is fixed
             fwts_json_data_dir = (
                 Path(os.environ["CHECKBOX_RUNTIME"]) / "share" / "fwts"
             )

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -7,6 +7,7 @@ from subprocess import Popen, PIPE, DEVNULL
 from shutil import which
 import os
 from pathlib import Path
+from checkbox_support.snap_utils.system import in_classic_snap
 
 # These tests require user interaction and need either special handling
 # or skipping altogether (right now, we skip them but they're kept here
@@ -181,9 +182,21 @@ def get_fwts_base_cmd() -> str:
     if "CHECKBOX_RUNTIME" in os.environ and "SNAP" in os.environ:
         # snap checkbox
         # must specify where the klog.json, clog.json files are
-        fwts_json_data_dir = (
-            Path(os.environ["SNAP"]) / "checkbox-runtime" / "share" / "fwts"
-        )
+        if in_classic_snap():
+            # workaround for issue 2295
+            # https://github.com/canonical/checkbox/issues/2295
+            # TODO: remove this logic and read CHECKBOX_RUNTIME directly
+            # after 2295 i fixed
+            fwts_json_data_dir = (
+                Path(os.environ["CHECKBOX_RUNTIME"]) / "share" / "fwts"
+            )
+        else:
+            fwts_json_data_dir = (
+                Path(os.environ["SNAP"])
+                / "checkbox-runtime"
+                / "share"
+                / "fwts"
+            )
         if not fwts_json_data_dir.exists():
             raise SystemExit(
                 "We are in a snap environment, "

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -174,15 +174,11 @@ def get_sleep_times(log: "str | Path", start_marker: str):
     suspend_time = ""
     resume_time = ""
     with open(log, "r", encoding="UTF-8", errors="ignore") as f:
-        line = ""
-        loglist = []  # type: list[str]
-        while start_marker not in line:
-            line = f.readline()
-            if start_marker in line:
-                loglist = f.readlines()
-                break
-        for i, l in enumerate(loglist):
-            if "Suspend/Resume Timings:" in l:
+        while start_marker not in f.readline():
+            continue
+        loglist = f.readlines() # read the remaining lines
+        for i, line in enumerate(loglist):
+            if "Suspend/Resume Timings:" in line:
                 suspend_line = loglist[i + 1]
                 resume_line = loglist[i + 2]
                 match = SLEEP_TIME_RE.search(suspend_line)

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -173,8 +173,6 @@ SLEEP_TIME_RE = re.compile(r"(Suspend|Resume):\s+([\d\.]+)\s+seconds.")
 def get_fwts_base_cmd() -> str:
     """Get the correct fwts command template depending on if we are inside a snap
 
-    :param log_file_path: where to put the log file
-    :param tests: list of fwts tests like 's3' 'klog'
     :raises SystemExit: If we are in snap, but the json files needed by
                         fwts's parser doesn't exist
     :return: command string

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -497,7 +497,7 @@ def main(args=None):
         tests = requested_tests
         iteration_results = (
             {}
-        )  #  # type: dict[int, tuple[float | str, float|str]]
+        )  # type: dict[int, tuple[float | str, float | str]]
         print("=" * 20 + " Test Results " + "=" * 20)
         progress_indicator_process = None
         if detect_progress_indicator():

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -598,7 +598,11 @@ def main(args=None):
                 if test == "acpitests":
                     test = "--acpitests"
                 results[test] = (
-                    Popen(get_sleep_test_command(log, [test]), stdout=PIPE, shell=True)
+                    Popen(
+                        get_sleep_test_command(log, [test]),
+                        stdout=PIPE,
+                        shell=True,
+                    )
                     .communicate()[0]
                     .strip()
                 ).decode()

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -169,7 +169,7 @@ TESTS = sorted(list(set(QA_TESTS + HWE_TESTS)))
 SLEEP_TIME_RE = re.compile(r"(Suspend|Resume):\s+([\d\.]+)\s+seconds.")
 
 
-def get_fwts_command(log_file_path: Path, tests: "list[str]") -> str:
+def get_fwts_base_cmd() -> str:
     """Get the correct fwts command template depending on if we are inside a snap
 
     :param log_file_path: where to put the log file
@@ -190,17 +190,10 @@ def get_fwts_command(log_file_path: Path, tests: "list[str]") -> str:
                 + "but {}".format(fwts_json_data_dir)
                 + "doesn't exist"
             )
-        return "fwts -j {} -q --stdout-summary -r {} {}".format(
-            fwts_json_data_dir,
-            str(log_file_path),
-            " ".join(tests),
-        )
+        return "fwts -j {}".format(fwts_json_data_dir)
     else:
         # deb, use the original command
-        return "fwts -q --stdout-summary -r {} {}".format(
-            str(log_file_path),
-            " ".join(tests),
-        )
+        return "fwts"
 
 
 def get_sleep_times(log, start_marker):
@@ -479,7 +472,7 @@ def main(args=None):
         fail_priority = fail_levels[args.fail_level]
 
     if args.fwts_help:
-        Popen("fwts -h", shell=True).communicate()[0]
+        Popen("{} -h".format(get_fwts_base_cmd()), shell=True).communicate()[0]
         return 0
     elif args.list:
         available, unavailable = filter_available_tests(TESTS)
@@ -540,7 +533,9 @@ def main(args=None):
                 f.write(marker)
             results["sleep"] = (
                 Popen(
-                    get_fwts_command(Path(args.log), tests),
+                    "{} -q --stdout-summary -r {} {}".format(
+                        get_fwts_base_cmd(), args.log, " ".join(tests)
+                    ),
                     stdout=PIPE,
                     shell=True,
                 )
@@ -601,13 +596,14 @@ def main(args=None):
         if tests:
             for test in tests:
                 # ACPI tests can now be run with --acpitests (fwts >= 15.07.00)
-                log = args.log
                 # Split the log file for HWE (only if -t is not used)
                 if test == "acpitests":
                     test = "--acpitests"
                 results[test] = (
                     Popen(
-                        get_fwts_command(log, [test]),
+                        "{} -q --stdout-summary -r {} {}".format(
+                            get_fwts_base_cmd(), args.log, test
+                        ),
                         stdout=PIPE,
                         shell=True,
                     )

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -169,7 +169,15 @@ TESTS = sorted(list(set(QA_TESTS + HWE_TESTS)))
 SLEEP_TIME_RE = re.compile(r"(Suspend|Resume):\s+([\d\.]+)\s+seconds.")
 
 
-def get_sleep_test_command(log_file_path: Path, tests: "list[str]") -> str:
+def get_fwts_command(log_file_path: Path, tests: "list[str]") -> str:
+    """Get the correct fwts command template depending on if we are inside a snap
+
+    :param log_file_path: where to put the log file
+    :param tests: list of fwts tests like 's3' 'klog'
+    :raises SystemExit: If we are in snap, but the json files needed by
+                        fwts's parser doesn't exist
+    :return: command string
+    """
     if "CHECKBOX_RUNTIME" in os.environ and "SNAP" in os.environ:
         # snap checkbox
         # must specify where the klog.json, clog.json files are
@@ -532,7 +540,7 @@ def main(args=None):
                 f.write(marker)
             results["sleep"] = (
                 Popen(
-                    get_sleep_test_command(Path(args.log), tests),
+                    get_fwts_command(Path(args.log), tests),
                     stdout=PIPE,
                     shell=True,
                 )
@@ -599,7 +607,7 @@ def main(args=None):
                     test = "--acpitests"
                 results[test] = (
                     Popen(
-                        get_sleep_test_command(log, [test]),
+                        get_fwts_command(log, [test]),
                         stdout=PIPE,
                         shell=True,
                     )

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -1,13 +1,12 @@
 #! /usr/bin/python3
 
-from pathlib import Path
 import sys
 import re
 from argparse import ArgumentParser, RawTextHelpFormatter, REMAINDER
 from subprocess import Popen, PIPE, DEVNULL
 from shutil import which
 import os
-import typing as T
+from pathlib import Path
 
 # These tests require user interaction and need either special handling
 # or skipping altogether (right now, we skip them but they're kept here
@@ -170,26 +169,6 @@ TESTS = sorted(list(set(QA_TESTS + HWE_TESTS)))
 SLEEP_TIME_RE = re.compile(r"(Suspend|Resume):\s+([\d\.]+)\s+seconds.")
 
 
-def get_sleep_times(log: "str | Path", start_marker: str):
-    suspend_time = ""
-    resume_time = ""
-    with open(log, "r", encoding="UTF-8", errors="ignore") as f:
-        while start_marker not in f.readline():
-            continue
-        loglist = f.readlines()  # read the remaining lines
-        for i, line in enumerate(loglist):
-            if "Suspend/Resume Timings:" in line:
-                suspend_line = loglist[i + 1]
-                resume_line = loglist[i + 2]
-                match = SLEEP_TIME_RE.search(suspend_line)
-                if match:
-                    suspend_time = float(match.group(2))
-                match = SLEEP_TIME_RE.search(resume_line)
-                if match:
-                    resume_time = float(match.group(2))
-    return (suspend_time, resume_time)
-
-
 def get_sleep_test_command(log_file_path: Path, tests: "list[str]") -> str:
     if "CHECKBOX_RUNTIME" in os.environ and "SNAP" in os.environ:
         # snap checkbox
@@ -216,7 +195,29 @@ def get_sleep_test_command(log_file_path: Path, tests: "list[str]") -> str:
         )
 
 
-def average_times(runs: "dict[T.Any, T.Any]"):
+def get_sleep_times(log, start_marker):
+    suspend_time = ""
+    resume_time = ""
+    with open(log, "r", encoding="UTF-8", errors="ignore") as f:
+        line = ""
+        while start_marker not in line:
+            line = f.readline()
+            if start_marker in line:
+                loglist = f.readlines()
+        for i, l in enumerate(loglist):
+            if "Suspend/Resume Timings:" in l:
+                suspend_line = loglist[i + 1]
+                resume_line = loglist[i + 2]
+                match = SLEEP_TIME_RE.search(suspend_line)
+                if match:
+                    suspend_time = float(match.group(2))
+                match = SLEEP_TIME_RE.search(resume_line)
+                if match:
+                    resume_time = float(match.group(2))
+    return (suspend_time, resume_time)
+
+
+def average_times(runs):
     sleep_run_count = 0
     sleep_total = 0.0
     resume_run_count = 0
@@ -258,8 +259,8 @@ def average_times(runs: "dict[T.Any, T.Any]"):
     print()
 
 
-def fix_sleep_args(args: "list[str]"):
-    new_args = []  # type: list[str]
+def fix_sleep_args(args):
+    new_args = []
     for arg in args:
         if "=" in arg:
             new_args.extend(arg.split("="))
@@ -268,7 +269,7 @@ def fix_sleep_args(args: "list[str]"):
     return new_args
 
 
-def detect_progress_indicator() -> "list[str]":
+def detect_progress_indicator():
     # Return a command suitable for piping progress information to its
     # stdin (invoked via Popen), in list format.
     # Return zenity if installed and DISPLAY (--auto-close)
@@ -282,7 +283,7 @@ def detect_progress_indicator() -> "list[str]":
     return []
 
 
-def print_log(logfile: "str | Path"):
+def print_log(logfile):
     """
     Print logfile to the output
     """
@@ -290,7 +291,7 @@ def print_log(logfile: "str | Path"):
         try:
             print(f.read())
         except UnicodeDecodeError as e:
-            print("WARNING: Found bad char in", logfile)
+            print("WARNING: Found bad char in " + logfile)
 
 
 def filter_available_tests(requested_tests):
@@ -440,10 +441,9 @@ def main(args=None):
         args = sys.argv[1:]
     args = parse_arguments(args)
 
-    tests = []  # type: list[str]
-    requested_tests = []  # type: list[str]
+    tests = []
+    requested_tests = []
     results = {}
-    # these are all list[str]
     critical_fails = []
     high_fails = []
     medium_fails = []
@@ -455,20 +455,19 @@ def main(args=None):
     warnings = []
 
     # Set correct fail level
-    iterations = None  # type: int | None
-    fail_priority = -99999  # report everything by default
-    # Get our failure priority and create the priority values
-    fail_levels = {
-        "FAILED_SUPERCRITICAL": 5,
-        "FAILED_CRITICAL": 4,
-        "FAILED_HIGH": 3,
-        "FAILED_MEDIUM": 2,
-        "FAILED_LOW": 1,
-        "FAILED_NONE": 0,
-        "FAILED_ABORTED": -1,
-    }
     if args.fail_level != "none":
         args.fail_level = "FAILED_%s" % args.fail_level.upper()
+
+        # Get our failure priority and create the priority values
+        fail_levels = {
+            "FAILED_SUPERCRITICAL": 5,
+            "FAILED_CRITICAL": 4,
+            "FAILED_HIGH": 3,
+            "FAILED_MEDIUM": 2,
+            "FAILED_LOW": 1,
+            "FAILED_NONE": 0,
+            "FAILED_ABORTED": -1,
+        }
         fail_priority = fail_levels[args.fail_level]
 
     if args.fwts_help:
@@ -519,11 +518,8 @@ def main(args=None):
 
         # run the tests we want
     if args.sleep:
-        assert iterations is not None
         tests = requested_tests
-        iteration_results = (
-            {}
-        )  # type: dict[int, tuple[float | str, float | str]]
+        iteration_results = {}
         print("=" * 20 + " Test Results " + "=" * 20)
         progress_indicator = None
         if detect_progress_indicator():
@@ -532,7 +528,8 @@ def main(args=None):
             )
         for iteration in range(1, iterations + 1):
             marker = "{:=^80}\n".format(" Iteration {} ".format(iteration))
-
+            with open(args.log, "a") as f:
+                f.write(marker)
             results["sleep"] = (
                 Popen(
                     get_sleep_test_command(Path(args.log), tests),
@@ -542,17 +539,13 @@ def main(args=None):
                 .communicate()[0]
                 .strip()
             ).decode()
-
             if "s4" not in args.sleep:
                 suspend_time, resume_time = get_sleep_times(args.log, marker)
                 iteration_results[iteration] = (suspend_time, resume_time)
                 if not suspend_time or not resume_time:
                     progress_string = (
                         "Cycle %s/%s - Suspend: N/A s - Resume: N/A s"
-                        % (
-                            iteration,
-                            iterations,
-                        )
+                        % (iteration, iterations)
                     )
                 else:
                     progress_string = (
@@ -561,7 +554,6 @@ def main(args=None):
                     )
                 progress_pct = "{}".format(int(100 * iteration / iterations))
                 if "zenity" in detect_progress_indicator():
-                    assert progress_indicator and progress_indicator.stdin
                     progress_indicator.stdin.write(
                         "# {}\n".format(progress_string).encode("utf-8")
                     )
@@ -573,7 +565,6 @@ def main(args=None):
                         # flushing its stdin would yield broken pipe
                         progress_indicator.stdin.flush()
                 elif "dialog" in detect_progress_indicator():
-                    assert progress_indicator and progress_indicator.stdin
                     progress_indicator.stdin.write("XXX\n".encode("utf-8"))
                     progress_indicator.stdin.write(
                         progress_pct.encode("utf-8")
@@ -589,7 +580,7 @@ def main(args=None):
                         progress_indicator.stdin.flush()
                 else:
                     print(progress_string, flush=True)
-        if progress_indicator:
+        if detect_progress_indicator():
             progress_indicator.terminate()
         if "s4" not in args.sleep:
             average_times(iteration_results)

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -211,6 +211,7 @@ def get_sleep_times(log, start_marker):
             line = f.readline()
             if start_marker in line:
                 loglist = f.readlines()
+                break
         for i, l in enumerate(loglist):
             if "Suspend/Resume Timings:" in l:
                 suspend_line = loglist[i + 1]

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -206,6 +206,7 @@ def get_sleep_times(log, start_marker):
     resume_time = ""
     with open(log, "r", encoding="UTF-8", errors="ignore") as f:
         line = ""
+        loglist = []  # type: list[str]
         while start_marker not in line:
             line = f.readline()
             if start_marker in line:
@@ -457,24 +458,24 @@ def main(args=None):
     passed = []
     aborted = []
     skipped = []
-    unavailable = []
+    unavailable = []  # type: list[str]
     warnings = []
 
     # Set correct fail level
     iterations = None  # type: int | None
+    fail_priority = -99999  # report everything by default
+    # Get our failure priority and create the priority values
+    fail_levels = {
+        "FAILED_SUPERCRITICAL": 5,
+        "FAILED_CRITICAL": 4,
+        "FAILED_HIGH": 3,
+        "FAILED_MEDIUM": 2,
+        "FAILED_LOW": 1,
+        "FAILED_NONE": 0,
+        "FAILED_ABORTED": -1,
+    }
     if args.fail_level != "none":
         args.fail_level = "FAILED_%s" % args.fail_level.upper()
-
-        # Get our failure priority and create the priority values
-        fail_levels = {
-            "FAILED_SUPERCRITICAL": 5,
-            "FAILED_CRITICAL": 4,
-            "FAILED_HIGH": 3,
-            "FAILED_MEDIUM": 2,
-            "FAILED_LOW": 1,
-            "FAILED_NONE": 0,
-            "FAILED_ABORTED": -1,
-        }
         fail_priority = fail_levels[args.fail_level]
 
     if args.fwts_help:
@@ -529,9 +530,9 @@ def main(args=None):
         tests = requested_tests
         iteration_results = {}
         print("=" * 20 + " Test Results " + "=" * 20)
-        progress_indicator = None
+        progress_indicator_process = None
         if detect_progress_indicator():
-            progress_indicator = Popen(
+            progress_indicator_process = Popen(
                 detect_progress_indicator(), stdin=PIPE, stderr=DEVNULL
             )
         for iteration in range(1, iterations + 1):
@@ -540,7 +541,8 @@ def main(args=None):
                 f.write(marker)
 
             if "CHECKBOX_RUNTIME" in os.environ and "SNAP" in os.environ:
-                # snap checkbox, must specify where the klog.json file is
+                # snap checkbox
+                # must specify where the klog.json, clog.json files are
                 fwts_json_data_dir = (
                     Path(os.environ["SNAP"])
                     / "checkbox-runtime"
@@ -554,13 +556,12 @@ def main(args=None):
                         + "doesn't exist"
                     )
                 command = "fwts -j {} -q --stdout-summary -r {} {}".format(
-                    # "/checkbox-runtime/share/fwts/klog.json",
                     fwts_json_data_dir,
                     args.log,
                     " ".join(tests),
                 )
             else:
-                # deb
+                # deb, use the original command
                 command = "fwts -q --stdout-summary -r {} {}".format(
                     args.log,
                     " ".join(tests),
@@ -586,36 +587,46 @@ def main(args=None):
                     )
                 progress_pct = "{}".format(int(100 * iteration / iterations))
                 if "zenity" in detect_progress_indicator():
-                    assert progress_indicator and progress_indicator.stdin
-                    progress_indicator.stdin.write(
+                    assert (
+                        progress_indicator_process
+                        and progress_indicator_process.stdin
+                    )
+                    progress_indicator_process.stdin.write(
                         "# {}\n".format(progress_string).encode("utf-8")
                     )
-                    progress_indicator.stdin.write(
+                    progress_indicator_process.stdin.write(
                         "{}\n".format(progress_pct).encode("utf-8")
                     )
-                    if progress_indicator.poll() is None:
+                    if progress_indicator_process.poll() is None:
                         # LP: #1741217 process may have already terminated
                         # flushing its stdin would yield broken pipe
-                        progress_indicator.stdin.flush()
+                        progress_indicator_process.stdin.flush()
                 elif "dialog" in detect_progress_indicator():
-                    assert progress_indicator and progress_indicator.stdin
-                    progress_indicator.stdin.write("XXX\n".encode("utf-8"))
-                    progress_indicator.stdin.write(
+                    assert (
+                        progress_indicator_process
+                        and progress_indicator_process.stdin
+                    )
+                    progress_indicator_process.stdin.write(
+                        "XXX\n".encode("utf-8")
+                    )
+                    progress_indicator_process.stdin.write(
                         progress_pct.encode("utf-8")
                     )
-                    progress_indicator.stdin.write(
+                    progress_indicator_process.stdin.write(
                         "\nTest progress\n".encode("utf-8")
                     )
-                    progress_indicator.stdin.write(
+                    progress_indicator_process.stdin.write(
                         progress_string.encode("utf-8")
                     )
-                    progress_indicator.stdin.write("\nXXX\n".encode("utf-8"))
-                    if progress_indicator.poll() is None:
-                        progress_indicator.stdin.flush()
+                    progress_indicator_process.stdin.write(
+                        "\nXXX\n".encode("utf-8")
+                    )
+                    if progress_indicator_process.poll() is None:
+                        progress_indicator_process.stdin.flush()
                 else:
                     print(progress_string, flush=True)
-        if detect_progress_indicator():
-            progress_indicator.terminate()
+        if progress_indicator_process:
+            progress_indicator_process.terminate()
         if "s4" not in args.sleep:
             average_times(iteration_results)
     else:

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -597,9 +597,8 @@ def main(args=None):
                 # Split the log file for HWE (only if -t is not used)
                 if test == "acpitests":
                     test = "--acpitests"
-                command = "fwts -q --stdout-summary -r %s %s" % (log, test)
                 results[test] = (
-                    Popen(command, stdout=PIPE, shell=True)
+                    Popen(get_sleep_test_command(log, [test]), stdout=PIPE, shell=True)
                     .communicate()[0]
                     .strip()
                 ).decode()

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -499,9 +499,9 @@ def main(args=None):
             {}
         )  # type: dict[int, tuple[float | str, float | str]]
         print("=" * 20 + " Test Results " + "=" * 20)
-        progress_indicator_process = None
+        progress_indicator = None
         if detect_progress_indicator():
-            progress_indicator_process = Popen(
+            progress_indicator = Popen(
                 detect_progress_indicator(), stdin=PIPE, stderr=DEVNULL
             )
         for iteration in range(1, iterations + 1):
@@ -557,45 +557,45 @@ def main(args=None):
                 progress_pct = "{}".format(int(100 * iteration / iterations))
                 if "zenity" in detect_progress_indicator():
                     assert (
-                        progress_indicator_process
-                        and progress_indicator_process.stdin
+                        progress_indicator
+                        and progress_indicator.stdin
                     )
-                    progress_indicator_process.stdin.write(
+                    progress_indicator.stdin.write(
                         "# {}\n".format(progress_string).encode("utf-8")
                     )
-                    progress_indicator_process.stdin.write(
+                    progress_indicator.stdin.write(
                         "{}\n".format(progress_pct).encode("utf-8")
                     )
-                    if progress_indicator_process.poll() is None:
+                    if progress_indicator.poll() is None:
                         # LP: #1741217 process may have already terminated
                         # flushing its stdin would yield broken pipe
-                        progress_indicator_process.stdin.flush()
+                        progress_indicator.stdin.flush()
                 elif "dialog" in detect_progress_indicator():
                     assert (
-                        progress_indicator_process
-                        and progress_indicator_process.stdin
+                        progress_indicator
+                        and progress_indicator.stdin
                     )
-                    progress_indicator_process.stdin.write(
+                    progress_indicator.stdin.write(
                         "XXX\n".encode("utf-8")
                     )
-                    progress_indicator_process.stdin.write(
+                    progress_indicator.stdin.write(
                         progress_pct.encode("utf-8")
                     )
-                    progress_indicator_process.stdin.write(
+                    progress_indicator.stdin.write(
                         "\nTest progress\n".encode("utf-8")
                     )
-                    progress_indicator_process.stdin.write(
+                    progress_indicator.stdin.write(
                         progress_string.encode("utf-8")
                     )
-                    progress_indicator_process.stdin.write(
+                    progress_indicator.stdin.write(
                         "\nXXX\n".encode("utf-8")
                     )
-                    if progress_indicator_process.poll() is None:
-                        progress_indicator_process.stdin.flush()
+                    if progress_indicator.poll() is None:
+                        progress_indicator.stdin.flush()
                 else:
                     print(progress_string, flush=True)
-        if progress_indicator_process:
-            progress_indicator_process.terminate()
+        if progress_indicator:
+            progress_indicator.terminate()
         if "s4" not in args.sleep:
             average_times(iteration_results)
     else:

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -556,10 +556,7 @@ def main(args=None):
                     )
                 progress_pct = "{}".format(int(100 * iteration / iterations))
                 if "zenity" in detect_progress_indicator():
-                    assert (
-                        progress_indicator
-                        and progress_indicator.stdin
-                    )
+                    assert progress_indicator and progress_indicator.stdin
                     progress_indicator.stdin.write(
                         "# {}\n".format(progress_string).encode("utf-8")
                     )
@@ -571,13 +568,8 @@ def main(args=None):
                         # flushing its stdin would yield broken pipe
                         progress_indicator.stdin.flush()
                 elif "dialog" in detect_progress_indicator():
-                    assert (
-                        progress_indicator
-                        and progress_indicator.stdin
-                    )
-                    progress_indicator.stdin.write(
-                        "XXX\n".encode("utf-8")
-                    )
+                    assert progress_indicator and progress_indicator.stdin
+                    progress_indicator.stdin.write("XXX\n".encode("utf-8"))
                     progress_indicator.stdin.write(
                         progress_pct.encode("utf-8")
                     )
@@ -587,9 +579,7 @@ def main(args=None):
                     progress_indicator.stdin.write(
                         progress_string.encode("utf-8")
                     )
-                    progress_indicator.stdin.write(
-                        "\nXXX\n".encode("utf-8")
-                    )
+                    progress_indicator.stdin.write("\nXXX\n".encode("utf-8"))
                     if progress_indicator.poll() is None:
                         progress_indicator.stdin.flush()
                 else:

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -275,7 +275,7 @@ def fix_sleep_args(args):
     return new_args
 
 
-def detect_progress_indicator() -> 'list[str]':
+def detect_progress_indicator() -> "list[str]":
     # Return a command suitable for piping progress information to its
     # stdin (invoked via Popen), in list format.
     # Return zenity if installed and DISPLAY (--auto-close)
@@ -541,22 +541,21 @@ def main(args=None):
 
             if "CHECKBOX_RUNTIME" in os.environ and "SNAP" in os.environ:
                 # snap checkbox, must specify where the klog.json file is
-                klog_json_path = (
+                fwts_json_data_dir = (
                     Path(os.environ["SNAP"])
                     / "checkbox-runtime"
                     / "share"
                     / "fwts"
-                    / "klog.json"
                 )
-                if not klog_json_path.exists():
+                if not fwts_json_data_dir.exists():
                     raise SystemExit(
                         "We are in a snap environment, "
-                        + "but {}".format(klog_json_path)
+                        + "but {}".format(fwts_json_data_dir)
                         + "doesn't exist"
                     )
-                command = "fwts -J {} -q --stdout-summary -r {} {}".format(
+                command = "fwts -j {} -q --stdout-summary -r {} {}".format(
                     # "/checkbox-runtime/share/fwts/klog.json",
-                    klog_json_path,
+                    fwts_json_data_dir,
                     args.log,
                     " ".join(tests),
                 )

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -176,7 +176,7 @@ def get_sleep_times(log: "str | Path", start_marker: str):
     with open(log, "r", encoding="UTF-8", errors="ignore") as f:
         while start_marker not in f.readline():
             continue
-        loglist = f.readlines() # read the remaining lines
+        loglist = f.readlines()  # read the remaining lines
         for i, line in enumerate(loglist):
             if "Suspend/Resume Timings:" in line:
                 suspend_line = loglist[i + 1]
@@ -417,6 +417,7 @@ def main(args=None):
     tests = []  # type: list[str]
     requested_tests = []  # type: list[str]
     results = {}
+    # these are all list[str]
     critical_fails = []
     high_fails = []
     medium_fails = []
@@ -424,7 +425,7 @@ def main(args=None):
     passed = []
     aborted = []
     skipped = []
-    unavailable = []  # type: list[str]
+    unavailable = []
     warnings = []
 
     # Set correct fail level
@@ -494,7 +495,9 @@ def main(args=None):
     if args.sleep:
         assert iterations is not None
         tests = requested_tests
-        iteration_results = {}
+        iteration_results = (
+            {}
+        )  #  # type: dict[int, tuple[float | str, float|str]]
         print("=" * 20 + " Test Results " + "=" * 20)
         progress_indicator_process = None
         if detect_progress_indicator():

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -190,6 +190,32 @@ def get_sleep_times(log: "str | Path", start_marker: str):
     return (suspend_time, resume_time)
 
 
+def get_sleep_test_command(log_file_path: Path, tests: "list[str]") -> str:
+    if "CHECKBOX_RUNTIME" in os.environ and "SNAP" in os.environ:
+        # snap checkbox
+        # must specify where the klog.json, clog.json files are
+        fwts_json_data_dir = (
+            Path(os.environ["SNAP"]) / "checkbox-runtime" / "share" / "fwts"
+        )
+        if not fwts_json_data_dir.exists():
+            raise SystemExit(
+                "We are in a snap environment, "
+                + "but {}".format(fwts_json_data_dir)
+                + "doesn't exist"
+            )
+        return "fwts -j {} -q --stdout-summary -r {} {}".format(
+            fwts_json_data_dir,
+            str(log_file_path),
+            " ".join(tests),
+        )
+    else:
+        # deb, use the original command
+        return "fwts -q --stdout-summary -r {} {}".format(
+            str(log_file_path),
+            " ".join(tests),
+        )
+
+
 def average_times(runs: "dict[T.Any, T.Any]"):
     sleep_run_count = 0
     sleep_total = 0.0
@@ -506,48 +532,27 @@ def main(args=None):
             )
         for iteration in range(1, iterations + 1):
             marker = "{:=^80}\n".format(" Iteration {} ".format(iteration))
-            with open(args.log, "a") as f:
-                f.write(marker)
-
-            if "CHECKBOX_RUNTIME" in os.environ and "SNAP" in os.environ:
-                # snap checkbox
-                # must specify where the klog.json, clog.json files are
-                fwts_json_data_dir = (
-                    Path(os.environ["SNAP"])
-                    / "checkbox-runtime"
-                    / "share"
-                    / "fwts"
-                )
-                if not fwts_json_data_dir.exists():
-                    raise SystemExit(
-                        "We are in a snap environment, "
-                        + "but {}".format(fwts_json_data_dir)
-                        + "doesn't exist"
-                    )
-                command = "fwts -j {} -q --stdout-summary -r {} {}".format(
-                    fwts_json_data_dir,
-                    args.log,
-                    " ".join(tests),
-                )
-            else:
-                # deb, use the original command
-                command = "fwts -q --stdout-summary -r {} {}".format(
-                    args.log,
-                    " ".join(tests),
-                )
 
             results["sleep"] = (
-                Popen(command, stdout=PIPE, shell=True)
+                Popen(
+                    get_sleep_test_command(Path(args.log), tests),
+                    stdout=PIPE,
+                    shell=True,
+                )
                 .communicate()[0]
                 .strip()
             ).decode()
+
             if "s4" not in args.sleep:
                 suspend_time, resume_time = get_sleep_times(args.log, marker)
                 iteration_results[iteration] = (suspend_time, resume_time)
                 if not suspend_time or not resume_time:
                     progress_string = (
                         "Cycle %s/%s - Suspend: N/A s - Resume: N/A s"
-                        % (iteration, iterations)
+                        % (
+                            iteration,
+                            iterations,
+                        )
                     )
                 else:
                     progress_string = (

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -7,6 +7,7 @@ from argparse import ArgumentParser, RawTextHelpFormatter, REMAINDER
 from subprocess import Popen, PIPE, DEVNULL
 from shutil import which
 import os
+import typing as T
 
 # These tests require user interaction and need either special handling
 # or skipping altogether (right now, we skip them but they're kept here
@@ -169,39 +170,7 @@ TESTS = sorted(list(set(QA_TESTS + HWE_TESTS)))
 SLEEP_TIME_RE = re.compile(r"(Suspend|Resume):\s+([\d\.]+)\s+seconds.")
 
 
-def get_available_fwts_tests():
-    """
-    Get a list of all available FWTS tests by running 'fwts --show-tests'.
-
-    Returns:
-        list: A list of available test names that can be run with FWTS.
-    """
-    cmd = "fwts --show-tests"
-    result = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)
-    stdout, stderr = result.communicate()
-
-    if result.returncode != 0:
-        raise RuntimeError(
-            "FWTS failed at listing available tests with: {}".format(
-                stderr.decode()
-            )
-        )
-
-    # Parse the output to extract test names
-    output_lines = stdout.decode().strip().split("\n")
-    available_tests = set()
-
-    for line in output_lines:
-        # Skip empty lines and section headers (lines ending with ':')
-        if line.strip() and not line.endswith(":"):
-            # Extract the first word as the test name
-            test_name = line.lstrip().split()[0]
-            available_tests.add(test_name)
-
-    return available_tests
-
-
-def get_sleep_times(log, start_marker):
+def get_sleep_times(log: "str | Path", start_marker: str):
     suspend_time = ""
     resume_time = ""
     with open(log, "r", encoding="UTF-8", errors="ignore") as f:
@@ -225,7 +194,7 @@ def get_sleep_times(log, start_marker):
     return (suspend_time, resume_time)
 
 
-def average_times(runs):
+def average_times(runs: "dict[T.Any, T.Any]"):
     sleep_run_count = 0
     sleep_total = 0.0
     resume_run_count = 0
@@ -267,8 +236,8 @@ def average_times(runs):
     print()
 
 
-def fix_sleep_args(args):
-    new_args = []
+def fix_sleep_args(args: "list[str]"):
+    new_args = []  # type: list[str]
     for arg in args:
         if "=" in arg:
             new_args.extend(arg.split("="))
@@ -291,7 +260,7 @@ def detect_progress_indicator() -> "list[str]":
     return []
 
 
-def print_log(logfile):
+def print_log(logfile: "str | Path"):
     """
     Print logfile to the output
     """
@@ -299,7 +268,7 @@ def print_log(logfile):
         try:
             print(f.read())
         except UnicodeDecodeError as e:
-            print("WARNING: Found bad char in " + logfile)
+            print("WARNING: Found bad char in", logfile)
 
 
 def filter_available_tests(requested_tests):

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python3
 
+from pathlib import Path
 import sys
 import re
 from argparse import ArgumentParser, RawTextHelpFormatter, REMAINDER
@@ -274,7 +275,7 @@ def fix_sleep_args(args):
     return new_args
 
 
-def detect_progress_indicator():
+def detect_progress_indicator() -> 'list[str]':
     # Return a command suitable for piping progress information to its
     # stdin (invoked via Popen), in list format.
     # Return zenity if installed and DISPLAY (--auto-close)
@@ -446,8 +447,8 @@ def main(args=None):
         args = sys.argv[1:]
     args = parse_arguments(args)
 
-    tests = []
-    requested_tests = []
+    tests = []  # type: list[str]
+    requested_tests = []  # type: list[str]
     results = {}
     critical_fails = []
     high_fails = []
@@ -460,6 +461,7 @@ def main(args=None):
     warnings = []
 
     # Set correct fail level
+    iterations = None  # type: int | None
     if args.fail_level != "none":
         args.fail_level = "FAILED_%s" % args.fail_level.upper()
 
@@ -523,6 +525,7 @@ def main(args=None):
 
         # run the tests we want
     if args.sleep:
+        assert iterations is not None
         tests = requested_tests
         iteration_results = {}
         print("=" * 20 + " Test Results " + "=" * 20)
@@ -535,10 +538,35 @@ def main(args=None):
             marker = "{:=^80}\n".format(" Iteration {} ".format(iteration))
             with open(args.log, "a") as f:
                 f.write(marker)
-            command = "fwts -q --stdout-summary -r %s %s" % (
-                args.log,
-                " ".join(tests),
-            )
+
+            if "CHECKBOX_RUNTIME" in os.environ and "SNAP" in os.environ:
+                # snap checkbox, must specify where the klog.json file is
+                klog_json_path = (
+                    Path(os.environ["SNAP"])
+                    / "checkbox-runtime"
+                    / "share"
+                    / "fwts"
+                    / "klog.json"
+                )
+                if not klog_json_path.exists():
+                    raise SystemExit(
+                        "We are in a snap environment, "
+                        + "but {}".format(klog_json_path)
+                        + "doesn't exist"
+                    )
+                command = "fwts -J {} -q --stdout-summary -r {} {}".format(
+                    # "/checkbox-runtime/share/fwts/klog.json",
+                    klog_json_path,
+                    args.log,
+                    " ".join(tests),
+                )
+            else:
+                # deb
+                command = "fwts -q --stdout-summary -r {} {}".format(
+                    args.log,
+                    " ".join(tests),
+                )
+
             results["sleep"] = (
                 Popen(command, stdout=PIPE, shell=True)
                 .communicate()[0]
@@ -559,6 +587,7 @@ def main(args=None):
                     )
                 progress_pct = "{}".format(int(100 * iteration / iterations))
                 if "zenity" in detect_progress_indicator():
+                    assert progress_indicator and progress_indicator.stdin
                     progress_indicator.stdin.write(
                         "# {}\n".format(progress_string).encode("utf-8")
                     )
@@ -570,6 +599,7 @@ def main(args=None):
                         # flushing its stdin would yield broken pipe
                         progress_indicator.stdin.flush()
                 elif "dialog" in detect_progress_indicator():
+                    assert progress_indicator and progress_indicator.stdin
                     progress_indicator.stdin.write("XXX\n".encode("utf-8"))
                     progress_indicator.stdin.write(
                         progress_pct.encode("utf-8")

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -7,7 +7,6 @@ from subprocess import Popen, PIPE, DEVNULL
 from shutil import which
 import os
 from pathlib import Path
-from checkbox_support.snap_utils.system import in_classic_snap
 
 # These tests require user interaction and need either special handling
 # or skipping altogether (right now, we skip them but they're kept here
@@ -180,21 +179,9 @@ def get_fwts_base_cmd() -> str:
     if "CHECKBOX_RUNTIME" in os.environ and "SNAP" in os.environ:
         # snap checkbox
         # must specify where the klog.json, clog.json files are
-        if in_classic_snap():
-            # workaround for issue 2295
-            # https://github.com/canonical/checkbox/issues/2295
-            # TODO: remove this logic and read CHECKBOX_RUNTIME directly
-            # after 2295 is fixed
-            fwts_json_data_dir = (
-                Path(os.environ["CHECKBOX_RUNTIME"]) / "share" / "fwts"
-            )
-        else:
-            fwts_json_data_dir = (
-                Path(os.environ["SNAP"])
-                / "checkbox-runtime"
-                / "share"
-                / "fwts"
-            )
+        fwts_json_data_dir = (
+            Path(os.environ["CHECKBOX_RUNTIME"]) / "share" / "fwts"
+        )
         if not fwts_json_data_dir.exists():
             raise SystemExit(
                 "We are in a snap environment, "

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -66,7 +66,7 @@ class TestGetSleepTestCommand(unittest.TestCase):
         self.assertEqual(result, expected)
 
     @patch.dict(
-        "os.environ",
+        os.environ,
         {
             "CHECKBOX_RUNTIME": "\n".join(
                 [

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -18,7 +18,6 @@
 
 import unittest
 from unittest.mock import patch, MagicMock
-from subprocess import PIPE
 
 from tempfile import NamedTemporaryFile
 import os
@@ -58,9 +57,7 @@ class LogPrinterTest(unittest.TestCase):
 class TestGetFwtsBaseCommand(unittest.TestCase):
 
     @patch.dict(os.environ, {}, clear=True)
-    @patch("checkbox_support.scripts.fwts_test.in_classic_snap")
-    def test_deb_environment(self, mock_in_classic_snap: MagicMock):
-        mock_in_classic_snap.return_value = False
+    def test_deb_environment(self):
         result = get_fwts_base_cmd()
         expected = "fwts"
         self.assertEqual(result, expected)
@@ -68,24 +65,14 @@ class TestGetFwtsBaseCommand(unittest.TestCase):
     @patch.dict(
         os.environ,
         {
-            "CHECKBOX_RUNTIME": "\n".join(
-                [
-                    "/snap/checkbox24/1437",
-                    "/snap/checkbox/20486/checkbox-runtime",
-                    "/snap/checkbox/20486/providers/blah-blah",
-                ]
-            ),
+            "CHECKBOX_RUNTIME": "/snap/checkbox/20486/checkbox-runtime",
             "SNAP": "/snap/checkbox/20486",
         },
         clear=True,
     )
-    @patch("checkbox_support.scripts.fwts_test.in_classic_snap")
     @patch("checkbox_support.scripts.fwts_test.Path.exists")
-    def test_snap_env_happy_path(
-        self, mock_exists: MagicMock, mock_in_classic_snap: MagicMock
-    ):
+    def test_snap_env_happy_path(self, mock_exists: MagicMock):
         mock_exists.return_value = True
-        mock_in_classic_snap.return_value = False
 
         result = get_fwts_base_cmd()
 
@@ -100,13 +87,9 @@ class TestGetFwtsBaseCommand(unittest.TestCase):
             "SNAP": "/snap/checkbox-20735/",
         },
     )
-    @patch("checkbox_support.scripts.fwts_test.in_classic_snap")
     @patch("checkbox_support.scripts.fwts_test.Path.exists")
-    def test_snap_env_missing_dir(
-        self, mock_exists: MagicMock, mock_in_classic_snap: MagicMock
-    ):
+    def test_snap_env_missing_dir(self, mock_exists: MagicMock):
         mock_exists.return_value = False
-        mock_in_classic_snap.return_value = True
 
         with self.assertRaises(SystemExit) as cm:
             get_fwts_base_cmd()

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -28,7 +28,7 @@ from checkbox_support.scripts.fwts_test import (
     print_log,
     get_sleep_test_command,
 )
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from pathlib import Path
 
 
@@ -37,7 +37,7 @@ class LogPrinterTest(unittest.TestCase):
         self.logfile = NamedTemporaryFile(delete=False)
 
     @patch("sys.stdout", new_callable=StringIO)
-    def test_logfile_with_encoding_error(self, mock_stdout):
+    def test_logfile_with_encoding_error(self, mock_stdout: MagicMock):
         with open(self.logfile.name, "wb") as f:
             f.write(b"Cannot read PCI config for device 0000:00:\xa1")
             f.write(b"<85>)PNP0B00:00\n")
@@ -76,14 +76,14 @@ class TestGetSleepTestCommand(unittest.TestCase):
         },
     )
     @patch("checkbox_support.scripts.fwts_test.Path.exists")
-    def test_snap_environment_success(self, mock_exists):
+    def test_snap_environment_success(self, mock_exists: MagicMock):
         """Test the snap behavior when the FWTS data directory exists."""
         mock_exists.return_value = True
 
         result = get_sleep_test_command(self.log_path, self.tests)
 
         expected_dir = "/snap/test-snap/checkbox-runtime/share/fwts"
-        expected_cmd = f"fwts -j {expected_dir} -q --stdout-summary -r /tmp/results.log s3 s4"
+        expected_cmd = "fwts -j {} -q --stdout-summary -r /tmp/results.log s3 s4".format(expected_dir)
         self.assertEqual(result, expected_cmd)
 
     @patch.dict(
@@ -94,7 +94,7 @@ class TestGetSleepTestCommand(unittest.TestCase):
         },
     )
     @patch("checkbox_support.scripts.fwts_test.Path.exists")
-    def test_snap_environment_missing_dir(self, mock_exists):
+    def test_snap_environment_missing_dir(self, mock_exists: MagicMock):
         """Test that SystemExit is raised if the FWTS directory is missing."""
         mock_exists.return_value = False
 

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -57,15 +57,12 @@ class LogPrinterTest(unittest.TestCase):
 
 
 class TestGetSleepTestCommand(unittest.TestCase):
-    def setUp(self):
-        self.log_path = Path("/tmp/results.log")
-        self.tests = ["s3", "s4"]
 
     @patch.dict(os.environ, {}, clear=True)
     def test_deb_environment(self):
 
-        result = get_fwts_base_cmd(self.log_path, self.tests)
-        expected = "fwts -q --stdout-summary -r /tmp/results.log s3 s4"
+        result = get_fwts_base_cmd()
+        expected = "fwts"
         self.assertEqual(result, expected)
 
     @patch.dict(
@@ -79,11 +76,11 @@ class TestGetSleepTestCommand(unittest.TestCase):
     def test_snap_env_happy_path(self, mock_exists: MagicMock):
         mock_exists.return_value = True
 
-        result = get_fwts_base_cmd(self.log_path, self.tests)
+        result = get_fwts_base_cmd()
 
         expected_dir = "/snap/test-snap/checkbox-runtime/share/fwts"
         expected_cmd = (
-            "fwts -j {} -q --stdout-summary -r /tmp/results.log s3 s4".format(
+            "fwts -j {}".format(
                 expected_dir
             )
         )
@@ -101,7 +98,7 @@ class TestGetSleepTestCommand(unittest.TestCase):
         mock_exists.return_value = False
 
         with self.assertRaises(SystemExit) as cm:
-            get_fwts_base_cmd(self.log_path, self.tests)
+            get_fwts_base_cmd()
 
         self.assertIn("doesn't exist", str(cm.exception))
 

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -83,7 +83,11 @@ class TestGetSleepTestCommand(unittest.TestCase):
         result = get_sleep_test_command(self.log_path, self.tests)
 
         expected_dir = "/snap/test-snap/checkbox-runtime/share/fwts"
-        expected_cmd = "fwts -j {} -q --stdout-summary -r /tmp/results.log s3 s4".format(expected_dir)
+        expected_cmd = (
+            "fwts -j {} -q --stdout-summary -r /tmp/results.log s3 s4".format(
+                expected_dir
+            )
+        )
         self.assertEqual(result, expected_cmd)
 
     @patch.dict(

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -26,10 +26,10 @@ from io import StringIO
 
 from checkbox_support.scripts.fwts_test import (
     print_log,
-    main,
-    filter_available_tests,
-    get_available_fwts_tests,
+    get_sleep_test_command,
 )
+from unittest.mock import patch
+from pathlib import Path
 
 
 class LogPrinterTest(unittest.TestCase):
@@ -56,536 +56,49 @@ class LogPrinterTest(unittest.TestCase):
             pass
 
 
-class FilterAvailableTestsTest(unittest.TestCase):
-    """Test the filter_available_tests helper function."""
-
-    @patch("checkbox_support.scripts.fwts_test.get_available_fwts_tests")
-    def test_filter_available_tests_all_available(self, mock_get_available):
-        """Test when all requested tests are available."""
-        mock_get_available.return_value = {"acpitests", "version", "mtrr"}
-        requested = ["acpitests", "version"]
-
-        available, unavailable = filter_available_tests(requested)
-
-        self.assertEqual(available, ["acpitests", "version"])
-        self.assertEqual(unavailable, [])
-
-    @patch("checkbox_support.scripts.fwts_test.get_available_fwts_tests")
-    def test_filter_available_tests_some_unavailable(self, mock_get_available):
-        """Test when some requested tests are unavailable."""
-        mock_get_available.return_value = {"acpitests", "version"}
-        requested = ["acpitests", "nonexistent_test", "version"]
-
-        available, unavailable = filter_available_tests(requested)
-
-        self.assertEqual(available, ["acpitests", "version"])
-        self.assertEqual(unavailable, ["nonexistent_test"])
-
-    @patch("checkbox_support.scripts.fwts_test.get_available_fwts_tests")
-    def test_filter_available_tests_none_available(self, mock_get_available):
-        """Test when none of the requested tests are available."""
-        mock_get_available.return_value = {"acpitests", "version"}
-        requested = ["nonexistent_test1", "nonexistent_test2"]
-
-        available, unavailable = filter_available_tests(requested)
-
-        self.assertEqual(available, [])
-        self.assertEqual(
-            unavailable, ["nonexistent_test1", "nonexistent_test2"]
-        )
-
-    @patch("checkbox_support.scripts.fwts_test.get_available_fwts_tests")
-    def test_filter_available_tests_empty_requested(self, mock_get_available):
-        """Test with empty requested tests list."""
-        mock_get_available.return_value = {"acpitests", "version"}
-        requested = []
-
-        available, unavailable = filter_available_tests(requested)
-
-        self.assertEqual(available, [])
-        self.assertEqual(unavailable, [])
-
-
-class ListOptionsTest(unittest.TestCase):
-    """Test the updated list options that use filter_available_tests."""
-
-    @patch("sys.stdout", new_callable=StringIO)
-    @patch("checkbox_support.scripts.fwts_test.filter_available_tests")
-    def test_list_option(self, mock_filter, mock_stdout):
-        """Test --list option."""
-        mock_filter.return_value = (["acpitests", "version"], [])
-
-        with patch("sys.argv", ["fwts_test.py", "--list"]):
-            result = main()
-
-        self.assertEqual(result, 0)
-        output = mock_stdout.getvalue()
-        self.assertIn("acpitests", output)
-        self.assertIn("version", output)
-
-    @patch("sys.stdout", new_callable=StringIO)
-    @patch("checkbox_support.scripts.fwts_test.filter_available_tests")
-    def test_list_hwe_option(self, mock_filter, mock_stdout):
-        """Test --list-hwe option."""
-        mock_filter.return_value = (["mtrr", "virt"], ["apicedge"])
-
-        with patch("sys.argv", ["fwts_test.py", "--list-hwe"]):
-            result = main()
-
-        self.assertEqual(result, 0)
-        output = mock_stdout.getvalue()
-        self.assertIn("mtrr", output)
-        self.assertIn("virt", output)
-        self.assertNotIn("apicedge", output)  # Should not show unavailable
-
-    @patch("sys.stdout", new_callable=StringIO)
-    @patch("checkbox_support.scripts.fwts_test.filter_available_tests")
-    def test_list_qa_option(self, mock_filter, mock_stdout):
-        """Test --list-qa option."""
-        mock_filter.return_value = (["acpitests", "version"], ["nonexistent"])
-
-        with patch("sys.argv", ["fwts_test.py", "--list-qa"]):
-            result = main()
-
-        self.assertEqual(result, 0)
-        output = mock_stdout.getvalue()
-        self.assertIn("acpitests", output)
-        self.assertIn("version", output)
-        self.assertNotIn("nonexistent", output)
-
-    @patch("sys.stdout", new_callable=StringIO)
-    @patch("checkbox_support.scripts.fwts_test.filter_available_tests")
-    def test_list_server_option(self, mock_filter, mock_stdout):
-        """Test --list-server option."""
-        mock_filter.return_value = (["acpitests", "version"], ["nonexistent"])
-
-        with patch("sys.argv", ["fwts_test.py", "--list-server"]):
-            result = main()
-
-        self.assertEqual(result, 0)
-        output = mock_stdout.getvalue()
-        self.assertIn("Server Certification Tests:", output)
-        self.assertIn("acpitests", output)
-        self.assertIn("version", output)
-        self.assertNotIn("nonexistent", output)
-
-
-class MainFunctionTest(unittest.TestCase):
+class TestGetSleepTestCommand(unittest.TestCase):
     def setUp(self):
-        self.logfile = NamedTemporaryFile(delete=False)
-        # Write some test content to the log file
-        with open(self.logfile.name, "w") as f:
-            f.write("Test log content\n")
+        self.log_path = Path("/tmp/results.log")
+        self.tests = ["s3", "s4"]
 
-    @patch("sys.argv", ["fwts_test.py", "--log", "test.log"])
-    @patch("sys.stdout", new_callable=StringIO)
-    @patch("checkbox_support.scripts.fwts_test.Popen")
-    def test_print_log_called_when_tests_are_run(
-        self, mock_popen, mock_stdout
-    ):
-        """Test that print_log is called when tests are actually run."""
-        # Mock Popen to return successful test results
-        mock_process = MagicMock()
-        mock_process.communicate.return_value = (
-            b"PASSED: Test completed successfully",
-            None,
-        )
-        mock_process.returncode = 0
-        mock_popen.return_value = mock_process
+    @patch.dict(os.environ, {}, clear=True)
+    def test_deb_environment(self):
+        """Test the default 'deb' behavior when env vars are missing."""
+        result = get_sleep_test_command(self.log_path, self.tests)
+        expected = "fwts -q --stdout-summary -r /tmp/results.log s3 s4"
+        self.assertEqual(result, expected)
 
-        # Mock fwts --show-tests to return some available tests
-        mock_fwts_process = MagicMock()
-        mock_fwts_process.communicate.return_value = (
-            b"acpitests\nversion\n",
-            None,
-        )
-        mock_fwts_process.returncode = 0
+    @patch.dict(
+        os.environ,
+        {
+            "CHECKBOX_RUNTIME": "/snap/test-snap/checkbox-runtime/",
+            "SNAP": "/snap/test-snap",
+        },
+    )
+    @patch("checkbox_support.scripts.fwts_test.Path.exists")
+    def test_snap_environment_success(self, mock_exists):
+        """Test the snap behavior when the FWTS data directory exists."""
+        mock_exists.return_value = True
 
-        # Configure Popen to return different results for different calls
-        mock_popen.side_effect = [mock_fwts_process, mock_process]
+        result = get_sleep_test_command(self.log_path, self.tests)
 
-        # Run main with a test that should be available
-        with patch(
-            "sys.argv",
-            [
-                "fwts_test.py",
-                "--test",
-                "acpitests",
-                "--log",
-                self.logfile.name,
-            ],
-        ):
-            main()
+        expected_dir = "/snap/test-snap/checkbox-runtime/share/fwts"
+        expected_cmd = f"fwts -j {expected_dir} -q --stdout-summary -r /tmp/results.log s3 s4"
+        self.assertEqual(result, expected_cmd)
 
-        # Verify that print_log was called (log content should be in stdout)
-        output = mock_stdout.getvalue()
-        self.assertIn("Test log content", output)
+    @patch.dict(
+        os.environ,
+        {
+            "CHECKBOX_RUNTIME": "/snap/test-snap/checkbox-runtime/",
+            "SNAP": "/snap/test-snap",
+        },
+    )
+    @patch("checkbox_support.scripts.fwts_test.Path.exists")
+    def test_snap_environment_missing_dir(self, mock_exists):
+        """Test that SystemExit is raised if the FWTS directory is missing."""
+        mock_exists.return_value = False
 
-    @patch("sys.argv", ["fwts_test.py", "--log", "test.log"])
-    @patch("sys.stdout", new_callable=StringIO)
-    @patch("checkbox_support.scripts.fwts_test.Popen")
-    def test_print_log_not_called_when_no_tests_run(
-        self, mock_popen, mock_stdout
-    ):
-        """Test that print_log is NOT called when no tests are run."""
-        # Mock fwts --show-tests to return different available tests
-        mock_fwts_process = MagicMock()
-        mock_fwts_process.communicate.return_value = (b"version\n", None)
-        mock_fwts_process.returncode = 0
-        mock_popen.return_value = mock_fwts_process
+        with self.assertRaises(SystemExit) as cm:
+            get_sleep_test_command(self.log_path, self.tests)
 
-        # Run main with a test that should NOT be available
-        with patch(
-            "sys.argv",
-            [
-                "fwts_test.py",
-                "--test",
-                "nonexistent_test",
-                "--log",
-                self.logfile.name,
-            ],
-        ):
-            main()
-
-        # Verify that print_log was NOT called (log content not in stdout)
-        output = mock_stdout.getvalue()
-        self.assertNotIn("Test log content", output)
-        # But we should see the unavailable test message
-        self.assertIn("Unavailable Tests: 1", output)
-
-    @patch("sys.argv", ["fwts_test.py", "--log", "test.log"])
-    @patch("sys.stdout", new_callable=StringIO)
-    @patch("checkbox_support.scripts.fwts_test.Popen")
-    def test_print_log_called_when_mixed_available_unavailable(
-        self, mock_popen, mock_stdout
-    ):
-        """Test print_log with some tests run, some unavailable."""
-        # Mock Popen to return successful test results
-        mock_process = MagicMock()
-        mock_process.communicate.return_value = (
-            b"PASSED: Test completed successfully",
-            None,
-        )
-        mock_process.returncode = 0
-        mock_popen.return_value = mock_process
-
-        # Mock fwts --show-tests to return some available tests
-        mock_fwts_process = MagicMock()
-        mock_fwts_process.communicate.return_value = (
-            b"acpitests\nversion\n",
-            None,
-        )
-        mock_fwts_process.returncode = 0
-
-        # Configure Popen to return different results for different calls
-        mock_popen.side_effect = [mock_fwts_process, mock_process]
-
-        # Run main with mixed available and unavailable tests
-        with patch(
-            "sys.argv",
-            [
-                "fwts_test.py",
-                "--test",
-                "acpitests",
-                "--test",
-                "nonexistent_test",
-                "--log",
-                self.logfile.name,
-            ],
-        ):
-            main()
-
-        # Verify that print_log was called (log content should be in stdout)
-        output = mock_stdout.getvalue()
-        self.assertIn("Test log content", output)
-        # Also verify that unavailable test message appears
-        self.assertIn("Unavailable Tests: 1", output)
-
-    @patch("sys.stdout", new_callable=StringIO)
-    @patch("checkbox_support.scripts.fwts_test.Popen")
-    def test_hwe_option_extends_requested_tests(self, mock_popen, mock_stdout):
-        """Test that --hwe option extends requested_tests with HWE_TESTS."""
-        # Mock fwts --show-tests to return some available tests
-        mock_fwts_process = MagicMock()
-        mock_fwts_process.communicate.return_value = (
-            b"acpitests\nversion\nmtrr\nvirt\napicedge\nklog\noops\n",
-            None,
-        )
-        mock_fwts_process.returncode = 0
-
-        # Mock Popen to return successful test results for each test
-        mock_process = MagicMock()
-        mock_process.communicate.return_value = (
-            b"PASSED: Test completed successfully",
-            None,
-        )
-        mock_process.returncode = 0
-
-        # Configure Popen to return different results for different calls
-        # First call is for fwts --show-tests, then one for each test in HWE_TESTS
-        mock_popen.side_effect = [
-            mock_fwts_process,  # fwts --show-tests
-            mock_process,  # version
-            mock_process,  # mtrr
-            mock_process,  # virt
-            mock_process,  # apicedge
-            mock_process,  # klog
-            mock_process,  # oops
-        ]
-
-        # Run main with --hwe option
-        with patch(
-            "sys.argv",
-            [
-                "fwts_test.py",
-                "--hwe",
-                "--log",
-                self.logfile.name,
-            ],
-        ):
-            main()
-
-        # Verify that print_log was called (log content should be in stdout)
-        output = mock_stdout.getvalue()
-        self.assertIn("Test log content", output)
-
-    @patch("sys.stdout", new_callable=StringIO)
-    @patch("checkbox_support.scripts.fwts_test.Popen")
-    def test_qa_option_extends_requested_tests(self, mock_popen, mock_stdout):
-        """Test that --qa option extends requested_tests with QA_TESTS."""
-        # Mock fwts --show-tests to return all QA_TESTS
-        from checkbox_support.scripts.fwts_test import QA_TESTS
-
-        mock_fwts_process = MagicMock()
-        mock_fwts_process.communicate.return_value = (
-            ("\n".join(QA_TESTS)).encode(),
-            None,
-        )
-        mock_fwts_process.returncode = 0
-
-        # Mock Popen to return successful test results for each test
-        mock_process = MagicMock()
-        mock_process.communicate.return_value = (
-            b"PASSED: Test completed successfully",
-            None,
-        )
-        mock_process.returncode = 0
-
-        # Provide enough mocks: 1 for fwts --show-tests, then one for each QA_TESTS
-        mock_popen.side_effect = [mock_fwts_process] + [mock_process] * len(
-            QA_TESTS
-        )
-
-        with patch(
-            "sys.argv",
-            [
-                "fwts_test.py",
-                "--qa",
-                "--log",
-                self.logfile.name,
-            ],
-        ):
-            main()
-
-        output = mock_stdout.getvalue()
-        self.assertIn("Test log content", output)
-
-    @patch("sys.stdout", new_callable=StringIO)
-    @patch("checkbox_support.scripts.fwts_test.Popen")
-    def test_server_option_extends_requested_tests(
-        self, mock_popen, mock_stdout
-    ):
-        """Test that --server option extends requested_tests with SERVER_TESTS."""
-        from checkbox_support.scripts.fwts_test import SERVER_TESTS
-
-        mock_fwts_process = MagicMock()
-        mock_fwts_process.communicate.return_value = (
-            ("\n".join(SERVER_TESTS)).encode(),
-            None,
-        )
-        mock_fwts_process.returncode = 0
-
-        mock_process = MagicMock()
-        mock_process.communicate.return_value = (
-            b"PASSED: Test completed successfully",
-            None,
-        )
-        mock_process.returncode = 0
-
-        mock_popen.side_effect = [mock_fwts_process] + [mock_process] * len(
-            SERVER_TESTS
-        )
-
-        with patch(
-            "sys.argv",
-            [
-                "fwts_test.py",
-                "--server",
-                "--log",
-                self.logfile.name,
-            ],
-        ):
-            main()
-
-        output = mock_stdout.getvalue()
-        self.assertIn("Test log content", output)
-
-    def tearDown(self):
-        try:
-            os.unlink(self.logfile.name)
-        except OSError:
-            pass
-
-
-class GetAvailableFwtsTestsTest(unittest.TestCase):
-    """Test the get_available_fwts_tests function."""
-
-    @patch("checkbox_support.scripts.fwts_test.Popen")
-    def test_get_available_fwts_tests_success(self, mock_popen):
-        """Test successful retrieval of available FWTS tests."""
-        # Mock successful command execution
-        mock_process = MagicMock()
-        mock_process.communicate.return_value = (
-            b"acpitests\nversion\nmtrr\nvirt\n",
-            b"",
-        )
-        mock_process.returncode = 0
-        mock_popen.return_value = mock_process
-
-        result = get_available_fwts_tests()
-
-        # Verify the command was called correctly
-        mock_popen.assert_called_once_with(
-            "fwts --show-tests", stdout=PIPE, stderr=PIPE, shell=True
-        )
-
-        # Verify the result
-        self.assertSetEqual(result, {"acpitests", "version", "mtrr", "virt"})
-
-    @patch("checkbox_support.scripts.fwts_test.Popen")
-    def test_get_available_fwts_tests_with_section_headers(self, mock_popen):
-        """Test parsing output with section headers (lines ending with ':')."""
-        # Mock output with section headers that should be ignored
-        mock_process = MagicMock()
-        mock_process.communicate.return_value = (
-            b"ACPI Tests:\nacpitests\nversion\n\nUEFI Tests:\nmtrr\nvirt\n",
-            b"",
-        )
-        mock_process.returncode = 0
-        mock_popen.return_value = mock_process
-
-        result = get_available_fwts_tests()
-
-        self.assertSetEqual(result, {"acpitests", "version", "mtrr", "virt"})
-
-    @patch("checkbox_support.scripts.fwts_test.Popen")
-    def test_get_available_fwts_tests_with_empty_lines(self, mock_popen):
-        """Test parsing output with empty lines."""
-        # Mock output with empty lines that should be ignored
-        mock_process = MagicMock()
-        mock_process.communicate.return_value = (
-            b"acpitests\n\nversion\n\n\nmtrr\n",
-            b"",
-        )
-        mock_process.returncode = 0
-        mock_popen.return_value = mock_process
-
-        result = get_available_fwts_tests()
-
-        self.assertSetEqual(result, {"acpitests", "version", "mtrr"})
-
-    @patch("checkbox_support.scripts.fwts_test.Popen")
-    def test_get_available_fwts_tests_with_whitespace(self, mock_popen):
-        """Test parsing output with leading/trailing whitespace."""
-        # Mock output with whitespace that should be handled
-        mock_process = MagicMock()
-        mock_process.communicate.return_value = (
-            b"  acpitests  \n\tversion\n  mtrr  \n",
-            b"",
-        )
-        mock_process.returncode = 0
-        mock_popen.return_value = mock_process
-
-        result = get_available_fwts_tests()
-
-        self.assertSetEqual(result, {"acpitests", "version", "mtrr"})
-
-    @patch("checkbox_support.scripts.fwts_test.Popen")
-    def test_get_available_fwts_tests_with_multiple_words(self, mock_popen):
-        """Test parsing output where lines have multiple words (takes first word)."""
-        # Mock output with multiple words per line
-        mock_process = MagicMock()
-        mock_process.communicate.return_value = (
-            b"acpitests - ACPI tests\nversion - Version info\n"
-            b"mtrr - MTRR tests\n",
-            b"",
-        )
-        mock_process.returncode = 0
-        mock_popen.return_value = mock_process
-
-        result = get_available_fwts_tests()
-
-        self.assertSetEqual(result, {"acpitests", "version", "mtrr"})
-
-    @patch("checkbox_support.scripts.fwts_test.Popen")
-    def test_get_available_fwts_tests_removes_duplicates(self, mock_popen):
-        """Test that duplicate test names are removed while preserving order."""
-        # Mock output with duplicates
-        mock_process = MagicMock()
-        mock_process.communicate.return_value = (
-            b"acpitests\nversion\nacpitests\nmtrr\nversion\n",
-            b"",
-        )
-        mock_process.returncode = 0
-        mock_popen.return_value = mock_process
-
-        result = get_available_fwts_tests()
-
-        self.assertSetEqual(result, {"acpitests", "version", "mtrr"})
-
-    @patch("checkbox_support.scripts.fwts_test.Popen")
-    def test_get_available_fwts_tests_command_failure(self, mock_popen):
-        """Test handling of command failure."""
-        # Mock command failure
-        mock_process = MagicMock()
-        mock_process.communicate.return_value = (
-            b"",
-            b"fwts: command not found",
-        )
-        mock_process.returncode = 1
-        mock_popen.return_value = mock_process
-
-        with self.assertRaises(RuntimeError) as context:
-            get_available_fwts_tests()
-
-        self.assertIn(
-            "FWTS failed at listing available tests with:",
-            str(context.exception),
-        )
-        self.assertIn("fwts: command not found", str(context.exception))
-
-    @patch("checkbox_support.scripts.fwts_test.Popen")
-    def test_get_available_fwts_tests_empty_output(self, mock_popen):
-        """Test handling of empty output."""
-        # Mock empty output
-        mock_process = MagicMock()
-        mock_process.communicate.return_value = (b"", b"")
-        mock_process.returncode = 0
-        mock_popen.return_value = mock_process
-
-        result = get_available_fwts_tests()
-
-        self.assertEqual(result, set())
-
-    @patch("checkbox_support.scripts.fwts_test.Popen")
-    def test_get_available_fwts_tests_only_whitespace(self, mock_popen):
-        """Test handling of output with only whitespace."""
-        # Mock output with only whitespace
-        mock_process = MagicMock()
-        mock_process.communicate.return_value = (b"   \n\t\n  \n", b"")
-        mock_process.returncode = 0
-        mock_popen.return_value = mock_process
-
-        result = get_available_fwts_tests()
-
-        self.assertEqual(result, set())
+        self.assertIn("doesn't exist", str(cm.exception))

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -58,18 +58,26 @@ class LogPrinterTest(unittest.TestCase):
 class TestGetSleepTestCommand(unittest.TestCase):
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_deb_environment(self):
-
+    @patch("checkbox_support.scripts.fwts_test.in_classic_snap")
+    def test_deb_environment(self, mock_in_classic_snap: MagicMock):
+        mock_in_classic_snap.return_value = False
         result = get_fwts_base_cmd()
         expected = "fwts"
         self.assertEqual(result, expected)
 
     @patch.dict(
-        os.environ,
+        "os.environ",
         {
-            "CHECKBOX_RUNTIME": "/snap/test-snap/checkbox-runtime/",
-            "SNAP": "/snap/test-snap",
+            "CHECKBOX_RUNTIME": "\n".join(
+                [
+                    "/snap/checkbox24/1437",
+                    "/snap/checkbox/20486/checkbox-runtime",
+                    "/snap/checkbox/20486/providers/blah-blah",
+                ]
+            ),
+            "SNAP": "/snap/checkbox/20486",
         },
+        clear=True,
     )
     @patch("checkbox_support.scripts.fwts_test.in_classic_snap")
     @patch("checkbox_support.scripts.fwts_test.Path.exists")
@@ -81,7 +89,7 @@ class TestGetSleepTestCommand(unittest.TestCase):
 
         result = get_fwts_base_cmd()
 
-        expected_dir = "/snap/test-snap/checkbox-runtime/share/fwts"
+        expected_dir = "/snap/checkbox/20486/checkbox-runtime/share/fwts"
         expected_cmd = "fwts -j {}".format(expected_dir)
         self.assertEqual(result, expected_cmd)
 

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -29,7 +29,6 @@ from checkbox_support.scripts.fwts_test import (
     get_fwts_base_cmd,
 )
 from unittest.mock import patch, MagicMock
-from pathlib import Path
 
 
 class LogPrinterTest(unittest.TestCase):
@@ -72,9 +71,13 @@ class TestGetSleepTestCommand(unittest.TestCase):
             "SNAP": "/snap/test-snap",
         },
     )
+    @patch("checkbox_support.scripts.fwts_test.in_classic_snap")
     @patch("checkbox_support.scripts.fwts_test.Path.exists")
-    def test_snap_env_happy_path(self, mock_exists: MagicMock):
+    def test_snap_env_happy_path(
+        self, mock_exists: MagicMock, mock_in_classic_snap: MagicMock
+    ):
         mock_exists.return_value = True
+        mock_in_classic_snap.return_value = False
 
         result = get_fwts_base_cmd()
 
@@ -85,13 +88,17 @@ class TestGetSleepTestCommand(unittest.TestCase):
     @patch.dict(
         os.environ,
         {
-            "CHECKBOX_RUNTIME": "/snap/test-snap/checkbox-runtime/",
-            "SNAP": "/snap/test-snap",
+            "CHECKBOX_RUNTIME": "/snap/checkbox24/current/",
+            "SNAP": "/snap/checkbox-20735/",
         },
     )
+    @patch("checkbox_support.scripts.fwts_test.in_classic_snap")
     @patch("checkbox_support.scripts.fwts_test.Path.exists")
-    def test_snap_env_missing_dir(self, mock_exists: MagicMock):
+    def test_snap_env_missing_dir(
+        self, mock_exists: MagicMock, mock_in_classic_snap: MagicMock
+    ):
         mock_exists.return_value = False
+        mock_in_classic_snap.return_value = True
 
         with self.assertRaises(SystemExit) as cm:
             get_fwts_base_cmd()

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -55,7 +55,7 @@ class LogPrinterTest(unittest.TestCase):
             pass
 
 
-class TestGetSleepTestCommand(unittest.TestCase):
+class TestGetFwtsBaseCommand(unittest.TestCase):
 
     @patch.dict(os.environ, {}, clear=True)
     @patch("checkbox_support.scripts.fwts_test.in_classic_snap")

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -26,7 +26,7 @@ from io import StringIO
 
 from checkbox_support.scripts.fwts_test import (
     print_log,
-    get_sleep_test_command,
+    get_fwts_command,
 )
 from unittest.mock import patch, MagicMock
 from pathlib import Path
@@ -63,8 +63,8 @@ class TestGetSleepTestCommand(unittest.TestCase):
 
     @patch.dict(os.environ, {}, clear=True)
     def test_deb_environment(self):
-        """Test the default 'deb' behavior when env vars are missing."""
-        result = get_sleep_test_command(self.log_path, self.tests)
+
+        result = get_fwts_command(self.log_path, self.tests)
         expected = "fwts -q --stdout-summary -r /tmp/results.log s3 s4"
         self.assertEqual(result, expected)
 
@@ -76,11 +76,10 @@ class TestGetSleepTestCommand(unittest.TestCase):
         },
     )
     @patch("checkbox_support.scripts.fwts_test.Path.exists")
-    def test_snap_environment_success(self, mock_exists: MagicMock):
-        """Test the snap behavior when the FWTS data directory exists."""
+    def test_snap_env_happy_path(self, mock_exists: MagicMock):
         mock_exists.return_value = True
 
-        result = get_sleep_test_command(self.log_path, self.tests)
+        result = get_fwts_command(self.log_path, self.tests)
 
         expected_dir = "/snap/test-snap/checkbox-runtime/share/fwts"
         expected_cmd = (
@@ -98,12 +97,11 @@ class TestGetSleepTestCommand(unittest.TestCase):
         },
     )
     @patch("checkbox_support.scripts.fwts_test.Path.exists")
-    def test_snap_environment_missing_dir(self, mock_exists: MagicMock):
-        """Test that SystemExit is raised if the FWTS directory is missing."""
+    def test_snap_env_missing_dir(self, mock_exists: MagicMock):
         mock_exists.return_value = False
 
         with self.assertRaises(SystemExit) as cm:
-            get_sleep_test_command(self.log_path, self.tests)
+            get_fwts_command(self.log_path, self.tests)
 
         self.assertIn("doesn't exist", str(cm.exception))
 

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -106,3 +106,7 @@ class TestGetSleepTestCommand(unittest.TestCase):
             get_sleep_test_command(self.log_path, self.tests)
 
         self.assertIn("doesn't exist", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -79,11 +79,7 @@ class TestGetSleepTestCommand(unittest.TestCase):
         result = get_fwts_base_cmd()
 
         expected_dir = "/snap/test-snap/checkbox-runtime/share/fwts"
-        expected_cmd = (
-            "fwts -j {}".format(
-                expected_dir
-            )
-        )
+        expected_cmd = "fwts -j {}".format(expected_dir)
         self.assertEqual(result, expected_cmd)
 
     @patch.dict(

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -26,7 +26,7 @@ from io import StringIO
 
 from checkbox_support.scripts.fwts_test import (
     print_log,
-    get_fwts_command,
+    get_fwts_base_cmd,
 )
 from unittest.mock import patch, MagicMock
 from pathlib import Path
@@ -64,7 +64,7 @@ class TestGetSleepTestCommand(unittest.TestCase):
     @patch.dict(os.environ, {}, clear=True)
     def test_deb_environment(self):
 
-        result = get_fwts_command(self.log_path, self.tests)
+        result = get_fwts_base_cmd(self.log_path, self.tests)
         expected = "fwts -q --stdout-summary -r /tmp/results.log s3 s4"
         self.assertEqual(result, expected)
 
@@ -79,7 +79,7 @@ class TestGetSleepTestCommand(unittest.TestCase):
     def test_snap_env_happy_path(self, mock_exists: MagicMock):
         mock_exists.return_value = True
 
-        result = get_fwts_command(self.log_path, self.tests)
+        result = get_fwts_base_cmd(self.log_path, self.tests)
 
         expected_dir = "/snap/test-snap/checkbox-runtime/share/fwts"
         expected_cmd = (
@@ -101,7 +101,7 @@ class TestGetSleepTestCommand(unittest.TestCase):
         mock_exists.return_value = False
 
         with self.assertRaises(SystemExit) as cm:
-            get_fwts_command(self.log_path, self.tests)
+            get_fwts_base_cmd(self.log_path, self.tests)
 
         self.assertIn("doesn't exist", str(cm.exception))
 

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -8,9 +8,12 @@ import filecmp
 import sys
 import typing as T
 from checkbox_support.scripts.image_checker import has_desktop_environment
+from checkbox_support.scripts.fwts_test import get_sleep_test_command
 from datetime import datetime
 import time
+from pathlib import Path
 import platform
+from shlex import split as sh_split
 
 # Checkbox could run in a snap container, so we need to prepend this root path
 RUNTIME_ROOT = os.getenv("CHECKBOX_RUNTIME", default="").rstrip("/")
@@ -189,7 +192,7 @@ class FwtsTester:
     def fwts_log_check_passed(
         self,
         output_directory: str,
-        fwts_arguments: T.Sequence[str] = ["klog", "oops"],
+        fwts_arguments: "list[str]" = ["klog", "oops"],
     ) -> bool:
         """
         Check if fwts logs passes the checks specified in sleep_test_log_check
@@ -203,7 +206,11 @@ class FwtsTester:
         log_file_path = "{}/fwts_{}.log".format(
             output_directory, "_".join(fwts_arguments)
         )
-        sp.run(["fwts", "-r", log_file_path, "-q", *fwts_arguments])
+        sp.run(
+            sh_split(
+                get_sleep_test_command(Path(log_file_path), fwts_arguments)
+            )
+        )
         result = sp.run(
             [
                 "sleep_test_log_check.py",

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -8,7 +8,7 @@ import filecmp
 import sys
 import typing as T
 from checkbox_support.scripts.image_checker import has_desktop_environment
-from checkbox_support.scripts.fwts_test import get_fwts_command
+from checkbox_support.scripts.fwts_test import get_fwts_base_cmd
 from datetime import datetime
 import time
 from pathlib import Path
@@ -206,7 +206,7 @@ class FwtsTester:
         log_file_path = "{}/fwts_{}.log".format(
             output_directory, "_".join(fwts_arguments)
         )
-        sp.run(sh_split(get_fwts_command(Path(log_file_path), fwts_arguments)))
+        sp.run(sh_split(get_fwts_base_cmd(Path(log_file_path), fwts_arguments)))
         result = sp.run(
             [
                 "sleep_test_log_check.py",

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -207,7 +207,13 @@ class FwtsTester:
             output_directory, "_".join(fwts_arguments)
         )
         sp.run(
-            sh_split(get_fwts_base_cmd(Path(log_file_path), fwts_arguments))
+            [
+                *sh_split(get_fwts_base_cmd()),
+                "-q",
+                "-r",
+                output_directory,
+                *fwts_arguments,
+            ]
         )
         result = sp.run(
             [

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -206,7 +206,9 @@ class FwtsTester:
         log_file_path = "{}/fwts_{}.log".format(
             output_directory, "_".join(fwts_arguments)
         )
-        sp.run(sh_split(get_fwts_base_cmd(Path(log_file_path), fwts_arguments)))
+        sp.run(
+            sh_split(get_fwts_base_cmd(Path(log_file_path), fwts_arguments))
+        )
         result = sp.run(
             [
                 "sleep_test_log_check.py",

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -210,7 +210,7 @@ class FwtsTester:
                 *sh_split(get_fwts_base_cmd()),
                 "-q",
                 "-r",
-                output_directory,
+                log_file_path,
                 *fwts_arguments,
             ]
         )

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -206,11 +206,7 @@ class FwtsTester:
         log_file_path = "{}/fwts_{}.log".format(
             output_directory, "_".join(fwts_arguments)
         )
-        sp.run(
-            sh_split(
-                get_fwts_command(Path(log_file_path), fwts_arguments)
-            )
-        )
+        sp.run(sh_split(get_fwts_command(Path(log_file_path), fwts_arguments)))
         result = sp.run(
             [
                 "sleep_test_log_check.py",

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -8,7 +8,7 @@ import filecmp
 import sys
 import typing as T
 from checkbox_support.scripts.image_checker import has_desktop_environment
-from checkbox_support.scripts.fwts_test import get_sleep_test_command
+from checkbox_support.scripts.fwts_test import get_fwts_command
 from datetime import datetime
 import time
 from pathlib import Path
@@ -208,7 +208,7 @@ class FwtsTester:
         )
         sp.run(
             sh_split(
-                get_sleep_test_command(Path(log_file_path), fwts_arguments)
+                get_fwts_command(Path(log_file_path), fwts_arguments)
             )
         )
         result = sp.run(

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -11,7 +11,6 @@ from checkbox_support.scripts.image_checker import has_desktop_environment
 from checkbox_support.scripts.fwts_test import get_fwts_base_cmd
 from datetime import datetime
 import time
-from pathlib import Path
 import platform
 from shlex import split as sh_split
 


### PR DESCRIPTION
## Description

This PR fixes #1997 by specifying the `-j` option in fwts when we detect that we are in a snap environment. 

## Resolved issues

1. #1997
2. Fixed a few unbound variables and undefined variable access

## Documentation

Basically we are telling fwts to read the directory in checkbox runtime instead of whatever `/usr/share/fwts` is inside a snap.

```
-j, --json-data-path         Specify path to fwts json data files - default is /usr/share/fwts
```

This PR also includes a small workaround for #2295.

## Tests

Original unit tests

C3 submission: TODO