### PR TITLE
cpuid.py fixes and supported Intel platforms update (New)

### DIFF
--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -217,6 +217,7 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
         "Cooper Lake":      ['0x5065a', '0x5065b'],                      # 2020
         "Tiger Lake":       ['0x806c1'],                                 # 2020
         "Elkhart Lake":     ['0x90660', '0x90661'],                      # 2021
+        "Jasper Lake":      ['0x906c0'],                                 # 2021
         "Rocket Lake":      ['0xa0671'],                                 # 2021
         "Alder Lake":       ['0x906a4', '0x906a3', '0x90675',            # 2021
                              '0x90672'],

--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -203,6 +203,7 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
         "Knights Landing":  ['0x5067'],                                  # 2016
         "Kaby Lake":        ['0x806e9', '0x906e9'],                      # 2016
         # Amber Lake Y (low power refresh of Kaby Lake) shares CPUID 0x806e9
+        "Apollo Lake":      ['0x506c9', '0x506ca'],                      # 2016
         "Knights Mill":     ['0x8065'],                                  # 2017
         "Coffee Lake":      ['0x806ea', '0x906ea', '0x906eb',            # 2017
                              '0x906ec', '0x906ed'],

--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -162,57 +162,72 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
     The dict inefficiency in this implementation is obvious. The lookup is
     done over the cpuid, so that should be the key. For now let's keep it
     consistent with how it was in the past.
