### PR TITLE
Remove all (un)translatable warnings (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/unit/category.py
+++ b/checkbox-ng/plainbox/impl/unit/category.py
@@ -106,7 +106,6 @@ class CategoryUnit(UnitWithId):
 
         field_validators = {
             fields.name: [
-                concrete_validators.translatable,
                 concrete_validators.templateVariant,
                 concrete_validators.present,
                 concrete_validators.oneLine,

--- a/checkbox-ng/plainbox/impl/unit/concrete_validators.py
+++ b/checkbox-ng/plainbox/impl/unit/concrete_validators.py
@@ -32,14 +32,10 @@ from plainbox.impl.unit.validators import (
     PresentFieldValidator,
     TemplateInvariantFieldValidator,
     TemplateVariantFieldValidator,
-    TranslatableFieldValidator,
-    UntranslatableFieldValidator,
 )
 
-translatable = TranslatableFieldValidator()
 templateVariant = TemplateVariantFieldValidator()
 templateInvariant = TemplateInvariantFieldValidator()
-untranslatable = UntranslatableFieldValidator()
 present = PresentFieldValidator()
 
 oneLine = CorrectFieldValueValidator(

--- a/checkbox-ng/plainbox/impl/unit/exporter.py
+++ b/checkbox-ng/plainbox/impl/unit/exporter.py
@@ -129,13 +129,11 @@ class ExporterUnit(UnitWithId):
         field_validators = {
             fields.summary: [
                 PresentFieldValidator(severity=Severity.advice),
-                concrete_validators.translatable,
                 concrete_validators.oneLine,
                 concrete_validators.shortValue,
             ],
             fields.entry_point: [
                 concrete_validators.present,
-                concrete_validators.untranslatable,
                 CorrectFieldValueValidator(
                     lambda entry_point: next(
                         iter(
@@ -150,18 +148,14 @@ class ExporterUnit(UnitWithId):
             ],
             fields.file_extension: [
                 concrete_validators.present,
-                concrete_validators.untranslatable,
                 CorrectFieldValueValidator(
                     lambda extension: re.search(r"^[\w\.\-]+$", extension),
                     Problem.syntax_error,
                     Severity.error,
                 ),
             ],
-            fields.options: [
-                concrete_validators.untranslatable,
-            ],
+            fields.options: [],
             fields.data: [
-                concrete_validators.untranslatable,
                 CorrectFieldValueValidator(
                     lambda value, unit: json.loads(value),
                     Problem.syntax_error,

--- a/checkbox-ng/plainbox/impl/unit/job.py
+++ b/checkbox-ng/plainbox/impl/unit/job.py
@@ -820,7 +820,6 @@ class JobDefinition(UnitWithId, IJobDefinition):
 
         field_validators = {
             fields.name: [
-                concrete_validators.untranslatable,
                 concrete_validators.templateVariant,
                 DeprecatedFieldValidator(
                     _("use 'id' and 'summary' instead of 'name'")
@@ -828,14 +827,12 @@ class JobDefinition(UnitWithId, IJobDefinition):
             ],
             # NOTE: 'id' validators are "inherited" so we don't have it here
             fields.summary: [
-                concrete_validators.translatable,
                 concrete_validators.templateVariant,
                 PresentFieldValidator(severity=Severity.advice),
                 concrete_validators.oneLine,
                 concrete_validators.shortValue,
             ],
             fields.plugin: [
-                concrete_validators.untranslatable,
                 concrete_validators.templateInvariant,
                 concrete_validators.present,
                 MemberOfFieldValidator(_PluginValues.get_all_symbols()),
@@ -847,7 +844,6 @@ class JobDefinition(UnitWithId, IJobDefinition):
                 ),
             ],
             fields.command: [
-                concrete_validators.untranslatable,
                 # All jobs except for manual must have a command
                 PresentFieldValidator(
                     message=_("command is mandatory for non-manual jobs"),
@@ -884,7 +880,6 @@ class JobDefinition(UnitWithId, IJobDefinition):
                 ShellProgramValidator(),
             ],
             fields.description: [
-                concrete_validators.translatable,
                 concrete_validators.templateVariant,
                 # Description is mandatory for manual jobs
                 PresentFieldValidator(
@@ -901,17 +896,10 @@ class JobDefinition(UnitWithId, IJobDefinition):
                 # Description or a set of purpose, steps and verification
                 # fields is recommended for all other jobs
             ],
-            fields.purpose: [
-                concrete_validators.translatable,
-            ],
-            fields.steps: [
-                concrete_validators.translatable,
-            ],
-            fields.verification: [
-                concrete_validators.translatable,
-            ],
+            fields.purpose: [],
+            fields.steps: [],
+            fields.verification: [],
             fields.user: [
-                concrete_validators.untranslatable,
                 concrete_validators.templateInvariant,
                 # User should be either None or 'root'
                 CorrectFieldValueValidator(
@@ -925,7 +913,6 @@ class JobDefinition(UnitWithId, IJobDefinition):
                 ),
             ],
             fields.environ: [
-                concrete_validators.untranslatable,
                 # Environ is useless without a command to run
                 UselessFieldValidator(
                     message=_("environ without a command makes no sense"),
@@ -933,7 +920,6 @@ class JobDefinition(UnitWithId, IJobDefinition):
                 ),
             ],
             fields.estimated_duration: [
-                concrete_validators.untranslatable,
                 concrete_validators.templateInvariant,
                 CorrectFieldValueValidator(
                     lambda duration: float(duration) > 0,
@@ -944,7 +930,6 @@ class JobDefinition(UnitWithId, IJobDefinition):
                 ),
             ],
             fields.depends: [
-                concrete_validators.untranslatable,
                 CorrectFieldValueValidator(
                     lambda value, unit: (
                         unit.get_direct_dependencies() is not None
@@ -963,7 +948,6 @@ class JobDefinition(UnitWithId, IJobDefinition):
                 #       onlyif job itself is not deprecated
             ],
             fields.after: [
-                concrete_validators.untranslatable,
                 CorrectFieldValueValidator(
                     lambda value, unit: (
                         unit.get_after_dependencies() is not None
@@ -980,7 +964,6 @@ class JobDefinition(UnitWithId, IJobDefinition):
                 ),
             ],
             fields.before: [
-                concrete_validators.untranslatable,
                 CorrectFieldValueValidator(
                     lambda value, unit: (
                         unit.get_before_dependencies() is not None
@@ -996,11 +979,8 @@ class JobDefinition(UnitWithId, IJobDefinition):
                     ],
                 ),
             ],
-            fields.group: [
-                concrete_validators.untranslatable,
-            ],
+            fields.group: [],
             fields.requires: [
-                concrete_validators.untranslatable,
                 CorrectFieldValueValidator(
                     lambda value, unit: unit.get_resource_program(),
                     onlyif=lambda unit: unit.requires is not None,
@@ -1029,7 +1009,6 @@ class JobDefinition(UnitWithId, IJobDefinition):
                 #       onlyif job itself is not deprecated
             ],
             fields.shell: [
-                concrete_validators.untranslatable,
                 concrete_validators.templateInvariant,
                 # Shell should be only '/bin/sh', or None (which gives bash)
                 MemberOfFieldValidator(
@@ -1038,7 +1017,6 @@ class JobDefinition(UnitWithId, IJobDefinition):
                 ),
             ],
             fields.imports: [
-                concrete_validators.untranslatable,
                 concrete_validators.templateInvariant,
                 CorrectFieldValueValidator(
                     lambda value, unit: (
@@ -1061,7 +1039,6 @@ class JobDefinition(UnitWithId, IJobDefinition):
                 #       onlyif job itself is not deprecated
             ],
             fields.category_id: [
-                concrete_validators.untranslatable,
                 concrete_validators.templateInvariant,
                 UnitReferenceValidator(
                     lambda unit: (
@@ -1080,18 +1057,15 @@ class JobDefinition(UnitWithId, IJobDefinition):
                 #       onlyif job itself is not deprecated
             ],
             fields.flags: [
-                concrete_validators.untranslatable,
                 concrete_validators.templateInvariant,
             ],
             fields.certification_status: [
-                concrete_validators.untranslatable,
                 concrete_validators.templateInvariant,
                 MemberOfFieldValidator(
                     _CertificationStatusValues.get_all_symbols()
                 ),
             ],
             fields.siblings: [
-                concrete_validators.translatable,
                 CorrectFieldValueValidator(
                     lambda value, unit: json.loads(value),
                     Problem.syntax_error,
@@ -1131,7 +1105,6 @@ class JobDefinition(UnitWithId, IJobDefinition):
                 ),
             ],
             fields.auto_retry: [
-                concrete_validators.untranslatable,
                 concrete_validators.templateInvariant,
                 MemberOfFieldValidator(_AutoRetryValues.get_all_symbols()),
             ],

--- a/checkbox-ng/plainbox/impl/unit/manifest.py
+++ b/checkbox-ng/plainbox/impl/unit/manifest.py
@@ -134,22 +134,18 @@ class ManifestEntryUnit(UnitWithId):
 
         field_validators = {
             fields.name: [
-                concrete_validators.translatable,
                 concrete_validators.templateVariant,
                 concrete_validators.present,
             ],
-            fields.prompt: [
-                concrete_validators.translatable,
-            ],
+            fields.prompt: [],
             fields.value_type: [
-                concrete_validators.untranslatable,
                 concrete_validators.present,
                 MemberOfFieldValidator(["bool", "natural"]),
             ],
             fields.value_unit: [
                 # OPTIONAL
             ],
-            fields.resource_key: [concrete_validators.untranslatable],
+            fields.resource_key: [],
             fields.hidden_reason: [
                 PresentFieldValidator(
                     message="hidden_reason is mandatory for hidden manifests",

--- a/checkbox-ng/plainbox/impl/unit/packaging_metadata.py
+++ b/checkbox-ng/plainbox/impl/unit/packaging_metadata.py
@@ -184,12 +184,9 @@ class PackagingMetaDataUnit(Unit):
 
         field_validators = {
             fields.os_id: [
-                concrete_validators.untranslatable,
                 concrete_validators.present,
             ],
-            fields.os_version_id: [
-                concrete_validators.untranslatable,
-            ],
+            fields.os_version_id: [],
             fields.Depends: [
                 UniqueValueValidator(),
             ],

--- a/checkbox-ng/plainbox/impl/unit/setup_job.py
+++ b/checkbox-ng/plainbox/impl/unit/setup_job.py
@@ -107,7 +107,6 @@ class SetupJobUnit(JobDefinition):
             fields.name: JobDefinition.Meta.field_validators[fields.name],
             fields.summary: JobDefinition.Meta.field_validators[fields.name],
             fields.plugin: [
-                concrete_validators.untranslatable,
                 concrete_validators.templateInvariant,
                 concrete_validators.present,
                 MemberOfFieldValidator(_PluginValues.get_all_symbols()),

--- a/checkbox-ng/plainbox/impl/unit/template.py
+++ b/checkbox-ng/plainbox/impl/unit/template.py
@@ -576,7 +576,6 @@ class TemplateUnit(UnitWithId):
 
         field_validators = {
             fields.template_id: [
-                concrete_validators.untranslatable,
                 concrete_validators.templateVariant,
                 UniqueValueValidator(),
                 # We want to have bare, namespace-less identifiers
@@ -589,7 +588,6 @@ class TemplateUnit(UnitWithId):
                 ),
             ],
             fields.template_summary: [
-                concrete_validators.translatable,
                 PresentFieldValidator(severity=Severity.advice),
                 CorrectFieldValueValidator(
                     lambda field: field.count("\n") == 0,
@@ -606,14 +604,9 @@ class TemplateUnit(UnitWithId):
                     onlyif=lambda unit: unit.template_summary,
                 ),
             ],
-            fields.template_description: [
-                concrete_validators.translatable,
-            ],
-            fields.template_unit: [
-                concrete_validators.untranslatable,
-            ],
+            fields.template_description: [],
+            fields.template_unit: [],
             fields.template_resource: [
-                concrete_validators.untranslatable,
                 concrete_validators.present,
                 UnitReferenceValidator(
                     lambda unit: (
@@ -641,7 +634,6 @@ class TemplateUnit(UnitWithId):
                 #       onlyif job itself is not deprecated
             ],
             fields.template_filter: [
-                concrete_validators.untranslatable,
                 # All templates need a valid (or empty) template filter
                 CorrectFieldValueValidator(
                     lambda value, unit: unit.get_filter_program(),
@@ -650,7 +642,6 @@ class TemplateUnit(UnitWithId):
                 # TODO: must refer to the same job as template-resource
             ],
             fields.template_imports: [
-                concrete_validators.untranslatable,
                 CorrectFieldValueValidator(
                     lambda value, unit: (
                         list(unit.get_imported_jobs()) is not None

--- a/checkbox-ng/plainbox/impl/unit/test_category.py
+++ b/checkbox-ng/plainbox/impl/unit/test_category.py
@@ -116,17 +116,6 @@ class CategoryUnitFieldValidationTests(UnitWithIdFieldValidationTests):
 
     unit_cls = CategoryUnit
 
-    def test_name__translatable(self):
-        issue_list = self.unit_cls(
-            {"name": "name"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.name,
-            Problem.expected_i18n,
-            Severity.warning,
-        )
-
     def test_name__template_variant(self):
         issue_list = self.unit_cls(
             {"name": "name"}, provider=self.provider, parameters={}

--- a/checkbox-ng/plainbox/impl/unit/test_exporter.py
+++ b/checkbox-ng/plainbox/impl/unit/test_exporter.py
@@ -113,7 +113,6 @@ class ExporterUnitFieldValidationTests(UnitWithIdFieldValidationTests):
             Severity.advice,
         )
 
-
     def test_file_extension__present(self):
         issue_list = self.unit_cls({}, provider=self.provider).check()
         self.assertIssueFound(

--- a/checkbox-ng/plainbox/impl/unit/test_exporter.py
+++ b/checkbox-ng/plainbox/impl/unit/test_exporter.py
@@ -113,27 +113,6 @@ class ExporterUnitFieldValidationTests(UnitWithIdFieldValidationTests):
             Severity.advice,
         )
 
-    def test_summary__translatable(self):
-        issue_list = self.unit_cls(
-            {"summary": "summary"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.summary,
-            Problem.expected_i18n,
-            Severity.warning,
-        )
-
-    def test_entry_point__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_entry_point": "entry_point"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.entry_point,
-            Problem.unexpected_i18n,
-            Severity.warning,
-        )
 
     def test_file_extension__present(self):
         issue_list = self.unit_cls({}, provider=self.provider).check()
@@ -144,17 +123,6 @@ class ExporterUnitFieldValidationTests(UnitWithIdFieldValidationTests):
             Severity.error,
         )
 
-    def test_file_extension__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_file_extension": "file_extension"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.file_extension,
-            Problem.unexpected_i18n,
-            Severity.warning,
-        )
-
     def test_entry_point__present(self):
         issue_list = self.unit_cls({}, provider=self.provider).check()
         self.assertIssueFound(
@@ -162,17 +130,6 @@ class ExporterUnitFieldValidationTests(UnitWithIdFieldValidationTests):
             self.unit_cls.Meta.fields.entry_point,
             Problem.missing,
             Severity.error,
-        )
-
-    def test_data__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_data": '{"foo": "bar"}'}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.data,
-            Problem.unexpected_i18n,
-            Severity.warning,
         )
 
     def test_data__json_content(self):

--- a/checkbox-ng/plainbox/impl/unit/test_job.py
+++ b/checkbox-ng/plainbox/impl/unit/test_job.py
@@ -226,17 +226,6 @@ class JobDefinitionFieldValidationTests(UnitWithIdFieldValidationTests):
         # disable this test.
         pass
 
-    def test_name__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_name": "name"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.name,
-            Problem.unexpected_i18n,
-            Severity.warning,
-        )
-
     def test_name__template_variant(self):
         issue_list = self.unit_cls(
             {"name": "name"}, parameters={}, provider=self.provider
@@ -257,17 +246,6 @@ class JobDefinitionFieldValidationTests(UnitWithIdFieldValidationTests):
             self.unit_cls.Meta.fields.name,
             Problem.deprecated,
             Severity.advice,
-        )
-
-    def test_summary__translatable(self):
-        issue_list = self.unit_cls(
-            {"summary": "summary"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.summary,
-            Problem.expected_i18n,
-            Severity.warning,
         )
 
     def test_summary__template_variant(self):
@@ -312,17 +290,6 @@ class JobDefinitionFieldValidationTests(UnitWithIdFieldValidationTests):
             Severity.warning,
         )
 
-    def test_plugin__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_plugin": "plugin"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.plugin,
-            Problem.unexpected_i18n,
-            Severity.warning,
-        )
-
     def test_plugin__template_invarinat(self):
         issue_list = self.unit_cls(
             {"plugin": "{attr}"},
@@ -364,17 +331,6 @@ class JobDefinitionFieldValidationTests(UnitWithIdFieldValidationTests):
             Problem.deprecated,
             Severity.advice,
             message,
-        )
-
-    def test_command__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_command": "command"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.command,
-            Problem.unexpected_i18n,
-            Severity.warning,
         )
 
     def test_command__present__on_non_manual(self):
@@ -464,17 +420,6 @@ class JobDefinitionFieldValidationTests(UnitWithIdFieldValidationTests):
             issue.origin.line_start, issue.unit.origin.line_start + 3
         )
 
-    def test_description__translatable(self):
-        issue_list = self.unit_cls(
-            {"description": "description"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.description,
-            Problem.expected_i18n,
-            Severity.warning,
-        )
-
     def test_description__template_variant(self):
         issue_list = self.unit_cls(
             {"description": "description"},
@@ -503,17 +448,6 @@ class JobDefinitionFieldValidationTests(UnitWithIdFieldValidationTests):
             Problem.missing,
             Severity.error,
             message,
-        )
-
-    def test_user__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_user": "user"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.user,
-            Problem.unexpected_i18n,
-            Severity.warning,
         )
 
     def test_user__template_invarinat(self):
@@ -555,15 +489,6 @@ class JobDefinitionFieldValidationTests(UnitWithIdFieldValidationTests):
             message,
         )
 
-    def test_environ__untranslatable(self):
-        issue_list = self.unit_cls({"_environ": "environ"}).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.environ,
-            Problem.unexpected_i18n,
-            Severity.warning,
-        )
-
     def test_environ__useless_without_command(self):
         message = "field 'environ', environ without a command makes no sense"
         issue_list = self.unit_cls(
@@ -575,18 +500,6 @@ class JobDefinitionFieldValidationTests(UnitWithIdFieldValidationTests):
             Problem.useless,
             Severity.warning,
             message,
-        )
-
-    def test_estimated_duration__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_estimated_duration": "estimated_duration"},
-            provider=self.provider,
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.estimated_duration,
-            Problem.unexpected_i18n,
-            Severity.warning,
         )
 
     def test_estimated_duration__template_invarinat(self):
@@ -613,17 +526,6 @@ class JobDefinitionFieldValidationTests(UnitWithIdFieldValidationTests):
             Problem.wrong,
             Severity.error,
             message,
-        )
-
-    def test_depends__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_depends": "depends"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.depends,
-            Problem.unexpected_i18n,
-            Severity.warning,
         )
 
     def test_depends__refers_to_other_units(self):
@@ -655,17 +557,6 @@ class JobDefinitionFieldValidationTests(UnitWithIdFieldValidationTests):
             message,
         )
 
-    def test_after__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_after": "after"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.after,
-            Problem.unexpected_i18n,
-            Severity.warning,
-        )
-
     def test_after__refers_to_other_units(self):
         unit = self.unit_cls({"after": "some-unit"}, provider=self.provider)
         message = "field 'after', unit 'ns::some-unit' is not available"
@@ -693,17 +584,6 @@ class JobDefinitionFieldValidationTests(UnitWithIdFieldValidationTests):
             Problem.bad_reference,
             Severity.error,
             message,
-        )
-
-    def test_requires__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_requires": "requires"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.requires,
-            Problem.unexpected_i18n,
-            Severity.warning,
         )
 
     def test_requires__refers_to_other_units(self):
@@ -758,17 +638,6 @@ class JobDefinitionFieldValidationTests(UnitWithIdFieldValidationTests):
             message,
         )
 
-    def test_shell__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_shell": "shell"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.shell,
-            Problem.unexpected_i18n,
-            Severity.warning,
-        )
-
     def test_shell__template_invarinat(self):
         issue_list = self.unit_cls(
             {"shell": "{attr}"},
@@ -793,17 +662,6 @@ class JobDefinitionFieldValidationTests(UnitWithIdFieldValidationTests):
             Problem.wrong,
             Severity.error,
             message,
-        )
-
-    def test_category_id__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_category_id": "category_id"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.category_id,
-            Problem.unexpected_i18n,
-            Severity.warning,
         )
 
     def test_category_id__template_invarinat(self):

--- a/checkbox-ng/plainbox/impl/unit/test_template.py
+++ b/checkbox-ng/plainbox/impl/unit/test_template.py
@@ -668,7 +668,6 @@ class TemplateUnitFieldValidationTests(UnitFieldValidationTests):
 
     unit_cls = TemplateUnit
 
-
     def test_template_id__bare(self):
         issue_list = self.unit_cls(
             {"template-id": "ns::id"}, provider=self.provider

--- a/checkbox-ng/plainbox/impl/unit/test_template.py
+++ b/checkbox-ng/plainbox/impl/unit/test_template.py
@@ -668,16 +668,6 @@ class TemplateUnitFieldValidationTests(UnitFieldValidationTests):
 
     unit_cls = TemplateUnit
 
-    def test_template_id__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_template-id": "template_id"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.template_id,
-            Problem.unexpected_i18n,
-            Severity.warning,
-        )
 
     def test_template_id__bare(self):
         issue_list = self.unit_cls(
@@ -731,32 +721,6 @@ class TemplateUnitFieldValidationTests(UnitFieldValidationTests):
             message,
         )
 
-    def test_template_unit__untranslatable(self):
-        issue_list = self.unit_cls(
-            {
-                # NOTE: the value must be a valid unit!
-                "_template-unit": "unit"
-            },
-            provider=self.provider,
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.template_unit,
-            Problem.unexpected_i18n,
-            Severity.warning,
-        )
-
-    def test_template_summary__translatable(self):
-        issue_list = self.unit_cls(
-            {"template-summary": "template_summary"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.template_summary,
-            Problem.expected_i18n,
-            Severity.warning,
-        )
-
     def test_template_summary__present(self):
         issue_list = self.unit_cls({}, provider=self.provider).check()
         self.assertIssueFound(
@@ -785,29 +749,6 @@ class TemplateUnitFieldValidationTests(UnitFieldValidationTests):
             issue_list,
             self.unit_cls.Meta.fields.template_summary,
             Problem.wrong,
-            Severity.warning,
-        )
-
-    def test_template_description__translatable(self):
-        issue_list = self.unit_cls(
-            {"template-description": "template_description"},
-            provider=self.provider,
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.template_description,
-            Problem.expected_i18n,
-            Severity.warning,
-        )
-
-    def test_template_resource__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_template-resource": "template_resource"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.template_resource,
-            Problem.unexpected_i18n,
             Severity.warning,
         )
 
@@ -849,15 +790,4 @@ class TemplateUnitFieldValidationTests(UnitFieldValidationTests):
             Problem.bad_reference,
             Severity.error,
             message,
-        )
-
-    def test_template_filter__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_template-filter": "template-filter"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.template_filter,
-            Problem.unexpected_i18n,
-            Severity.warning,
         )

--- a/checkbox-ng/plainbox/impl/unit/test_unit.py
+++ b/checkbox-ng/plainbox/impl/unit/test_unit.py
@@ -398,16 +398,6 @@ class UnitFieldValidationTests(TestCase, IssueMixIn):
         self.provider = mock.Mock(spec_set=IProvider1)
         self.provider.namespace = "ns"
 
-    def test_unit__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_unit": "unit"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.unit,
-            Problem.unexpected_i18n,
-            Severity.warning,
-        )
 
     def test_unit__template_invariant(self):
         issue_list = self.unit_cls(

--- a/checkbox-ng/plainbox/impl/unit/test_unit.py
+++ b/checkbox-ng/plainbox/impl/unit/test_unit.py
@@ -398,7 +398,6 @@ class UnitFieldValidationTests(TestCase, IssueMixIn):
         self.provider = mock.Mock(spec_set=IProvider1)
         self.provider.namespace = "ns"
 
-
     def test_unit__template_invariant(self):
         issue_list = self.unit_cls(
             {"unit": "{attr}"},

--- a/checkbox-ng/plainbox/impl/unit/test_unit_with_id.py
+++ b/checkbox-ng/plainbox/impl/unit/test_unit_with_id.py
@@ -35,17 +35,6 @@ class UnitWithIdFieldValidationTests(UnitFieldValidationTests):
 
     unit_cls = UnitWithId
 
-    def test_id__untranslatable(self):
-        issue_list = self.unit_cls(
-            {"_id": "id"}, provider=self.provider
-        ).check()
-        self.assertIssueFound(
-            issue_list,
-            self.unit_cls.Meta.fields.id,
-            Problem.unexpected_i18n,
-            Severity.warning,
-        )
-
     def test_id__template_variant(self):
         issue_list = self.unit_cls(
             {"id": "id"}, parameters={}, provider=self.provider

--- a/checkbox-ng/plainbox/impl/unit/test_validators.py
+++ b/checkbox-ng/plainbox/impl/unit/test_validators.py
@@ -31,10 +31,8 @@ from plainbox.impl.unit.validators import IFieldValidator
 from plainbox.impl.unit.validators import PresentFieldValidator
 from plainbox.impl.unit.validators import TemplateInvariantFieldValidator
 from plainbox.impl.unit.validators import TemplateVariantFieldValidator
-from plainbox.impl.unit.validators import TranslatableFieldValidator
 from plainbox.impl.unit.validators import UniqueValueValidator
 from plainbox.impl.unit.validators import UnitReferenceValidator
-from plainbox.impl.unit.validators import UntranslatableFieldValidator
 
 
 class NoTestsForAllThatCode(TestCase):
@@ -47,8 +45,6 @@ class NoTestsForAllThatCode(TestCase):
         PresentFieldValidator
         TemplateInvariantFieldValidator
         TemplateVariantFieldValidator
-        TranslatableFieldValidator
         UniqueValueValidator
         UnitReferenceValidator
-        UntranslatableFieldValidator
         self.assertTrue(True)

--- a/checkbox-ng/plainbox/impl/unit/testplan.py
+++ b/checkbox-ng/plainbox/impl/unit/testplan.py
@@ -646,14 +646,12 @@ class TestPlanUnit(UnitWithId):
 
         field_validators = {
             fields.name: [
-                concrete_validators.translatable,
                 concrete_validators.templateVariant,
                 concrete_validators.present,
                 concrete_validators.oneLine,
                 concrete_validators.shortValue,
             ],
             fields.description: [
-                concrete_validators.translatable,
                 concrete_validators.templateVariant,
             ],
             fields.include: [
@@ -663,7 +661,6 @@ class TestPlanUnit(UnitWithId):
                 NoBaseIncludeValidator(),
             ],
             fields.setup_include: [
-                concrete_validators.untranslatable,
                 NoBaseIncludeValidator(),
                 UnitReferenceValidator(
                     lambda unit: unit.get_setup_job_ids(),
@@ -685,7 +682,6 @@ class TestPlanUnit(UnitWithId):
                 ),
             ],
             fields.bootstrap_include: [
-                concrete_validators.untranslatable,
                 NoBaseIncludeValidator(),
                 UnitReferenceValidator(
                     lambda unit: unit.get_bootstrap_job_ids(),
@@ -705,12 +701,9 @@ class TestPlanUnit(UnitWithId):
                 ),
             ],
             fields.estimated_duration: [
-                concrete_validators.untranslatable,
                 concrete_validators.templateInvariant,
             ],
-            fields.icon: [
-                concrete_validators.untranslatable,
-            ],
+            fields.icon: [],
         }
 
 

--- a/checkbox-ng/plainbox/impl/unit/unit.py
+++ b/checkbox-ng/plainbox/impl/unit/unit.py
@@ -334,10 +334,6 @@ class UnitValidator:
         Problem.variable: _("value must be invariant (unparametrized)"),
         Problem.unknown_param: _("field refers to unknown parameter"),
         Problem.not_unique: _("field value is not unique"),
-        Problem.expected_i18n: _("field should be marked as translatable"),
-        Problem.unexpected_i18n: (
-            _("field should not be marked as translatable")
-        ),
         Problem.syntax_error: _("syntax error inside the field"),
         Problem.bad_reference: _("bad reference to another unit"),
     }
@@ -884,18 +880,6 @@ class Unit(metaclass=UnitType):
         # If we have nothing better let's just return the default value
         return default
 
-    @instance_method_lru_cache(maxsize=None)
-    def is_translatable_field(self, name):
-        """
-        Check if a field is marked as translatable
-
-        :param name:
-            Name of the field to check
-        :returns:
-            True if the field is marked as translatable, False otherwise
-        """
-        return "_{}".format(name) in self._data
-
     def qualify_id(self, some_id):
         """
         Transform some unit identifier to be fully qualified
@@ -1065,7 +1049,6 @@ class Unit(metaclass=UnitType):
 
         field_validators = {
             fields.unit: [
-                concrete_validators.untranslatable,
                 concrete_validators.templateInvariant,
                 PresentFieldValidator(
                     severity=Severity.advice,

--- a/checkbox-ng/plainbox/impl/unit/unit_with_id.py
+++ b/checkbox-ng/plainbox/impl/unit/unit_with_id.py
@@ -114,7 +114,6 @@ class UnitWithId(Unit):
 
         field_validators = {
             fields.id: [
-                concrete_validators.untranslatable,
                 concrete_validators.present,
                 concrete_validators.templateVariant,
                 UniqueValueValidator(),

--- a/checkbox-ng/plainbox/impl/unit/validators.py
+++ b/checkbox-ng/plainbox/impl/unit/validators.py
@@ -46,10 +46,8 @@ __all__ = [
     "PresentFieldValidator",
     "TemplateInvariantFieldValidator",
     "TemplateVariantFieldValidator",
-    "TranslatableFieldValidator",
     "UniqueValueValidator",
     "UnitReferenceValidator",
-    "UntranslatableFieldValidator",
 ]
 
 
@@ -442,44 +440,6 @@ class DeprecatedFieldValidator(FieldValidatorBase):
             yield parent.report_issue(
                 unit, field, Problem.deprecated, Severity.advice, self.message
             )
-
-
-class TranslatableFieldValidator(FieldValidatorBase):
-    """
-    Validator ensuring that a field is marked as translatable
-
-    The validator can be customized by passing the following keyword arguments:
-
-    message:
-        Customized error message. This message will be used to report the
-        issue if the validation fails. By default it is derived from
-        ``Problem.expected_i18n`` by :meth:`UnitValidator.explain()`.
-    """
-
-    def check(self, parent, unit, field):
-        if (
-            unit.virtual is False
-            and unit.get_record_value(field) is not None
-            and not unit.is_translatable_field(field)
-        ):
-            yield parent.warning(unit, field, Problem.expected_i18n)
-
-
-class UntranslatableFieldValidator(FieldValidatorBase):
-    """
-    Validator ensuring that a field is not marked as translatable
-
-    The validator can be customized by passing the following keyword arguments:
-
-    message:
-        Customized error message. This message will be used to report the
-        issue if the validation fails. By default it is derived from
-        ``Problem.unexpected_i18n`` by :meth:`UnitValidator.explain()`.
-    """
-
-    def check(self, parent, unit, field):
-        if unit.get_record_value(field) and unit.is_translatable_field(field):
-            yield parent.warning(unit, field, Problem.unexpected_i18n)
 
 
 class TemplateInvariantFieldValidator(FieldValidatorBase):

--- a/checkbox-ng/plainbox/test_provider_manager.py
+++ b/checkbox-ng/plainbox/test_provider_manager.py
@@ -592,7 +592,6 @@ class ProviderManagerToolTests(TestCase):
             test_io.stdout,
             inline_output("""
             warning: jobs/broken.pxu:4: job 'broken', field 'command', command on a manual job makes no sense
-            warning: jobs/broken.pxu:3: job 'broken', field 'description', field should be marked as translatable
             Validation of provider com.example:test has failed
             """),
         )
@@ -613,7 +612,6 @@ class ProviderManagerToolTests(TestCase):
             test_io.stdout,
             inline_output("""
             warning: jobs/broken.pxu:4: job 'broken', field 'command', command on a manual job makes no sense
-            warning: jobs/broken.pxu:3: job 'broken', field 'description', field should be marked as translatable
             advice: jobs/broken.pxu:1: job 'broken', field 'name', use 'id' and 'summary' instead of 'name'
             Validation of provider com.example:test has failed
             """),


### PR DESCRIPTION
## Description

This is the first step in hard deprecating translation, a feature that is overengineered and not used anymore. If we need them in the future, I hope we can implement them better without polluting the whole codebase + all the tests

## Resolved issues

N/A

## Documentation

N/A

## Tests

N/A
