### PR TITLE
Avoid collecting 80k lines of logs in checkbox collector (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/__init__.py
+++ b/checkbox-ng/plainbox/impl/__init__.py
@@ -210,3 +210,17 @@ def get_plainbox_dir():
     Return the root directory of the plainbox package.
     """
     return os.path.dirname(getabsfile(plainbox))
+
+
+def low_memory_device():
+    """
+    Returns if the system we are runing on has very low RAM installed
+
+    This is used to disable or tune down some subsystems to avoid filling
+    the RAM with Checkbox itself and crashing the system.
+    """
+    mem_bytes = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+    mem_mib = mem_bytes / (1024.0**2)
+    if mem_mib < 1024 * 2:
+        return True
+    return False

--- a/checkbox-ng/plainbox/impl/__init__.py
+++ b/checkbox-ng/plainbox/impl/__init__.py
@@ -212,9 +212,9 @@ def get_plainbox_dir():
     return os.path.dirname(getabsfile(plainbox))
 
 
-def low_memory_device():
+def low_memory_device() -> bool:
     """
-    Returns if the system we are runing on has very low RAM installed
+    Returns `True` if the system we are running on has very low RAM installed
 
     This is used to disable or tune down some subsystems to avoid filling
     the RAM with Checkbox itself and crashing the system.

--- a/checkbox-ng/plainbox/impl/exporter/tar.py
+++ b/checkbox-ng/plainbox/impl/exporter/tar.py
@@ -30,6 +30,7 @@ import tarfile
 import time
 from tempfile import SpooledTemporaryFile
 
+from plainbox.impl import low_memory_device
 from plainbox.impl.exporter import SessionStateExporterBase
 from plainbox.impl.exporter.jinja2 import Jinja2SessionStateExporter
 from plainbox.impl.providers import get_providers
@@ -53,14 +54,12 @@ class TARSessionStateExporter(SessionStateExporterBase):
 
         """
         preset = None
-        mem_bytes = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
-        mem_mib = mem_bytes / (1024.0**2)
         # On systems with less than 1GiB of RAM, create the submission tarball
         # without any compression level (i.e preset=0).
         # See https://docs.python.org/3/library/lzma.html
         # With preset 9 for example, the overhead for an LZMACompressor object
         # can be as high as 800 MiB.
-        if mem_mib < 1200:
+        if low_memory_device():
             preset = 0
 
         job_state_map = manager.default_device_context.state.job_state_map

--- a/checkbox-ng/plainbox/impl/session/system_information.py
+++ b/checkbox-ng/plainbox/impl/session/system_information.py
@@ -2,8 +2,10 @@
 
 import abc
 import json
+
 from subprocess import run, PIPE, check_output, STDOUT, CalledProcessError
 
+from plainbox.impl import low_memory_device
 from plainbox import vendor
 from plainbox.impl.session.storage import WellKnownDirsHelper
 from checkbox_ng import __version__ as checkbox_version
@@ -296,6 +298,11 @@ class JournalctlCollector(Collector):
         return list(map(json.loads, collector_output.splitlines()))
 
     def __init__(self):
+        to_collect = 80_000  # limit the lines to 80k, ~80Mb of memory
+        if low_memory_device():
+            # when memory is low, we can't afford to load all that json into
+            # memory, try to collect a few logs either way
+            to_collect = 8_000
         super().__init__(
             collection_cmd=[
                 "journalctl",
@@ -304,7 +311,7 @@ class JournalctlCollector(Collector):
                 "--since",
                 "-3 days",
                 "-n",
-                "80000",  # limit the lines to 80k, ~80Mb of memory
+                str(to_collect),
             ],
             version_cmd=["journalctl", "--version"],
         )

--- a/checkbox-ng/plainbox/impl/session/system_information.py
+++ b/checkbox-ng/plainbox/impl/session/system_information.py
@@ -298,11 +298,11 @@ class JournalctlCollector(Collector):
         return list(map(json.loads, collector_output.splitlines()))
 
     def __init__(self):
-        to_collect = 80_000  # limit the lines to 80k, ~80Mb of memory
+        to_collect = 80000  # limit the lines to 80k, ~80Mb of memory
         if low_memory_device():
             # when memory is low, we can't afford to load all that json into
             # memory, try to collect a few logs either way
-            to_collect = 8_000
+            to_collect = 8000
         super().__init__(
             collection_cmd=[
                 "journalctl",

--- a/checkbox-ng/plainbox/impl/test_init.py
+++ b/checkbox-ng/plainbox/impl/test_init.py
@@ -23,11 +23,11 @@ plainbox.impl.test_init
 Test definitions for plainbox.impl module
 """
 
-from unittest import TestCase
 import warnings
+from unittest import TestCase
+from unittest.mock import patch
 
-from plainbox.impl import _get_doc_margin
-from plainbox.impl import deprecated
+from plainbox.impl import _get_doc_margin, deprecated, low_memory_device
 
 
 class MiscTests(TestCase):
@@ -113,3 +113,16 @@ class DeprecatedDecoratorTests(TestCase):
             str(boom.exception),
             "@deprecated() must be called with a parameter",
         )
+
+
+class LowMemoryDeviceTests(TestCase):
+
+    @patch("os.sysconf")
+    def test_not_lowmem(self, sysconf_mock):
+        sysconf_mock.side_effect = [4096, 7627054]
+        self.assertFalse(low_memory_device())
+
+    @patch("os.sysconf")
+    def test_lowmem(self, sysconf_mock):
+        sysconf_mock.side_effect = [4096, 4]
+        self.assertTrue(low_memory_device())


### PR DESCRIPTION
## Description

When exporting on devices with really low memory and no swap, Checkbox will be killed by the OOM killer (both local and remote) if there is a lot of logs or the logs weren't purged before the test run. 

## Resolved issues

Fixes: CHECKBOX-2153
May help with: https://github.com/canonical/checkbox/issues/1961

## Documentation

This adds an explanation in the docstring, given that the definition of low memory is arbitrary, I've increased it to 2Gb which is still quite low and also includes all devices with slightly more than 1Gb

## Tests

Create the following yaml somewhere:
```yaml
name: low_mem
description: "Low memory profile"
config:
  limits.cpu: "1"
  limits.memory: 512MB
  limits.memory.swap: "false"
project: default
```
Test via the following
```shell
# Import the profile
lxc profile create low_mem < low_mem.yaml 
# Create a machine with this low memory 
lxc launch ubuntu:noble low-mem-noble --profile low_mem --profile default
apt update && apt upgrade && apt install python3 python3-venv python3-pip
# Install checkbox + all
git clone https://github.com/canonical/checkbox.git
python3 -m venv venv
. venv/bin/activate
cd checkbox/checkbox-ng
pip install -e .
cd ../checkbox-support
pip install -e .
cd ../providers
for f in */manage.py; do ./$f develop; done
cd ../metabox/metabox/metabox-provider
./manage.py develop
# Now lets create a lot of data in the journal to collect
for i in {0..80000..1}; do echo some | systemd-cat; done
```
Launch checkbox-cli. Before this patch, it will be killed while creating the tar, after this patch, it will terminate without a problem

