### PR TITLE
Add device information to any submission JSON generated by Checkbox (New)

### DIFF
--- a/checkbox-ng/checkbox_ng/support/device_info.py
+++ b/checkbox-ng/checkbox_ng/support/device_info.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+import json
+import platform
+import subprocess
+
+from checkbox_ng.support.release_info import get_release_info
+from checkbox_ng.support.parsers.meminfo import MeminfoParser
+from checkbox_ng.support.parsers.udevadm import parse_udevadm_output
+from checkbox_ng.support.parsers import _json_fallback
+
+
+"""
+Device Information Collector
+
+This script aggregates system metadata (OS release, kernel parameters,
+hardware via udev and installed packages) into a single JSON object.
+"""
+
+
+def get_kernel_cmdline(cmdline_path="/proc/cmdline"):
+    with open(cmdline_path) as fp:
+        cmdline = fp.read().strip()
+    return cmdline
+
+
+def get_udevadm_db():
+    cmd = ["udevadm", "info", "--export-db"]
+    return subprocess.check_output(cmd, universal_newlines=True)
+
+
+def get_packages():
+    cmd = ["dpkg-query", "-W", "-f=${Package}\t${Version}\t${Architecture}\n"]
+    output = subprocess.check_output(cmd, universal_newlines=True)
+    packages = []
+    for line in output.splitlines():
+        name, version, arch = line.split("\t")
+        pkg = {"name": name, "version": version, "architecture": arch}
+        packages.append(pkg)
+    return packages
+
+
+def main():
+    mem_info = MeminfoParser().run()
+    udevadm_output = get_udevadm_db()
+    device_info = {
+        "distribution": get_release_info(),
+        "uname": {
+            "system": platform.system(),
+            "node": platform.node(),
+            "kernel": platform.release(),
+            "version": platform.version(),
+            "architecture": platform.machine(),
+        },
+        "memory": mem_info,
+        "kernel_cmdline": get_kernel_cmdline(),
+        "devices": parse_udevadm_output(udevadm_output),
+        "packages": get_packages()
+    }
+    print(json.dumps(
+                     device_info,
+                     indent=4,
+                     sort_keys=True,
+                     default=_json_fallback
+                 )
+      )
+
+
+if __name__ == "__main__":
+    main()

--- a/checkbox-ng/checkbox_ng/support/device_info.py
+++ b/checkbox-ng/checkbox_ng/support/device_info.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import json
 import platform
 import subprocess
@@ -8,27 +9,28 @@ from checkbox_ng.support.parsers.meminfo import MeminfoParser
 from checkbox_ng.support.parsers.udevadm import parse_udevadm_output
 from checkbox_ng.support.parsers import _json_fallback
 
-
 """
 Device Information Collector
 
-This script aggregates system metadata (OS release, kernel parameters,
-hardware via udev and installed packages) into a single JSON object.
+Script that collects information about the device under test and returns it
+as JSON.
 """
 
 
-def get_kernel_cmdline(cmdline_path="/proc/cmdline"):
+def get_kernel_cmdline(cmdline_path="/proc/cmdline") -> str:
     with open(cmdline_path) as fp:
         cmdline = fp.read().strip()
     return cmdline
 
 
-def get_udevadm_db():
+def get_devices():
     cmd = ["udevadm", "info", "--export-db"]
-    return subprocess.check_output(cmd, universal_newlines=True)
+    udevadm_output = subprocess.check_output(cmd, universal_newlines=True)
+    devices = parse_udevadm_output(udevadm_output)
+    return devices
 
 
-def get_packages():
+def get_debian_packages():
     cmd = ["dpkg-query", "-W", "-f=${Package}\t${Version}\t${Architecture}\n"]
     output = subprocess.check_output(cmd, universal_newlines=True)
     packages = []
@@ -39,30 +41,62 @@ def get_packages():
     return packages
 
 
