### PR TITLE
Workaround bad CHECKBOX_RUNTIME value in gl_support and reboot tests and fix bad path in gl_support (Bugfix)

### DIFF
--- a/providers/base/bin/gl_support.py
+++ b/providers/base/bin/gl_support.py
@@ -34,6 +34,7 @@ if "SNAP" in os.environ:
     if in_classic_snap():
         CHECKBOX_RUNTIME = Path(os.environ["CHECKBOX_RUNTIME"])
     else:
+        # in strict frontend, CHECKBOX_RUNTIME has multiple lines
         CHECKBOX_RUNTIME = Path(os.environ["SNAP"]) / "checkbox-runtime"
 
 GLMARK2_DATA_PATH = Path("/usr/share/glmark2")

--- a/providers/base/bin/gl_support.py
+++ b/providers/base/bin/gl_support.py
@@ -26,10 +26,10 @@ import argparse
 from pathlib import Path
 from checkbox_support.snap_utils.system import in_classic_snap
 
-GLMARK2_DATA_ABS_PATH = Path("/usr/share/glmark2")
-
 
 class GLSupportTester:
+
+    GLMARK2_DATA_ABS_PATH = Path("/usr/share/glmark2")
 
     def __init__(self) -> None:
         if "SNAP" in os.environ:
@@ -154,7 +154,7 @@ class GLSupportTester:
 
         try:
             if self.CHECKBOX_RUNTIME and not os.path.exists(
-                GLMARK2_DATA_ABS_PATH
+                self.GLMARK2_DATA_ABS_PATH
             ):
                 # the official way to specify the location of the data files
                 # is "--data-path path/to/data/files"
@@ -165,7 +165,7 @@ class GLSupportTester:
                 # do not directly truediv against GLMARK2_DATA_PATH
                 # absolute path on the right will overwrite the left hand side
                 src = self.CHECKBOX_RUNTIME / "usr" / "share" / "glmark2"
