### PR TITLE
graphics_card: add `drm_node` field (New)

### DIFF
--- a/providers/resource/bin/graphics_card_resource.py
+++ b/providers/resource/bin/graphics_card_resource.py
@@ -219,21 +219,17 @@ def main():
                     record["driver"]
                 ][1]
 
-            # DRM node named in the udev record
-            if (
-                "name" in record
-                and (drm_path := Path("/dev/") / record["name"]).exists()
-            ):
-                record["drm_node"] = drm_path
-            # Find the DRM node in device tree
-            elif (
-                cards := tuple(Path("/sys" + record["path"]).glob("drm/card*"))
-            ) and len(cards) == 1:
+            cards = tuple(Path("/sys" + record["path"]).glob("drm/card*"))
+            if "name" in record and (Path("/dev/") / record["name"]).exists():
+                # DRM node named in the udev record
+                record["drm_node"] = Path("/dev/") / record["name"]
+            elif len(cards) == 1:
+                # Find the DRM node in device tree
                 record["drm_node"] = Path("/dev/dri") / cards[0].name
             else:
                 sys.stderr.write(
                     "Warning: could not find DRM node for device at path "
-                    f"{record['path']}\n"
+                    "{path}\n".format(path=record["path"])
                 )
                 record["drm_node"] = ""
 

--- a/providers/resource/bin/graphics_card_resource.py
+++ b/providers/resource/bin/graphics_card_resource.py
@@ -20,8 +20,10 @@
 
 import argparse
 import collections
+from pathlib import Path
 import subprocess
 import shlex
+import sys
 
 from checkbox_support.helpers.slugify import slugify
 from checkbox_support.helpers.release_info import get_release_info
@@ -216,6 +218,25 @@ def main():
                 video_devices[0]["switch_to_cmd"] = switch_cmds[
                     record["driver"]
                 ][1]
+
+            # DRM node named in the udev record
+            if (
+                "name" in record
+                and (drm_path := Path("/dev/") / record["name"]).exists()
+            ):
+                record["drm_node"] = drm_path
+            # Find the DRM node in device tree
+            elif (
+                cards := tuple(Path("/sys" + record["path"]).glob("drm/card*"))
+            ) and len(cards) == 1:
+                record["drm_node"] = Path("/dev/dri") / cards[0].name
+            else:
+                sys.stderr.write(
+                    "Warning: could not find DRM node for device at path "
+                    f"{record['path']}\n"
+                )
+                record["drm_node"] = ""
+
         # Finally, print the records
         for record in video_devices:
             items = [

--- a/providers/resource/tests/test_graphics_card_resource.py
+++ b/providers/resource/tests/test_graphics_card_resource.py
@@ -28,10 +28,13 @@ class GraphicsCardResourceTests(unittest.TestCase):
 
     def _run_main_with_udev_data(self, udev_data):
         """Helper to run main() with mocked udev data."""
-        with patch("graphics_card_resource.parse_args") as mock_args, \
-             patch("graphics_card_resource.subprocess_lines_generator") as mock_gen, \
-             patch("graphics_card_resource.sys.stderr", new_callable=StringIO) as mock_stderr, \
-             patch("builtins.print"):
+        with patch("graphics_card_resource.parse_args") as mock_args, patch(
+            "graphics_card_resource.subprocess_lines_generator"
+        ) as mock_gen, patch(
+            "graphics_card_resource.sys.stderr", new_callable=StringIO
+        ) as mock_stderr, patch(
+            "builtins.print"
+        ):
 
             mock_args.return_value = MagicMock(command="udev_resource.py")
             mock_gen.return_value = iter(udev_data)
@@ -77,7 +80,7 @@ class GraphicsCardResourceTests(unittest.TestCase):
             "category: VIDEO",
             "path: /devices/pci0000:00/0000:00:02.0",
             "name: card0",
-            ""
+            "",
         ]
 
         def path_factory(path_str):
