### PR TITLE
MANIFEST.in checking CI (infra)

### DIFF
--- a/.github/workflows/verify-manifest.yaml
+++ b/.github/workflows/verify-manifest.yaml
@@ -1,0 +1,81 @@
+name: Verify MANIFEST.in is up to date
+permissions:
+  contents: read
+on:
+  push:
+    paths:
+      - checkbox-ng/**
+      - checkbox-support/**
+      - .github/workflows/verify-manifest.yaml
+  pull_request:
+    paths:
+      - checkbox-ng/**
+      - checkbox-support/**
+      - .github/workflows/verify-manifest.yaml
+  workflow_dispatch:
+
+jobs:
+  get_path_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      path: ${{ steps.paths.outputs.paths }}
+    steps:
+      - name: Checkout Checkbox monorepo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Fetch all modified paths
+        id: paths
+        run: |
+          CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          if [ "$CURRENT_BRANCH" == "main" ]; then
+            echo "Workflow triggered on main, diffing with HEAD~1"
+            DIFF=$(git diff --name-only HEAD~1)
+          else
+            echo "Workflow triggered on a branch, diffing with origin/main"
+            DIFF=$(git diff --name-only origin/main)
+          fi
+          # Checks if a specific path has changed
+          changed(){ echo "$DIFF" | grep -o $1; }
+          if changed ".github/workflows/verify-manifest.yaml"; then
+            # when changing the workflow, re-test all tox to check they still work
+            echo "The workflow has been changed, all tox will be retriggered"
+            changed(){ true; }
+          fi;
+
+          echo -n "paths=[" >> to_output
+          for path in \
+              checkbox-ng \
+              checkbox-support; do
+            if changed $path; then
+              echo -n "\"$path\"," >> to_output
+            fi;
+          done
+          sed -i '$ s/.$//' to_output
+          echo -n "]" >> to_output
+
+          cat to_output >> $GITHUB_STEP_SUMMARY
+          cat to_output >> $GITHUB_OUTPUT
+
+  check_manifest_path:
+    needs: get_path_matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        path: ${{ fromJson(needs.get_path_matrix.outputs.path) }}
+    name: Verify MANIFEST.in for ${{ matrix.path }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.path }}
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y -qq check-manifest
+      - name: Run check-manifest
+        run: check-manifest

--- a/checkbox-ng/MANIFEST.in
+++ b/checkbox-ng/MANIFEST.in
@@ -6,6 +6,11 @@ global-include COPYING LICENSE
 global-include README*
 global-include Vagrantfile
 
+exclude HACKING.md
+exclude .coveragerc
+exclude mk-venv
+exclude tox.ini
+
 include plainbox/impl/resource_constants.yaml
 include plainbox/impl/providers/categories/README.md
 include plainbox/impl/providers/categories/manage.py
@@ -37,6 +42,7 @@ recursive-include docs *.rst *.py *.html *.conf
 recursive-include plainbox/test-data *.json *.html *.tar.xz
 recursive-exclude debian *
 recursive-exclude build *
+recursive-exclude contrib *
 
 include checkbox_ng/support/parsers/cputable
 recursive-include checkbox_ng/support/parsers/tests/cpuinfo_data *.txt

--- a/checkbox-support/MANIFEST.in
+++ b/checkbox-support/MANIFEST.in
@@ -1,5 +1,9 @@
 global-include COPYING
 global-include README*
+global-include LICENSE*
+global-include CHANGELOG*
 recursive-include checkbox_support/vendor/brisque/models *.txt *.pickle
 recursive-include checkbox_support/snap_utils/tests/asserts_data *.txt
 recursive-exclude debian *
+exclude .coveragerc
+exclude tox.ini


### PR DESCRIPTION
## Description

MANIFEST.in inclusions are a recurrent rake we step on. For this reason, this adds CI that checks if a file that was added to `checkbox-support` or `checkbox-ng` is correctly included or excluded from the manifest.

The reason why we only see this issue in debian builds or snapcraft remote builds is because if `.git` is shipped to the build env, `setuptools-scm` automatically uses it to know what to include. In these two environments `.git` is not present, so we fallback to MANIFEST and we fail to build. 

Additionally this forces us to take into consideration all additions from this lens. This also caught another problem, we weren't shipping the LICENSE for some vendorized dependencies

## Resolved issues

Fixes: CER-3481

## Documentation

N/A

## Tests

This should fail first PR push, rebase on main should pass after [this](https://github.com/canonical/checkbox/pull/2400) lands
