### PR TITLE
Ask the user to use headphones for both input/output in external headphone tests (BugFix)

### DIFF
--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -324,7 +324,8 @@ _purpose:
     This test will check that the headphones connector works correctly.
 _steps:
     1. Connect a pair of headphones to your audio device.
-    2. Commence the test to play a sound through your audio device.
+    2. If the headphones port is a 3.5mm combo jack (mic + playback), make sure BOTH the input and output are set to the headphones.
+    3. Commence the test to play a sound through your audio device.
 _verification:
     Did you hear a sound through the headphones, and did the sound play without any distortion, clicks, or other strange noises from your headphones?
 _summary: Verify headphone connectivity and audio playback quality.
@@ -397,8 +398,9 @@ _purpose:
      This test will check that recording sound using an external microphone works correctly
 _steps:
      1. Connect a microphone to your microphone port
-     2. Click "Test", then speak into the external microphone
-     3. After a few seconds, your speech will be played back to you
+     2. If the port is a 3.5mm combo jack (mic + playback), make sure BOTH the input and output are set to the headphones.
+     3. Click "Test", then speak into the external microphone
+     4. After a few seconds, your speech will be played back to you
 _verification:
      Did you hear your speech played back?
 _summary: Verify external microphone sound recording and playback.

--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -402,7 +402,7 @@ _steps:
      3. Click "Test", then speak into the external microphone
      4. After a few seconds, your speech will be played back to you
 _verification:
-     Did you hear your speech played back?
+     Did you hear your speech played back? If the port is a combo jack, your speech must be played back through the same headphones used for recording.
 _summary: Verify external microphone sound recording and playback.
 
 plugin: user-interact-verify


### PR DESCRIPTION
## Description

This PR is a follow up on the office hour discussion on 03/13. Basically now the user is supposed to choose the external headphones for both input and output when running `audio/alsa_record_playback_internal` and `audio/playback_headphones` even though the test case is only testing 1 at a time.

## Resolved issues

A DUT last week would freeze when both external input and output are used simultaneously, but using only 1 at a time would work.

## Documentation


## Tests

Only the test description is changed
