### PR TITLE
Support extra envvars per snap (New)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -96,6 +96,21 @@ parts:
     stage:
       - version.txt
 ################################################################################
+  extra-environment:
+    plugin: nil
+    override-pull: |
+      echo "#fwts is in /lib/fwts instead of /lib
+      LD_LIBRARY_PATH+=/lib/fwts
+      # lapack and blas are pulled by opencv and install libraries in a directory
+      LD_LIBRARY_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lapack
+      LD_LIBRARY_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas
+      # GLIB object paths are ofc. not default as well
+      GI_TYPELIB_PATH+=/usr/lib/girepository-1.0
+      GI_TYPELIB_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/girepository-1.0
+      " >> $SNAPCRAFT_PART_INSTALL/extra_environment
+    stage:
+      - extra_environment
+################################################################################
   plz-run:
     plugin: go
     source: https://github.com/Hook25/plz-run.git

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -96,7 +96,7 @@ parts:
     stage:
       - version.txt
 ################################################################################
-  extra-environment:
+  extra-path-environment:
     plugin: nil
     override-pull: |
       echo "#fwts is in /lib/fwts instead of /lib
@@ -107,9 +107,9 @@ parts:
       # GLIB object paths are ofc. not default as well
       GI_TYPELIB_PATH+=/usr/lib/girepository-1.0
       GI_TYPELIB_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/girepository-1.0
-      " >> $SNAPCRAFT_PART_INSTALL/extra_environment
+      " >> $SNAPCRAFT_PART_INSTALL/extra_path_environment
     stage:
-      - extra_environment
+      - extra_path_environment
 ################################################################################
   plz-run:
     plugin: go

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -100,7 +100,7 @@ parts:
     stage:
       - version.txt
 ################################################################################
-  extra-environment:
+  extra-path-environment:
     plugin: nil
     override-pull: |
       echo "#fwts is in /lib/fwts instead of /lib
@@ -111,9 +111,9 @@ parts:
       # GLIB object paths are ofc. not default as well
       GI_TYPELIB_PATH+=/usr/lib/girepository-1.0
       GI_TYPELIB_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/girepository-1.0
-      " >> $SNAPCRAFT_PART_INSTALL/extra_environment
+      " >> $SNAPCRAFT_PART_INSTALL/extra_path_environment
     stage:
-      - extra_environment
+      - extra_path_environment
 ################################################################################
   plz-run:
     plugin: go

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -100,6 +100,21 @@ parts:
     stage:
       - version.txt
 ################################################################################
+  extra-environment:
+    plugin: nil
+    override-pull: |
+      echo "#fwts is in /lib/fwts instead of /lib
+      LD_LIBRARY_PATH+=/lib/fwts
+      # lapack and blas are pulled by opencv and install libraries in a directory
+      LD_LIBRARY_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lapack
+      LD_LIBRARY_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas
+      # GLIB object paths are ofc. not default as well
+      GI_TYPELIB_PATH+=/usr/lib/girepository-1.0
+      GI_TYPELIB_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/girepository-1.0
+      " >> $SNAPCRAFT_PART_INSTALL/extra_environment
+    stage:
+      - extra_environment
+################################################################################
   plz-run:
     plugin: go
     source: https://github.com/Hook25/plz-run.git

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -100,7 +100,7 @@ parts:
     stage:
       - version.txt
 ################################################################################
-  extra-environment:
+  extra-path-environment:
     plugin: nil
     override-pull: |
       echo "#fwts is in /lib/fwts instead of /lib
@@ -111,9 +111,9 @@ parts:
       # GLIB object paths are ofc. not default as well
       GI_TYPELIB_PATH+=/usr/lib/girepository-1.0
       GI_TYPELIB_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/girepository-1.0
-      " >> $SNAPCRAFT_PART_INSTALL/extra_environment
+      " >> $SNAPCRAFT_PART_INSTALL/extra_path_environment
     stage:
-      - extra_environment
+      - extra_path_environment
 ################################################################################
   plz-run:
     plugin: go

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -100,6 +100,21 @@ parts:
     stage:
       - version.txt
 ################################################################################