-def main():
-    mem_info = MeminfoParser().run()
-    udevadm_output = get_udevadm_db()
-    device_info = {
-        "distribution": get_release_info(),
-        "uname": {
-            "system": platform.system(),
-            "node": platform.node(),
-            "kernel": platform.release(),
-            "version": platform.version(),
-            "architecture": platform.machine(),
-        },
-        "memory": mem_info,
-        "kernel_cmdline": get_kernel_cmdline(),
-        "devices": parse_udevadm_output(udevadm_output),
-        "packages": get_packages()
+def get_meminfo():
+    return MeminfoParser().run()
+
+
+def get_uname():
+    return {
+        "system": platform.system(),
+        "node": platform.node(),
+        "kernel": platform.release(),
+        "version": platform.version(),
+        "architecture": platform.machine(),
     }
-    print(json.dumps(
-                     device_info,
-                     indent=4,
-                     sort_keys=True,
-                     default=_json_fallback
-                 )
-      )
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Collect device information as JSON"
+    )
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.required = True
+    subparsers.add_parser(
+        "kernel_cmdline", help="Return kernel command line information"
+    )
+    subparsers.add_parser(
+        "devices", help="Return devices found by the udeadvm parser"
+    )
+    subparsers.add_parser(
+        "debian_packages", help="Return installed package information"
+    )
+    subparsers.add_parser(
+        "distribution",
+        help="Return information about the Linux distribution being used",
+    )
+    subparsers.add_parser("memory", help="Return memory information")
+    subparsers.add_parser("uname", help="Return uname information")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    command_map = {
+        "distribution": get_release_info,
+        "kernel_cmdline": get_kernel_cmdline,
+        "devices": get_devices,
+        "debian_packages": get_debian_packages,
+        "memory": get_meminfo,
+        "uname": get_uname,
+    }
+
+    if args.command:
+        getter = command_map[args.command]
+        print(
+            json.dumps(
+                getter(), indent=4, sort_keys=True, default=_json_fallback
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/checkbox-ng/checkbox_ng/support/tests/test_device_info.py
+++ b/checkbox-ng/checkbox_ng/support/tests/test_device_info.py
@@ -1,0 +1,61 @@
+import io
+import json
+from unittest import TestCase
+from unittest.mock import patch, mock_open
+
+from checkbox_ng.support import device_info
+
+
+class TestDeviceInfoCLI(TestCase):
+    def test_get_kernel_cmdline(self):
+        read_data = "BOOT_IMAGE=/boot/vmlinuz-6.17.0-1012-oem quiet splash\n"
+        with patch("builtins.open", mock_open(read_data=read_data)) as _:
+            returned = device_info.get_kernel_cmdline()
+            expected = "BOOT_IMAGE=/boot/vmlinuz-6.17.0-1012-oem quiet splash"
+            self.assertEqual(returned, expected)
+
+    @patch("checkbox_ng.support.device_info.subprocess.check_output")
+    @patch("checkbox_ng.support.device_info.parse_udevadm_output")
+    def test_get_devices(self, mock_parse_udevadm, mock_co):
+        device_info.get_devices()
+        self.assertTrue(mock_co.called)
+        self.assertTrue(mock_parse_udevadm.called)
+
+    @patch("checkbox_ng.support.device_info.subprocess.check_output")
+    def test_get_debian_packages(self, mock_co):
+        mock_co.return_value = "7zip\t23.01+dfsg-11\tamd64\naccountsservice\t23.13.9-2ubuntu6\tamd64\n"
+        pkg = device_info.get_debian_packages()
+        self.assertEqual(len(pkg), 2)
+        self.assertEqual(pkg[0]["name"], "7zip")
+        self.assertEqual(pkg[0]["version"], "23.01+dfsg-11")
+        self.assertEqual(pkg[0]["architecture"], "amd64")
+
+    @patch("checkbox_ng.support.device_info.get_debian_packages")
+    @patch("checkbox_ng.support.device_info.get_devices")
+    @patch("checkbox_ng.support.device_info.get_release_info")
+    @patch("checkbox_ng.support.device_info.get_meminfo")
+    @patch("checkbox_ng.support.device_info.get_uname")
+    @patch("checkbox_ng.support.device_info.get_kernel_cmdline")
+    def test_kernel_cmdline_subcommand_uses_only_kernel_getter(
+        self,
+        mock_kernel_cmdline,
+        mock_uname,
+        mock_meminfo,
+        mock_release_info,
+        mock_devices,
+        mock_debian_packages,
+    ):
+        mock_kernel_cmdline.return_value = "splash quiet"
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            device_info.main(["kernel_cmdline"])
+
+        self.assertEqual(
+            json.loads(mock_stdout.getvalue()),
+            "splash quiet",
+        )
+        mock_kernel_cmdline.assert_called_once_with()
+        mock_uname.assert_not_called()
+        mock_meminfo.assert_not_called()
+        mock_release_info.assert_not_called()
+        mock_devices.assert_not_called()
+        mock_debian_packages.assert_not_called()

--- a/checkbox-ng/plainbox/impl/session/system_information.py
+++ b/checkbox-ng/plainbox/impl/session/system_information.py
@@ -323,12 +323,62 @@ class ManifestCollector(Collector):
         )
 
 
-class DeviceInfoCollector(Collector):
-    COLLECTOR_NAME = "device_information"
+class KernelCmdline(Collector):
+    COLLECTOR_NAME = "kernel_cmdline"
 
     def __init__(self):
         super().__init__(
-            collection_cmd=["device-info"],
+            collection_cmd=["device-info", "kernel_cmdline"],
+            version_cmd=["echo", "-n", checkbox_version],
+        )
+
+
+class UdevDevices(Collector):
+    COLLECTOR_NAME = "udev_devices"
+
+    def __init__(self):
+        super().__init__(
+            collection_cmd=["device-info", "devices"],
+            version_cmd=["echo", "-n", checkbox_version],
+        )
+
+
+class DebianPackages(Collector):
+    COLLECTOR_NAME = "debian_packages"
+
+    def __init__(self):
+        super().__init__(
+            collection_cmd=["device-info", "debian_packages"],
+            version_cmd=["echo", "-n", checkbox_version],
+        )
+
+
+class Meminfo(Collector):
+    COLLECTOR_NAME = "meminfo"
+
+    def __init__(self):
+        super().__init__(
+            collection_cmd=["device-info", "meminfo"],
+            version_cmd=["echo", "-n", checkbox_version],
+        )
+
+
+class Uname(Collector):
+    COLLECTOR_NAME = "uname"
+
+    def __init__(self):
+        super().__init__(
+            collection_cmd=["device-info", "uname"],
+            version_cmd=["echo", "-n", checkbox_version],
+        )
+
+
+class Distribution(Collector):
+    COLLECTOR_NAME = "distribution"
+
+    def __init__(self):
+        super().__init__(
+            collection_cmd=["device-info", "distribution"],
             version_cmd=["echo", "-n", checkbox_version],
         )
 

--- a/checkbox-ng/plainbox/impl/session/system_information.py
+++ b/checkbox-ng/plainbox/impl/session/system_information.py
@@ -18,7 +18,7 @@ class CollectorOutputs(dict):
     collector will include in its output
     """
 
-    COLLECTOR_OUTPUTS_VERSION = 2
+    COLLECTOR_OUTPUTS_VERSION = 3
 
     def to_json(self) -> str:
         to_dump = {

--- a/checkbox-ng/plainbox/impl/session/system_information.py
+++ b/checkbox-ng/plainbox/impl/session/system_information.py
@@ -353,8 +353,8 @@ class DebianPackagesCollector(Collector):
         )
 
 
-    COLLECTOR_NAME = "meminfo"
 class MemoryCollector(Collector):
+    COLLECTOR_NAME = "memory"
 
     def __init__(self):
         super().__init__(

--- a/checkbox-ng/plainbox/impl/session/system_information.py
+++ b/checkbox-ng/plainbox/impl/session/system_information.py
@@ -323,6 +323,16 @@ class ManifestCollector(Collector):
         )
 
 
+class DeviceInfoCollector(Collector):
+    COLLECTOR_NAME = "device_information"
+
+    def __init__(self):
+        super().__init__(
+            collection_cmd=["device-info"],
+            version_cmd=["echo", "-n", checkbox_version],
+        )
+
+
 if __name__ == "__main__":
     collection = collect()
     print(collection.to_json())

--- a/checkbox-ng/plainbox/impl/session/system_information.py
+++ b/checkbox-ng/plainbox/impl/session/system_information.py
@@ -358,7 +358,7 @@ class Meminfo(Collector):
 
     def __init__(self):
         super().__init__(
-            collection_cmd=["device-info", "meminfo"],
+            collection_cmd=["device-info", "memory"],
             version_cmd=["echo", "-n", checkbox_version],
         )
 

--- a/checkbox-ng/plainbox/impl/session/system_information.py
+++ b/checkbox-ng/plainbox/impl/session/system_information.py
@@ -323,7 +323,7 @@ class ManifestCollector(Collector):
         )
 
 
-class KernelCmdline(Collector):
+class KernelCmdlineCollector(Collector):
     COLLECTOR_NAME = "kernel_cmdline"
 
     def __init__(self):
@@ -333,7 +333,7 @@ class KernelCmdline(Collector):
         )
 
 
-class UdevDevices(Collector):
+class UdevDevicesCollector(Collector):
     COLLECTOR_NAME = "udev_devices"
 
     def __init__(self):
@@ -343,7 +343,7 @@ class UdevDevices(Collector):
         )
 
 
-class DebianPackages(Collector):
+class DebianPackagesCollector(Collector):
     COLLECTOR_NAME = "debian_packages"
 
     def __init__(self):
@@ -353,8 +353,8 @@ class DebianPackages(Collector):
         )
 
 
-class Meminfo(Collector):
     COLLECTOR_NAME = "meminfo"
+class MemoryCollector(Collector):
 
     def __init__(self):
         super().__init__(
@@ -363,7 +363,7 @@ class Meminfo(Collector):
         )
 
 
-class Uname(Collector):
+class UnameCollector(Collector):
     COLLECTOR_NAME = "uname"
 
     def __init__(self):
@@ -373,7 +373,7 @@ class Uname(Collector):
         )
 
 
-class Distribution(Collector):
+class DistributionCollector(Collector):
     COLLECTOR_NAME = "distribution"
 
     def __init__(self):

--- a/checkbox-ng/pyproject.toml
+++ b/checkbox-ng/pyproject.toml
@@ -105,6 +105,7 @@ translator = [
 [project.scripts]
   checkbox-cli = "checkbox_ng.launcher.checkbox_cli:main"
   checkbox-provider-tools = "checkbox_ng.launcher.provider_tools:main"
+  device-info = "checkbox_ng.support.device_info:main"
 [project.entry-points."plainbox.exporter"]
   text = "plainbox.impl.exporter.text:TextSessionStateExporter"
   tar = "plainbox.impl.exporter.tar:TARSessionStateExporter"

--- a/checkbox-ng/setup.cfg
+++ b/checkbox-ng/setup.cfg
@@ -23,6 +23,7 @@ name=checkbox-ng
 console_scripts=
   checkbox-cli=checkbox_ng.launcher.checkbox_cli:main
   checkbox-provider-tools=checkbox_ng.launcher.provider_tools:main
+  device-info=checkbox_ng.support.device_info:main
 plainbox.exporter=
   text=plainbox.impl.exporter.text:TextSessionStateExporter
   tar=plainbox.impl.exporter.tar:TARSessionStateExporter


### PR DESCRIPTION


## Description

Add a `device_information` Collector that captures the following Device metadata for now:

- kernel command line
- devices (via the udevadm parser)
- Debian packages installed
- uname
- distribution (aka Ubuntu release info)
- meminfo (total, swap)

This is done by using a standalone script that makes heavy use of the parsers we recently moved from checkbox-support to checkbox-ng (see #2312 for more info). 

## Resolved issues

Fix CHECKBOX-2132

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

I added unit tests for the `device_info.py` script that does most of the heavy lifting.

I also ran `checkbox-cli` locally, selected the `usb-automated` test plan and ran it.

I also [built snaps](https://github.com/canonical/checkbox/actions/runs/23014314975), installed them (both checkbox24 and classic24), then ran `checkbox.checkbox-cli`, selected the `usb-automated` test plan and ran it.

In both cases, after completion, I can see the following in the `submission.json` under the `system_information` section:

```json
{
  "inxi": ...,
  "image_info": ...,
  "journalctl": ...,
  "machine_manifest": ...,
  "kernel_cmdline": {
    "tool_version": "7.0.1.dev25+g9a3965953.d20260311",
    "success": true,
    "outputs": {
      "payload": "BOOT_IMAGE=/boot/vmlinuz-6.17.0-1012-oem root=UUID=e2679ed2-f0ba-4f9e-992d-84cb5fa40795 ro quiet splash vt.handoff=7",
      "stderr": ""
    }
  },
  "udev_devices": {
    "tool_version": "7.0.1.dev25+g9a3965953.d20260311",
    "success": true,
    "outputs": {
      "payload": [
        ...
        {
          "bus": "platform",
          "driver": "acpi-wmi",
          "path": "/devices/platform/PNP0C14:01",
          "product_id": 3092,
          "vendor": "PNP",
          "vendor_slug": "PNP"
        }
      ],
      "stderr": ""
    }
  },
  "debian_packages": {
    "tool_version": "7.0.1.dev25+g9a3965953.d20260311",
    "success": true,
    "outputs": {
      "payload": [
        ...
        {
          "architecture": "amd64",
          "name": "zstd",
          "version": "1.5.5+dfsg2-2build1.1"
        }
      ],
      "stderr": ""
    }
  },
  "memory": {
    "tool_version": "7.0.1.dev25+g9a3965953.d20260311",
    "success": true,
    "outputs": {
      "payload": {
        "swap": 8589930496,
        "total": 64898310144
      },
      "stderr": ""
    }
  },
  "uname": {
    "tool_version": "7.0.1.dev25+g9a3965953.d20260311",
    "success": true,
    "outputs": {
      "payload": {
        "architecture": "x86_64",
        "kernel": "6.17.0-1012-oem",
        "node": "pieq-X870",
        "system": "Linux",
        "version": "#12-Ubuntu SMP PREEMPT_DYNAMIC Tue Feb 10 04:51:46 UTC 2026"
      },
      "stderr": ""
    }
  },
  "distribution": {
    "tool_version": "7.0.1.dev25+g9a3965953.d20260311",
    "success": true,
    "outputs": {
      "payload": {
        "codename": "noble",
        "description": "Ubuntu 24.04.4 LTS",
        "distributor_id": "Ubuntu",
        "release": "24.04"
      },
      "stderr": ""
    }
  },
  "version": 3
}
```