### PR TITLE
Add bios mode to submission json (new)

### DIFF
--- a/checkbox-ng/checkbox_ng/support/device_info.py
+++ b/checkbox-ng/checkbox_ng/support/device_info.py
@@ -45,6 +45,9 @@ def get_bios_info() -> dict:
 
     This function extracts the content from these files and returns a dict,
     using the filename as a key, defaulting to `None` if it cannot find data.
+
+    In addition, it provides the boot mode by checking the existence of the
+    /sys/firmware/efi directory.
     """
     bios_data = {
         "date": None,
@@ -65,6 +68,11 @@ def get_bios_info() -> dict:
                 "Failed to read bios {}. Error: {}".format(key, e),
                 file=sys.stderr,
             )
+    if Path("/sys/firmware/efi").is_dir():
+        boot_mode = "UEFI"
+    else:
+        boot_mode = "BIOS"
+    bios_data["boot_mode"] = boot_mode
     return bios_data
 
 

--- a/checkbox-ng/checkbox_ng/support/tests/test_device_info.py
+++ b/checkbox-ng/checkbox_ng/support/tests/test_device_info.py
@@ -30,7 +30,8 @@ class TestDeviceInfoCLI(TestCase):
         self.assertEqual(pkg[0]["version"], "23.01+dfsg-11")
         self.assertEqual(pkg[0]["architecture"], "amd64")
 
-    def test_get_bios_info_success(self):
+    @patch("checkbox_ng.support.device_info.Path.is_dir", return_value=True)
+    def test_get_bios_info_success(self, mock_path_is_dir):
         """Test successful retrieval of multiple BIOS files."""
 
         file_contents = [
@@ -48,9 +49,11 @@ class TestDeviceInfoCLI(TestCase):
 
             self.assertEqual(result["vendor"], "Dell Inc.")
             self.assertEqual(result["version"], "1.5.0")
-            self.assertEqual(len(result), 4)
+            self.assertEqual(result["boot_mode"], "UEFI")
+            self.assertEqual(len(result), 5)
 
-    def test_get_bios_info_empty(self):
+    @patch("checkbox_ng.support.device_info.Path.is_dir", return_value=False)
+    def test_get_bios_info_empty(self, mock_path_is_dir):
         """Test behavior when no bios_* files are found."""
         with patch(
             "checkbox_ng.support.device_info.Path.read_text",
@@ -60,10 +63,17 @@ class TestDeviceInfoCLI(TestCase):
 
         self.assertEqual(
             result,
-            {"date": None, "release": None, "vendor": None, "version": None},
+            {
+                "date": None,
+                "release": None,
+                "vendor": None,
+                "version": None,
+                "boot_mode": "BIOS",
+            },
         )
 
-    def test_get_bios_info_permission_denied(self):
+    @patch("checkbox_ng.support.device_info.Path.is_dir", return_value=True)
+    def test_get_bios_info_permission_denied(self, mock_path_is_dir):
         """Test behavior when a file exists but cannot be read."""
         with patch(
             "checkbox_ng.support.device_info.Path.read_text",
@@ -73,7 +83,13 @@ class TestDeviceInfoCLI(TestCase):
 
         self.assertEqual(
             result,
-            {"date": None, "release": None, "vendor": None, "version": None},
+            {
+                "date": None,
+                "release": None,
+                "vendor": None,
+                "version": None,
+                "boot_mode": "UEFI",
+            },
         )
 
     @patch("checkbox_ng.support.device_info.get_debian_packages")


### PR DESCRIPTION


## Description

After discussing with @pedro-avalos, add the boot mode, which was part of the previous BIOS metadata provided by the `raw_device_dmi_json` job.

Instead of relying on INXI, the mechanism to determine whether we booted using UEFI or BIOS is just to check the existence of the `/sys/firmware/efi` directory.

## Resolved issues

Fix https://warthogs.atlassian.net/browse/CHECKBOX-2191

## Tests

- Unit tests updated
- Ran in a UC24 VM, get the following `bios` section in `submission.json`:

```json
    "bios": {
        "tool_version": "7.1.0.dev67",
        "success": true,
        "outputs": {
            "payload": {
                "boot_mode": "UEFI",
                "date": "08/13/2024",
                "release": "0.0",
                "vendor": "EDK II",
                "version": "edk2-stable202408-prebuilt.qemu.org"
            },
            "stderr": ""
        }
```