### PR TITLE
fix typo in example code for 'Grouping related jobs' (Infra)

### DIFF
--- a/docs/tutorial/writing-tests/test-case.rst
+++ b/docs/tutorial/writing-tests/test-case.rst
@@ -323,7 +323,7 @@ put them all in the same group:
 
     id: network_available
     flags: simple
-    depends: network_available
+    depends: network_setup
     before: network_teardown
     group: network_tests
     _summary: Test that the internet is reachable


### PR DESCRIPTION
## Description

The example code provided in this section is not valid / does not run. I believe the cyclic dependency in `network_available` was meant to be `network_setup` instead.

## Resolved issues

None

## Documentation

Nothing else on the page is adversely affected by this change.

## Tests

Was not tested, as it is purely a documentation change. I have however tested the configuration given in my PR, and it runs and makes sense in the context of what the tutorial is attempting to teach here.