### PR TITLE
Fix fstrim test to not run when fstrim is not supported (bugfix)

### DIFF
--- a/providers/base/units/disk/jobs.pxu
+++ b/providers/base/units/disk/jobs.pxu
@@ -103,7 +103,7 @@ template-id: disk/fstrim_name
 estimated_duration: 1.0
 user: root
 requires:
- block_device.rotation == 'no' and block_device.name == '{name}'
+ (block_device.fstrim == 'True' and block_device.name == '{name}')
 _summary: Filesystem TRIM check for {product_slug}
 _purpose: Take the path of the storage device and test its TRIM capabilities
 command: fstrim_test.py --device-file {name}

--- a/providers/resource/bin/block_device_resource.py
+++ b/providers/resource/bin/block_device_resource.py
@@ -57,19 +57,20 @@ def usb_support(name, version):
     return "unsupported"
 
 
-def device_rotation(name):
+def device_fstrim(name):
     """
-    Check the device queue/rotational parameter to determine if it's a spinning
-    device or a non-spinning device, which indicates it's an SSD.
+    Check the device hw maximum discard bytes value. If it's 0, fstrim is
+    not supported; if it's anything else, fstrim should work. Assume a
+    missing file is equivalent to a 0 value (no support).
     """
-    path = "/sys/block/{0}/device/block/{0}/queue/rotational".format(name)
+    path = "/sys/block/{}/queue/discard_max_bytes".format(name)
     if not os.path.exists(path):
-        return "no"
+        return "False"
     with open(path, "rt") as f:
-        if f.read(1) == "1":
-            return "yes"
+        if int(f.read()) > 0:
+            return "True"
 
-    return "no"
+    return "False"
 
 
 def smart_supporting_diskinfo(diskinfo) -> bool:
@@ -160,7 +161,7 @@ def main():
         state = device_state(disk_name)
         usb2 = usb_support(disk_name, 2.00)
         usb3 = usb_support(disk_name, 3.00)
-        rotation = device_rotation(disk_name)
+        fstrim = device_fstrim(disk_name)
         smart = smart_support(disk_name)
         resource_text = textwrap.dedent(
             """
@@ -168,14 +169,14 @@ def main():
             state: {state}
             usb2: {usb2}
             usb3: {usb3}
-            rotation: {rotation}
+            fstrim: {fstrim}
             smart: {smart}
             """.format(
                 disk_name=disk_name,
                 state=state,
                 usb2=usb2,
                 usb3=usb3,
-                rotation=rotation,
+                fstrim=fstrim,
                 smart=smart,
             )
         ).lstrip()

--- a/providers/resource/tests/test_block_device_resource.py
+++ b/providers/resource/tests/test_block_device_resource.py
@@ -46,20 +46,30 @@ class TestUsbSupport(unittest.TestCase):
         self.assertEqual(result, "unsupported")
 
 
-class TestDeviceRotation(unittest.TestCase):
-    @patch("builtins.open", new_callable=mock_open, read_data="1")
+class TestDeviceFstrimSupport(unittest.TestCase):
+    @patch("builtins.open", new_callable=mock_open, read_data="0")
     @patch("os.path.exists")
-    def test_device_rotation_spinning(self, mock_path_exists, mock_file):
+    def test_device_fstrim_no_support(self, mock_path_exists, mock_file):
         mock_path_exists.return_value = True
-        result = block_device_resource.device_rotation("sda")
-        self.assertEqual(result, "yes")
+        result = block_device_resource.device_fstrim("sda")
+        self.assertEqual(result, "False")
+
+    @patch("builtins.open", new_callable=mock_open, read_data="2199023255040")
+    @patch("os.path.exists")
+    def test_device_fstrim(self, mock_path_exists, mock_file):
+        mock_path_exists.return_value = True
+        result = block_device_resource.device_fstrim("sdb")
+        self.assertEqual(result, "True")
 
     @patch("builtins.open", new_callable=mock_open, read_data="0")
     @patch("os.path.exists")
