### PR TITLE
Update submission JSON schema to include system_information (bugfix)

### DIFF
--- a/submission-schema/schema.json
+++ b/submission-schema/schema.json
@@ -69,6 +69,53 @@
         "launcher": {
           "$ref": "#/definitions/Launcher"
         },
+        "system_information": {
+          "type": "object",
+          "properties": {
+              "bios": {
+                "$ref": "#/definitions/SystemInformationOject"
+              },
+              "debian_packages": {
+                "$ref": "#/definitions/SystemInformationOject"
+              },
+              "distribution": {
+                "$ref": "#/definitions/SystemInformationOject"
+              },
+              "image_info": {
+                "$ref": "#/definitions/SystemInformationOject"
+              },
+              "inxi": {
+                "$ref": "#/definitions/SystemInformationOject"
+              },
+              "journalctl": {
+                "$ref": "#/definitions/SystemInformationOject"
+              },
+              "kernel_cmdline": {
+                "$ref": "#/definitions/SystemInformationOject"
+              },
+              "kernel_modules": {
+                "$ref": "#/definitions/SystemInformationOject"
+              },
+              "machine_manifest": {
+                "$ref": "#/definitions/SystemInformationOject"
+              },
+              "memory": {
+                "$ref": "#/definitions/SystemInformationOject"
+              },
+              "snaps": {
+                "$ref": "#/definitions/SystemInformationOject"
+              },
+              "udev_devices": {
+                "$ref": "#/definitions/SystemInformationOject"
+              },
+              "uname": {
+                "$ref": "#/definitions/SystemInformationOject"
+              },
+              "version": {
+                "type": "integer"
+              }
+        }
+        },
         "testplan_id": {
           "type": "string"
         },
@@ -541,6 +588,29 @@
         "version"
       ],
       "title": "Package"
+    },
+    "SystemInformationOject": {
+      "type": "object",
+      "properties": {
+        "tool_version": { "type": "string" },
+        "success": { "type": "boolean" },
+        "outputs": {
+          "type": "object",
+          "properties": {
+            "stdout": { "type": "string" },
+            "stderr": { "type": "string" },
+            "return_code": { "type": "integer" },
+            "payload": {
+              "oneOf": [
+                { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+                { "type": "object", "additionalProperties": true },
+                { "type": "string", "additionalProperties": true }
+              ]
+            }
+          }
+        }
+      },
+      "required": ["tool_version", "success", "outputs"]
     },
     "Launcher": {
       "type": "object",


### PR DESCRIPTION


## Description

Add system_information section to the JSON schema : This is a basic schema which only introduces the different fields at a higher level, since all of these fields will output something slightly different in their payloads.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

Tested using `check-jsonschema` python package using a sample submission from the most recent Checkbox from main

[submission_uc24.zip](https://github.com/user-attachments/files/26308601/submission_uc24.zip)

```
> check-jsonschema --schemafile schema.json submission_uc24.json 
Schema validation errors were encountered.
  submission_uc24.json::$.launcher.launcher.stock_reports: 'text,submission_json' is not of type 'array'
  submission_uc24.json::$.launcher.launcher.local_submission: 'True' is not of type 'boolean'
  submission_uc24.json::$.launcher.launcher: 'launcher_version' is a required property
  submission_uc24.json::$.launcher.launcher: 'app_id' is a required property
  submission_uc24.json::$.launcher.launcher: 'app_version' is a required property
  submission_uc24.json::$.launcher.launcher: 'session_title' is a required property
  submission_uc24.json::$.launcher.launcher: 'session_desc' is a required property
  submission_uc24.json::$.launcher['report:local_json'].forced: 'yes' is not of type 'boolean'
  submission_uc24.json::$.launcher['report:local_html'].forced: 'yes' is not of type 'boolean'
  submission_uc24.json::$.launcher['report:local_text'].forced: 'yes' is not of type 'boolean'
```

(Note that the errors here have nothing to do with the system_information section and will have to be dealt with separately)