### PR TITLE
Fix: Discard KlogAcpiDisabled for DTB boot (BugFix)

### DIFF
--- a/providers/base/bin/reboot_check_test.py
+++ b/providers/base/bin/reboot_check_test.py
@@ -701,8 +701,14 @@ def main() -> int:
 
     if args.do_fwts_check:
         tester = FwtsTester()
+        sys_fw = "/sys/firmware"
+        has_dt = os.path.isdir(os.path.join(sys_fw, "devicetree"))
+        has_acpi = os.path.isdir(os.path.join(sys_fw, "acpi"))
+        fwts_args = ["klog", "oops"]
+        if has_dt and not has_acpi:
+            fwts_args.extend(["--filter-error-discard", "KlogAcpiDisabled"])
         if tester.is_fwts_supported() and not tester.fwts_log_check_passed(
-            args.output_directory
+            output_directory=args.output_directory, fwts_arguments=fwts_args
         ):
             fwts_passed = False
         else:


### PR DESCRIPTION
## Description

 * Embedded devices like the ones used by the Tegra team boot through device tree, therefore on those the following message is displayed.
   ```
   ACPI: Interpreter disabled.
   ```

   However `fwts klog` treats these as critical error messages, since `fwts` expects an ACPI boot, for the cases that device boots from a DTB it is better to not treat these informational messages as errors.

## Resolved issues

https://warthogs.atlassian.net/browse/PERI-1342

## Documentation

## Tests

The reboot_check_test.py has been executed locally having the Device tree / ACPI detection enabled and disabled.

* [no-dts-detection-fail.txt](https://github.com/user-attachments/files/26197539/no-dts-detection-fail.txt)
* [dts-detection-succeed.txt](https://github.com/user-attachments/files/26197546/dts-detection-succeed.txt)

