### PR TITLE
Statically link nsenter and use nsenter.static (bugfix)

### DIFF
--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -105,6 +105,34 @@ parts:
     source: https://github.com/Hook25/plz-run.git
     source-type: git
 ################################################################################
+# statically linked nsenter as plz-run launches nsenter outside of the namespace
+# so if the user is using a different base / os with a different version of
+# glibc, nsenter won't work at all.
+  static-nsenter:
+    plugin: nil
+    source-tag: "v2.41.1"
+    source-depth: 1
+    source: https://github.com/util-linux/util-linux.git
+    build-packages:
+      - build-essential
+      - libcap-ng-dev
+      - git
+      - autoconf
+      - automake
+      - libtool
+      - gettext
+      - bison
+      - pkg-config
+      - flex
+      - autopoint
+    override-build: |
+      snapcraftctl build
+      ./autogen.sh
+      ./configure --disable-all-programs --enable-nsenter --enable-setpriv \
+        --enable-static-programs=nsenter
+      make LDFLAGS="-static -all-static"
+      install -D -m 755 nsenter.static "$SNAPCRAFT_PART_INSTALL/usr/bin/nsenter.static"
+################################################################################
 # Upstream: https://github.com/fwts/fwts/blob/master/snapcraft.yaml
   fwts:
     source-tag: "V25.07.00"

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -128,8 +128,8 @@ parts:
     override-build: |
       snapcraftctl build
       ./autogen.sh
-      ./configure --disable-all-programs --enable-nsenter --enable-setpriv \
-        --enable-static-programs=nsenter
+      ./configure --disable-all-programs --disable-year2038 --enable-nsenter \
+        --enable-setpriv --enable-static-programs=nsenter
       make LDFLAGS="-static -all-static"
       install -D -m 755 nsenter.static "$SNAPCRAFT_PART_INSTALL/usr/bin/nsenter.static"
 ################################################################################

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -105,6 +105,34 @@ parts:
     source: https://github.com/Hook25/plz-run.git
     source-type: git
 ################################################################################
+# statically linked nsenter as plz-run launches nsenter outside of the namespace
+# so if the user is using a different base / os with a different version of
+# glibc, nsenter won't work at all.
+  static-nsenter:
+    plugin: nil
+    source-tag: "v2.41.1"
+    source-depth: 1
+    source: https://github.com/util-linux/util-linux.git
+    build-packages:
+      - build-essential
+      - libcap-ng-dev
+      - git
+      - autoconf
+      - automake
+      - libtool
+      - gettext
+      - bison
+      - pkg-config
+      - flex
+      - autopoint
+    override-build: |
+      snapcraftctl build
+      ./autogen.sh
+      ./configure --disable-all-programs --enable-nsenter --enable-setpriv \
+        --enable-static-programs=nsenter
+      make LDFLAGS="-static -all-static"
+      install -D -m 755 nsenter.static "$SNAPCRAFT_PART_INSTALL/usr/bin/nsenter.static"
+################################################################################
 # Upstream: https://github.com/fwts/fwts/blob/master/snapcraft.yaml
   fwts:
     source-tag: "V25.07.00"

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -128,8 +128,8 @@ parts:
     override-build: |
       snapcraftctl build
       ./autogen.sh
-      ./configure --disable-all-programs --enable-nsenter --enable-setpriv \
-        --enable-static-programs=nsenter
+      ./configure --disable-all-programs --disable-year2038 --enable-nsenter \
+        --enable-setpriv --enable-static-programs=nsenter
       make LDFLAGS="-static -all-static"
       install -D -m 755 nsenter.static "$SNAPCRAFT_PART_INSTALL/usr/bin/nsenter.static"
 ################################################################################

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -112,6 +112,34 @@ parts:
     build-snaps:
       - go/latest/stable
 ################################################################################
