### PR TITLE
Remove legacy autorestart flag handling (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -588,22 +588,6 @@ class SessionAssistant:
         self._metadata = self._context.state.metadata
         self._command_io_delegate = JobRunnerUIDelegate(_SilentUI())
         self._init_runner(runner_cls, runner_kwargs)
-        if self._metadata.running_job_name:
-            job = self._context.get_unit(
-                self._metadata.running_job_name, "job"
-            )
-            if "autorestart" in job.get_flag_set():
-                result = JobResultBuilder(
-                    outcome=(
-                        IJobResult.OUTCOME_PASS
-                        if "noreturn" in job.get_flag_set()
-                        else IJobResult.OUTCOME_FAIL
-                    ),
-                    return_code=0,
-                    io_log_filename=self._runner.get_record_path_for_job(job),
-                ).get_result()
-                self._context.state.update_job_result(job, result)
-                self._manager.checkpoint()
         self._restart_strategy = detect_restart_strategy(self)
         _logger.info("Session strategy: %r", self._restart_strategy)
         self._job_start_time = self._metadata.last_job_start_time


### PR DESCRIPTION
## Description

`autorestart` doesn't have any purpose anymore but, pending full deprecation, it is still handled in a couple of spots in the codebase (notably, it provides autoresume for local as far as I can tell via janky xdg mechanisms). This handler is bugged as it doesn't note the duration nor conform to the new behaviour where one can override via the interrupt menu the result. Additionally now both local and remote correctly handle resume on their own, without relying on this handler to set the result of *some* jobs, so its purpose is now better handled upstream this function call.

Note that the new codepath also adds a sensible comment to the test when the result is auto assigned, so it doesn't just fix the issue, it actually makes the result more documented.

This also fixes another `autorestart` bug, if an `autorestart` test is not `noreturn` (for some reason), this code path would mark the test as failed, while the correct result is crashed.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-2150

## Documentation

N/A

## Tests

Modify the following testplan in the metabox provider:
```
 unit: test plan
 id: checkbox-crash-then-reboot
-_name: Checkbox crash then reboot
+_name: Checkbox crash then reboot ASDFASDF
 include:
+ com.canonical.certification::power-management/warm-reboot
  checkbox-crasher
  reboot-emulator
```
so that you have a testplan with both a test exposing this bug (power-management/warm-reboot is autorestart).

Start the checkbox agent with `ALLOW_CHECKBOX_AGENT_NONSUDO=1 checkbox-cli run-agent` (so that its more conveneint to test this, as you can intercept the password asking and simply ctrl+c, avoiding the reboot!). Use control to select this testplan (launcher for your convenience)
```
[launcher]
stock_reports = submission_json
[test plan]
unit=2021.com.canonical.certification::checkbox-crash-then-reboot
forced=yes
[test selection]
forced=yes
```
When prompted for password by the agent, ctrl+c and restart it (3 times). Open the submission.json

Before this patch, `com.canonical.certification::power-management/warm-reboot` has duration 0, the others have a sensible duration. After this patch, all tests have a sensible duration.