### PR TITLE
Add logic handle codec type for h264 265 (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_encoder_psnr.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_encoder_psnr.py
@@ -584,7 +584,8 @@ class RenesasProject(PipelineInterface):
         # Renesas RZ series support h264 and h265 as hardware decoder
         # And some platform support both decoder.
         # We make a simple logic to choose the decoder and build the pipeline,
-        # If the decoder is omxh265dec, we use h265parse, else we use h264parse.
+        # If the decoder is omxh265dec, we use h265parse, else we use
+        # h264parse.
 
         if "omxh264enc" in self._codec or "omxh265enc" in self._codec:
             return self._264_265_pipeline_builder()

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_encoder_psnr.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_encoder_psnr.py
@@ -531,6 +531,10 @@ class RenesasProject(PipelineInterface):
         self._framerate = framerate
         self._artifact_file = ""
         self._golden_sample = ""
+        self._codec_parser_map = {
+            GStreamerEncodePlugins.OMXH264ENC.value: "h264parse",
+            GStreamerEncodePlugins.OMXH265ENC.value: "h265parse",
+        }
 
     @property
     def artifact_file(self) -> str:
@@ -542,25 +546,29 @@ class RenesasProject(PipelineInterface):
     def psnr_reference_file(self) -> str:
         return self._golden_sample
 
-    def _omxh264_pipeline_builder(self) -> str:
+    def _264_265_pipeline_builder(self) -> str:
         """
         Build gstreamer pipeline for omxh264enc
         """
+        encode_parser = self._codec_parser_map.get(self._codec)
+
         self._golden_sample = os.path.join(
             VIDEO_CODEC_TESTING_DATA,
             "{}p_{}fps_h264.mp4".format(self._height, self._framerate),
         )
         pipeline = (
-            "{} filesrc location={} ! qtdemux ! h264parse !"
+            "{} filesrc location={} ! qtdemux ! {} !"
             " omxh264dec use-dmabuf=false !"
             " video/x-raw,format={} ! {} use-dmabuf=true"
             " target-bitrate=10485760 !"
-            " h264parse ! mp4mux ! filesink location={}"
+            " {} ! mp4mux ! filesink location={}"
         ).format(
             GST_LAUNCH_BIN,
             self._golden_sample,
+            encode_parser,
             self._color_space,
             self._codec,
+            encode_parser,
             self.artifact_file,
         )
 
@@ -573,10 +581,13 @@ class RenesasProject(PipelineInterface):
         Returns:
             str: A GStreamer command.
         """
-        # RZG2 series support only omxh264enc as hardware encoder
-        # And only RZG2L supported.
-        if "rzg2l" in self._platform and self._codec == "omxh264enc":
-            return self._omxh264_pipeline_builder()
+        # Renesas RZ series support h264 and h265 as hardware decoder
+        # And some platform support both decoder.
+        # We make a simple logic to choose the decoder and build the pipeline,
+        # If the decoder is omxh265dec, we use h265parse, else we use h264parse.
+
+        if "omxh264enc" in self._codec or "omxh265enc" in self._codec:
+            return self._264_265_pipeline_builder()
         else:
             raise SystemExit(
                 "Error: unknow encoder '{}' be used".format(self._codec)

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_encoder_psnr.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_encoder_psnr.py
@@ -29,6 +29,7 @@ from gst_utils import (
     PipelineInterface,
     GStreamerMuxerType,
     GStreamerEncodePlugins,
+    GStreamerDecodePlugins,
     MetadataValidator,
     get_big_bug_bunny_golden_sample,
     generate_artifact_name,
@@ -557,9 +558,9 @@ class RenesasProject(PipelineInterface):
             "{}p_{}fps_h264.mp4".format(self._height, self._framerate),
         )
         if "h264" in self._codec:
-            decoder = "omxh264dec"
+            decoder = GStreamerDecodePlugins.OMXH264DEC.value
         elif "h265" in self._codec:
-            decoder = "omxh265dec"
+            decoder = GStreamerDecodePlugins.OMXH265DEC.value
         pipeline = (
             "{} filesrc location={} ! qtdemux ! {} !"
             " {} use-dmabuf=false !"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_encoder_psnr.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_encoder_psnr.py
@@ -552,13 +552,18 @@ class RenesasProject(PipelineInterface):
         """
         encode_parser = self._codec_parser_map.get(self._codec)
 
+
         self._golden_sample = os.path.join(
             VIDEO_CODEC_TESTING_DATA,
             "{}p_{}fps_h264.mp4".format(self._height, self._framerate),
         )
+        if "h264" in self._codec:
+            decoder = "omxh264dec"
+        elif "h265" in self._codec:
+            decoder = "omxh265dec"
         pipeline = (
             "{} filesrc location={} ! qtdemux ! {} !"
-            " omxh264dec use-dmabuf=false !"
+            " {} use-dmabuf=false !"
             " video/x-raw,format={} ! {} use-dmabuf=true"
             " target-bitrate=10485760 !"
             " {} ! mp4mux ! filesink location={}"
@@ -566,6 +571,7 @@ class RenesasProject(PipelineInterface):
             GST_LAUNCH_BIN,
             self._golden_sample,
             encode_parser,
+            decoder,
             self._color_space,
             self._codec,
             encode_parser,
@@ -587,7 +593,10 @@ class RenesasProject(PipelineInterface):
         # If the decoder is omxh265dec, we use h265parse, else we use
         # h264parse.
 
-        if "omxh264enc" in self._codec or "omxh265enc" in self._codec:
+        if self._codec in (
+            GStreamerEncodePlugins.OMXH264ENC.value,
+            GStreamerEncodePlugins.OMXH265ENC.value,
+        ):
             return self._264_265_pipeline_builder()
         else:
             raise SystemExit(

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_encoder_psnr.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_encoder_psnr.py
@@ -552,7 +552,6 @@ class RenesasProject(PipelineInterface):
         """
         encode_parser = self._codec_parser_map.get(self._codec)
 
-
         self._golden_sample = os.path.join(
             VIDEO_CODEC_TESTING_DATA,
             "{}p_{}fps_h264.mp4".format(self._height, self._framerate),

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_utils.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_utils.py
@@ -32,7 +32,11 @@ class GStreamerEncodePlugins(Enum):
     V4L2JPEGENC = "v4l2jpegenc"
     V4L2VP8ENC = "v4l2vp8enc"
     OMXH264ENC = "omxh264enc"
+    OMXH265ENC = "omxh265enc"
 
+class GStreamerDecodePlugins(Enum):
+    OMXH264DEC = "omxh264dec"
+    OMXH265DEC = "omxh265dec"
 
 class GStreamerMuxerType(Enum):
     """

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_utils.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_utils.py
@@ -34,9 +34,11 @@ class GStreamerEncodePlugins(Enum):
     OMXH264ENC = "omxh264enc"
     OMXH265ENC = "omxh265enc"
 
+
 class GStreamerDecodePlugins(Enum):
     OMXH264DEC = "omxh264dec"
     OMXH265DEC = "omxh265dec"
+
 
 class GStreamerMuxerType(Enum):
     """

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_video_decoder_performance.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_video_decoder_performance.py
@@ -222,12 +222,18 @@ def build_renesas_gst_command(
     :returns:
         The GStreamer command to execute.
     """
-    # RZG2 series support only omxh264dec as hardware decoder
-    # And only RZG2L supported.
-    if "rzg2l" in platform:
-        part_pipeline = "qtdemux ! h264parse ! {} use-dmabuf=true".format(
-            decoder
-        )
+    # Renesas RZ series support h264 and h265 as hardware decoder
+    # And some platform support both decoder.
+    # We make a simple logic to choose the decoder and build the pipeline,
+    # If the decoder is omxh265dec, we use h265parse, else we use h264parse.
+
+    logging.info("Building pipeline for platform: %s", platform)
+
+    codec_type = "265" if "265" in decoder else "264"
+    part_pipeline = "qtdemux ! h{}parse ! {} use-dmabuf=true".format(
+        codec_type,
+        decoder
+    )
 
     cmd = (
         "{} -v filesrc location={} ! {} ! queue !"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_video_decoder_performance.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_video_decoder_performance.py
@@ -234,8 +234,7 @@ def build_renesas_gst_command(
 
     encode_parser = codec_parser_map.get(decoder)
     part_pipeline = "qtdemux ! {} ! {} use-dmabuf=true".format(
-        encode_parser,
-        decoder
+        encode_parser, decoder
     )
 
     cmd = (

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_video_decoder_performance.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_video_decoder_performance.py
@@ -23,7 +23,7 @@ import os
 import re
 
 from performance_mode_controller import get_performance_ctx_function
-from gst_utils import execute_command
+from gst_utils import execute_command, GStreamerDecodePlugins
 
 logging.basicConfig(level=logging.INFO)
 
@@ -226,12 +226,15 @@ def build_renesas_gst_command(
     # And some platform support both decoder.
     # We make a simple logic to choose the decoder and build the pipeline,
     # If the decoder is omxh265dec, we use h265parse, else we use h264parse.
-
+    codec_parser_map = {
+        GStreamerDecodePlugins.OMXH264DEC.value: "h264parse",
+        GStreamerDecodePlugins.OMXH265DEC.value: "h265parse",
+    }
     logging.info("Building pipeline for platform: %s", platform)
 
-    codec_type = "265" if "265" in decoder else "264"
-    part_pipeline = "qtdemux ! h{}parse ! {} use-dmabuf=true".format(
-        codec_type,
+    encode_parser = codec_parser_map.get(decoder)
+    part_pipeline = "qtdemux ! {} ! {} use-dmabuf=true".format(
+        encode_parser,
         decoder
     )
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/data/video-codec-test-confs/rzg3e.json
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/data/video-codec-test-confs/rzg3e.json
@@ -1,0 +1,36 @@
+{
+  "gst_video_decoder_performance_fakesink": [
+    {
+      "decoder_plugin": "omxh264dec",
+      "golden_sample_file": "1080p_30fps_h264.mp4",
+      "minimum_fps": 30,
+      "enable_performance_mode": false
+    },
+    {
+      "decoder_plugin": "omxh265dec",
+      "golden_sample_file": "1080p_30fps_h265.mp4",
+      "minimum_fps": 30,
+      "enable_performance_mode": false
+    }
+  ],
+  "gst_encoder_psnr": [
+    {
+      "encoder_plugin": "omxh264enc",
+      "resolutions": [
+        { "width": 1920, "height": 1080, "fps": 30 }
+      ],
+      "color_spaces": [
+        "NV12"
+      ]
+    },
+    {
+      "encoder_plugin": "omxh265enc",
+      "resolutions": [
+        { "width": 1920, "height": 1080, "fps": 30 }
+      ],
+      "color_spaces": [
+        "NV12"
+      ]
+    }
+  ]
+}

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/data/video-codec-test-confs/rzv2l.json
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/data/video-codec-test-confs/rzv2l.json
@@ -1,0 +1,21 @@
+{
+  "gst_video_decoder_performance_fakesink": [
+    {
+      "decoder_plugin": "omxh264dec",
+      "golden_sample_file": "1080p_30fps_h264.mp4",
+      "minimum_fps": 30,
+      "enable_performance_mode": false
+    }
+  ],
+  "gst_encoder_psnr": [
+    {
+      "encoder_plugin": "omxh264enc",
+      "resolutions": [
+        { "width": 1920, "height": 1080, "fps": 30 }
+      ],
+      "color_spaces": [
+        "NV12"
+      ]
+    }
+  ]
+}

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/video-codec/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/video-codec/jobs.pxu
@@ -183,13 +183,12 @@ template-engine: jinja2
 template-resource: video_codec_resource
 template-filter:
     video_codec_resource.scenario == "gst_encoder_psnr"
-    video_codec_resource.platform == "rzg2l"
 template-unit: job
 template-id: ce-oem-video-codec/renesas-gst_encoder_psnr
-_template-summary: Verify the PSNR ratio for specific encoder on Renesas RZG2L platform
+_template-summary: Verify the PSNR ratio for specific encoder on Renesas platform
 id: ce-oem-video-codec/renesas-{{ scenario }}-{{ encoder_plugin }}-{{ width }}x{{ height }}@{{ framerate }}fps-{{ color_space }}
-_summary: Encoder PSNR - RZG2L - {{ encoder_plugin }}-{{ width }}x{{ height }}@{{ framerate }}fps-{{ color_space }}
-_description: Test if the PSNR value of an artifact which is generated from {{ encoder_plugin }} encoder reaches the acceptable threshold on Renesas RZG2L platform
+_summary: Encoder PSNR - Renesas - {{ encoder_plugin }}-{{ width }}x{{ height }}@{{ framerate }}fps-{{ color_space }}
+_description: Test if the PSNR value of an artifact which is generated from {{ encoder_plugin }} encoder reaches the acceptable threshold on Renesas platform
 plugin: shell
 user: root
 category_id: video-codec


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
We add logic to handle different decoder accrossing renesas platforms.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
```
========[ Bootstrap com.canonical.contrib::video_codec_resource (1/1) ]=========
--------------------------------------------------------------------------------
Outcome: job passed
-----------------------------[ Running job 1 / 2 ]------------------------------
-------------[ Performance test of decoder omxh264dec - fakesink ]--------------
ID: com.canonical.contrib::ce-oem-video-codec/gst_video_decoder_performance_fakesink-omxh264dec
Category: Video Codec tests
--------------------------------------------------------------------------------
INFO:root:Pass Criteria 
 1. All dropped frames must be 0
 2. All average fps values must greater than or equal to 30
INFO:root:Building pipeline for platform: rzv2l
INFO:root:User defined LD_LIBRARY_PATH: /lib/aarch64-linux-gnu/
INFO:root:User defined LD_PLUGIN_PATH: /usr/lib/aarch64-linux-gnu/gstreamer-1.0/
INFO:root:Append /lib/aarch64-linux-gnu/ to LD_LIBRARY_PATH for GStreamer
INFO:root:Append /usr/lib/aarch64-linux-gnu/gstreamer-1.0/ to GST_PLUGIN_PATH for GStreamer
INFO:root:Starting command: '/usr/bin/gst-launch-1.0 -v filesrc location=/home/ubuntu/video/1080p_30fps_h264.mp4 ! qtdemux ! h264parse ! omxh264dec use-dmabuf=true ! queue ! vspmfilter dmabuf-use=true ! queue ! fpsdisplaysink video-sink='fakesink' text-overlay=false sync=true'
INFO:root:Setting pipeline to PAUSED ...
Pipeline is PREROLLING ...
/GstPipeline:pipeline0/GstFPSDisplaySink:fpsdisplaysink0/GstFakeSink:fakesink0: sync = true
/GstPipeline:pipeline0/GstH264Parse:h264parse0.GstPad:sink: caps = video/x-h264, stream-format=(string)avc, alignment=(string)au, level=(string)4, profile=(string)high, codec_data=(buffer)01640028ffe1001b67640028acd940780227e5c044000003000400000300f03c60c65801000668ebe24b22c0fdf8f800, width=(int)1920, height=(int)1080, framerate=(fraction)30/1, pixel-aspect-ratio=(fraction)1/1
Redistribute latency...
/GstPipeline:pipeline0/GstH264Parse:h264parse0.GstPad:src: caps = video/x-h264, stream-format=(string)byte-stream, alignment=(string)au, level=(string)4, profile=(string)high, width=(int)1920, height=(int)1080, framerate=(fraction)30/1, pixel-aspect-ratio=(fraction)1/1, coded-picture-structure=(string)frame, chroma-format=(string)4:2:0, bit-depth-luma=(uint)8, bit-depth-chroma=(uint)8, parsed=(boolean)true
/GstPipeline:pipeline0/GstOMXH264Dec-omxh264dec:omxh264dec-omxh264dec0.GstPad:sink: caps = video/x-h264, stream-format=(string)byte-stream, alignment=(string)au, level=(string)4, profile=(string)high, width=(int)1920, height=(int)1080, framerate=(fraction)30/1, pixel-aspect-ratio=(fraction)1/1, coded-picture-structure=(string)frame, chroma-format=(string)4:2:0, bit-depth-luma=(uint)8, bit-depth-chroma=(uint)8, parsed=(boolean)true
/GstPipeline:pipeline0/GstOMXH264Dec-omxh264dec:omxh264dec-omxh264dec0.GstPad:src: caps = video/x-raw, format=(string)NV12, width=(int)1920, height=(int)1080, interlace-mode=(string)progressive, multiview-mode=(string)mono, multiview-flags=(GstVideoMultiviewFlagsSet)0:ffffffff:/right-view-first/left-flipped/left-flopped/right-flipped/right-flopped/half-aspect/mixed-mono, pixel-aspect-ratio=(fraction)1/1, framerate=(fraction)30/1
/GstPipeline:pipeline0/GstQueue:queue0.GstPad:sink: caps = video/x-raw, format=(string)NV12, width=(int)1920, height=(int)1080, interlace-mode=(string)progressive, multiview-mode=(string)mono, multiview-flags=(GstVideoMultiviewFlagsSet)0:ffffffff:/right-view-first/left-flipped/left-flopped/right-flipped/right-flopped/half-aspect/mixed-mono, pixel-aspect-ratio=(fraction)1/1, framerate=(fraction)30/1
/GstPipeline:pipeline0/GstQueue:queue0.GstPad:src: caps = video/x-raw, format=(string)NV12, width=(int)1920, height=(int)1080, interlace-mode=(string)progressive, multiview-mode=(string)mono, multiview-flags=(GstVideoMultiviewFlagsSet)0:ffffffff:/right-view-first/left-flipped/left-flopped/right-flipped/right-flopped/half-aspect/mixed-mono, pixel-aspect-ratio=(fraction)1/1, framerate=(fraction)30/1
/GstPipeline:pipeline0/GstVspmFilter:vspmfilter0.GstPad:src: caps = video/x-raw, format=(string)NV12, width=(int)1920, height=(int)1080, interlace-mode=(string)progressive, multiview-mode=(string)mono, multiview-flags=(GstVideoMultiviewFlagsSet)0:ffffffff:/right-view-first/left-flipped/left-flopped/right-flipped/right-flopped/half-aspect/mixed-mono, pixel-aspect-ratio=(fraction)1/1, framerate=(fraction)30/1
/GstPipeline:pipeline0/GstQueue:queue1.GstPad:sink: caps = video/x-raw, format=(string)NV12, width=(int)1920, height=(int)1080, interlace-mode=(string)progressive, multiview-mode=(string)mono, multiview-flags=(GstVideoMultiviewFlagsSet)0:ffffffff:/right-view-first/left-flipped/left-flopped/right-flipped/right-flopped/half-aspect/mixed-mono, pixel-aspect-ratio=(fraction)1/1, framerate=(fraction)30/1
/GstPipeline:pipeline0/GstVspmFilter:vspmfilter0.GstPad:sink: caps = video/x-raw, format=(string)NV12, width=(int)1920, height=(int)1080, interlace-mode=(string)progressive, multiview-mode=(string)mono, multiview-flags=(GstVideoMultiviewFlagsSet)0:ffffffff:/right-view-first/left-flipped/left-flopped/right-flipped/right-flopped/half-aspect/mixed-mono, pixel-aspect-ratio=(fraction)1/1, framerate=(fraction)30/1
/GstPipeline:pipeline0/GstQueue:queue1.GstPad:src: caps = video/x-raw, format=(string)NV12, width=(int)1920, height=(int)1080, interlace-mode=(string)progressive, multiview-mode=(string)mono, multiview-flags=(GstVideoMultiviewFlagsSet)0:ffffffff:/right-view-first/left-flipped/left-flopped/right-flipped/right-flopped/half-aspect/mixed-mono, pixel-aspect-ratio=(fraction)1/1, framerate=(fraction)30/1
/GstPipeline:pipeline0/GstFPSDisplaySink:fpsdisplaysink0.GstGhostPad:sink.GstProxyPad:proxypad0: caps = video/x-raw, format=(string)NV12, width=(int)1920, height=(int)1080, interlace-mode=(string)progressive, multiview-mode=(string)mono, multiview-flags=(GstVideoMultiviewFlagsSet)0:ffffffff:/right-view-first/left-flipped/left-flopped/right-flipped/right-flopped/half-aspect/mixed-mono, pixel-aspect-ratio=(fraction)1/1, framerate=(fraction)30/1
/GstPipeline:pipeline0/GstFPSDisplaySink:fpsdisplaysink0/GstFakeSink:fakesink0.GstPad:sink: caps = video/x-raw, format=(string)NV12, width=(int)1920, height=(int)1080, interlace-mode=(string)progressive, multiview-mode=(string)mono, multiview-flags=(GstVideoMultiviewFlagsSet)0:ffffffff:/right-view-first/left-flipped/left-flopped/right-flipped/right-flopped/half-aspect/mixed-mono, pixel-aspect-ratio=(fraction)1/1, framerate=(fraction)30/1
/GstPipeline:pipeline0/GstFPSDisplaySink:fpsdisplaysink0.GstGhostPad:sink: caps = video/x-raw, format=(string)NV12, width=(int)1920, height=(int)1080, interlace-mode=(string)progressive, multiview-mode=(string)mono, multiview-flags=(GstVideoMultiviewFlagsSet)0:ffffffff:/right-view-first/left-flipped/left-flopped/right-flipped/right-flopped/half-aspect/mixed-mono, pixel-aspect-ratio=(fraction)1/1, framerate=(fraction)30/1
Pipeline is PREROLLED ...
Setting pipeline to PLAYING ...
Redistribute latency...
New clock: GstSystemClock
/GstPipeline:pipeline0/GstFPSDisplaySink:fpsdisplaysink0/GstFakeSink:fakesink0: sync = true
/GstPipeline:pipeline0/GstFPSDisplaySink:fpsdisplaysink0: last-message = rendered: 17, dropped: 0, current: 33.85, average: 33.85
/GstPipeline:pipeline0/GstFPSDisplaySink:fpsdisplaysink0: last-message = rendered: 32, dropped: 0, current: 30.00, average: 31.93
/GstPipeline:pipeline0/GstFPSDisplaySink:fpsdisplaysink0: last-message = rendered: 48, dropped: 0, current: 30.00, average: 31.26
/GstPipeline:pipeline0/GstFPSDisplaySink:fpsdisplaysink0: last-message = rendered: 63, dropped: 0, current: 30.00, average: 30.95
/GstPipeline:pipeline0/GstFPSDisplaySink:fpsdisplaysink0: last-message = rendered: 78, dropped: 0, current: 30.00, average: 30.76
/GstPipeline:pipeline0/GstFPSDisplaySink:fpsdisplaysink0: last-message = rendered: 94, dropped: 0, current: 30.00, average: 30.63
/GstPipeline:pipeline0/GstFPSDisplaySink:fpsdisplaysink0: last-message = rendered: 110, dropped: 0, current: 30.00, average: 30.54
/GstPipeline:pipeline0/GstFPSDisplaySink:fpsdisplaysink0: last-message = rendered: 125, dropped: 0, current: 30.00, average: 30.47
/GstPipeline:pipeline0/GstFPSDisplaySink:fpsdisplaysink0: last-message = rendered: 141, dropped: 0, current: 30.02, average: 30.42
Got EOS from element "pipeline0".
Execution ended after 0:00:05.007801412
Setting pipeline to NULL ...
Freeing pipeline ...

INFO:root:Pass
--------------------------------------------------------------------------------
Outcome: job passed
-----------------------------[ Running job 2 / 2 ]------------------------------
-----------[ Encoder PSNR - RZG2L - omxh264enc-1920x1080@30fps-NV12 ]-----------
ID: com.canonical.contrib::ce-oem-video-codec/renesas-gst_encoder_psnr-omxh264enc-1920x1080@30fps-NV12
Category: Video Codec tests
--------------------------------------------------------------------------------
INFO:root:Step 1: Generating artifact...
INFO:root:User defined LD_LIBRARY_PATH: /lib/aarch64-linux-gnu/
INFO:root:User defined LD_PLUGIN_PATH: /usr/lib/aarch64-linux-gnu/gstreamer-1.0/
INFO:root:Append /lib/aarch64-linux-gnu/ to LD_LIBRARY_PATH for GStreamer
INFO:root:Append /usr/lib/aarch64-linux-gnu/gstreamer-1.0/ to GST_PLUGIN_PATH for GStreamer
INFO:root:Starting command: '/usr/bin/gst-launch-1.0 filesrc location=/home/ubuntu/video/1080p_30fps_h264.mp4 ! qtdemux ! h264parse ! omxh264dec use-dmabuf=false ! video/x-raw,format=NV12 ! omxh264enc use-dmabuf=true target-bitrate=10485760 ! h264parse ! mp4mux ! filesink location=/var/tmp/checkbox-ng/sessions/session_title-2026-03-26T02.49.32.session/session-share/de54b2.mp4'
INFO:root:Setting pipeline to PAUSED ...
Pipeline is PREROLLING ...
Redistribute latency...
Redistribute latency...
Pipeline is PREROLLED ...
Setting pipeline to PLAYING ...
Redistribute latency...
New clock: GstSystemClock
Got EOS from element "pipeline0".
Execution ended after 0:00:07.797873610
Setting pipeline to NULL ...
Freeing pipeline ...

INFO:root:
Step 2: Checking metadata...
INFO:root:User defined LD_LIBRARY_PATH: /lib/aarch64-linux-gnu/
INFO:root:User defined LD_PLUGIN_PATH: /usr/lib/aarch64-linux-gnu/gstreamer-1.0/
INFO:root:Append /lib/aarch64-linux-gnu/ to LD_LIBRARY_PATH for GStreamer
INFO:root:Append /usr/lib/aarch64-linux-gnu/gstreamer-1.0/ to GST_PLUGIN_PATH for GStreamer
INFO:root:Starting command: 'gst-discoverer-1.0 /var/tmp/checkbox-ng/sessions/session_title-2026-03-26T02.49.32.session/session-share/de54b2.mp4'
INFO:root:Analyzing file:///var/tmp/checkbox-ng/sessions/session_title-2026-03-26T02.49.32.session/session-share/de54b2.mp4
Done discovering file:///var/tmp/checkbox-ng/sessions/session_title-2026-03-26T02.49.32.session/session-share/de54b2.mp4

Properties:
  Duration: 0:00:05.000000000
  Seekable: yes
  Live: no
  container #0: Quicktime
    video #1: H.264 (Constrained Baseline Profile)
      Stream ID: 39567e07fe6fddf93071d94a3576520e5cb43bb24a92287c67d66ca6b9e408db/001
      Width: 1920
      Height: 1080
      Depth: 24
      Frame rate: 30/1
      Pixel aspect ratio: 1/1
      Interlaced: false
      Bitrate: 10601738
      Max bitrate: 35761920


INFO:root:
Step 3: Comparing PSNR...
INFO:root:Compare the PSNR: /home/ubuntu/video/1080p_30fps_h264.mp4 vs /var/tmp/checkbox-ng/sessions/session_title-2026-03-26T02.49.32.session/session-share/de54b2.mp4
INFO:root:Average PSNR: 46.119277836054664
INFO:root:Pass: Average PSNR meets the acceptable threshold
--------------------------------------------------------------------------------
Outcome: job passed

```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