+  extra-environment:
+    plugin: nil
+    override-pull: |
+      echo "#fwts is in /lib/fwts instead of /lib
+      LD_LIBRARY_PATH+=/lib/fwts
+      # lapack and blas are pulled by opencv and install libraries in a directory
+      LD_LIBRARY_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lapack
+      LD_LIBRARY_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas
+      # GLIB object paths are ofc. not default as well
+      GI_TYPELIB_PATH+=/usr/lib/girepository-1.0
+      GI_TYPELIB_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/girepository-1.0
+      " >> $SNAPCRAFT_PART_INSTALL/extra_environment
+    stage:
+      - extra_environment
+################################################################################
   plz-run:
     plugin: go
     source: https://github.com/Hook25/plz-run.git

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -106,7 +106,7 @@ parts:
     stage:
       - version.txt
 ################################################################################
-  extra-environment:
+  extra-path-environment:
     plugin: nil
     override-pull: |
       echo "#fwts is in /lib/fwts instead of /lib
@@ -117,9 +117,9 @@ parts:
       # GLIB object paths are ofc. not default as well
       GI_TYPELIB_PATH+=/usr/lib/girepository-1.0
       GI_TYPELIB_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/girepository-1.0
-      " >> $SNAPCRAFT_PART_INSTALL/extra_environment
+      " >> $SNAPCRAFT_PART_INSTALL/extra_path_environment
     stage:
-      - extra_environment
+      - extra_path_environment
 ################################################################################
   plz-run:
     plugin: go

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -106,6 +106,21 @@ parts:
     stage:
       - version.txt
 ################################################################################
+  extra-environment:
+    plugin: nil
+    override-pull: |
+      echo "#fwts is in /lib/fwts instead of /lib
+      LD_LIBRARY_PATH+=/lib/fwts
+      # lapack and blas are pulled by opencv and install libraries in a directory
+      LD_LIBRARY_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lapack
+      LD_LIBRARY_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas
+      # GLIB object paths are ofc. not default as well
+      GI_TYPELIB_PATH+=/usr/lib/girepository-1.0
+      GI_TYPELIB_PATH+=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/girepository-1.0
+      " >> $SNAPCRAFT_PART_INSTALL/extra_environment
+    stage:
+      - extra_environment
+################################################################################
   plz-run:
     plugin: go
     source: https://github.com/Hook25/plz-run.git

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -104,6 +104,21 @@ parts:
     stage:
       - version.txt
   ################################################################################
+  extra-environment:
+    plugin: nil
+    override-pull: |
+      echo "#fwts is in /lib/fwts instead of /lib
+      LD_LIBRARY_PATH+=/lib/fwts
+      # lapack and blas are pulled by opencv and install libraries in a directory
+      LD_LIBRARY_PATH+=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack
+      LD_LIBRARY_PATH+=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas
+      # GLIB object paths are ofc. not default as well
+      GI_TYPELIB_PATH+=/usr/lib/girepository-1.0
+      GI_TYPELIB_PATH+=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0
+      " >> $CRAFT_PART_INSTALL/extra_environment
+    stage:
+      - extra_environment
+  ################################################################################
   plz-run:
     plugin: go
     source: https://github.com/Hook25/plz-run.git

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -104,7 +104,7 @@ parts:
     stage:
       - version.txt
   ################################################################################
-  extra-environment:
+  extra-path-environment:
     plugin: nil
     override-pull: |
       echo "#fwts is in /lib/fwts instead of /lib
@@ -115,9 +115,9 @@ parts:
       # GLIB object paths are ofc. not default as well
       GI_TYPELIB_PATH+=/usr/lib/girepository-1.0
       GI_TYPELIB_PATH+=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0
-      " >> $CRAFT_PART_INSTALL/extra_environment
+      " >> $CRAFT_PART_INSTALL/extra_path_environment
     stage:
-      - extra_environment
+      - extra_path_environment
   ################################################################################
   plz-run:
     plugin: go

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -541,6 +541,17 @@ class FakeJobRunner(UnifiedRunner):
         return builder.get_result()
 
 