@@ -99,7 +102,7 @@ class GraphicsCardResourceTests(unittest.TestCase):
         udev_data = [
             "category: VIDEO",
             "path: /devices/pci0000:00/0000:00:02.0",
-            ""
+            "",
         ]
 
         mock_card = MagicMock(spec=Path, name="card0")
@@ -109,7 +112,9 @@ class GraphicsCardResourceTests(unittest.TestCase):
             if path_str.startswith("/sys"):
                 mock_path.glob.return_value = iter([mock_card])
             elif path_str == "/dev/dri":
-                mock_path.__truediv__ = MagicMock(return_value=MagicMock(spec=Path))
+                mock_path.__truediv__ = MagicMock(
+                    return_value=MagicMock(spec=Path)
+                )
             return mock_path
 
         with patch("graphics_card_resource.Path", side_effect=path_factory):
@@ -121,7 +126,7 @@ class GraphicsCardResourceTests(unittest.TestCase):
         udev_data = [
             "category: VIDEO",
             "path: /devices/pci0000:00/0000:00:02.0",
-            ""
+            "",
         ]
 
         def path_factory(path_str):
@@ -140,7 +145,7 @@ class GraphicsCardResourceTests(unittest.TestCase):
         udev_data = [
             "category: VIDEO",
             "path: /devices/pci0000:00/0000:00:02.0",
-            ""
+            "",
         ]
 
         mock_card1 = MagicMock(spec=Path, name="card0")

--- a/providers/resource/tests/test_graphics_card_resource.py
+++ b/providers/resource/tests/test_graphics_card_resource.py
@@ -18,11 +18,25 @@
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+from io import StringIO
 import graphics_card_resource
 
 
 class GraphicsCardResourceTests(unittest.TestCase):
+
+    def _run_main_with_udev_data(self, udev_data):
+        """Helper to run main() with mocked udev data."""
+        with patch("graphics_card_resource.parse_args") as mock_args, \
+             patch("graphics_card_resource.subprocess_lines_generator") as mock_gen, \
+             patch("graphics_card_resource.sys.stderr", new_callable=StringIO) as mock_stderr, \
+             patch("builtins.print"):
+
+            mock_args.return_value = MagicMock(command="udev_resource.py")
+            mock_gen.return_value = iter(udev_data)
+            graphics_card_resource.main()
+            return mock_stderr.getvalue()
 
     @patch("graphics_card_resource.get_release_info")
     def test_compare_ubuntu_release_version(self, mock_release_info):
@@ -56,6 +70,92 @@ class GraphicsCardResourceTests(unittest.TestCase):
         record_list = list(record)
         self.assertEqual(len(record_list), 1)
         self.assertEqual(record_list[0]["pci_device_name"], "0000:01:00.0")
