### PR TITLE
Build static nsenter for core16 (bugfix)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -101,6 +101,34 @@ parts:
     source: https://github.com/Hook25/plz-run.git
     source-type: git
 ################################################################################
+# statically linked nsenter as plz-run launches nsenter outside of the namespace
+# so if the user is using a different base / os with a different version of
+# glibc, nsenter won't work at all.
+  static-nsenter:
+    plugin: nil
+    source-tag: "v2.41.1"
+    source-depth: 1
+    source: https://github.com/util-linux/util-linux.git
+    build-packages:
+      - build-essential
+      - libcap-ng-dev
+      - git
+      - autoconf
+      - automake
+      - libtool
+      - gettext
+      - bison
+      - pkg-config
+      - flex
+      - autopoint
+    override-build: |
+      snapcraftctl build
+      ./autogen.sh
+      ./configure --disable-all-programs --disable-year2038 --enable-nsenter \
+        --enable-setpriv --enable-static-programs=nsenter
+      make LDFLAGS="-static -all-static"
+      install -D -m 755 nsenter.static "$SNAPCRAFT_PART_INSTALL/usr/bin/nsenter.static"
+################################################################################
 # Upstream: https://kernel.ubuntu.com/git/hwe/fwts.git/plain/snapcraft.yaml
   fwts:
     source-tag: "V23.09.00"

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -887,8 +887,6 @@ def get_snap_mount_namespace_commands(target_user, shared_location):
         ]
     # these binaries are not reliably shipped / may not be in path
     runtime_path = get_checkbox_runtime_path()
-    # Note: on core16 we use dangerous nsenter, nsenter.static is not part of
-    #       the snap
     runtime_nsenter = runtime_path / "usr" / "bin" / "nsenter.static"
 
     snap_name = os.getenv("SNAP_NAME", "checkbox")


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

We actually do use it if the test is launched as root. Uh oh

## Resolved issues

Fixes: CHECKBOX-2174

## Documentation

Removed misleading comment

## Tests

```
image-garden allocate ubuntu-core-16.x86_64
# download and scp the snap from the CI
# run test plan with agent/local
```

Build: https://github.com/canonical/checkbox/actions/runs/21832537172/job/62994651953

Note: failing runs are not due to this patch, its GH being weird yd. Those snaps aren't touched by this pr
