### PR TITLE
Provide CHECKBOX_RUNTIME environment variable during job execution only (BugFix)

### DIFF
--- a/checkbox-core-snap/common_files/config/wrapper_common
+++ b/checkbox-core-snap/common_files/config/wrapper_common
@@ -39,7 +39,7 @@ fi
 
 # make sure we always know where the content snap is especially for classic
 # checkbox snaps where the checkbox-runtime bind mount does not exist
-export CHECKBOX_RUNTIME=$(findmnt -oTARGET -n $(findmnt -oSOURCE -n $RUNTIME) | grep -P "^\/snap\/checkbox(|\d{2})\/")
+# export CHECKBOX_RUNTIME=$(findmnt -oTARGET -n $(findmnt -oSOURCE -n $RUNTIME) | grep -P "^\/snap\/checkbox(|\d{2})\/")
 
 # Tell GStreamer where to find its plugins
 export GST_PLUGIN_PATH=$RUNTIME/usr/lib/$ARCH/gstreamer-1.0

--- a/checkbox-core-snap/common_files/config/wrapper_common
+++ b/checkbox-core-snap/common_files/config/wrapper_common
@@ -37,10 +37,6 @@ else
   append_path PYTHONPATH $RUNTIME/lib/python3*/dist-packages
 fi
 
-# make sure we always know where the content snap is especially for classic
-# checkbox snaps where the checkbox-runtime bind mount does not exist
-# export CHECKBOX_RUNTIME=$(findmnt -oTARGET -n $(findmnt -oSOURCE -n $RUNTIME) | grep -P "^\/snap\/checkbox(|\d{2})\/")
-
 # Tell GStreamer where to find its plugins
 export GST_PLUGIN_PATH=$RUNTIME/usr/lib/$ARCH/gstreamer-1.0
 export GST_PLUGIN_SYSTEM_PATH=$RUNTIME/usr/lib/$ARCH/gstreamer-1.0

--- a/checkbox-core-snap/common_files/config/wrapper_common_classic
+++ b/checkbox-core-snap/common_files/config/wrapper_common_classic
@@ -47,7 +47,7 @@ fi
 
 # make sure we always know where the content snap is especially for classic
 # checkbox snaps where the checkbox-runtime bind mount does not exist
-export CHECKBOX_RUNTIME=$RUNTIME
+# export CHECKBOX_RUNTIME=$RUNTIME
 
 # Use a modules directory which doesn't exist so we don't load random things
 # which may then get deleted (or their dependencies) and potentially segfault

--- a/checkbox-core-snap/common_files/config/wrapper_common_classic
+++ b/checkbox-core-snap/common_files/config/wrapper_common_classic
@@ -45,10 +45,6 @@ else
   append_path PYTHONPATH $RUNTIME/lib/python3*/dist-packages
 fi
 
-# make sure we always know where the content snap is especially for classic
-# checkbox snaps where the checkbox-runtime bind mount does not exist
-# export CHECKBOX_RUNTIME=$RUNTIME
-
 # Use a modules directory which doesn't exist so we don't load random things
 # which may then get deleted (or their dependencies) and potentially segfault
 export GIO_MODULE_DIR=$SNAP/gio/modules-dummy

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -626,6 +626,8 @@ def get_execution_environment(job, environ, session_id, nest_dir):
     set_if_not_none("PLAINBOX_PROVIDER_DATA", job.provider.data_dir)
     set_if_not_none("PLAINBOX_PROVIDER_UNITS", job.provider.units_dir)
     set_if_not_none("CHECKBOX_SHARE", job.provider.CHECKBOX_SHARE)
+    if os.getenv("SNAP"):
+        set_if_not_none("CHECKBOX_RUNTIME", str(get_checkbox_runtime_path()))
     # Inject additional variables that are requested in the config
     if environ is not None:
         for env_var in environ:

--- a/checkbox-ng/plainbox/impl/test_execution.py
+++ b/checkbox-ng/plainbox/impl/test_execution.py
@@ -481,7 +481,9 @@ class TestGetExecutionEnvironment(TestCase):
     def test_basic_environment(self, mock_well_known):
         mock_well_known.session_share.return_value = "/session/share"
 
