### PR TITLE
Revise network.py to support per-run and overall test criteria (New)

### DIFF
--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -61,10 +61,12 @@ class IPerfPerformanceTest(object):
         interface,
         target,
         fail_threshold,
+        overall_fail_threshold,
         cpu_load_fail_threshold,
         iperf3,
         num_threads,
         reverse,
+        percent_total=0,
         protocol="tcp",
         data_size="1",
         run_time=None,
@@ -75,8 +77,10 @@ class IPerfPerformanceTest(object):
         self.iface = Interface(interface)
         self.interface = interface
         self.target = target
+        self.percent_total = percent_total
         self.protocol = protocol
         self.fail_threshold = fail_threshold
+        self.overall_fail_threshold = overall_fail_threshold
         self.cpu_load_fail_threshold = cpu_load_fail_threshold
         self.iperf3 = iperf3
         self.num_threads = num_threads
@@ -210,7 +214,7 @@ class IPerfPerformanceTest(object):
         """Extract a list of CPU cores from a line of the form:
         NUMA node# CPU(s):    a-b[,c-d[,...]]"""
         colon = line.find(":")
-        cpu_list = line[colon + 1 :]
+        cpu_list = line[colon + 1 :]  # noqa: E203
         core_list = []
         for core_range in cpu_list.split(","):
             # Skip it if the CPU list for the NUMA node is empty....
@@ -353,6 +357,7 @@ class IPerfPerformanceTest(object):
             # it's up to the reviewer to pass or fail.
             percent = 0
             invalid_speed = True
+        self.percent_total += percent
         logging.info("Avg Transfer speed: {} Mb/s".format(throughput))
         if invalid_speed:
             # If we have no link_speed (e.g. wireless interfaces don't
@@ -673,12 +678,15 @@ def run_test(args, test_target):
         return 1
 
     # Execute requested networking test
+    if args.overall_fail_threshold is None:
+        args.overall_fail_threshold = args.fail_threshold
     if args.test_type.lower() == "iperf":
         error_number = 0
         iperf_benchmark = IPerfPerformanceTest(
             args.interface,
             test_target,
             args.fail_threshold,
+            args.overall_fail_threshold,
             args.cpu_load_fail_threshold,
             args.iperf3,
             args.num_threads,
@@ -698,11 +706,24 @@ def run_test(args, test_target):
             )
             if iperf_benchmark.num_threads > 2:
                 iperf_benchmark.optimize_num_threads()
+        iperf_benchmark.percent_total = 0
         while not error_number and run_num < args.num_runs:
             run_num += 1
             logging.info(" Test Run Number %s ".center(60, "-"), run_num)
             error_number = iperf_benchmark.run()
             logging.info("")
