### PR TITLE
Add test-snapd-tools-core24 support (New)

### DIFF
--- a/providers/base/bin/snap_tests.py
+++ b/providers/base/bin/snap_tests.py
@@ -26,7 +26,7 @@ except KeyError:
         TEST_SNAP = "test-snapd-tools-core22"
     elif "checkbox24" in runtime:
         TEST_SNAP = "test-snapd-tools-core24"
-    # This needs to be uncommented once test-snapd-tools-core26 will have a stable version.
+    # Uncomment once test-snapd-tools-core26 will have a stable version.
     # elif "checkbox26" in runtime:
     #     TEST_SNAP = "test-snapd-tools-core26"
     else:

--- a/providers/base/bin/snap_tests.py
+++ b/providers/base/bin/snap_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2015-2020 Canonical Ltd.
+# Copyright 2015-2026 Canonical Ltd.
 # All rights reserved.
 #
 # Written by:
@@ -24,6 +24,11 @@ except KeyError:
         TEST_SNAP = "test-snapd-tools-core20"
     elif "checkbox22" in runtime:
         TEST_SNAP = "test-snapd-tools-core22"
+    elif "checkbox24" in runtime:
+        TEST_SNAP = "test-snapd-tools-core24"
+    # This needs to be uncommented once test-snapd-tools-core26 will have a stable version.
+    # elif "checkbox26" in runtime:
+    #     TEST_SNAP = "test-snapd-tools-core26"
     else:
         TEST_SNAP = "test-snapd-tools"
 SNAPD_TASK_TIMEOUT = int(os.getenv("SNAPD_TASK_TIMEOUT", 30))


### PR DESCRIPTION
## Description
Add support for test-snapd-tools-core24 to match checkbox24 runtime.
This ensures the test snap uses the same base as the checkbox runtime, avoiding unnecessary downloads of a different core base snap.

Also prepare for core26 support (commented out until the snap has a stable release).

## Resolved issues
[CHECKBOX-2167](https://warthogs.atlassian.net/browse/CHECKBOX-2167)

## Documentation

N/A

## Tests

N/A


[CHECKBOX-2167]: https://warthogs.atlassian.net/browse/CHECKBOX-2167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