-        env = get_execution_environment(self.job, None, "test_session", "/nest")
+        env = get_execution_environment(
+            self.job, None, "test_session", "/nest"
+        )
 
         self.assertIn("ORIGINAL_ENV", env)
         self.assertEqual(env["ORIGINAL_ENV"], "value")
@@ -498,7 +500,9 @@ class TestGetExecutionEnvironment(TestCase):
         mock_well_known.session_share.return_value = "/session/share"
         mock_runtime_path.return_value = Path("/snap/checkbox24/current")
 
-        env = get_execution_environment(self.job, None, "test_session", "/nest")
+        env = get_execution_environment(
+            self.job, None, "test_session", "/nest"
+        )
 
         self.assertEqual(env["CHECKBOX_RUNTIME"], "/snap/checkbox24/current")
 
@@ -511,6 +515,8 @@ class TestGetExecutionEnvironment(TestCase):
 
         environ = {"EXISTING_VAR": "new_value"}
 
-        env = get_execution_environment(self.job, environ, "test_session", "/nest")
+        env = get_execution_environment(
+            self.job, environ, "test_session", "/nest"
+        )
 
         self.assertEqual(env["EXISTING_VAR"], "original_value")

--- a/checkbox-ng/plainbox/impl/test_execution.py
+++ b/checkbox-ng/plainbox/impl/test_execution.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import contextlib
+import os
 from pathlib import Path
 from unittest import TestCase, mock
 
@@ -28,6 +28,7 @@ from plainbox.impl.execution import (
     dangerous_nsenter,
     get_execution_command_subshell,
     get_execution_command_systemd_unit,
+    get_execution_environment,
 )
 from plainbox.impl.unit.job import InvalidJob
 
@@ -459,3 +460,57 @@ class TestAddToEnvironment(TestCase):
         self.assertIn("og_path2", new_path)
         self.assertIn("some", new_path)
         self.assertIn("path", new_path)
+
+
+class TestGetExecutionEnvironment(TestCase):
+    def setUp(self):
+        self.job = mock.Mock()
+        self.job.get_flag_set.return_value = set()
+        self.job.provider.gettext_domain = None
+        self.job.provider.locale_dir = None
+        self.job.provider.extra_PYTHONPATH = []
+        self.job.provider.extra_PATH = []
+        self.job.provider.extra_LD_LIBRARY_PATH = []
+        self.job.provider.extra_snap_environment = {}
+        self.job.provider.data_dir = None
+        self.job.provider.units_dir = None
+        self.job.provider.CHECKBOX_SHARE = None
+
+    @mock.patch.dict(os.environ, {"ORIGINAL_ENV": "value"}, clear=True)
+    @mock.patch("plainbox.impl.execution.WellKnownDirsHelper")
+    def test_basic_environment(self, mock_well_known):
+        mock_well_known.session_share.return_value = "/session/share"
+
+        env = get_execution_environment(self.job, None, "test_session", "/nest")
+
+        self.assertIn("ORIGINAL_ENV", env)
+        self.assertEqual(env["ORIGINAL_ENV"], "value")
+        self.assertEqual(env["PLAINBOX_SESSION_SHARE"], "/session/share")
+        self.assertIn("/nest", env["PATH"])
+        mock_well_known.session_share.assert_called_once_with("test_session")
+
+    @mock.patch.dict(os.environ, {"SNAP": "/snap/checkbox24"}, clear=True)
+    @mock.patch("plainbox.impl.execution.get_checkbox_runtime_path")
+    @mock.patch("plainbox.impl.execution.WellKnownDirsHelper")
+    def test_checkbox_runtime_in_snap(
+        self, mock_well_known, mock_runtime_path
+    ):
+        mock_well_known.session_share.return_value = "/session/share"
+        mock_runtime_path.return_value = Path("/snap/checkbox24/current")
+
+        env = get_execution_environment(self.job, None, "test_session", "/nest")
+
+        self.assertEqual(env["CHECKBOX_RUNTIME"], "/snap/checkbox24/current")
+
+    @mock.patch.dict(
+        os.environ, {"EXISTING_VAR": "original_value"}, clear=True
+    )
+    @mock.patch("plainbox.impl.execution.WellKnownDirsHelper")
+    def test_environ_dict_does_not_override_existing(self, mock_well_known):
+        mock_well_known.session_share.return_value = "/session/share"
+
+        environ = {"EXISTING_VAR": "new_value"}
+
+        env = get_execution_environment(self.job, environ, "test_session", "/nest")
+
+        self.assertEqual(env["EXISTING_VAR"], "original_value")

