### PR TITLE
Add sleep key and suspend led jobs for suspend dependency (BugFix)

### DIFF
--- a/providers/base/units/keys/jobs.pxu
+++ b/providers/base/units/keys/jobs.pxu
@@ -72,6 +72,7 @@ _summary:
 plugin: manual
 category_id: com.canonical.plainbox::keys
 id: keys/sleep
+depends: suspend/suspend_advanced_auto
 estimated_duration: 90.0
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_key_sleep == 'True'

--- a/providers/base/units/keys/jobs.pxu
+++ b/providers/base/units/keys/jobs.pxu
@@ -76,7 +76,6 @@ depends: suspend/suspend_advanced_auto
 estimated_duration: 90.0
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_key_sleep == 'True'
-flags: also-after-suspend
 _purpose:
      This test will test the sleep key
 _steps:

--- a/providers/base/units/keys/test-plan.pxu
+++ b/providers/base/units/keys/test-plan.pxu
@@ -27,8 +27,6 @@ include:
  keys/power-button                              certification-status=blocker
  keys/power-button-event                        certification-status=blocker
  keys/fn-lock                                   certification-status=non-blocker
- keys/power-button-suspend                      certification-status=blocker
- keys/sleep                                     certification-status=blocker
 
 id: after-suspend-keys-cert-manual
 unit: test plan
@@ -49,8 +47,8 @@ include:
    after-suspend-keys/power-button                certification-status=blocker
    after-suspend-keys/power-button-event          certification-status=blocker
    after-suspend-keys/fn-lock                     certification-status=non-blocker
-   after-suspend-keys/power-button-suspend        certification-status=blocker
-   after-suspend-keys/sleep                       certification-status=blocker
+   keys/power-button-suspend                      certification-status=blocker
+   keys/sleep                                     certification-status=blocker
 
 id: keys-cert-automated
 unit: test plan

--- a/providers/base/units/led/jobs.pxu
+++ b/providers/base/units/led/jobs.pxu
@@ -15,6 +15,7 @@ requires:
  manifest.has_led_power == 'True'
 
 id: led/power-blink-suspend
+depends: suspend/suspend_advanced_auto
 _summary: Power LED behavior when suspended
 _purpose:
  Check power led is blinking when system is in suspend


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

1. Add dependency for two jobs.

- keys/sleep
- led/power-blink-suspend

2. Modify the test plan and make it clearly in the after suspend test plan.

- keys/power-button-suspend
- keys/sleep

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
https://certification.canonical.com/hardware/202603-38484/submission/480327/

keys-cert-manual
--
| Item |
| :--- |
| `com.canonical.plainbox::manifest` |
| `com.canonical.certification::keys/lock-screen` |
| `com.canonical.certification::keys/super` |
| `com.canonical.certification::keys/brightness` |
| `com.canonical.certification::keys/media-control` |
| `com.canonical.certification::keys/mute` |
| `com.canonical.certification::keys/volume` |
| `com.canonical.certification::keys/video-out` |
| `com.canonical.certification::keys/wireless` |
| `com.canonical.certification::keys/keyboard-backlight` |
| `com.canonical.certification::package` |
| `com.canonical.certification::keys/microphone-mute` |
| `com.canonical.certification::keys/power-button` |
| `com.canonical.certification::keys/power-button-event` |
| `com.canonical.certification::keys/fn-lock` |

 
after-suspend-keys-cert-manual
--
| Item |
|  :--- |
| `com.canonical.plainbox::manifest` |
| `com.canonical.certification::keys/lock-screen` |
| `com.canonical.certification::rtc` |
| `com.canonical.certification::sleep` |
| `com.canonical.certification::package` |
| `com.canonical.certification::keys/power-button-event` |
| `com.canonical.certification::keys/media-control` |
| `com.canonical.certification::keys/power-button` |
| `com.canonical.certification::keys/microphone-mute` |
| `com.canonical.certification::keys/super` |
| `com.canonical.certification::keys/wireless` |
| `com.canonical.certification::keys/video-out` |
| `com.canonical.certification::keys/volume` |
| `com.canonical.certification::keys/fn-lock` |
| `com.canonical.certification::keys/brightness` |
| `com.canonical.certification::keys/keyboard-backlight` |
| `com.canonical.certification::keys/mute` |
| `com.canonical.certification::suspend/suspend_advanced_auto` |
| `com.canonical.certification::after-suspend-keys/lock-screen` |
| `com.canonical.certification::after-suspend-keys/super` |
| `com.canonical.certification::after-suspend-keys/brightness` |
| `com.canonical.certification::after-suspend-keys/media-control` |
| `com.canonical.certification::after-suspend-keys/mute` |
| `com.canonical.certification::after-suspend-keys/volume` |
| `com.canonical.certification::after-suspend-keys/video-out` |
| `com.canonical.certification::after-suspend-keys/wireless` |
| `com.canonical.certification::after-suspend-keys/keyboard-backlight` |
| `com.canonical.certification::after-suspend-keys/microphone-mute` |
| `com.canonical.certification::after-suspend-keys/power-button` |
| `com.canonical.certification::after-suspend-keys/power-button-event` |
| `com.canonical.certification::after-suspend-keys/fn-lock` |
| `com.canonical.certification::keys/power-button-suspend` |
| `com.canonical.certification::keys/sleep` |
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