-    def test_device_rotation_non_spinning(self, mock_path_exists, mock_file):
-        mock_path_exists.return_value = True
-        result = block_device_resource.device_rotation("sdb")
-        self.assertEqual(result, "no")
+    def test_device_fstrim_file_missing(self, mock_path_exists, mock_file):
+        """Test device_fstrim when discard_max_bytes file doesn't exist."""
+        mock_path_exists.return_value = False
+        result = block_device_resource.device_fstrim("sdc")
+        self.assertEqual(result, "False")
+        # Verify the file was never opened since it doesn't exist
+        mock_file.assert_not_called()
 
 
 class TestSmartSupportDiskInfo(unittest.TestCase):
@@ -163,12 +173,12 @@ class TestMainFunction(unittest.TestCase):
     @patch("block_device_resource.Path.glob")
     @patch("block_device_resource.device_state")
     @patch("block_device_resource.usb_support")
-    @patch("block_device_resource.device_rotation")
+    @patch("block_device_resource.device_fstrim")
     @patch("block_device_resource.smart_support")
     def test_block_device_resource_main(
         self,
         mock_smart_support,
-        mock_device_rotation,
+        mock_device_fstrim,
         mock_usb_support,
         mock_device_state,
         mock_path_glob,
@@ -184,7 +194,7 @@ class TestMainFunction(unittest.TestCase):
         mock_usb_support.side_effect = lambda name, version: (
             "supported" if version == 3.00 else "unsupported"
         )
-        mock_device_rotation.return_value = "yes"
+        mock_device_fstrim.return_value = "False"
         mock_smart_support.return_value = "True"
 
         # Capturing the output of print statements
@@ -198,7 +208,7 @@ class TestMainFunction(unittest.TestCase):
                 state: internal
                 usb2: unsupported
                 usb3: supported
-                rotation: yes
+                fstrim: False
                 smart: True
                 """
             ).lstrip()


### PR DESCRIPTION
Title: Fixed fstrim resource job to not run the disk/fstrim_{name} test when it's not supported (BugFix)

## Description

The disk/fstrim_{name} tests were running even on disks (mainly spinning disks) that do not support TRIM, leading to failed tests when those tests should be skipped instead. This submission changes that behavior, mainly by altering a resource job:

* There actually was a resource job to detect if a disk was a spinning disk, which would not support fstrim; however, it was broken because it was looking at a file in the `sys` directory that no longer existed. Also, a test for whether a disk is a spinning disk isn't quite adequate, because some SSDs don't support fstrim (if they're in a RAID array, for instance).
* This pre-existing resource job is renamed and re-worked so that it works to more directly and correctly detect TRIM support, not simply whether a disk is a spinning disk. The basic mechanism is the same; it looks for TRIM support in the `sys` directory tree, but in different files. Re-naming the job required modifying the user of the resource job (see below).
* These changes required changes to the unit test.
* The user of this resource job, in `providers/base/units/disk/jobs.pxu`, is updated to use the new name and syntax. Also, it had been broken because of a lack of parentheses around the `requires` test; this has been fixed.

## Resolved issues

Jira: https://warthogs.atlassian.net/browse/SERVCERT-256
GitHub: https://github.com/canonical/checkbox/issues/216
Launchpad: https://bugs.launchpad.net/plainbox-provider-checkbox/+bug/1969663 (defunct; including for completeness)

## Documentation

No documentation changes are required.

As noted, changes to the unit tests were required, and are included in this PR.

## Tests

I've tested on a number of systems, and they all now perform as expected, skipping disks that do not support fstrim. For instance:

* https://certification.canonical.com/hardware/201409-15506/submission/472493/ -- A test of teela, one of my personal systems with an SSD and a spinning disk;
* https://certification.canonical.com/hardware/202409-35406/submission/472498/ -- A test of amontons, a server in TOR-3 with one NVMe and four spinning disks

In all cases, disks that lack fstrim support are now skipped, while those that do support it are tested.