### PR TITLE
Add custom-frontend slot to checkbox-ce-oem (New)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic24/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic24/snap/snapcraft.yaml
@@ -4,9 +4,16 @@ description: "Checkbox CE OEM test runner and public providers for 24.04 classic
 confinement: classic
 grade: stable
 
-version: '1.0-noble'
+version: '1.1-noble'
 
 base: core24
+
+slots:
+  custom-frontend:
+    interface: content
+    content: custom-frontend
+    read:
+      - /
 
 apps:
   checkbox-cli:


### PR DESCRIPTION
## Description

With this, the runtime will be able to see `checkbox-ce-oem` provider test plans after connecting to it.
This essentially adds a slot similarly to what is done in `checkbox-core-snap`. This allows the snap to be used alongside other snaps using the custom-frontend interface.

## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/OEIOT-731

## Documentation

## Tests

After installing the snap and connecting it to `checkbox24`, I can run a test from the provider.

```bash
snap install checkbox-ce-oem --classic
snap install checkbox24 --devmode
snap connect checkbox24:custom-frontend checkbox-ce-oem
checkbox24.checkbox run com.canonical.contrib::ce-oem-cpu/cpufreq_driver_detect
```