### PR TITLE
exporters:html: fix I/O log links when not-supported jobs exist (BugFix)

### DIFF
--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
@@ -372,7 +372,7 @@
         {%- endif %}
     {%- for cat_id, cat_name in category_map|dictsort(false, 'value') %}
         {% set mainloop = loop %}
-        {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+        {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.result.outcome != 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
         {%- if job_state.result.io_log_as_flat_text != "" %}
         <div class="jqm-demos ui-page" tabindex="0" data-url="{{ mainloop.index }}-{{ loop.index }}" id="{{ mainloop.index }}-{{ loop.index }}-log" data-role="page">
             <div data-role="header" class="jqm-header">

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/multi-page.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/multi-page.html
@@ -424,7 +424,7 @@
 
 {%- for cat_id, cat_name in category_map|dictsort(false, 'value') %}
     {% set mainloop = loop %}
-    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.result.outcome != 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
     {%- if job_state.result.io_log_as_flat_text != "" %}
     <div class="jqm-demos ui-page" tabindex="0" data-url="{{ managerloop.index }}-{{ mainloop.index }}-{{ loop.index }}" id="{{ managerloop.index }}-{{ mainloop.index }}-{{ loop.index }}-log" data-role="page">
         <div data-role="header" class="jqm-header">


### PR DESCRIPTION


## Problem

Commit f8299d0d added a 'not-supported' filter to the table display loop but forgot to apply the same filter to the I/O log page generation loop.

Both loops use `loop.index` to build anchor IDs (`#iolog-1`, `#iolog-2`, ...). When a not-supported job appears alphabetically before a pass/fail job in the same category, the indices diverge, causing I/O log links to point to the wrong test's log.

## Fix

Apply the same `not-supported` filter to the page generation loop in both `checkbox.html` and `multi-page.html` so the indices always stay in sync.

## Test
Run some test with the command "checkbox-cli merge-reports submission_2026-03-31T10.40.40.826383.tar.xz -o before_apply_patch.html"  and "checkbox-cli merge-reports submission_2026-03-31T10.40.40.826383.tar.xz after_apply_patch.html" after apply the fix in /usr/lib/python3/dist-packages/plainbox/impl/providers/exporters/data. The io-log is correct after apply the patch.

The generated html report was attached.
[before_apply_patch.html](https://github.com/user-attachments/files/26428793/before_apply_patch.html)
[after_apply_patch.html](https://github.com/user-attachments/files/26428800/after_apply_patch.html)
