### PR TITLE
Translator from pxu to yaml (New)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
+++ b/checkbox-ng/checkbox_ng/launcher/checkbox_cli.py
@@ -47,6 +47,8 @@ from checkbox_ng.launcher.merge_submissions import MergeSubmissions
 from checkbox_ng.launcher.controller import RemoteController
 from checkbox_ng.launcher.agent import RemoteAgent
 
+from checkbox_ng.launcher.translator import Translator
+
 _ = gettext.gettext
 
 _logger = logging.getLogger("checkbox-cli")
@@ -109,6 +111,7 @@ def main():
         "tp-export": TestPlanExport,
         "run-agent": RemoteAgent,
         "control": RemoteController,
+        "translate": Translator,
     }
     deprecated_commands = {
         "slave": "run-agent",

--- a/checkbox-ng/checkbox_ng/launcher/test_translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_translator.py
@@ -150,8 +150,7 @@ class TranslatorTestCase(TestCase):
 class TranslatorJobUnitTests(TranslatorTestCase):
 
     def test_basic_job_unit(self):
-        pxu_input = dedent(
-            """
+        pxu_input = dedent("""
             id: test-job
             _summary: A test job
             plugin: shell
@@ -161,11 +160,9 @@ class TranslatorJobUnitTests(TranslatorTestCase):
                 other-job
                 another-job
             flags: simple, preserve-cwd
-            """
-        ).strip()
+            """).strip()
 
-        expected_yaml = dedent(
-            """
+        expected_yaml = dedent("""
             id: test-job
             summary: A test job
             plugin: shell
@@ -178,16 +175,14 @@ class TranslatorJobUnitTests(TranslatorTestCase):
             flags:
               - simple
               - preserve-cwd
-            """
-        ).strip()
+            """).strip()
 
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_job_unit_with_comments(self):
-        pxu_input = dedent(
-            """
+        pxu_input = dedent("""
             id: test-job  # the job identifier
             _summary: A test job
             plugin: shell  # automated test
@@ -199,11 +194,9 @@ class TranslatorJobUnitTests(TranslatorTestCase):
                 package.version > 10
             depends: other-job another-job  # must run after these
             flags: simple, preserve-cwd  # keep it simple
-            """
-        ).strip()
+            """).strip()
 
-        expected_yaml = dedent(
-            """
+        expected_yaml = dedent("""
             id: test-job  # the job identifier
             summary: A test job
             plugin: shell  # automated test
@@ -219,39 +212,33 @@ class TranslatorJobUnitTests(TranslatorTestCase):
             flags:
               - simple
               - preserve-cwd  # keep it simple
-            """
-        ).strip()
+            """).strip()
 
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_dont_translate_jinja(self):
-        pxu_input = dedent(
-            """
+        pxu_input = dedent("""
             requires:
                 {% jinja comments, for some reson %}
                 package.name == 'foo'
                 package.version > 10
-            """
-        ).strip()
+            """).strip()
 
-        expected_yaml = dedent(
-            """
+        expected_yaml = dedent("""
             requires: |
                 {% jinja comments, for some reson %}
                 package.name == 'foo'
                 package.version > 10
-            """
-        )
+            """)
 
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_multiline_fields(self):
-        pxu_input = dedent(
-            """
+        pxu_input = dedent("""
             id: test-job
             _summary: A test job
             plugin: user-interact-verify
@@ -269,11 +256,9 @@ class TranslatorJobUnitTests(TranslatorTestCase):
             requires:
               package.name == 'foo'
               device.category == 'DISK'
-            """
-        ).strip()
+            """).strip()
 
-        expected_yaml = dedent(
-            """
+        expected_yaml = dedent("""
             id: test-job
             summary: A test job
             plugin: user-interact-verify
@@ -289,16 +274,14 @@ class TranslatorJobUnitTests(TranslatorTestCase):
             requires:
               - package.name == 'foo'
               - device.category == 'DISK'
-            """
-        ).strip()
+            """).strip()
 
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_siblings_json_to_yaml(self):
-        pxu_input = dedent(
-            """
+        pxu_input = dedent("""
             id: foo
             _summary: foo foo foo
             plugin: shell
@@ -312,11 +295,9 @@ class TranslatorJobUnitTests(TranslatorTestCase):
                   "_summary": "foo foo foo after reboot",
                   "depends": "reboot/advanced"}
                 ]
-            """
-        ).strip()
+            """).strip()
 
-        expected_yaml = dedent(
-            """
+        expected_yaml = dedent("""
             id: foo
             summary: foo foo foo
             plugin: shell
@@ -332,37 +313,31 @@ class TranslatorJobUnitTests(TranslatorTestCase):
                 summary: foo foo foo after reboot
                 depends:
                   - reboot/advanced
-            """
-        ).strip()
+            """).strip()
 
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_siblings_template_json_to_yaml(self):
-        pxu_input = dedent(
-            """
+        pxu_input = dedent("""
             _siblings: [
                 {{ "id": "{id_field}",
                   "_summary": "{summary_field}"}}
                 ]
-            """
-        ).strip()
+            """).strip()
 
-        expected_yaml = dedent(
-            """
+        expected_yaml = dedent("""
             siblings:
               - id: '{id_field}'
                 summary: '{summary_field}'
-            """
-        ).strip()
+            """).strip()
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_imports_lines_to_array(self):
-        pxu_input = dedent(
-            """
+        pxu_input = dedent("""
             id: test-job
             _summary: A test job
             plugin: shell
@@ -374,11 +349,9 @@ class TranslatorJobUnitTests(TranslatorTestCase):
             requires:
               'armhf' in cpuinfo.platform
               'avx2' in cpu01.other
-            """
-        ).strip()
+            """).strip()
 
-        expected_yaml = dedent(
-            """
+        expected_yaml = dedent("""
             id: test-job
             summary: A test job
             plugin: shell
@@ -390,16 +363,14 @@ class TranslatorJobUnitTests(TranslatorTestCase):
             requires:
               - "'armhf' in cpuinfo.platform"
               - "'avx2' in cpu01.other"
-            """
-        ).strip()
+            """).strip()
 
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_other_array_fields(self):
-        pxu_input = dedent(
-            """
+        pxu_input = dedent("""
             id: test-job # test job comment
             _summary: A test job
             plugin: shell
@@ -409,11 +380,9 @@ class TranslatorJobUnitTests(TranslatorTestCase):
             after: setup-job prepare-job
             before: cleanup-job teardown-job
             salvages: failed-job broken-job
-            """
-        ).strip()
+            """).strip()
 
-        expected_yaml = dedent(
-            """
+        expected_yaml = dedent("""
             id: test-job
             summary: A test job
             plugin: shell
@@ -432,16 +401,14 @@ class TranslatorJobUnitTests(TranslatorTestCase):
             salvages:
               - failed-job
               - broken-job
-            """
-        ).strip()
+            """).strip()
 
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_top_level_comment(self):
-        pxu_input = dedent(
-            """
+        pxu_input = dedent("""
             # top level comments
             # should be preserved (best effort)
             id: test-job
@@ -449,11 +416,9 @@ class TranslatorJobUnitTests(TranslatorTestCase):
             # not this one, this one is impossible
             plugin: shell
             command: echo "test"
-            """
-        ).strip()
+            """).strip()
 
-        expected_yaml = dedent(
-            """
+        expected_yaml = dedent("""
             # top level comments
             # should be preserved (best effort)
             id: test-job
@@ -461,16 +426,14 @@ class TranslatorJobUnitTests(TranslatorTestCase):
             # not this one, this one is impossible
             plugin: shell
             command: echo "test"
-            """
-        ).strip()
+            """).strip()
 
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_jinja_depends_ignored(self):
-        pxu_input = dedent(
-            """
+        pxu_input = dedent("""
             id: test-job
             _summary: A test job
             depends:
@@ -480,11 +443,9 @@ class TranslatorJobUnitTests(TranslatorTestCase):
                 b
             plugin: shell
             command: echo "test"
-            """
-        ).strip()
+            """).strip()
 
-        expected_yaml = dedent(
-            """
+        expected_yaml = dedent("""
             id: test-job
             summary: A test job
             depends: |
@@ -494,19 +455,16 @@ class TranslatorJobUnitTests(TranslatorTestCase):
                 b
             plugin: shell
             command: echo "test"
-            """
-        ).strip()
+            """).strip()
 
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
 
-
 class TranslatorTestPlanTests(TranslatorTestCase):
     def test_basic_test_plan(self):
-        pxu_input = dedent(
-            """
+        pxu_input = dedent("""
             unit: test plan
             id: my-test-plan
             _name: My Test Plan
@@ -521,11 +479,9 @@ class TranslatorTestPlanTests(TranslatorTestCase):
                 job-baz certification-status=blocker
             exclude:
                 job-skip-me
-            """
-        ).strip()
+            """).strip()
 