-                dst = GLMARK2_DATA_ABS_PATH
+                dst = self.GLMARK2_DATA_ABS_PATH
                 print(
                     "[ DEBUG ] Symlinking glmark2 data dir ({} -> {})".format(
                         src, dst
@@ -184,9 +184,11 @@ class GLSupportTester:
             return glmark2_output
         finally:
             # immediately cleanup
-            if self.CHECKBOX_RUNTIME and os.path.islink(GLMARK2_DATA_ABS_PATH):
+            if self.CHECKBOX_RUNTIME and os.path.islink(
+                self.GLMARK2_DATA_ABS_PATH
+            ):
                 print("[ DEBUG ] Un-symlinking glmark2 data")
-                os.unlink(GLMARK2_DATA_ABS_PATH)
+                os.unlink(self.GLMARK2_DATA_ABS_PATH)
 
 
 def remove_prefix(s: str, prefix: str) -> str:

--- a/providers/base/bin/gl_support.py
+++ b/providers/base/bin/gl_support.py
@@ -32,13 +32,9 @@ CHECKBOX_RUNTIME = None
 if "SNAP" in os.environ:
     # don't use $CHECKBOX_RUNTIME in Path() unless in classic
     if in_classic_snap():
-        CHECKBOX_RUNTIME = Path(  # pyright: ignore[reportConstantRedefinition]
-            os.environ["CHECKBOX_RUNTIME"]
-        )
+        CHECKBOX_RUNTIME = Path(os.environ["CHECKBOX_RUNTIME"])
     else:
-        CHECKBOX_RUNTIME = (  # pyright: ignore[reportConstantRedefinition]
-            Path(os.environ["SNAP"]) / "checkbox-runtime"
-        )
+        CHECKBOX_RUNTIME = Path(os.environ["SNAP"]) / "checkbox-runtime"
 
 GLMARK2_DATA_PATH = Path("/usr/share/glmark2")
 

--- a/providers/base/bin/gl_support.py
+++ b/providers/base/bin/gl_support.py
@@ -24,14 +24,22 @@ import os
 import platform
 import argparse
 from pathlib import Path
-
+from checkbox_support.snap_utils.system import in_classic_snap
 
 # Checkbox could run in a snap container, so we need to prepend this root path
-try:
-    # don't use $CHECKBOX_RUNTIME in Path(), it has multiple paths
-    CHECKBOX_RUNTIME = Path(os.environ["SNAP"]) / "checkbox-runtime"
-except KeyError:  # from indexing os.environ
-    CHECKBOX_RUNTIME = None  # pyright: ignore[reportConstantRedefinition]
+
+CHECKBOX_RUNTIME = None
+if "SNAP" in os.environ:
+    # don't use $CHECKBOX_RUNTIME in Path() unless in classic
+    if in_classic_snap():
+        CHECKBOX_RUNTIME = Path(  # pyright: ignore[reportConstantRedefinition]
+            os.environ["CHECKBOX_RUNTIME"]
+        )
+    else:
+        CHECKBOX_RUNTIME = (  # pyright: ignore[reportConstantRedefinition]
+            Path(os.environ["SNAP"]) / "checkbox-runtime"
+        )
+
 GLMARK2_DATA_PATH = Path("/usr/share/glmark2")
 
 

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -12,11 +12,13 @@ from datetime import datetime
 import time
 import platform
 
-# Checkbox could run in a snap container, so we need to prepend this root path
-RUNTIME_ROOT = os.getenv("CHECKBOX_RUNTIME", default="").rstrip("/")
 # Snap mount point, see
 # https://snapcraft.io/docs/environment-variables#heading--snap
 SNAP = os.getenv("SNAP", default="").rstrip("/")
+if SNAP:
+    RUNTIME_ROOT = "{}/checkbox-runtime".format(SNAP)
+else:
+    RUNTIME_ROOT = ""  # pyright: ignore[reportConstantRedefinition]
 # global const for subprocess calls that should timeout
 COMMAND_TIMEOUT_SECONDS = 30
 

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -12,13 +12,20 @@ from datetime import datetime
 import time
 import platform
 
+from checkbox_support.snap_utils.system import in_classic_snap
+
 # Snap mount point, see
 # https://snapcraft.io/docs/environment-variables#heading--snap
 SNAP = os.getenv("SNAP", default="").rstrip("/")
 if SNAP:
-    RUNTIME_ROOT = "{}/checkbox-runtime".format(SNAP)
+    if in_classic_snap():
+        RUNTIME_ROOT = os.environ["CHECKBOX_RUNTIME"].rstrip("/")
+    else:
+        RUNTIME_ROOT = "{}/checkbox-runtime".format(SNAP)
 else:
-    RUNTIME_ROOT = ""  # pyright: ignore[reportConstantRedefinition]
+    RUNTIME_ROOT = ""
+
+
 # global const for subprocess calls that should timeout
 COMMAND_TIMEOUT_SECONDS = 30
 

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -19,13 +19,13 @@ from checkbox_support.snap_utils.system import in_classic_snap
 SNAP = os.getenv("SNAP", default="").rstrip("/")
 if SNAP:
     if in_classic_snap():
-        RUNTIME_ROOT = os.environ["CHECKBOX_RUNTIME"].rstrip("/")
+        CHECKBOX_RUNTIME = os.environ["CHECKBOX_RUNTIME"].rstrip("/")
     else:
         # in strict frontend, CHECKBOX_RUNTIME has multiple lines
         # explicitly build this path
-        RUNTIME_ROOT = "{}/checkbox-runtime".format(SNAP)
+        CHECKBOX_RUNTIME = "{}/checkbox-runtime".format(SNAP)
 else:
-    RUNTIME_ROOT = ""
+    CHECKBOX_RUNTIME = ""
 
 
 # global const for subprocess calls that should timeout
@@ -95,7 +95,7 @@ class DeviceInfoCollector:
             [
                 "checkbox-support-lsusb",
                 "-f",
-                '"{}"/var/lib/usbutils/usb.ids'.format(RUNTIME_ROOT),
+                '"{}"/var/lib/usbutils/usb.ids'.format(CHECKBOX_RUNTIME),
                 "-s",
             ],
             universal_newlines=True,
@@ -437,13 +437,13 @@ class HardwareRendererTester:
         glmark2_data_path = "/usr/share/glmark2"
 
         try:
-            if RUNTIME_ROOT and not os.path.exists(glmark2_data_path):
+            if CHECKBOX_RUNTIME and not os.path.exists(glmark2_data_path):
                 # the official way to specify the location of the data files
                 # is "--data-path path/to/data/files"
                 # but 16, 18, 20 doesn't have this option
                 # and the /usr/share/glmark2 is hard-coded inside glmark2
                 # by the GLMARK_DATA_PATH build macro
-                src = "{}/usr/share/glmark2".format(RUNTIME_ROOT)
+                src = "{}/usr/share/glmark2".format(CHECKBOX_RUNTIME)
                 dst = glmark2_data_path
                 print(
                     "[ DEBUG ] Symlinking glmark2 data dir ({} -> {})".format(
@@ -475,7 +475,7 @@ class HardwareRendererTester:
             return False
         finally:
             # immediately cleanup
-            if RUNTIME_ROOT and os.path.islink(glmark2_data_path):
+            if CHECKBOX_RUNTIME and os.path.islink(glmark2_data_path):
                 print("[ DEBUG ] Un-symlinking glmark2 data")
                 os.unlink(glmark2_data_path)
 

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -21,6 +21,8 @@ if SNAP:
     if in_classic_snap():
         RUNTIME_ROOT = os.environ["CHECKBOX_RUNTIME"].rstrip("/")
     else:
+        # in strict frontend, CHECKBOX_RUNTIME has multiple lines
+        # explicitly build this path
         RUNTIME_ROOT = "{}/checkbox-runtime".format(SNAP)
 else:
     RUNTIME_ROOT = ""

--- a/providers/base/tests/test_gl_support.py
+++ b/providers/base/tests/test_gl_support.py
@@ -289,7 +289,7 @@ class TestGLSupportTests(ut.TestCase):
                 PosixPath("/snap/checkbox/20486/checkbox-runtime"),
             )
 
-        with patch.dict({}, clear=True):
+        with patch.dict("os.environ", {}, clear=True):
             mock_in_classic_snap.return_value = False
             tester = gl_support.GLSupportTester()
             self.assertEqual(

--- a/providers/base/tests/test_gl_support.py
+++ b/providers/base/tests/test_gl_support.py
@@ -288,7 +288,7 @@ class TestGLSupportTests(ut.TestCase):
                 tester.CHECKBOX_RUNTIME,
                 PosixPath("/snap/checkbox/20486/checkbox-runtime"),
             )
-        
+
         with patch.dict({}, clear=True):
             mock_in_classic_snap.return_value = False
             tester = gl_support.GLSupportTester()

--- a/providers/base/tests/test_gl_support.py
+++ b/providers/base/tests/test_gl_support.py
@@ -166,8 +166,8 @@ class TestGLSupportTests(ut.TestCase):
                 {
                     "DISPLAY": ":0",
                     "XDG_SESSION_TYPE": "wayland",
-                }
-                | (snap_env_dict if is_snap else {}),
+                    **(snap_env_dict if is_snap else {}),
+                },
             ):
                 mock_islink.return_value = is_snap
                 # deb case, the file actually exists

--- a/providers/base/tests/test_gl_support.py
+++ b/providers/base/tests/test_gl_support.py
@@ -137,8 +137,7 @@ class TestGLSupportTests(ut.TestCase):
 
                 if is_snap:
                     mock_symlink.assert_called_once_with(
-                        gl_support.CHECKBOX_RUNTIME
-                        / gl_support.GLMARK2_DATA_PATH,
+                        PosixPath("/snap/runtime/path/usr/share/glmark2"),
                         PosixPath("/usr/share/glmark2"),
                         target_is_directory=True,
                     )

--- a/providers/base/tests/test_gl_support.py
+++ b/providers/base/tests/test_gl_support.py
@@ -149,6 +149,17 @@ class TestGLSupportTests(ut.TestCase):
     ):
         mock_pick_glmark2_executable.return_value = "glmark2"
         mock_in_classic_snap.return_value = False
