### PR TITLE
Refactor light sensor test (Bugfix)

### DIFF
--- a/providers/base/bin/light_sensor_test.py
+++ b/providers/base/bin/light_sensor_test.py
@@ -125,12 +125,21 @@ def main():
 
     elif args.command == "test":
         sensors = get_all_sensors()
-        target = next((s for s in sensors if s["name"] == args.name), None)
-        if not target:
+        sensors_with_matching_name = [
+            s for s in sensors if s["name"] == args.name
+        ]
+        if len(sensors_with_matching_name) == 0:
             raise SystemExit("Error: Sensor '{}' not found.".format(args.name))
+        elif len(sensors_with_matching_name) > 1:
+            raise SystemExit(
+                "Warning: More than 1 sensor has the name '{}'.".format(
+                    args.name
+                )
+            )
+        target_sensor = sensors_with_matching_name[0]
 
         passes = 0
-        path = target["path"]
+        path = target_sensor["path"]
         print("Press enter to start test ")
         input()
         for i in range(1, args.rounds + 1):
@@ -164,7 +173,11 @@ def main():
                 print("Result: PASS ({:.1f}%)".format(pct), flush=True)
                 passes += 1
             else:
-                print("Result: FAIL ({:.1f}%)".format(pct), flush=True)
+                print(
+                    "Result: FAIL ({:.1f}%) was detected, "
+                    "but >= ({}%) was required".format(pct, args.threshold),
+                    flush=True,
+                )
 
             if i < args.rounds:
                 time.sleep(args.delay)

