### PR TITLE
Add bios metadata to submission json (new)

### DIFF
--- a/checkbox-ng/checkbox_ng/support/device_info.py
+++ b/checkbox-ng/checkbox_ng/support/device_info.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 import argparse
-import glob
 import json
-import os
+from pathlib import Path
 import platform
 import subprocess
+import sys
 
 from checkbox_ng.support.release_info import get_release_info
 from checkbox_ng.support.parsers.meminfo import MeminfoParser
@@ -44,20 +44,27 @@ def get_bios_info() -> dict:
     - bios_version
 
     This function extracts the content from these files and returns a dict,
-    using the filename as a key.
+    using the filename as a key, defaulting to `None` if it cannot find data.
     """
-    bios_data = {}
-    base_path = "/sys/class/dmi/id/bios_*"
-
-    for filepath in glob.glob(base_path):
-        key = os.path.basename(filepath)
+    bios_data = {
+        "date": None,
+        "release": None,
+        "vendor": None,
+        "version": None,
+    }
+    bios_root = Path("/sys/class/dmi/id/")
+    bios_data_name = "bios_{}"
+    for key in bios_data:
         try:
-            with open(filepath, "r") as f:
-                bios_data[key] = f.read().strip()
-        except (PermissionError, OSError):
-            # If a specific file is restricted or unreadable, skip it
-            continue
-
+            value = (
+                (bios_root / bios_data_name.format(key)).read_text().strip()
+            )
+            bios_data[key] = value
+        except (PermissionError, FileNotFoundError) as e:
+            print(
+                "Failed to read bios {}. Error: {}".format(key, e),
+                file=sys.stderr,
+            )
     return bios_data
 
 

--- a/checkbox-ng/checkbox_ng/support/device_info.py
+++ b/checkbox-ng/checkbox_ng/support/device_info.py
@@ -54,7 +54,7 @@ def get_bios_info() -> dict:
     }
     bios_root = Path("/sys/class/dmi/id/")
     bios_data_name = "bios_{}"
-    for key in bios_data:
+    for key in sorted(bios_data.keys()):
         try:
             value = (
                 (bios_root / bios_data_name.format(key)).read_text().strip()

--- a/checkbox-ng/checkbox_ng/support/device_info.py
+++ b/checkbox-ng/checkbox_ng/support/device_info.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import argparse
+import glob
 import json
+import os
 import platform
 import subprocess
 
@@ -29,6 +31,34 @@ def get_devices():
     udevadm_output = subprocess.check_output(cmd, universal_newlines=True)
     devices = parse_udevadm_output(udevadm_output)
     return devices
+
+
+def get_bios_info() -> dict:
+    """
+    Retrieve BIOS information from sysfs.
+
+    Usually, Linux provides the following information in /sys/class/dmi/id/:
+    - bios_date
+    - bios_release
+    - bios_vendor
+    - bios_version
+
+    This function extracts the content from these files and returns a dict,
+    using the filename as a key.
+    """
+    bios_data = {}
+    base_path = "/sys/class/dmi/id/bios_*"
+
+    for filepath in glob.glob(base_path):
+        key = os.path.basename(filepath)
+        try:
+            with open(filepath, "r") as f:
+                bios_data[key] = f.read().strip()
+        except (PermissionError, OSError):
+            # If a specific file is restricted or unreadable, skip it
+            continue
+
+    return bios_data
 
 
 def get_debian_packages():
@@ -79,6 +109,9 @@ def parse_args(argv=None):
         "distribution",
         help="Return information about the Linux distribution being used",
     )
+    subparsers.add_parser(
+        "bios", help="Return BIOS information provided by /sys/class/dmi/id/"
+    )
     subparsers.add_parser("memory", help="Return memory information")
     subparsers.add_parser(
         "snaps", help="Return information about installed Snaps"
@@ -94,6 +127,7 @@ def main(argv=None):
         "kernel_cmdline": get_kernel_cmdline,
         "devices": get_devices,
         "debian_packages": get_debian_packages,
+        "bios": get_bios_info,
         "memory": get_meminfo,
         "snaps": get_snap_packages,
         "uname": get_uname,

--- a/checkbox-ng/checkbox_ng/support/tests/test_device_info.py
+++ b/checkbox-ng/checkbox_ng/support/tests/test_device_info.py
@@ -30,53 +30,51 @@ class TestDeviceInfoCLI(TestCase):
         self.assertEqual(pkg[0]["version"], "23.01+dfsg-11")
         self.assertEqual(pkg[0]["architecture"], "amd64")
 
-    @patch("glob.glob")
-    def test_get_bios_info_success(self, mock_glob):
+    def test_get_bios_info_success(self):
         """Test successful retrieval of multiple BIOS files."""
-        # Setup mocks
-        mock_glob.return_items = [
-            "/sys/class/dmi/id/bios_vendor",
-            "/sys/class/dmi/id/bios_version",
+
+        file_contents = [
+            "2026/03/20",
+            "v1.0",
+            "Dell Inc.",
+            "1.5.0",
         ]
-        mock_glob.return_value = mock_glob.return_items
 
-        # Use a mapping for mock_open to return different data for different files
-        file_contents = {
-            "/sys/class/dmi/id/bios_vendor": "Dell Inc.",
-            "/sys/class/dmi/id/bios_version": "1.5.0",
-        }
-
-        def side_effect_open(filename, mode):
-            content = file_contents.get(filename, "")
-            return mock_open(read_data=content).return_value
-
-        with patch("builtins.open", side_effect=side_effect_open):
+        with patch(
+            "checkbox_ng.support.device_info.Path.read_text",
+            side_effect=file_contents,
+        ):
             result = device_info.get_bios_info()
 
-            self.assertEqual(result["bios_vendor"], "Dell Inc.")
-            self.assertEqual(result["bios_version"], "1.5.0")
-            self.assertEqual(len(result), 2)
+            self.assertEqual(result["vendor"], "Dell Inc.")
+            self.assertEqual(result["version"], "1.5.0")
+            self.assertEqual(len(result), 4)
 
-    @patch("glob.glob")
-    def test_get_bios_info_empty(self, mock_glob):
+    def test_get_bios_info_empty(self):
         """Test behavior when no bios_* files are found."""
-        mock_glob.return_value = []
-
-        result = device_info.get_bios_info()
-
-        self.assertEqual(result, {})
-
-    @patch("glob.glob")
-    @patch("os.path.basename")
-    def test_get_bios_info_permission_denied(self, mock_basename, mock_glob):
-        """Test behavior when a file exists but cannot be read."""
-        mock_glob.return_value = ["/sys/class/dmi/id/bios_version"]
-        mock_basename.return_value = "bios_version"
-
-        # Force a PermissionError when trying to open the file
-        with patch("builtins.open", side_effect=PermissionError):
+        with patch(
+            "checkbox_ng.support.device_info.Path.read_text",
+            side_effect=FileNotFoundError,
+        ):
             result = device_info.get_bios_info()
-            self.assertEqual(result, {})
+
+        self.assertEqual(
+            result,
+            {"date": None, "release": None, "vendor": None, "version": None},
+        )
+
+    def test_get_bios_info_permission_denied(self):
+        """Test behavior when a file exists but cannot be read."""
+        with patch(
+            "checkbox_ng.support.device_info.Path.read_text",
+            side_effect=PermissionError,
+        ):
+            result = device_info.get_bios_info()
+
+        self.assertEqual(
+            result,
+            {"date": None, "release": None, "vendor": None, "version": None},
+        )
 
     @patch("checkbox_ng.support.device_info.get_debian_packages")
     @patch("checkbox_ng.support.device_info.get_devices")
@@ -84,10 +82,12 @@ class TestDeviceInfoCLI(TestCase):
     @patch("checkbox_ng.support.device_info.get_meminfo")
     @patch("checkbox_ng.support.device_info.get_snap_packages")
     @patch("checkbox_ng.support.device_info.get_uname")
+    @patch("checkbox_ng.support.device_info.get_bios_info")
     @patch("checkbox_ng.support.device_info.get_kernel_cmdline")
     def test_kernel_cmdline_subcommand_uses_only_kernel_getter(
         self,
         mock_kernel_cmdline,
+        mock_bios_info,
         mock_uname,
         mock_snap_packages,
         mock_meminfo,
@@ -105,6 +105,7 @@ class TestDeviceInfoCLI(TestCase):
         )
         mock_kernel_cmdline.assert_called_once_with()
         mock_uname.assert_not_called()
+        mock_bios_info.assert_not_called()
         mock_meminfo.assert_not_called()
         mock_release_info.assert_not_called()
         mock_devices.assert_not_called()

--- a/checkbox-ng/checkbox_ng/support/tests/test_device_info.py
+++ b/checkbox-ng/checkbox_ng/support/tests/test_device_info.py
@@ -30,6 +30,54 @@ class TestDeviceInfoCLI(TestCase):
         self.assertEqual(pkg[0]["version"], "23.01+dfsg-11")
         self.assertEqual(pkg[0]["architecture"], "amd64")
 
+    @patch("glob.glob")
+    def test_get_bios_info_success(self, mock_glob):
+        """Test successful retrieval of multiple BIOS files."""
+        # Setup mocks
+        mock_glob.return_items = [
+            "/sys/class/dmi/id/bios_vendor",
+            "/sys/class/dmi/id/bios_version",
+        ]
+        mock_glob.return_value = mock_glob.return_items
+
+        # Use a mapping for mock_open to return different data for different files
+        file_contents = {
+            "/sys/class/dmi/id/bios_vendor": "Dell Inc.",
+            "/sys/class/dmi/id/bios_version": "1.5.0",
+        }
+
+        def side_effect_open(filename, mode):
+            content = file_contents.get(filename, "")
+            return mock_open(read_data=content).return_value
+
+        with patch("builtins.open", side_effect=side_effect_open):
+            result = device_info.get_bios_info()
+
+            self.assertEqual(result["bios_vendor"], "Dell Inc.")
+            self.assertEqual(result["bios_version"], "1.5.0")
+            self.assertEqual(len(result), 2)
+
+    @patch("glob.glob")
+    def test_get_bios_info_empty(self, mock_glob):
+        """Test behavior when no bios_* files are found."""
+        mock_glob.return_value = []
+
+        result = device_info.get_bios_info()
+
+        self.assertEqual(result, {})
+
+    @patch("glob.glob")
+    @patch("os.path.basename")
+    def test_get_bios_info_permission_denied(self, mock_basename, mock_glob):
+        """Test behavior when a file exists but cannot be read."""
+        mock_glob.return_value = ["/sys/class/dmi/id/bios_version"]
+        mock_basename.return_value = "bios_version"
+
+        # Force a PermissionError when trying to open the file
+        with patch("builtins.open", side_effect=PermissionError):
+            result = device_info.get_bios_info()
+            self.assertEqual(result, {})
+
     @patch("checkbox_ng.support.device_info.get_debian_packages")
     @patch("checkbox_ng.support.device_info.get_devices")
     @patch("checkbox_ng.support.device_info.get_release_info")

--- a/checkbox-ng/plainbox/impl/session/system_information.py
+++ b/checkbox-ng/plainbox/impl/session/system_information.py
@@ -18,7 +18,7 @@ class CollectorOutputs(dict):
     collector will include in its output
     """
 
-    COLLECTOR_OUTPUTS_VERSION = 4
+    COLLECTOR_OUTPUTS_VERSION = 5
 
     def to_json(self) -> str:
         to_dump = {
@@ -389,6 +389,16 @@ class DistributionCollector(Collector):
     def __init__(self):
         super().__init__(
             collection_cmd=["device-info", "distribution"],
+            version_cmd=["echo", "-n", checkbox_version],
+        )
+
+
+class BiosCollector(Collector):
+    COLLECTOR_NAME = "bios"
+
+    def __init__(self):
+        super().__init__(
+            collection_cmd=["device-info", "bios"],
             version_cmd=["echo", "-n", checkbox_version],
         )
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Update device-bios script with a new `bios` subcommand that extracts data from `/sys/class/dmi/id/bios_*` files and returns them as JSON. Sysfs is accessed directly (instead of using dmidecode, for instance) since these files are user-readable (while dmidecode requires root access).

The collector version is bumped to v5.

## Resolved issues

Fix CHECKBOX-2191

## Documentation



## Tests

Tested locally:

```
$ device-info bios
{
    "date": "09/18/2025",
    "release": "5.35",
    "vendor": "American Megatrends International, LLC.",
    "version": "F8d"
}
```
