### PR TITLE
Append LD_LIBRARY_PATH for lapack and blas (Bugfix)

### DIFF
--- a/checkbox-core-snap/common_files/config/wrapper_common
+++ b/checkbox-core-snap/common_files/config/wrapper_common
@@ -18,6 +18,9 @@ else
   append_path LD_LIBRARY_PATH $RUNTIME/lib/$ARCH
   append_path LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH
   append_path LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/fwts
+  # add paths for lapack and blas to import cv2
+  append_path LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/lapack
+  append_path LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/blas
   append_path LD_LIBRARY_PATH $RUNTIME/lib/fwts
   append_path GI_TYPELIB_PATH $RUNTIME/usr/lib/girepository-1.0
   append_path GI_TYPELIB_PATH $RUNTIME/usr/lib/$ARCH/girepository-1.0


### PR DESCRIPTION
To fix the issue of lacking libs for import cv2. ImportError: liblapack.so.3: cannot open shared object file: No such file or directory. And ImportError: libblas.so.3: cannot open shared object file: No such file or directory

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
We found it not able to find liblapack.so.3 and libblas.so.3 while import cv2. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
We builded and tried in UC24.
```
ce-certification-qa@localhost:~$ sudo snap install checkbox24_7.0.0-dev97_arm64.snap --dangerous                                                                                     
checkbox24 7.0.0-dev97 installed
ce-certification-qa@localhost:~$ checkbox-koto.shell 
checkbox-koto runtime shell, type 'exit' to quit the session
ce-certification-qa@localhost:/home/ce-certification-qa$ export|grep -i ld_library
declare -x LD_LIBRARY_PATH="/usr/lib/aarch64-linux-gnu:/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void:/snap/checkbox-koto/12/usr/lib:/snap/checkbox-koto/12/usr/lib/aarch64-linux-gnu:/snap/checkbox-ce-oem/current/usr/lib/aarch64-linux-gnu:/snap/checkbox-koto/12/checkbox-runtime/lib:/snap/checkbox-koto/12/checkbox-runtime/lib/aarch64-linux-gnu:/snap/checkbox-koto/12/checkbox-runtime/usr/lib/aarch64-linux-gnu:/snap/checkbox-koto/12/checkbox-runtime/usr/lib/aarch64-linux-gnu/lapack:/snap/checkbox-koto/12/checkbox-runtime/usr/lib/aarch64-linux-gnu/blas:/snap/checkbox-koto/12/checkbox-runtime/lib/fwts"
ce-certification-qa@localhost:/home/ce-certification-qa$ python3
Python 3.12.3 (main, Aug 14 2025, 17:47:21) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import cv2

>>> 
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
