### PR TITLE
add bluetooth/detect  + after-suspend bluetooth/detect to bluetooth-cert-automated (Bugfix)

### DIFF
--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -6,7 +6,7 @@ plugin: shell
 command:
   bt_list_adapters.py && udev_resource.py -f BLUETOOTH
 estimated_duration: 2s
-flags: preserve-locale
+flags: also-after-suspend, preserve-locale
 requires: manifest.has_bt_adapter == 'True'
 imports: from com.canonical.plainbox import manifest
 

--- a/providers/base/units/bluetooth/test-plan.pxu
+++ b/providers/base/units/bluetooth/test-plan.pxu
@@ -24,6 +24,7 @@ unit: test plan
 _name: Bluetooth tests (automated)
 _description: Bluetooth tests (automated)
 include:
+    bluetooth/detect                               certification-status=blocker
     bluetooth/detect-output                        certification-status=blocker
     bluetooth/bluetooth_obex_send                  certification-status=blocker
     bluetooth4/beacon_eddystone_url_.*             certification-status=blocker
@@ -184,6 +185,7 @@ unit: test plan
 _name: Automated Bluetooth tests (after suspend)
 _description: Automated Bluetooth tests (after suspend)
 include:
+    after-suspend-bluetooth/detect                         certification-status=blocker
     after-suspend-bluetooth/detect-output                  certification-status=blocker
     after-suspend-bluetooth/bluetooth_obex_send            certification-status=blocker
     after-suspend-bluetooth4/beacon_eddystone_url_.*       certification-status=blocker


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
The `bluetooth/detect` test case is an old one that might have been forgotten during the migration to the [bluetooth-cert-automated test plan](https://github.com/canonical/checkbox/commit/a356e60f0be30262ee6eae88af481bb1aa77a3d5). Therefore, the SRU team would like to add it back.

## WARNING: This modifies com.canonical.certification::sru-server

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
https://warthogs.atlassian.net/browse/OEMQA-6517

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
- 24.04: https://certification.canonical.com/hardware/202001-27667/submission/467863/
- 22.04: https://certification.canonical.com/hardware/202106-29207/submission/467873/
- 20.04: https://certification.canonical.com/hardware/202004-27818/submission/467874/

Note: Snap and [debian](https://github.com/canonical/checkbox/issues/2301) version of checkbox cannot work on 18.04