### PR TITLE
Fix: USB SD card reader support (Bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -369,6 +369,23 @@ class MediacardComboStorage(MediacardStorage, USBStorage):
         MediacardStorage._parse_journal_line(self, line_str)
         USBStorage._parse_journal_line(self, line_str)
 
+        # Also handle SD card readers that appear as SCSI/USB mass storage (sd*)
+        # Check for capacity change patterns first (for action detection)
+        if (
+            "detected capacity change from 0 to" in line_str
+            and " to 0" not in line_str
+        ):
+            # This is an insertion - always update to reflect current action
+            self.action = "insertion"
+            self.device = "SD/MMC via USB reader"
+        elif (
+            "detected capacity change from" in line_str and " to 0" in line_str
+        ):
+            # This is a removal - always update to reflect current action
+            self.action = "removal"
+
+        return super()._parse_journal_line(line_str)
+
 
 class ThunderboltStorage(StorageWatcher):
     """


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The mediacard_combo storage watcher was unable to detect SD card readers that appear as SCSI/USB mass storage devices (/dev/sda) instead of mmcblk devices. This caused insertion tests to timeout.

This patch enhances MediacardComboStorage._parse_journal_line() to:
- Detect insertions via 'detected capacity change from 0 to X' messages
- Detect removals via 'detected capacity change from X to 0' messages
- Extract partition names from 'sda: sda1' style journal entries
- Label these devices as 'SD/MMC via USB reader'

The fix allows the action state to be updated dynamically, properly handling multiple insert/remove cycles even when a card is already inserted at test start.

Tested with USB SD card readers that enumerate as /dev/sda devices.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CPL-258

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

N/A

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

`sudo ./run_watcher.py insertion mediacard_combo
`
Wait for the "INSERT NOW" prompt, then insert the card.



<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