-        expected_yaml = dedent(
-            """
+        expected_yaml = dedent("""
             unit: test plan
             id: my-test-plan
             name: My Test Plan
@@ -541,16 +497,14 @@ class TranslatorTestPlanTests(TranslatorTestCase):
                   certification-status: blocker
             exclude:
               - job-skip-me
-            """
-        ).strip()
+            """).strip()
 
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_test_plan_all_inclusions(self):
-        pxu_input = dedent(
-            """
+        pxu_input = dedent("""
             unit: test plan
             id: full-test-plan
             _name: Full Test Plan
@@ -569,11 +523,9 @@ class TranslatorTestPlanTests(TranslatorTestCase):
             nested_part:
                 nested-part1
                 nested-part2
-            """
-        ).strip()
+            """).strip()
 
-        expected_yaml = dedent(
-            """
+        expected_yaml = dedent("""
             unit: test plan
             id: full-test-plan
             name: Full Test Plan
@@ -592,43 +544,37 @@ class TranslatorTestPlanTests(TranslatorTestCase):
             nested_part:
               - nested-part1
               - nested-part2
-            """
-        ).strip()
+            """).strip()
 
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_test_plan_empty_include(self):
-        pxu_input = dedent(
-            """
+        pxu_input = dedent("""
             unit: test plan
             id: composite-test-plan
             _name: Composite Test Plan
             nested_part:
                 other-test-plan
             include:
-            """
-        ).strip()
+            """).strip()
 
-        expected_yaml = dedent(
-            """
+        expected_yaml = dedent("""
             unit: test plan
             id: composite-test-plan
             name: Composite Test Plan
             nested_part:
               - other-test-plan
             include: []
-            """
-        ).strip()
+            """).strip()
 
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_test_plan_with_nested_parts_and_overrides(self):
-        pxu_input = dedent(
-            """
+        pxu_input = dedent("""
             unit: test plan
             id: composite-test-plan
             _name: Composite Test Plan
@@ -636,11 +582,9 @@ class TranslatorTestPlanTests(TranslatorTestCase):
             certification_status_overrides:
                 apply blocker to .*wireless.*
                 apply non-blocker to audio/.*
-            """
-        ).strip()
+            """).strip()
 
-        expected_yaml = dedent(
-            """
+        expected_yaml = dedent("""
             unit: test plan
             id: composite-test-plan
             name: Composite Test Plan
@@ -648,8 +592,7 @@ class TranslatorTestPlanTests(TranslatorTestCase):
             certification_status_overrides:
               - apply blocker to .*wireless.*
               - apply non-blocker to audio/.*
-            """
-        ).strip()
+            """).strip()
 
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)

--- a/checkbox-ng/checkbox_ng/launcher/test_translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_translator.py
@@ -27,6 +27,8 @@ from checkbox_ng.launcher.translator import (
     split_comment,
     split_string_values,
     Translator,
+    commentable_value,
+    CommentedError,
 )
 
 
@@ -72,6 +74,18 @@ class SplitStringableTests(TestCase):
             value, '"bluetooth/bluez-internal-hci-tests_Read Country Code"'
         )
         self.assertEqual(attributes, "certification-status=blocker")
+
+
+class CommentedValueTranslatorTests(TestCase):
+    def test_no_comment(self):
+        value = commentable_value("value")
+        self.assertEqual(value, "value")
+
+    def test_comment(self):
+        with self.assertRaises(CommentedError) as cm:
+            _ = commentable_value("value # some comment")
+        self.assertEqual("value", cm.exception.value)
+        self.assertEqual("some comment", cm.exception.comment)
 
 
 class TranslatorTestCase(TestCase):
