### PR TITLE
Remove screen-private-ppa test definition from contrib because it was added in base provider (Bugfix)

### DIFF
--- a/contrib/pc-sanity/units/pc-sanity/pc-sanity-screen-oem-gaps.pxu
+++ b/contrib/pc-sanity/units/pc-sanity/pc-sanity-screen-oem-gaps.pxu
@@ -16,16 +16,3 @@ _summary: check if pkgs are not supported by Canonical
 _description:
  This lists the packages which is not coming from main or restricted component.
 
-plugin: shell
-category_id: com.canonical.plainbox::miscellanea
-id: miscellanea/screen-private-ppa
-user: root
-command:
-  if grep -qrE 'private-ppa\.launchpad(|content)\.net' "/etc/apt/sources.list"* ; then
-      >&2 printf 'The following files have private PPA access:\n'
-      >&2 grep -lrE 'private-ppa\.launchpad(|content)\.net' "/etc/apt/sources.list"*
-      exit 1
-  fi
-_summary: check if any private ppas are added
-_description:
- This checks if any private ppas are added to the system, fails if any found.


### PR DESCRIPTION
This change removes screen-private-ppa job from contrib provider commited in 2025 (8877aa9c02be76a6667d641c1dd48c18959e771c). The same job was later added in base provider in 2026 (commit d8c8ff30f) and now causes below error when run pc-sanity plan: 

```

checkbox-cli control 10.102.164.66 checkbox-launcher
Connecting to 10.102.164.66:18871. Timeout: 600s
Traceback (most recent call last):
  File "/usr/bin/checkbox-cli", line 8, in <module>
    sys.exit(main())
  File "/usr/lib/python3/dist-packages/checkbox_ng/launcher/checkbox_cli.py", line 183, in main
    return subcmd.invoked(ctx)
  File "/usr/lib/python3/dist-packages/checkbox_ng/launcher/controller.py", line 205, in invoked
    return self.connect_and_run(ctx.args.host, port)
  File "/usr/lib/python3/dist-packages/checkbox_ng/launcher/controller.py", line 337, in connect_and_run
    keep_running = self.continue_session()
  File "/usr/lib/python3/dist-packages/checkbox_ng/launcher/controller.py", line 511, in continue_session
    return self.connection_strategy()[state](self, payload)
  File "/usr/lib/python3/dist-packages/checkbox_ng/launcher/controller.py", line 492, in resume_or_start_new_session
    return self.automatically_start_via_launcher_and_continue()
  File "/usr/lib/python3/dist-packages/checkbox_ng/launcher/controller.py", line 464, in automatically_start_via_launcher_and_continue
    _ = self.start_session()
  File "/usr/lib/python3/dist-packages/checkbox_ng/launcher/controller.py", line 480, in start_session
    tps = self.sa.start_session_json(json.dumps(configuration))
  File "/usr/lib/python3/dist-packages/plainbox/vendor/rpyc/core/netref.py", line 240, in __call__
    return syncreq(_self, consts.HANDLE_CALL, args, kwargs)
  File "/usr/lib/python3/dist-packages/plainbox/vendor/rpyc/core/netref.py", line 63, in syncreq
    return conn.sync_request(handler, proxy, *args)
  File "/usr/lib/python3/dist-packages/plainbox/vendor/rpyc/core/protocol.py", line 718, in sync_request
    return _async_res.value
  File "/usr/lib/python3/dist-packages/plainbox/vendor/rpyc/core/async_.py", line 108, in value
    raise self._obj
plainbox.vendor.rpyc.core.vinegar/plainbox.impl.depmgr._get_exception_class.<locals>.Derived: ("<JobDefinition id:'com.canonical.certification::miscellanea/screen-private-ppa' plugin:'shell'>", "<JobDefinition id:'com.canonical.certification::miscellanea/screen-private-ppa' plugin:'shell'>")

========= Remote Traceback (1) =========
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/plainbox/vendor/rpyc/core/protocol.py", line 359, in _dispatch_request
    res = self._HANDLERS[handler](self, *args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/plainbox/vendor/rpyc/core/protocol.py", line 837, in _handle_call
    return obj(*args, **dict(kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/plainbox/impl/session/remote_assistant.py", line 111, in fun
    return f(self, *args)
           ^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/plainbox/impl/session/remote_assistant.py", line 376, in start_session_json
    return json.dumps(self.start_session(json.loads(configuration)))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/plainbox/impl/session/remote_assistant.py", line 111, in fun
    return f(self, *args)
           ^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/plainbox/impl/session/remote_assistant.py", line 417, in start_session
    self._sa.start_new_session(session_title, UnifiedRunner, runner_kwargs)
  File "/usr/lib/python3/dist-packages/plainbox/impl/decorators.py", line 153, in wrapper
    raise exc
  File "/usr/lib/python3/dist-packages/plainbox/impl/decorators.py", line 145, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/plainbox/impl/session/assistant.py", line 518, in start_new_session
    self._context.add_provider(provider)
  File "/usr/lib/python3/dist-packages/plainbox/impl/session/state.py", line 510, in add_provider
    self.add_unit(unit, False)
  File "/usr/lib/python3/dist-packages/plainbox/impl/session/state.py", line 532, in add_unit
    self.state.add_unit(unit, recompute)
  File "/usr/lib/python3/dist-packages/plainbox/impl/session/state.py", line 1150, in add_unit
    return self._add_job_unit(new_unit, recompute, via)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/plainbox/impl/session/state.py", line 1177, in _add_job_unit
    raise DependencyDuplicateError(existing_job, new_job)
plainbox.impl.depmgr.DependencyDuplicateError: duplicate job id: 'com.canonical.certification::miscellanea/screen-private-ppa'

````
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
