### PR TITLE
Remove all jinja conditionals from commands (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -21,40 +21,34 @@ Definition for UnifiedRunner class.
 """
 
 import contextlib
+import enum
+import functools
 import getpass
 import gzip
 import io
 import logging
+import operator
 import os
 import select
+import shlex
+import shutil
+import signal
 import subprocess
 import sys
 import tempfile
 import threading
 import time
-import shlex
-import signal
-import shutil
-import functools
-import operator
-import enum
-
 from contextlib import suppress
-from subprocess import check_output, check_call, run
+from subprocess import check_call, check_output, run
 
 from plainbox.abc import IJobResult, IJobRunner
 from plainbox.i18n import gettext as _
 from plainbox.impl.color import Colorizer
-from plainbox.impl.unit.job import supported_plugins
-from plainbox.impl.unit.unit import (
-    on_ubuntucore,
-    get_snap_base,
-    get_checkbox_runtime_path,
-)
+from plainbox.impl.jobcache import ResourceJobCache
 from plainbox.impl.result import (
+    IOLogRecord,
     IOLogRecordWriter,
     JobResultBuilder,
-    IOLogRecord,
 )
 from plainbox.impl.runner import (
     CommandOutputWriter,
@@ -62,11 +56,16 @@ from plainbox.impl.runner import (
     JobRunnerUIDelegate,
     slugify,
 )
-from plainbox.impl.jobcache import ResourceJobCache
 from plainbox.impl.secure.sudo_broker import sudo_password_provider
 from plainbox.impl.session.storage import WellKnownDirsHelper
+from plainbox.impl.unit.job import InvalidJob, supported_plugins
+from plainbox.impl.unit.unit import (
+    get_checkbox_runtime_path,
+    get_snap_base,
+    on_os_ubuntucore,
+    on_ubuntucore,
+)
 from plainbox.vendor import extcmd
-from plainbox.impl.unit.job import InvalidJob
 
 logger = logging.getLogger("plainbox.unified")
 
@@ -628,6 +627,13 @@ def get_execution_environment(job, environ, session_id, nest_dir):
     set_if_not_none("CHECKBOX_SHARE", job.provider.CHECKBOX_SHARE)
     if os.getenv("SNAP"):
         set_if_not_none("CHECKBOX_RUNTIME", str(get_checkbox_runtime_path()))
+
+    if on_ubuntucore():
+        set_if_not_none("CHECKBOX_RUNNING_STRICT_SNAP", "1")
+
+    if on_os_ubuntucore():
+        set_if_not_none("CHECKBOX_OS_IS_UBUNTUCORE", "1")
+
     # Inject additional variables that are requested in the config
     if environ is not None:
         for env_var in environ:

--- a/checkbox-ng/plainbox/impl/unit/test_unit.py
+++ b/checkbox-ng/plainbox/impl/unit/test_unit.py
@@ -27,7 +27,12 @@ import textwrap
 from unittest import TestCase, mock
 
 from plainbox.abc import IProvider1
-from plainbox.impl.unit.unit import Unit, MissingParam, get_snap_base
+from plainbox.impl.unit.unit import (
+    Unit,
+    MissingParam,
+    get_snap_base,
+    on_os_ubuntucore,
+)
 from plainbox.impl.validation import Problem, Severity
 
 
@@ -470,3 +475,35 @@ class GetSnapBaseTests(TestCase):
         get_snap_base.cache_clear()
         with self.assertRaises(ValueError):
             get_snap_base()
+
+
+class OnOSUbuntuCore(TestCase):
+    @mock.patch(
+        "plainbox.impl.unit.unit.Path.read_text",
+        return_value='NAME="Ubuntu Core"\nVERSION="20"',
+    )
+    def test_on_uc_strict_snap(self, _):
+        on_os_ubuntucore.cache_clear()
+
+        self.assertTrue(on_os_ubuntucore())
+
+    @mock.patch(
+        "plainbox.impl.unit.unit.Path.read_text",
+        side_effect=[
+            FileNotFoundError(),
+            'NAME="Ubuntu Core"',
+        ],
+    )
+    def test_on_uc_source(self, _):
+        on_os_ubuntucore.cache_clear()
+
+        self.assertTrue(on_os_ubuntucore())
+
+    @mock.patch(
+        "plainbox.impl.unit.unit.Path.read_text",
+        side_effect=[FileNotFoundError(), 'NAME="Ubuntu"'],
+    )
+    def test_not_on_uc(self, _):
+        on_os_ubuntucore.cache_clear()
+
+        self.assertFalse(on_os_ubuntucore())

--- a/checkbox-ng/plainbox/impl/unit/unit.py
+++ b/checkbox-ng/plainbox/impl/unit/unit.py
@@ -57,13 +57,13 @@ logger = logging.getLogger("plainbox.unit")
 @lru_cache(maxsize=None)
 def on_ubuntucore():
     """
-    Check if the running from a strict snap
+    Returns `True` when running in a strict snap
     """
     snap = os.getenv("SNAP")
     if snap:
         with open(os.path.join(snap, "meta/snap.yaml")) as f:
-            for l in f.readlines():
-                if l == "confinement: classic\n":
+            for line in f.readlines():
+                if line == "confinement: classic\n":
                     return False
         return True
     return False
@@ -72,7 +72,7 @@ def on_ubuntucore():
 @lru_cache(maxsize=None)
 def on_os_ubuntucore() -> bool:
     """
-    This returns `True` if the host OS is Ubuntu Core
+    Returns `True` if the host OS is Ubuntu Core
     """
     with suppress(FileNotFoundError):
         # if this path exists, we are in a strict snap, but we may not be on UC

--- a/checkbox-ng/plainbox/impl/unit/unit.py
+++ b/checkbox-ng/plainbox/impl/unit/unit.py
@@ -29,28 +29,24 @@ import json
 import logging
 import os
 import string
-from pathlib import Path
+from contextlib import suppress
 from functools import lru_cache
+from pathlib import Path
 
 from jinja2 import Template
 
 from plainbox.i18n import gettext as _
-from plainbox.impl.decorators import cached_property
-from plainbox.impl.decorators import instance_method_lru_cache
+from plainbox.impl.decorators import cached_property, instance_method_lru_cache
 from plainbox.impl.secure.origin import Origin
 from plainbox.impl.secure.rfc822 import normalize_rfc822_value
-from plainbox.impl.symbol import Symbol
-from plainbox.impl.symbol import SymbolDef
-from plainbox.impl.symbol import SymbolDefMeta
-from plainbox.impl.symbol import SymbolDefNs
-from plainbox.impl.unit import concrete_validators
-from plainbox.impl.unit import get_accessed_parameters
-from plainbox.impl.unit.validators import IFieldValidator
-from plainbox.impl.unit.validators import MultiUnitFieldIssue
-from plainbox.impl.unit.validators import PresentFieldValidator
-from plainbox.impl.unit.validators import UnitFieldIssue
-from plainbox.impl.validation import Problem
-from plainbox.impl.validation import Severity
+from plainbox.impl.symbol import Symbol, SymbolDef, SymbolDefMeta, SymbolDefNs
+from plainbox.impl.unit import concrete_validators, get_accessed_parameters
+from plainbox.impl.unit.validators import (
+    MultiUnitFieldIssue,
+    PresentFieldValidator,
+    UnitFieldIssue,
+)
+from plainbox.impl.validation import Problem, Severity
 
 __all__ = ["Unit", "UnitValidator"]
 
@@ -61,7 +57,7 @@ logger = logging.getLogger("plainbox.unit")
 @lru_cache(maxsize=None)
 def on_ubuntucore():
     """
-    Check if running from on ubuntu core
+    Check if the running from a strict snap
     """
     snap = os.getenv("SNAP")
     if snap:
@@ -71,6 +67,20 @@ def on_ubuntucore():
                     return False
         return True
     return False
+
+
+@lru_cache(maxsize=None)
+def on_os_ubuntucore() -> bool:
+    """
+    This returns `True` if the host OS is Ubuntu Core
+    """
+    with suppress(FileNotFoundError):
+        # if this path exists, we are in a strict snap, but we may not be on UC
+        return (
+            'NAME="Ubuntu Core"'
+            in Path("/var/lib/snapd/hostfs/etc/os-release").read_text()
+        )
+    return 'NAME="Ubuntu Core"' in Path("/etc/os-release").read_text()
 
 
 @lru_cache(maxsize=None)

--- a/providers/base/units/disk/encryption.pxu
+++ b/providers/base/units/disk/encryption.pxu
@@ -1,7 +1,6 @@
 id: disk/encryption/detect
 category_id: com.canonical.plainbox::disk
 plugin: shell
-template-engine: jinja2
 user: root
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -14,11 +13,11 @@ _purpose:
   Examine the system to detect if one of the standard full disk encryption
   implementations is in use
 command:
-  {%- if __on_ubuntucore__ %}
+  if [ "$CHECKBOX_RUNNING_STRICT_SNAP" = "1" ]; then
   fde_tests.py
-  {%- else %}
+  else
   fde_tests.py desktop
-  {% endif -%}
+  fi
 estimated_duration: 2.0
 
 id: disk/encryption/check-fde-tpm

--- a/providers/base/units/info/jobs.pxu
+++ b/providers/base/units/info/jobs.pxu
@@ -376,12 +376,11 @@ _summary: Attaches info about disk partitions
 plugin: attachment
 category_id: com.canonical.plainbox::info
 id: info/buildstamp
-template-engine: jinja2
 estimated_duration: 0.1
 _description: Attaches the buildstamp identifier for the OS
 _summary: Attaches the buildstamp identifier for the OS
 command:
-    {%- if __on_ubuntucore__ %}
+    if [ "$CHECKBOX_RUNNING_STRICT_SNAP" = "1" ]; then
         if [ -s /run/mnt/ubuntu-seed/.disk/info ]; then
             cat /run/mnt/ubuntu-seed/.disk/info
         elif [ -s /writable/system-data/etc/buildstamp ]; then
@@ -391,7 +390,7 @@ command:
         else
             exit 1
         fi
-    {% else -%}
+    else
         if [ -s /var/lib/ubuntu_dist_channel ]; then  # PC projects
             cat /var/lib/ubuntu_dist_channel
         elif [ -s /var/log/installer/media-info ]; then  # Stock installer info
@@ -403,7 +402,7 @@ command:
         else
             exit 1
         fi
-    {% endif -%}
+    fi
 
 plugin: shell
 category_id: com.canonical.plainbox::info

--- a/providers/base/units/oob-management/jobs.pxu
+++ b/providers/base/units/oob-management/jobs.pxu
@@ -112,12 +112,12 @@ requires:
   package.name == 'lms'
   {% endif -%}
 command:
-  {%- if __on_ubuntucore__ %}
-  {# TODO: name is a guess until snap provided #}
+  if [ "$CHECKBOX_RUNNING_STRICT_SNAP" = "1" ]; then
+  # TODO: name is a guess until snap provided
   SERVICE_NAME="snap.lms.lms.service"
-  {%- else %}
+  else
   SERVICE_NAME="lms.service"
-  {% endif -%}
+  fi
   systemctl is-active --quiet "$SERVICE_NAME"
   RETVAL=$?
   if [ $RETVAL -ne 0 ]; then

--- a/providers/base/units/submission/jobs.pxu
+++ b/providers/base/units/submission/jobs.pxu
@@ -1,14 +1,13 @@
 id: dkms_info_json
-template-engine: jinja2
 plugin: attachment
 category_id: com.canonical.plainbox::info
 command:
- {%- if __on_ubuntucore__ %}
+ if [ "$CHECKBOX_RUNNING_STRICT_SNAP" = "1" ]; then
  echo "{}"
- {%- else %}
+ else
  dkms_info.py  --format json | checkbox-support-parse dkms-info | \
  jq '.dkms_info'
- {% endif -%}
+ fi
 _description: Attaches json dumps of installed dkms package information.
 _summary: Attaches json dumps of installed dkms package information.
 

--- a/providers/resource/jobs/resource.pxu
+++ b/providers/resource/jobs/resource.pxu
@@ -232,7 +232,7 @@ command:
  for version in 2 3; do
      echo -n "usb$version: "
      if [ "$CHECKBOX_RUNNING_STRICT_SNAP" = "1" ]; then
-         checkbox-support-lsusb -f $SNAP/checkbox-runtime/var/lib/usbutils/usb.ids | grep -Pq "Linux Foundation ${version}.\d+ root hub" && echo "supported" || echo "unsupported"
+         checkbox-support-lsusb -f "$SNAP"/checkbox-runtime/var/lib/usbutils/usb.ids | grep -Pq "Linux Foundation ${version}.\d+ root hub" && echo "supported" || echo "unsupported"
      else
          lsusb | grep -q "Linux Foundation ${version}.0 root hub" && echo "supported" || echo "unsupported"
      fi

--- a/providers/resource/jobs/resource.pxu
+++ b/providers/resource/jobs/resource.pxu
@@ -223,7 +223,6 @@ command: block_device_resource.py
 _summary: Create resource info for removable block devices
 
 id: usb
-template-engine: jinja2
 estimated_duration: 0.33
 plugin: resource
 category_id: information_gathering
@@ -232,11 +231,11 @@ _summary: Collect information about supported types of USB
 command:
  for version in 2 3; do
      echo -n "usb$version: "
- {%- if __on_ubuntucore__ %}
-     checkbox-support-lsusb -f $SNAP/checkbox-runtime/var/lib/usbutils/usb.ids | grep -Pq "Linux Foundation ${version}.\d+ root hub" && echo "supported" || echo "unsupported"
- {% else %}
-     lsusb | grep -q "Linux Foundation ${version}.0 root hub" && echo "supported" || echo "unsupported"
- {% endif -%}
+     if [ "$CHECKBOX_RUNNING_STRICT_SNAP" = "1" ]; then
+         checkbox-support-lsusb -f $SNAP/checkbox-runtime/var/lib/usbutils/usb.ids | grep -Pq "Linux Foundation ${version}.\d+ root hub" && echo "supported" || echo "unsupported"
+     else
+         lsusb | grep -q "Linux Foundation ${version}.0 root hub" && echo "supported" || echo "unsupported"
+     fi
  done
 
 id: xinput


### PR DESCRIPTION
## WARNING: This modifies com.canonical.certification::sru-server
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

Jinja conditionals in commands introduce an unnecessary level of dinamicity to the units for no clear upside. The reason it was used seems for the most part to call a different script when running in a strict snap or not. 

This PR introduces an alternative: 2 environment variables, one that tells the job if it is running in a strict snap (which is what the macro `__on_ubuntucore__` did actually mean) and one that tells the job if it is running on ubuntu core (which we didn't have before but may be useful)

This PR also uses the first envvar to remove all ifs from all the command sections in the repo.

## Resolved issues

Fixes: CHECKBOX-1389

## Documentation

N/A

## Tests

Tested patching the snap and running this job on ubuntu core
```
id: test_out_new_if
plugin: resource
category_id: information_gathering
_summary: test new if thing
command:
  if [ "$CHECKBOX_RUNNING_STRICT_SNAP" = "1" ]; then
    echo "I'm in a strict snap"
  else
    echo "I'm not in a strict snap"
  fi
```
Result:
```
ubuntu@ubuntu-core-24:~$ checkbox24.checkbox run test_out_new_if
===========================[ Running Selected Jobs ]============================
=========[ Running job 1 / 1. Estimated time left (at least): 0:00:00 ]=========
------[ Check whether a desktop session is available and of which type. ]-------
ID: com.canonical.certification::test_out_new_if
Category: com.canonical.certification::information_gathering
... 8< -------------------------------------------------------------------------
I'm in a strict snap
------------------------------------------------------------------------- >8 ---
Outcome: job passed
local script com.canonical.certification::test_out_new_if returned invalid RFC822 data: Unexpected non-empty line: "I'm in a strict snap\n" (line 1)
Finalizing session that hasn't been submitted anywhere: checkbox-run-2026-03-24T15.12.09
==================================[ Results ]===================================
 ☑ : Check whether a desktop session is available and of which type.
```

This is outside:
```
(venv)  checkbox-ng>  checkbox-cli run test_out_new_if
$PROVIDERPATH is defined, so following provider sources are ignored ['/usr/local/share/plainbox-providers-1', '/usr/share/plainbox-providers-1', '/home/h25/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
===========================[ Running Selected Jobs ]============================
=========[ Running job 1 / 1. Estimated time left (at least): 0:00:00 ]=========
-----------------------------[ test new if thing ]------------------------------
ID: com.canonical.certification::test_out_new_if
Category: com.canonical.certification::information_gathering
... 8< -------------------------------------------------------------------------
I'm not in a strict snap
------------------------------------------------------------------------- >8 ---
Outcome: job passed
local script com.canonical.certification::test_out_new_if returned invalid RFC822 data: Unexpected non-empty line: "I'm not in a strict snap\n" (line 1)
Finalizing session that hasn't been submitted anywhere: checkbox-run-2026-03-24T15.13.38
==================================[ Results ]===================================
 ☑ : test new if thing
```
