### PR TITLE
Force using fork multiprocessing (bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/timeout.py
+++ b/checkbox-support/checkbox_support/helpers/timeout.py
@@ -30,10 +30,17 @@ import traceback
 import subprocess
 
 from queue import Empty
-from functools import partial
+from functools import partial, wraps
 from unittest.mock import patch
-from contextlib import wraps, suppress
-from multiprocessing import Process, Queue
+from contextlib import suppress
+import multiprocessing
+
+# The inner function `_f` in run_with_timeout may be a closure and cannot be
+# pickled, so it requires the "fork" start method. Python 3.14 changed the
+# default start method on Linux away from "fork", so we request it explicitly.
+_fork_context = multiprocessing.get_context("fork")
+Process = _fork_context.Process
+Queue = _fork_context.Queue
 
 
 def is_picklable(value):


### PR DESCRIPTION
## Description

On Python3.14, they've changed the default handler for Process, now defaulting to forkserver. This is good for a multitude of reasons but breaks our decorator because forkserver needs all arguments (including the target) to be picklable. This of course is not the case for decorators. It is not quite clear to me what is the principled solution to this, but one solution is to force the "fork" usage, which is problematic only in threaded applications, which our tests are for the most part not.

## Resolved issues

Partially fixes: https://warthogs.atlassian.net/browse/CHECKBOX-2201

## Documentation

Adds a comment to explain why we are doing the context thing

## Tests

Tests were already in place, they now pass on python3.14
