### PR TITLE
Move "Not Supported Tests" in their own section in the HTML report (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
@@ -86,18 +86,24 @@
                                 datasets: [{
                                     data: [
                                         {%- for outcome, total in state.get_test_outcome_stats()|dictsort %}
+                                        {%- if outcome != 'not-supported' %}
                                         {{ total }},
+                                        {%- endif %}
                                         {%- endfor %}
                                     ],
                                     backgroundColor: [
                                         {%- for outcome, total in state.get_test_outcome_stats()|dictsort %}
+                                        {%- if outcome != 'not-supported' %}
                                         "{{ OUTCOME_METADATA_MAP[outcome].color_hex }}",
+                                        {%- endif %}
                                         {%- endfor %}
                                     ],
                                 }],
                                 labels: [
                                     {%- for outcome, total in state.get_test_outcome_stats()|dictsort %}
+                                    {%- if outcome != 'not-supported' %}
                                     "{{ OUTCOME_METADATA_MAP[outcome].tr_label }}",
+                                    {%- endif %}
                                     {%- endfor %}
                                 ]
                             },

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
@@ -212,6 +212,48 @@
                     {%- endif %}
                     {%- endfor %}
                     <p></p>
+                    {%- set has_any_not_supported = [] %}
+                    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome == 'not-supported' and job_state.job.plugin not in ("resource", "attachment") %}
+                        {%- if has_any_not_supported.append(1) %}{% endif %}
+                    {%- endfor %}
+                    {%- if has_any_not_supported|length > 0 %}
+                    <h2>Not Supported Tests</h2>
+                    <p>The following tests are part of the test plan but were not run because they don't match the device's available features (for instance, wireless tests are skipped on a device without a WiFi chip).</p>
+                    {%- for cat_id, cat_name in category_map|dictsort(false, 'value') %}
+                    {% set mainloop = loop %}
+                    {%- set has_not_supported = [] %}
+                    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome == 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+                        {%- if has_not_supported.append(1) %}{% endif %}
+                    {%- endfor %}
+                    {%- if has_not_supported|length > 0 %}
+                    <div data-role="collapsible" data-filter="true" data-input="#filterTable-input1" class="openMe" style="margin: 0;" data-content-theme="false">
+                    <h3>{{ cat_name }}</h3>
+                        <table data-role="table" id="{{ cat_id }}-not-supported" data-filter="true" data-input="#filterTable-input1" class="ui-body-d ui-shadow table-stroke ui-responsive">
+                            <thead>
+                                <tr class="ui-bar-d">
+                                </tr>
+                            </thead>
+                            <tbody>
+                            {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome == 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+                                <tr>
+                                    <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%'>{{ job_id|strip_ns }}</td>
+                                    <td style='width:10%; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
+                                    {%- if job_state.effective_certification_status != "non-blocker" %}
+                                    <td style='width:10%'>{{ job_state.effective_certification_status }}</td>
+                                    {%- else %}
+                                    <td style='width:10%'></td>
+                                    {%- endif %}
+                                    <td style='width:10%'></td>
+                                    <td style='width:35%'>{% autoescape false %}{{ job_state.result.comments if job_state.result.comments != None }}{% endautoescape %}</td>
+                                </tr>
+                            {%- endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {%- endif %}
+                    {%- endfor %}
+                    <p></p>
+                    {%- endif %}
                     <h2>Logs</h2>
                     {%- if resource_map %}
                     <div data-role="collapsible" data-filter="true" data-input="#filterTable-input1" class="openMe" data-content-theme="false">

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
@@ -218,7 +218,7 @@
                     {%- endfor %}
                     {%- if has_any_not_supported|length > 0 %}
                     <h2>Not Supported Tests</h2>
-                    <p>The following tests are part of the test plan but were not run because they don't match the device's available features (for instance, wireless tests are skipped on a device without a WiFi chip).</p>
+                    <p>The following tests are part of the test plan but were not run because they don't match the device's available features (for example, wireless tests are skipped on a device without a WiFi chip).</p>
                     {%- for cat_id, cat_name in category_map|dictsort(false, 'value') %}
                     {% set mainloop = loop %}
                     {%- set has_not_supported = [] %}

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
@@ -176,6 +176,11 @@
                     </fieldset>
                     {%- for cat_id, cat_name in category_map|dictsort(false, 'value') %}
                     {% set mainloop = loop %}
+                    {%- set has_supported = [] %}
+                    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.result.outcome != 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+                        {%- if has_supported.append(1) %}{% endif %}
+                    {%- endfor %}
+                    {%- if has_supported|length > 0 %}
                     <div data-role="collapsible" data-filter="true" data-input="#filterTable-input1" class="openMe" style="margin: 0;" data-content-theme="false">
                     <h3>{{ cat_name }}<span class="ui-li-count {{ OUTCOME_METADATA_MAP[category_outcome_map[cat_id]].tr_label }}Count">{{ OUTCOME_METADATA_MAP[category_outcome_map[cat_id]].tr_label }}</span></h3>
                         <table data-role="table" id="{{ cat_id }}" data-filter="true" data-input="#filterTable-input1" class="ui-body-d ui-shadow table-stroke ui-responsive">
@@ -184,7 +189,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                            {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+                            {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.result.outcome != 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
                                 <tr>
                                     <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%'>{{ job_id|strip_ns }}</td>
                                     <td style='width:10%; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
@@ -204,6 +209,7 @@
                             </tbody>
                         </table>
                     </div>
+                    {%- endif %}
                     {%- endfor %}
                     <p></p>
                     <h2>Logs</h2>

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/multi-page.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/multi-page.html
@@ -136,18 +136,24 @@
                 datasets: [{
                     data: [
                         {%- for outcome, total in state.get_test_outcome_stats()|dictsort %}
+                        {%- if outcome != 'not-supported' %}
                         {{ total }},
+                        {%- endif %}
                         {%- endfor %}
                     ],
                     backgroundColor: [
                         {%- for outcome, total in state.get_test_outcome_stats()|dictsort %}
+                        {%- if outcome != 'not-supported' %}
                         "{{ OUTCOME_METADATA_MAP[outcome].color_hex }}",
+                        {%- endif %}
                         {%- endfor %}
                     ],
                 }],
                 labels: [
                     {%- for outcome, total in state.get_test_outcome_stats()|dictsort %}
+                    {%- if outcome != 'not-supported' %}
                     "{{ OUTCOME_METADATA_MAP[outcome].tr_label }}",
+                    {%- endif %}
                     {%- endfor %}
                 ]
             },
@@ -215,6 +221,11 @@
     </fieldset>
     {%- for cat_id, cat_name in category_map|dictsort(false, 'value') %}
     {% set mainloop = loop %}
+    {%- set has_supported = [] %}
+    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.result.outcome != 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+        {%- if has_supported.append(1) %}{% endif %}
+    {%- endfor %}
+    {%- if has_supported|length > 0 %}
     <div data-role="collapsible" data-filter="true" data-input="#filterTable-input{{ managerloop.index }}" class="openMe{{ managerloop.index }}" style="margin: 0;" data-content-theme="false">
     <h3>{{ cat_name }}<span class="ui-li-count {{ OUTCOME_METADATA_MAP[category_outcome_map[cat_id]].tr_label }}Count">{{ OUTCOME_METADATA_MAP[category_outcome_map[cat_id]].tr_label }}</span></h3>
         <table data-role="table" id="{{ cat_id }}" data-filter="true" data-input="#filterTable-input{{ managerloop.index }}" class="ui-body-d ui-shadow table-stroke ui-responsive">
@@ -223,7 +234,7 @@
                 </tr>
             </thead>
             <tbody>
-            {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+            {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.result.outcome != 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
                 <tr>
                     <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%'>{{ job_id|strip_ns }}</td>
                     <td style='width:10%; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
@@ -243,8 +254,51 @@
             </tbody>
         </table>
     </div>
+    {%- endif %}
     {%- endfor %}
     <p></p>
+    {%- set has_any_not_supported = [] %}
+    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome == 'not-supported' and job_state.job.plugin not in ("resource", "attachment") %}
+        {%- if has_any_not_supported.append(1) %}{% endif %}
+    {%- endfor %}
+    {%- if has_any_not_supported|length > 0 %}
+    <h2>Not Supported Tests</h2>
+    <p>The following tests are part of the test plan but were not run because they don't match the device's available features (for example, wireless tests are skipped on a device without a WiFi chip).</p>
+    {%- for cat_id, cat_name in category_map|dictsort(false, 'value') %}
+    {% set mainloop = loop %}
+    {%- set has_not_supported = [] %}
+    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome == 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+        {%- if has_not_supported.append(1) %}{% endif %}
+    {%- endfor %}
+    {%- if has_not_supported|length > 0 %}
+    <div data-role="collapsible" data-filter="true" data-input="#filterTable-input{{ managerloop.index }}" class="openMe{{ managerloop.index }}" style="margin: 0;" data-content-theme="false">
+    <h3>{{ cat_name }}</h3>
+        <table data-role="table" id="{{ cat_id }}-not-supported" data-filter="true" data-input="#filterTable-input{{ managerloop.index }}" class="ui-body-d ui-shadow table-stroke ui-responsive">
+            <thead>
+                <tr class="ui-bar-d">
+                </tr>
+            </thead>
+            <tbody>
+            {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome == 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+                <tr>
+                    <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%'>{{ job_id|strip_ns }}</td>
+                    <td style='width:10%; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
+                    {%- if job_state.effective_certification_status != "non-blocker" %}
+                    <td style='width:10%'>{{ job_state.effective_certification_status }}</td>
+                    {%- else %}
+                    <td style='width:10%'></td>
+                    {%- endif %}
+                    <td style='width:10%'></td>
+                    <td style='width:35%'>{% autoescape false %}{{ job_state.result.comments if job_state.result.comments != None }}{% endautoescape %}</td>
+                </tr>
+            {%- endfor %}
+            </tbody>
+        </table>
+    </div>
+    {%- endif %}
+    {%- endfor %}
+    <p></p>
+    {%- endif %}
     <h2>Logs</h2>
     {%- if resource_map %}
     <div data-role="collapsible" data-filter="true" data-input="#filterTable-input{{ managerloop.index }}" class="openMe{{ managerloop.index }}" data-content-theme="false">


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

1. Move "Not Supported Tests" into a separate section of the HTML report. This section only shows up if there are "not-supported" jobs, and contains a small explanation paragraph. This helps reviewing test runs, since often, readers don't care about jobs that are skipped because the feature to be tested is not present in the device.
2. Remove "not-supported" counts from the pie chart: reviewers are more interested into results that target the DUT (pass/fail/skip), not tests that have not been executed because said DUT cannot test them in the first place.

The same was done for the multi-page HTML template which is used when launching the `checkbox-cli merge-reports` command.
## Resolved issues

Fix https://warthogs.atlassian.net/browse/CHECKBOX-651

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

These HTML reports show the outcome when running locally with the smoke test plan, and when using the `checkbox-cli merge-reports` command with 2 submissions (this uses the multi-page template):

[html-reports.zip](https://github.com/user-attachments/files/24669947/html-reports.zip)

I've also run this on checkbox16 and it worked as expected.

Run locally using different test plans (manual, automated), manually skipping tests. Here is the screenshot of a test run on 24.04, with all the fields expanded (they're all collapsed by default):

<img width="3528" height="8978" alt="Screenshot 2026-01-14 at 14-14-30 System Testing Report" src="https://github.com/user-attachments/assets/de01f798-2d5a-495f-8a7e-4c72045ebd6a" />