### PR TITLE
providers/base: fix race condition in turn_down_nm_connections (BugFix)

### DIFF
--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -100,7 +100,10 @@ def turn_down_nm_connections():
         print("Turn down connection", name)
         cmd = "nmcli c down {}".format(uuid)
         print_cmd(cmd)
-        sp.check_call(shlex.split(cmd))
+        ret = sp.call(shlex.split(cmd))
+        # exit code 10: connection is not active — already down, that's fine
+        if ret not in (0, 10):
+            raise sp.CalledProcessError(ret, cmd)
         print("{} {} is down now".format(name, uuid))
     print()
 

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -112,15 +112,7 @@ def turn_down_nm_connections():
             continue
         cmd = "nmcli c down {}".format(uuid)
         print_cmd(cmd)
-        try:
-            sp.check_call(shlex.split(cmd))
-        except sp.CalledProcessError as e:
-            # The connection may have gone inactive in the narrow window
-            # between the state pre-check and this call. Exit code 10
-            # ("connection/device/AP does not exist") means it is already
-            # down — treat as success.
-            if e.returncode != 10:
-                raise
+        sp.check_call(shlex.split(cmd))
         print("{} {} is down now".format(name, uuid))
     print()
 

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -112,7 +112,15 @@ def turn_down_nm_connections():
             continue
         cmd = "nmcli c down {}".format(uuid)
         print_cmd(cmd)
-        sp.check_call(shlex.split(cmd))
+        try:
+            sp.check_call(shlex.split(cmd))
+        except sp.CalledProcessError as e:
+            # The connection may have gone inactive in the narrow window
+            # between the state pre-check and this call. Exit code 10
+            # ("connection/device/AP does not exist") means it is already
+            # down — treat as success.
+            if e.returncode != 10:
+                raise
         print("{} {} is down now".format(name, uuid))
     print()
 

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -100,10 +100,12 @@ def turn_down_nm_connections():
         print("Turn down connection", name)
         cmd = "nmcli c down {}".format(uuid)
         print_cmd(cmd)
-        ret = sp.call(shlex.split(cmd))
-        # exit code 10: connection is not active — already down, that's fine
-        if ret not in (0, 10):
-            raise sp.CalledProcessError(ret, cmd)
+        try:
+            sp.check_call(shlex.split(cmd))
+        except sp.CalledProcessError as e:
+            # exit code 10: connection is not active — already down, that's fine
+            if e.returncode != 10:
+                raise
         print("{} {} is down now".format(name, uuid))
     print()
 

--- a/providers/base/bin/wifi_nmcli_test.py
+++ b/providers/base/bin/wifi_nmcli_test.py
@@ -98,14 +98,21 @@ def turn_down_nm_connections():
             continue
         uuid = value["uuid"]
         print("Turn down connection", name)
+        # Re-check this specific UUID's state right before calling down
+        # to handle the race condition where a connection becomes inactive
+        # between the initial query and this point (e.g. another connection
+        # was brought down first, causing NM to deactivate this one too).
+        check_cmd = "nmcli -t -f GENERAL.STATE c show {}".format(uuid)
+        print_cmd(check_cmd)
+        current_state = sp.check_output(
+            shlex.split(check_cmd), universal_newlines=True
+        ).strip()
+        if current_state != "GENERAL.STATE:activated":
+            print("WARN: {} is no longer active, skipping".format(name))
+            continue
         cmd = "nmcli c down {}".format(uuid)
         print_cmd(cmd)
-        try:
-            sp.check_call(shlex.split(cmd))
-        except sp.CalledProcessError as e:
-            # exit code 10: connection is not active — already down, that's fine
-            if e.returncode != 10:
-                raise
+        sp.check_call(shlex.split(cmd))
         print("{} {} is down now".format(name, uuid))
     print()
 

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -149,7 +149,7 @@ class TestTurnDownNmConnections(unittest.TestCase):
         self.assertEqual(get_connections_mock.call_count, 1)
         sp_call_mock.assert_not_called()
 
-    @patch("wifi_nmcli_test.sp.check_call")
+    @patch("wifi_nmcli_test.sp.call", return_value=0)
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
         return_value={
@@ -158,31 +158,45 @@ class TestTurnDownNmConnections(unittest.TestCase):
         },
     )
     def test_turn_down_single_connection(
-        self, get_connections_mock, sp_check_call_mock
+        self, get_connections_mock, sp_call_mock
     ):
         turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
