### PR TITLE
gnome monitor doesn't return the *active* resolution (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -37,8 +37,10 @@ from typing import (
     Set,
     Tuple,
 )
-from checkbox_support.monitor_config import MonitorConfig
+
 from gi.repository import Gio, GLib  # type: ignore
+
+from checkbox_support.monitor_config import MonitorConfig
 
 
 class Transform(IntEnum):
@@ -117,7 +119,6 @@ _PhysicalMonitorT = NamedTuple(
 
 
 class PhysicalMonitor(_PhysicalMonitorT):
-
     @classmethod
     def from_variant(cls, v: GLib.Variant):
         # not going to do extensive checks here
@@ -281,6 +282,7 @@ class MonitorConfigGnome(MonitorConfig):
             monitor.info.connector: mode.resolution
             for monitor in state.physical_monitors
             for mode in monitor.modes
+            if mode.is_current
         }
 
     def set_extended_mode(self) -> Dict[str, str]:
@@ -342,7 +344,7 @@ class MonitorConfigGnome(MonitorConfig):
         cycle_transforms: bool = False,
         resolution_filter: Optional[ResolutionFilter] = None,
         post_cycle_action: Callable[..., Any] = lambda *a, **k: sleep(5),
-        **post_cycle_action_kwargs: Any
+        **post_cycle_action_kwargs: Any,
     ):
         """Automatically cycle through the supported monitor configurations.
 

--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -344,7 +344,7 @@ class MonitorConfigGnome(MonitorConfig):
         cycle_transforms: bool = False,
         resolution_filter: Optional[ResolutionFilter] = None,
         post_cycle_action: Callable[..., Any] = lambda *a, **k: sleep(5),
-        **post_cycle_action_kwargs: Any,
+        **post_cycle_action_kwargs: Any
     ):
         """Automatically cycle through the supported monitor configurations.
 

--- a/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
@@ -170,6 +170,92 @@ class MonitorConfigGnomeTests(unittest.TestCase):
         )
 
     @patch("checkbox_support.dbus.gnome_monitor.Gio.DBusProxy")
+    def test_get_current_resolution_excludes_non_current(
+        self, mock_dbus_proxy
+    ):
+        """
+        Test that get_current_resolutions only returns resolutions
+        for modes that are marked as current.
+        """
+
+        mock_proxy = Mock()
+        mock_dbus_proxy.new_for_bus_sync.return_value = mock_proxy
+
+        gnome_monitor = MonitorConfigGnome()
+
+        # Use plain booleans instead of GLib.Variant since GLib is
+        # mocked; the code accesses properties via dict.get() so plain
+        # values work correctly and let us test truthy/falsy behavior.
+        raw = (
+            1,
+            [
+                (
+                    ("eDP-1", "LGD", "0x06b3", "0x00000000"),
+                    [
+                        (
+                            "1920x1200@59.950",
+                            1920,
+                            1200,
+                            59.950172424316406,
+                            1.0,
+                            [1.0, 2.0],
+                            {
+                                "is-current": True,
+                                "is-preferred": True,
+                            },
+                        ),
+                        (
+                            "1280x720@60.000",
+                            1280,
+                            720,
+                            60.0,
+                            1.0,
+                            [1.0],
+                            {
+                                "is-current": False,
+                                "is-preferred": False,
+                            },
+                        ),
+                    ],
+                    {
+                        "is-builtin": GLib.Variant("b", True),
+                        "display-name": GLib.Variant("s", "Built-in display"),
+                    },
+                ),
+                (
+                    ("HDMI-1", "LGD", "0x06b3", "0x00000000"),
+                    [
+                        (
+                            "2560x1440@59.950",
+                            2560,
+                            1440,
+                            59.950172424316406,
+                            1.0,
+                            [1.0, 2.0],
+                            {
+                                "is-current": False,
+                                "is-preferred": True,
+                            },
+                        )
+                    ],
+                    {
+                        "is-builtin": GLib.Variant("b", False),
+                        "display-name": GLib.Variant("s", "External Display"),
+                    },
+                ),
+            ],
+            [],
+            {},
+        )
+        mock_proxy.call_sync.return_value = (
+            self.MockGetCurrentStateReturnValue(raw)
+        )
+        resolutions = gnome_monitor.get_current_resolutions()
+        # Only eDP-1's current mode should appear;
+        # HDMI-1 has no current mode and eDP-1's non-current mode is excluded
+        self.assertEqual(resolutions, {"eDP-1": "1920x1200"})
+
+    @patch("checkbox_support.dbus.gnome_monitor.Gio.DBusProxy")
     def test_bad_input_type(self, mock_dbus_proxy):
         mock_proxy = Mock()
         mock_dbus_proxy.new_for_bus_sync.return_value = mock_proxy


### PR DESCRIPTION
## Description

Due to a simple regression in this module, the function `get_current_resolutions` is returning the last available resolution instead of the currently active.

## Resolved issues

Part of https://warthogs.atlassian.net/browse/RTW-577

## Documentation

N/A

## Tests

Updated the test cases.
