### PR TITLE
Remove bodge to disconnect double controller (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -338,15 +338,7 @@ class RemoteController(ReportsStage, MainLoopStage):
             except EOFError as exc:
                 if keep_running:
                     print("Connection lost!")
-                    # this is yucky but it works, in case of explicit
-                    # connection closing by the agent we get this msg
                     _logger.info("controller: Connection lost due to: %s", exc)
-                    if str(exc) == "stream has been closed":
-                        print(
-                            "Agent explicitly disconnected you. Possible "
-                            "reason: new controller connected to the agent"
-                        )
-                        break
                     print(exc)
                     time.sleep(1)
                 else:


### PR DESCRIPTION
## Description

This old bodge seems to be a remnant of the old behaviour of having two controllers connect. Nowadays when a second controller connects to the same agent the following is printed:
```
Forcefully disconnected by new controller from 127.0.0.1:39530
```
(The session actually crashes but that an unrelated bug I suspect)

This bodge is blocking remodel testing because if the machine briefly comes online and then reboots again, checkbox controller is briefly able to connect with the agent but it then fails to fully get going, triggering this exception and stopping the whole session. This is clearly tragic from a CI point of view. 

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-2141

## Documentation

N/A

## Tests

Tested locally by running `2021.com.canonical.certification::checkbox-crash-then-reboot `. The testplan crashes both the agent and the controller. Given that it runs as root, if you use `ALLOW_CHECKBOX_AGENT_NONROOT=1` it will prompt for password. Exit the agent. The controller will now start to try to reconnect. Start the agent, after the controller notices and reconnect, Ctrl+C out of the agent again. This will make the controller end the run with the "Agent explicitly disconnected you" error before this patch, after it will simply try to reconnect.