-        sp_check_call_mock.assert_called_once_with(
+        sp_call_mock.assert_called_once_with(
             "nmcli c down uuid1".split()
         )
 
-    @patch("wifi_nmcli_test.sp.check_call")
+    @patch("wifi_nmcli_test.sp.call", return_value=10)
+    @patch(
+        "wifi_nmcli_test._get_nm_wireless_connections",
+        return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
+    )
+    def test_turn_down_connection_already_inactive(
+        self, get_connections_mock, sp_call_mock
+    ):
+        # exit code 10 means connection is not active — should not raise
+        turn_down_nm_connections()
+        self.assertEqual(get_connections_mock.call_count, 1)
+        sp_call_mock.assert_called_once_with(
+            "nmcli c down uuid1".split()
+        )
+
+    @patch("wifi_nmcli_test.sp.call", return_value=1)
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
         return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
     )
     def test_turn_down_single_connection_with_exception(
-        self, get_connections_mock, sp_check_call_mock
+        self, get_connections_mock, sp_call_mock
     ):
-        sp_check_call_mock.side_effect = subprocess.CalledProcessError("", 1)
         with self.assertRaises(subprocess.CalledProcessError):
             turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
-        sp_check_call_mock.assert_called_once_with(
+        sp_call_mock.assert_called_once_with(
             "nmcli c down uuid1".split()
         )
 
-    @patch("wifi_nmcli_test.sp.check_call")
+    @patch("wifi_nmcli_test.sp.call", return_value=0)
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
         return_value={
@@ -191,7 +205,7 @@ class TestTurnDownNmConnections(unittest.TestCase):
         },
     )
     def test_turn_down_multiple_connections(
-        self, get_connections_mock, sp_check_call_mock
+        self, get_connections_mock, sp_call_mock
     ):
         turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
@@ -199,7 +213,7 @@ class TestTurnDownNmConnections(unittest.TestCase):
             call("nmcli c down uuid1".split()),
             call("nmcli c down uuid2".split()),
         ]
-        sp_check_call_mock.assert_has_calls(calls, any_order=True)
+        sp_call_mock.assert_has_calls(calls, any_order=True)
 
 
 class TestDeleteTestApSsidConnection(unittest.TestCase):

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -140,15 +140,21 @@ class TestTurnUpConnection(unittest.TestCase):
 
 
 class TestTurnDownNmConnections(unittest.TestCase):
+    @patch("wifi_nmcli_test.sp.check_output")
     @patch("wifi_nmcli_test.sp.check_call")
     @patch("wifi_nmcli_test._get_nm_wireless_connections", return_value={})
     def test_no_connections_to_turn_down(
-        self, get_connections_mock, sp_check_call_mock
+        self, get_connections_mock, sp_check_call_mock, sp_check_output_mock
     ):
         turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
+        sp_check_output_mock.assert_not_called()
         sp_check_call_mock.assert_not_called()
 
+    @patch(
+        "wifi_nmcli_test.sp.check_output",
+        return_value="GENERAL.STATE:activated",
+    )
     @patch("wifi_nmcli_test.sp.check_call")
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
@@ -158,40 +164,56 @@ class TestTurnDownNmConnections(unittest.TestCase):
         },
     )
     def test_turn_down_single_connection(
-        self, get_connections_mock, sp_check_call_mock
+        self, get_connections_mock, sp_check_call_mock, sp_check_output_mock
     ):
         turn_down_nm_connections()
-        self.assertEqual(get_connections_mock.call_count, 1)
+        sp_check_output_mock.assert_called_once_with(
+            "nmcli -t -f GENERAL.STATE c show uuid1".split(),
+            universal_newlines=True,
+        )
         sp_check_call_mock.assert_called_once_with("nmcli c down uuid1".split())
 
+    @patch(
+        "wifi_nmcli_test.sp.check_output",
+        return_value="GENERAL.STATE:deactivated",
+    )
     @patch("wifi_nmcli_test.sp.check_call")
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
         return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
     )
     def test_turn_down_connection_already_inactive(
-        self, get_connections_mock, sp_check_call_mock
+        self, get_connections_mock, sp_check_call_mock, sp_check_output_mock
     ):
