### PR TITLE
Fix thermal zone index issue in thermal sensor tests (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_thermal_sensor_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_thermal_sensor_test.py
@@ -21,7 +21,7 @@ class ThermalMonitorTest(unittest.TestCase):
         mock_file.return_value = True
         mock_text.side_effect = mock_results
 
-        thermal_node = thermal_sensor_test.ThermalMonitor("fake-thermal")
+        thermal_node = thermal_sensor_test.ThermalMonitor(name="fake-thermal")
         self.assertListEqual(
             [
                 thermal_node.name,
@@ -39,7 +39,9 @@ class ThermalMonitorTest(unittest.TestCase):
         """
         mock_file.return_value = False
         with self.assertRaises(FileNotFoundError):
-            thermal_node = thermal_sensor_test.ThermalMonitor("fake-thermal")
+            thermal_node = thermal_sensor_test.ThermalMonitor(
+                name="fake-thermal"
+            )
             thermal_node.type
 
     @mock.patch("thermal_sensor_test.check_temperature")
@@ -54,7 +56,10 @@ class ThermalMonitorTest(unittest.TestCase):
         """
         mock_args = mock.Mock(
             return_value=argparse.Namespace(
-                name="fake-thermal", duration=30, extra_commands="stress-ng"
+                name="fake-thermal",
+                type=None,
+                duration=30,
+                extra_commands="stress-ng",
             )
         )
         mock_text.side_effect = ["30000", "30000", "31000"]
@@ -76,7 +81,10 @@ class ThermalMonitorTest(unittest.TestCase):
     ):
         mock_args = mock.Mock(
             return_value=argparse.Namespace(
-                name="fake-thermal", duration=2, extra_commands="stress-ng"
+                name="fake-thermal",
+                type=None,
+                duration=2,
+                extra_commands="stress-ng",
             )
         )
         mock_text.return_value = "30000"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/jobs.pxu
@@ -8,14 +8,14 @@ command: thermal_sensor_test.py dump
 
 unit: template
 template-resource: thermal_zones
-id: ce-oem-thermal/temperature_{name}_{type}
-_summary: Check Thermal temperature of {name} - {type}
+id: ce-oem-thermal/temperature_{type}
+_summary: Check Thermal temperature of {type}
 _description:
-    Test a thermal temperature for {name} - {type}.
+    Test a thermal temperature for {type}.
 category_id: thermal
 plugin: shell
 user: root
 estimated_duration: 5m
 flags: also-after-suspend
 command:
-    thermal_sensor_test.py monitor -n {name}
+    thermal_sensor_test.py monitor -t {type}


### PR DESCRIPTION
## Description

Thermal zone indices can change across reboots, making name-based identification unreliable. This change uses the zone type field instead, ensuring consistent test execution.

Additionally, thermal zone interfaces are sometimes repurposed for monitoring non-thermal parameters (e.g., voltages on Qualcomm RB3, RB8 platforms). These edge cases are excluded from test plans using regex patterns matched against the type field.

When both pre-suspend and after-suspend tests are generated from templates, a watchdog-triggered reboot can cause zone index changes, invalidating regex exclusions based on zone names and causing previously excluded tests to run unexpectedly.

This PR makes the test use `type` such as `cpu5-thermal` instead of index `thermal_zone8`

## Resolved issues

https://warthogs.atlassian.net/browse/PECA-1263

