### PR TITLE
Add fscrypt tests to client-cert-iot-24-04 test plan (New)

### DIFF
--- a/providers/certification-client/units/client-cert-iot-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-iot-desktop-24-04.pxu
@@ -140,6 +140,7 @@ nested_part:
   edac-automated
   eeprom-automated
   ethernet-automated
+  fscrypt-automated
   graphics-discrete-gpu-cert-automated
   graphics-integrated-gpu-cert-automated
   gpio-automated

--- a/providers/certification-client/units/client-cert-iot-server-24-04.pxu
+++ b/providers/certification-client/units/client-cert-iot-server-24-04.pxu
@@ -133,6 +133,7 @@ nested_part:
   edac-automated
   eeprom-automated
   ethernet-automated
+  fscrypt-automated
   gpio-automated
   iot-fwts-automated
   i2c-automated


### PR DESCRIPTION
## Description

add fscrypt-automated tests to client-cert-iot-server-24-04-automated and client-cert-iot-desktop-24-04-automated as suggested by @weizhenwu 