-        # exit code 10 means connection is not active — should not raise
-        sp_check_call_mock.side_effect = subprocess.CalledProcessError(10, "")
+        # UUID state re-check shows connection already inactive — skip down
         turn_down_nm_connections()
-        self.assertEqual(get_connections_mock.call_count, 1)
-        sp_check_call_mock.assert_called_once_with("nmcli c down uuid1".split())
+        sp_check_output_mock.assert_called_once_with(
+            "nmcli -t -f GENERAL.STATE c show uuid1".split(),
+            universal_newlines=True,
+        )
+        sp_check_call_mock.assert_not_called()
 
+    @patch(
+        "wifi_nmcli_test.sp.check_output",
+        return_value="GENERAL.STATE:activated",
+    )
     @patch("wifi_nmcli_test.sp.check_call")
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
         return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
     )
     def test_turn_down_single_connection_with_exception(
-        self, get_connections_mock, sp_check_call_mock
+        self, get_connections_mock, sp_check_call_mock, sp_check_output_mock
     ):
         sp_check_call_mock.side_effect = subprocess.CalledProcessError(1, "")
         with self.assertRaises(subprocess.CalledProcessError):
             turn_down_nm_connections()
-        self.assertEqual(get_connections_mock.call_count, 1)
         sp_check_call_mock.assert_called_once_with("nmcli c down uuid1".split())
 
+    @patch(
+        "wifi_nmcli_test.sp.check_output",
+        return_value="GENERAL.STATE:activated",
+    )
     @patch("wifi_nmcli_test.sp.check_call")
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
@@ -201,10 +223,11 @@ class TestTurnDownNmConnections(unittest.TestCase):
         },
     )
     def test_turn_down_multiple_connections(
-        self, get_connections_mock, sp_check_call_mock
+        self, get_connections_mock, sp_check_call_mock, sp_check_output_mock
     ):
         turn_down_nm_connections()
-        self.assertEqual(get_connections_mock.call_count, 1)
+        # one UUID state check per activated connection
+        self.assertEqual(sp_check_output_mock.call_count, 2)
         calls = [
             call("nmcli c down uuid1".split()),
             call("nmcli c down uuid2".split()),

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -204,6 +204,29 @@ class TestTurnDownNmConnections(unittest.TestCase):
         "wifi_nmcli_test._get_nm_wireless_connections",
         return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
     )
+    def test_turn_down_connection_goes_inactive_during_down(
+        self, get_connections_mock, sp_check_call_mock, sp_check_output_mock
+    ):
+        # Pre-check passes (activated), but nmcli c down returns exit code 10
+        # because the connection went inactive in the narrow window between
+        # the pre-check and the down call — should not raise.
+        sp_check_call_mock.side_effect = subprocess.CalledProcessError(
+            10, "nmcli c down uuid1"
+        )
+        turn_down_nm_connections()
+        sp_check_call_mock.assert_called_once_with(
+            "nmcli c down uuid1".split()
+        )
+
+    @patch(
+        "wifi_nmcli_test.sp.check_output",
+        return_value="GENERAL.STATE:activated",
+    )
+    @patch("wifi_nmcli_test.sp.check_call")
+    @patch(
+        "wifi_nmcli_test._get_nm_wireless_connections",
+        return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
+    )
     def test_turn_down_single_connection_with_exception(
         self, get_connections_mock, sp_check_call_mock, sp_check_output_mock
     ):

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -140,16 +140,16 @@ class TestTurnUpConnection(unittest.TestCase):
 
 
 class TestTurnDownNmConnections(unittest.TestCase):
-    @patch("wifi_nmcli_test.sp.call")
+    @patch("wifi_nmcli_test.sp.check_call")
     @patch("wifi_nmcli_test._get_nm_wireless_connections", return_value={})
     def test_no_connections_to_turn_down(
-        self, get_connections_mock, sp_call_mock
+        self, get_connections_mock, sp_check_call_mock
     ):
         turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
-        sp_call_mock.assert_not_called()
+        sp_check_call_mock.assert_not_called()
 
-    @patch("wifi_nmcli_test.sp.call", return_value=0)
+    @patch("wifi_nmcli_test.sp.check_call")
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
         return_value={
@@ -158,39 +158,41 @@ class TestTurnDownNmConnections(unittest.TestCase):
         },
     )
     def test_turn_down_single_connection(
-        self, get_connections_mock, sp_call_mock
+        self, get_connections_mock, sp_check_call_mock
     ):
         turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
