### PR TITLE
Only run suspend-on-AC-power on devices with batteries (bugfix)

### DIFF
--- a/providers/base/units/power-management/jobs.pxu
+++ b/providers/base/units/power-management/jobs.pxu
@@ -602,6 +602,9 @@ plugin: manual
 category_id: com.canonical.plainbox::power-management
 id: power-management/suspend-on-AC-power
 depends: com.canonical.certification::suspend/suspend_advanced_auto
+imports: from com.canonical.plainbox import manifest
+requires:
+    manifest.has_dc_mode == 'True'
 estimated_duration: 20.0
 _purpose:
     Verify the system can enter suspend being idle for 15 minutes on AC power.


### PR DESCRIPTION

## Description

Align `power-management/suspend-on-AC-power` with
`power-management/suspend-on-battery-power` in terms of requirements, since both should only be run on laptops with batteries.

(has_dc_mode  manifest checks that the device has Battery Power Support)





## Resolved issues

On some certification requests for desktops, we sometimes get this job manually skipped with a comment such as 

> It is desktop, not laptop. skip the case

However, this job is a cert-blocker, which causes our validation to fail.

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