+        snap_env_dict = {
+            "CHECKBOX_RUNTIME": "\n".join(
+                [
+                    "/snap/checkbox24/1437",
+                    "/snap/checkbox/20486/checkbox-runtime",
+                    "/snap/checkbox/20486/providers/blah-blah",
+                ]
+            ),
+            "SNAP": "/snap/checkbox/20486",
+        }
+
         for is_snap in (True, False):
             with patch.dict(
                 "os.environ",
@@ -156,20 +167,7 @@ class TestGLSupportTests(ut.TestCase):
                     "DISPLAY": ":0",
                     "XDG_SESSION_TYPE": "wayland",
                 }
-                | (
-                    {
-                        "CHECKBOX_RUNTIME": "\n".join(
-                            [
-                                "/snap/checkbox24/1437",
-                                "/snap/checkbox/20486/checkbox-runtime",
-                                "/snap/checkbox/20486/providers/blah-blah",
-                            ]
-                        ),
-                        "SNAP": "/snap/checkbox/20486",
-                    }
-                    if is_snap
-                    else {}
-                ),
+                | (snap_env_dict if is_snap else {}),
             ):
                 mock_islink.return_value = is_snap
                 # deb case, the file actually exists

--- a/providers/base/tests/test_gl_support.py
+++ b/providers/base/tests/test_gl_support.py
@@ -131,7 +131,9 @@ class TestGLSupportTests(ut.TestCase):
                 mock_path_exists.return_value = not is_snap
                 # hack for this unittest, since we import gl_support early
                 # so the variable assignment was already done during import
