### PR TITLE
Use AmbientCapabilities on non-core16 systems (bugfix)

### DIFF
--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -198,6 +198,7 @@ parts:
       - zlib1g-dev
       - build-essential
     stage-packages:
+      - setpriv # used to downgrade AmbientCapabilities of systemd-based runner
       - python3-markupsafe
       - python3-jinja2
       - python3-packaging

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -206,6 +206,7 @@ parts:
       - zlib1g-dev
       - build-essential
     stage-packages:
+      - setpriv # used to downgrade AmbientCapabilities of systemd-based runner
       - python3-markupsafe
       - python3-jinja2
       - python3-packaging

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -213,6 +213,7 @@ parts:
       - zlib1g-dev
       - build-essential
     stage-packages:
+      - setpriv # used to downgrade AmbientCapabilities of systemd-based runner
       - python3-markupsafe
       - python3-jinja2
       - python3-packaging

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -154,6 +154,7 @@ parts:
     source: checkbox-support
     source-type: local
     stage-packages:
+      - setpriv # used to downgrade AmbientCapabilities of systemd-based runner
       # actual requirements
       - python3-bluez
       - python3-pyparsing

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -853,8 +853,6 @@ def get_snap_mount_namespace_commands(target_user, shared_location):
         # when not on ubuntucore, there is no snap namespace to mount
         return wrapper_cmd, cmd, namespace_mounting_helper
     dangerous_nsenter_path = None
-    snap_base = get_snap_base()
-
     # mounting namespaces is not allowed as non-root, the following makes it
     # possible
     if mounting_strategy == MountingStrategy.MOUNT_DANGEROUS_NSENTER:

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -776,17 +776,13 @@ def dangerous_nsenter(path):
     """
     Creates a dangerous nsenter copy at path with cap_sys_admin,cap_sys_chroot
     """
-    if path is None:
-        # this command doens't need dangerous nsenter
-        yield path
-        return
     try:
         # here recover setcap and nsenter binaries path outside the sandbox
         runtime_path = get_checkbox_runtime_path()
         runtime_nsenter = runtime_path / "usr" / "bin" / "nsenter"
         # Note: this path only works on core<24, on core24+ this is in
-        #       /usr/sbin but this code should only work on core16, so this is
-        #       fine
+        #       /usr/sbin but this code should only be used on core16, so this
+        #       is fine
         runtime_setcap = runtime_path / "sbin" / "setcap"
         setcap_path = str(runtime_setcap)
         nsenter_path = str(runtime_nsenter)

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -802,16 +802,17 @@ def dangerous_nsenter(path):
         run(get_plz_run(["rm", path]))
 
 
+# TODO: use enum.auto once python3.5 support is dropped
 class MountingStrategy(enum.Enum):
     # mount is not needed in this context
-    DONT_MOUNT = enum.auto()
+    DONT_MOUNT = 0
     # mount is needed but not permission is required
-    MOUNT_ROOT = enum.auto()
+    MOUNT_ROOT = 1
     # mount is needed and permission has to be aquired via dangerous nsenter
-    MOUNT_DANGEROUS_NSENTER = enum.auto()
+    MOUNT_DANGEROUS_NSENTER = 2
     # mount is needed and permission has to be aquired via ambient capabilities
     # this is the preferred option when available and needed
-    MOUNT_AMBIENT_CAPABILITIES = enum.auto()
+    MOUNT_AMBIENT_CAPABILITIES = 3
 
     @classmethod
     def from_user_core(cls, job_user, on_core, snap_base):

--- a/checkbox-ng/plainbox/impl/test_execution.py
+++ b/checkbox-ng/plainbox/impl/test_execution.py
@@ -18,6 +18,8 @@
 
 import contextlib
 
