### PR TITLE
updated udevadm filter for capture devices (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/parsers/udevadm.py
+++ b/checkbox-support/checkbox_support/parsers/udevadm.py
@@ -691,7 +691,7 @@ class UdevadmDevice(object):
                     "mtk-vcodec-dec",
                     "mtk-jpeg",
                     "mtk-mdp3",
-                    "intel[-_]ipu[0-9][-_].*",
+                    "intel[-_]ipu[0-9].*",
                 )
                 for b in drivers_blocklist:
                     match = re.search(b, str(self.driver))


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
The video devices were detected wrongly by the udevparser, since it included `ipu` devices as capture devices 
https://certification.canonical.com/hardware/202405-34051/submission/466451/test-results/?term=video
https://certification.canonical.com/hardware/202407-34207/submission/466446/test-results/?term=video

This PR should include these devices in the into the `drivers_blocklist` so they are not included as CAPTURE devices for testing
 
## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

Fixes #2228

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

N/A

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
- [202301-31085](https://certification.canonical.com/hardware/202301-31085): https://github.com/canonical/checkbox/actions/runs/21254367385/job/61164566204
- [202407-34207](https://certification.canonical.com/hardware/202407-34207): https://github.com/canonical/checkbox/actions/runs/21254735153/job/61165920246
- [202405-34051](https://certification.canonical.com/hardware/202405-34051): https://github.com/canonical/checkbox/actions/runs/21254735153/job/61165920397
- [202112-29800](https://certification.canonical.com/hardware/202112-29800): https://github.com/canonical/checkbox/actions/runs/21255338003/job/61168152161

Capture devices before from "udev_resource":
```
path: /devices/pci0000:00/0000:00:05.0/video4linux/video1
name: video1
bus: video4linux
category: CAPTURE
driver: intel-ipu7
product: ipu7
product_slug: ipu7

path: /devices/pci0000:00/0000:00:05.0/video4linux/video10
name: video10
bus: video4linux
category: CAPTURE
driver: intel-ipu7
product: ipu7
product_slug: ipu7

[...]

path: /devices/virtual/video4linux/video0
name: video0
bus: video4linux
category: CAPTURE
product: Intel MIPI Camera
product_slug: Intel_MIPI_Camera
```

Capture devices now:
```
path: /devices/virtual/video4linux/video0
name: video0
bus: video4linux
category: CAPTURE
product: Intel MIPI Camera
product_slug: Intel_MIPI_Camera
```
