### PR TITLE
Use private endpoint runners (Infra)

### DIFF
--- a/.github/workflows/checkbox-promote-beta-to-candidate.yml
+++ b/.github/workflows/checkbox-promote-beta-to-candidate.yml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   checkbox-promotion-beta-to-candidate-test:
-    runs-on: [self-hosted, testflinger]
+    runs-on: self-hosted-linux-amd64-jammy-private-endpoint-medium
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dispatch_lab_job.yaml
+++ b/.github/workflows/dispatch_lab_job.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   run-matrix:
-    runs-on: [self-hosted, testflinger]
+    runs-on: self-hosted-linux-amd64-jammy-private-endpoint-medium
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/testflinger-contrib-dss-regression.yaml
+++ b/.github/workflows/testflinger-contrib-dss-regression.yaml
@@ -49,7 +49,7 @@ jobs:
   regression-tests:
     needs: checkbox-dss-snap-build
     name: Tests
-    runs-on: [testflinger]
+    runs-on: self-hosted-linux-amd64-jammy-private-endpoint-medium
     defaults:
       run:
         working-directory: contrib/checkbox-dss-validation


### PR DESCRIPTION
## Description

- Self-hosted Testflinger-enabled runners are being deprecated in favor of centralized private endpoint runners

## Resolved issues

- [CER-3225](https://warthogs.atlassian.net/browse/CER-3225)

## Documentation

## Tests

- [Test run](https://github.com/canonical/checkbox/actions/runs/22676071859) (yes, the workflow failed, but it's because the spec was not found, the Testflinger connection worked)


[CER-3225]: https://warthogs.atlassian.net/browse/CER-3225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