### PR TITLE
Fix RVS confinement issues (BugFix)

### DIFF
--- a/providers/gpgpu/bin/rvs.py
+++ b/providers/gpgpu/bin/rvs.py
@@ -33,6 +33,9 @@ from pathlib import Path
 # Default location for ROCm Validation Suite binary.
 RVS_BIN = Path("/opt/rocm/bin/rvs")
 
+# ROCm Validation Suite snap common directory for sharing configuration files.
+RVS_SNAP_COMMON = Path("/var/snap/rocm-validation-suite/common")
+
 # Location of the RVS module configurations.
 PLAINBOX_PROVIDER_DATA = Path(os.getenv("PLAINBOX_PROVIDER_DATA", "."))
 
@@ -42,16 +45,14 @@ class ModuleRunner:
 
     def __init__(self, rvs: Path, config: Path) -> None:
         """Initializes the module runner."""
+        self.rvs = rvs
         self.config = config
 
         # CHECKBOX-2021: Snap confinement prevents access to /usr/share
         snap_bins = ["/snap/bin/rvs", "/snap/bin/rocm-validation-suite"]
         if any(rvs.match(p) for p in snap_bins):
-            # To avoid confinement issues we run the binary directly
-            snap_current = Path("/snap/rocm-validation-suite/current")
-            self.rvs = list(snap_current.glob("opt/rocm-*/bin/rvs"))[0]
-        else:
-            self.rvs = rvs
+            shutil.copy(config, RVS_SNAP_COMMON)
+            self.config = RVS_SNAP_COMMON / config.name
 
     def run(self, module: str):
         """Runs and validates the RVS module.

--- a/providers/gpgpu/bin/rvs.py
+++ b/providers/gpgpu/bin/rvs.py
@@ -30,11 +30,11 @@ import shutil
 import subprocess
 from pathlib import Path
 
+# Default location for ROCm Validation Suite binary.
 RVS_BIN = Path("/opt/rocm/bin/rvs")
-"""Default location for ROCm Validation Suite binary."""
 
+# Location of the RVS module configurations.
 PLAINBOX_PROVIDER_DATA = Path(os.getenv("PLAINBOX_PROVIDER_DATA", "."))
-"""Location of the RVS module configurations."""
 
 
 class ModuleRunner:

--- a/providers/gpgpu/bin/rvs.py
+++ b/providers/gpgpu/bin/rvs.py
@@ -34,7 +34,7 @@ from pathlib import Path
 RVS_BIN = Path("/opt/rocm/bin/rvs")
 
 # ROCm Validation Suite snap common directory for sharing configuration files.
-RVS_SNAP_COMMON = Path("/var/snap/rocm-validation-suite/common")
+RVS_SNAP_COMMON = Path("~/snap/rocm-validation-suite/common").expanduser()
 
 # Location of the RVS module configurations.
 PLAINBOX_PROVIDER_DATA = Path(os.getenv("PLAINBOX_PROVIDER_DATA", "."))

--- a/providers/gpgpu/tests/test_rvs.py
+++ b/providers/gpgpu/tests/test_rvs.py
@@ -99,8 +99,8 @@ class TestModuleRunner(TestCase):
         config = Path("/usr/share/checkbox-provider-gpgpu/data/rvs-gpup.conf")
         snap_rvs = Path("/snap/bin/rvs")
         expected_config = Path(
-            "/var/snap/rocm-validation-suite/common/rvs-gpup.conf"
-        )
+            "~/snap/rocm-validation-suite/common/rvs-gpup.conf"
+        ).expanduser()
         runner = ModuleRunner(snap_rvs, config)
         self.assertEqual(runner.rvs, snap_rvs)
         self.assertEqual(runner.config, expected_config)

--- a/providers/gpgpu/tests/test_rvs.py
+++ b/providers/gpgpu/tests/test_rvs.py
@@ -94,16 +94,17 @@ class TestMain(TestCase):
 
 @patch("rvs.logging")
 class TestModuleRunner(TestCase):
-    @patch("pathlib.Path.glob")
-    def test_rvs_snap(self, glob_mock, logging_mock):
+    @patch("shutil.copy")
+    def test_rvs_snap(self, copy_mock, logging_mock):
         config = Path("/usr/share/checkbox-provider-gpgpu/data/rvs-gpup.conf")
         snap_rvs = Path("/snap/bin/rvs")
-        expected_rvs = Path(
-            "/snap/rocm-validation-suite/current/opt/rocm-6.4.1/bin/rvs"
+        expected_config = Path(
+            "/var/snap/rocm-validation-suite/common/rvs-gpup.conf"
         )
-        glob_mock.return_value = [expected_rvs]
         runner = ModuleRunner(snap_rvs, config)
-        self.assertEqual(runner.rvs, expected_rvs)
+        self.assertEqual(runner.rvs, snap_rvs)
+        self.assertEqual(runner.config, expected_config)
+        self.assertTrue(copy_mock.called)
 
     @patch("subprocess.run", return_value=MagicMock(returncode=255))
     def test_run_failure(self, run_mock, logging_mock):


### PR DESCRIPTION
## Description

- The ROCm Validation Suite snap is strictly confined, so it can't access the configuration templates in `/usr/share` (where the checkbox deb stores the data files)
  - Previously, the script would run the snap unconfined, but that leads to issues with dependencies/libraries that the snap bundles in, but may not be installed on the system (the `LD_LIBRARY` path of the snap would not be included with this hack)
  - Based on #2384, I have changed this behavior to copy the config files to the snap common directory when using the RVS snap; however, since these tests are not run by root user, the common directory is the one in home, rather than `/var` 

## Resolved issues

- Partly resolves SERVCERT-2057

## Documentation

## Tests

- Update unit tests
- Lab submissions: https://certification.canonical.com/hardware/202409-35688/submission/478069/ (device has an AMD CPU with some compatibility with ROCm, the submission shows, however, that the data files are being copied and the tool is finding the right files in the accessible directory)
