### PR TITLE
Preserve nsenter cwd (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -777,6 +777,11 @@ def dangerous_nsenter(path):
     try:
         # here recover setcap and nsenter binaries path outside the sandbox
         runtime_path = get_checkbox_runtime_path()
+        # nsenter is invoked outside this namespace, we must use the static
+        # one.
+        # Note: This is a newer version of nsenter we compile ad-hoc in the
+        #       snap. Xenial nsenter is too old and does not support -W which
+        #       we need
         runtime_nsenter = runtime_path / "usr" / "bin" / "nsenter.static"
         # Note: this path only works on core<24, on core24+ this is in
         #       /usr/sbin but this code should only be used on core16, so this

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -349,47 +349,42 @@ class UnifiedRunner(IJobRunner):
         if as_systemd_unit:
             get_execution_command = get_execution_command_systemd_unit
         # Setup the executable nest directory
-        with self.configured_filesystem(job) as nest_dir:
-            # Get the command and the environment.
-            # of this execution controller
-            with get_execution_command(
-                job,
-                environ,
-                self._session_id,
-                nest_dir,
-                target_user,
-                self._extra_env,
-            ) as cmd:
-                env = get_execution_environment(
-                    job, environ, self._session_id, nest_dir
-                )
-                if self._user_provider():
-                    env["NORMAL_USER"] = self._user_provider()
-                # Always set SYSTEMD_IGNORE_CHROOT
-                # See https://bugs.launchpad.net/snapd/+bug/2003955
-                env["SYSTEMD_IGNORE_CHROOT"] = "1"
-                # run the command
-                logger.info(
-                    _("Starting job [%(ID)s] executing: %(CMD)r"),
-                    {"ID": job.id, "CMD": join_cmd(cmd)},
-                )
-                if "preserve-cwd" in job.get_flag_set() or os.getenv("SNAP"):
-                    return_code = call(
-                        extcmd_popen, cmd, stdin=subprocess.PIPE, env=env
-                    )
-                else:
-                    with self.temporary_cwd(job) as cwd_dir:
-                        return_code = call(
-                            extcmd_popen,
-                            cmd,
-                            stdin=subprocess.PIPE,
-                            env=env,
-                            cwd=cwd_dir,
-                        )
-                logger.info("Finished job [{}]".format(job.id))
-                if "noreturn" in job.get_flag_set():
-                    signal.pause()
-                return return_code
+        with self.configured_filesystem(job) as nest_dir, self.proper_job_cwd(
+            job
+        ) as cwd_dir, get_execution_command(
+            job,
+            environ,
+            self._session_id,
+            nest_dir,
+            target_user,
+            self._extra_env,
+            cwd_dir,
+        ) as cmd:
+            env = get_execution_environment(
+                job, environ, self._session_id, nest_dir
+            )
+            if self._user_provider():
+                env["NORMAL_USER"] = self._user_provider()
+            # Always set SYSTEMD_IGNORE_CHROOT
+            # See https://bugs.launchpad.net/snapd/+bug/2003955
+            env["SYSTEMD_IGNORE_CHROOT"] = "1"
+            # run the command
+            logger.info(
+                _("Starting job [%(ID)s] executing: %(CMD)r"),
+                {"ID": job.id, "CMD": join_cmd(cmd)},
+            )
+
+            return_code = call(
+                extcmd_popen,
+                cmd,
+                stdin=subprocess.PIPE,
+                env=env,
+                cwd=cwd_dir,
+            )
+            logger.info("Finished job [{}]".format(job.id))
+            if "noreturn" in job.get_flag_set():
+                signal.pause()
+            return return_code
 
     @contextlib.contextmanager
     def configured_filesystem(self, job):
@@ -417,16 +412,19 @@ class UnifiedRunner(IJobRunner):
             yield nest_dir
 
     @contextlib.contextmanager
-    def temporary_cwd(self, job):
+    def proper_job_cwd(self, job):
         """
-        Context manager for handling temporary current working directory
-        for a particular execution of a job definition command.
+        Context manager for handling current working directory for a particular
+        execution of a job definition command.
 
         :param job:
             The JobDefinition to execute
         :returns:
-            Pathname of the new temporary directory
+            Pathname of the new directory
         """
+        if "preserve-cwd" in job.get_flag_set() or os.getenv("SNAP"):
+            yield os.getcwd()
+            return
         # Create a nest for all the private executables needed for execution
         prefix = "cwd-"
         suffix = ".{}".format(job.checksum)
@@ -705,7 +703,13 @@ def get_differential_execution_environment(
 
 @contextlib.contextmanager
 def get_execution_command_subshell(
-    job, environ, session_id, nest_dir, target_user=None, extra_env=None
+    job,
+    environ,
+    session_id,
+    nest_dir,
+    target_user=None,
+    extra_env=None,
+    cwd=None,  # for simmetry, ignored!
 ):
     """
     Generate a command that if executed runs a Checkbox command section
@@ -818,7 +822,7 @@ class MountingStrategy(enum.Enum):
         return cls.MOUNT_AMBIENT_CAPABILITIES
 
 
-def get_snap_mount_namespace_commands(target_user, shared_location):
+def get_snap_mount_namespace_commands(target_user, shared_location, cwd):
     """
     Returns commands and helpers to mount the current snap namespace
 
@@ -889,7 +893,7 @@ def get_snap_mount_namespace_commands(target_user, shared_location):
             else str(dangerous_nsenter_path)
         ),
         "-m/run/snapd/ns/{}.mnt".format(snap_name),
-        "-w.",  # wrapper command expects cwd to not change!
+        "-W{}".format(cwd),  # wrapper command expects cwd to not change!
     ]
     if mounting_strategy == MountingStrategy.MOUNT_AMBIENT_CAPABILITIES:
         # on non-core16 we have given ourselves AmbientCapabilities. After
