### PR TITLE
Allow user to nsenter without sudo (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -769,9 +769,9 @@ def get_execution_command_systemd_unit(
     executed not as a child process of Checkbox in the current slice, but as a
     new transient systemd unit in the appropriate slice for the user.
 
-    Note: This dumps the command to a temporary file because there is a
+    Note: Dumps the command to a temporary file because there is a
     limitation on core16's systemd that makes commands longer than 2k
-    characters. See: https://github.com/systemd/systemd/issues/3302
+    characters fail. See: https://github.com/systemd/systemd/issues/3302
     """
     wrapper_cmd = [
         "sudo",
@@ -791,7 +791,7 @@ def get_execution_command_systemd_unit(
     cmd = []
     if on_ubuntucore():
         if target_user != "root":
-            # if we aren't root we need to temporarely give ourselves some
+            # if we aren't root we need to temporarily give ourselves some
             # capabilities to mount the namespace
             # from linux/capability.h
             # uint64(1 << 21| 1<<18 | 1<<6 | 1<<7))}
@@ -814,7 +814,7 @@ def get_execution_command_systemd_unit(
         snap_name = os.getenv("SNAP_NAME", "checkbox")
         cmd += [
             # Note: don't make this absolute! We must use the system nsenter
-            #       as we have yet to mount the namespace, so the snap one wont
+            #       as we have yet to mount the namespace, so the snap one won't
             #       work
             "nsenter",
             "-m/run/snapd/ns/{}.mnt".format(snap_name),
@@ -828,7 +828,7 @@ def get_execution_command_systemd_unit(
         job, environ, session_id, nest_dir, extra_env
     )
     # SYSTEMD_IGNORE_CHROOT intentionally at the end because without this
-    # any systemd command will not work
+    # no systemd command will work
     env_cmds = [
         "{key}={value}".format(key=key, value=value)
         for key, value in sorted(env.items())

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -822,7 +822,6 @@ def get_execution_command_systemd_unit(
     ) as f:
         f.write("#!/bin/bash\neval ")
         f.write(cmd_text)
-        f.seek(0)
         os.chmod(f.name, 0o777)
         path = f.name
 

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -862,9 +862,9 @@ def get_execution_command_systemd_unit(
             ),
             "-m/run/snapd/ns/{}.mnt".format(snap_name),
         ]
-    env = get_differential_execution_environment(
-        job, environ, session_id, nest_dir, extra_env
-    )
+    env = get_execution_environment(job, environ, session_id, nest_dir)
+    if extra_env:
+        env.update(extra_env())
     # SYSTEMD_IGNORE_CHROOT intentionally at the end because without this
     # no systemd command will work
     env_cmds = [

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -834,16 +834,17 @@ def get_execution_command_systemd_unit(
         wrapper_cmd += ["-pam", "system-login"]
     cmd = []
     dangerous_nsenter_path = None
+    # this location must be accessible and in the same path for both this
+    # process (that may be inside a snap) and the systemd unit (which is not)
+    # fallback mechanism is for debian/source checkbox
+    shared_location = os.getenv("SNAP_COMMON", "/var/tmp")
     if on_ubuntucore():
         if target_user != "root":
             # here we need a dangerous copy of nsenter that works as "normal"
             # user because the unit will be normal user and else it wont be
             # able to mount the snap namespace
             with tempfile.NamedTemporaryFile(
-                mode="w",
-                delete=False,
-                prefix="nsenter_",
-                dir="/var/tmp",
+                mode="w", delete=False, prefix="nsenter_", dir=shared_location
             ) as f:
                 dangerous_nsenter_path = f.name
 
@@ -877,7 +878,7 @@ def get_execution_command_systemd_unit(
         delete=False,
         prefix="job_command_",
         suffix=".sh",
-        dir="/var/tmp",
+        dir=shared_location,
     ) as f:
         f.write("#!/bin/bash\n")
         f.write(cmd_text)

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -820,7 +820,7 @@ def get_execution_command_systemd_unit(
         suffix=".sh",
         dir="/var/tmp",
     ) as f:
-        f.write("#!/bin/bash\neval ")
+        f.write("#!/bin/bash\nexec ")
         f.write(cmd_text)
         os.chmod(f.name, 0o777)
         path = f.name

--- a/checkbox-ng/plainbox/impl/test_execution.py
+++ b/checkbox-ng/plainbox/impl/test_execution.py
@@ -284,9 +284,11 @@ class TestDangerousNsenter(TestCase):
     @mock.patch("plainbox.impl.execution.check_output")
     @mock.patch("plainbox.impl.execution.check_call")
     @mock.patch("plainbox.impl.execution.run")
+    @mock.patch("shutil.which")
     def test_dangerous_nsenter_cleanup(
-        self, run_mock, check_call_mock, check_output_mock
+        self, which_mock, run_mock, check_call_mock, check_output_mock
     ):
+        which_mock.return_value = "/bin/plz-run"
         with self.assertRaises(ValueError):
             with dangerous_nsenter("/var/tmp/nsenter_dangerous"):
                 # prepared dangerous nsenter is copied somewhere, made extable

--- a/checkbox-ng/plainbox/impl/test_execution.py
+++ b/checkbox-ng/plainbox/impl/test_execution.py
@@ -59,9 +59,7 @@ class UnifiedRunnerTests(TestCase):
     @mock.patch("os.chmod")
     @mock.patch("tempfile.NamedTemporaryFile")
     @mock.patch("shutil.which")
-    @mock.patch(
-        "plainbox.impl.execution.get_differential_execution_environment"
-    )
+    @mock.patch("plainbox.impl.execution.get_execution_environment")
     @mock.patch("plainbox.impl.execution.on_ubuntucore")
     def test_get_execution_command_systemd_unit_command_and_envvars(
         self,
@@ -97,9 +95,7 @@ class UnifiedRunnerTests(TestCase):
     @mock.patch("os.chmod")
     @mock.patch("tempfile.NamedTemporaryFile")
     @mock.patch("shutil.which")
-    @mock.patch(
-        "plainbox.impl.execution.get_differential_execution_environment"
-    )
+    @mock.patch("plainbox.impl.execution.get_execution_environment")
     @mock.patch("plainbox.impl.execution.on_ubuntucore")
     @mock.patch("os.getenv")
     def test_get_execution_command_systemd_unit_nsenter_on_core(

--- a/checkbox-ng/plainbox/impl/test_execution.py
+++ b/checkbox-ng/plainbox/impl/test_execution.py
@@ -267,7 +267,7 @@ class UnifiedRunnerTests(TestCase):
 
 class TestDangerousNsenter(TestCase):
     def call_args_to_string(self, call_arg):
-        return " ".join(str(x) for x in call_arg.args[0])
+        return " ".join(str(x) for x in call_arg[0][0])
 
     @mock.patch("plainbox.impl.execution.check_output")
     @mock.patch("plainbox.impl.execution.check_call")


### PR DESCRIPTION
## Description

Given that with the new runner we use systemd units, we are impacted by the bug below. Any command that is more than 2k characters, is silently truncated and fails. This impacts only core16.

This PR fixes this by creating a script file and using plz-run to launch that script file, completely bypassing the limitation. 

## Resolved issues

See: https://github.com/systemd/systemd/issues/3302 

## Documentation

N/A

## Tests

Tested locally using pass then fail. 

Note: this is a sister PR to: https://github.com/canonical/plz-run/pull/6

How I tested this on snaps:
```bash
$ snap install image-garden
$ image-garden allocate ubuntu-cloud-16.04.x86_64
[...] 
localhost:5000 # this will print the port at the end of the log
$ ssh -p 5000 ubuntu@localhost
# passowrd is ubuntu

# Try first with the checkbox16 snap
(ubuntu16.04) $ snap install checkbox16 --edge --devmode
(ubuntu16.04) $ checkbox16.checkbox
# run smoke!
#
# update.go:85: cannot change mount namespace according to change mount (/var/lib/snapd/hostfs/boot /boot none bind,ro 0 0): permission denied
# Preparing...
# Reports will be saved to: /home/ubuntu/snap/checkbox16/2724/.local/share/checkbox-ng
# ========[ Running job 1 / 20. Estimated time left (at least): 0:00:06 ]=========
# ---------------------[ Collect information about the CPU ]----------------------
# ID: com.canonical.certification::cpuinfo
# Category: com.canonical.certification::information_gathering
# WARNING:checkbox_ng.user_utils:Using `ubuntu` user
# ... 8< -------------------------------------------------------------------------
# plz-run error: cannot call StartTransientUnit: Unit plz-run-8782571740010359843.service is not loaded properly: Invalid argument.------------------------------------------------------------------------- >8 ---
# [...]

(ubuntu16.04) $ snap download checkbox16 --edge
(ubuntu16.04) $ unsquashfs checkbox16*.snap
# here scp the execution.py file in the squash-fs
(ubuntu16.04) $ snap try --devmode squashfs-root
(ubuntu16.04) $ checkbox16.checkbox
# run smoke!
#
# Preparing...
# Reports will be saved to: /home/ubuntu/snap/checkbox16/x1/.local/share/checkbox-ng
# ========[ Running job 1 / 20. Estimated time left (at least): 0:00:06 ]=========
# ---------------------[ Collect information about the CPU ]----------------------
# ID: com.canonical.certification::cpuinfo
# Category: com.canonical.certification::information_gathering
# WARNING:checkbox_ng.user_utils:Using `ubuntu` user
# ... 8< -------------------------------------------------------------------------
# bogomips: 7586
# cache: 524288
# count: 4
# model: AMD Ryzen 7 7840HS with Radeon 780M Graphics
# model_number: 25
# model_revision: 1
# model_version: 116
# other: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm rep_good nopl extd_apicid tsc_known_freq pni pclmulqdq ssse3 fma cx16 sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw perfctr_core ssbd ibrs ibpb stibp vmmcall fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid avx512f rdseed adx smap clflushopt clwb avx512cd sha_ni xsaveopt xsavec xgetbv1 clzero arat npt lbrv nrip_save tsc_scale vmcb_clean flushbyasid pausefilter pfthreshold pku rdpid flush_l1d arch_capabilities
# platform: x86_64
# speed: 3792
# type: AuthenticAMD
# governors: GOVERNORS NOT FOUND
# scaling: non-supported
# ------------------------------------------------------------------------- >8 ---
# Outcome: job passed
# [...]
```