-                gl_support.CHECKBOX_RUNTIME = PosixPath("/snap/checkbox/20486/")
+                gl_support.CHECKBOX_RUNTIME = PosixPath(
+                    "/snap/checkbox/20486/"
+                )
 
                 tester.call_glmark2_validate()
 

--- a/providers/base/tests/test_gl_support.py
+++ b/providers/base/tests/test_gl_support.py
@@ -251,6 +251,52 @@ class TestGLSupportTests(ut.TestCase):
             "glmark2-es2",
         )
 
+    @patch("gl_support.in_classic_snap")
+    def test_checkbox_runtime_path(self, mock_in_classic_snap: MagicMock):
+        with patch.dict(
+            "os.environ",
+            {
+                "CHECKBOX_RUNTIME": "\n".join(
+                    [
+                        "/snap/checkbox24/1437",
+                        "/snap/checkbox/20486/checkbox-runtime",
+                        "/snap/checkbox/20486/providers/blah-blah",
+                    ]
+                ),
+                "SNAP": "/snap/checkbox/20486",
+            },
+            clear=True,
+        ):
+            mock_in_classic_snap.return_value = False
+            tester = gl_support.GLSupportTester()
+            self.assertEqual(
+                tester.CHECKBOX_RUNTIME,
+                PosixPath("/snap/checkbox/20486/checkbox-runtime"),
+            )
+
+        with patch.dict(
+            "os.environ",
+            {
+                "CHECKBOX_RUNTIME": "/snap/checkbox/20486/checkbox-runtime",
+                "SNAP": "/snap/checkbox/20486",
+            },
+            clear=True,
+        ):
+            mock_in_classic_snap.return_value = True
+            tester = gl_support.GLSupportTester()
+            self.assertEqual(
+                tester.CHECKBOX_RUNTIME,
+                PosixPath("/snap/checkbox/20486/checkbox-runtime"),
+            )
+        
+        with patch.dict({}, clear=True):
+            mock_in_classic_snap.return_value = False
+            tester = gl_support.GLSupportTester()
+            self.assertEqual(
+                tester.CHECKBOX_RUNTIME,
+                None,
+            )
+
 
 if __name__ == "__main__":
     ut.main()

--- a/providers/base/tests/test_gl_support.py
+++ b/providers/base/tests/test_gl_support.py
@@ -131,13 +131,13 @@ class TestGLSupportTests(ut.TestCase):
                 mock_path_exists.return_value = not is_snap
                 # hack for this unittest, since we import gl_support early
                 # so the variable assignment was already done during import
-                gl_support.CHECKBOX_RUNTIME = PosixPath("/snap/runtime/path/")
+                gl_support.CHECKBOX_RUNTIME = PosixPath("/snap/checkbox/20486/")
 
                 tester.call_glmark2_validate()
 
                 if is_snap:
                     mock_symlink.assert_called_once_with(
-                        PosixPath("/snap/runtime/path/usr/share/glmark2"),
+                        PosixPath("/snap/checkbox/20486/usr/share/glmark2"),
                         PosixPath("/usr/share/glmark2"),
                         target_is_directory=True,
                     )