+def add_to_environment(environment, key, values):
+    """
+    Modifies in place environment to add to `key` `values`
+    """
+    if not values:
+        return environment
+    current_value = environment.get(key, "").split(os.pathsep)
+    environment[key] = os.pathsep.join(values + current_value)
+    return environment
+
+
 def get_execution_environment(job, environ, session_id, nest_dir):
     """
     Get the environment required to execute the specified job:
@@ -583,39 +594,20 @@ def get_execution_environment(job, environ, session_id, nest_dir):
             env["TEXTDOMAINDIR"] = env["PLAINBOX_PROVIDER_LOCALE_DIR"] = (
                 job.provider.locale_dir
             )
-        if os.getenv("SNAP") or os.getenv("SNAP_APP_PATH"):
-            copy_vars = [
-                "PYTHONHOME",
-                "PYTHONUSERBASE",
-                "LD_LIBRARY_PATH",
-                "GI_TYPELIB_PATH",
-                "PERL5LIB",
-                "QT_PLUGIN_PATH",
-                "QT_QPA_PLATFORM",
-                "QT_QPA_PLATFORMTHEME",
-                "QT_DEBUG_PLUGINS",
-                "QML2_IMPORT_PATH",
-            ]
-            for key, value in env.items():
-                if key in copy_vars or key.startswith("SNAP"):
-                    env[key] = value
     # Use PATH that can lookup checkbox scripts
-    if job.provider.extra_PYTHONPATH:
-        env["PYTHONPATH"] = os.pathsep.join(
-            job.provider.extra_PYTHONPATH
-            + env.get("PYTHONPATH", "").split(os.pathsep)
-        )
+    env = add_to_environment(env, "PYTHONPATH", job.provider.extra_PYTHONPATH)
+
     # Inject nest_dir into PATH
-    env["PATH"] = os.pathsep.join(
-        [nest_dir]
-        + env.get("PATH", "").split(os.pathsep)
-        + job.provider.extra_PATH
+    env = add_to_environment(env, "PATH", [nest_dir] + job.provider.extra_PATH)
+
+    env = add_to_environment(
+        env, "LD_LIBRARY_PATH", job.provider.extra_LD_LIBRARY_PATH
     )
-    if job.provider.extra_LD_LIBRARY_PATH:
-        env["LD_LIBRARY_PATH"] = os.pathsep.join(
-            env.get("LD_LIBRARY_PATH", "").split(os.pathsep)
-            + job.provider.extra_LD_LIBRARY_PATH
-        )
+
+    # custom frontend / runtime may define extra envvars in this config file
+    for key, value in job.provider.extra_snap_environment.items():
+        env = add_to_environment(env, key, value)
+
     # Add per-session shared state directory
     env["PLAINBOX_SESSION_SHARE"] = WellKnownDirsHelper.session_share(
         session_id

--- a/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
@@ -1104,6 +1104,7 @@ class Provider1Tests(TestCase):
                 },
             ),
         ]
+        # Note the order, custom frontend variables have precedence
         self.assertEqual(
             Provider1.extra_snap_environment.func(provider),
             {

--- a/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
@@ -1062,7 +1062,7 @@ class Provider1Tests(TestCase):
             path = Path("/frontend_root")
             extra_env = Provider1._parse_extra_environment_file(path)
 
-        self.assertEqual(list(extra_env), ["LD_LIBRARY_PATH", "PATH"])
+        self.assertEqual(set(extra_env), {"LD_LIBRARY_PATH", "PATH"})
         self.assertEqual(
             extra_env["PATH"], ["/frontend_root/extra/path/location"]
         )

--- a/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
@@ -23,6 +23,8 @@ Test definitions for plainbox.impl.secure.providers.v1 module
 """
 
 from unittest import TestCase
+from collections import defaultdict
+from textwrap import dedent
 from unittest.mock import Mock, MagicMock, patch
 from pathlib import Path
 
@@ -1039,6 +1041,82 @@ class Provider1Tests(TestCase):
     def test_custom_frontend_root_value_error(self):
         with self.assertRaises(ValueError):
             self.provider.custom_frontend_root()
