### PR TITLE
Try to give a more informative error as this is user facing (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/exporter/jinja2.py
+++ b/checkbox-ng/plainbox/impl/exporter/jinja2.py
@@ -82,6 +82,25 @@ def highlight_keys(text):
     return re.sub(r"(\w+:\s)", r"<b>\1</b>", text)
 
 
+def pretty_json_decode_error(
+    error: json.decoder.JSONDecodeError, lines_around=3
+):
+    lineno = error.lineno
+    colno = error.colno
+    lines = error.doc.splitlines()
+    min_line = max(lineno - lines_around, 0)
+    max_line = min(lineno + lines_around, len(lines) - 1)
+    center = min(lineno + 1, len(lines))
+    error_repr = lines[min_line:center]
+    error_repr.append(" " * colno + "^^^ " + str(error))
+    error_repr += lines[center:max_line]
+    if isinstance(error_repr[0], str):
+        return "\n".join(error_repr)
+    else:
+        # defer decoding here to avoid decoding the whole document
+        return b"\n".join(error_repr).decode("utf8")
+
+
 class Jinja2SessionStateExporter(SessionStateExporterBase):
     """Session state exporter that renders output using jinja2 template."""
 
@@ -279,20 +298,6 @@ class Jinja2SessionStateExporter(SessionStateExporterBase):
             json.loads(s)
             return []
         except json.decoder.JSONDecodeError as exc:
-            lineno = exc.lineno
-            colno = exc.colno
-            lines = exc.doc.splitlines()
-            around = 3  # print 3 lines before and after
-            min_line = max(lineno - around, 0)
-            max_line = min(lineno + around, len(lines) - 1)
-            center = min(lineno + 1, len(lines))
-            error_repr = lines[min_line:center]
-            error_repr.append(" " * colno + "^^^ " + str(exc))
-            error_repr += lines[center:max_line]
-            if isinstance(error_repr[0], str):
-                return "\n".join(error_repr)
-            else:
-                return b"\n".join(error_repr).decode("utf8")
-
+            return pretty_json_decode_error(exc)
         except Exception as exc:
             return [str(exc)]

--- a/checkbox-ng/plainbox/impl/exporter/jinja2.py
+++ b/checkbox-ng/plainbox/impl/exporter/jinja2.py
@@ -52,7 +52,6 @@ from plainbox.impl.result import OUTCOME_METADATA_MAP
 from plainbox.impl.unit.exporter import ExporterError
 from plainbox.impl.config import CheckboxINIParser
 
-
 #: Name-space prefix for Canonical Certification
 CERTIFICATION_NS = "com.canonical.certification::"
 
@@ -279,5 +278,21 @@ class Jinja2SessionStateExporter(SessionStateExporterBase):
             s = raw.decode("utf-8") if type(raw) == bytes else raw
             json.loads(s)
             return []
+        except json.decoder.JSONDecodeError as exc:
+            lineno = exc.lineno
+            colno = exc.colno
+            lines = exc.doc.splitlines()
+            around = 3  # print 3 lines before and after
+            min_line = max(lineno - around, 0)
+            max_line = min(lineno + around, len(lines) - 1)
+            center = min(lineno + 1, len(lines))
+            error_repr = lines[min_line:center]
+            error_repr.append(" " * colno + "^^^ " + str(exc))
+            error_repr += lines[center:max_line]
+            if isinstance(error_repr[0], str):
+                return "\n".join(error_repr)
+            else:
+                return b"\n".join(error_repr).decode("utf8")
+
         except Exception as exc:
             return [str(exc)]

--- a/checkbox-ng/plainbox/impl/exporter/test_jinja2.py
+++ b/checkbox-ng/plainbox/impl/exporter/test_jinja2.py
@@ -193,6 +193,9 @@ class PrettyJsonDecodeErrorTests(TestCase):
     def test_trailing_comma_in_object(self):
         self._check('{"key": "value",}')
 
+    def test_trailing_comma_in_object_bindoc(self):
+        self._check(b'{"key": "value",}')
+
     def test_trailing_comma_in_array(self):
         self._check("[1, 2, 3,]")
 

--- a/checkbox-ng/plainbox/impl/exporter/test_jinja2.py
+++ b/checkbox-ng/plainbox/impl/exporter/test_jinja2.py
@@ -27,9 +27,11 @@ from io import BytesIO
 from tempfile import TemporaryDirectory
 from textwrap import dedent
 from unittest import TestCase
+import json
 import os
 
 from plainbox.impl.exporter.jinja2 import Jinja2SessionStateExporter
+from plainbox.impl.exporter.jinja2 import pretty_json_decode_error
 from plainbox.impl.result import MemoryJobResult
 from plainbox.impl.session.state import SessionMetaData
 from plainbox.impl.unit.exporter import ExporterError
@@ -165,3 +167,55 @@ class Jinja2SessionStateExporterTests(TestCase):
                 exporter.dump_from_session_manager(
                     self.manager_single_job, stream
                 )
+
+
+class PrettyJsonDecodeErrorTests(TestCase):
+
+    def _get_error(self, bad_json):
+        try:
+            json.loads(bad_json)
+        except json.decoder.JSONDecodeError as e:
+            return e
+        self.fail("Expected JSONDecodeError was not raised")
+
+    def _check(self, bad_json):
+        error = self._get_error(bad_json)
+        result = pretty_json_decode_error(error)
+        self.assertIsInstance(result, str)
+        # The original error message should always be present
+        self.assertIn(str(error), result)
+        return result
+
+    def test_error_at_start(self):
+        result = self._check("not json at all")
+        self.assertIn("not json", result)
+
+    def test_trailing_comma_in_object(self):
+        self._check('{"key": "value",}')
+
+    def test_trailing_comma_in_array(self):
+        self._check("[1, 2, 3,]")
+
+    def test_missing_colon(self):
+        self._check('{"key" "value"}')
+
+    def test_single_quotes(self):
+        self._check("{'key': 'value'}")
+
+    def test_empty_string(self):
+        self._check("")
+
+    def test_truncated_object(self):
+        self._check('{"key": "value"')
+
+    def test_error_deep_in_long_document(self):
+        bad_json = '{"a": 1, ' * 100 + "BROKEN}"
+        self._check(bad_json)
+
+    def test_multiline_json(self):
+        self._check('{\n  "a": 1,\n  "b": ,\n  "c": 3\n}')
+
+    def test_result_contains_error_neighbourhood(self):
+        bad_json = '{"good": 1, "bad": tralse, "other": 2}'
+        result = self._check(bad_json)
+        self.assertIn("tralse", result)

--- a/checkbox-ng/plainbox/impl/exporter/test_jinja2.py
+++ b/checkbox-ng/plainbox/impl/exporter/test_jinja2.py
@@ -193,9 +193,6 @@ class PrettyJsonDecodeErrorTests(TestCase):
     def test_trailing_comma_in_object(self):
         self._check('{"key": "value",}')
 
-    def test_trailing_comma_in_object_bindoc(self):
-        self._check(b'{"key": "value",}')
-
     def test_trailing_comma_in_array(self):
         self._check("[1, 2, 3,]")
 


### PR DESCRIPTION

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

The previous error gave basically no reason why the json was invalid. This improves the situation adding exactly what the json decoder thinks is invalid with a primitive ^ hightlight

## Resolved issues

Before this patch:
<details>

```
Problem with a '2_json_file' report using 'com.canonical.plainbox::json' exporter sent to '/root/snap/checkbox24/x1/.local/share/checkbox-ng/submission_2026-02-24T08.25.37.991019.json' transport. Reason: ['Expecting value: line 71827 column 17 (char 4856300)']

========= Remote Traceback (1) =========
Traceback (most recent call last):
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/protocol.py", line 359, in _dispatch_request
    res = self._HANDLERS[handler](self, *args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/protocol.py", line 837, in _handle_call
    return obj(*args, **dict(kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/impl/session/remote_assistant.py", line 1048, in exposed_cache_report
    exporter.dump_from_session_manager(self._sa._manager, exported_stream)
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/impl/exporter/jinja2.py", line 221, in dump_from_session_manager
    self.validate(stream)
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/impl/exporter/jinja2.py", line 268, in validate
    raise ExporterError(problems)
plainbox.impl.unit.exporter.ExporterError: ['Expecting value: line 71827 column 17 (char 4856300)']

Traceback (most recent call last):
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/checkbox_ng/launcher/stages.py", line 753, in _export_results
    result = self._export_fn(exporter_id, transport)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/checkbox_ng/launcher/controller.py", line 921, in local_export
    rf = self.sa.cache_report(exporter_id, options)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/netref.py", line 240, in __call__
    return syncreq(_self, consts.HANDLE_CALL, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/netref.py", line 63, in syncreq
    return conn.sync_request(handler, proxy, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/protocol.py", line 718, in sync_request
    return _async_res.value
           ^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/async_.py", line 108, in value
    raise self._obj
plainbox.vendor.rpyc.core.vinegar/plainbox.impl.unit.exporter._get_exception_class.<locals>.Derived: ['Expecting value: line 71827 column 17 (char 4856300)']

========= Remote Traceback (1) =========
Traceback (most recent call last):
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/protocol.py", line 359, in _dispatch_request
    res = self._HANDLERS[handler](self, *args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/protocol.py", line 837, in _handle_call
    return obj(*args, **dict(kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/impl/session/remote_assistant.py", line 1048, in exposed_cache_report
    exporter.dump_from_session_manager(self._sa._manager, exported_stream)
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/impl/exporter/jinja2.py", line 221, in dump_from_session_manager
    self.validate(stream)
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/impl/exporter/jinja2.py", line 268, in validate
    raise ExporterError(problems)
plainbox.impl.unit.exporter.ExporterError: ['Expecting value: line 71827 column 17 (char 4856300)']

Problem with a 'local_json' report using 'com.canonical.plainbox::json' exporter sent to './submission.json' transport. Reason: ['Expecting value: line 71827 column 17 (char 4856300)']

========= Remote Traceback (1) =========
Traceback (most recent call last):
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/protocol.py", line 359, in _dispatch_request
    res = self._HANDLERS[handler](self, *args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/protocol.py", line 837, in _handle_call
    return obj(*args, **dict(kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/impl/session/remote_assistant.py", line 1048, in exposed_cache_report
    exporter.dump_from_session_manager(self._sa._manager, exported_stream)
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/impl/exporter/jinja2.py", line 221, in dump_from_session_manager
    self.validate(stream)
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/impl/exporter/jinja2.py", line 268, in validate
    raise ExporterError(problems)
plainbox.impl.unit.exporter.ExporterError: ['Expecting value: line 71827 column 17 (char 4856300)']

Traceback (most recent call last):
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/checkbox_ng/launcher/stages.py", line 753, in _export_results
    result = self._export_fn(exporter_id, transport)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/checkbox_ng/launcher/controller.py", line 921, in local_export
    rf = self.sa.cache_report(exporter_id, options)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/netref.py", line 240, in __call__
    return syncreq(_self, consts.HANDLE_CALL, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/netref.py", line 63, in syncreq
    return conn.sync_request(handler, proxy, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/protocol.py", line 718, in sync_request
    return _async_res.value
           ^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/async_.py", line 108, in value
    raise self._obj
plainbox.vendor.rpyc.core.vinegar/plainbox.impl.unit.exporter._get_exception_class.<locals>.Derived: ['Expecting value: line 71827 column 17 (char 4856300)']

========= Remote Traceback (1) =========
Traceback (most recent call last):
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/protocol.py", line 359, in _dispatch_request
    res = self._HANDLERS[handler](self, *args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/vendor/rpyc/core/protocol.py", line 837, in _handle_call
    return obj(*args, **dict(kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/impl/session/remote_assistant.py", line 1048, in exposed_cache_report
    exporter.dump_from_session_manager(self._sa._manager, exported_stream)
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/impl/exporter/jinja2.py", line 221, in dump_from_session_manager
    self.validate(stream)
  File "/snap/checkbox24/x1/lib/python3.12/site-packages/plainbox/impl/exporter/jinja2.py", line 268, in validate
    raise ExporterError(problems)
plainbox.impl.unit.exporter.ExporterError: ['Expecting value: line 71827 column 17 (char 4856300)']
```

</details>

After this patch:

<details>
<img width="795" height="140" alt="image" src="https://github.com/user-attachments/assets/bb94104b-295c-4000-a9dc-a7bb0186d371" />
</details>


## Documentation

N/A

## Tests

Unittested
