### PR TITLE
series16/snapcraft.yaml: remove fscrypt dependency (bugfix)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -287,7 +287,6 @@ parts:
       - ethtool
       - freeipmi-tools
       - freeglut3
-      - fscrypt
       - fswebcam
       - gir1.2-cheese-3.0
       - gir1.2-clutter-1.0


### PR DESCRIPTION
fscrypt does not exist in series16.