--- a/providers/base/tests/test_reboot_check_test.py
+++ b/providers/base/tests/test_reboot_check_test.py
@@ -428,7 +428,7 @@ class InfoDumpTests(unittest.TestCase):
         shutil.rmtree(self.temp_output_dir, ignore_errors=True)
         shutil.rmtree(self.temp_comparison_dir, ignore_errors=True)
 
-    def mock_run(self, args: T.List[str], **_) -> sp.CompletedProcess[str]:
+    def mock_run(self, args: T.List[str], **_) -> sp.CompletedProcess:
         stdout = ""
         if args[0] == "iw":
             stdout = """\

--- a/providers/base/tests/test_reboot_check_test.py
+++ b/providers/base/tests/test_reboot_check_test.py
@@ -20,7 +20,7 @@ class DisplayConnectionTests(unittest.TestCase):
 
     def setUp(self) -> None:
         self.tester = RCT.HardwareRendererTester()
-        RCT.RUNTIME_ROOT = ""
+        RCT.CHECKBOX_RUNTIME = ""
         RCT.SNAP = ""
 
     def test_display_check_happy_path(self):
@@ -346,7 +346,7 @@ class DisplayConnectionTests(unittest.TestCase):
                 mock_run.side_effect = sp.TimeoutExpired("glmark2", 120)
             for is_snap in (True, False):
                 mock_getenv.side_effect = lambda k: custom_env(k, is_snap)
-                RCT.RUNTIME_ROOT = custom_env("CHECKBOX_RUNTIME", is_snap)
+                RCT.CHECKBOX_RUNTIME = custom_env("CHECKBOX_RUNTIME", is_snap)
                 RCT.SNAP = custom_env("SNAP", is_snap)
                 mock_islink.return_value = is_snap
                 # deb case, the file actually exists
@@ -357,7 +357,7 @@ class DisplayConnectionTests(unittest.TestCase):
 
                 if is_snap:
                     mock_symlink.assert_called_once_with(
-                        "{}/usr/share/glmark2".format(RCT.RUNTIME_ROOT),
+                        "{}/usr/share/glmark2".format(RCT.CHECKBOX_RUNTIME),
                         "/usr/share/glmark2",
                         target_is_directory=True,
                     )


### PR DESCRIPTION
## Description

This PR is a workaround for #2295. Explicitly constructing CHECKBOX_RUNTIME sort of avoids this problem for now.

## Resolved issues

$CHECKBOX_RUNTIME looks like this:

```
$ echo $CHECKBOX_RUNTIME

/snap/checkbox24/1417 /snap/checkbox/20486/checkbox-runtime /snap/checkbox/20486/providers/checkbox-provider-certification-client /snap/checkbox/20486/providers/checkbox-provider-certification-server /snap/checkbox/20486/providers/checkbox-provider-checkbox /snap/checkbox/20486/providers/checkbox-provider-docker /snap/checkbox/20486/providers/checkbox-provider-gpgpu /snap/checkbox/20486/providers/checkbox-provider-resource /snap/checkbox/20486/providers/checkbox-provider-sru /snap/checkbox/20486/providers/checkbox-provider-tpm2
```

but we only want `/snap/checkbox/20486/checkbox-runtime`, which can be constructed with `$SNAP/checkbox-runtime`.

Also fixed the issue with `CHECKBOX_RUNTIME / GLMARK2_DATA_PATH` resolving to just GLMARK2_DATA_PATH. Originally GLMARK2_DATA_PATH had a leading slash which would override CHECKBOX_RUNTIME when using the truediv operator `/`. 

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

Classic frontend gl support test: https://certification.canonical.com/hardware/201812-26713/submission/470611/

> [!IMPORTANT]  
> That submission was done with `checkbox control <ip>`. If we directly run checkbox.checkbox-cli, it will fail because XDG_SESSION_TYPE is not captured.

Strict frontend gl support test: https://certification.canonical.com/hardware/201812-26713/submission/470624/
- Supposed to fail on desktop, but the arguments to os.symlink is correct

Classic frontend reboot test: https://certification.canonical.com/hardware/201812-26713/submission/470628/

