### PR TITLE
pulseaudio server utils not listing unused profiles (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/audio_server_utils.py
+++ b/checkbox-support/checkbox_support/helpers/audio_server_utils.py
@@ -604,8 +604,10 @@ class PulseaudioUtils(AudioServerUtils):
         """
         Set the specified sink as default output.
 
-        For PulseAudio, nodes from list_sinks() or iter_sinks() are both
-        ready to use without additional activation.
+        Important: This method assumes the node's profile is already active
+        (e.g., the node was obtained from iter_sinks()). If you need to set
+        a sink obtained from list_sinks(), call iter_sinks() to activate it
+        first, or activate the profile manually.
 
         Args:
             sink: The sink node to set as default
@@ -627,8 +629,10 @@ class PulseaudioUtils(AudioServerUtils):
         """
         Set the specified source as default input.
 
-        For PulseAudio, nodes from list_sources() or iter_sources() are both
-        ready to use without additional activation.
+        Important: This method assumes the node's profile is already active
+        (e.g., the node was obtained from iter_sources()). If you need to set
+        a source obtained from list_sources(), call iter_sources() to activate
+        it first, or activate the profile manually.
 
         Args:
             source: The source node to set as default

--- a/checkbox-support/checkbox_support/helpers/audio_server_utils.py
+++ b/checkbox-support/checkbox_support/helpers/audio_server_utils.py
@@ -39,6 +39,7 @@ import abc
 import argparse
 import json
 import logging
+import re
 import subprocess
 import time
 from enum import Enum
@@ -471,21 +472,133 @@ class PulseaudioUtils(AudioServerUtils):
 
     def list_sinks(self) -> List[Node]:
         """Get list of available audio sinks."""
-        return self._parse_pactl_list("sinks")
+        return list(self._iter_nodes_of_type(NodeType.SINK))
 
     def list_sources(self) -> List[Node]:
         """Get list of available audio sources."""
-        return self._parse_pactl_list("sources")
+        return list(self._iter_nodes_of_type(NodeType.SOURCE))
+
+    def _get_cards(self) -> List[dict]:
+        """Get available audio cards and their profiles."""
+        try:
+            output = subprocess.check_output(
+                ["pactl", "list", "cards"], universal_newlines=True
+            )
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError("Failed to run pactl list cards: {}".format(e))
+
+        cards = []
+        current_card = {}
+        in_profiles = False
+        profiles_indent = 0
+
+        for line in output.strip().split("\n"):
+            stripped = line.strip()
+
+            if line.startswith("Card #"):
+                if current_card.get("name"):
+                    cards.append(current_card)
+                current_card = {"name": "", "profiles": []}
+                in_profiles = False
+
+            elif stripped.startswith("Name: "):
+                current_card["name"] = stripped.split("Name: ", 1)[1]
+
+            elif stripped == "Profiles:":
+                in_profiles = True
+                profiles_indent = len(line) - len(line.lstrip())
+
+            elif in_profiles and (
+                stripped.startswith("Active Profile:")
+                or not stripped
+                or len(line) - len(line.lstrip()) <= profiles_indent
+            ):
+                in_profiles = False
+
+            elif in_profiles:
+                # Profile line format:
+                # output:analog-stereo: ... (sinks: 1, sources: 0,
+                #   priority: 6500, available: yes)
+                match = re.match(
+                    r"(\S+): .+?"
+                    r"\(sinks: (\d+), sources: (\d+),"
+                    r" priority: \d+, available: (yes|no)\)",
+                    stripped,
+                )
+                if match:
+                    name, sinks, sources, available = match.groups()
+                    if available == "yes":
+                        current_card["profiles"].append(
+                            {
+                                "name": name,
+                                "sinks": int(sinks),
+                                "sources": int(sources),
+                            }
+                        )
+
+        if current_card.get("name"):
+            cards.append(current_card)
+
+        return cards
+
+    def _get_available_profiles(
+        self, card: dict, target: NodeType
+    ) -> List[dict]:
+        """Get profiles on a card that provide the target node type."""
+        key = "sinks" if target == NodeType.SINK else "sources"
+        return [p for p in card["profiles"] if p[key] > 0]
+
+    def _set_card_profile(self, card_name: str, profile_name: str) -> None:
+        try:
+            cmd = ["pactl", "set-card-profile", card_name, profile_name]
+            logger.debug("[shell] %s", " ".join(cmd))
+            subprocess.check_output(cmd)
+        except subprocess.CalledProcessError:
+            raise RuntimeError(
+                "Cannot set profile '{}' on card '{}'".format(
+                    profile_name, card_name
+                )
+            )
+
+    def _iter_nodes_of_type(
+        self, target: NodeType
+    ) -> Generator[Node, None, None]:
+        """Iterator that activates each card profile and yields nodes."""
+        cards = self._get_cards()
+        target_type = "sinks" if target == NodeType.SINK else "sources"
+        logger.debug("Found %s available audio card(s)", len(cards))
+
+        seen_names = set()
+
+        for card in cards:
+            profiles = self._get_available_profiles(card, target)
+            logger.debug(
+                "Found %s available profile(s) for card %s",
+                len(profiles),
+                card["name"],
+            )
+
+            for profile in profiles:
+                self._set_card_profile(card["name"], profile["name"])
+
+                nodes = self._parse_pactl_list(target_type)
+                logger.debug(
+                    "Found %s available node(s) for card %s@%s",
+                    len(nodes),
+                    card["name"],
+                    profile["name"],
+                )
+
+                for node in nodes:
+                    if node.name not in seen_names:
+                        seen_names.add(node.name)
+                        yield node
 
     def iter_sinks(self) -> Generator[Node, None, None]:
-        """Iterate over available sinks. For PulseAudio, just yields all nodes."""
-        for node in self._parse_pactl_list("sinks"):
-            yield node
+        return self._iter_nodes_of_type(NodeType.SINK)
 
     def iter_sources(self) -> Generator[Node, None, None]:
-        """Iterate over available sources. For PulseAudio, just yields all nodes."""
-        for node in self._parse_pactl_list("sources"):
-            yield node
+        return self._iter_nodes_of_type(NodeType.SOURCE)
 
     def set_sink(self, sink: Node) -> None:
         """

--- a/checkbox-support/checkbox_support/helpers/audio_server_utils.py
+++ b/checkbox-support/checkbox_support/helpers/audio_server_utils.py
@@ -490,7 +490,6 @@ class PulseaudioUtils(AudioServerUtils):
         cards = []
         current_card = {}
         in_profiles = False
-        profiles_indent = 0
 
         for line in output.strip().split("\n"):
             stripped = line.strip()
@@ -506,12 +505,9 @@ class PulseaudioUtils(AudioServerUtils):
 
             elif stripped == "Profiles:":
                 in_profiles = True
-                profiles_indent = len(line) - len(line.lstrip())
 
             elif in_profiles and (
-                stripped.startswith("Active Profile:")
-                or not stripped
-                or len(line) - len(line.lstrip()) <= profiles_indent
+                not stripped or stripped.startswith("Active Profile:")
             ):
                 in_profiles = False
 

--- a/checkbox-support/checkbox_support/helpers/tests/test_audio_server_utils.py
+++ b/checkbox-support/checkbox_support/helpers/tests/test_audio_server_utils.py
@@ -304,6 +304,18 @@ class PipewireUtilsTests(unittest.TestCase):
             ["wpctl", "set-volume", "123", "0.8"]
         )
 
+    @patch(
+        "checkbox_support.helpers.audio_server_utils.subprocess.check_output"
+    )
+    def test_set_volume_error(self, mock_check_output):
+        """Test setting volume raises RuntimeError on failure."""
+        mock_check_output.side_effect = subprocess.CalledProcessError(
+            1, "wpctl"
+        )
+        node = Node("dev1", "prof1", "sink1", "123", "Sink 1")
+        with self.assertRaises(RuntimeError):
+            self.pipewire.set_volume(node, 0.8)
+
     def test_set_volume_invalid(self):
         """Test volume validation raises ValueError."""
         node = Node("dev1", "prof1", "sink1", "123", "Sink 1")
@@ -351,6 +363,13 @@ class PipewireUtilsTests(unittest.TestCase):
             device, NodeType.SOURCE
         )
         self.assertEqual({"1": source}, profiles)
+
+    def test_get_available_profiles_empty_classes(self):
+        """Test profile with empty classes list is excluded."""
+        profile_no_class = {"available": "yes", "index": 2, "classes": []}
+        device = {"info": {"params": {"EnumProfile": [profile_no_class]}}}
+        profiles = self.pipewire._get_available_profiles(device, NodeType.SINK)
+        self.assertEqual({}, profiles)
 
     def test_set_node_of_type(self):
         """Test setting a node by type and name."""
@@ -555,6 +574,17 @@ class PulseaudioUtilsTests(unittest.TestCase):
         nodes = self.pulseaudio._parse_pactl_list("sinks")
         self.assertEqual(len(nodes), 0)
 
+    @patch(
+        "checkbox_support.helpers.audio_server_utils.subprocess.check_output"
+    )
+    def test_parse_pactl_list_error(self, mock_check_output):
+        """Test that CalledProcessError in _parse_pactl_list raises RuntimeError."""
+        mock_check_output.side_effect = subprocess.CalledProcessError(
+            1, "pactl"
+        )
+        with self.assertRaises(RuntimeError):
+            self.pulseaudio._parse_pactl_list("sinks")
+
     def test_list_sinks(self):
         """Test listing all available sinks cycles through card profiles."""
         node1 = Node("0", None, "sink1", "0", "Sink 1")
@@ -584,6 +614,43 @@ class PulseaudioUtilsTests(unittest.TestCase):
         self.pulseaudio._iter_nodes_of_type.assert_called_once_with(
             NodeType.SOURCE
         )
+
+    @patch(
+        "checkbox_support.helpers.audio_server_utils.subprocess.check_output"
+    )
+    def test_get_cards_error(self, mock_check_output):
+        """Test that CalledProcessError in _get_cards raises RuntimeError."""
+        mock_check_output.side_effect = subprocess.CalledProcessError(
+            1, "pactl"
+        )
+        with self.assertRaises(RuntimeError):
+            self.pulseaudio._get_cards()
+
+    @patch(
+        "checkbox_support.helpers.audio_server_utils.subprocess.check_output"
+    )
+    def test_get_cards_malformed_profile_skipped(self, mock_check_output):
+        """Test that malformed profile lines are skipped."""
+        mock_check_output.return_value = (
+            "Card #0\n"
+            "        Name: alsa_card.test\n"
+            "        Profiles:\n"
+            "                malformed-profile-line\n"
+            "        Active Profile: output:analog-stereo\n"
+        )
+        cards = self.pulseaudio._get_cards()
+        self.assertEqual(len(cards), 1)
+        self.assertEqual(cards[0]["name"], "alsa_card.test")
+        self.assertEqual(len(cards[0]["profiles"]), 0)
+
+    @patch(
+        "checkbox_support.helpers.audio_server_utils.subprocess.check_output"
+    )
+    def test_get_cards_unnamed_card_skipped(self, mock_check_output):
+        """Test that cards without a name are excluded."""
+        mock_check_output.return_value = "Card #0\n"
+        cards = self.pulseaudio._get_cards()
+        self.assertEqual(len(cards), 0)
 
     @patch(
         "checkbox_support.helpers.audio_server_utils.subprocess.check_output"
@@ -868,6 +935,33 @@ class PulseaudioUtilsTests(unittest.TestCase):
         mock_check_output.assert_called_once_with(
             ["pactl", "set-sink-volume", "test_sink", "50%"]
         )
+
+    @patch(
+        "checkbox_support.helpers.audio_server_utils.subprocess.check_output"
+    )
+    def test_set_volume_source_fallback(self, mock_check_output):
+        """Test volume falls back to set-source-volume when set-sink-volume fails."""
+        node = Node("0", None, "test_node", "0", "Test Node")
+        mock_check_output.side_effect = [
+            subprocess.CalledProcessError(1, "pactl"),  # set-sink-volume fails
+            None,  # set-source-volume succeeds
+        ]
+        self.pulseaudio.set_volume(node, 0.5)
+        mock_check_output.assert_called_with(
+            ["pactl", "set-source-volume", "test_node", "50%"]
+        )
+
+    @patch(
+        "checkbox_support.helpers.audio_server_utils.subprocess.check_output"
+    )
+    def test_set_volume_all_fail(self, mock_check_output):
+        """Test that RuntimeError is raised when all volume commands fail."""
+        node = Node("0", None, "test_node", "0", "Test Node")
+        mock_check_output.side_effect = subprocess.CalledProcessError(
+            1, "pactl"
+        )
+        with self.assertRaises(RuntimeError):
+            self.pulseaudio.set_volume(node, 0.5)
 
     def test_set_volume_invalid(self):
         """Test setting invalid volume raises ValueError."""

--- a/checkbox-support/checkbox_support/helpers/tests/test_audio_server_utils.py
+++ b/checkbox-support/checkbox_support/helpers/tests/test_audio_server_utils.py
@@ -556,48 +556,263 @@ class PulseaudioUtilsTests(unittest.TestCase):
         self.assertEqual(len(nodes), 0)
 
     def test_list_sinks(self):
-        """Test listing all available sinks."""
+        """Test listing all available sinks cycles through card profiles."""
         node1 = Node("0", None, "sink1", "0", "Sink 1")
-        self.pulseaudio._parse_pactl_list = Mock(return_value=[node1])
+        node2 = Node("1", None, "sink2", "1", "Sink 2")
+        self.pulseaudio._iter_nodes_of_type = Mock(
+            return_value=iter([node1, node2])
+        )
 
         sinks = self.pulseaudio.list_sinks()
 
-        self.assertEqual(len(sinks), 1)
+        self.assertEqual(len(sinks), 2)
         self.assertEqual(sinks[0], node1)
-        self.pulseaudio._parse_pactl_list.assert_called_once_with("sinks")
+        self.assertEqual(sinks[1], node2)
+        self.pulseaudio._iter_nodes_of_type.assert_called_once_with(
+            NodeType.SINK
+        )
 
     def test_list_sources(self):
-        """Test listing all available sources."""
+        """Test listing all available sources cycles through card profiles."""
         node1 = Node("0", None, "source1", "0", "Source 1")
-        self.pulseaudio._parse_pactl_list = Mock(return_value=[node1])
+        self.pulseaudio._iter_nodes_of_type = Mock(
+            return_value=iter([node1])
+        )
 
         sources = self.pulseaudio.list_sources()
 
         self.assertEqual(len(sources), 1)
         self.assertEqual(sources[0], node1)
-        self.pulseaudio._parse_pactl_list.assert_called_once_with("sources")
+        self.pulseaudio._iter_nodes_of_type.assert_called_once_with(
+            NodeType.SOURCE
+        )
+
+    @patch(
+        "checkbox_support.helpers.audio_server_utils.subprocess.check_output"
+    )
+    def test_get_cards(self, mock_check_output):
+        """Test parsing pactl list cards output."""
+        mock_check_output.return_value = (
+            "Card #0\n"
+            "        Name: alsa_card.pci-0000_00_1f.3\n"
+            "        Driver: module-alsa-card.c\n"
+            "        Owner Module: 7\n"
+            "        Properties:\n"
+            "                alsa.card = \"0\"\n"
+            "        Profiles:\n"
+            "                output:analog-stereo: Analog Stereo Output (sinks: 1, sources: 0, priority: 6500, available: yes)\n"
+            "                output:hdmi-stereo: Digital Stereo (HDMI) Output (sinks: 1, sources: 0, priority: 5900, available: yes)\n"
+            "                input:analog-stereo: Analog Stereo Input (sinks: 0, sources: 1, priority: 1900, available: yes)\n"
+            "                off: Off (sinks: 0, sources: 0, priority: 0, available: yes)\n"
+            "        Active Profile: output:analog-stereo\n"
+            "        Ports:\n"
+            "                analog-output: Analog Output (type: Analog, priority: 9900)\n"
+            "\n"
+            "Card #1\n"
+            "        Name: alsa_card.usb-audio\n"
+            "        Driver: module-alsa-card.c\n"
+            "        Owner Module: 23\n"
+            "        Properties:\n"
+            "                alsa.card = \"1\"\n"
+            "        Profiles:\n"
+            "                output:analog-stereo: Analog Stereo Output (sinks: 1, sources: 0, priority: 6500, available: yes)\n"
+            "                input:analog-stereo: Analog Stereo Input (sinks: 0, sources: 1, priority: 1900, available: no)\n"
+            "                off: Off (sinks: 0, sources: 0, priority: 0, available: yes)\n"
+            "        Active Profile: output:analog-stereo\n"
+        )
+        cards = self.pulseaudio._get_cards()
+        self.assertEqual(len(cards), 2)
+
+        self.assertEqual(cards[0]["name"], "alsa_card.pci-0000_00_1f.3")
+        # All 4 profiles with available: yes are included (including off)
+        self.assertEqual(len(cards[0]["profiles"]), 4)
+        self.assertEqual(
+            cards[0]["profiles"][0]["name"], "output:analog-stereo"
+        )
+        self.assertEqual(cards[0]["profiles"][0]["sinks"], 1)
+        self.assertEqual(cards[0]["profiles"][0]["sources"], 0)
+        self.assertEqual(
+            cards[0]["profiles"][1]["name"], "output:hdmi-stereo"
+        )
+        self.assertEqual(
+            cards[0]["profiles"][2]["name"], "input:analog-stereo"
+        )
+        self.assertEqual(cards[0]["profiles"][3]["name"], "off")
+        self.assertEqual(cards[0]["profiles"][3]["sinks"], 0)
+        self.assertEqual(cards[0]["profiles"][3]["sources"], 0)
+
+        self.assertEqual(cards[1]["name"], "alsa_card.usb-audio")
+        # input:analog-stereo is available: no, so excluded
+        self.assertEqual(len(cards[1]["profiles"]), 2)
+        self.assertEqual(
+            cards[1]["profiles"][0]["name"], "output:analog-stereo"
+        )
+        self.assertEqual(cards[1]["profiles"][1]["name"], "off")
+
+    def test_get_available_profiles_sinks(self):
+        """Test filtering profiles for sink type."""
+        card = {
+            "name": "test_card",
+            "profiles": [
+                {"name": "output:analog", "sinks": 1, "sources": 0},
+                {"name": "input:analog", "sinks": 0, "sources": 1},
+                {"name": "output:hdmi", "sinks": 1, "sources": 0},
+            ],
+        }
+        profiles = self.pulseaudio._get_available_profiles(
+            card, NodeType.SINK
+        )
+        self.assertEqual(len(profiles), 2)
+        self.assertEqual(profiles[0]["name"], "output:analog")
+        self.assertEqual(profiles[1]["name"], "output:hdmi")
+
+    def test_get_available_profiles_sources(self):
+        """Test filtering profiles for source type."""
+        card = {
+            "name": "test_card",
+            "profiles": [
+                {"name": "output:analog", "sinks": 1, "sources": 0},
+                {"name": "input:analog", "sinks": 0, "sources": 1},
+            ],
+        }
+        profiles = self.pulseaudio._get_available_profiles(
+            card, NodeType.SOURCE
+        )
+        self.assertEqual(len(profiles), 1)
+        self.assertEqual(profiles[0]["name"], "input:analog")
+
+    @patch(
+        "checkbox_support.helpers.audio_server_utils.subprocess.check_output"
+    )
+    def test_set_card_profile(self, mock_check_output):
+        """Test setting a card profile."""
+        self.pulseaudio._set_card_profile(
+            "alsa_card.pci-0000_00_1f.3", "output:hdmi-stereo"
+        )
+        mock_check_output.assert_called_once_with(
+            [
+                "pactl",
+                "set-card-profile",
+                "alsa_card.pci-0000_00_1f.3",
+                "output:hdmi-stereo",
+            ]
+        )
+
+    @patch(
+        "checkbox_support.helpers.audio_server_utils.subprocess.check_output"
+    )
+    def test_set_card_profile_error(self, mock_check_output):
+        """Test setting a card profile raises on error."""
+        mock_check_output.side_effect = subprocess.CalledProcessError(1, "")
+        with self.assertRaises(RuntimeError):
+            self.pulseaudio._set_card_profile("card", "profile")
 
     def test_iter_sinks(self):
-        """Test iterating over sinks."""
+        """Test iterating over sinks cycles through card profiles."""
         node1 = Node("0", None, "sink1", "0", "Sink 1")
         node2 = Node("1", None, "sink2", "1", "Sink 2")
-        self.pulseaudio._parse_pactl_list = Mock(return_value=[node1, node2])
+        self.pulseaudio._iter_nodes_of_type = Mock(
+            return_value=iter([node1, node2])
+        )
 
         result = list(self.pulseaudio.iter_sinks())
 
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0], node1)
         self.assertEqual(result[1], node2)
+        self.pulseaudio._iter_nodes_of_type.assert_called_once_with(
+            NodeType.SINK
+        )
 
     def test_iter_sources(self):
-        """Test iterating over sources."""
+        """Test iterating over sources cycles through card profiles."""
         node1 = Node("0", None, "source1", "0", "Source 1")
-        self.pulseaudio._parse_pactl_list = Mock(return_value=[node1])
+        self.pulseaudio._iter_nodes_of_type = Mock(
+            return_value=iter([node1])
+        )
 
         result = list(self.pulseaudio.iter_sources())
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0], node1)
+        self.pulseaudio._iter_nodes_of_type.assert_called_once_with(
+            NodeType.SOURCE
+        )
+
+    def test_iter_nodes_of_type(self):
+        """Test _iter_nodes_of_type cycles through cards and profiles."""
+        cards = [
+            {
+                "name": "card0",
+                "profiles": [
+                    {"name": "output:analog", "sinks": 1, "sources": 0},
+                    {"name": "output:hdmi", "sinks": 1, "sources": 0},
+                ],
+            },
+        ]
+        node_analog = Node("0", None, "analog-sink", "0", "Analog")
+        node_hdmi = Node("1", None, "hdmi-sink", "1", "HDMI")
+
+        self.pulseaudio._get_cards = Mock(return_value=cards)
+        self.pulseaudio._set_card_profile = Mock()
+        self.pulseaudio._parse_pactl_list = Mock(
+            side_effect=[[node_analog], [node_hdmi]]
+        )
+
+        result = list(self.pulseaudio._iter_nodes_of_type(NodeType.SINK))
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], node_analog)
+        self.assertEqual(result[1], node_hdmi)
+        self.pulseaudio._set_card_profile.assert_any_call(
+            "card0", "output:analog"
+        )
+        self.pulseaudio._set_card_profile.assert_any_call(
+            "card0", "output:hdmi"
+        )
+
+    def test_iter_nodes_of_type_deduplicates(self):
+        """Test that duplicate sinks from different profiles are skipped."""
+        cards = [
+            {
+                "name": "card0",
+                "profiles": [
+                    {"name": "output:analog", "sinks": 1, "sources": 0},
+                    {
+                        "name": "output:analog+input:analog",
+                        "sinks": 1,
+                        "sources": 1,
+                    },
+                    {"name": "output:hdmi", "sinks": 1, "sources": 0},
+                    {
+                        "name": "output:hdmi+input:analog",
+                        "sinks": 1,
+                        "sources": 1,
+                    },
+                ],
+            },
+        ]
+        node_analog = Node("0", None, "analog-sink", "0", "Analog")
+        node_analog_dup = Node("0", None, "analog-sink", "0", "Analog")
+        node_hdmi = Node("1", None, "hdmi-sink", "1", "HDMI")
+        node_hdmi_dup = Node("1", None, "hdmi-sink", "1", "HDMI")
+
+        self.pulseaudio._get_cards = Mock(return_value=cards)
+        self.pulseaudio._set_card_profile = Mock()
+        self.pulseaudio._parse_pactl_list = Mock(
+            side_effect=[
+                [node_analog],
+                [node_analog_dup],
+                [node_hdmi],
+                [node_hdmi_dup],
+            ]
+        )
+
+        result = list(self.pulseaudio._iter_nodes_of_type(NodeType.SINK))
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].name, "analog-sink")
+        self.assertEqual(result[1].name, "hdmi-sink")
 
     @patch(
         "checkbox_support.helpers.audio_server_utils.subprocess.check_output"
@@ -776,27 +991,52 @@ class IntegrationTests(unittest.TestCase):
         """Test PulseAudio workflow: iterate sinks and set one as default."""
         mock_get_server.return_value = AudioServer.PULSEAUDIO
 
-        pactl_output = textwrap.dedent(
+        pactl_cards_output = (
+            "Card #0\n"
+            "        Name: alsa_card.pci-0000_00_1f.3\n"
+            "        Driver: module-alsa-card.c\n"
+            "        Owner Module: 7\n"
+            "        Properties:\n"
+            "                alsa.card = \"0\"\n"
+            "        Profiles:\n"
+            "                output:analog-stereo: Analog Stereo Output (sinks: 1, sources: 0, priority: 6500, available: yes)\n"
+            "                output:hdmi-stereo: Digital Stereo (HDMI) Output (sinks: 1, sources: 0, priority: 5900, available: yes)\n"
+            "                off: Off (sinks: 0, sources: 0, priority: 0, available: yes)\n"
+            "        Active Profile: output:analog-stereo\n"
+        )
+
+        analog_sinks_output = textwrap.dedent(
             """\
             Sink #0
-            	State: RUNNING
-            	Name: alsa_output.pci-0000_00_1f.3.analog-stereo
-            	Description: Built-in Audio Analog Stereo
-            	Driver: module-alsa-card.c
-            	Index: 0
-
-            Sink #1
-            	State: IDLE
-            	Name: alsa_output.usb-audio.analog-stereo
-            	Description: USB Audio
-            	Driver: module-alsa-card.c
-            	Index: 1
+            \tState: RUNNING
+            \tName: alsa_output.pci-0000_00_1f.3.analog-stereo
+            \tDescription: Built-in Audio Analog Stereo
+            \tDriver: module-alsa-card.c
+            \tIndex: 0
             """
         )
 
+        hdmi_sinks_output = textwrap.dedent(
+            """\
+            Sink #1
+            \tState: IDLE
+            \tName: alsa_output.pci-0000_00_1f.3.hdmi-stereo
+            \tDescription: Built-in Audio HDMI Stereo
+            \tDriver: module-alsa-card.c
+            \tIndex: 1
+            """
+        )
+
+        call_count = {"list_sinks": 0}
+
         def check_output_side_effect(cmd, **kwargs):
+            if cmd == ["pactl", "list", "cards"]:
+                return pactl_cards_output
             if cmd == ["pactl", "list", "sinks"]:
-                return pactl_output
+                call_count["list_sinks"] += 1
+                if call_count["list_sinks"] == 1:
+                    return analog_sinks_output
+                return hdmi_sinks_output
             return ""
 
         mock_check_output.side_effect = check_output_side_effect
@@ -811,8 +1051,12 @@ class IntegrationTests(unittest.TestCase):
             sinks[0].name, "alsa_output.pci-0000_00_1f.3.analog-stereo"
         )
         self.assertEqual(sinks[0].description, "Built-in Audio Analog Stereo")
-        self.assertEqual(sinks[1].name, "alsa_output.usb-audio.analog-stereo")
-        self.assertEqual(sinks[1].description, "USB Audio")
+        self.assertEqual(
+            sinks[1].name, "alsa_output.pci-0000_00_1f.3.hdmi-stereo"
+        )
+        self.assertEqual(
+            sinks[1].description, "Built-in Audio HDMI Stereo"
+        )
 
         mock_check_output.side_effect = None
 

--- a/checkbox-support/checkbox_support/helpers/tests/test_audio_server_utils.py
+++ b/checkbox-support/checkbox_support/helpers/tests/test_audio_server_utils.py
@@ -575,9 +575,7 @@ class PulseaudioUtilsTests(unittest.TestCase):
     def test_list_sources(self):
         """Test listing all available sources cycles through card profiles."""
         node1 = Node("0", None, "source1", "0", "Source 1")
-        self.pulseaudio._iter_nodes_of_type = Mock(
-            return_value=iter([node1])
-        )
+        self.pulseaudio._iter_nodes_of_type = Mock(return_value=iter([node1]))
 
         sources = self.pulseaudio.list_sources()
 
@@ -598,7 +596,7 @@ class PulseaudioUtilsTests(unittest.TestCase):
             "        Driver: module-alsa-card.c\n"
             "        Owner Module: 7\n"
             "        Properties:\n"
-            "                alsa.card = \"0\"\n"
+            '                alsa.card = "0"\n'
             "        Profiles:\n"
             "                output:analog-stereo: Analog Stereo Output (sinks: 1, sources: 0, priority: 6500, available: yes)\n"
             "                output:hdmi-stereo: Digital Stereo (HDMI) Output (sinks: 1, sources: 0, priority: 5900, available: yes)\n"
@@ -613,7 +611,7 @@ class PulseaudioUtilsTests(unittest.TestCase):
             "        Driver: module-alsa-card.c\n"
             "        Owner Module: 23\n"
             "        Properties:\n"
-            "                alsa.card = \"1\"\n"
+            '                alsa.card = "1"\n'
             "        Profiles:\n"
             "                output:analog-stereo: Analog Stereo Output (sinks: 1, sources: 0, priority: 6500, available: yes)\n"
             "                input:analog-stereo: Analog Stereo Input (sinks: 0, sources: 1, priority: 1900, available: no)\n"
@@ -631,9 +629,7 @@ class PulseaudioUtilsTests(unittest.TestCase):
         )
         self.assertEqual(cards[0]["profiles"][0]["sinks"], 1)
         self.assertEqual(cards[0]["profiles"][0]["sources"], 0)
-        self.assertEqual(
-            cards[0]["profiles"][1]["name"], "output:hdmi-stereo"
-        )
+        self.assertEqual(cards[0]["profiles"][1]["name"], "output:hdmi-stereo")
         self.assertEqual(
             cards[0]["profiles"][2]["name"], "input:analog-stereo"
         )
@@ -659,9 +655,7 @@ class PulseaudioUtilsTests(unittest.TestCase):
                 {"name": "output:hdmi", "sinks": 1, "sources": 0},
             ],
         }
-        profiles = self.pulseaudio._get_available_profiles(
-            card, NodeType.SINK
-        )
+        profiles = self.pulseaudio._get_available_profiles(card, NodeType.SINK)
         self.assertEqual(len(profiles), 2)
         self.assertEqual(profiles[0]["name"], "output:analog")
         self.assertEqual(profiles[1]["name"], "output:hdmi")
@@ -727,9 +721,7 @@ class PulseaudioUtilsTests(unittest.TestCase):
     def test_iter_sources(self):
         """Test iterating over sources cycles through card profiles."""
         node1 = Node("0", None, "source1", "0", "Source 1")
-        self.pulseaudio._iter_nodes_of_type = Mock(
-            return_value=iter([node1])
-        )
+        self.pulseaudio._iter_nodes_of_type = Mock(return_value=iter([node1]))
 
         result = list(self.pulseaudio.iter_sources())
 
@@ -997,7 +989,7 @@ class IntegrationTests(unittest.TestCase):
             "        Driver: module-alsa-card.c\n"
             "        Owner Module: 7\n"
             "        Properties:\n"
-            "                alsa.card = \"0\"\n"
+            '                alsa.card = "0"\n'
             "        Profiles:\n"
             "                output:analog-stereo: Analog Stereo Output (sinks: 1, sources: 0, priority: 6500, available: yes)\n"
             "                output:hdmi-stereo: Digital Stereo (HDMI) Output (sinks: 1, sources: 0, priority: 5900, available: yes)\n"
@@ -1054,9 +1046,7 @@ class IntegrationTests(unittest.TestCase):
         self.assertEqual(
             sinks[1].name, "alsa_output.pci-0000_00_1f.3.hdmi-stereo"
         )
-        self.assertEqual(
-            sinks[1].description, "Built-in Audio HDMI Stereo"
-        )
+        self.assertEqual(sinks[1].description, "Built-in Audio HDMI Stereo")
 
         mock_check_output.side_effect = None
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Pulseaudio utils relies on `pactl list sinks` command which only returns the active sinks. This PR adds a parser around `pactl list cards`, which give much more details on the whole available cards and profiles.

## Resolved issues

N/A

## Documentation

N/A

## Tests

Tested on Ubuntu 22.04 running the included main function.