@@ -312,7 +326,7 @@ class TranslatorJobUnitTests(TranslatorTestCase):
     def test_other_array_fields(self):
         pxu_input = dedent(
             """
-            id: test-job
+            id: test-job # test job comment
             _summary: A test job
             plugin: shell
             command: echo "test"

--- a/checkbox-ng/checkbox_ng/launcher/test_translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_translator.py
@@ -32,7 +32,7 @@ from checkbox_ng.launcher.translator import (
 )
 
 
-def only_if_rumel_installed_or_skip(f):
+def only_if_ruamel_installed_or_skip(f):
     try:
         from ruamel.yaml import YAML
 
@@ -106,7 +106,7 @@ class CommentedValueTranslatorTests(TestCase):
 
 
 class TranslatorTestCase(TestCase):
-    @only_if_rumel_installed_or_skip
+    @only_if_ruamel_installed_or_skip
     def run_translator(self, pxu_input):
         from ruamel.yaml import YAML
 
@@ -131,7 +131,7 @@ class TranslatorTestCase(TestCase):
         yaml = YAML()
         return list(yaml.load_all(output_file))
 
-    @only_if_rumel_installed_or_skip
+    @only_if_ruamel_installed_or_skip
     def parse_yaml(self, yaml_str):
         from ruamel.yaml import YAML
 

--- a/checkbox-ng/checkbox_ng/launcher/test_translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_translator.py
@@ -1,0 +1,70 @@
+# This file is part of Checkbox.
+#
+# Copyright 2023 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from unittest import TestCase, mock
+
+from checkbox_ng.launcher.translator import (
+    split_comment,
+    split_string_values,
+    Translator,
+)
+
+
+class SplitStringableTests(TestCase):
+    def test_no_comment_in_string(self):
+        value, comment = split_comment("just some text")
+        self.assertEqual(value, "just some text")
+        self.assertEqual(comment, "")
+
+    def test_string_is_just_a_comment(self):
+        value, comment = split_comment("# this is only a comment")
+        self.assertEqual(value, "")
+        self.assertEqual(comment, "this is only a comment")
+
+    def test_normal_text_with_comment(self):
+        value, comment = split_comment("some text # a comment")
+        self.assertEqual(value, "some text")
+        self.assertEqual(comment, "a comment")
+
+    def test_fake_comment_in_string_delimiters(self):
+        # Double quotes
+        value, comment = split_comment('"fake # inside" # real comment')
+        self.assertEqual(value, '"fake # inside"')
+        self.assertEqual(comment, "real comment")
+
+        # Single quotes
+        value, comment = split_comment("'fake # inside' # real comment")
+        self.assertEqual(value, "'fake # inside'")
+        self.assertEqual(comment, "real comment")
+
+    def test_nested_escaped_delimiters_with_fake_comments(self):
+        # Escaped quote inside string, fake comments, real comment at end
+        value, comment = split_comment("'it\\'s \"a #fake\" test' # real")
+        self.assertEqual(value, "'it\\'s \"a #fake\" test'")
+        self.assertEqual(comment, "real")
+
+    def test_string_values(self):
+        value, attributes = split_string_values(
+            '"bluetooth/bluez-internal-hci-tests_Read Country Code" '
+            "certification-status=blocker"
+        )
+        self.assertEqual(
+            value, '"bluetooth/bluez-internal-hci-tests_Read Country Code"'
+        )
+        self.assertEqual(attributes, "certification-status=blocker")

--- a/checkbox-ng/checkbox_ng/launcher/test_translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_translator.py
@@ -1,6 +1,6 @@
 # This file is part of Checkbox.
 #
-# Copyright 2023 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # Written by:
 #   Massimiliano Girardi <massimiliano.girardi@canonical.com>
 #
@@ -17,7 +17,11 @@
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from io import StringIO
+from textwrap import dedent
 from unittest import TestCase, mock
+
+from ruamel.yaml import YAML
 
 from checkbox_ng.launcher.translator import (
     split_comment,
@@ -68,3 +72,308 @@ class SplitStringableTests(TestCase):
             value, '"bluetooth/bluez-internal-hci-tests_Read Country Code"'
         )
         self.assertEqual(attributes, "certification-status=blocker")
+
+
+class TranslatorJobUnitTests(TestCase):
+
+    def _run_translator(self, pxu_input):
+        input_file = StringIO(pxu_input)
+        output_file = StringIO()
+
+        mock_path = mock.MagicMock()
+        mock_path.open.return_value.__enter__.return_value = input_file
+        mock_path.__str__.return_value = "test.pxu"
+
+        mock_yaml_path = mock.MagicMock()
+        mock_yaml_path.open.return_value.__enter__.return_value = output_file
+        mock_path.with_suffix.return_value = mock_yaml_path
+
+        mock_ctx = mock.MagicMock()
+        mock_ctx.args.paths = [mock_path]
+
+        translator = Translator()
+        translator.invoked(mock_ctx)
+
+        output_file.seek(0)
+        yaml = YAML()
+        return list(yaml.load_all(output_file))
+
+    def _parse_yaml(self, yaml_str):
+        yaml = YAML()
+        return list(yaml.load_all(StringIO(yaml_str)))
+
+    def assertYamlEqual(self, first, second):
+        """
+        Compare two yamls ignoring order of keys
+        """
+        first = [dict(sorted(x.items())) for x in first]
+        second = [dict(sorted(x.items())) for x in second]
+        self.assertEqual(first, second)
+
+    def test_basic_job_unit(self):
+        pxu_input = dedent(
+            """
+            id: test-job
+            _summary: A test job
+            plugin: shell
+            command: echo "hello"
+            requires: package.name == 'foo'
+            depends:
+                other-job
+                another-job
+            flags: simple, preserve-cwd
+            """
+        ).strip()
+
+        expected_yaml = dedent(
+            """
+            id: test-job
+            summary: A test job
+            plugin: shell
+            command: echo "hello"
+            requires:
+              - package.name == 'foo'
+            depends:
+              - other-job
+              - another-job
+            flags:
+              - simple
+              - preserve-cwd
+            """
+        ).strip()
+
+        result = self._run_translator(pxu_input)
+        expected = self._parse_yaml(expected_yaml)
+        self.assertYamlEqual(result, expected)
+
+    def test_job_unit_with_comments(self):
+        pxu_input = dedent(
+            """
+            id: test-job
+            _summary: A test job
+            plugin: shell
+            command: echo "hello"
+            requires: package.name == 'foo'  # need foo installed
+            depends: other-job another-job  # must run after these
+            flags: simple, preserve-cwd  # keep it simple
+            """
+        ).strip()
+
+        expected_yaml = dedent(
+            """
+            id: test-job  # the job identifier
+            summary: A test job
+            plugin: shell  # automated test
+            command: echo "hello"
+            requires:
+              - package.name == 'foo'  # need foo installed
+            depends:
+              - other-job
+              - another-job  # must run after these
+            flags:
+              - simple
+              - preserve-cwd  # keep it simple
+            """
+        ).strip()
+
+        result = self._run_translator(pxu_input)
+        expected = self._parse_yaml(expected_yaml)
+        self.assertYamlEqual(result, expected)
+
+    def test_multiline_fields(self):
+        pxu_input = dedent(
+            """
+            id: test-job
+            _summary: A test job
+            plugin: user-interact-verify
+            command:
+              echo "hello"
+            _purpose:
+              This test verifies that the thing works.
+              It does multiple checks.
+            _steps:
+              1. Do the first thing
+              2. Do the second thing
+              3. Observe the result
+            _verification:
+              Did the thing work correctly?
+            requires:
+              package.name == 'foo'
+              device.category == 'DISK'
+            """
+        ).strip()
+
+        expected_yaml = dedent(
+            """
+            id: test-job
+            summary: A test job
+            plugin: user-interact-verify
+            command: echo "hello"
+            purpose: |
+              This test verifies that the thing works.
+              It does multiple checks.
+            steps: |
+              1. Do the first thing
+              2. Do the second thing
+              3. Observe the result
+            verification: Did the thing work correctly?
+            requires:
+              - package.name == 'foo'
+              - device.category == 'DISK'
+            """
+        ).strip()
+
+        result = self._run_translator(pxu_input)
+        expected = self._parse_yaml(expected_yaml)
+        self.assertYamlEqual(result, expected)
+
+    def test_siblings_json_to_yaml(self):
+        pxu_input = dedent(
+            """
+            id: foo
+            _summary: foo foo foo
+            plugin: shell
+            command: echo "Hello world"
+            flags: simple
+            _siblings: [
+                { "id": "foo-after-suspend",
+                  "_summary": "foo foo foo after suspend",
+                  "depends": "suspend/advanced"},
+                { "id": "foo-after-reboot",
+                  "_summary": "foo foo foo after reboot",
+                  "depends": "reboot/advanced"}
+                ]
+            """
+        ).strip()
+
+        expected_yaml = dedent(
+            """
+            id: foo
+            summary: foo foo foo
+            plugin: shell
+            command: echo "Hello world"
+            flags:
+              - simple
+            siblings:
+              - id: foo-after-suspend
+                summary: foo foo foo after suspend
+                depends:
+                  - suspend/advanced
+              - id: foo-after-reboot
+                summary: foo foo foo after reboot
+                depends:
+                  - reboot/advanced
+            """
+        ).strip()
+
+        result = self._run_translator(pxu_input)
+        expected = self._parse_yaml(expected_yaml)
+        self.assertYamlEqual(result, expected)
+
+    def test_imports_lines_to_array(self):
+        pxu_input = dedent(
+            """
+            id: test-job
+            _summary: A test job
+            plugin: shell
+            command: echo "test"
+            imports:
+              from com.canonical.certification import cpuinfo
+              from com.canonical.certification import cpu-01-info as cpu01
+              from com.canonical.certification import meminfo
+            requires:
+              'armhf' in cpuinfo.platform
+              'avx2' in cpu01.other
+            """
+        ).strip()
+
+        expected_yaml = dedent(
+            """
+            id: test-job
+            summary: A test job
+            plugin: shell
+            command: echo "test"
+            imports:
+              - from com.canonical.certification import cpuinfo
+              - from com.canonical.certification import cpu-01-info as cpu01
+              - from com.canonical.certification import meminfo
+            requires:
+              - "'armhf' in cpuinfo.platform"
+              - "'avx2' in cpu01.other"
+            """
+        ).strip()
+
+        result = self._run_translator(pxu_input)
+        expected = self._parse_yaml(expected_yaml)
+        self.assertYamlEqual(result, expected)
+
+    def test_other_array_fields(self):
+        pxu_input = dedent(
+            """
+            id: test-job
+            _summary: A test job
+            plugin: shell
+            command: echo "test"
+            user: root
+            environ: HOME PATH DISPLAY
+            after: setup-job prepare-job
+            before: cleanup-job teardown-job
+            salvages: failed-job broken-job
+            """
+        ).strip()
+
+        expected_yaml = dedent(
+            """
+            id: test-job
+            summary: A test job
+            plugin: shell
+            command: echo "test"
+            user: root
+            environ:
+              - HOME
+              - PATH
+              - DISPLAY
+            after:
+              - setup-job
+              - prepare-job
+            before:
+              - cleanup-job
+              - teardown-job
+            salvages:
+              - failed-job
+              - broken-job
+            """
+        ).strip()
+
+        result = self._run_translator(pxu_input)
+        expected = self._parse_yaml(expected_yaml)
+        self.assertYamlEqual(result, expected)
+
+    def test_top_level_comment(self):
+        pxu_input = dedent(
+            """
+            # top level comments
+            # should be preserved (best effort)
+            id: test-job
+            _summary: A test job
+            # not this one, this one is impossible
+            plugin: shell
+            command: echo "test"
+            """
+        ).strip()
+
+        expected_yaml = dedent(
+            """
+            # top level comments
+            # should be preserved (best effort)
+            id: test-job
+            summary: A test job
+            # not this one, this one is impossible
+            plugin: shell
+            command: echo "test"
+            """
+        ).strip()
+
+        result = self._run_translator(pxu_input)
+        expected = self._parse_yaml(expected_yaml)
+        self.assertYamlEqual(result, expected)

--- a/checkbox-ng/checkbox_ng/launcher/test_translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_translator.py
@@ -188,11 +188,15 @@ class TranslatorJobUnitTests(TranslatorTestCase):
     def test_job_unit_with_comments(self):
         pxu_input = dedent(
             """
-            id: test-job
+            id: test-job  # the job identifier
             _summary: A test job
-            plugin: shell
+            plugin: shell  # automated test
             command: echo "hello"
-            requires: package.name == 'foo'  # need foo installed
+            requires:
+                # requires comment above
+                package.name == 'foo'  # need foo installed
+                # requires comment in the middle
+                package.version > 10
             depends: other-job another-job  # must run after these
             flags: simple, preserve-cwd  # keep it simple
             """
@@ -205,7 +209,10 @@ class TranslatorJobUnitTests(TranslatorTestCase):
             plugin: shell  # automated test
             command: echo "hello"
             requires:
+              # requires comment above
               - package.name == 'foo'  # need foo installed
+              # requires comment in the middle
+              - package.version > 10
             depends:
               - other-job
               - another-job  # must run after these
@@ -214,6 +221,29 @@ class TranslatorJobUnitTests(TranslatorTestCase):
               - preserve-cwd  # keep it simple
             """
         ).strip()