-        sp_call_mock.assert_called_once_with("nmcli c down uuid1".split())
+        sp_check_call_mock.assert_called_once_with("nmcli c down uuid1".split())
 
-    @patch("wifi_nmcli_test.sp.call", return_value=10)
+    @patch("wifi_nmcli_test.sp.check_call")
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
         return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
     )
     def test_turn_down_connection_already_inactive(
-        self, get_connections_mock, sp_call_mock
+        self, get_connections_mock, sp_check_call_mock
     ):
         # exit code 10 means connection is not active — should not raise
+        sp_check_call_mock.side_effect = subprocess.CalledProcessError(10, "")
         turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
-        sp_call_mock.assert_called_once_with("nmcli c down uuid1".split())
+        sp_check_call_mock.assert_called_once_with("nmcli c down uuid1".split())
 
-    @patch("wifi_nmcli_test.sp.call", return_value=1)
+    @patch("wifi_nmcli_test.sp.check_call")
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
         return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
     )
     def test_turn_down_single_connection_with_exception(
-        self, get_connections_mock, sp_call_mock
+        self, get_connections_mock, sp_check_call_mock
     ):
+        sp_check_call_mock.side_effect = subprocess.CalledProcessError(1, "")
         with self.assertRaises(subprocess.CalledProcessError):
             turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
-        sp_call_mock.assert_called_once_with("nmcli c down uuid1".split())
+        sp_check_call_mock.assert_called_once_with("nmcli c down uuid1".split())
 
-    @patch("wifi_nmcli_test.sp.call", return_value=0)
+    @patch("wifi_nmcli_test.sp.check_call")
     @patch(
         "wifi_nmcli_test._get_nm_wireless_connections",
         return_value={
@@ -199,7 +201,7 @@ class TestTurnDownNmConnections(unittest.TestCase):
         },
     )
     def test_turn_down_multiple_connections(
-        self, get_connections_mock, sp_call_mock
+        self, get_connections_mock, sp_check_call_mock
     ):
         turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
@@ -207,7 +209,7 @@ class TestTurnDownNmConnections(unittest.TestCase):
             call("nmcli c down uuid1".split()),
             call("nmcli c down uuid2".split()),
         ]
-        sp_call_mock.assert_has_calls(calls, any_order=True)
+        sp_check_call_mock.assert_has_calls(calls, any_order=True)
 
 
 class TestDeleteTestApSsidConnection(unittest.TestCase):

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -204,29 +204,6 @@ class TestTurnDownNmConnections(unittest.TestCase):
         "wifi_nmcli_test._get_nm_wireless_connections",
         return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
     )
-    def test_turn_down_connection_goes_inactive_during_down(
-        self, get_connections_mock, sp_check_call_mock, sp_check_output_mock
-    ):
-        # Pre-check passes (activated), but nmcli c down returns exit code 10
-        # because the connection went inactive in the narrow window between
-        # the pre-check and the down call — should not raise.
-        sp_check_call_mock.side_effect = subprocess.CalledProcessError(
-            10, "nmcli c down uuid1"
-        )
-        turn_down_nm_connections()
-        sp_check_call_mock.assert_called_once_with(
-            "nmcli c down uuid1".split()
-        )
-
-    @patch(
-        "wifi_nmcli_test.sp.check_output",
-        return_value="GENERAL.STATE:activated",
-    )
-    @patch("wifi_nmcli_test.sp.check_call")
-    @patch(
-        "wifi_nmcli_test._get_nm_wireless_connections",
-        return_value={"Wireless1": {"uuid": "uuid1", "state": "activated"}},
-    )
     def test_turn_down_single_connection_with_exception(
         self, get_connections_mock, sp_check_call_mock, sp_check_output_mock
     ):

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -162,9 +162,7 @@ class TestTurnDownNmConnections(unittest.TestCase):
     ):
         turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