+
+    def test_drm_node_from_udev_name(self):
+        """Test DRM node detection when name is in udev record."""
+        udev_data = [
+            "category: VIDEO",
+            "path: /devices/pci0000:00/0000:00:02.0",
+            "name: card0",
+            ""
+        ]
+
+        def path_factory(path_str):
+            mock_path = MagicMock(spec=Path)
+            if path_str.startswith("/sys"):
+                mock_path.glob.return_value = iter([])
+            elif path_str == "/dev/":
+                mock_result = MagicMock(spec=Path)
+                mock_result.exists.return_value = True
+                mock_path.__truediv__ = MagicMock(return_value=mock_result)
+            return mock_path
+
+        with patch("graphics_card_resource.Path", side_effect=path_factory):
+            stderr = self._run_main_with_udev_data(udev_data)
+        self.assertEqual(stderr, "")
+
+    def test_drm_node_single_card_in_sysfs(self):
+        """Test DRM node detection when exactly one card found in sysfs."""
+        udev_data = [
+            "category: VIDEO",
+            "path: /devices/pci0000:00/0000:00:02.0",
+            ""
+        ]
+
+        mock_card = MagicMock(spec=Path, name="card0")
+
+        def path_factory(path_str):
+            mock_path = MagicMock(spec=Path)
+            if path_str.startswith("/sys"):
+                mock_path.glob.return_value = iter([mock_card])
+            elif path_str == "/dev/dri":
+                mock_path.__truediv__ = MagicMock(return_value=MagicMock(spec=Path))
+            return mock_path
+
+        with patch("graphics_card_resource.Path", side_effect=path_factory):
+            stderr = self._run_main_with_udev_data(udev_data)
+        self.assertEqual(stderr, "")
+
+    def test_drm_node_warning_no_cards(self):
+        """Test DRM node detection when no cards found (warning case)."""
+        udev_data = [
+            "category: VIDEO",
+            "path: /devices/pci0000:00/0000:00:02.0",
+            ""
+        ]
+
+        def path_factory(path_str):
+            mock_path = MagicMock(spec=Path)
+            if path_str.startswith("/sys"):
+                mock_path.glob.return_value = iter([])
+            return mock_path
+
+        with patch("graphics_card_resource.Path", side_effect=path_factory):
+            stderr = self._run_main_with_udev_data(udev_data)
+        self.assertIn("Warning: could not find DRM node", stderr)
+        self.assertIn("/devices/pci0000:00/0000:00:02.0", stderr)
+
+    def test_drm_node_warning_multiple_cards(self):
+        """Test DRM node detection when multiple cards found (warning case)."""
+        udev_data = [
+            "category: VIDEO",
+            "path: /devices/pci0000:00/0000:00:02.0",
+            ""
+        ]
+
+        mock_card1 = MagicMock(spec=Path, name="card0")
+        mock_card2 = MagicMock(spec=Path, name="card1")
+
+        def path_factory(path_str):
+            mock_path = MagicMock(spec=Path)
+            if path_str.startswith("/sys"):
+                mock_path.glob.return_value = iter([mock_card1, mock_card2])
+            return mock_path
+
+        with patch("graphics_card_resource.Path", side_effect=path_factory):
+            stderr = self._run_main_with_udev_data(udev_data)
+        self.assertIn("Warning: could not find DRM node", stderr)
+        self.assertIn("/devices/pci0000:00/0000:00:02.0", stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Adds a `drm_node` field to the `graphics_card` resource:

```
bus: pci                                                                                                                                                                                                                              
category: VIDEO                                                                                                                                                                                                                       
driver: i915                                                                                                                                                                                                                          
drm_node: /dev/dri/card1                                                                                                                                                                                                              gpu_count: 1
index: 1                                                                                                                                                                                                                              path: /devices/pci0000:00/0000:00:02.0
pci_device_name: 0000:00:02.0                                                                                                                                                                                                         prime_gpu_offload: Off
product: Meteor Lake-P [Intel Arc Graphics]                                                                                                                                                                                           product_id: 32085
product_slug: Meteor_Lake_P__Intel_Arc_Graphics_                                                                                                                                                                                      subproduct_id: 9
subvendor_id: 61713                                                                                                                                                                                                                   switch_to_cmd: false
vendor: Intel Corporation                                                                                                                                                                                                             vendor_id: 32902
vendor_slug: Intel_Corporation
```

## Resolved issues

Closes: #2283

## Documentation

N/A

## Tests

The `com.canonical.certification::graphics_card` resource has `drm_node` on my Intel HW above and on a Raspberry Pi:
```
bus: drm
category: VIDEO
driver: v3d
drm_node: /dev/dri/card0
gpu_count: 2
index: 1
name: dri/card0
path: /devices/platform/axi/1002000000.v3d/drm/card0
prime_gpu_offload: Off
product: drm-platform-1002000000_v3d
product_slug: drm_platform_1002000000_v3d
switch_to_cmd: false
vendor: PCI ID 0x0
vendor_slug: PCI_ID_0x0

bus: drm
category: VIDEO
driver: vc4-drm
drm_node: /dev/dri/card1
gpu_count: 2
index: 2
name: dri/card1
path: /devices/platform/axi/axi:gpu/drm/card1
prime_gpu_offload: Off
product: drm-platform-axi_gpu
product_slug: drm_platform_axi_gpu
switch_to_cmd: false
vendor: PCI ID 0x0
vendor_slug: PCI_ID_0x0
```