@@ -903,7 +907,7 @@ def get_snap_mount_namespace_commands(target_user, shared_location):
 
 @contextlib.contextmanager
 def get_execution_command_systemd_unit(
-    job, environ, session_id, nest_dir, target_user, extra_env=None
+    job, environ, session_id, nest_dir, target_user, extra_env=None, cwd=None
 ):
     """
     Generates a command that if executed spawns a Checkbox command section as a
@@ -917,6 +921,9 @@ def get_execution_command_systemd_unit(
     limitation on core16's systemd that makes commands longer than 2k
     characters fail. See: https://github.com/systemd/systemd/issues/3302
     """
+    if cwd is None:
+        cwd = os.getcwd()
+
     wrapper_cmd = [
         "sudo",
         "--prompt",
@@ -942,7 +949,7 @@ def get_execution_command_systemd_unit(
     # when in a core snap, we need the snap mount namespace to use anything
     # that was shared via a content interface
     extra_wrapper_cmd, extra_cmd, namespace_mounting_helper = (
-        get_snap_mount_namespace_commands(target_user, shared_location)
+        get_snap_mount_namespace_commands(target_user, shared_location, cwd)
     )
     wrapper_cmd += extra_wrapper_cmd
     cmd += extra_cmd

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -777,7 +777,7 @@ def dangerous_nsenter(path):
     try:
         # here recover setcap and nsenter binaries path outside the sandbox
         runtime_path = get_checkbox_runtime_path()
-        runtime_nsenter = runtime_path / "usr" / "bin" / "nsenter"
+        runtime_nsenter = runtime_path / "usr" / "bin" / "nsenter.static"
         # Note: this path only works on core<24, on core24+ this is in
         #       /usr/sbin but this code should only be used on core16, so this
         #       is fine

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -349,7 +349,9 @@ class UnifiedRunner(IJobRunner):
         if as_systemd_unit:
             get_execution_command = get_execution_command_systemd_unit
         # Setup the executable nest directory
-        with self.configured_filesystem(job) as nest_dir, self.proper_job_cwd(
+        with self.configured_filesystem(
+            job
+        ) as nest_dir, self.get_proper_job_cwd(
             job
         ) as cwd_dir, get_execution_command(
             job,
@@ -412,7 +414,7 @@ class UnifiedRunner(IJobRunner):
             yield nest_dir
 
     @contextlib.contextmanager
-    def proper_job_cwd(self, job):
+    def get_proper_job_cwd(self, job):
         """
         Context manager for handling current working directory for a particular
         execution of a job definition command.

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -889,6 +889,7 @@ def get_snap_mount_namespace_commands(target_user, shared_location):
             else str(dangerous_nsenter_path)
         ),
         "-m/run/snapd/ns/{}.mnt".format(snap_name),
+        "-w.",  # wrapper command expects cwd to not change!
     ]
     if mounting_strategy == MountingStrategy.MOUNT_AMBIENT_CAPABILITIES:
         # on non-core16 we have given ourselves AmbientCapabilities. After

--- a/checkbox-ng/plainbox/impl/test_execution.py
+++ b/checkbox-ng/plainbox/impl/test_execution.py
@@ -259,10 +259,16 @@ class UnifiedRunnerTests(TestCase):
         get_execution_environment_mock,
     ):
         @contextlib.contextmanager
-        def configured_filesystem_mock(self, *args, **kwargs):
+        def empty_ctx_manager(self, *args, **kwargs):
             yield
 
-        self_mock = mock.Mock(configured_filesystem=configured_filesystem_mock)
+        configured_filesystem_mock = empty_ctx_manager
+        get_proper_job_cwd_mock = empty_ctx_manager
+
+        self_mock = mock.Mock(
+            configured_filesystem=configured_filesystem_mock,
+            get_proper_job_cwd=get_proper_job_cwd_mock,
+        )
         self_mock._user_provider.return_value = None
 
         job_mock = mock.Mock(user="ubuntu")
@@ -291,10 +297,16 @@ class UnifiedRunnerTests(TestCase):
         get_execution_environment_mock,
     ):
         @contextlib.contextmanager
-        def configured_filesystem_mock(self, *args, **kwargs):
+        def empty_ctx_manager(self, *args, **kwargs):
             yield
 
-        self_mock = mock.Mock(configured_filesystem=configured_filesystem_mock)
+        configured_filesystem_mock = empty_ctx_manager
+        get_proper_job_cwd_mock = empty_ctx_manager
+
+        self_mock = mock.Mock(
+            configured_filesystem=configured_filesystem_mock,
+            get_proper_job_cwd=get_proper_job_cwd_mock,
+        )
         self_mock._user_provider.return_value = None
 
         job_mock = mock.Mock(user="ubuntu")
@@ -310,7 +322,6 @@ class UnifiedRunnerTests(TestCase):
             UnifiedRunner.execute_job(
                 self_mock, job_mock, {}, mock.Mock(), as_systemd_unit=True
             )
-
         self.assertEqual(str(e.exception), "systemd")
 
 

--- a/checkbox-ng/plainbox/impl/test_execution.py
+++ b/checkbox-ng/plainbox/impl/test_execution.py
@@ -324,6 +324,24 @@ class UnifiedRunnerTests(TestCase):
             )
         self.assertEqual(str(e.exception), "systemd")
 
+    @mock.patch("os.getcwd")
+    def test_get_proper_job_cwd_preserve_cwd(self, os_cwd_mock):
+        self_mock = mock.Mock()
+        job_mock = mock.Mock()
+        job_mock.get_flag_set.return_value = {"preserve-cwd"}
+        with UnifiedRunner.get_proper_job_cwd(self_mock, job_mock) as cwd:
+            self.assertEqual(cwd, os_cwd_mock())
+
+    @mock.patch("os.getcwd")
+    @mock.patch("os.getenv")
+    def test_get_proper_job_cwd_snap(self, os_getenv_mock, os_cwd_mock):
+        self_mock = mock.Mock()
+        job_mock = mock.Mock()
+        job_mock.get_flag_set.return_value = {}
+        os_getenv_mock.return_value = "/snap/checkbox24"
+        with UnifiedRunner.get_proper_job_cwd(self_mock, job_mock) as cwd:
+            self.assertEqual(cwd, os_cwd_mock())
+
 
 class TestDangerousNsenter(TestCase):
     def call_args_to_string(self, call_arg):


### PR DESCRIPTION
## Description

nsenter resets cwd to `/` by default but Checkbox assumes the test starter (which calls plz-run with -same-dir for the same reason) doesn't change the CWD. This manifests as docker tests failing but it basically breaks a core assumption of Checkbox.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-2169
Fixes: https://github.com/canonical/checkbox/issues/2318

## Documentation

Added a comment to explain why `-w.`

## Tests

Tested locally with image garden patching the edge snap
