### PR TITLE
Specify fwts data directory for snap checkbox (Bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -188,7 +188,7 @@ def get_fwts_base_cmd() -> str:
                 + "but '{}' ".format(fwts_json_data_dir)
                 + "doesn't exist"
             )
-        return 'fwts -j "{}"'.format(fwts_json_data_dir)
+        return "fwts -j '{}'".format(fwts_json_data_dir)
     else:
         # deb, use the original command
         return "fwts"

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -188,7 +188,7 @@ def get_fwts_base_cmd() -> str:
                 + "but '{}' ".format(fwts_json_data_dir)
                 + "doesn't exist"
             )
-        return "fwts -j {}".format(fwts_json_data_dir)
+        return 'fwts -j "{}"'.format(fwts_json_data_dir)
     else:
         # deb, use the original command
         return "fwts"

--- a/checkbox-support/checkbox_support/scripts/fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/fwts_test.py
@@ -6,6 +6,7 @@ from argparse import ArgumentParser, RawTextHelpFormatter, REMAINDER
 from subprocess import Popen, PIPE, DEVNULL
 from shutil import which
 import os
+from pathlib import Path
 
 # These tests require user interaction and need either special handling
 # or skipping altogether (right now, we skip them but they're kept here
@@ -166,6 +167,31 @@ SERVER_TESTS.extend(
 # By default, we launch all the tests
 TESTS = sorted(list(set(QA_TESTS + HWE_TESTS)))
 SLEEP_TIME_RE = re.compile(r"(Suspend|Resume):\s+([\d\.]+)\s+seconds.")
+
+
+def get_fwts_base_cmd() -> str:
+    """Get the correct fwts command template depending on if we are inside a snap
+
+    :raises SystemExit: If we are in snap, but the json files needed by
+                        fwts's parser doesn't exist
+    :return: command string
+    """
+    if "CHECKBOX_RUNTIME" in os.environ and "SNAP" in os.environ:
+        # snap checkbox
+        # must specify where the klog.json, clog.json files are
+        fwts_json_data_dir = (
+            Path(os.environ["CHECKBOX_RUNTIME"]) / "share" / "fwts"
+        )
+        if not fwts_json_data_dir.exists():
+            raise SystemExit(
+                "We are in a snap environment, "
+                + "but '{}' ".format(fwts_json_data_dir)
+                + "doesn't exist"
+            )
+        return "fwts -j {}".format(fwts_json_data_dir)
+    else:
+        # deb, use the original command
+        return "fwts"
 
 
 def get_available_fwts_tests():
@@ -535,9 +561,8 @@ def main(args=None):
             marker = "{:=^80}\n".format(" Iteration {} ".format(iteration))
             with open(args.log, "a") as f:
                 f.write(marker)
-            command = "fwts -q --stdout-summary -r %s %s" % (
-                args.log,
-                " ".join(tests),
+            command = "{} -q --stdout-summary -r {} {}".format(
+                get_fwts_base_cmd(), args.log, " ".join(tests)
             )
             results["sleep"] = (
                 Popen(command, stdout=PIPE, shell=True)
@@ -602,7 +627,9 @@ def main(args=None):
                 # Split the log file for HWE (only if -t is not used)
                 if test == "acpitests":
                     test = "--acpitests"
-                command = "fwts -q --stdout-summary -r %s %s" % (log, test)
+                command = "{} -q --stdout-summary -r {} {}".format(
+                    get_fwts_base_cmd(), log, test
+                )
                 results[test] = (
                     Popen(command, stdout=PIPE, shell=True)
                     .communicate()[0]

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -615,7 +615,7 @@ class TestGetFwtsBaseCommand(unittest.TestCase):
         result = get_fwts_base_cmd()
 
         expected_dir = "/snap/checkbox/20486/checkbox-runtime/share/fwts"
-        expected_cmd = "fwts -j {}".format(expected_dir)
+        expected_cmd = "fwts -j '{}'".format(expected_dir)
         self.assertEqual(result, expected_cmd)
 
     @patch.dict(

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -25,6 +25,7 @@ import os
 from io import StringIO
 
 from checkbox_support.scripts.fwts_test import (
+    get_fwts_base_cmd,
     print_log,
     main,
     filter_available_tests,
@@ -589,3 +590,50 @@ class GetAvailableFwtsTestsTest(unittest.TestCase):
         result = get_available_fwts_tests()
 
         self.assertEqual(result, set())
+
+
+class TestGetFwtsBaseCommand(unittest.TestCase):
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_deb_environment(self):
+        result = get_fwts_base_cmd()
+        expected = "fwts"
+        self.assertEqual(result, expected)
+
+    @patch.dict(
+        os.environ,
+        {
+            "CHECKBOX_RUNTIME": "/snap/checkbox/20486/checkbox-runtime",
+            "SNAP": "/snap/checkbox/20486",
+        },
+        clear=True,
+    )
+    @patch("checkbox_support.scripts.fwts_test.Path.exists")
+    def test_snap_env_happy_path(self, mock_exists: MagicMock):
+        mock_exists.return_value = True
+
+        result = get_fwts_base_cmd()
+
+        expected_dir = "/snap/checkbox/20486/checkbox-runtime/share/fwts"
+        expected_cmd = "fwts -j {}".format(expected_dir)
+        self.assertEqual(result, expected_cmd)
+
+    @patch.dict(
+        os.environ,
+        {
+            "CHECKBOX_RUNTIME": "/snap/checkbox24/current/",
+            "SNAP": "/snap/checkbox-20735/",
+        },
+    )
+    @patch("checkbox_support.scripts.fwts_test.Path.exists")
+    def test_snap_env_missing_dir(self, mock_exists: MagicMock):
+        mock_exists.return_value = False
+
+        with self.assertRaises(SystemExit) as cm:
+            get_fwts_base_cmd()
+
+        self.assertIn("doesn't exist", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_fwts_test.py
@@ -624,6 +624,7 @@ class TestGetFwtsBaseCommand(unittest.TestCase):
             "CHECKBOX_RUNTIME": "/snap/checkbox24/current/",
             "SNAP": "/snap/checkbox-20735/",
         },
+        clear=True,
     )
     @patch("checkbox_support.scripts.fwts_test.Path.exists")
     def test_snap_env_missing_dir(self, mock_exists: MagicMock):

--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -8,6 +8,8 @@ import filecmp
 import sys
 import typing as T
 from checkbox_support.scripts.image_checker import has_desktop_environment
+from checkbox_support.scripts.fwts_test import get_fwts_base_cmd
+from shlex import split as sh_split
 from datetime import datetime
 import time
 import platform
@@ -203,7 +205,15 @@ class FwtsTester:
         log_file_path = "{}/fwts_{}.log".format(
             output_directory, "_".join(fwts_arguments)
         )
-        sp.run(["fwts", "-r", log_file_path, "-q", *fwts_arguments])
+        sp.run(
+            [
+                *sh_split(get_fwts_base_cmd()),
+                "-r",
+                log_file_path,
+                "-q",
+                *fwts_arguments,
+            ]
+        )
         result = sp.run(
             [
                 "sleep_test_log_check.py",


### PR DESCRIPTION
(I accidentally broke #2252 during rebase xD this PR is a copy of that based on the current main)

## Description

This PR fixes #1997 by specifying the `-j` option in fwts when we detect that we are in a snap environment. 

## Resolved issues

1. #1997
2. Fixed a few unbound variables and undefined variable access

## Documentation

Basically we are telling fwts to read the directory in checkbox runtime instead of whatever `/usr/share/fwts` is inside a snap.

```
-j, --json-data-path         Specify path to fwts json data files - default is /usr/share/fwts
```

## Tests

Original unit tests

Real hardware with snaps built [here](https://github.com/canonical/checkbox/actions/runs/21849207739):
- https://certification.canonical.com/hardware/201812-26713/submission/472544/ (18.04 classic frontend)
- https://certification.canonical.com/hardware/201812-26713/submission/472576/ (24.04 classic frontend)
The tests failed from real fwts errors, but fwts was correctly invoked with `-j`