+
+    def test__parse_extra_environment_file(self):
+        extra_envvar_file = dedent("""# some comment
+        LD_LIBRARY_PATH+=some_path
+          # can also be indented
+          LD_LIBRARY_PATH += /some other path starts slash
+        PATH+=extra/path/location
+        malformed lines are ignored
+        """)
+
+        class PathMock(Path):
+            def read_text(self, *args, **kwargs):
+                return extra_envvar_file
+
+            def exists(self, **kwargs):
+                return True
+
+        path = PathMock("/frontend_root")
+        extra_env = Provider1._parse_extra_environment_file(path)
+
+        self.assertEqual(list(extra_env), ["LD_LIBRARY_PATH", "PATH"])
+        self.assertEqual(
+            extra_env["PATH"], ["/frontend_root/extra/path/location"]
+        )
+        self.assertEqual(
+            extra_env["LD_LIBRARY_PATH"],
+            [
+                "/frontend_root/some_path",
+                "/frontend_root/some other path starts slash",
+            ],
+        )
+
+    @patch("os.getenv")
+    def test_extra_snap_environment_not_snap(self, getenv):
+        getenv.return_value = None
+        self.assertFalse(Provider1.extra_snap_environment.func(MagicMock()))
+
+    @patch("os.getenv")
+    def test_extra_snap_environment_snap(self, getenv):
+        getenv.return_value = "/snap/checkbox24/current"
+        provider = MagicMock(custom_frontend_provider=True)
+        provider._parse_extra_environment_file.side_effect = [
+            defaultdict(
+                list,
+                {
+                    "LD_LIBRARY_PATH": [
+                        "/snap/checkbox24/current/some",
+                        "/snap/checkbox24/current/other",
+                    ]
+                },
+            ),
+            defaultdict(
+                list,
+                {
+                    "LD_LIBRARY_PATH": [
+                        "/snap/custom_frontend/current/some",
+                    ],
+                    "PATH": [
+                        "/snap/custom_frontend/random/bin/path",
+                    ],
+                },
+            ),
+        ]
+        self.assertEqual(
+            Provider1.extra_snap_environment.func(provider),
+            {
+                "LD_LIBRARY_PATH": [
+                    "/snap/custom_frontend/current/some",
+                    "/snap/checkbox24/current/some",
+                    "/snap/checkbox24/current/other",
+                ],
+                "PATH": [
+                    "/snap/custom_frontend/random/bin/path",
+                ],
+            },
+        )
 
 
 class CustomFrontendPROVIDERPATHTest(TestCase):

--- a/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
@@ -1043,13 +1043,15 @@ class Provider1Tests(TestCase):
             self.provider.custom_frontend_root()
 
     def test__parse_extra_environment_file(self):
-        extra_envvar_file = dedent("""# some comment
+        extra_envvar_file = dedent(
+            """# some comment
         LD_LIBRARY_PATH+=some_path
           # can also be indented
           LD_LIBRARY_PATH += /some other path starts slash
         PATH+=extra/path/location
         malformed lines are ignored
-        """)
+        """
+        )
 
         class PathMock(Path):
             def read_text(self, *args, **kwargs):

--- a/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
@@ -21,6 +21,7 @@ plainbox.impl.secure.providers.test_v1
 
 Test definitions for plainbox.impl.secure.providers.v1 module
 """
+
 from unittest import TestCase
 from unittest.mock import Mock, MagicMock, patch
 from pathlib import Path
@@ -777,9 +778,9 @@ class Provider1Tests(TestCase):
     @patch("os.getenv", new=Mock(return_value=None))
     def test_extra_PYTHONPATH(self):
         """
-        Verify that Provider1.extra_PYTHONPATH is always None
+        Verify that Provider1.extra_PYTHONPATH is always empty in unittests
         """
-        self.assertIsNone(self.provider.extra_PYTHONPATH)
+        self.assertFalse(self.provider.extra_PYTHONPATH)
 
     def test_fake(self):
         """

--- a/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
@@ -1053,15 +1053,14 @@ class Provider1Tests(TestCase):
         """
         )
 
-        class PathMock(Path):
-            def read_text(self, *args, **kwargs):
-                return extra_envvar_file
+        with patch(
+            "pathlib.Path.read_text",
+            return_value=extra_envvar_file,
+        ):
+            from pathlib import Path
 
-            def exists(self, **kwargs):
-                return True
-
-        path = PathMock("/frontend_root")
-        extra_env = Provider1._parse_extra_environment_file(path)
+            path = Path("/frontend_root")
+            extra_env = Provider1._parse_extra_environment_file(path)
 
         self.assertEqual(list(extra_env), ["LD_LIBRARY_PATH", "PATH"])
         self.assertEqual(

--- a/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
@@ -1042,7 +1042,7 @@ class Provider1Tests(TestCase):
         with self.assertRaises(ValueError):
             self.provider.custom_frontend_root()
 
-    def test__parse_extra_environment_file(self):
+    def test__parse_extra_path_environment_file(self):
         extra_envvar_file = dedent(
             """# some comment
         LD_LIBRARY_PATH+=some_path
@@ -1060,7 +1060,7 @@ class Provider1Tests(TestCase):
             from pathlib import Path
 
             path = Path("/frontend_root")