+from pathlib import Path
+
 from plainbox.impl.execution import (
     UnifiedRunner,
     get_execution_command_systemd_unit,
@@ -61,8 +63,10 @@ class UnifiedRunnerTests(TestCase):
     @mock.patch("shutil.which")
     @mock.patch("plainbox.impl.execution.get_execution_environment")
     @mock.patch("plainbox.impl.execution.on_ubuntucore")
+    @mock.patch("plainbox.impl.execution.get_snap_base")
     def test_get_execution_command_systemd_unit_command_and_envvars(
         self,
+        mock_get_snap_base,
         mock_on_ubuntucore,
         mock_get_diff_env,
         mock_shutil_which,
@@ -97,10 +101,14 @@ class UnifiedRunnerTests(TestCase):
     @mock.patch("shutil.which")
     @mock.patch("plainbox.impl.execution.get_execution_environment")
     @mock.patch("plainbox.impl.execution.on_ubuntucore")
+    @mock.patch("plainbox.impl.execution.get_snap_base")
+    @mock.patch("plainbox.impl.execution.get_checkbox_runtime_path")
     @mock.patch("os.getenv")
     def test_get_execution_command_systemd_unit_nsenter_on_core(
         self,
         mock_os_getenv,
+        mock_get_checkbox_runtime_path,
+        mock_get_snap_base,
         mock_on_ubuntucore,
         mock_get_diff_env,
         mock_shutil_which,
@@ -111,6 +119,8 @@ class UnifiedRunnerTests(TestCase):
         mock_on_ubuntucore.return_value = True
         mock_os_getenv.return_value = "test_snap"
         mock_get_diff_env.return_value = {}
+
+        mock_get_checkbox_runtime_path.return_value = Path("")
 
         def shutil_which(x):
             return "/bin/{}".format(x)

--- a/checkbox-ng/plainbox/impl/test_execution.py
+++ b/checkbox-ng/plainbox/impl/test_execution.py
@@ -278,18 +278,6 @@ class TestDangerousNsenter(TestCase):
     @mock.patch("plainbox.impl.execution.check_output")
     @mock.patch("plainbox.impl.execution.check_call")
     @mock.patch("plainbox.impl.execution.run")
-    def test_dangerous_nsenter_not_needed(
-        self, run_mock, check_call_mock, check_output_mock
-    ):
-        with dangerous_nsenter(None):
-            pass
-        self.assertFalse(run_mock.called)
-        self.assertFalse(check_call_mock.called)
-        self.assertFalse(check_output_mock.called)
-
-    @mock.patch("plainbox.impl.execution.check_output")
-    @mock.patch("plainbox.impl.execution.check_call")
-    @mock.patch("plainbox.impl.execution.run")
     @mock.patch("shutil.which")
     def test_dangerous_nsenter_cleanup(
         self, which_mock, run_mock, check_call_mock, check_output_mock

--- a/checkbox-ng/plainbox/impl/test_execution.py
+++ b/checkbox-ng/plainbox/impl/test_execution.py
@@ -123,8 +123,11 @@ class UnifiedRunnerTests(TestCase):
         mock_file.name = "/var/tmp/job_command_test.sh"
         mock_temp_file().__enter__.return_value = mock_file
 
+        def extra_envvars():
+            return []
+
         with get_execution_command_systemd_unit(
-            job, {}, "test_session", "/tmp/nest", "ubuntu", None
+            job, {}, "test_session", "/tmp/nest", "ubuntu", extra_envvars
         ) as result:
             result = " ".join(result)
 

--- a/checkbox-ng/plainbox/impl/unit/test_unit.py
+++ b/checkbox-ng/plainbox/impl/unit/test_unit.py
@@ -23,13 +23,12 @@ plainbox.impl.unit.test_init
 Test definitions for plainbox.impl.unit (package init file)
 """
 
-from unittest import TestCase
+import textwrap
+from unittest import TestCase, mock
 
 from plainbox.abc import IProvider1
-from plainbox.impl.unit.unit import Unit, MissingParam
-from plainbox.impl.validation import Problem
-from plainbox.impl.validation import Severity
-from plainbox.vendor import mock
+from plainbox.impl.unit.unit import Unit, MissingParam, get_snap_base
+from plainbox.impl.validation import Problem, Severity
 
 
 class IssueMixIn:
@@ -433,3 +432,64 @@ class UnitFieldValidationTests(TestCase, IssueMixIn):
             Severity.advice,
             message,
         )
+
+
+class GetSnapBaseTests(TestCase):
+    @mock.patch(
+        "plainbox.impl.unit.unit.open",
+        new=mock.mock_open(
+            read_data=textwrap.dedent(
+                """
+                name: checkbox
+                version: 7.0.0-dev76
+                summary: Checkbox test runner
+                base: core
+                """
+            )
+        ),
+    )
+    @mock.patch("os.getenv", new=mock.Mock(return_value="checkbox"))
+    def test_core16_just_core(self):
+        get_snap_base.cache_clear()
+        self.assertEqual(get_snap_base(), "core16")
+
+    @mock.patch(
+        "plainbox.impl.unit.unit.open",
+        new=mock.mock_open(
+            read_data=textwrap.dedent(
+                """
+                name: checkbox
+                version: 7.0.0-dev76
+                summary: Checkbox test runner
+                """
+            )
+        ),
+    )
+    @mock.patch("os.getenv", new=mock.Mock(return_value="checkbox"))
+    def test_core16_undeclared(self):
+        get_snap_base.cache_clear()
+        self.assertEqual(get_snap_base(), "core16")
+
+    @mock.patch(
+        "plainbox.impl.unit.unit.open",
+        new=mock.mock_open(
+            read_data=textwrap.dedent(
+                """
+                name: checkbox
+                version: 7.0.0-dev76
+                summary: Checkbox test runner
+                base: core24
+                """
+            )
+        ),
+    )
+    @mock.patch("os.getenv", new=mock.Mock(return_value="checkbox"))
+    def test_core24(self):
+        get_snap_base.cache_clear()
+        self.assertEqual(get_snap_base(), "core24")
+
+    @mock.patch("os.getenv", new=mock.Mock(return_value=None))
+    def test_no_snap_envvar(self):
+        get_snap_base.cache_clear()
+        with self.assertRaises(ValueError):
+            get_snap_base()

--- a/checkbox-ng/plainbox/impl/unit/test_unit.py
+++ b/checkbox-ng/plainbox/impl/unit/test_unit.py
@@ -26,8 +26,7 @@ Test definitions for plainbox.impl.unit (package init file)
 from unittest import TestCase
 
 from plainbox.abc import IProvider1
-from plainbox.impl.unit.unit import Unit
-from plainbox.impl.unit.unit import MissingParam
+from plainbox.impl.unit.unit import Unit, MissingParam
 from plainbox.impl.validation import Problem
 from plainbox.impl.validation import Severity
 from plainbox.vendor import mock

--- a/checkbox-ng/plainbox/impl/unit/unit.py
+++ b/checkbox-ng/plainbox/impl/unit/unit.py
@@ -79,19 +79,21 @@ def get_snap_base():
     Get the current snap base
     """
     snap = os.getenv("SNAP")
-    if snap:
-        with open(os.path.join(snap, "meta/snap.yaml")) as f:
-            for l in f.readlines():
-                if "base:" in l:
-                    core_version = l.replace("base:", "").strip()
-                    if core_version == "core":
-                        return "core16"
-                    return core_version
-        return "core16"  # core16 may not declare base
-    raise ValueError("Couldn't detect snap path. Missing SNAP envvar")
+    if not snap:
+        raise ValueError("Couldn't detect snap path. Missing SNAP envvar")
+    with open(os.path.join(snap, "meta/snap.yaml")) as f:
+        for l in f.readlines():
+            if "base:" in l:
+                core_version = l.replace("base:", "").strip()
+                if core_version == "core":
+                    return "core16"
+                return core_version
+    return "core16"  # core16 may not declare base
 
 
 def get_checkbox_runtime_path():
+    # Note: this is not the same as using SNAP as this will always be the
+    #       runtime, while SNAP on the legacy arch is the frontend
     snap_base_n = get_snap_base().replace("core", "")
     # the bases of the runtime and frontend must always match
     runtime_name = "checkbox" + snap_base_n

--- a/checkbox-ng/plainbox/impl/unit/unit.py
+++ b/checkbox-ng/plainbox/impl/unit/unit.py
@@ -29,6 +29,7 @@ import json
 import logging
 import os
 import string
+from pathlib import Path
 from functools import lru_cache
 
 from jinja2 import Template
@@ -70,6 +71,31 @@ def on_ubuntucore():
                     return False
         return True
     return False
+
+
+@lru_cache(maxsize=None)
+def get_snap_base():
+    """
+    Get the current snap base
+    """
+    snap = os.getenv("SNAP")
+    if snap:
+        with open(os.path.join(snap, "meta/snap.yaml")) as f:
+            for l in f.readlines():
+                if "base:" in l:
+                    core_version = l.replace("base:", "").strip()
+                    if core_version == "core":
+                        return "core16"
+                    return core_version
+        return "core16"  # core16 may not declare base
+    raise ValueError("Couldn't detect snap path. Missing SNAP envvar")
+
+
+def get_checkbox_runtime_path():
+    snap_base_n = get_snap_base().replace("core", "")
+    # the bases of the runtime and frontend must always match
+    runtime_name = "checkbox" + snap_base_n
+    return Path("/snap") / ("checkbox" + snap_base_n) / "current"
 
 
 class MissingParam(Exception):


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

fs caps dont work on newer bases because all mounted fs are no setuid, which also means no setcap, so the current implementation doesnt work. This also add setpriv to the dependencies, which is already staged on core!=18, but still putting it there so that if it gets removed we have it

## Resolved issues

N/A

## Documentation

Decisions documented in comments

## Tests

Tested manually on all bases and coreXX using image-garden, to replicate testing use the snaps built in this PR here:
- https://github.com/canonical/checkbox/actions/runs/21290922107
- https://github.com/canonical/checkbox/actions/runs/21290926322
