### PR TITLE
Removed camera tests form core16 on rpi (BugFix)

### DIFF
--- a/providers/base/units/camera/jobs.pxu
+++ b/providers/base/units/camera/jobs.pxu
@@ -204,7 +204,7 @@ estimated_duration: 16.0
 depends: camera/detect-rpi
 requires: 
  cpuinfo.platform == 'armv7l'
- os.release >= '18.04'
+ os.release >= '18'
 command:
   camera_test_rpi.py --device /dev/{name}
 _purpose:

--- a/providers/base/units/camera/jobs.pxu
+++ b/providers/base/units/camera/jobs.pxu
@@ -202,7 +202,9 @@ template-id: camera/multiple-resolution-images-rpi_name
 _summary: Webcam multiple resolution capture test for Pi Camera
 estimated_duration: 16.0
 depends: camera/detect-rpi
-requires: cpuinfo.platform == 'armv7l'
+requires: 
+ cpuinfo.platform == 'armv7l'
+ os.release >= '18.04'
 command:
   camera_test_rpi.py --device /dev/{name}
 _purpose:


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

These camera tests have never been run successfully on core 16 and maybe they’ve never passed. Previous runs of core 16 used only devices without camera, and the current one is a mixed queue that only passes if you are lucky and you get a device without camera.

We will remove the camera tests.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
https://warthogs.atlassian.net/browse/CHECKBOX-2182
## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

N/A
## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Previous behavior: The camera test started, but it got stuck trying to get the stream from picamera.
```
-----------------------------[ Running job 4 / 8 ]------------------------------
-----------[ Webcam multiple resolution capture test for Pi Camera ]------------
ID: com.canonical.certification::camera/multiple-resolution-images-rpi_vchiq
Category: Camera tests
--------------------------------------------------------------------------------
Resolutions test on device: /dev/vchiq
Images will be written to:
/var/tmp/checkbox-ng/sessions/session_title-2026-03-06T11.14.52.session/session-share
```

Submission with the new filter:
core16
https://certification.canonical.com/hardware/201811-26649/submission/476261/
core18
https://certification.canonical.com/hardware/201811-26649/submission/476488/
