### PR TITLE
Add screen-private-ppa test to misc-client-cert-automated (New)

### DIFF
--- a/providers/base/units/miscellanea/test-plan.pxu
+++ b/providers/base/units/miscellanea/test-plan.pxu
@@ -41,6 +41,7 @@ include:
     miscellanea/ubuntu-desktop-recommends          certification-status=blocker
     miscellanea/ubuntu-desktop-minimal-recommends  certification-status=blocker
     miscellanea/grub_file_check                    certification-status=blocker
+    miscellanea/screen-private-ppa                 certification-status=blocker 
 bootstrap_include:
     fwts
 


### PR DESCRIPTION
## WARNING: This modifies com.canonical.certification::sru-server

## Description
Add miscellanea/screen-private-ppa test to  misc-client-cert-automated test plan.
This test checks for any private PPAs in the system and fails if found.

As suggest by @stanley31huang here: https://code.launchpad.net/~carmel-team/carmel/+git/checkbox-provider-carmel/+merge/495859

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/PECA-1400

## Documentation


## Tests

- Run this branch on any device with Private PPA entry in the source.list* 