-            extra_env = Provider1._parse_extra_environment_file(path)
+            extra_env = Provider1._parse_extra_path_environment_file(path)
 
         self.assertEqual(set(extra_env), {"LD_LIBRARY_PATH", "PATH"})
         self.assertEqual(
@@ -1083,7 +1083,7 @@ class Provider1Tests(TestCase):
     def test_extra_snap_environment_snap(self, getenv):
         getenv.return_value = "/snap/checkbox24/current"
         provider = MagicMock(custom_frontend_provider=True)
-        provider._parse_extra_environment_file.side_effect = [
+        provider._parse_extra_path_environment_file.side_effect = [
             defaultdict(
                 list,
                 {

--- a/checkbox-ng/plainbox/impl/secure/providers/v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/v1.py
@@ -1104,10 +1104,10 @@ class Provider1(IProvider1):
         return [str(path) for path in frontend_paths if path.exists()]
 
     @staticmethod
-    def _parse_extra_environment_file(source_root) -> defaultdict:
-        extra_environment = source_root / "extra_environment"
+    def _parse_extra_path_environment_file(source_root) -> defaultdict:
+        extra_path_environment = source_root / "extra_path_environment"
         try:
-            text = extra_environment.read_text()
+            text = extra_path_environment.read_text()
         except FileNotFoundError:
             return defaultdict(list)
         lines = text.splitlines()
@@ -1125,7 +1125,7 @@ class Provider1(IProvider1):
                 to_r[key].append(str(source_root / value))
             except ValueError:
                 logger.error(
-                    "Ignoring malformed line in extra_environment {}".format(
+                    "Ignoring malformed line in extra_path_environment {}".format(
                         line
                     )
                 )
@@ -1134,7 +1134,7 @@ class Provider1(IProvider1):
     @cached_property
     def extra_snap_environment(self) -> dict:
         """
-        Additional environment variables from `$PROVIDER_ROOT/extra_environment`
+        Additional environment variables from `$PROVIDER_ROOT/extra_path_environment`
 
         $PROVIDER_ROOT is either $SNAP if test comes from a runtime provider
         or custom_frontend_root
@@ -1146,12 +1146,12 @@ class Provider1(IProvider1):
         runtime_root = Path(runtime_root)
         # Always load the runtime ones as frontend assume that the dependencies
         # from the frontend are available
-        to_r = self._parse_extra_environment_file(runtime_root)
+        to_r = self._parse_extra_path_environment_file(runtime_root)
 
         if not self.custom_frontend_provider:
             return dict(to_r)
 
-        custom_frontend_envvars = self._parse_extra_environment_file(
+        custom_frontend_envvars = self._parse_extra_path_environment_file(
             self.custom_frontend_root()
         )
 

--- a/checkbox-ng/plainbox/impl/secure/providers/v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/v1.py
@@ -1104,9 +1104,10 @@ class Provider1(IProvider1):
         return [str(path) for path in frontend_paths if path.exists()]
 
     @staticmethod
-    def _parse_extra_environment_file(path) -> defaultdict:
+    def _parse_extra_environment_file(source_root) -> defaultdict:
+        extra_environment = source_root / "extra_environment"
         try:
-            text = path.read_text()
+            text = extra_environment.read_text()
         except FileNotFoundError:
             return defaultdict(list)
         lines = text.splitlines()
@@ -1121,7 +1122,7 @@ class Provider1(IProvider1):
                 value = value.strip()
                 if value.startswith("/"):
                     value = value[1:]
-                to_r[key].append(str(path / value))
+                to_r[key].append(str(source_root / value))
             except ValueError:
                 logger.error(
                     "Ignoring malformed line in extra_environment {}".format(
@@ -1145,15 +1146,13 @@ class Provider1(IProvider1):
         runtime_root = Path(runtime_root)
         # Always load the runtime ones as frontend assume that the dependencies
         # from the frontend are available
-        to_r = self._parse_extra_environment_file(
-            runtime_root / "extra_environment"
-        )
+        to_r = self._parse_extra_environment_file(runtime_root)
 
         if not self.custom_frontend_provider:
             return dict(to_r)
 
         custom_frontend_envvars = self._parse_extra_environment_file(
-            self.custom_frontend_root() / "extra_environment"
+            self.custom_frontend_root()
         )
 
         # give priority to the custom_frontend additions

--- a/checkbox-ng/plainbox/impl/secure/providers/v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/v1.py
@@ -24,12 +24,14 @@
 :mod:`plainbox.impl.secure.providers.v1` -- Implementation of V1 provider
 =========================================================================
 """
+
 import collections
 import gettext
 import logging
 import os
 import sys
 from pathlib import Path
+from collections import defaultdict
 
 from plainbox.abc import IProvider1
 from plainbox.i18n import gettext as _
@@ -55,9 +57,9 @@ from plainbox.impl.unit import all_units
 from plainbox.impl.unit.file import FileRole
 from plainbox.impl.unit.file import FileUnit
 from plainbox.impl.unit.testplan import TestPlanUnit
+from plainbox.impl.unit.unit import on_ubuntucore
 from plainbox.impl.validation import Severity
 from plainbox.impl.validation import ValidationError
-
 
 logger = logging.getLogger("plainbox.secure.providers.v1")
 
@@ -1098,18 +1100,52 @@ class Provider1(IProvider1):
         return [str(path) for path in frontend_paths if path.exists()]
 
     @property
+    def extra_snap_environment(self) -> dict:
+        """
+        Additional environment variables from `$PROVIDER_ROOT/extra_environment`
+
+        $PROVIDER_ROOT is either $SNAP if test comes from a runtime provider
+        or custom_frontend_root
+        """
+        if not on_ubuntucore():
+            return {}
+        provider_snap_root = Path(os.environ["SNAP"])
+        if self.custom_frontend_provider:
+            provider_snap_root = self.custom_frontend_root
+        extra_environment_path = provider_snap_root / "extra_environment"
+        if not extra_environment_path.exists():
+            return {}
+        with extra_environment_path.open("r") as f:
+            lines = (l.strip() for l in f if not l.startswith("#"))
+            # allow empty lines
+            lines = list(filter(bool, lines))
+        to_r = defaultdict(list)
+        for line in lines:
+            try:
+                key, value = line.split("+=", maxsplit=1)
+                key = key.strip()
+                value = value.strip()
+                if value.startswith("/"):
+                    value = value[1:]
+                to_r[key].append(str(provider_snap_root / value))
+            except ValueError:
+                logger.error(
+                    "Ignoring malformed line in extra_environment {}".format(
+                        line
+                    )
+                )
+        return dict(to_r)
+
+    @property
     def extra_PYTHONPATH(self) -> list:
         """
         additional entry for PYTHONPATH, if needed.
 
         This entry is required for CheckBox scripts to import the correct
         CheckBox python libraries.
-
-        .. note::
-            The result may be None
         """
         if not self.custom_frontend_provider:
-            return None
+            return []
         python_name = "python{}.{}".format(
             sys.version_info.major, sys.version_info.minor
         )

--- a/checkbox-ng/plainbox/impl/secure/providers/v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/v1.py
@@ -1,6 +1,6 @@
 # This file is part of Checkbox.
 #
-# Copyright 2013-2015 Canonical Ltd.
+# Copyright 2013-2026 Canonical Ltd.
 # Written by:
 #   Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
 #   Massimiliano Girardi <massimiliano.girardi@canonical.com>
@@ -30,36 +30,40 @@ import gettext
 import logging
 import os
 import sys
-from pathlib import Path
 from collections import defaultdict
+from pathlib import Path
 
 from plainbox.abc import IProvider1
 from plainbox.i18n import gettext as _
-from plainbox.impl.secure.config import Config, Variable
+from plainbox.impl.decorators import cached_property
+from plainbox.impl.secure.config import (
+    Config,
+    IValidator,
+    NotEmptyValidator,
+    NotUnsetValidator,
+    PatternValidator,
+    Unset,
+    Variable,
+)
 from plainbox.impl.secure.config import (
     ValidationError as ConfigValidationError,
 )
-from plainbox.impl.secure.config import IValidator
-from plainbox.impl.secure.config import NotEmptyValidator
-from plainbox.impl.secure.config import NotUnsetValidator
-from plainbox.impl.secure.config import PatternValidator
-from plainbox.impl.secure.config import Unset
 from plainbox.impl.secure.origin import Origin
-from plainbox.impl.secure.plugins import FsPlugInCollection
-from plainbox.impl.secure.plugins import LazyFsPlugInCollection
-from plainbox.impl.secure.plugins import PlugIn
-from plainbox.impl.secure.plugins import PlugInError
-from plainbox.impl.secure.plugins import now
-from plainbox.impl.secure.rfc822 import FileTextSource
-from plainbox.impl.secure.rfc822 import RFC822SyntaxError
-from plainbox.impl.secure.rfc822 import load_rfc822_records
+from plainbox.impl.secure.plugins import (
+    FsPlugInCollection,
+    LazyFsPlugInCollection,
+    PlugIn,
+    PlugInError,
+    now,
+)
+from plainbox.impl.secure.rfc822 import (
+    FileTextSource,
+    RFC822SyntaxError,
+    load_rfc822_records,
+)
 from plainbox.impl.unit import all_units
-from plainbox.impl.unit.file import FileRole
-from plainbox.impl.unit.file import FileUnit
-from plainbox.impl.unit.testplan import TestPlanUnit
-from plainbox.impl.unit.unit import on_ubuntucore
-from plainbox.impl.validation import Severity
-from plainbox.impl.validation import ValidationError
+from plainbox.impl.unit.file import FileRole, FileUnit
+from plainbox.impl.validation import Severity, ValidationError
 
 logger = logging.getLogger("plainbox.secure.providers.v1")
 
@@ -1099,26 +1103,16 @@ class Provider1(IProvider1):
         frontend_paths = [frontend_root / path for path in paths]
         return [str(path) for path in frontend_paths if path.exists()]
 
-    @property
-    def extra_snap_environment(self) -> dict:
-        """
-        Additional environment variables from `$PROVIDER_ROOT/extra_environment`
-
-        $PROVIDER_ROOT is either $SNAP if test comes from a runtime provider
-        or custom_frontend_root
-        """
-        if not on_ubuntucore():
-            return {}
-        provider_snap_root = Path(os.environ["SNAP"])
-        if self.custom_frontend_provider:
-            provider_snap_root = self.custom_frontend_root
-        extra_environment_path = provider_snap_root / "extra_environment"
-        if not extra_environment_path.exists():
-            return {}
-        with extra_environment_path.open("r") as f:
-            lines = (l.strip() for l in f if not l.startswith("#"))
-            # allow empty lines
-            lines = list(filter(bool, lines))
+    @staticmethod
+    def _parse_extra_environment_file(path) -> defaultdict:
+        try:
+            text = path.read_text()
+        except FileNotFoundError:
+            return defaultdict(list)
+        lines = text.splitlines()
+        lines = (l.strip() for l in lines)
+        lines = filter(bool, lines)
+        lines = [l for l in lines if not l.startswith("#")]
         to_r = defaultdict(list)
         for line in lines:
             try:
@@ -1127,13 +1121,45 @@ class Provider1(IProvider1):
                 value = value.strip()
                 if value.startswith("/"):
                     value = value[1:]
-                to_r[key].append(str(provider_snap_root / value))
+                to_r[key].append(str(path / value))
             except ValueError:
                 logger.error(
                     "Ignoring malformed line in extra_environment {}".format(
                         line
                     )
                 )
+        return to_r
+
+    @cached_property
+    def extra_snap_environment(self) -> dict:
+        """
+        Additional environment variables from `$PROVIDER_ROOT/extra_environment`
+
+        $PROVIDER_ROOT is either $SNAP if test comes from a runtime provider
+        or custom_frontend_root
+        """
+        runtime_root = os.getenv("SNAP")
+        if not runtime_root:
+            return {}
+
+        runtime_root = Path(runtime_root)
+        # Always load the runtime ones as frontend assume that the dependencies
+        # from the frontend are available
+        to_r = self._parse_extra_environment_file(
+            runtime_root / "extra_environment"
+        )
+
+        if not self.custom_frontend_provider:
+            return dict(to_r)
+
+        custom_frontend_envvars = self._parse_extra_environment_file(
+            self.custom_frontend_root() / "extra_environment"
+        )
+
+        # give priority to the custom_frontend additions
+        for key, value in custom_frontend_envvars.items():
+            to_r[key] = value + to_r[key]
+
         return dict(to_r)
 
     @property

--- a/checkbox-ng/plainbox/impl/test_execution.py
+++ b/checkbox-ng/plainbox/impl/test_execution.py
@@ -16,20 +16,20 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import contextlib
-
 from pathlib import Path
+from unittest import TestCase, mock
 
 from plainbox.impl.execution import (
-    UnifiedRunner,
-    get_execution_command_systemd_unit,
-    get_execution_command_subshell,
-    dangerous_nsenter,
     MountingStrategy,
+    UnifiedRunner,
+    add_to_environment,
+    dangerous_nsenter,
+    get_execution_command_subshell,
+    get_execution_command_systemd_unit,
 )
 from plainbox.impl.unit.job import InvalidJob
-
-from unittest import TestCase, mock
 
 
 @contextlib.contextmanager
@@ -393,3 +393,23 @@ class TestMountingStrategy(TestCase):
             MountingStrategy.from_user_core("ubuntu", True, "core24"),
             MountingStrategy.MOUNT_AMBIENT_CAPABILITIES,
         )
+
+
+class TestAddToEnvironment(TestCase):
+    def test_no_values(self):
+        env = {}
+        self.assertEqual(env, add_to_environment(env, "some", []))
+
+    def test_not_present(self):
+        env = add_to_environment({}, "PATH", ["some", "path"])
+        self.assertIn("some", env["PATH"])
+        self.assertIn("path", env["PATH"])
+
+    def test_present(self):
+        og_path = os.pathsep.join(["og_path1", "og_path2"])
+        env = add_to_environment({"PATH": og_path}, "PATH", ["some", "path"])
+        new_path = env["PATH"].split(os.pathsep)
+        self.assertIn("og_path1", new_path)
+        self.assertIn("og_path2", new_path)
+        self.assertIn("some", new_path)
+        self.assertIn("path", new_path)

--- a/docs/how-to/custom-frontend-envvars.rst
+++ b/docs/how-to/custom-frontend-envvars.rst
@@ -1,0 +1,28 @@
+Custom Frontend Extra Path Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To define extra path environment variables that can be accessed globally by
+all tests in a frontend create a file in the root of the snap
+called ``extra_path_environment``.
+All paths in the file are relative to the root of your snap and will be
+correctly made absolute before passing them to your tests.
+
+Example:
+
+.. code-block::
+
+  # This library we are installing in a weird location
+  LD_LIBRARY_PATH += path to library
+  # Additionally we need to define this very important path
+  SOME_PATH += /very/important/location
+
+.. note::
+
+   This mechanism is designed to define PATH variables specifically to
+   address issues in packaging. Do not use this for general purpose environment
+   variable setting.
+
+.. warning::
+
+   All variables paths point to the root of your snap at runtime, regardless
+   if you prefix them with a ``/`` or not.

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -15,3 +15,4 @@ These how-to guides cover key operations and processes in Checkbox.
    using-match
    using-groups
    ancient-python
+   custom-frontend-envvars


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Some libraries are not the default locations and, without ldconfig support, which we don't have in snaps, we don't have an easy way to point to them. 
The old approach was to add them to the wrapper common, but this leads to:
- code duplication, all frontends have a copy of this file
- forced inheritance, Checkbox itself and all jobs of all providers see this variables and are influenced by them
- broken w/ the new interface. Now that custom frontends no longer have an independent agent,  this mechanism to define these variables doesn't work anymore. 

This introduces a new mechanism, in the form of a file in the root of the snap with a very simple sintax and comments support. This file is supposed to be created during snap creation and is in the form of:
```
# comments
VARIABLE_NAME+=value
```

## Resolved issues

Fixes: CHECKBOX-2172

## Documentation

Added a HowTo that expains how to use the new packaging feature

## Tests

Tested on a rebuilt version of Checkbox24. Use this command to run the test
```
snap download --edge checkbox24
unsquashfs checkbox24*.snap
cd squashfs-root
snap try --devmode .
checkbox24.checkbox run fwts
# ^^^ this fails
# lets patch it
```
Add this file under squashfs-root
```
#fwts is in /lib/fwts instead of /lib
LD_LIBRARY_PATH+=/lib/fwts
# lapack and blas are pulled by opencv and install libraries in a directory
LD_LIBRARY_PATH+=/usr/lib/x86_64-linux-gnu/lapack
LD_LIBRARY_PATH+=/usr/lib/x86_64-linux-gnu/blas
GI_TYPELIB_PATH+=/usr/lib/girepository-1.0
GI_TYPELIB_PATH+=/usr/lib/x86_64-linux-gnu/girepository-1.0
```
Now patch the snap and run the test(assuming `../checkbox` points to checkbox repo at this branch
```
cp -rT ../checkbox/checkbox-ng/checkbox_ng/ `find . -name "checkbox_ng"`; cp -rT ../checkbox/checkbox-ng/plainbox/ `find . -name "plainbox"`; checkbox24.checkbox run fwts
```