+
+    The dict should be sorted in chronological release order, so that the most
+    recent cpuid is at the end. So there is no regression when a new cpuid is
+    added that ends up having the same cpuid as an older one.
     """
     # let's disable the formatting so the structure is easier to follow
     # fmt: off
     CPUIDS = {
-        "AMD EPYC":         ['0x800f12'],
-        "AMD Genoa":        ['0xa10f11'],
-        "AMD Lisbon":       ['0x100f81'],
-        "AMD Magny-Cours":  ['0x100f91'],
-        "AMD Milan":        ['0xa00f11'],
-        "AMD Milan-X":      ['0xa00f12'],
-        "AMD ROME":         ['0x830f10'],
-        "AMD Ryzen":        ['0x810f81'],
-        "AMD Bergamo":      ['0xaa0f01'],
-        "AMD Siena SP6":    ['0xaa0f02'],
-        "AMD Raphael":      ['0xa60f12'],
-        "AMD Turin":        ['0xb00f21', '0xb10f10'],
-        "AMD Grado":        ['0xb40f40'],
-        "Broadwell":        ['0x4067', '0x306d4', '0x5066', '0x406f'],
-        "Canon Lake":       ['0x6066'],
-        "Cascade Lake":     ['0x50655', '0x50656', '0x50657'],
-        "Coffee Lake":      [
-            '0x806ea', '0x906ea', '0x906eb', '0x906ec', '0x906ed'],
-        "Comet Lake":       ['0x806ec', '0xa065'],
-        "Cooper Lake":      ['0x5065a', '0x5065b'],
-        "Emerald Rapids":   ['0xc06f2'],
-        "Haswell":          ['0x306c', '0x4065', '0x4066', '0x306f'],
-        "Hygon Dhyana Plus": ["0x900f22"],
-        "Hygon C86-4G 7490": ['0x900f41'],
-        "Ice Lake":         ['0x606e6', '0x606a6', '0x706e6', '0x606c1'],
-        "Ivy Bridge":       ['0x306a', '0x306e'],
-        "Kaby Lake":        ['0x806e9', '0x906e9'],
-        "Knights Landing":  ['0x5067'],
-        "Knights Mill":     ['0x8065'],
-        "Nehalem":          ['0x106a', '0x106e5', '0x206e'],
-        "Pineview":         ['0x106ca'],
-        "Penryn":           ['0x1067a'],
-        "Raptor Lake":      ['0xb0671', '0xb06f2', '0xb06f5', '0xb06a2'],
-        "Rocket Lake":      ['0xa0671'],
-        "Sandy Bridge":     ['0x206a', '0x206d6', '0x206d7'],
-        "Sapphire Rapids":  ['0x806f3', '0x806f6', '0x806f7', '0x806f8'],
-        "Skylake":          ['0x406e3', '0x506e3', '0x50654', '0x50652'],
-        "Tiger Lake":       ['0x806c1'],
-        "Alder Lake":       ['0x906a4', '0x906a3', '0x90675', '0x90672'],
-        "Westmere":         ['0x2065', '0x206c', '0x206f'],
-        "Whisky Lake":      ['0x806eb', '0x806ec'],
-        "Sierra Forest":    ['0xa06f3'],
-        "Granite Rapids":   ['0xa06e0', '0xa06d0', '0xa06d1'],
-        "Granite Rapids-D": ['0xa06e1'],
-        "Meteor Lake":      ['0xa06a4'],
-        "Arrow Lake":       ['0xc0660', '0xc0652'],
-        "Lunar Lake":       ['0xb06d1']
+        # AMD
+        "AMD Magny-Cours":  ['0x100f91'],                                # 2010
+        "AMD Lisbon":       ['0x100f81'],                                # 2010
+        "AMD Ryzen":        ['0x810f81'],                                # 2017
+        "AMD EPYC":         ['0x800f12'],                                # 2017
+        "AMD ROME":         ['0x830f10'],                                # 2019
+        "AMD Milan":        ['0xa00f11'],                                # 2021
+        "AMD Milan-X":      ['0xa00f12'],                                # 2022
+        "AMD Raphael":      ['0xa60f12'],                                # 2022
+        "AMD Genoa":        ['0xa10f11'],                                # 2022
+        "AMD Bergamo":      ['0xaa0f01'],                                # 2023
+        "AMD Siena SP6":    ['0xaa0f02'],                                # 2023
+        "AMD Turin":        ['0xb00f21', '0xb10f10'],                    # 2024
+        "AMD Grado":        ['0xb40f40'],                                # 2025
+
+        # Hygon
+        "Hygon Dhyana Plus": ["0x900f22"],                               # 2019
+        "Hygon C86-4G 7490": ['0x900f41'],                               # 2024
+
+        # Intel
+        "Penryn":           ['0x1067a'],                                 # 2007
+        "Nehalem":          ['0x106a', '0x106e5', '0x206e'],             # 2008
+        "Pineview":         ['0x106ca'],                                 # 2009
+        "Westmere":         ['0x2065', '0x206c', '0x206f'],              # 2010
+        "Sandy Bridge":     ['0x206a', '0x206d6', '0x206d7'],            # 2011
+        "Ivy Bridge":       ['0x306a', '0x306e'],                        # 2012
+        "Haswell":          ['0x306c', '0x4065', '0x4066', '0x306f'],    # 2013
+        "Broadwell":        ['0x4067', '0x306d4', '0x5066', '0x406f'],   # 2014
+        "Skylake":          ['0x406e3', '0x506e3', '0x50654',            # 2015
+                             '0x50652'],
+        "Knights Landing":  ['0x5067'],                                  # 2016
+        "Kaby Lake":        ['0x806e9', '0x906e9'],                      # 2016
+        # Amber Lake Y (low power refresh of Kaby Lake) shares CPUID 0x806e9
+        "Knights Mill":     ['0x8065'],                                  # 2017
+        "Coffee Lake":      ['0x806ea', '0x906ea', '0x906eb',            # 2017
+                             '0x906ec', '0x906ed'],
+        "Canon Lake":       ['0x6066'],                                  # 2018
+        "Whisky Lake":      ['0x806eb', '0x806ec'],                      # 2018
+        "Cascade Lake":     ['0x50655', '0x50656', '0x50657'],           # 2019
+        "Ice Lake":         ['0x606e6', '0x606a6', '0x706e6',            # 2019
+                             '0x606c1'],
+        "Comet Lake":       ['0x806ec', '0xa065'],                       # 2019
+        "Cooper Lake":      ['0x5065a', '0x5065b'],                      # 2020
+        "Tiger Lake":       ['0x806c1'],                                 # 2020
+        "Rocket Lake":      ['0xa0671'],                                 # 2021
+        "Alder Lake":       ['0x906a4', '0x906a3', '0x90675',            # 2021
+                             '0x90672'],
+        "Raptor Lake":      ['0xb0671', '0xb06f2', '0xb06f5',            # 2022
+                             '0xb06a2'],
+        "Sapphire Rapids":  ['0x806f3', '0x806f6', '0x806f7',            # 2023
+                             '0x806f8'],
+        "Emerald Rapids":   ['0xc06f2'],                                 # 2023
+        "Meteor Lake":      ['0xa06a4'],                                 # 2023
+        "Sierra Forest":    ['0xa06f3'],                                 # 2024
+        "Granite Rapids":   ['0xa06e0', '0xa06d0', '0xa06d1'],           # 2024
+        "Granite Rapids-D": ['0xa06e1'],                                 # 2024
+        "Lunar Lake":       ['0xb06d1'],                                 # 2024
+        "Arrow Lake":       ['0xc0660', '0xc0652']                       # 2024
     }
     for key in CPUIDS.keys():
         for value in CPUIDS[key]:

--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -231,7 +231,8 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
         "Granite Rapids":   ['0xa06e0', '0xa06d0', '0xa06d1'],           # 2024
         "Granite Rapids-D": ['0xa06e1'],                                 # 2024
         "Lunar Lake":       ['0xb06d1'],                                 # 2024
-        "Arrow Lake":       ['0xc0660', '0xc0652']                       # 2024
+        "Arrow Lake":       ['0xc0660', '0xc0652'],                      # 2024
+        "Panther Lake":     ['0xc06c0']                                  # 2025
     }
     for key in CPUIDS.keys():
         for value in CPUIDS[key]:

--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -207,6 +207,7 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
         "Knights Mill":     ['0x8065'],                                  # 2017
         "Coffee Lake":      ['0x806ea', '0x906ea', '0x906eb',            # 2017
                              '0x906ec', '0x906ed'],
+        "Gemini Lake":      ['0x706a1', '0x706a8'],                      # 2017
         "Canon Lake":       ['0x6066'],                                  # 2018
         "Whisky Lake":      ['0x806eb', '0x806ec'],                      # 2018
         "Cascade Lake":     ['0x50655', '0x50656', '0x50657'],           # 2019

--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -210,6 +210,8 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
         "Gemini Lake":      ['0x706a1', '0x706a8'],                      # 2017
         "Canon Lake":       ['0x6066'],                                  # 2018
         "Whisky Lake":      ['0x806eb', '0x806ec'],                      # 2018
+        # Amber Lake Y shares CPUID 0x806ec and 0x806eb with Whisky Lake
+        "Amber Lake Y":     ['0x406e8'],                                 # 2018
         "Cascade Lake":     ['0x50655', '0x50656', '0x50657'],           # 2019
         "Ice Lake":         ['0x606e6', '0x606a6', '0x706e6',            # 2019
                              '0x606c1'],

--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -213,7 +213,7 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
         "Granite Rapids-D": ['0xa06e1'],
         "Meteor Lake":      ['0xa06a4'],
         "Arrow Lake":       ['0xc0660', '0xc0652'],
-        "Lunar Lake":       ["0xb06d1"]
+        "Lunar Lake":       ['0xb06d1']
     }
     for key in CPUIDS.keys():
         for value in CPUIDS[key]:

--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -216,6 +216,7 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
         "Comet Lake":       ['0x806ec', '0xa065'],                       # 2019
         "Cooper Lake":      ['0x5065a', '0x5065b'],                      # 2020
         "Tiger Lake":       ['0x806c1'],                                 # 2020
+        "Elkhart Lake":     ['0x90660', '0x90661'],                      # 2021
         "Rocket Lake":      ['0xa0671'],                                 # 2021
         "Alder Lake":       ['0x906a4', '0x906a3', '0x90675',            # 2021
                              '0x90672'],

--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -166,7 +166,6 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
     # let's disable the formatting so the structure is easier to follow
     # fmt: off
     CPUIDS = {
-        "Amber Lake":       ['0x806e9'],
         "AMD EPYC":         ['0x800f12'],
         "AMD Genoa":        ['0xa10f11'],
         "AMD Lisbon":       ['0x100f81'],


### PR DESCRIPTION
## Description

- Update cpuid detection data with new Intel CPU IDs (Panther Lake, Jasper Lake, Elkhart Lake, Gemini Lake, Apollo Lake).
- Reorganize CPU identifier mappings for clarity/consistency.
- Remove Amber Lake entries that was causing miss identification with Kaby Lake platforms.

## Resolved issues

Amber Lake is just a Kaby Lake update for low power. Thus, they share the same CPUID. Previous to this PR, all Kaby Lake platforms were identified as Amber Lake wrongly.

## Documentation

Not applicable

## Tests

Tested on a machine affected by the miss-identification (Kaby Lake/Amber Lake).
The rest of the CPUID were identified in conformance with Intel official documentation and existing steppings found on our test fleet.