--- a/checkbox-ng/plainbox/impl/unit/unit.py
+++ b/checkbox-ng/plainbox/impl/unit/unit.py
@@ -96,7 +96,6 @@ def get_checkbox_runtime_path():
     #       runtime, while SNAP on the legacy arch is the frontend
     snap_base_n = get_snap_base().replace("core", "")
     # the bases of the runtime and frontend must always match
-    runtime_name = "checkbox" + snap_base_n
     return Path("/snap") / ("checkbox" + snap_base_n) / "current"
 
 

--- a/docs/reference/envvar.rst
+++ b/docs/reference/envvar.rst
@@ -1,0 +1,28 @@
+.. _envvar:
+
+Environment variables set by Checkbox
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Checkbox sets a few environment variables during execution. These can be
+used in the job definition itself or even in the script called by the
+``command`` field of a the job.
+
+``PLAINBOX_SESSION_SHARE``
+    Path to a directory that can be used to store temporary data during the
+    test run. This is useful if you have one test gathering data, and another
+    one checking said data. For example, the first test would write its
+    output to ``$PLAINBOX_SESSION_SHARE/my_test_output``, and the other one
+    would retrieve the content of the file to analyze it.
+
+``PLAINBOX_PROVIDER_DATA``
+    Directory within the provider that contains additional data required by
+    some jobs. For instance, the `Base provider data directory`_ contains
+    files used to assign the GPIO pins specific to some hardware.
+
+``CHECKBOX_RUNTIME``
+    Directory where the Checkbox runtime is located. This is especially useful
+    when in a snap environment where test authors may need to point to specific
+    files within the runtime environment. For example, when using the
+    checkbox24 snap, the runtime is ``/snap/checkbox24/current``.
+
+.. _Base provider data directory: https://github.com/canonical/checkbox/tree/main/providers/base/data

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -8,6 +8,7 @@ Reference
    glossary
    stack
    launcher
+   envvar
    units/index
    snaps
    submission-schema


### PR DESCRIPTION


## Description

Providing `$CHECKBOX_RUNTIME` when executing the snap (in a wrapper script) is hackish and often does not work because of the problems described in #2295 .

Instead, it is now provided by Checkbox during the job execution phase (similarly to `$PLAINBOX_SESSION_SHARE` and the like).

This means that it cannot be used directly from the Shell (when entering `snap run --shell checkbox.checkbox-cli` or `checkbox.shell`), but it should work as expected when running a job that relies on `$CHECKBOX_RUNTIME`.

## Resolved issues

Fix #2295 
Fix CHECKBOX-2164


## Tests

Apart from adding some unit tests for the get_execution_environment function, I built [snaps](https://github.com/canonical/checkbox/actions/runs/22664270888) from this branch and used the checkbox24_amd64 artifact to run a spread test using @Hook25 's new shiny tool, [checkbox_snap_spread](https://github.com/Hook25/checkbox_snap_spread):

- I modified `tests/run-canary/launcher.conf` to not exclude anything and run the `com.canonical.certification::misc-client-cert-automated` test plan (since this one has some fwts-related tests)
- I put `checkbox24_7.1.0-dev27_amd64.snap` at the root of the directory, and ran `image-garden.spread -artifacts=artifacts ubuntu-core-24`

When running jobs that run an fwts command, I can see that the CHECKBOX_RUNTIME has been set to the right thing. For example, with the `miscellanea/oops` job:

```
----------------------------[ Run FWTS OOPS check ]-----------------------------
ID: com.canonical.certification::miscellanea/oops
(...)
Command: "fwts -j /snap/checkbox24/current/share/fwts -q --stdout-summary -r 
/var/tmp/checkbox-ng/sessions/session_title-2026-03-04T12.46.53.session/session-share/fwts_oops_results.log
oops".
Running tests: oops.

oops: Scan kernel log for Oopses.
--------------------------------------------------------------------------------
Test 1 of 1: Kernel log oops check.
PASSED: Test 1, Found no oopses in kernel log.
PASSED: Test 1, Found no WARN_ON warnings in kernel log.
(...)
```