--- a/providers/base/bin/light_sensor_test.py
+++ b/providers/base/bin/light_sensor_test.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+import argparse
+import os
+import time
+from typing import Dict, List, Optional
+
+
+def get_all_sensors() -> List[Dict[str, str]]:
+    """Returns a list of dictionaries for all detected light sensors."""
+    sensors = []
+    base_path = "/sys/bus/iio/devices/"
+
+    if not os.path.exists(base_path):
+        return sensors
+
+    for device in sorted(os.listdir(base_path)):
+        if "trigger" in device:
+            continue
+
+        dev_path = os.path.join(base_path, device)
+        name_file = os.path.join(dev_path, "name")
+
+        sensor_name = None
+        if os.path.exists(name_file):
+            try:
+                with open(name_file, "r") as f:
+                    sensor_name = f.read().strip()
+            except IOError:
+                continue
+
+        is_light = False
+        # Check by name or file presence
+        if sensor_name and any(
+            x in sensor_name.lower() for x in ["light", "als", "tsl", "ltr"]
+        ):
+            is_light = True
+        else:
+            try:
+                if any("in_illuminance" in f for f in os.listdir(dev_path)):
+                    is_light = True
+            except OSError:
+                continue
+
+        if is_light:
+            sensors.append(
+                {
+                    "name": sensor_name if sensor_name else device,
+                    "path": dev_path,
+                }
+            )
+
+    return sensors
+
+
+def read_illuminance(sensor_path: str) -> Optional[float]:
+    """Reads lux/illuminance value from sysfs."""
+    targets = ["in_illuminance_input", "in_illuminance_raw", "in_illuminance"]
+    for target in targets:
+        file_path = os.path.join(sensor_path, target)
+        if os.path.exists(file_path):
+            try:
+                with open(file_path, "r") as f:
+                    return float(f.read().strip())
+            except (ValueError, IOError):
+                continue
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Light Sensor Utility")
+    subparsers = parser.add_subparsers(dest="command")
+
+    subparsers.add_parser("resource", help="Print all sensor device names")
+
+    subparsers.add_parser("detect", help="Detect if light sensors exist")
+
+    test_parser = subparsers.add_parser("test", help="Test specific sensor")
+    test_parser.add_argument("--name", required=True, help="Device name")
+    test_parser.add_argument(
+        "--rounds", type=int, default=5, help="Test rounds"
+    )
+    test_parser.add_argument(
+        "--period",
+        type=int,
+        default=10,
+        help="Seconds to wait for light change between readings",
+    )
+    test_parser.add_argument(
+        "--delay", type=int, default=2, help="Seconds of delay between rounds"
+    )
+    test_parser.add_argument(
+        "--threshold",
+        type=float,
+        default=10.0,
+        help="Minimum %% change to count as PASS",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "resource":
+        sensors = get_all_sensors()
+        for s in sensors:
+            print("name: {}".format(s["name"]))
+            print()
+
+    elif args.command == "detect":
+        sensors = get_all_sensors()
+        if not sensors:
+            raise SystemExit("There is no light sensor")
+
+    elif args.command == "test":
+        sensors = get_all_sensors()
+        target = next((s for s in sensors if s["name"] == args.name), None)
+        if not target:
+            raise SystemExit("Error: Sensor '{}' not found.".format(args.name))
+
+        passes = 0
+        path = target["path"]
+        print("Press enter to start test ")
+        input()
+        for i in range(1, args.rounds + 1):
+            print("\n--- ROUND {}/{} ---".format(i, args.rounds), flush=True)
+            val1 = read_illuminance(path)
+            if val1 is None:
+                print("Error: Could not read sensor.", flush=True)
+                continue
+
+            print(
+                "Initial: {:.2f}. Change light now!".format(val1), flush=True
+            )
+            time.sleep(args.period)
+
+            val2 = read_illuminance(path)
+            if val2 is None:
+                print("Error: Failed second reading.", flush=True)
+                continue
+
+            diff = abs(val2 - val1)
+            # When val1 is 0, any positive val2 is a 100% change; otherwise
+            # compute percentage relative to the baseline reading.
+            pct = (
+                (diff / val1 * 100)
+                if val1 != 0
+                else (100.0 if val2 > 0 else 0)
+            )
+
+            print("Catch new value: {:.2f}.".format(val2), flush=True)
+            if pct >= args.threshold:
+                print("Result: PASS ({:.1f}%)".format(pct), flush=True)
+                passes += 1
+            else:
+                print("Result: FAIL ({:.1f}%)".format(pct), flush=True)
+
+            if i < args.rounds:
+                time.sleep(args.delay)
+
+        print(
+            "\nFINAL RESULTS: {}/{} Passed".format(passes, args.rounds),
+            flush=True,
+        )
+        if passes != args.rounds:
+            raise SystemExit("Test failed")
+
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/base/tests/test_light_sensor_test.py
+++ b/providers/base/tests/test_light_sensor_test.py
@@ -351,6 +351,17 @@ class TestMainTest(unittest.TestCase):
                 lst.main()
         self.assertIn("not found", str(ctx.exception).lower())
 
+    def test_raises_systemexit_when_duplicate_sensor_names(self):
+        duplicate_sensors = [self.SENSOR, self.SENSOR]
+        with patch(
+            "sys.argv", ["lst", "test", "--name", "tsl2591", "--rounds", "1"]
+        ), patch(
+            "light_sensor_test.get_all_sensors", return_value=duplicate_sensors
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                lst.main()
+        self.assertIn("more than 1", str(ctx.exception).lower())
+
     def test_all_rounds_pass(self):
         out, exc = self._run_test_cmd([100.0, 200.0, 100.0, 200.0])
         self.assertIsNone(exc)

--- a/providers/base/tests/test_light_sensor_test.py
+++ b/providers/base/tests/test_light_sensor_test.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+import sys
+import os
+import unittest
+from io import StringIO
+from unittest.mock import patch, mock_open
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import light_sensor_test as lst
+
+BASE = "/sys/bus/iio/devices/"
+
+
+def _dev(name):
+    return os.path.join(BASE, name)
+
+
+def _name_file(dev):
+    return os.path.join(dev, "name")
+
+
+def _make_exists(present_paths):
+    def _exists(path):
+        return path in present_paths
+
+    return _exists
+
+
+class TestGetAllSensors(unittest.TestCase):
+    @patch("light_sensor_test.os.path.exists", return_value=False)
+    def test_returns_empty_when_base_path_missing(self, mock_exists):
+        result = lst.get_all_sensors()
+        self.assertEqual(result, [])
+        mock_exists.assert_called_once_with(BASE)
+
+    @patch(
+        "light_sensor_test.os.listdir", return_value=["trigger0", "trigger1"]
+    )
+    @patch("light_sensor_test.os.path.exists", return_value=True)
+    def test_skips_trigger_devices(self, _exists, _listdir):
+        result = lst.get_all_sensors()
+        self.assertEqual(result, [])
+
+    @patch("light_sensor_test.os.listdir", return_value=["iio:device0"])
+    @patch("light_sensor_test.os.path.exists")
+    def test_detects_sensor_by_name_keyword_light(self, mock_exists, _listdir):
+        dev = _dev("iio:device0")
+        mock_exists.side_effect = _make_exists([BASE, _name_file(dev)])
+        with patch("builtins.open", mock_open(read_data="apds9960_light\n")):
+            result = lst.get_all_sensors()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "apds9960_light")
+        self.assertEqual(result[0]["path"], dev)
+
+    @patch("light_sensor_test.os.listdir", return_value=["iio:device0"])
+    @patch("light_sensor_test.os.path.exists")
+    def test_detects_sensor_by_name_keyword_als(self, mock_exists, _listdir):
+        dev = _dev("iio:device0")
+        mock_exists.side_effect = _make_exists([BASE, _name_file(dev)])
+        with patch("builtins.open", mock_open(read_data="stk3310_als")):
+            result = lst.get_all_sensors()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "stk3310_als")
+
+    @patch("light_sensor_test.os.listdir", return_value=["iio:device0"])
+    @patch("light_sensor_test.os.path.exists")
+    def test_detects_sensor_by_name_keyword_tsl(self, mock_exists, _listdir):
+        dev = _dev("iio:device0")
+        mock_exists.side_effect = _make_exists([BASE, _name_file(dev)])
+        with patch("builtins.open", mock_open(read_data="tsl2591")):
+            result = lst.get_all_sensors()
+        self.assertEqual(len(result), 1)
+
+    @patch("light_sensor_test.os.listdir", return_value=["iio:device0"])
+    @patch("light_sensor_test.os.path.exists")
+    def test_detects_sensor_by_name_keyword_ltr(self, mock_exists, _listdir):
+        dev = _dev("iio:device0")
+        mock_exists.side_effect = _make_exists([BASE, _name_file(dev)])
+        with patch("builtins.open", mock_open(read_data="ltr559")):
+            result = lst.get_all_sensors()
+        self.assertEqual(len(result), 1)
+
+    @patch("light_sensor_test.os.listdir")
+    @patch("light_sensor_test.os.path.exists")
+    def test_detects_sensor_by_illuminance_file_presence(
+        self, mock_exists, mock_listdir
+    ):
+        _ = _dev("iio:device0")
+        mock_exists.side_effect = _make_exists([BASE])
+        mock_listdir.side_effect = lambda p: (
+            ["iio:device0"]
+            if p == BASE
+            else ["in_illuminance_input", "in_illuminance_raw"]
+        )
+        result = lst.get_all_sensors()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "iio:device0")
+
+    @patch("light_sensor_test.os.listdir", return_value=["iio:device0"])
+    @patch("light_sensor_test.os.path.exists")
+    def test_skips_device_on_ioerror_reading_name_file(
+        self, mock_exists, _listdir
+    ):
+        dev = _dev("iio:device0")
+        mock_exists.side_effect = _make_exists([BASE, _name_file(dev)])
+        with patch("builtins.open", side_effect=IOError("permission denied")):
+            result = lst.get_all_sensors()
+        self.assertEqual(result, [])
+
+    @patch("light_sensor_test.os.listdir")
+    @patch("light_sensor_test.os.path.exists")
+    def test_skips_device_on_oserror_listing_dev_path(
+        self, mock_exists, mock_listdir
+    ):
+        mock_exists.side_effect = _make_exists([BASE])
+        # name file absent; listing dev_path raises OSError
+        mock_listdir.side_effect = lambda p: (
+            ["iio:device0"]
+            if p == BASE
+            else (_ for _ in ()).throw(OSError("no access"))
+        )
+        result = lst.get_all_sensors()
+        self.assertEqual(result, [])
+
+    @patch("light_sensor_test.os.listdir")
+    @patch("light_sensor_test.os.path.exists")
+    def test_excludes_non_light_device(self, mock_exists, mock_listdir):
+        dev = _dev("iio:device0")
+        mock_exists.side_effect = _make_exists([BASE, _name_file(dev)])
+        mock_listdir.side_effect = lambda p: (
+            ["iio:device0"] if p == BASE else ["in_accel_x", "in_accel_y"]
+        )
+        with patch("builtins.open", mock_open(read_data="mpu6050")):
+            result = lst.get_all_sensors()
+        self.assertEqual(result, [])
+
+    @patch(
+        "light_sensor_test.os.listdir",
+        return_value=["iio:device1", "iio:device0"],
+    )
+    @patch("light_sensor_test.os.path.exists")
+    def test_returns_devices_in_sorted_order(self, mock_exists, mock_listdir):
+        dev0 = _dev("iio:device0")
+        dev1 = _dev("iio:device1")
+        mock_exists.side_effect = _make_exists(
+            [BASE, _name_file(dev0), _name_file(dev1)]
+        )
+
+        def _open(path, *a, **kw):
+            data = "tsl2591" if "device0" in path else "ltr559"
+            return mock_open(read_data=data)()
+
+        with patch("builtins.open", side_effect=_open):
+            result = lst.get_all_sensors()
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["name"], "tsl2591")
+        self.assertEqual(result[1]["name"], "ltr559")
+
+
+class TestReadIlluminance(unittest.TestCase):
+
+    SENSOR_PATH = "/sys/bus/iio/devices/iio:device0"
+
+    def _file(self, name):
+        return os.path.join(self.SENSOR_PATH, name)
+
+    @patch("light_sensor_test.os.path.exists")
+    def test_reads_from_input_file_first(self, mock_exists):
+        mock_exists.side_effect = _make_exists(
+            [self._file("in_illuminance_input")]
+        )
+        with patch("builtins.open", mock_open(read_data="512.0")):
+            result = lst.read_illuminance(self.SENSOR_PATH)
+        self.assertAlmostEqual(result, 512.0)
+
+    @patch("light_sensor_test.os.path.exists")
+    def test_falls_back_to_raw_file(self, mock_exists):
+        mock_exists.side_effect = _make_exists(
+            [self._file("in_illuminance_raw")]
+        )
+        with patch("builtins.open", mock_open(read_data="300")):
+            result = lst.read_illuminance(self.SENSOR_PATH)
+        self.assertAlmostEqual(result, 300.0)
+
+    @patch("light_sensor_test.os.path.exists")
+    def test_falls_back_to_bare_illuminance_file(self, mock_exists):
+        mock_exists.side_effect = _make_exists([self._file("in_illuminance")])
+        with patch("builtins.open", mock_open(read_data="  128\n")):
+            result = lst.read_illuminance(self.SENSOR_PATH)
+        self.assertAlmostEqual(result, 128.0)
+
+    @patch("light_sensor_test.os.path.exists", return_value=False)
+    def test_returns_none_when_no_file_found(self, _exists):
+        result = lst.read_illuminance(self.SENSOR_PATH)
+        self.assertIsNone(result)
+
+    @patch("light_sensor_test.os.path.exists")
+    def test_returns_none_on_value_error(self, mock_exists):
+        mock_exists.side_effect = _make_exists(
+            [self._file("in_illuminance_input")]
+        )
+        with patch("builtins.open", mock_open(read_data="not_a_number")):
+            result = lst.read_illuminance(self.SENSOR_PATH)
+        self.assertIsNone(result)
+
+    @patch("light_sensor_test.os.path.exists")
+    def test_returns_none_on_ioerror(self, mock_exists):
+        mock_exists.side_effect = _make_exists(
+            [self._file("in_illuminance_input")]
+        )
+        with patch("builtins.open", side_effect=IOError("read error")):
+            result = lst.read_illuminance(self.SENSOR_PATH)
+        self.assertIsNone(result)
+
+    @patch("light_sensor_test.os.path.exists")
+    def test_skips_bad_file_and_tries_next(self, mock_exists):
+        # input file exists but raises IOError; raw file succeeds
+        mock_exists.side_effect = _make_exists(
+            [
+                self._file("in_illuminance_input"),
+                self._file("in_illuminance_raw"),
+            ]
+        )
+        call_count = {"n": 0}
+
+        def _open(path, *a, **kw):
+            call_count["n"] += 1
+            if "input" in path:
+                raise IOError("unreadable")
+            return mock_open(read_data="99.5")()
+
+        with patch("builtins.open", side_effect=_open):
+            result = lst.read_illuminance(self.SENSOR_PATH)
+        self.assertAlmostEqual(result, 99.5)
+
+
+class TestMainResource(unittest.TestCase):
+    @patch("light_sensor_test.get_all_sensors")
+    def test_prints_sensor_names(self, mock_sensors):
+        mock_sensors.return_value = [
+            {"name": "tsl2591", "path": "/sys/bus/iio/devices/iio:device0"},
+            {"name": "ltr559", "path": "/sys/bus/iio/devices/iio:device1"},
+        ]
+        with patch("sys.argv", ["lst", "resource"]):
+            with patch("sys.stdout", new_callable=StringIO) as mock_out:
+                lst.main()
+        output = mock_out.getvalue()
+        self.assertIn("name: tsl2591", output)
+        self.assertIn("name: ltr559", output)
+
+    @patch("light_sensor_test.get_all_sensors", return_value=[])
+    def test_no_output_when_no_sensors(self, _sensors):
+        with patch("sys.argv", ["lst", "resource"]):
+            with patch("sys.stdout", new_callable=StringIO) as mock_out:
+                lst.main()
+        self.assertEqual(mock_out.getvalue(), "")
+
+
+class TestMainDetect(unittest.TestCase):
+    @patch("light_sensor_test.get_all_sensors")
+    def test_exits_cleanly_when_sensors_present(self, mock_sensors):
+        mock_sensors.return_value = [{"name": "tsl2591", "path": "/dev/null"}]
+        with patch("sys.argv", ["lst", "detect"]):
+            lst.main()  # must not raise
+
+    @patch("light_sensor_test.get_all_sensors", return_value=[])
+    def test_raises_systemexit_when_no_sensors(self, _sensors):
+        with patch("sys.argv", ["lst", "detect"]):
+            with self.assertRaises(SystemExit) as ctx:
+                lst.main()
+        self.assertIn("no light sensor", str(ctx.exception).lower())
+
+
+class TestMainNoCommand(unittest.TestCase):
+    def test_prints_help_when_no_command_given(self):
+        with patch("sys.argv", ["lst"]):
+            with patch("argparse.ArgumentParser.print_help") as mock_help:
+                lst.main()
+        self.assertEqual(mock_help.call_count, 1)
+
+
+class TestMainTest(unittest.TestCase):
+
+    SENSOR = {"name": "tsl2591", "path": "/sys/bus/iio/devices/iio:device0"}
+
+    def _run_test_cmd(self, read_values, extra_args=None, sensors=None):
+        """
+        Helper: run `lst test --name tsl2591 --rounds N ...` with mocked
+        read_illuminance returning successive values from read_values.
+        Returns (stdout_str, exception_or_None).
+        """
+        if sensors is None:
+            sensors = [self.SENSOR]
+        args = [
+            "lst",
+            "test",
+            "--name",
+            "tsl2591",
+            "--rounds",
+            str(len(read_values) // 2),
+            "--period",
+            "0",
+            "--delay",
+            "0",
+        ]
+        if extra_args:
+            args += extra_args
+
+        read_iter = iter(read_values)
+        with patch("sys.argv", args), patch(
+            "light_sensor_test.get_all_sensors", return_value=sensors
+        ), patch(
+            "light_sensor_test.read_illuminance",
+            side_effect=lambda _: next(read_iter),
+        ), patch(
+            "light_sensor_test.time.sleep"
+        ), patch(
+            "builtins.input"
+        ), patch(
+            "sys.stdout", new_callable=StringIO
+        ) as mock_out:
+            try:
+                lst.main()
+                return mock_out.getvalue(), None
+            except SystemExit as e:
+                return mock_out.getvalue(), e
+
+    def test_raises_systemexit_when_sensor_not_found(self):
+        with patch(
+            "sys.argv", ["lst", "test", "--name", "unknown", "--rounds", "1"]
+        ), patch(
+            "light_sensor_test.get_all_sensors", return_value=[self.SENSOR]
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                lst.main()
+        self.assertIn("not found", str(ctx.exception).lower())
+
+    def test_all_rounds_pass(self):
+        out, exc = self._run_test_cmd([100.0, 200.0, 100.0, 200.0])
+        self.assertIsNone(exc)
+        self.assertIn("2/2 Passed", out)
+
+    def test_all_rounds_fail_raises_systemexit(self):
+        out, exc = self._run_test_cmd([100.0, 101.0, 100.0, 101.0])
+        self.assertIsNotNone(exc)
+        self.assertIn("Test failed", str(exc))
+        self.assertIn("0/2 Passed", out)
+
+    def test_partial_pass_raises_systemexit(self):
+        out, exc = self._run_test_cmd([100.0, 200.0, 100.0, 101.0])
+        self.assertIsNotNone(exc)
+        self.assertIn("1/2 Passed", out)
+
+    def test_custom_threshold_respected(self):
+        out, exc = self._run_test_cmd(
+            [100.0, 105.0, 100.0, 105.0],
+            extra_args=["--threshold", "4.0"],
+        )
+        self.assertIsNone(exc)
+        self.assertIn("2/2 Passed", out)
+
+    def test_zero_baseline_positive_val2_is_pass(self):
+        out, exc = self._run_test_cmd([0.0, 50.0])
+        self.assertIsNone(exc)
+        self.assertIn("1/1 Passed", out)
+
+    def test_zero_baseline_zero_val2_is_fail(self):
+        out, exc = self._run_test_cmd([0.0, 0.0])
+        self.assertIsNotNone(exc)
+        self.assertIn("FAIL", out)
+
+    def test_skips_round_on_first_read_failure(self):
+        read_values = iter([None, 100.0, 200.0])
+        with patch(
+            "sys.argv",
+            [
+                "lst",
+                "test",
+                "--name",
+                "tsl2591",
+                "--rounds",
+                "2",
+                "--period",
+                "0",
+                "--delay",
+                "0",
+            ],
+        ), patch(
+            "light_sensor_test.get_all_sensors", return_value=[self.SENSOR]
+        ), patch(
+            "light_sensor_test.read_illuminance",
+            side_effect=lambda _: next(read_values),
+        ), patch(
+            "light_sensor_test.time.sleep"
+        ), patch(
+            "builtins.input"
+        ), patch(
+            "sys.stdout", new_callable=StringIO
+        ) as mock_out:
+            with self.assertRaises(SystemExit):
+                lst.main()
+        out = mock_out.getvalue()
+        self.assertIn("Could not read sensor", out)
+        self.assertIn("1/2 Passed", out)
+
+    def test_skips_round_on_second_read_failure(self):
+        read_values = iter([100.0, None, 100.0, 200.0])
+        with patch(
+            "sys.argv",
+            [
+                "lst",
+                "test",
+                "--name",
+                "tsl2591",
+                "--rounds",
+                "2",
+                "--period",
+                "0",
+                "--delay",
+                "0",
+            ],
+        ), patch(
+            "light_sensor_test.get_all_sensors", return_value=[self.SENSOR]
+        ), patch(
+            "light_sensor_test.read_illuminance",
+            side_effect=lambda _: next(read_values),
+        ), patch(
+            "light_sensor_test.time.sleep"
+        ), patch(
+            "builtins.input"
+        ), patch(
+            "sys.stdout", new_callable=StringIO
+        ) as mock_out:
+            with self.assertRaises(SystemExit):
+                lst.main()
+        out = mock_out.getvalue()
+        self.assertIn("Failed second reading", out)
+        self.assertIn("1/2 Passed", out)
+
+    def test_sleep_called_with_period_and_delay(self):
+        with patch(
+            "sys.argv",
+            [
+                "lst",
+                "test",
+                "--name",
+                "tsl2591",
+                "--rounds",
+                "2",
+                "--period",
+                "7",
+                "--delay",
+                "3",
+            ],
+        ), patch(
+            "light_sensor_test.get_all_sensors", return_value=[self.SENSOR]
+        ), patch(
+            "light_sensor_test.read_illuminance", return_value=100.0
+        ), patch(
+            "light_sensor_test.time.sleep"
+        ) as mock_sleep, patch(
+            "builtins.input"
+        ), patch(
+            "sys.stdout", new_callable=StringIO
+        ):
+            with self.assertRaises(SystemExit):
+                lst.main()
+        sleep_args = [c[0][0] for c in mock_sleep.call_args_list]
+        self.assertIn(7, sleep_args)
+        self.assertIn(3, sleep_args)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/providers/base/units/monitor/jobs.pxu
+++ b/providers/base/units/monitor/jobs.pxu
@@ -490,3 +490,22 @@ imports: from com.canonical.plainbox import manifest
 requires: manifest.has_vga == 'True'
 estimated_duration: 300
 flags: also-after-suspend
+
+plugin: manual
+category_id: com.canonical.plainbox::monitor
+id: monitor/als_monitor_brightness_control
+flags: also-after-suspend
+imports: from com.canonical.plainbox import manifest
+depends: power-management/light_sensor_detect
+estimated_duration: 10.0
+requires:
+  manifest.has_monitor_als_brightness_control == 'True'
+purpose:
+    This test checks whether your monitor's brightness can be controlled by the ambient light sensor.
+steps:
+    1. Make sure "Automatic brightness" is ON in Power settings.
+    2. Locate the Ambient Light Sensor, which should be around the Camera.
+    3. Cover your hand over the Ambient Light Sensor.
+verification:
+    Did the screen brightness change ?
+summary: This test checks whether your monitor's brightness can be controlled by the ambient light sensor.

--- a/providers/base/units/monitor/manifest.pxu
+++ b/providers/base/units/monitor/manifest.pxu
@@ -9,3 +9,8 @@ id: has_muxpi_hdmi
 _prompt: Is the device connected to the following?:
 _name: MuxPi HDMI Port
 value-type: bool
+
+unit: manifest entry
+id: has_monitor_als_brightness_control
+_name: Ambient Light Sensor for Monitor Brightness Control
+value-type: bool

--- a/providers/base/units/power-management/jobs.pxu
+++ b/providers/base/units/power-management/jobs.pxu
@@ -616,3 +616,34 @@ _steps:
 _verification:
     The system turns the screen off after 1 minute of idle.
     The system enters suspend mode after 15 minutes of idle.
+
+
+unit: job
+plugin: shell
+category_id: com.canonical.plainbox::power-management
+id: power-management/light_sensor_detect
+flags: also-after-suspend
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_light_sensor == 'True'
+command:
+    light_sensor_test.py detect
+estimated_duration: 5s
+summary:
+    Test this machine have the light sensor support or not
+description:
+    The light sensor will be shown under /sys/bus/iio/devices/ and could be validated by
+    the outcome of name automatically.
+
+unit: template
+template-resource: light_sensor_resource
+template-unit: job
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::power-management
+id: power-management/light_sensor_test_{name}
+template-id: power-management/light_sensor_test_device
+flags: also-after-suspend
+estimated_duration: 50
+depends: com.canonical.certification::power-management/light_sensor_detect
+command:
+    light_sensor_test.py test --name {name} --rounds 5 --period 5 --delay 5
+summary: Verify if light sensor {name} can detect the light change or not.

--- a/providers/base/units/power-management/manifest.pxu
+++ b/providers/base/units/power-management/manifest.pxu
@@ -7,3 +7,8 @@ unit: manifest entry
 id: has_dc_mode
 _name: Battery Power Support
 value-type: bool
+
+unit: manifest entry
+id: has_light_sensor
+_name: Light Sensor Support
+value-type: bool

--- a/providers/base/units/power-management/resource.pxu
+++ b/providers/base/units/power-management/resource.pxu
@@ -1,0 +1,16 @@
+# Copyright 2026 Canonical Ltd.
+# All rights reserved.
+#
+# Written by:
+#   Hanhsuan Lee <hanhsuan.lee@canonical.com>
+
+unit: job
+id: light_sensor_resource
+plugin: resource
+summary: Show all light sensor that need to be tested.
+description:
+    Show all light sensor that need to be tested.
+command:
+    light_sensor_test.py resource
+estimated_duration: 3s
+flags: preserve-locale


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
This PR is going to replace the old shell script test case with following change:
1. Doesn't need `monitor-sensor` anymore
2. Get light sensor device from `/sys/bus/iio/devices/`
3. Get `illuminance` form `/sys/bus/iio/devices/` directly.
4. Support multiple light sensors
5. new manifest entries `has_light_sensor` and `has_monitor_als_brightness_control`
6. New test case `light_sensor_detect` and `monitor/als_monitor_brightness_control`
7. Using template job `light_sensor_test_device` instead of `light_sensor`


## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
https://github.com/canonical/checkbox/issues/2182

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
For testing purpose, adding to the monitor test-plan as follow:
```
id: monitor-gpu-cert-manual
unit: test plan
_name: Monitor tests (GPU) (Manual)
_description:
 Monitor tests (GPU) (Manual)
include:
 monitor/1_powersaving_.*                   certification-status=blocker
 power-management/light_sensor_detect
 power-management/light_sensor_test_device
 monitor/als_monitor_brightness_control
 monitor/1_dim_brightness_.*                certification-status=blocker
 monitor/1_displayport_.*                   certification-status=blocker
 audio/1_playback_displayport_.*            certification-status=blocker
 monitor/1_type-c_displayport_.*            certification-status=blocker
 audio/1_playback_type-c_displayport_.*     certification-status=blocker
 monitor/1_type-c_hdmi_.*                   certification-status=blocker
 audio/1_playback_type-c_hdmi_.*            certification-status=blocker
 monitor/1_type-c_vga_.*                    certification-status=blocker
 monitor/1_dvi_.*                           certification-status=blocker
 monitor/1_hdmi_.*                          certification-status=blocker
 audio/1_playback_hdmi_.*                   certification-status=blocker
 monitor/1_thunderbolt3_.*                  certification-status=non-blocker
 audio/1_playback_thunderbolt3_.*           certification-status=non-blocker
 thunderbolt3/daisy-chain                   certification-status=non-blocker
 monitor/multi-head                         certification-status=blocker
bootstrap_include:
    graphics_card
    light_sensor_resource

id: after-suspend-monitor-gpu-cert-manual
unit: test plan
_name: Monitor tests (after suspend, GPU) (Manual)
_description:
 Monitor tests (after suspend, GPU) (Manual)
include:
 after-suspend-monitor/1_powersaving_.*                   certification-status=blocker
 after-suspend-power-management/light_sensor_detect
 after-suspend-power-management/light_sensor_test_device
 after-suspend-monitor/als_monitor_brightness_control
 after-suspend-monitor/1_dim_brightness_.*                certification-status=blocker
 after-suspend-monitor/1_displayport_.*                   certification-status=blocker
 after-suspend-audio/1_playback_displayport_.*            certification-status=blocker
 after-suspend-monitor/1_type-c_displayport_.*            certification-status=blocker
 after-suspend-audio/1_playback_type-c_displayport_.*     certification-status=blocker
 after-suspend-monitor/1_type-c_hdmi_.*                   certification-status=blocker
 after-suspend-audio/1_playback_type-c_hdmi_.*            certification-status=blocker
 after-suspend-monitor/1_type-c_vga_.*                    certification-status=blocker
 after-suspend-monitor/1_dvi_.*                           certification-status=blocker
 after-suspend-monitor/1_hdmi_.*                          certification-status=blocker
 after-suspend-audio/1_playback_hdmi_.*                   certification-status=blocker
 after-suspend-monitor/1_thunderbolt3_.*                  certification-status=non-blocker
 after-suspend-audio/1_playback_thunderbolt3_.*           certification-status=non-blocker
 after-suspend-thunderbolt3/daisy-chain                   certification-status=non-blocker
 after-suspend-monitor/multi-head                         certification-status=blocker
bootstrap_include:
    graphics_card
    light_sensor_resource
```

- With light sensor:
  - test success: https://certification.canonical.com/hardware/202001-27667/submission/481442/
  - test failed: https://certification.canonical.com/hardware/202001-27667/submission/480261/
- Without light sensor:
  - test failed: https://certification.canonical.com/hardware/202603-38481/submission/480265/