### PR TITLE
Fix bare except clauses (BugFix) and Remove duplicate CI path trigger (Infra)

### DIFF
--- a/.github/workflows/tox-checkbox.yaml
+++ b/.github/workflows/tox-checkbox.yaml
@@ -13,7 +13,6 @@ on:
       - providers/gpgpu/**
       - providers/resource/**
       - providers/sru/**
-      - providers/genio/**
       - providers/iiotg/**
       - .github/workflows/tox-checkbox.yaml
   pull_request:

--- a/checkbox-support/checkbox_support/scripts/audio_settings.py
+++ b/checkbox-support/checkbox_support/scripts/audio_settings.py
@@ -333,7 +333,7 @@ def set_audio_settings(device, mute, volume):
                             str(int(mute)),
                         ]
                     )
-                except:
+                except CalledProcessError:
                     logging.error("Failed to set mute for {}".format(name))
                     sys.exit(1)
 
@@ -346,7 +346,7 @@ def set_audio_settings(device, mute, volume):
                             "{}%".format(str(volume)),
                         ]
                     )
-                except:
+                except CalledProcessError:
                     logging.error("Failed to set volume for {}".format(name))
                     sys.exit(1)
 
@@ -400,13 +400,13 @@ def restore_audio_settings(file):
 
         try:
             check_call(["pactl", "set-{}-mute".format(type), name, muted])
-        except:
+        except CalledProcessError:
             logging.error("Failed to restore mute for {}".format(name))
             return 1
 
         try:
             check_call(["pactl", "set-{}-volume".format(type), name, volume])
-        except:
+        except CalledProcessError:
             logging.error("Failed to restore volume for {}".format(name))
             return 1
 


### PR DESCRIPTION
## Description

This PR has two very minor changes:
1. There are several bare except clauses, which can capture other types of exceptions like keyboard interrupts. Added more specific exceptions (as is already done elsewhere in the file for shell checks). 
2. There is a redundant filepath in the CI's push trigger. Just cleaned that up

Since these are such simple changes, I didn't want to clog up the PR list with both small changes, so apologies if the dual-purpose PR is not correct policy-wise

## Resolved issues

1. The targeted except clauses will not be able to accidentally capture unrelated exceptions
2. On-push filepath no longer duplicated

## Documentation

N/A

## Tests

Ran `python3 -m pytest checkbox-support/checkbox_support/scripts/tests/test_audio_settings.py` and 9/9 tests pass