+        overall_avg = iperf_benchmark.percent_total / run_num
+        logging.info("Overall run results: {}".format(overall_avg))
+        if overall_avg < iperf_benchmark.overall_fail_threshold:
+            logging.warning(
+                "Test failed because overall results are less than the "
+            )
+            logging.warning(
+                "minimum ({} percent).".format(
+                    iperf_benchmark.overall_fail_threshold
+                )
+            )
+            error_number = 1
     elif args.test_type.lower() == "stress":
         stress_benchmark = StressPerformanceTest(
             args.interface, test_target, args.iperf3
@@ -1211,6 +1232,16 @@ TEST_TARGET_IPERF = iperf-server.example.com
             "IPERF Test ONLY. Set the failure threshold (Percent of maximum "
             "theoretical bandwidth) as a number like 80.  (Default is "
             "%(default)s)"
+        ),
+    )
+    test_parser.add_argument(
+        "--overall-fail-threshold",
+        type=int,
+        default=None,
+        help=(
+            "IPERF Test ONLY. Set the overall failure threshold (percent of "
+            "maximum theoretical bandwidth, averaged across all runs). "
+            "(Default is the same as specified by --fail-threshold.)"
         ),
     )
     test_parser.add_argument(

--- a/providers/base/tests/test_network.py
+++ b/providers/base/tests/test_network.py
@@ -607,6 +607,28 @@ class NetworkTests(unittest.TestCase):
         args = Namespace()
         self.assertIsNone(network.interface_test(args))
 
+    # test_run_test_with_overall_fail_threshold
+    @patch("network.run_test")
+    def test_run_test_with_overall_fail_threshold(self):
+        # Setup for testing overall_fail_threshold
+        overall_fail_threshold = 5
+        result = run_test(overall_fail_threshold=overall_fail_threshold)
+        self.assertLessEqual(
+            result.fail_count,
+            overall_fail_threshold,
+            "Expected fail count to be <= the overall fail threshold.",
+        )
+
+    # test_run_test_with_no_overall_fail_threshold
+    @patch("network.run_test")
+    def test_run_test_with_no_overall_fail_threshold(self):
+        # Setup for testing when no overall_fail_threshold is specified
+        result = run_test()
+        self.assertIsNotNone(
+            result,
+            "Expected result should != None without overall_fail_threshold.",
+        )
+
     @patch("logging.error")
     @patch("network.make_target_list")
     @patch("network.get_test_parameters")

--- a/providers/base/units/ethernet/jobs.pxu
+++ b/providers/base/units/ethernet/jobs.pxu
@@ -89,7 +89,7 @@ requires:
  executable.name == 'nmap'
 user: root
 environ: TEST_TARGET_IPERF
-command: network.py test -i {interface} -t iperf --iperf3 --scan-timeout 3600 --fail-threshold 80 --cpu-load-fail-threshold 90 --runtime 900 --num_runs 4
+command: network.py test -i {interface} -t iperf --iperf3 --scan-timeout 3600 --fail-threshold 80 --overall-fail-threshold 90 --cpu-load-fail-threshold 90 --runtime 900 --num_runs 4
 _purpose: This test uses iperf3 to ensure network devices pass data at an acceptable
  minimum percentage of advertised speed.
 
@@ -108,7 +108,7 @@ requires:
  executable.name == 'nmap'
 user: root
 environ: TEST_TARGET_IPERF
-command: network.py test -i {interface} -t iperf --iperf3 --scan-timeout 3600 --fail-threshold 80 --cpu-load-fail-threshold 90 --runtime 1200
+command: network.py test -i {interface} -t iperf --iperf3 --scan-timeout 3600 --fail-threshold 80 --overall-fail-threshold 90 --cpu-load-fail-threshold 90 --runtime 1200
 _purpose:
  This is a shorter SRU version of the standard iperf3 based network test for
  servers. It is intended to ONLY be used for SRU and is not valid for official
@@ -129,7 +129,7 @@ requires:
  executable.name == 'nmap'
 user: root
 environ: TEST_TARGET_IPERF
-command: network.py test -i {interface} -t iperf --iperf3 --scan-timeout 3600 --fail-threshold 80 --cpu-load-fail-threshold 90 --runtime 900 --num_runs 4 --underspeed-ok
+command: network.py test -i {interface} -t iperf --iperf3 --scan-timeout 3600 --fail-threshold 80 --overall-fail-threshold 90 --cpu-load-fail-threshold 90 --runtime 900 --num_runs 4 --underspeed-ok
 _purpose:
  This is the standard Multi-NIC Iperf3 test with the speed check disabled
  for retesting systems that are incorrectly reporting supported speeds.


### PR DESCRIPTION
Title: Revise network.py to support per-run and overall test criteria (New)

## Description

This PR adds a new command-line parameter (`--overall-fail-threshold`) to the `network.py` script, enabling setting separate per-run and overall failure thresholds. That is, previously, if `--fail-threshold` was set to, say, 90, and if `--num_runs` was set to, say, 4, then this script would cause a re-run if any individual run fell below 90%, and if the timeout period passed and any run was under 90%, then the script would return an error code and the test would fail. This change permits setting a separate criterion for the overall failure threshold. That is, if `--fail-threshold` is set to 80 and `--overall-fail-threshold` is set to 90, then with four runs, results on individual runs could fall as low as 80% and not trigger a re-run, so long as the final average is above 90% -- so, for example, if the individual results were 92%, 93%, 89%, and 93%, the test would pass without re-running. The new `--overall-fail-threshold` parameter is optional; if it's missing, the value defaults to the same value set by `--fail-threshold`. Thus, there is no change in the script's behavior if the new option is not specified.

This PR also adjusts the `providers/base/unit/ethernet/jobs.pxu` file so that the new option is set to 90 for the `ethernet/sru_iperf3_stress_device-{__index__}_{interface}`, `ethernet/multi_iperf3_nic_device{__index__}_{interface}`, and `ethernet/multi_iperf3_nic_underspeed_device{__index__}_{interface}` tests, used exclusively in server certification. This change satisfies the Jira task noted below, as discussed by Jeff Lane and Rod Smith to create stricter pass criteria (previously set to 80) without creating undo problems because of occasional sub-runs that produce sub-90% results.

## Resolved issues

(https://warthogs.atlassian.net/browse/SERVCERT-1893)

## Documentation

No changes are required to Checkbox documentation. Changes will be needed to some of the Server Certification partner documentation. These changes will be implemented as part of the updates for the Ubuntu 26.04 release.

## Tests

Testing was done by running `network.py` manually, with commands like the following:

```
sudo /usr/lib/checkbox-provider-base/bin/network.py test -i eno1 -t iperf --iperf3 --scan-timeout 36 --fail-threshold 80 --overall-fail-threshold 90 --cpu-load-fail-threshold 90 --runtime 30 --num_runs 2 --target 192.168.1.2
```

This was a shorter run than the usual test (which takes an hour to complete), for ease of testing. The `--fail-threshold` and `--overall-fail-threshold` values were adjusted so that the machine's naturally tested speeds passed or failed and observing the results, which matched expectations; for instance, when speeds were about 94%, setting `--fail-threshold` to 80 and `--overall-fail-threshold` to 95 caused no re-runs of the individual runs, but the overall test failed, as expected. When `--overall-fail-threshold` was reduced to 90, the test passed.

In addition, the complete set of tests was run in Checkbox, having replaced both files. The results are here:

https://certification.canonical.com/hardware/201409-15506/submission/476574/

The relevant run was:

https://certification.canonical.com/hardware/201409-15506/submission/476574/test/74015/result/56526890/

These results are not notably different from runs with the previous version of the script; but there is a new line that provides the overall result at the end of the test output.