+# statically linked nsenter as plz-run launches nsenter outside of the namespace
+# so if the user is using a different base / os with a different version of
+# glibc, nsenter won't work at all.
+  static-nsenter:
+    plugin: nil
+    source-tag: "v2.41.1"
+    source-depth: 1
+    source: https://github.com/util-linux/util-linux.git
+    build-packages:
+      - build-essential
+      - libcap-ng-dev
+      - git
+      - autoconf
+      - automake
+      - libtool
+      - gettext
+      - bison
+      - pkg-config
+      - flex
+      - autopoint
+    override-build: |
+      snapcraftctl build
+      ./autogen.sh
+      ./configure --disable-all-programs --enable-nsenter --enable-setpriv \
+        --enable-static-programs=nsenter
+      make LDFLAGS="-static -all-static"
+      install -D -m 755 nsenter.static "$SNAPCRAFT_PART_INSTALL/usr/bin/nsenter.static"
+################################################################################
 # Upstream: https://github.com/fwts/fwts/blob/master/snapcraft.yaml
   fwts:
     source-tag: "V25.07.00"

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -110,6 +110,34 @@ parts:
     build-snaps:
       - go/latest/stable
   ################################################################################
+  # statically linked nsenter as plz-run launches nsenter outside of the namespace
+  # so if the user is using a different base / os with a different version of
+  # glibc, nsenter won't work at all.
+  static-nsenter:
+    plugin: nil
+    source-tag: "v2.41.1"
+    source-depth: 1
+    source: https://github.com/util-linux/util-linux.git
+    build-packages:
+      - build-essential
+      - libcap-ng-dev
+      - git
+      - autoconf
+      - automake
+      - libtool
+      - gettext
+      - bison
+      - pkg-config
+      - flex
+      - autopoint
+    override-build: |
+      snapcraftctl build
+      ./autogen.sh
+      ./configure --disable-all-programs --enable-nsenter --enable-setpriv \
+        --enable-static-programs=nsenter
+      make LDFLAGS="-static -all-static"
+      install -D -m 755 nsenter.static "$CRAFT_PART_INSTALL/usr/bin/nsenter.static"
+  ################################################################################
   fwts:
     source-tag: "V25.07.00"
     source-depth: 1

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -887,7 +887,9 @@ def get_snap_mount_namespace_commands(target_user, shared_location):
         ]
     # these binaries are not reliably shipped / may not be in path
     runtime_path = get_checkbox_runtime_path()
-    runtime_nsenter = runtime_path / "usr" / "bin" / "nsenter"
+    # Note: on core16 we use dangerous nsenter, nsenter.static is not part of
+    #       the snap
+    runtime_nsenter = runtime_path / "usr" / "bin" / "nsenter.static"
 
     snap_name = os.getenv("SNAP_NAME", "checkbox")
     cmd += [


### PR DESCRIPTION
## Description

When using a snap with a different glibc version than the base system, nsenter will fail to start as plz-run starts the job outside the namespace (that is why we need nsenter!). This results in criptic error messages like the following:
```
/snap/checkbox22/current/usr/bin/nsenter: /lib/aarch64-linux-gnu/libselinux.so.1: no version information available (required by /snap/checkbox22/current/usr/bin/nsenter)
/snap/checkbox22/current/usr/bin/nsenter: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /snap/checkbox22/current/usr/bin/nsenter)
/snap/checkbox22/current/usr/bin/nsenter: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /snap/checkbox22/current/usr/bin/nsenter)
```

Although using a snap from a different base was never a supported use case, given the very weird nature of the message and the relatively easy bugfix, this fixes the issue.

## Resolved issues

Fixes: CHECKBOX-2170

## Documentation

Documented why we need the part in snapcraft yaml

## Tests

I've manually tested this by compiling nsenter.static (with the part commands) on a noble lxc and used it on bionic, it seems to work fine

Done the same the other way around, also works fine

- https://github.com/canonical/checkbox/actions/runs/21713410097
- https://github.com/canonical/checkbox/actions/runs/21713412989

Armhf builfs failed in previous. Retrigger tests:
- https://github.com/canonical/checkbox/actions/runs/21718742185
- https://github.com/canonical/checkbox/actions/runs/21718747154
