### PR TITLE
use awk instead of cut for session filtering (Bugfix)

### DIFF
--- a/providers/base/bin/graphics_env.sh
+++ b/providers/base/bin/graphics_env.sh
@@ -22,7 +22,8 @@ ensure_xdg_session_type() {
         sleep 1
 
         echo "Waiting for XDG_SESSION_TYPE to be set"
-        SESSION=$(loginctl list-sessions --no-legend | grep 'seat0' | cut -d ' ' -f 1)
+        SESSION=$(loginctl list-sessions --no-legend | grep 'seat0' | awk '{print $1}')
+
 
         XDG_SESSION_TYPE=$(loginctl show-session "${SESSION}" | grep 'Type' | cut -d '=' -f 2)
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
use awk instead of cut for session filtering (Bugfix) (#2268) 
Because there are some spaces before the session id, using cut to extract the session id results in an empty value, which causes the subsequent retrieval of xdg_session_type to be incorrect.
```
u@Lamarr2-SVT-C1:~$  SESSION=$(loginctl list-sessions --no-legend | grep 'seat0' | cut -d ' ' -f 1)
u@Lamarr2-SVT-C1:~$ echo $SESSION

u@Lamarr2-SVT-C1:~$ XDG_SESSION_TYPE=$(loginctl show-session "${SESSION}" | grep 'Type' | cut -d '=' -f 2)
u@Lamarr2-SVT-C1:~$ echo $XDG_SESSION_TYPE
tty
```

If use the awk, the SESSION could be get correctly.

```
u@Lamarr2-SVT-C1:~$ SESSION=$(loginctl list-sessions --no-legend | grep 'seat0' | awk '{print $1}')
u@Lamarr2-SVT-C1:~$ echo $SESSION
1
u@Lamarr2-SVT-C1:~$ XDG_SESSION_TYPE=$(loginctl show-session "${SESSION}" | grep 'Type' | cut -d '=' -f 2)
u@Lamarr2-SVT-C1:~$ echo $XDG_SESSION_TYPE
x11
```



<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
[The test graphics/{index}_driver_version_{product_slug} always failed on system running Wayland](https://github.com/canonical/checkbox/issues/2268)

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
The test with original cut command:
https://certification.canonical.com/hardware/202504-36705/submission/467075/

The test with side load fix:
https://certification.canonical.com/hardware/202504-36705/submission/467076/

The side load test on x11 machine:
https://certification.canonical.com/hardware/202509-37928/submission/467277/

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
