### PR TITLE
Tox only on PRS and main pushes (infra)

### DIFF
--- a/.github/workflows/tox-checkbox.yaml
+++ b/.github/workflows/tox-checkbox.yaml
@@ -3,6 +3,7 @@ permissions:
   contents: read
 on:
   push:
+    branches: [ main ]
     paths:
       - checkbox-ng/**
       - checkbox-support/**

--- a/.github/workflows/tox-contrib-pc-sanity.yaml
+++ b/.github/workflows/tox-contrib-pc-sanity.yaml
@@ -2,6 +2,11 @@ name: Test pc-sanity (from contrib area) with tox
 permissions:
   contents: read
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - contrib/pc-sanity/**
+      - .github/workflows/tox-contrib-pc-sanity.yaml
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This doubles CI jobs for nothing, if one wants to trigger CI without a PR attached, they can just trigger it manually.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-2198

## Documentation

N/A

## Tests

N/A