### PR TITLE
Add screen-private-ppa test (New)

### DIFF
--- a/providers/base/units/miscellanea/jobs.pxu
+++ b/providers/base/units/miscellanea/jobs.pxu
@@ -568,6 +568,27 @@ requires:
   bootloader.name == "grub"
 command: grub_file_check.sh
 
+plugin: shell
+category_id: com.canonical.plainbox::miscellanea
+id: miscellanea/screen-private-ppa
+user: root
+command:
+  echo "Checking for private PPAs in /etc/apt/sources.list and /etc/apt/sources.list.d/*"
+  if grep -qrE 'private-ppa.launchpad.net' "/etc/apt/sources.list"* ; then
+      echo 'The following files have private PPA access'
+      grep -lrE 'private-ppa.launchpad.net' "/etc/apt/sources.list"*
+      exit 1
+  fi
+  if grep -qrE 'private-ppa.launchpadcontent.net' "/etc/apt/sources.list"* ; then
+      echo 'The following files have private PPA access'
+      grep -lrE 'private-ppa.launchpadcontent.net' "/etc/apt/sources.list"*
+      exit 1
+  fi
+  echo "No private PPAs found in sources list files."
+_summary: check if any private ppas are added
+_description:
+ This checks if any private ppas are added to the system, fails if any found.
+
 plugin: manual
 category_id: com.canonical.plainbox::miscellanea
 id: miscellanea/wallpaper


### PR DESCRIPTION
## WARNING: This modifies com.canonical.certification::sru-server

## Description

This test is to avoid any leak of private PPA credentials in the release image.
This checks if any private PPAs are present in the system, fails if present. 

adds `miscellanea/screen-private-ppa` test to base

This is same as https://github.com/canonical/checkbox/pull/2212, but I want to the test in base provider instead.

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/PECA-1148

## Documentation

## Tests

Tested on Qualcomm RB3Gen2 Lite, should work on any system.