+
+        result = self.run_translator(pxu_input)
+        expected = self.parse_yaml(expected_yaml)
+        self.assertYamlEqual(result, expected)
+
+    def test_dont_translate_jinja(self):
+        pxu_input = dedent(
+            """
+            requires:
+                {% jinja comments, for some reson %}
+                package.name == 'foo'
+                package.version > 10
+            """
+        ).strip()
+
+        expected_yaml = dedent(
+            """
+            requires: |
+                {% jinja comments, for some reson %}
+                package.name == 'foo'
+                package.version > 10
+            """
+        )
 
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)
@@ -305,6 +335,27 @@ class TranslatorJobUnitTests(TranslatorTestCase):
             """
         ).strip()
 
+        result = self.run_translator(pxu_input)
+        expected = self.parse_yaml(expected_yaml)
+        self.assertYamlEqual(result, expected)
+
+    def test_siblings_template_json_to_yaml(self):
+        pxu_input = dedent(
+            """
+            _siblings: [
+                {{ "id": "{id_field}",
+                  "_summary": "{summary_field}"}}
+                ]
+            """
+        ).strip()
+
+        expected_yaml = dedent(
+            """
+            siblings:
+              - id: '{id_field}'
+                summary: '{summary_field}'
+            """
+        ).strip()
         result = self.run_translator(pxu_input)
         expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
@@ -429,8 +480,10 @@ class TranslatorTestPlanTests(TranslatorTestCase):
                 This is a test plan that runs some tests.
                 It has multiple lines.
             include:
+                # first item comment
                 job-foo
-                job-bar
+                job-bar # comment in line
+                # middle comment
                 job-baz certification-status=blocker
             exclude:
                 job-skip-me
@@ -446,8 +499,10 @@ class TranslatorTestPlanTests(TranslatorTestCase):
                 This is a test plan that runs some tests.
                 It has multiple lines.
             include:
+              # first item comment
               - job-foo
-              - job-bar
+              - job-bar # comment in line
+              # middle comment
               - job-baz:
                   certification-status: blocker
             exclude:

--- a/checkbox-ng/checkbox_ng/launcher/test_translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_translator.py
@@ -19,9 +19,9 @@
 
 from io import StringIO
 from textwrap import dedent
-from unittest import TestCase, mock
+from unittest import TestCase, mock, SkipTest
+from functools import wraps
 
-from ruamel.yaml import YAML
 
 from checkbox_ng.launcher.translator import (
     split_comment,
@@ -30,6 +30,23 @@ from checkbox_ng.launcher.translator import (
     commentable_value,
     CommentedError,
 )
+
+
+def only_if_rumel_installed_or_skip(f):
+    try:
+        from ruamel.yaml import YAML
+
+        return f
+    except ModuleNotFoundError:
+        pass
+
+    @wraps(f)
+    def _f(self, *args, **kwargs):
+        raise SkipTest(
+            "Not testing as translator wasn't installed. To test install checkbox-ng[translator]"
+        )
+
+    return _f
 
 
 class SplitStringableTests(TestCase):
@@ -89,7 +106,10 @@ class CommentedValueTranslatorTests(TestCase):
 
 
 class TranslatorTestCase(TestCase):
+    @only_if_rumel_installed_or_skip
     def run_translator(self, pxu_input):
+        from ruamel.yaml import YAML
+
         input_file = StringIO(pxu_input)
         output_file = StringIO()
 
@@ -111,7 +131,10 @@ class TranslatorTestCase(TestCase):
         yaml = YAML()
         return list(yaml.load_all(output_file))
 
+    @only_if_rumel_installed_or_skip
     def parse_yaml(self, yaml_str):
+        from ruamel.yaml import YAML
+
         yaml = YAML()
         return list(yaml.load_all(StringIO(yaml_str)))
 

--- a/checkbox-ng/checkbox_ng/launcher/test_translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_translator.py
@@ -74,9 +74,8 @@ class SplitStringableTests(TestCase):
         self.assertEqual(attributes, "certification-status=blocker")
 
 
-class TranslatorJobUnitTests(TestCase):
-
-    def _run_translator(self, pxu_input):
+class TranslatorTestCase(TestCase):
+    def run_translator(self, pxu_input):
         input_file = StringIO(pxu_input)
         output_file = StringIO()
 
@@ -98,7 +97,7 @@ class TranslatorJobUnitTests(TestCase):
         yaml = YAML()
         return list(yaml.load_all(output_file))
 
-    def _parse_yaml(self, yaml_str):
+    def parse_yaml(self, yaml_str):
         yaml = YAML()
         return list(yaml.load_all(StringIO(yaml_str)))
 
@@ -109,6 +108,9 @@ class TranslatorJobUnitTests(TestCase):
         first = [dict(sorted(x.items())) for x in first]
         second = [dict(sorted(x.items())) for x in second]
         self.assertEqual(first, second)
+
+
+class TranslatorJobUnitTests(TranslatorTestCase):
 
     def test_basic_job_unit(self):
         pxu_input = dedent(
@@ -142,8 +144,8 @@ class TranslatorJobUnitTests(TestCase):
             """
         ).strip()
 
-        result = self._run_translator(pxu_input)
-        expected = self._parse_yaml(expected_yaml)
+        result = self.run_translator(pxu_input)
+        expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_job_unit_with_comments(self):
@@ -176,8 +178,8 @@ class TranslatorJobUnitTests(TestCase):
             """
         ).strip()
 
-        result = self._run_translator(pxu_input)
-        expected = self._parse_yaml(expected_yaml)
+        result = self.run_translator(pxu_input)
+        expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_multiline_fields(self):
@@ -223,8 +225,8 @@ class TranslatorJobUnitTests(TestCase):
             """
         ).strip()
 
-        result = self._run_translator(pxu_input)
-        expected = self._parse_yaml(expected_yaml)
+        result = self.run_translator(pxu_input)
+        expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_siblings_json_to_yaml(self):
@@ -266,8 +268,8 @@ class TranslatorJobUnitTests(TestCase):
             """
         ).strip()
 
-        result = self._run_translator(pxu_input)
-        expected = self._parse_yaml(expected_yaml)
+        result = self.run_translator(pxu_input)
+        expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_imports_lines_to_array(self):
@@ -303,8 +305,8 @@ class TranslatorJobUnitTests(TestCase):
             """
         ).strip()
 
-        result = self._run_translator(pxu_input)
-        expected = self._parse_yaml(expected_yaml)
+        result = self.run_translator(pxu_input)
+        expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_other_array_fields(self):
@@ -345,8 +347,8 @@ class TranslatorJobUnitTests(TestCase):
             """
         ).strip()
 
-        result = self._run_translator(pxu_input)
-        expected = self._parse_yaml(expected_yaml)
+        result = self.run_translator(pxu_input)
+        expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
     def test_top_level_comment(self):
@@ -374,6 +376,155 @@ class TranslatorJobUnitTests(TestCase):
             """
         ).strip()
 
-        result = self._run_translator(pxu_input)
-        expected = self._parse_yaml(expected_yaml)
+        result = self.run_translator(pxu_input)
+        expected = self.parse_yaml(expected_yaml)
+        self.assertYamlEqual(result, expected)
+
+
+class TranslatorTestPlanTests(TranslatorTestCase):
+    def test_basic_test_plan(self):
+        pxu_input = dedent(
+            """
+            unit: test plan
+            id: my-test-plan
+            _name: My Test Plan
+            _description:
+                This is a test plan that runs some tests.
+                It has multiple lines.
+            include:
+                job-foo
+                job-bar
+                job-baz certification-status=blocker
+            exclude:
+                job-skip-me
+            """
+        ).strip()
+
+        expected_yaml = dedent(
+            """
+            unit: test plan
+            id: my-test-plan
+            name: My Test Plan
+            description: |
+                This is a test plan that runs some tests.
+                It has multiple lines.
+            include:
+              - job-foo
+              - job-bar
+              - job-baz:
+                  certification-status: blocker
+            exclude:
+              - job-skip-me
+            """
+        ).strip()
+
+        result = self.run_translator(pxu_input)
+        expected = self.parse_yaml(expected_yaml)
+        self.assertYamlEqual(result, expected)
+
+    def test_test_plan_all_inclusions(self):
+        pxu_input = dedent(
+            """
+            unit: test plan
+            id: full-test-plan
+            _name: Full Test Plan
+            setup_include:
+                setup-job1
+                com.canonical.qa::setup-job2
+            bootstrap_include:
+                resource-job-1
+                resource-job-2
+            mandatory_include:
+                critical-job
+                com.canonical.certification::submission-cert-automated
+            include:
+                test-job-1
+                test-job-2
+            nested_part:
+                nested-part1
+                nested-part2
+            """
+        ).strip()
+
+        expected_yaml = dedent(
+            """
+            unit: test plan
+            id: full-test-plan
+            name: Full Test Plan
+            setup_include:
+              - setup-job1
+              - com.canonical.qa::setup-job2
+            bootstrap_include:
+              - resource-job-1
+              - resource-job-2
+            mandatory_include:
+              - critical-job
+              - com.canonical.certification::submission-cert-automated
+            include:
+              - test-job-1
+              - test-job-2
+            nested_part:
+              - nested-part1
+              - nested-part2
+            """
+        ).strip()
+
+        result = self.run_translator(pxu_input)
+        expected = self.parse_yaml(expected_yaml)
+        self.assertYamlEqual(result, expected)
+
+    def test_test_plan_empty_include(self):
+        pxu_input = dedent(
+            """
+            unit: test plan
+            id: composite-test-plan
+            _name: Composite Test Plan
+            nested_part:
+                other-test-plan
+            include:
+            """
+        ).strip()
+
+        expected_yaml = dedent(
+            """
+            unit: test plan
+            id: composite-test-plan
+            name: Composite Test Plan
+            nested_part:
+              - other-test-plan
+            include: []
+            """
+        ).strip()
+
+        result = self.run_translator(pxu_input)
+        expected = self.parse_yaml(expected_yaml)
+        self.assertYamlEqual(result, expected)
+
+    def test_test_plan_with_nested_parts_and_overrides(self):
+        pxu_input = dedent(
+            """
+            unit: test plan
+            id: composite-test-plan
+            _name: Composite Test Plan
+            include:
+            certification_status_overrides:
+                apply blocker to .*wireless.*
+                apply non-blocker to audio/.*
+            """
+        ).strip()
+
+        expected_yaml = dedent(
+            """
+            unit: test plan
+            id: composite-test-plan
+            name: Composite Test Plan
+            include: []
+            certification_status_overrides:
+              - apply blocker to .*wireless.*
+              - apply non-blocker to audio/.*
+            """
+        ).strip()
+
+        result = self.run_translator(pxu_input)
+        expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)

