### PR TITLE
Remove setpriv from dependencies (bugfix)

### DIFF
--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -206,7 +206,6 @@ parts:
       - zlib1g-dev
       - build-essential
     stage-packages:
-      - setpriv # used to downgrade AmbientCapabilities of systemd-based runner
       - python3-markupsafe
       - python3-jinja2
       - python3-packaging

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -213,7 +213,6 @@ parts:
       - zlib1g-dev
       - build-essential
     stage-packages:
-      - setpriv # used to downgrade AmbientCapabilities of systemd-based runner
       - python3-markupsafe
       - python3-jinja2
       - python3-packaging

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -154,7 +154,6 @@ parts:
     source: checkbox-support
     source-type: local
     stage-packages:
-      - setpriv # used to downgrade AmbientCapabilities of systemd-based runner
       # actual requirements
       - python3-bluez
       - python3-pyparsing


### PR DESCRIPTION
setpriv deosn't exist anymore, it is in utils-linux which is in every base but core and core18

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

setpriv is now included in all bases as it is now part of utils-linux which is always included in the base. I've downloaded all bases from core to core24 and they indeed include it (I've tested amd64 and armhf) from 20+ (we dont use it on 16)

## Resolved issues

N/A

## Documentation

N/A

## Tests

building snaps on this branch
- https://github.com/canonical/checkbox/actions/runs/21390346163
- https://github.com/canonical/checkbox/actions/runs/21390343041
