### PR TITLE
Fix utitiles readiness for ce-oem-mipi-camera tests (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/camera_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/camera_test.py
@@ -230,7 +230,7 @@ def register_arguments() -> argparse.Namespace:
     )
 
     # subparser for readiness
-    parser_readiness = subparsers.add_parser("readiness")
+    subparsers.add_parser("readiness")
 
     # Subparser for testing
     parser_testing = subparsers.add_parser(

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/camera_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/camera_test.py
@@ -477,7 +477,7 @@ def readiness_test():
             logging.error("%s is not available", util)
         if not os.path.exists(binary):
             result = False
-            logging.error ("%s path is not exists", util)
+            logging.error("%s path is not exists", util)
         else:
             logging.info("the location of %s is %s", util, binary)
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/camera_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/camera_test.py
@@ -36,7 +36,6 @@ from camera_utils import (
     check_nonzero_files,
     CameraInterface,
     GST_LAUNCH_BIN,
-    GST_DISCOVERER,
     V4L2_CTL_CMD,
     MEDIA_CTL_CMD,
 )
@@ -468,13 +467,12 @@ def readiness_test():
     result = True
 
     utilities_mapping = {
-        "gst-launch-1.0": GST_LAUNCH_BIN, 
-        "gst-discoverer-1.0": GST_DISCOVERER, 
-        "media-ctl": MEDIA_CTL_CMD, 
+        "gst-launch-1.0": GST_LAUNCH_BIN,
+        "media-ctl": MEDIA_CTL_CMD,
         "v4l2-ctl": V4L2_CTL_CMD,
     }
-    for util, binary in utilities.items():
-        if not util:
+    for util, binary in utilities_mapping.items():
+        if not binary:
             result = False
             logging.error("%s is not available", util)
         else:
@@ -493,9 +491,11 @@ def main() -> None:
 
     if args.action == "testing":
         _run_camera_test(args)
+        return
 
     if args.action == "readiness":
         readiness_test()
+        return
 
 
 if __name__ == "__main__":

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/camera_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/camera_test.py
@@ -475,6 +475,9 @@ def readiness_test():
         if not binary:
             result = False
             logging.error("%s is not available", util)
+        if not os.path.exists(binary):
+            result = False
+            logging.error ("%s path is not exists", util)
         else:
             logging.info("the location of %s is %s", util, binary)
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/camera_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/camera_test.py
@@ -35,6 +35,10 @@ from camera_utils import (
     list_device_by_v4l2_ctl,
     check_nonzero_files,
     CameraInterface,
+    GST_LAUNCH_BIN,
+    GST_DISCOVERER,
+    V4L2_CTL_CMD,
+    MEDIA_CTL_CMD,
 )
 
 logging.basicConfig(
@@ -225,6 +229,9 @@ def register_arguments() -> argparse.Namespace:
         required=True,
         help=("Path of the specified test configuration file."),
     )
+
+    # subparser for readiness
+    parser_readiness = subparsers.add_parser("readiness")
 
     # Subparser for testing
     parser_testing = subparsers.add_parser(
@@ -457,6 +464,26 @@ def _run_camera_test(args: argparse.Namespace) -> None:
     _cleanup_artifacts_if_needed(args, artifact_store_path)
 
 
+def readiness_test():
+    result = True
+
+    utilities_mapping = {
+        "gst-launch-1.0": GST_LAUNCH_BIN, 
+        "gst-discoverer-1.0": GST_DISCOVERER, 
+        "media-ctl": MEDIA_CTL_CMD, 
+        "v4l2-ctl": V4L2_CTL_CMD,
+    }
+    for util, binary in utilities.items():
+        if not util:
+            result = False
+            logging.error("%s is not available", util)
+        else:
+            logging.info("the location of %s is %s", util, binary)
+
+    if not result:
+        raise SystemExit("the test utilities for camera test are not ready")
+
+
 def main() -> None:
     args = register_arguments()
 
@@ -466,6 +493,9 @@ def main() -> None:
 
     if args.action == "testing":
         _run_camera_test(args)
+
+    if args.action == "readiness":
+        readiness_test()
 
 
 if __name__ == "__main__":

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/camera/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/camera/jobs.pxu
@@ -14,7 +14,7 @@ _description: Checks if the system has the necessary binaries installed to proce
 estimated_duration: 2s
 category_id: com.canonical.plainbox::camera
 plugin: shell
-environ: GST_LAUNCH_BIN GST_DISCOVERER MEDIA_CTL_CMD V4L2_CTL_CMD
+environ: GST_LAUNCH_BIN MEDIA_CTL_CMD V4L2_CTL_CMD
 command:
     camera_test.py readiness
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/camera/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/camera/jobs.pxu
@@ -8,6 +8,16 @@ environ: MIPI_SCENARIO_DEFINITION_FILE_PATH
 command:
     camera_test.py generate_resource -sf "$MIPI_SCENARIO_DEFINITION_FILE_PATH"
 
+id: ce-oem-mipi-camera/readiness
+_summary: Verify installation of V4L2 and GStreamer tools
+_description: Checks if the system has the necessary binaries installed to proceed with camera testing.
+estimated_duration: 2s
+category_id: com.canonical.plainbox::camera
+plugin: shell
+environ: GST_LAUNCH_BIN GST_DISCOVERER MEDIA_CTL_CMD V4L2_CTL_CMD
+command:
+    camera_test.py readiness
+
 unit: template
 template-engine: jinja2
 template-resource: mipi_camera_resource
@@ -23,14 +33,11 @@ plugin: shell
 category_id: com.canonical.plainbox::camera
 estimated_duration: 10s
 flags: also-after-suspend
+depends: ce-oem-mipi-camera/readiness
 imports:
     from com.canonical.certification import executable
     from com.canonical.plainbox import manifest
 requires:
-    executable.name == "v4l2-ctl"
-    executable.name == "media-ctl"
-    executable.name == "gst-launch-1.0"
-    executable.name == "gst-discoverer-1.0"
     manifest.has_vendor_specific_mipi_camera == "True"
 environ: PLATFORM_NAME MIPI_CAMERA_SETUP_CONF_FILE_PATH
 command:
@@ -51,14 +58,11 @@ plugin: shell
 category_id: com.canonical.plainbox::camera
 estimated_duration: 10s
 flags: also-after-suspend
+depends: ce-oem-mipi-camera/readiness
 imports:
     from com.canonical.certification import executable
     from com.canonical.plainbox import manifest
 requires:
-    executable.name == "v4l2-ctl"
-    executable.name == "media-ctl"
-    executable.name == "gst-launch-1.0"
-    executable.name == "gst-discoverer-1.0"
     manifest.has_vendor_specific_mipi_camera == "True"
 environ: PLATFORM_NAME MIPI_CAMERA_SETUP_CONF_FILE_PATH
 command:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/camera/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/camera/test-plan.pxu
@@ -21,5 +21,6 @@ _description: Automated tests for MIPI Camera in before suspend and post suspend
 bootstrap_include:
     mipi_camera_resource
 include:
+    ce-oem-mipi-camera/readiness
     ce-oem-mipi-camera/capture-image-scenario
     ce-oem-mipi-camera/record-video-scenario


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
there are some gstreamer and v4l2-ctl utilites are needed for the camera tests, and the utilities name might be diffrent on classic image and core image, so this fixed will remove those `requires` fileds from the functional tests, and add a new uitilities readiness test.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
```
========[ Bootstrap com.canonical.contrib::mipi_camera_resource (1/1) ]=========
WARNING:checkbox_ng.user_utils:Using `ceqa` user
Reports will be saved to: /home/ceqa/snap/checkbox-ce-oem/5797/.local/share/checkbox-ng
==============[ Running job 1 / 1. Estimated time left: 0:00:02 ]===============
--------------[ Verify installation of V4L2 and GStreamer tools ]---------------
ID: com.canonical.contrib::ce-oem-mipi-camera/readiness
Category: com.canonical.plainbox::camera
... 8< -------------------------------------------------------------------------
INFO     - camera_test: readiness_test 480  - the location of gst-launch-1.0 is /snap/bin/oem-imx-gstreamer.gst-launch
INFO     - camera_test: readiness_test 480  - the location of media-ctl is /snap/checkbox-ce-oem/5797/usr/bin/media-ctl
INFO     - camera_test: readiness_test 480  - the location of v4l2-ctl is /snap/checkbox-ce-oem/5797/usr/bin/v4l2-ctl
------------------------------------------------------------------------- >8 ---
Outcome: job passed
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
