### PR TITLE
Remove all glmark2 symlink hacks (Bugfix)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -8,6 +8,10 @@ adopt-info: version-calculator
 
 base: core
 
+layout: 
+  /usr/share/glmark2:
+    bind: $SNAP/usr/share/glmark2
+
 # Don't forget to add a new slot if a new provider part is added in the parts
 # section below.
 slots:

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -6,6 +6,10 @@ confinement: strict
 
 adopt-info: version-calculator
 
+layout: 
+  /usr/share/glmark2:
+    bind: $SNAP/usr/share/glmark2
+
 base: core18
 
 # Don't forget to add a new slot if a new provider part is added in the parts

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -8,6 +8,10 @@ adopt-info: version-calculator
 
 base: core20
 
+layout: 
+  /usr/share/glmark2:
+    bind: $SNAP/usr/share/glmark2
+
 # Don't forget to add a new slot if a new provider part is added in the parts
 # section below.
 slots:

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -8,6 +8,10 @@ adopt-info: version-calculator
 
 base: core22
 
+layout: 
+  /usr/share/glmark2:
+    bind: $SNAP/usr/share/glmark2
+
 # Don't forget to add a new slot if a new provider part is added in the parts
 # section below.
 slots:

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -66,6 +66,10 @@ plugs:
     content: custom-frontend
     target: $SNAP/custom_frontends/custom_frontend
 
+layout: 
+  /usr/share/glmark2:
+    bind: $SNAP/usr/share/glmark2
+
 apps:
   checkbox:
     command: bin/checkbox-cli

--- a/checkbox-snap/series_uc16/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc16/snap/snapcraft.yaml
@@ -9,6 +9,10 @@ confinement: strict
 
 base: core
 
+layout: 
+  /usr/share/glmark2:
+    symlink: $SNAP/checkbox-runtime/usr/share/glmark2
+
 plugs:
   checkbox-runtime:
     interface: content

--- a/checkbox-snap/series_uc18/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc18/snap/snapcraft.yaml
@@ -9,6 +9,10 @@ confinement: strict
 
 base: core18
 
+layout: 
+  /usr/share/glmark2:
+    symlink: $SNAP/checkbox-runtime/usr/share/glmark2
+
 plugs:
   checkbox-runtime:
     interface: content

--- a/checkbox-snap/series_uc20/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc20/snap/snapcraft.yaml
@@ -9,6 +9,10 @@ confinement: strict
 
 base: core20
 
+layout: 
+  /usr/share/glmark2:
+    symlink: $SNAP/checkbox-runtime/usr/share/glmark2
+
 plugs:
   checkbox-runtime:
     interface: content

--- a/checkbox-snap/series_uc22/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc22/snap/snapcraft.yaml
@@ -9,6 +9,11 @@ confinement: strict
 
 base: core22
 
+layout: 
+  /usr/share/glmark2:
+    symlink: $SNAP/checkbox-runtime/usr/share/glmark2
+
+
 plugs:
   checkbox-runtime:
     interface: content

--- a/checkbox-snap/series_uc24/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc24/snap/snapcraft.yaml
@@ -47,6 +47,10 @@ plugs:
     target: $SNAP/providers/checkbox-provider-certification-server
     default-provider: checkbox24
 
+layout: 
+  /usr/share/glmark2:
+    bind: $SNAP/checkbox-runtime/usr/share/glmark2
+
 apps:
   checkbox-cli:
     command-chain: [bin/wrapper_local]

--- a/checkbox-snap/series_uc24/snap/snapcraft.yaml
+++ b/checkbox-snap/series_uc24/snap/snapcraft.yaml
@@ -49,7 +49,7 @@ plugs:
 
 layout: 
   /usr/share/glmark2:
-    bind: $SNAP/checkbox-runtime/usr/share/glmark2
+    symlink: $SNAP/checkbox-runtime/usr/share/glmark2
 
 apps:
   checkbox-cli:

--- a/providers/base/bin/gl_support.py
+++ b/providers/base/bin/gl_support.py
@@ -4,6 +4,7 @@
 # Copyright 2024 Canonical Ltd.
 # Written by:
 #   Hanhsuan Lee <hanhsuan.lee@canonical.com>
+#   Zhongning Li <zhongning.li@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/base/bin/gl_support.py
+++ b/providers/base/bin/gl_support.py
@@ -23,15 +23,6 @@ import typing as T
 import os
 import platform
 import argparse
-from pathlib import Path
-
-
-# Checkbox could run in a snap container, so we need to prepend this root path
-try:
-    CHECKBOX_RUNTIME = Path(os.environ["CHECKBOX_RUNTIME"])
-except KeyError:  # from indexing os.environ
-    CHECKBOX_RUNTIME = None
-GLMARK2_DATA_PATH = Path("/usr/share/glmark2")
 
 
 class GLSupportTester:
@@ -113,14 +104,15 @@ class GLSupportTester:
         self, glmark2_executable_override: "str | None" = None
     ) -> str:
         """
-        Calls 'glmark2 --validate --offscreen' with the symlink hack,
-        but allow errors to be thrown unlike reboot_check_test.py
+        Calls 'glmark2 --validate --offscreen' but allow errors to be thrown early
 
         :raises SystemExit: when XDG_SESSION_TYPE is not x11/wayland
         :return: stdout of `glmark2 --validate`
         """
 
         XDG_SESSION_TYPE = os.environ.get("XDG_SESSION_TYPE")
+        XDG_RUNTIME_DIR = os.environ.get("XDG_RUNTIME_DIR")
+
         if XDG_SESSION_TYPE not in ("x11", "wayland"):
             # usually it's tty if we get here,
             # happens when gnome failed to start or not using graphical session
@@ -130,6 +122,7 @@ class GLSupportTester:
             )
 
         print("XDG_SESSION type used by the desktop is:", XDG_SESSION_TYPE)
+        print("XDG_RUNTIME_DIR is:", XDG_RUNTIME_DIR)
 
         if glmark2_executable_override is not None:
             if shutil.which(glmark2_executable_override) is None:
@@ -144,38 +137,14 @@ class GLSupportTester:
                 XDG_SESSION_TYPE, platform.uname().machine
             )
 
-        try:
-            if CHECKBOX_RUNTIME and not os.path.exists(GLMARK2_DATA_PATH):
-                # the official way to specify the location of the data files
-                # is "--data-path path/to/data/files"
-                # but 16, 18, 20 doesn't have this option
-                # and the /usr/share/glmark2 path is hard-coded inside glmark2
-                # by the GLMARK_DATA_PATH build macro
-                src = CHECKBOX_RUNTIME / GLMARK2_DATA_PATH
-                dst = GLMARK2_DATA_PATH
-                print(
-                    "[ DEBUG ] Symlinking glmark2 data dir ({} -> {})".format(
-                        src, dst
-                    )
-                )
-                os.symlink(src, dst, target_is_directory=True)
-            # override is needed for snaps on classic ubuntu
-            # to allow the glmark2 command itself to be discovered
-            # in debian version of checkbox this line does nothing
-            glmark2_output = sp.check_output(
-                # all glmark2 programs share the same args
-                [glmark2_executable, "--off-screen", "--validate"],
-                universal_newlines=True,
-                # be more relaxed on this timeout in case
-                # the device needs a lot of time to wake up the GPU
-                timeout=120,
-            )
-            return glmark2_output
-        finally:
-            # immediately cleanup
-            if CHECKBOX_RUNTIME and os.path.islink(GLMARK2_DATA_PATH):
-                print("[ DEBUG ] Un-symlinking glmark2 data")
-                os.unlink(GLMARK2_DATA_PATH)
+        return sp.check_output(
+            # all glmark2 programs share the same args
+            [glmark2_executable, "--off-screen", "--validate"],
+            universal_newlines=True,
+            # be more relaxed on this timeout in case
+            # the device needs a lot of time to wake up the GPU
+            timeout=120,
+        )
 
 
 def remove_prefix(s: str, prefix: str) -> str:

--- a/providers/base/bin/gl_support.py
+++ b/providers/base/bin/gl_support.py
@@ -151,7 +151,7 @@ class GLSupportTester:
                 # but 16, 18, 20 doesn't have this option
                 # and the /usr/share/glmark2 path is hard-coded inside glmark2
                 # by the GLMARK_DATA_PATH build macro
-                src = CHECKBOX_RUNTIME / GLMARK2_DATA_PATH
+                src = CHECKBOX_RUNTIME / (str(GLMARK2_DATA_PATH).lstrip("/"))
                 dst = GLMARK2_DATA_PATH
                 print(
                     "[ DEBUG ] Symlinking glmark2 data dir ({} -> {})".format(

--- a/providers/base/bin/gl_support.py
+++ b/providers/base/bin/gl_support.py
@@ -56,7 +56,7 @@ class GLSupportTester:
         """Checks if gl_renderer is produced by a hardware renderer.
 
         This uses the same logic as unity_support_test. Details:
-        https://github.com/canonical/checkbox/issues/1630#issuecomment-2540843110
+        https://github.com/canonical/checkbox/issues/1630#issuecomment-2540843110 # noqa: E501
 
         :param gl_renderer: the GL_RENDERER string.
         https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetString.xhtml
@@ -104,7 +104,8 @@ class GLSupportTester:
         self, glmark2_executable_override: "str | None" = None
     ) -> str:
         """
-        Calls 'glmark2 --validate --offscreen' but allow errors to be thrown early
+        Calls 'glmark2 --validate --offscreen'
+        but allow errors to be thrown early
 
         :raises SystemExit: when XDG_SESSION_TYPE is not x11/wayland
         :return: stdout of `glmark2 --validate`

--- a/providers/base/bin/gl_support.py
+++ b/providers/base/bin/gl_support.py
@@ -151,7 +151,7 @@ class GLSupportTester:
                 # but 16, 18, 20 doesn't have this option
                 # and the /usr/share/glmark2 path is hard-coded inside glmark2
                 # by the GLMARK_DATA_PATH build macro
-                src = CHECKBOX_RUNTIME / (str(GLMARK2_DATA_PATH).lstrip("/"))
+                src = CHECKBOX_RUNTIME / GLMARK2_DATA_PATH
                 dst = GLMARK2_DATA_PATH
                 print(
                     "[ DEBUG ] Symlinking glmark2 data dir ({} -> {})".format(

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -48,13 +48,14 @@ def get_current_boot_id() -> str:
         # journalctl doesn't use hyphens so we just remove it
         return f.read().strip().replace("-", "")
 
+  # TODO: use path objects for these 
 
 # Snap mount point, see
 # https://snapcraft.io/docs/environment-variables#heading--snap
 SNAP = os.getenv("SNAP", default="").rstrip("/")
 # global const for subprocess calls that should timeout
 COMMAND_TIMEOUT_SECONDS = 30
-CHECKBOX_RUNTIME = get_checkbox_runtime_path() or ""  # TODO: use path objects
+CHECKBOX_RUNTIME = (get_checkbox_runtime_path() or "").rstrip("/")
 
 
 class DeviceInfoCollector:

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -444,7 +444,6 @@ class HardwareRendererTester:
         glmark2_executable = self.pick_glmark2_executable(
             XDG_SESSION_TYPE, platform.uname().machine
         )
-        glmark2_data_path = "/usr/share/glmark2"
 
         try:
             # PATH override is needed for snaps on classic ubuntu

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -48,7 +48,8 @@ def get_current_boot_id() -> str:
         # journalctl doesn't use hyphens so we just remove it
         return f.read().strip().replace("-", "")
 
-  # TODO: use path objects for these 
+
+# TODO: use path objects for these
 
 # Snap mount point, see
 # https://snapcraft.io/docs/environment-variables#heading--snap

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -12,13 +12,22 @@ from datetime import datetime
 import time
 import platform
 
-# Checkbox could run in a snap container, so we need to prepend this root path
-CHECKBOX_RUNTIME = os.getenv("CHECKBOX_RUNTIME", default="").rstrip("/")
-# Snap mount point, see
-# https://snapcraft.io/docs/environment-variables#heading--snap
-SNAP = os.getenv("SNAP", default="").rstrip("/")
-# global const for subprocess calls that should timeout
-COMMAND_TIMEOUT_SECONDS = 30
+
+def get_checkbox_runtime_path() -> "str | None":
+    """Finds the correct checkbox runtime path in $CHECKBOX_RUNTIME
+    CHECKBOX_RUNTIME is a string of paths separated by \n
+    Only the /snap/checkbox/checkbox-runtime/... lines is the one we need
+    Iter the lines and find it
+
+    :return: None if not in a snap or failed to find this
+    """
+    if "CHECKBOX_RUNTIME" not in os.environ:
+        return None
+
+    lines = os.environ["CHECKBOX_RUNTIME"].strip().splitlines()
+    for line in lines:
+        if "checkbox-runtime" in line:
+            return line
 
 
 def get_timestamp_str() -> str:
@@ -38,6 +47,14 @@ def get_current_boot_id() -> str:
         # the boot_id file has a Version 4 UUID with hyphens
         # journalctl doesn't use hyphens so we just remove it
         return f.read().strip().replace("-", "")
+
+
+# Snap mount point, see
+# https://snapcraft.io/docs/environment-variables#heading--snap
+SNAP = os.getenv("SNAP", default="").rstrip("/")
+# global const for subprocess calls that should timeout
+COMMAND_TIMEOUT_SECONDS = 30
+CHECKBOX_RUNTIME = get_checkbox_runtime_path() or "" # TODO: use path objects 
 
 
 class DeviceInfoCollector:

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -54,7 +54,7 @@ def get_current_boot_id() -> str:
 SNAP = os.getenv("SNAP", default="").rstrip("/")
 # global const for subprocess calls that should timeout
 COMMAND_TIMEOUT_SECONDS = 30
-CHECKBOX_RUNTIME = get_checkbox_runtime_path() or "" # TODO: use path objects 
+CHECKBOX_RUNTIME = get_checkbox_runtime_path() or ""  # TODO: use path objects
 
 
 class DeviceInfoCollector:

--- a/providers/base/tests/test_gl_support.py
+++ b/providers/base/tests/test_gl_support.py
@@ -137,8 +137,7 @@ class TestGLSupportTests(ut.TestCase):
 
                 if is_snap:
                     mock_symlink.assert_called_once_with(
-                        gl_support.CHECKBOX_RUNTIME
-                        / gl_support.GLMARK2_DATA_PATH,
+                        PosixPath("/snap/runtime/path/usr/share/glmark2"),
                         PosixPath("/usr/share/glmark2"),
                         target_is_directory=True,
                     )

--- a/providers/base/tests/test_gl_support.py
+++ b/providers/base/tests/test_gl_support.py
@@ -137,7 +137,8 @@ class TestGLSupportTests(ut.TestCase):
 
                 if is_snap:
                     mock_symlink.assert_called_once_with(
-                        PosixPath("/snap/runtime/path/usr/share/glmark2"),
+                        gl_support.CHECKBOX_RUNTIME
+                        / gl_support.GLMARK2_DATA_PATH,
                         PosixPath("/usr/share/glmark2"),
                         target_is_directory=True,
                     )


### PR DESCRIPTION
## Description

This is the followup PR for #2281 that removes all symlink hacks.

## Resolved issues

1. Remove all symlink hacks
2. CHECKBOX_RUNTIME has multiple lines. Added a function that explicitly searches for `$SNAP/checkbox-runtime`

## Documentation

## Tests

C3 submissions:
- classic desktop
- ubuntu frame
