### PR TITLE
Move site-packages to higher priority (bugfix)

### DIFF
--- a/checkbox-core-snap/common_files/config/wrapper_common
+++ b/checkbox-core-snap/common_files/config/wrapper_common
@@ -32,8 +32,10 @@ else
   append_path ALSA_CONFIG_PATH $RUNTIME/usr/share/alsa/alsa.conf
   append_path PYTHONUSERBASE $RUNTIME
   append_path PYTHONHOME $RUNTIME/usr
-  append_path PYTHONPATH $RUNTIME/usr/lib/python3/dist-packages
+  # site packages first because if we pull a dependency we must use that
+  # instead of dist-package version
   append_path PYTHONPATH $RUNTIME/lib/python3*/site-packages
+  append_path PYTHONPATH $RUNTIME/usr/lib/python3/dist-packages
   append_path PYTHONPATH $RUNTIME/lib/python3*/dist-packages
 fi
 

--- a/checkbox-core-snap/common_files/config/wrapper_common_classic
+++ b/checkbox-core-snap/common_files/config/wrapper_common_classic
@@ -40,8 +40,10 @@ else
   append_path ALSA_CONFIG_PATH $RUNTIME/usr/share/alsa/alsa.conf
   append_path PYTHONUSERBASE $RUNTIME
   append_path PYTHONHOME $RUNTIME/usr
-  append_path PYTHONPATH $RUNTIME/usr/lib/python3/dist-packages
+  # site packages first because if we pull a dependency we must use that
+  # instead of dist-package version
   append_path PYTHONPATH $RUNTIME/lib/python3*/site-packages
+  append_path PYTHONPATH $RUNTIME/usr/lib/python3/dist-packages
   append_path PYTHONPATH $RUNTIME/lib/python3*/dist-packages
 fi
 


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

On core16 Checkbox is failing to collect the manifest (although it is not clear to me why it is able to run at all). The issue is masked/hidden by the exception handlers in the `all_units.load` function but, when exposed with a `try: except: print`  manifests as:
```
 File "/snap/checkbox/22487/checkbox-runtime/lib/python3.5/site-packages/plainbox/impl/secure/providers/v1.py", line 375, in inspect
    unit_cls = self._get_unit_cls(unit_name)
  File "/snap/checkbox/22487/checkbox-runtime/lib/python3.5/site-packages/plainbox/impl/secure/providers/v1.py", line 451, in _get_unit_cls
    all_units.load()
  File "/snap/checkbox/22487/checkbox-runtime/lib/python3.5/site-packages/plainbox/impl/secure/plugins.py", line 536, in load
    obj = entry_point.load()
  File "/snap/checkbox/22487/checkbox-runtime/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2460, in load
    self.require(*args, **kwargs)
  File "/snap/checkbox/22487/checkbox-runtime/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2483, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "/snap/checkbox/22487/checkbox-runtime/lib/python3.5/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.VersionConflict: (pyparsing 2.0.3 (/snap/checkbox/22487/checkbox-runtime/usr/lib/python3/dist-packages), Requirement.parse('pyparsing>=2.2.0'))
```

This happens because `dist-packages` (the debian python packages) contain an outdated version that doesn't satisfy the requirements that `pkg_resources` (used to load entry points/parsers) decides to validate and blows up. The fix is to make `site-packages` first in the PATH. This also makes sense from a more meta point of view, considering that, if we pull a pip package, we want that, not the debian package.

## Resolved issues

Fixes: CHECKBOX-2203
Fixes: https://github.com/canonical/checkbox/issues/2437

## Documentation

N/A

## Tests

In a focal lxd run:
```shell
snap download checkbox16 --edge
unsquashfs checkbox16*.snap
snap try --devmode squashfs-root
snap install checkbox --channel=uc16/edge
snap connect checkbox:checkbox-runtime checkbox16:checkbox-runtime
snap connect checkbox:provider-resource checkbox16:provider-resource
checkbox.checkbox-cli run manifest
... <- this will fail
# apply the patch
checkbox.checkbox-cli run manifest
```