--- a/checkbox-ng/checkbox_ng/launcher/test_translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_translator.py
@@ -37,7 +37,7 @@ def only_if_rumel_installed_or_skip(f):
         from ruamel.yaml import YAML
 
         return f
-    except ModuleNotFoundError:
+    except ImportError:
         pass
 
     @wraps(f)

--- a/checkbox-ng/checkbox_ng/launcher/test_translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_translator.py
@@ -468,6 +468,40 @@ class TranslatorJobUnitTests(TranslatorTestCase):
         expected = self.parse_yaml(expected_yaml)
         self.assertYamlEqual(result, expected)
 
+    def test_jinja_depends_ignored(self):
+        pxu_input = dedent(
+            """
+            id: test-job
+            _summary: A test job
+            depends:
+                {% if true %}
+                a
+                {% endif %}
+                b
+            plugin: shell
+            command: echo "test"
+            """
+        ).strip()
+
+        expected_yaml = dedent(
+            """
+            id: test-job
+            summary: A test job
+            depends: |
+                {% if true %}
+                a
+                {% endif %}
+                b
+            plugin: shell
+            command: echo "test"
+            """
+        ).strip()
+
+        result = self.run_translator(pxu_input)
+        expected = self.parse_yaml(expected_yaml)
+        self.assertYamlEqual(result, expected)
+
+
 
 class TranslatorTestPlanTests(TranslatorTestCase):
     def test_basic_test_plan(self):

--- a/checkbox-ng/checkbox_ng/launcher/translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/translator.py
@@ -138,6 +138,7 @@ def translate_requires(value):
     for requires_line in requires_lines:
         require, comment = split_comment(requires_line)
         if require:
+            require = require.strip()
             to_r.append(require)
             if comment:
                 to_r.yaml_add_eol_comment(comment, len(to_r) - 1)
@@ -159,13 +160,17 @@ def translate_single_multiline_stringable_values(value):
     to_r = CommentedSeq()
     if "\n" not in value:
         depends, comment = split_comment(value)
-        to_r += depends.split()
+        if "," in depends:
+            to_r += [x.strip() for x in depends.split(",")]
+        else:
+            to_r += depends.split()
         if comment:
             to_r.yaml_set_start_comment(comment)
         return to_r
     depends = value.splitlines()
     for depend in depends:
         depend, comment = split_comment(depend)
+        depend = depend.strip()
         if depend:
             to_r.append(depend)
             if comment:
@@ -179,6 +184,7 @@ def translate_single_multiline_stringable_values(value):
                 )
             else:
                 to_r.yaml_set_start_comment(comment)
+    return to_r
 
 
 @dont_translate_jinja
