### PR TITLE
Lock focal version to 5.12 and transition all others to latest (bugfix)

### DIFF
--- a/.github/workflows/metabox.yaml
+++ b/.github/workflows/metabox.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee
         with:
-          channel: ${{ matrix.os == '16.04' && '5.12/stable' || 'latest/stable' }}
+          channel: ${{ matrix.os == '16.04' && '5.21/stable' || 'latest/stable' }}
       - name: Add ZFS storage
         run: |
           lxc storage list


### PR DESCRIPTION
## Description

Non-5.12 versions of lxd were never supported on focal, now this manifests in this error: [Error](https://github.com/canonical/checkbox/actions/runs/22057348478/job/63737549698?pr=2336)

This fixes the ci to that version on focal (used for 16.04) and given that focal runners are very few, moves all the other pipelines to latest, which is fine. 

## Resolved issues

Fixes: CHECKBOX-2179

## Documentation

N/A

## Tests

CI here!
