### PR TITLE
A dynamic ethernet resource script (Bugfix)

### DIFF
--- a/providers/base/bin/ethernet_dynamic_resource.py
+++ b/providers/base/bin/ethernet_dynamic_resource.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import os
+from typing import List
+
+
+def get_excluded_from_env(env_var: str) -> List[str]:
+    """Parses comma-separated strings from environment variables."""
+    val = os.environ.get(env_var, "")
+    return [item.strip() for item in val.split(",") if item.strip()]
+
+
+def is_real_hardware(iface_path: str) -> bool:
+    """
+    Checks if the interface is backed by physical hardware (PCI/USB/etc).
+    Virtual interfaces like lo, bridges, and veth lack the 'device' link.
+    """
+    device_path = os.path.join(iface_path, "device")
+    if not os.path.islink(device_path):
+        return False
+
+    # Filter out wireless interfaces
+    if os.path.exists(os.path.join(iface_path, "wireless")):
+        return False
+
+    # Ensure the subsystem is not 'virtual'
+    subsystem_path = os.path.join(device_path, "subsystem")
+    if os.path.islink(subsystem_path):
+        subsystem_name = os.path.basename(os.readlink(subsystem_path))
+        if subsystem_name == "virtual":
+            return False
+
+    return True
+
+
+def list_interfaces(
+    ignored_ifaces: List[str], ignored_macs: List[str]
+) -> None:
+    """
+    Scans /sys/class/net and filters by hardware subsystem and env vars.
+    """
+    base_path = "/sys/class/net/"
+    if not os.path.exists(base_path):
+        return
+
+    # Sort for deterministic output
+    for iface in sorted(os.listdir(base_path)):
+        iface_path = os.path.join(base_path, iface)
+
+        if not is_real_hardware(iface_path):
+            continue
+
+        if iface in ignored_ifaces:
+            continue
+
+        try:
+            with open(os.path.join(iface_path, "address"), "r") as f:
+                mac = f.read().strip()
+        except (OSError, IOError):
+            continue
+
+        if mac.lower() in ignored_macs:
+            continue
+
+        print("interface: {}".format(iface))
+        print("mac: {}".format(mac))
+        print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="List hardware Ethernet interfaces and MAC addresses."
+    )
+    parser.add_argument(
+        "--env-mac",
+        default="EXCLUDE_MACS",
+        help="Env var for MACs to filter (default: EXCLUDE_MACS)",
+    )
+    parser.add_argument(
+        "--env-iface",
+        default="EXCLUDE_INTERFACES",
+        help="Env var for interfaces to filter (default: EXCLUDE_INTERFACES)",
+    )
+
+    args = parser.parse_args()
+
+    ignored_macs = [m.lower() for m in get_excluded_from_env(args.env_mac)]
+    ignored_ifaces = get_excluded_from_env(args.env_iface)
+
+    list_interfaces(ignored_ifaces, ignored_macs)
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/base/tests/test_ethernet_dynamic_resource.py
+++ b/providers/base/tests/test_ethernet_dynamic_resource.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+from io import StringIO
+from unittest.mock import mock_open, patch
+
+import ethernet_dynamic_resource as edr
+
+
+class TestGetExcludedFromEnv(unittest.TestCase):
+    """Tests for get_excluded_from_env()"""
+
+    def test_empty_env_var_returns_empty_list(self):
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("EXCLUDE_MACS", None)
+            result = edr.get_excluded_from_env("EXCLUDE_MACS")
+        self.assertEqual(result, [])
+
+    def test_single_value(self):
+        with patch.dict(os.environ, {"EXCLUDE_MACS": "aa:bb:cc:dd:ee:ff"}):
+            result = edr.get_excluded_from_env("EXCLUDE_MACS")
+        self.assertEqual(result, ["aa:bb:cc:dd:ee:ff"])
+
+    def test_multiple_comma_separated_values(self):
+        with patch.dict(
+            os.environ, {"EXCLUDE_MACS": "aa:bb:cc:dd:ee:ff,11:22:33:44:55:66"}
+        ):
+            result = edr.get_excluded_from_env("EXCLUDE_MACS")
+        self.assertEqual(result, ["aa:bb:cc:dd:ee:ff", "11:22:33:44:55:66"])
+
+    def test_values_with_whitespace_are_stripped(self):
+        with patch.dict(
+            os.environ,
+            {"EXCLUDE_MACS": " aa:bb:cc:dd:ee:ff , 11:22:33:44:55:66 "},
+        ):
+            result = edr.get_excluded_from_env("EXCLUDE_MACS")
+        self.assertEqual(result, ["aa:bb:cc:dd:ee:ff", "11:22:33:44:55:66"])
+
+    def test_empty_entries_are_ignored(self):
+        with patch.dict(
+            os.environ,
+            {"EXCLUDE_MACS": "aa:bb:cc:dd:ee:ff,,11:22:33:44:55:66"},
+        ):
+            result = edr.get_excluded_from_env("EXCLUDE_MACS")
+        self.assertEqual(result, ["aa:bb:cc:dd:ee:ff", "11:22:33:44:55:66"])
+
+    def test_env_var_not_set_returns_empty_list(self):
+        env = {k: v for k, v in os.environ.items() if k != "NO_SUCH_VAR_XYZ"}
+        with patch.dict(os.environ, env, clear=True):
+            result = edr.get_excluded_from_env("NO_SUCH_VAR_XYZ")
+        self.assertEqual(result, [])
+
+
+class TestIsRealHardware(unittest.TestCase):
+    """Tests for is_real_hardware()"""
+
+    def test_no_device_symlink_returns_false(self):
+        with patch("os.path.islink", return_value=False):
+            self.assertFalse(edr.is_real_hardware("/sys/class/net/lo"))
+
+    def test_wireless_interface_returns_false(self):
+        def islink(path):
+            return path.endswith("device")
+
+        def exists(path):
+            return path.endswith("wireless")
+
+        with patch("os.path.islink", side_effect=islink), patch(
+            "os.path.exists", side_effect=exists
+        ):
+            self.assertFalse(edr.is_real_hardware("/sys/class/net/wlan0"))
+
+    def test_virtual_subsystem_returns_false(self):
+        def islink(path):
+            # device symlink and subsystem symlink both exist
+            return path.endswith("device") or path.endswith("subsystem")
+
+        def exists(path):
+            return False  # no wireless dir
+
+        with patch("os.path.islink", side_effect=islink), patch(
+            "os.path.exists", side_effect=exists
+        ), patch("os.readlink", return_value="/sys/bus/virtual"):
+            self.assertFalse(edr.is_real_hardware("/sys/class/net/veth0"))
+
+    def test_non_virtual_subsystem_returns_true(self):
+        def islink(path):
+            return path.endswith("device") or path.endswith("subsystem")
+
+        def exists(path):
+            return False
+
+        with patch("os.path.islink", side_effect=islink), patch(
+            "os.path.exists", side_effect=exists
+        ), patch("os.readlink", return_value="/sys/bus/pci"):
+            self.assertTrue(edr.is_real_hardware("/sys/class/net/eth0"))
+
+    def test_missing_subsystem_symlink_still_returns_true(self):
+        """
+        If subsystem link is absent, interface is still treated as hardware.
+        """
+
+        def islink(path):
+            # device exists but subsystem symlink does not
+            return path.endswith("device")
+
+        def exists(path):
+            return False
+
+        with patch("os.path.islink", side_effect=islink), patch(
+            "os.path.exists", side_effect=exists
+        ):
+            self.assertTrue(edr.is_real_hardware("/sys/class/net/eth0"))
+
+
+class TestListInterfaces(unittest.TestCase):
+    """Tests for list_interfaces()"""
+
+    def test_base_path_missing_produces_no_output(self):
+        with patch("os.path.exists", return_value=False):
+            with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+                edr.list_interfaces([], [])
+        self.assertEqual(mock_stdout.getvalue(), "")
+
+    def _make_list_interfaces_env(self, ifaces, mac_map, real_hw_ifaces):
+        """
+        Helper: patches os so list_interfaces sees a controlled /sys/class/net.
+        ifaces: list of interface names in base_path
+        mac_map: dict {iface: mac}
+        real_hw_ifaces: set of ifaces is_real_hardware returns True for
+        """
+
+        def fake_exists(path):
+            return path == "/sys/class/net/"
+
+        def fake_listdir(path):
+            return ifaces
+
+        def fake_is_real_hardware(iface_path):
+            iface = os.path.basename(iface_path)
+            return iface in real_hw_ifaces
+
+        def fake_open(path, *args, **kwargs):
+            iface = path.split("/sys/class/net/")[1].split("/")[0]
+            mac = mac_map.get(iface, "")
+            return mock_open(read_data=mac)()
+
+        return fake_exists, fake_listdir, fake_is_real_hardware, fake_open
+
+    def test_single_hardware_interface_is_printed(self):
+        (
+            fake_exists,
+            fake_listdir,
+            fake_is_real_hw,
+            fake_open,
+        ) = self._make_list_interfaces_env(
+            ifaces=["eth0"],
+            mac_map={"eth0": "aa:bb:cc:dd:ee:ff"},
+            real_hw_ifaces={"eth0"},
+        )
+        with patch("os.path.exists", side_effect=fake_exists), patch(
+            "os.listdir", return_value=["eth0"]
+        ), patch(
+            "ethernet_dynamic_resource.is_real_hardware",
+            side_effect=fake_is_real_hw,
+        ), patch(
+            "builtins.open", side_effect=fake_open
+        ), patch(
+            "sys.stdout", new_callable=StringIO
+        ) as mock_stdout:
+            edr.list_interfaces([], [])
+        output = mock_stdout.getvalue()
+        self.assertIn("interface: eth0", output)
+        self.assertIn("mac: aa:bb:cc:dd:ee:ff", output)
+
+    def test_non_hardware_interface_is_skipped(self):
+        (
+            fake_exists,
+            _,
+            fake_is_real_hw,
+            fake_open,
+        ) = self._make_list_interfaces_env(
+            ifaces=["lo"],
+            mac_map={"lo": "00:00:00:00:00:00"},
+            real_hw_ifaces=set(),  # lo is not hardware
+        )
+        with patch("os.path.exists", side_effect=fake_exists), patch(
+            "os.listdir", return_value=["lo"]
+        ), patch(
+            "ethernet_dynamic_resource.is_real_hardware",
+            side_effect=fake_is_real_hw,
+        ), patch(
+            "builtins.open", side_effect=fake_open
+        ), patch(
+            "sys.stdout", new_callable=StringIO
+        ) as mock_stdout:
+            edr.list_interfaces([], [])
+        self.assertEqual(mock_stdout.getvalue(), "")
+
+    def test_ignored_interface_name_is_skipped(self):
+        (
+            fake_exists,
+            _,
+            fake_is_real_hw,
+            fake_open,
+        ) = self._make_list_interfaces_env(
+            ifaces=["eth0"],
+            mac_map={"eth0": "aa:bb:cc:dd:ee:ff"},
+            real_hw_ifaces={"eth0"},
+        )
+        with patch("os.path.exists", side_effect=fake_exists), patch(
+            "os.listdir", return_value=["eth0"]
+        ), patch(
+            "ethernet_dynamic_resource.is_real_hardware",
+            side_effect=fake_is_real_hw,
+        ), patch(
+            "builtins.open", side_effect=fake_open
+        ), patch(
+            "sys.stdout", new_callable=StringIO
+        ) as mock_stdout:
+            edr.list_interfaces(["eth0"], [])
+        self.assertEqual(mock_stdout.getvalue(), "")
+
+    def test_ignored_mac_is_skipped(self):
+        (
+            fake_exists,
+            _,
+            fake_is_real_hw,
+            fake_open,
+        ) = self._make_list_interfaces_env(
+            ifaces=["eth0"],
+            mac_map={"eth0": "aa:bb:cc:dd:ee:ff"},
+            real_hw_ifaces={"eth0"},
+        )
+        with patch("os.path.exists", side_effect=fake_exists), patch(
+            "os.listdir", return_value=["eth0"]
+        ), patch(
+            "ethernet_dynamic_resource.is_real_hardware",
+            side_effect=fake_is_real_hw,
+        ), patch(
+            "builtins.open", side_effect=fake_open
+        ), patch(
+            "sys.stdout", new_callable=StringIO
+        ) as mock_stdout:
+            edr.list_interfaces([], ["aa:bb:cc:dd:ee:ff"])
+        self.assertEqual(mock_stdout.getvalue(), "")
+
+    def test_ignored_mac_comparison_is_case_insensitive(self):
+        (
+            fake_exists,
+            _,
+            fake_is_real_hw,
+            fake_open,
+        ) = self._make_list_interfaces_env(
+            ifaces=["eth0"],
+            mac_map={"eth0": "aa:bb:cc:dd:ee:ff"},
+            real_hw_ifaces={"eth0"},
+        )
+        with patch("os.path.exists", side_effect=fake_exists), patch(
+            "os.listdir", return_value=["eth0"]
+        ), patch(
+            "ethernet_dynamic_resource.is_real_hardware",
+            side_effect=fake_is_real_hw,
+        ), patch(
+            "builtins.open", side_effect=fake_open
+        ), patch(
+            "sys.stdout", new_callable=StringIO
+        ) as mock_stdout:
+            # ignored_macs already lowercased by main(); simulate that here
+            edr.list_interfaces([], ["aa:bb:cc:dd:ee:ff"])
+        self.assertEqual(mock_stdout.getvalue(), "")
+
+    def test_mac_read_error_skips_interface(self):
+        fake_exists, _, fake_is_real_hw, _ = self._make_list_interfaces_env(
+            ifaces=["eth0"],
+            mac_map={},
+            real_hw_ifaces={"eth0"},
+        )
+        with patch("os.path.exists", side_effect=fake_exists), patch(
+            "os.listdir", return_value=["eth0"]
+        ), patch(
+            "ethernet_dynamic_resource.is_real_hardware",
+            side_effect=fake_is_real_hw,
+        ), patch(
+            "builtins.open", side_effect=OSError("permission denied")
+        ), patch(
+            "sys.stdout", new_callable=StringIO
+        ) as mock_stdout:
+            edr.list_interfaces([], [])
+        self.assertEqual(mock_stdout.getvalue(), "")
+
+    def test_multiple_interfaces_sorted_output(self):
+        ifaces = ["eth1", "eth0"]
+        mac_map = {"eth0": "00:11:22:33:44:55", "eth1": "66:77:88:99:aa:bb"}
+
+        def fake_exists(path):
+            return path == "/sys/class/net/"
+
+        def fake_is_real_hw(iface_path):
+            return True
+
+        def fake_open(path, *args, **kwargs):
+            iface = path.split("/sys/class/net/")[1].split("/")[0]
+            return mock_open(read_data=mac_map[iface])()
+
+        with patch("os.path.exists", side_effect=fake_exists), patch(
+            "os.listdir", return_value=ifaces
+        ), patch(
+            "ethernet_dynamic_resource.is_real_hardware",
+            side_effect=fake_is_real_hw,
+        ), patch(
+            "builtins.open", side_effect=fake_open
+        ), patch(
+            "sys.stdout", new_callable=StringIO
+        ) as mock_stdout:
+            edr.list_interfaces([], [])
+
+        output = mock_stdout.getvalue()
+        eth0_pos = output.index("interface: eth0")
+        eth1_pos = output.index("interface: eth1")
+        self.assertLess(eth0_pos, eth1_pos)
+
+
+class TestMain(unittest.TestCase):
+    """Tests for main() argument parsing and wiring."""
+
+    def test_main_defaults_use_standard_env_vars(self):
+        with patch.dict(
+            os.environ,
+            {"EXCLUDE_MACS": "", "EXCLUDE_INTERFACES": ""},
+            clear=False,
+        ), patch("sys.argv", ["prog"]), patch(
+            "ethernet_dynamic_resource.list_interfaces"
+        ) as mock_list:
+            edr.main()
+        mock_list.assert_called_once_with([], [])
+
+    def test_main_custom_env_vars(self):
+        with patch.dict(
+            os.environ, {"MY_MACS": "AA:BB:CC:DD:EE:FF", "MY_IFACES": "eth0"}
+        ), patch(
+            "sys.argv",
+            ["prog", "--env-mac", "MY_MACS", "--env-iface", "MY_IFACES"],
+        ), patch(
+            "ethernet_dynamic_resource.list_interfaces"
+        ) as mock_list:
+            edr.main()
+        mock_list.assert_called_once_with(["eth0"], ["aa:bb:cc:dd:ee:ff"])
+
+    def test_main_macs_are_lowercased(self):
+        with patch.dict(
+            os.environ, {"EXCLUDE_MACS": "AA:BB:CC:DD:EE:FF"}
+        ), patch("sys.argv", ["prog"]), patch(
+            "ethernet_dynamic_resource.list_interfaces"
+        ) as mock_list:
+            edr.main()
+        _, call_kwargs = mock_list.call_args
+        passed_macs = mock_list.call_args[0][1]
+        self.assertEqual(passed_macs, ["aa:bb:cc:dd:ee:ff"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
There are more and more Ethernet interfaces that cannot be tested for all checkbox Ethernet suite. Such as [Virtual Ethernet](https://github.com/canonical/checkbox/issues/2385), [Hardware limitation of hotplug](https://bugs.launchpad.net/shiner/+bug/2098451), part of wake on LAN support(s3, s4, s5) etc and hard to be controlled by manifest. It is not possible to filter them without defining for specific device. Therefore, we would like to provide one resource script that can be set dynamically from checkbox.conf and can be utilized by multiple resource job.

The example resource job that uses this script:
```
unit: job
id: iperf_resource
plugin: resource
environ:
    NON_SUPPORT_IPERF_MAC
    NON_SUPPORT_IPERF_INTERFACE
summary: Show all ethernet interface that need to be tested.
description:
    Show all ethernet interface that need to be tested.
command:
    concept.py --env-mac NON_SUPPORT_IPERF_MAC --env-iface NON_SUPPORT_IPERF_INTERFACE
estimated_duration: 3s
flags: preserve-locale
```

The demo test result: https://certification.canonical.com/hardware/202001-27667/submission/480613/

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