@@ -233,7 +239,7 @@ field_translators = {
     "id": identity,
     "unit": identity,
     "name": identity,
-    "description": identity,
+    "description": no_trailing_spaces,
     "estimated_duration": identity,
     "description": no_trailing_spaces,
     "os-id": identity,
@@ -241,18 +247,18 @@ field_translators = {
     "category_id": identity,
     "user": identity,
     "command": identity,
-    "summary": identity,
-    "purpose": identity,
-    "steps": identity,
-    "prompt": identity,
+    "summary": no_trailing_spaces,
+    "purpose": no_trailing_spaces,
+    "steps": no_trailing_spaces,
+    "prompt": no_trailing_spaces,
     "value-type": identity,
-    "hidden-reason": identity,
-    "verification": identity,
+    "hidden-reason": no_trailing_spaces,
+    "verification": no_trailing_spaces,
     "template-resource": identity,
     "template-unit": identity,
     "template-id": identity,
     "template-engine": identity,
-    "template-summary": identity,
+    "template-summary": no_trailing_spaces,
     "entry_point": identity,
     "file_extension": identity,
     "Depends": identity,
@@ -285,14 +291,14 @@ field_translators = {
 
 def translate_unit(unit_dict: dict) -> dict:
 
-    def no_translation(x):
+    def no_more_translations(x):
         if x.startswith("_"):
             return x[1:]
         return x
 
     to_return = {}
     for key, value in unit_dict.items():
-        key = no_translation(key)
+        key = no_more_translations(key)
         try:
             translated = field_translators[key](value)
             to_return[key] = translated

--- a/checkbox-ng/checkbox_ng/launcher/translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/translator.py
@@ -7,12 +7,34 @@ from functools import wraps
 from plainbox.impl.secure.rfc822 import load_rfc822_records
 
 
-def identity(value):
+def multiline_text(value):
+    # no more trailing spaces
+    lines = (x.rstrip() for x in value.splitlines())
+    # line composed by a . is actually a hack to add an empty line in pxus
+    lines = (x if x != "." else "" for x in lines)
+    return "\n".join(lines)
+
+
+class CommentedError(ValueError):
+    def __init__(self, value, comment):
+        self.value = value
+        self.comment = comment
+        super().__init__()
+
+
+def commentable_value(value):
+    """
+    This returns the value or raises a CommentedError if the value contains
+    a comment
+    """
+    # this is technically not proper, as these values are not stringable, but
+    # validation is not the job of the translator
+    value, comment = split_comment(value)
+    if comment:
+        # here we raise an exception as rumel.yaml doesn't support returning
+        # commented fields
+        raise CommentedError(value, comment)
     return value
-
-
-def no_trailing_spaces(value):
-    return "\n".join(x.rstrip() for x in value.splitlines())
 
 
 class JinjaError(ValueError):
@@ -236,36 +258,36 @@ def translate_options(value):
 
 
 field_translators = {
-    "id": identity,
-    "unit": identity,
-    "name": identity,
-    "description": no_trailing_spaces,
-    "estimated_duration": identity,
-    "description": no_trailing_spaces,
-    "os-id": identity,
-    "plugin": identity,
-    "category_id": identity,
-    "user": identity,
-    "command": identity,
-    "summary": no_trailing_spaces,
-    "purpose": no_trailing_spaces,
-    "steps": no_trailing_spaces,
-    "prompt": no_trailing_spaces,
-    "value-type": identity,
-    "hidden-reason": no_trailing_spaces,
-    "verification": no_trailing_spaces,
-    "template-resource": identity,
-    "template-unit": identity,
-    "template-id": identity,
-    "template-engine": identity,
-    "template-summary": no_trailing_spaces,
-    "entry_point": identity,
-    "file_extension": identity,
-    "Depends": identity,
-    "Suggests": identity,
-    "Recommends": identity,
-    "os-version-id": identity,
-    "group": identity,
+    "id": commentable_value,
+    "unit": commentable_value,
+    "name": commentable_value,
+    "estimated_duration": commentable_value,
+    "os-id": commentable_value,
+    "plugin": commentable_value,
+    "category_id": commentable_value,
+    "user": commentable_value,
+    "command": commentable_value,
+    "value-type": commentable_value,
+    "template-resource": commentable_value,
+    "template-unit": commentable_value,
+    "template-id": commentable_value,
+    "template-engine": commentable_value,
+    "entry_point": commentable_value,
+    "file_extension": commentable_value,
+    "Depends": commentable_value,
+    "Suggests": commentable_value,
+    "Recommends": commentable_value,
+    "os-version-id": commentable_value,
+    "group": commentable_value,
+    "description": multiline_text,
+    "description": multiline_text,
+    "summary": multiline_text,
+    "purpose": multiline_text,
+    "steps": multiline_text,
+    "prompt": multiline_text,
+    "hidden-reason": multiline_text,
+    "verification": multiline_text,
+    "template-summary": multiline_text,
     "data": translate_raw_json,
     "environ": translate_single_multiline_stringable_values,
     "flags": translate_single_multiline_stringable_values,
@@ -290,13 +312,14 @@ field_translators = {
 
 
 def translate_unit(unit_dict: dict) -> dict:
+    from ruamel.yaml.comments import CommentedMap
 
     def no_more_translations(x):
         if x.startswith("_"):
             return x[1:]
         return x
 
-    to_return = {}
+    to_return = CommentedMap()
     for key, value in unit_dict.items():
         key = no_more_translations(key)
         try:
@@ -318,61 +341,11 @@ def translate_unit(unit_dict: dict) -> dict:
                 ).format(key, unit_dict.get("id", str(unit_dict)))
             )
             to_return[key] = value
+        except CommentedError as e:
+            to_return[key] = e.value
+            to_return.yaml_add_eol_comment(e.comment, key)
 
     return to_return
-
-
-def sort_unit(unit_dict):
-    """
-    Units should have keys in this order to be easier to read
-    """
-    key_order = [
-        "id",
-        "name",
-        "template-id",
-        "unit",
-        "template-unit",
-        "template-imports",
-        "template-resource",
-        "template-filter",
-        "template-summary",
-        "template-engine",
-        "imports",
-        "requires",
-        "plugin",
-        "description",
-        "summary",
-        "purpose",
-        "steps",
-        "verification",
-        "estimated_duration",
-        "before",
-        "after",
-        "depends",
-        "salvages",
-        "group",
-        "environ",
-        "flags",
-        "category_id",
-        "setup_include",
-        "bootstrap_include",
-        "include",
-        "exclude",
-        "nested_part",
-        "user",
-        "command",
-        "certification_status_overrides",
-        "sibling",
-    ]
-
-    def sorter(kv):
-        k = kv[0]
-        try:
-            return key_order.index(k)
-        except ValueError:
-            return len(key_order) + ord(k[0])
-
-    return dict(sorted(unit_dict.items(), key=sorter))
 
 
 def multiline_str_representer(dumper, data):
@@ -420,7 +393,7 @@ class Translator:
 
             yaml = YAML()
             for unit_dict in loaded:
-                documents.append(sort_unit(translate_unit(unit_dict.data)))
+                documents.append(translate_unit(unit_dict.data))
 
             yaml.width = 120
             yaml.default_flow_style = False

--- a/checkbox-ng/checkbox_ng/launcher/translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/translator.py
@@ -1,0 +1,424 @@
+import json
+import logging
+from pathlib import Path
+from functools import wraps
+
+
+from plainbox.impl.secure.rfc822 import load_rfc822_records
+
+
+def identity(value):
+    return value
+
+
+def no_trailing_spaces(value):
+    return "\n".join(x.rstrip() for x in value.splitlines())
+
+
+class JinjaError(ValueError):
+    pass
+
+
+def dont_translate_jinja(f):
+    """
+    For backward compatibility, avoid touching jinja values
+
+    Given that jinja may completely change the semantic of the unit, it is
+    virtually impossible to translate it. For example:
+
+        requires:
+          package.name == 'bluez' or snap.name == 'bluez'
+          {%- if __on_ubuntucore__ %}
+          connections.slot == 'bluez:service'
+          {% endif -%}
+
+        This would correclty be translated as
+
+        requires:
+          - package.name == 'bluez' or snap.name == 'bluez'
+          {%- if __on_ubuntucore__ %}
+          - connections.slot == 'bluez:service'
+          {% endif -%}
+
+        but this wouldn't work if the value in the if was
+
+        requires:
+          package.name == 'bluez' or snap.name == 'bluez'
+          {%- if __on_ubuntucore__ %}some.foo == 'bar'
+          connections.slot == 'bluez:service'
+          {% endif -%}
+
+
+    """
+
+    @wraps(f)
+    def _f(value):
+        if "{#" in value or "{%" in value:
+            raise JinjaError()
+        return f(value)
+
+    return _f
+
+
+def split_stringable(value, delimiter):
+    """
+    Split value given a delimiter respecting string delimiters
+
+    When the delimiter is inside a string, it is part of the string and not
+    to be used in the split. Classic example is:
+
+        "abc #123" # <- this part is the comment, not 123
+    """
+    if delimiter not in value:
+        return value, ""
+    in_string = False  # False, ', "
+    just_escaped = False
+    start_of_comment = -1
+    for i, c in enumerate(value):
+        if just_escaped:
+            just_escaped = False
+        elif in_string and c == in_string:
+            in_string = False
+        elif c == "\\":  # escape char
+            just_escaped = True
+        elif c == delimiter and not in_string:
+            start_of_comment = i
+            break
+        elif (
+            c in ["'", '"'] and not in_string
+        ):  # string contains ' or " handled above
+            in_string = c
+    if start_of_comment >= 0:
+        return (
+            value[:start_of_comment].rstrip(),
+            value[start_of_comment + 1 :].lstrip(),
+        )
+    return value, ""
+
+
+def split_comment(value):
+    return split_stringable(value, "#")
+
+
+def split_string_values(value):
+    """
+    These are strings delimited values separated by spaces
+
+    Example:
+        "bluetooth/bluez-internal-hci-tests_Read Country Code" certification-status=blocker
+    """
+    return split_stringable(value, " ")
+
+
+def translate_raw_json(value):
+    return json.loads(value)
+
+
+@dont_translate_jinja
+def translate_siblings(value):
+    # value may be invalid json because it contains formatters, so objects
+    # will be delimited with {{ and }}. Given that we are now parsing this as
+    # data, this is no longer needed.
+    class no_replace(dict):
+        def __missing__(self, key):
+            return "{" + key + "}"
+
+    if "{{" in value:
+        value = value.format_map(no_replace())
+    units = json.loads(value)
+    return [translate_unit(unit) for unit in units]
+
+
+@dont_translate_jinja
+def translate_requires(value):
+    from ruamel.yaml.comments import CommentedSeq
+
+    requires_lines = value.splitlines()
+    to_r = CommentedSeq()
+    for requires_line in requires_lines:
+        require, comment = split_comment(requires_line)
+        if require:
+            to_r.append(require)
+            if comment:
+                to_r.yaml_add_eol_comment(comment, len(to_r) - 1)
+        elif comment:
+            if (
+                len(to_r) != 0
+            ):  # else this doesn't work, cant set for unknown line
+                to_r.yaml_set_comment_before_after_key(
+                    len(to_r), before=comment
+                )
+            else:
+                to_r.yaml_set_start_comment(comment)
+    return to_r
+
+
+def translate_single_multiline_stringable_values(value):
+    from ruamel.yaml.comments import CommentedSeq
+
+    to_r = CommentedSeq()
+    if "\n" not in value:
+        depends, comment = split_comment(value)
+        to_r += depends.split()
+        if comment:
+            to_r.yaml_set_start_comment(comment)
+        return to_r
+    depends = value.splitlines()
+    for depend in depends:
+        depend, comment = split_comment(depend)
+        if depend:
+            to_r.append(depend)
+            if comment:
+                to_r.yaml_add_eol_comment(comment, len(to_r) - 1)
+        elif comment:
+            if (
+                len(to_r) != 0
+            ):  # else this doesn't work, cant set for unknown line
+                to_r.yaml_set_comment_before_after_key(
+                    len(to_r), before=comment
+                )
+            else:
+                to_r.yaml_set_start_comment(comment)
+
+
+@dont_translate_jinja
+def translate_include(value):
+    includes = value.splitlines()
+    from ruamel.yaml.comments import CommentedSeq, CommentedMap
+
+    to_r = CommentedSeq()
+    for inclusion in includes:
+        inclusion = inclusion.strip()
+        value, comment = split_comment(inclusion)
+        if value:
+            value, overrides = split_string_values(value)
+        else:
+            value = overrides = ""
+        if overrides:  # we can assume there is value as well here
+            assert overrides.startswith("certification-status")
+            assert " " not in overrides
+            assert "," not in overrides
+            overriden, override_value = overrides.strip().split(
+                "="
+            )  # assumes 1 per line
+            translation = {value: {overriden: override_value}}
+            if comment:
+                translation = CommentedMap(translation)
+                translation.yaml_add_eol_comment(comment, value)
+            to_r.append(translation)
+        elif value:
+            to_r.append(value)
+            if comment:
+                to_r.yaml_add_eol_comment(comment, len(to_r) - 1)
+        elif comment:
+            if (
+                len(to_r) != 0
+            ):  # else this doesn't work, cant set for unknown line
+                to_r.yaml_set_comment_before_after_key(
+                    len(to_r), before=comment
+                )
+            else:
+                to_r.yaml_set_start_comment(comment)
+        else:
+            assert False, "Tragedy"
+    return to_r
+
+
+def translate_options(value):
+    assert "#" not in value
+    return [x.strip() for x in value.split(",")]
+
+
+field_translators = {
+    "id": identity,
+    "unit": identity,
+    "name": identity,
+    "description": identity,
+    "estimated_duration": identity,
+    "description": no_trailing_spaces,
+    "os-id": identity,
+    "plugin": identity,
+    "category_id": identity,
+    "user": identity,
+    "command": identity,
+    "summary": identity,
+    "purpose": identity,
+    "steps": identity,
+    "prompt": identity,
+    "value-type": identity,
+    "hidden-reason": identity,
+    "verification": identity,
+    "template-resource": identity,
+    "template-unit": identity,
+    "template-id": identity,
+    "template-engine": identity,
+    "template-summary": identity,
+    "entry_point": identity,
+    "file_extension": identity,
+    "Depends": identity,
+    "Suggests": identity,
+    "Recommends": identity,
+    "os-version-id": identity,
+    "group": identity,
+    "data": translate_raw_json,
+    "environ": translate_single_multiline_stringable_values,
+    "flags": translate_single_multiline_stringable_values,
+    "after": translate_single_multiline_stringable_values,
+    "salvages": translate_single_multiline_stringable_values,
+    "depends": translate_single_multiline_stringable_values,
+    "before": translate_single_multiline_stringable_values,
+    "setup_include": translate_include,
+    "include": translate_include,
+    "bootstrap_include": translate_include,
+    "nested_part": translate_include,
+    "exclude": translate_include,
+    "mandatory_include": translate_include,
+    "requires": translate_requires,
+    "template-imports": translate_requires,
+    "imports": translate_requires,
+    "template-filter": translate_requires,
+    "siblings": translate_siblings,
+    "certification_status_overrides": translate_requires,
+    "options": translate_options,
+}
+
+
+def translate_unit(unit_dict: dict) -> dict:
+
+    def no_translation(x):
+        if x.startswith("_"):
+            return x[1:]
+        return x
+
+    to_return = {}
+    for key, value in unit_dict.items():
+        key = no_translation(key)
+        try:
+            translated = field_translators[key](value)
+            to_return[key] = translated
+        except KeyError as e:
+            logging.error(
+                (
+                    "Unit {} has invalid field '{}', is it a typo? "
+                    "Dumping it as-is in the unit"
+                ).format(unit_dict.get("id", str(unit_dict)), str(e))
+            )
+            to_return[key] = value
+        except JinjaError as e:
+            logging.error(
+                (
+                    "Refusing to translate field '{}' of unit '{}' as it"
+                    "contains jinja markers. Dumping it as-is in the unit"
+                ).format(key, unit_dict.get("id", str(unit_dict)))
+            )
+            to_return[key] = value
+
+    return to_return
+
+
+def sort_unit(unit_dict):
+    """
+    Units should have keys in this order to be easier to read
+    """
+    key_order = [
+        "id",
+        "name",
+        "template-id",
+        "unit",
+        "template-unit",
+        "template-imports",
+        "template-resource",
+        "template-filter",
+        "template-summary",
+        "template-engine",
+        "imports",
+        "requires",
+        "plugin",
+        "description",
+        "summary",
+        "purpose",
+        "steps",
+        "verification",
+        "estimated_duration",
+        "before",
+        "after",
+        "depends",
+        "salvages",
+        "group",
+        "environ",
+        "flags",
+        "category_id",
+        "setup_include",
+        "bootstrap_include",
+        "include",
+        "exclude",
+        "nested_part",
+        "user",
+        "command",
+        "certification_status_overrides",
+        "sibling",
+    ]
+
+    def sorter(kv):
+        k = kv[0]
+        try:
+            return key_order.index(k)
+        except ValueError:
+            return len(key_order) + ord(k[0])
+
+    return dict(sorted(unit_dict.items(), key=sorter))
+
+
+def multiline_str_representer(dumper, data):
+    """
+    Render multiline strings as blocks, leave other strings unchanged.
+
+    This is a custom YAML representer for strings.
+    """
+    # see section "Constructors, representers resolvers"
+    # at https://pyyaml.org/wiki/PyYAMLDocumentation
+    # and https://yaml.org/spec/1.2.2/#literal-style
+    if "\n" in data:
+        # remove trailing whitespace from each line
+        # (suggested fix for https://github.com/yaml/pyyaml/issues/240)
+        data = "\n".join(line.rstrip() for line in data.splitlines()) + "\n"
+        return dumper.represent_scalar(
+            "tag:yaml.org,2002:str", data, style="|"
+        )
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+class Translator:
+    def register_arguments(self, parser):
+        parser.add_argument(
+            "paths",
+            nargs="+",
+            help="Units to be translated",
+            type=Path,
+        )
+
+    def invoked(self, ctx):
+        try:
+            from ruamel.yaml import YAML
+        except ModuleNotFoundError:
+            raise SystemExit(
+                "The translator can be used only by installing Checkbox "
+                "from source with:\n"
+                "  pip install checkbox-ng[translator]"
+            )
+        print("Starting...")
+        for path in ctx.args.paths:
+            with path.open("r") as f:
+                loaded = load_rfc822_records(f, source=str(path))
+            documents = []
+
+            yaml = YAML()
+            for unit_dict in loaded:
+                documents.append(sort_unit(translate_unit(unit_dict.data)))
+
+            yaml.width = 120
+            yaml.default_flow_style = False
+            yaml.representer.add_representer(str, multiline_str_representer)
+            yaml.indent(mapping=2, sequence=4, offset=2)
+            with path.with_suffix(".yaml").open("w+") as f:
+                yaml.dump_all(documents, f)

--- a/checkbox-ng/checkbox_ng/launcher/translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/translator.py
@@ -8,6 +8,10 @@ from itertools import takewhile
 from plainbox.impl.secure.rfc822 import load_rfc822_records
 
 
+def identity(value):
+    return value
+
+
 def multiline_text(value):
     # no more trailing spaces
     lines = (x.rstrip() for x in value.splitlines())
@@ -261,6 +265,10 @@ def translate_options(value):
 
 
 field_translators = {
+    "command": identity,
+    "Depends": identity,
+    "Suggests": identity,
+    "Recommends": identity,
     "id": commentable_value,
     "unit": commentable_value,
     "name": commentable_value,
@@ -269,7 +277,6 @@ field_translators = {
     "plugin": commentable_value,
     "category_id": commentable_value,
     "user": commentable_value,
-    "command": commentable_value,
     "value-type": commentable_value,
     "template-resource": commentable_value,
     "template-unit": commentable_value,
@@ -277,9 +284,6 @@ field_translators = {
     "template-engine": commentable_value,
     "entry_point": commentable_value,
     "file_extension": commentable_value,
-    "Depends": commentable_value,
-    "Suggests": commentable_value,
-    "Recommends": commentable_value,
     "os-version-id": commentable_value,
     "group": commentable_value,
     "description": multiline_text,
@@ -414,6 +418,11 @@ class Translator:
             documents = []
 
             yaml = YAML()
+            yaml.width = 120
+            yaml.default_flow_style = False
+            yaml.representer.add_representer(str, multiline_str_representer)
+            yaml.indent(mapping=2, sequence=4, offset=2)
+
             for unit_dict in loaded:
                 documents.append(translate_unit(unit_dict.data))
 
@@ -421,9 +430,5 @@ class Translator:
             if header_comment:
                 documents[0].yaml_set_start_comment(header_comment)
 
-            yaml.width = 120
-            yaml.default_flow_style = False
-            yaml.representer.add_representer(str, multiline_str_representer)
-            yaml.indent(mapping=2, sequence=4, offset=2)
             with path.with_suffix(".yaml").open("w+") as f:
                 yaml.dump_all(documents, f)

--- a/checkbox-ng/checkbox_ng/launcher/translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/translator.py
@@ -219,6 +219,7 @@ def translate_single_multiline_stringable_values(value):
 
 @dont_translate_jinja
 def translate_include(value):
+    original_value = value
     includes = value.splitlines()
     from ruamel.yaml.comments import CommentedSeq, CommentedMap
 
@@ -231,9 +232,12 @@ def translate_include(value):
         else:
             value = overrides = ""
         if overrides:  # we can assume there is value as well here
-            assert overrides.startswith("certification-status")
-            assert " " not in overrides, "Multi overrides are not supported"
-            assert "," not in overrides, "Multi overrides are not supported"
+            if " " in overrides or "," in overrides:
+                raise RuntimeError(
+                    "Multi overrides are not supported, remove: {}".format(
+                        overrides
+                    )
+                )
             overridden, override_value = overrides.strip().split(
                 "="
             )  # assumes 1 per line
@@ -256,17 +260,23 @@ def translate_include(value):
             else:
                 to_r.yaml_set_start_comment(comment)
         else:
-            assert False, "Tragedy"
+            raise RuntimeError(
+                "This should be unreachable code, report it with: {}".format(
+                    original_value
+                )
+            )
     return to_r
 
 
 def translate_options(value):
-    assert "#" not in value
+    if  "#" in value:
+        raise RuntimeError("Comments on options are not supported, remove it from: {}".format(value))
     return [x.strip() for x in value.split(",")]
 
 
 field_translators = {
     "command": identity,
+    "shell": identity,
     "Depends": identity,
     "Suggests": identity,
     "Recommends": identity,
@@ -288,7 +298,6 @@ field_translators = {
     "os-version-id": commentable_value,
     "group": commentable_value,
     "description": multiline_text,
-
     "summary": multiline_text,
     "purpose": multiline_text,
     "steps": multiline_text,

--- a/checkbox-ng/checkbox_ng/launcher/translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/translator.py
@@ -269,8 +269,12 @@ def translate_include(value):
 
 
 def translate_options(value):
-    if  "#" in value:
-        raise RuntimeError("Comments on options are not supported, remove it from: {}".format(value))
+    if "#" in value:
+        raise RuntimeError(
+            "Comments on options are not supported, remove it from: {}".format(
+                value
+            )
+        )
     return [x.strip() for x in value.split(",")]
 
 
@@ -417,7 +421,7 @@ class Translator:
             raise SystemExit(
                 "The translator can be used only by installing Checkbox "
                 "from source with:\n"
-                "  pip install checkbox-ng[translator]"
+                "  pip install -Ue checkbox-ng[translator]"
             )
 
         print("Starting...")

--- a/checkbox-ng/checkbox_ng/launcher/translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/translator.py
@@ -2,6 +2,7 @@ import json
 import logging
 from pathlib import Path
 from functools import wraps
+from itertools import takewhile
 
 
 from plainbox.impl.secure.rfc822 import load_rfc822_records
@@ -27,6 +28,8 @@ def commentable_value(value):
     This returns the value or raises a CommentedError if the value contains
     a comment
     """
+    # sibling will have mixed types (int), so we need to str it here
+    value = str(value)
     # this is technically not proper, as these values are not stringable, but
     # validation is not the job of the translator
     value, comment = split_comment(value)
@@ -224,8 +227,8 @@ def translate_include(value):
             value = overrides = ""
         if overrides:  # we can assume there is value as well here
             assert overrides.startswith("certification-status")
-            assert " " not in overrides
-            assert "," not in overrides
+            assert " " not in overrides, "Multi overrides are not supported"
+            assert "," not in overrides, "Multi overrides are not supported"
             overriden, override_value = overrides.strip().split(
                 "="
             )  # assumes 1 per line
@@ -336,7 +339,7 @@ def translate_unit(unit_dict: dict) -> dict:
         except JinjaError as e:
             logging.error(
                 (
-                    "Refusing to translate field '{}' of unit '{}' as it"
+                    "Refusing to translate field '{}' of unit '{}' as it "
                     "contains jinja markers. Dumping it as-is in the unit"
                 ).format(key, unit_dict.get("id", str(unit_dict)))
             )
@@ -367,6 +370,23 @@ def multiline_str_representer(dumper, data):
     return dumper.represent_scalar("tag:yaml.org,2002:str", data)
 
 
+def get_header_comment(text: str) -> str:
+    lines = iter(text.splitlines())
+    to_return = "\n".join(
+        # remove # and possible following spaces
+        x[1:].strip()
+        for x in takewhile(lambda x: x.startswith("#"), lines)
+    )
+    # if there are more comments, lets warn the user they will be ignored
+    other_comments = (x for x in lines if x.startswith("#"))
+    for comment in other_comments:
+        logging.error(
+            "Translator doesn't support non-header comments, ignoring: '%s'",
+            comment,
+        )
+    return to_return
+
+
 class Translator:
     def register_arguments(self, parser):
         parser.add_argument(
@@ -385,15 +405,21 @@ class Translator:
                 "from source with:\n"
                 "  pip install checkbox-ng[translator]"
             )
+
         print("Starting...")
         for path in ctx.args.paths:
             with path.open("r") as f:
-                loaded = load_rfc822_records(f, source=str(path))
+                text = f.read()
+            loaded = load_rfc822_records(text, source=str(path))
             documents = []
 
             yaml = YAML()
             for unit_dict in loaded:
                 documents.append(translate_unit(unit_dict.data))
+
+            header_comment = get_header_comment(text)
+            if header_comment:
+                documents[0].yaml_set_start_comment(header_comment)
 
             yaml.width = 120
             yaml.default_flow_style = False

--- a/checkbox-ng/checkbox_ng/launcher/translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/translator.py
@@ -183,6 +183,7 @@ def translate_requires(value):
     return to_r
 
 
+@dont_translate_jinja
 def translate_single_multiline_stringable_values(value):
     from ruamel.yaml.comments import CommentedSeq
 

--- a/checkbox-ng/checkbox_ng/launcher/translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/translator.py
@@ -38,7 +38,7 @@ def commentable_value(value):
     # validation is not the job of the translator
     value, comment = split_comment(value)
     if comment:
-        # here we raise an exception as rumel.yaml doesn't support returning
+        # here we raise an exception as ruamel.yaml doesn't support returning
         # commented fields
         raise CommentedError(value, comment)
     return value
@@ -61,7 +61,7 @@ def dont_translate_jinja(f):
           connections.slot == 'bluez:service'
           {% endif -%}
 
-        This would correclty be translated as
+        This would correctly be translated as
 
         requires:
           - package.name == 'bluez' or snap.name == 'bluez'
@@ -234,10 +234,10 @@ def translate_include(value):
             assert overrides.startswith("certification-status")
             assert " " not in overrides, "Multi overrides are not supported"
             assert "," not in overrides, "Multi overrides are not supported"
-            overriden, override_value = overrides.strip().split(
+            overridden, override_value = overrides.strip().split(
                 "="
             )  # assumes 1 per line
-            translation = {value: {overriden: override_value}}
+            translation = {value: {overridden: override_value}}
             if comment:
                 translation = CommentedMap(translation)
                 translation.yaml_add_eol_comment(comment, value)
@@ -288,7 +288,7 @@ field_translators = {
     "os-version-id": commentable_value,
     "group": commentable_value,
     "description": multiline_text,
-    "description": multiline_text,
+
     "summary": multiline_text,
     "purpose": multiline_text,
     "steps": multiline_text,
@@ -334,15 +334,15 @@ def translate_unit(unit_dict: dict) -> dict:
             translated = field_translators[key](value)
             to_return[key] = translated
         except KeyError as e:
-            logging.error(
+            logging.warning(
                 (
                     "Unit {} has invalid field '{}', is it a typo? "
                     "Dumping it as-is in the unit"
-                ).format(unit_dict.get("id", str(unit_dict)), str(e))
+                ).format(unit_dict.get("id", str(unit_dict)), key)
             )
             to_return[key] = value
         except JinjaError as e:
-            logging.error(
+            logging.warning(
                 (
                     "Refusing to translate field '{}' of unit '{}' as it "
                     "contains jinja markers. Dumping it as-is in the unit"
@@ -428,6 +428,9 @@ class Translator:
                 documents.append(translate_unit(unit_dict.data))
 
             header_comment = get_header_comment(text)
+            if not documents:
+                continue
+
             if header_comment:
                 documents[0].yaml_set_start_comment(header_comment)
 

--- a/checkbox-ng/checkbox_ng/launcher/translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/translator.py
@@ -399,7 +399,7 @@ class Translator:
     def invoked(self, ctx):
         try:
             from ruamel.yaml import YAML
-        except ModuleNotFoundError:
+        except ImportError:
             raise SystemExit(
                 "The translator can be used only by installing Checkbox "
                 "from source with:\n"

--- a/checkbox-ng/checkbox_ng/urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/urwid_ui.py
@@ -29,7 +29,7 @@ from gettext import gettext as _
 
 try:
     import urwid.raw_display as raw_display
-except ModuleNotFoundError:
+except ImportError:
     import urwid.display.raw as raw_display
 import urwid
 

--- a/checkbox-ng/pyproject.toml
+++ b/checkbox-ng/pyproject.toml
@@ -90,6 +90,9 @@ noble_prod = [
   'xlsxwriter==3.1.9',
   'pyyaml==6.0.1',
 ]
+translator = [
+  'ruamel.yaml'
+]
 [tool.black]
   line-length = 79
   # Exclude vendorized code (e.g. the stuff in plainbox/vendor/)

--- a/checkbox-ng/tox.ini
+++ b/checkbox-ng/tox.ini
@@ -72,6 +72,7 @@ deps =
     tqdm == 4.57.0
     psutil == 5.9.5
     PyYAML == 6.0.1
+    ruamel.yaml == 0.19.1 # note, this is for the translator, carry this over to new versions
 
 [testenv:py312]
 deps =
@@ -86,4 +87,4 @@ deps =
     tqdm == 4.66.2
     psutil == 5.9.8
     PyYAML == 6.0.1
-    ruamel.yaml == 0.19.1
+    ruamel.yaml == 0.19.1 # note, this is for the translator, carry this over to new versions

--- a/checkbox-ng/tox.ini
+++ b/checkbox-ng/tox.ini
@@ -86,3 +86,4 @@ deps =
     tqdm == 4.66.2
     psutil == 5.9.8
     PyYAML == 6.0.1
+    ruamel.yaml == 0.19.1


### PR DESCRIPTION
## Description

With this PR we introduce a new migration tool to translate PXUs to YAML. This already translates the unit with the new schema, which will be formalized (and bugfixed probably) in a followup PR. 

Support for comments is best effort. All inline comments should be supported. Header comments are supported. Comments on the top level (unindented commets) are not supported. Untranslatable comments yield a warning.

Jinja support is best effort. Jinja blocks the translation of fields, all fields that contain jinja template are translated as is. Given that jinja can technically modify the semantics (keys) of pxus, the translator, even dumping fields as they are, may break units. All jinja fields yield a warning.

The following fields are unchanged, lines with `.` are reduced to `""` as that is the semantic of them:
- description
- description
- summary
- purpose
- steps
- prompt
- hidden-reason
- verification
- template-summary

The following fields are now objects, no longer raw json (although json is an option, yaml > json)
 - data
 - siblings

The following fields are now a list:
 - environ
 - flags
 - after
 - salvages
 - depends
 - before
 - setup_include
 - include
 - bootstrap_include
 - nested_part
 - exclude
 - mandatory_include
 - requires
 - template-imports
 - imports
 - template-filter
 - certification_status_overrides
 - options

Inline overrides (which are effectively annotations in inclusions) are translated as such:

pxu:
```
include:
    job-baz certification-status=blocker
```

yaml:
```yaml
include:
  - job-baz:
      certification-status: blocker
```

## Resolved issues

Fixes: CHECKBOX-1393

## Documentation

Documentation of the new schema is not part of this PR. All decisions takes are documented in line in the code.

## Tests

Translator is tested
