### PR TITLE
preserve-cwd only when preserve-cwd is provided (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -426,14 +426,17 @@ class UnifiedRunner(IJobRunner):
         :returns:
             Pathname of the new directory
         """
-        if "preserve-cwd" in job.get_flag_set() or os.getenv("SNAP"):
+        if "preserve-cwd" in job.get_flag_set():
             yield os.getcwd()
             return
         # Create a nest for all the private executables needed for execution
         prefix = "cwd-"
         suffix = ".{}".format(job.checksum)
         try:
-            with tempfile.TemporaryDirectory(suffix, prefix) as cwd_dir:
+            # use /var/tmp because in snaps /tmp is private to the snap
+            with tempfile.TemporaryDirectory(
+                suffix, prefix, "/var/tmp"
+            ) as cwd_dir:
                 os.chmod(cwd_dir, 0o777)
                 logger.debug(
                     _("Job temporary current working directory: %s"), cwd_dir

--- a/checkbox-ng/plainbox/impl/test_execution.py
+++ b/checkbox-ng/plainbox/impl/test_execution.py
@@ -334,13 +334,30 @@ class UnifiedRunnerTests(TestCase):
 
     @mock.patch("os.getcwd")
     @mock.patch("os.getenv")
-    def test_get_proper_job_cwd_snap(self, os_getenv_mock, os_cwd_mock):
+    @mock.patch("os.chmod")
+    def test_get_proper_job_cwd_snap(
+        self, chmod_mock, os_getenv_mock, os_cwd_mock
+    ):
         self_mock = mock.Mock()
         job_mock = mock.Mock()
         job_mock.get_flag_set.return_value = {}
         os_getenv_mock.return_value = "/snap/checkbox24"
-        with UnifiedRunner.get_proper_job_cwd(self_mock, job_mock) as cwd:
-            self.assertEqual(cwd, os_cwd_mock())
+
+        class TemporaryDirectoryMock:
+            def __init__(self, suffix, prefix, dir, *args, **kwargs):
+                self.dir = dir
+
+            def __enter__(self):
+                return self.dir + "/some"
+
+            def __exit__(self, *args): ...
+
+        with mock.patch(
+            "tempfile.TemporaryDirectory", new=TemporaryDirectoryMock
+        ) as tmp:
+            with UnifiedRunner.get_proper_job_cwd(self_mock, job_mock) as cwd:
+                self.assertTrue(str(cwd).startswith("/var/tmp"))
+            self.assertTrue(self_mock._check_leftovers.called)
 
 
 class TestDangerousNsenter(TestCase):


### PR DESCRIPTION

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Snaps services cwd is calculated by snapd and depends on the user that starts the service among other factors. Using the service cwd as the job cwd present one challenge, if the job is a user job it may not have access to that agent cwd (that may be in /root/snap/...). Additionally I believe that preserving cwd always in snaps was something done in the past because `/tmp` is private for snaps and it was a quick workaround, which also drops the leftovers check.

A solution that fixes both issues is using `/var/tmp` isntead of `/tmp`. We already use this quite a lot (for the nest), so until it becomes private as well, we can rely on it being globally accessible. 


## Resolved issues

Fixes: CHECKBOX-2181

## Documentation

N/A
I don't think this needs additional documentation as this restores the "normal" behaviour one expects from checkbox, it was weird we wouldn't create a temp cwd for snaps making all jobs effectively preserve-cwd

## Tests

Tested on image-garden.spread running the docker test (which, as it calls a snap it may be impacted)