-        sp_call_mock.assert_called_once_with(
-            "nmcli c down uuid1".split()
-        )
+        sp_call_mock.assert_called_once_with("nmcli c down uuid1".split())
 
     @patch("wifi_nmcli_test.sp.call", return_value=10)
     @patch(
@@ -177,9 +175,7 @@ class TestTurnDownNmConnections(unittest.TestCase):
         # exit code 10 means connection is not active — should not raise
         turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
-        sp_call_mock.assert_called_once_with(
-            "nmcli c down uuid1".split()
-        )
+        sp_call_mock.assert_called_once_with("nmcli c down uuid1".split())
 
     @patch("wifi_nmcli_test.sp.call", return_value=1)
     @patch(
@@ -192,9 +188,7 @@ class TestTurnDownNmConnections(unittest.TestCase):
         with self.assertRaises(subprocess.CalledProcessError):
             turn_down_nm_connections()
         self.assertEqual(get_connections_mock.call_count, 1)
-        sp_call_mock.assert_called_once_with(
-            "nmcli c down uuid1".split()
-        )
+        sp_call_mock.assert_called_once_with("nmcli c down uuid1".split())
 
     @patch("wifi_nmcli_test.sp.call", return_value=0)
     @patch(

--- a/providers/base/tests/test_wifi_nmcli_test.py
+++ b/providers/base/tests/test_wifi_nmcli_test.py
@@ -171,7 +171,9 @@ class TestTurnDownNmConnections(unittest.TestCase):
             "nmcli -t -f GENERAL.STATE c show uuid1".split(),
             universal_newlines=True,
         )
-        sp_check_call_mock.assert_called_once_with("nmcli c down uuid1".split())
+        sp_check_call_mock.assert_called_once_with(
+            "nmcli c down uuid1".split()
+        )
 
     @patch(
         "wifi_nmcli_test.sp.check_output",
@@ -208,7 +210,9 @@ class TestTurnDownNmConnections(unittest.TestCase):
         sp_check_call_mock.side_effect = subprocess.CalledProcessError(1, "")
         with self.assertRaises(subprocess.CalledProcessError):
             turn_down_nm_connections()
-        sp_check_call_mock.assert_called_once_with("nmcli c down uuid1".split())
+        sp_check_call_mock.assert_called_once_with(
+            "nmcli c down uuid1".split()
+        )
 
     @patch(
         "wifi_nmcli_test.sp.check_output",


### PR DESCRIPTION
## Problem

There is a race condition in `turn_down_nm_connections()` in `wifi_nmcli_test.py`.

The function calls `_get_nm_wireless_connections()` to list active connections, then runs `nmcli c down <uuid>` for each activated one. However, between the query and the `nmcli c down` call, the connection may have already become inactive (e.g., due to a network event or prior disconnect).

In this case `nmcli` returns exit code **10** ("not an active connection"), which caused `sp.check_call()` to raise `CalledProcessError` and crash the test — even though the connection being down is exactly the desired outcome.

**Observed failure:**
```
Turn down connection Canonical
+ nmcli c down cf0b6f04-db09-46f5-a8bb-e703f97c003a
Error: 'cf0b6f04-db09-46f5-a8bb-e703f97c003a' is not an active connection.
subprocess.CalledProcessError: Command returned non-zero exit status 10.
```
https://warthogs.atlassian.net/browse/SUTTON-4809
https://certification.canonical.com/hardware/202603-38441/submission/482952/test/84491/result/57704127/
https://certification.canonical.com/hardware/202602-38419/submission/481505/test/221519/result/57390085/


## Fix

Replace `sp.check_call()` with `sp.call()` and explicitly handle the return code:
- Exit code `0`: success
- Exit code `10`: connection already inactive — goal achieved, treat as success
- Any other non-zero code: still raises `CalledProcessError`

## Tests

- Updated existing unit tests to mock `sp.call` instead of `sp.check_call`
- Added new test `test_turn_down_connection_already_inactive` to verify exit code 10 is handled gracefully
- https://certification.canonical.com/hardware/202603-38440/submission/482955/
- https://certification.canonical.com/hardware/202603-38440/submission/482963/
- https://certification.canonical.com/hardware/202603-38440/submission/483237/
- https://certification.canonical.com/hardware/202603-38442/submission/483250/

Re-run the test with the new way which use statce check other than ignore exit 10:
[CE-QA-PC]: Automatic (BugFix) #2449_use_state_check test for Paris-P-SIT-S15
https://certification.canonical.com/hardware/202603-38440/submission/483385/