### PR TITLE
Avoid crashing on one word commits (infra)

### DIFF
--- a/tools/release/get_version.py
+++ b/tools/release/get_version.py
@@ -141,8 +141,9 @@ def get_needed_bump(history: "list[str]") -> TraceabilityEnum:
 
     # categorize all commits in the history
     for commit_message in history:
-        *_, trace_str, pr = commit_message.rsplit(" ", 2)
+        pr = commit_message
         try:
+            *_, trace_str, pr = commit_message.rsplit(" ", 2)
             current_trace = TraceabilityEnum.parse(trace_str)
         except ValueError:
             # clean up the pr so that we can use it in the warning

--- a/tools/release/test_get_version.py
+++ b/tools/release/test_get_version.py
@@ -183,3 +183,14 @@ class MainTests(unittest.TestCase):
         # (so nothing to release here)
         with self.assertRaises(SystemExit):
             get_version.main([])
+
+    @patch("get_version.check_output")
+    @patch("get_version.print")
+    def test_get_version_dont_crash_nospace(
+        self, print_mock, check_output_mock
+    ):
+        check_output_mock.side_effect = [
+            "v1.2.3",
+            "a (new) #1\nb",
+        ]
+        get_version.main([])


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Script crashes on commits that are 1w long. This shouldn't happen.

## Resolved issues

N/A

## Documentation

N/A

## Tests

N/A
