### PR TITLE
Dont use SNAP_USER_COMMON as it is not always normal-user readable (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -837,7 +837,9 @@ def get_execution_command_systemd_unit(
     # this location must be accessible and in the same path for both this
     # process (that may be inside a snap) and the systemd unit (which is not)
     # fallback mechanism is for debian/source checkbox
-    shared_location = os.getenv("SNAP_USER_COMMON", "/var/tmp")
+    # DONT use SNAP_COMMON (not writable by normal user)
+    # DONT use SNAP_USER_COMMON (not writable by normal user if running as root)
+    shared_location = "/var/tmp"
     if on_ubuntucore():
         if target_user != "root":
             # here we need a dangerous copy of nsenter that works as "normal"


### PR DESCRIPTION
## Description

Remote is broken and doesn't work when using it because it is not readable/wriable by normal user

## Resolved issues

N/A

## Documentation

N/A

## Tests

Do the same steps of the previous PR but this time also run remote. On edge it doesn't work as remote is root, therefore SNAP_USER_COMMON is SNAP_COMMON, aka: not readable by normal user

See: https://github.com/canonical/checkbox/pull/2286
