### PR TITLE
Hardcode XDG_RUNTIME_DIR and DBUS path (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -325,8 +325,6 @@ class RemoteSessionAssistant:
             "XAUTHORITY",
             "XDG_CURRENT_DESKTOP",
             "XDG_SESSION_TYPE",
-            "XDG_RUNTIME_DIR",
-            "DBUS_SESSION_BUS_ADDRESS",
             "WAYLAND_DISPLAY",
         }
         extra_env = {}
@@ -363,15 +361,14 @@ class RemoteSessionAssistant:
             present_keys = i_env.keys() & missing_keys
             extra_env.update({k: i_env[k] for k in present_keys})
 
+        # inheriting these two basically never works because they are either
+        # the following or a transient value inherited from another snap, which
+        # will not work.
         uid = pwd.getpwnam(self._normal_user).pw_uid
-        # we may be starting before a user session, lets try to assign a
-        # default value to the runtime dir and dbus session
-        if "XDG_RUNTIME_DIR" not in extra_env:
-            extra_env["XDG_RUNTIME_DIR"] = "/run/user/{}".format(uid)
-        if "DBUS_SESSION_BUS_ADDRESS" not in extra_env:
-            extra_env["DBUS_SESSION_BUS_ADDRESS"] = (
-                "unix:path=/run/user/{}/bus".format(uid)
-            )
+        extra_env["XDG_RUNTIME_DIR"] = "/run/user/{}".format(uid)
+        extra_env["DBUS_SESSION_BUS_ADDRESS"] = (
+            "unix:path=/run/user/{}/bus".format(uid)
+        )
         return extra_env
 
     @allowed_when(RemoteSessionStates.Idle)


### PR DESCRIPTION

## Description

As stated in the description, as far as I know, the inherited value is basically always wrong, so it doesn't make sense to adopt it. We need the "main" dbus and runtime dir to interact with the services we need. When inherited these values are either the ones I hardcoded here (which work, as reported) or are wrong because they come from a random snap which have a runtime dir and a dbus that have their own permissions (and we can't work with that). 

## Resolved issues

Fixes: CHECKBOX-2134
Fixes: https://github.com/canonical/checkbox/issues/2220

## Documentation

Documented in comment

## Tests

Tested in person in taipei. Also, this is exaclty what the issue expects
