### PR TITLE
Use `checkbox-pipewire-utils default_device_is_real` in test jobs (New)

### DIFF
--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -560,8 +560,10 @@ id: audio/channels
 flags: also-after-suspend
 estimated_duration:  20.0
 command: 
-  set -e
-  checkbox-support-pipewire-utils default_device_is_real -d audio-sink
+  if check_audio_daemon.sh; then
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
+  fi
   speaker-test -c 2 -l 1 -t wav
 imports: from com.canonical.plainbox import manifest
 requires:

--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -49,6 +49,8 @@ requires:
 command:
   if check_audio_daemon.sh ; then
     checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
     checkbox-support-pipewire-utils gst -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -88,6 +90,8 @@ flags: also-after-suspend
 command:
   if check_audio_daemon.sh ; then
     checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
     checkbox-support-pipewire-utils gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -125,6 +129,8 @@ flags: also-after-suspend
 command:
   if check_audio_daemon.sh ; then
     checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
     checkbox-support-pipewire-utils gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -162,6 +168,8 @@ flags: also-after-suspend
 command:
   if check_audio_daemon.sh ; then
     checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
     checkbox-support-pipewire-utils gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -199,6 +207,8 @@ flags: also-after-suspend
 command:
   if check_audio_daemon.sh ; then
     checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
     checkbox-support-pipewire-utils gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -236,6 +246,8 @@ flags: also-after-suspend
 command:
   if check_audio_daemon.sh ; then
     checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
     checkbox-support-pipewire-utils gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -273,6 +285,8 @@ flags: also-after-suspend
 command:
   if check_audio_daemon.sh ; then
     checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
     checkbox-support-pipewire-utils gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -309,6 +323,8 @@ requires:
 command:
   if check_audio_daemon.sh ; then
     checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
     checkbox-support-pipewire-utils gst -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -347,6 +363,8 @@ requires:
 command:
   if check_audio_daemon.sh ; then
     checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-source
     alsa_record_playback.sh
     EXIT_CODE=$?
   else
@@ -384,6 +402,9 @@ requires:
 command:
   if check_audio_daemon.sh ; then
     checkbox-support-pipewire-utils show -t audio
+    set -e    
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
+    checkbox-support-pipewire-utils default_device_is_real -d audio-source
     alsa_record_playback.sh
     EXIT_CODE=$?
   else
@@ -418,6 +439,9 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_daemon.sh ; then
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
+    checkbox-support-pipewire-utils default_device_is_real -d audio-source
     alsa_record_playback.sh
     EXIT_CODE=$?
   else
@@ -456,6 +480,9 @@ requires:
  manifest.has_audio_playback == 'True'
 command:
   if check_audio_daemon.sh ; then
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
+    checkbox-support-pipewire-utils default_device_is_real -d audio-source
     pipewire_test.py
   else
     audio_test.py
@@ -477,7 +504,9 @@ requires:
   manifest.has_audio_playback == 'True'
 command:
   if check_audio_daemon.sh ; then
+    set -e
     checkbox-support-pipewire-utils detect -t audio -c sinks
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
   else
     pactl_list.sh sinks
   fi
@@ -495,6 +524,8 @@ requires:
   manifest.has_audio_capture == 'True'
 command:
   if check_audio_daemon.sh ; then
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-source
     checkbox-support-pipewire-utils detect -t audio -c sources
   else
     pactl_list.sh sources
@@ -528,7 +559,10 @@ category_id: com.canonical.plainbox::audio
 id: audio/channels
 flags: also-after-suspend
 estimated_duration:  20.0
-command: speaker-test -c 2 -l 1 -t wav
+command: 
+  set -e
+  checkbox-support-pipewire-utils default_device_is_real -d audio-sink
+  speaker-test -c 2 -l 1 -t wav
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_internal_speakers == 'True'
@@ -595,6 +629,8 @@ requires:
 command:
   if check_audio_daemon.sh ; then
     checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
     alsa_record_playback.sh
     EXIT_CODE=$?
   else
@@ -702,6 +738,8 @@ requires:
 command:
   if check_audio_daemon.sh ; then
     checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
     checkbox-support-pipewire-utils gst -t 2 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
     EXIT_CODE=$?
   else
@@ -742,6 +780,9 @@ requires:
  manifest.has_audio_capture == 'True'
 command: audio_test.py
   if check_audio_daemon.sh ; then
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
+    checkbox-support-pipewire-utils default_device_is_real -d audio-source
     pipewire_test.py
   else
     audio_test.py
@@ -757,6 +798,8 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
 command:
   if check_audio_daemon.sh ; then
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
     checkbox-support-pipewire-utils detect -t audio -c sinks
   else
     pactl_list.sh sinks

--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -402,7 +402,7 @@ requires:
 command:
   if check_audio_daemon.sh ; then
     checkbox-support-pipewire-utils show -t audio
-    set -e    
+    set -e
     checkbox-support-pipewire-utils default_device_is_real -d audio-sink
     checkbox-support-pipewire-utils default_device_is_real -d audio-source
     alsa_record_playback.sh
@@ -780,7 +780,7 @@ requires:
  package.name in ['pulseaudio-utils', 'pipewire']
  manifest.has_audio_playback == 'True'
  manifest.has_audio_capture == 'True'
-command: audio_test.py
+command:
   if check_audio_daemon.sh ; then
     set -e
     checkbox-support-pipewire-utils default_device_is_real -d audio-sink

--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -504,9 +504,7 @@ requires:
   manifest.has_audio_playback == 'True'
 command:
   if check_audio_daemon.sh ; then
-    set -e
     checkbox-support-pipewire-utils detect -t audio -c sinks
-    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
   else
     pactl_list.sh sinks
   fi
@@ -524,8 +522,6 @@ requires:
   manifest.has_audio_capture == 'True'
 command:
   if check_audio_daemon.sh ; then
-    set -e
-    checkbox-support-pipewire-utils default_device_is_real -d audio-source
     checkbox-support-pipewire-utils detect -t audio -c sources
   else
     pactl_list.sh sources


### PR DESCRIPTION
## WARNING: This modifies com.canonical.certification::sru-server

## Description

This PR is the 2nd half of #2317 with all the job changes.

## Resolved issues

Prevents virtual devices from being used in tests

## Documentation

See #2317 for code changes.

One thing to note is that we are still **allowing** all the audio jobs to run even if the speakers are completely not detected by the system (i.e. `audio/detect_sources` and `audio/detect_sinks` do not use this check). This hopefully makes the results clearer, lmk what you think.

## Tests

Happy path: https://certification.canonical.com/hardware/202503-36476/submission/478430/
Dummy sink (virtual machine result): https://certification.canonical.com/hardware/202503-36476/submission/478750/
