### PR TITLE
Provide more information in the HTML reports (New)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/merge_reports.py
+++ b/checkbox-ng/checkbox_ng/launcher/merge_reports.py
@@ -107,14 +107,9 @@ class MergeReports:
                     self.category_dict[cat_id] = CategoryUnit(
                         {"id": cat_id, "name": cat_name}
                     )
-            if mode == "list":
-                self.system_information.append(
-                    CollectorOutputs.from_dict(data["system_information"])
-                )
-            elif mode == "dict":
-                self.system_information = CollectorOutputs.from_dict(
-                    data["system_information"]
-                )
+            self.system_information = CollectorOutputs.from_dict(
+                data["system_information"]
+            )
         except OSError as e:
             raise SystemExit(e)
         except KeyError as e:

--- a/checkbox-ng/plainbox/impl/exporter/test_html.py
+++ b/checkbox-ng/plainbox/impl/exporter/test_html.py
@@ -27,7 +27,7 @@ Test definitions for plainbox.impl.exporter.html module
 """
 
 import io
-from unittest import TestCase
+from unittest import mock, TestCase
 
 try:
     from importlib.resources import files
@@ -78,6 +78,7 @@ class HTMLExporterTests(TestCase):
             {
                 "outcome": IJobResult.OUTCOME_FAIL,
                 "return_code": 1,
+                "execution_duration": 1.0,
                 "io_log": [(0, "stderr", b"FATAL ERROR\n")],
             }
         )
@@ -85,12 +86,17 @@ class HTMLExporterTests(TestCase):
             {
                 "outcome": IJobResult.OUTCOME_PASS,
                 "return_code": 0,
+                "execution_duration": 1.0,
                 "io_log": [(0, "stdout", b"foo\n")],
                 "comments": "blah blah",
             }
         )
         self.result_skip = MemoryJobResult(
-            {"outcome": IJobResult.OUTCOME_SKIP, "comments": "No such device"}
+            {
+                "outcome": IJobResult.OUTCOME_SKIP,
+                "execution_duration": 1.0,
+                "comments": "No such device",
+            }
         )
         self.attachment = JobDefinition(
             {"id": "dmesg_attachment", "plugin": "attachment"}
@@ -98,6 +104,7 @@ class HTMLExporterTests(TestCase):
         self.attachment_result = MemoryJobResult(
             {
                 "outcome": IJobResult.OUTCOME_PASS,
+                "execution_duration": 1.0,
                 "io_log": [(0, "stdout", b"bar\n")],
                 "return_code": 0,
             }
@@ -105,6 +112,7 @@ class HTMLExporterTests(TestCase):
         self.res1_result = MemoryJobResult(
             {
                 "outcome": IJobResult.OUTCOME_PASS,
+                "execution_duration": 1.0,
                 "io_log": [(0, "stdout", b"description: Ubuntu 14.04 LTS\n")],
                 "return_code": 0,
             }
@@ -112,6 +120,7 @@ class HTMLExporterTests(TestCase):
         self.res2_result = MemoryJobResult(
             {
                 "outcome": IJobResult.OUTCOME_PASS,
+                "execution_duration": 1.0,
                 "io_log": [
                     (0, "stdout", b"name: plainbox\n"),
                     (1, "stdout", b"version: 1.0\n"),
@@ -178,7 +187,11 @@ class HTMLExporterTests(TestCase):
             "blocker", "non-blocker", "non-blocker"
         )
 
-    def test_perfect_match_without_certification_status(self):
+    @mock.patch(
+        "plainbox.impl.session.state.collect_system_information",
+        return_value={},
+    )
+    def test_perfect_match_without_certification_status(self, mock_sys_info):
         """
         Test that output from the exporter exactly matches known
         good HTML output, inlining and everything included.
@@ -206,7 +219,11 @@ class HTMLExporterTests(TestCase):
         )  # unintuitively, resource_string returns bytes
         self.assertEqual(actual_result, expected_result)
 
-    def test_perfect_match_with_certification_blocker(self):
+    @mock.patch(
+        "plainbox.impl.session.state.collect_system_information",
+        return_value={},
+    )
+    def test_perfect_match_with_certification_blocker(self, mock_sys_info):
         """
         Test that output from the exporter exactly matches known
         good HTML output, inlining and everything included.

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.css
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.css
@@ -41,6 +41,62 @@
     src: local("Ubuntu Mono"), local("UbuntuMono-Regular"), url("https://fonts.gstatic.com/s/ubuntumono/v6/ViZhet7Ak-LRXZMXzuAfkYbN6UDyHWBl620a-IRfuBk.woff") format("woff");
 }
 
+html {
+    font-size: 62.5%; /* Sets base to 10px */
+}
+
+body {
+    font-size: 1.4em;
+}
+
+details {
+    padding-bottom: 1em;
+}
+
+summary>h3 {
+    color: #DD4815;
+    background-color: transparent;
+    font-size: 1.4em;
+    font-weight: 300;
+    margin: 0 0 1em;
+    display:inline;
+}
+
+summary {
+  list-style: none;
+  cursor: pointer;
+  &::before {
+    content: "+";
+    color: #DD4815;
+    padding: 0 0.5em 0 0;
+    margin-inline-start: 0.5em;
+  }
+  [open] &::before {
+    content: "–";
+  }
+}
+
+th {
+    text-align: left;
+}
+
+tbody tr:nth-child(odd) {
+  background-color: #eeeeee;
+}
+
+td > p {
+    padding: 0;
+    margin: 0;
+}
+
+.ui-table td {
+    padding: 0em;
+}
+
+td {
+    padding: 0.25em;
+}
+
 /* JQM Demos custom CSS */
 
 .ui-collapsible-content,
@@ -180,7 +236,7 @@
     line-height: 1.5;
 }
 .jqm-demos .jqm-content > ul:not(.jqm-list) li {
-    font-size: 1.2em;
+    font-size: 1em;
     line-height: 1.5;
 }
 .jqm-demos .jqm-content > p {

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
@@ -2,6 +2,7 @@
 {%- set state = manager.default_device_context.state -%}
 {%- set resource_map = state.resource_map -%}
 {%- set job_state_map = state.job_state_map -%}
+{%- set system_information = state.system_information -%}
 {%- set category_map = state.category_map_lite -%}
 {%- set category_outcome_map = state.category_outcome_map -%}
 {%- set resource_global_outcome = state.resource_global_outcome -%}
@@ -41,19 +42,20 @@
                     <h1>System Testing Report</h1>
                 </div><!-- /header -->
             <div role="main" class="ui-content jqm-content">
-                {%- if ns ~ 'system_info_json' in state.job_state_map and state.job_state_map[ns ~ 'system_info_json'].result.outcome == 'pass' %}
                 <h2>System Information</h2>
+                <h3>Summary</h3>
+                {%- if ns ~ 'system_info_json' in state.job_state_map and state.job_state_map[ns ~ 'system_info_json'].result.outcome == 'pass' %}
                 {%- set system_info_json = state.job_state_map[ns ~ 'system_info_json'].result.io_log_as_text_attachment.rstrip() %}
                 {%- set system_info = system_info_json|json_load_ordered_dict %}
                 <table data-role="table" id="system-info" data-mode="reflow" class="ui-body-d ui-responsive table-stroke">
                     <thead><tr class="ui-bar-d"></tr></thead>
-                    </tbody>
+                    <tbody>
                     {%- for section, section_data in system_info.items() %}
-                        <tr style="margin-top: 0px; margin-bottom: 0px; padding-top: 0px; padding-bottom: 0px;">
-                        <th style="margin-top: 0px; margin-bottom: 0px; padding-top: 0px; padding-bottom: 0px; vertical-align:top; font-size: 0.85em;">{{ section }}</th>
-                        <td style="margin-top: 0px; margin-bottom: 0px; padding-top: 0px; padding-bottom: 0px; line-height: 1em;">
+                        <tr>
+                        <th>{{ section }}</th>
+                        <td>
                         {%- for info in section_data %}
-                        <p style="margin-top: 0px; margin-bottom: 0px; padding-top: 0px; padding-bottom: 0px; font-size: 0.85em">
+                        <p>
                         {% autoescape false %}
                         {%- if section in ('System', 'Machine', 'CPU') %}
                         {{ info|highlight_keys }}
@@ -67,8 +69,130 @@
                     {%- endfor %}
                     </tbody>
                 </table>
-                <br>
-                {%- endif %}
+                {% elif system_information %}
+                    <ul>
+                        {% if system_information.distribution and system_information.distribution.success %}
+                        <li>Distribution: {{ system_information.distribution.outputs.payload.description }}</li>
+                        {% endif %}
+                        {% if system_information.uname and system_information.uname.success %}
+                        <li>Kernel: {{ system_information.uname.outputs.payload.kernel }} ({{ system_information.uname.outputs.payload.architecture }})</li>
+                        {% endif %}
+                        {% if system_information.memory and system_information.memory.success %}
+                        <li>Memory: {{ (system_information.memory.outputs.payload.total / 1024 / 1024 / 1024) | round(2) }} GiB</li>
+                        {% endif %}
+                    </ul>
+                {% endif %}
+                {% if system_information %}
+                    {% if system_information.image_info.success %}
+                    <details>
+                    <summary><h3>Image Information</h3></summary>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <th>Project</th>
+                                <td>{{ system_information.image_info.outputs.payload.project }}</td>
+                            </tr>
+                            <tr>
+                                <th>Series</th>
+                                <td>{{ system_information.image_info.outputs.payload.series }}</td>
+                            </tr>
+                            <tr>
+                                <th>Build Date</th>
+                                <td>{{ system_information.image_info.outputs.payload.build_date }}</td>
+                            </tr>
+                            <tr>
+                                <th>Build Number</th>
+                                <td>{{ system_information.image_info.outputs.payload.build_number }}</td>
+                            </tr>
+                            <tr>
+                                <th>Kernel</th>
+                                <td>{{ system_information.image_info.outputs.payload.kernel_type }} {{ system_information.image_info.outputs.payload.kernel_version }}</td>
+                            </tr>
+                            <tr>
+                                <th>Link</th>
+                                <td><a href="{{ system_information.image_info.outputs.payload.url }}">OEM Image</a></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    </details>
+                    {% endif %}
+                    {% if system_information.bios and system_information.bios.success %}
+                    <details>
+                    <summary><h3>BIOS</h3></summary>
+                    <table>
+                    {% for key, value in system_information.bios.outputs.payload.items() %}
+                    <tr>
+                        <th>{{ key }}</th>
+                        <td>{{ value }}</td>
+                    </tr>
+                    {% endfor %}
+                    </table>
+                    </details>
+                    {% endif %}
+                    {% if system_information.machine_manifest and system_information.machine_manifest.success %}
+                    <details>
+                    <summary><h3>Machine Manifest</h3></summary>
+                    <table>
+                        <thead>
+                            <tr>
+                            <th>Name</th>
+                            <th>Value</th>
+                            </tr>
+                        </thead>
+                        {% for key, value in system_information.machine_manifest.outputs.payload.items() %}
+                        <tr>
+                            <th>{{ key }}</th>
+                            <td>{{ value }}</td>
+                        </tr>
+                        {% endfor %}
+                    </table>
+                    </details>
+                    {% endif %}
+                    {% if system_information.snaps and system_information.snaps.success %}
+                    <details>
+                    <summary><h3>Snaps</h3></summary>
+                    <table>
+                        <thead>
+                            <tr>
+                            <th>Name</th>
+                            <th>Version</th>
+                            <th>Channel</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for snap in system_information.snaps.outputs.payload %}
+                            <tr>
+                            <th>{{ snap.name }}</th>
+                            <td>{{ snap.version }} (rev{{ snap.revision }})</td>
+                            <td>{{ snap.channel }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    </details>
+                    {% endif %}
+                    {% if system_information.debian_packages and system_information.debian_packages.success %}
+                    <details>
+                    <summary><h3>Debian Packages</h3></summary>
+                    <table>
+                        <thead>
+                            <tr>
+                            <th>Name</th>
+                            <th>Version</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for pkg in system_information.debian_packages.outputs.payload %}
+                            <tr>
+                            <th>{{ pkg.name }}</th>
+                            <td>{{ pkg.version }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    </details>
+                    {% endif %}
+                {% endif %}
                 <h2>Tests Results</h2>
                     {%- if manager.test_plans %}
                     <p>Test plan: {{ manager.test_plans[0] }}</p>
@@ -186,6 +310,12 @@
                         <table data-role="table" id="{{ cat_id }}" data-filter="true" data-input="#filterTable-input1" class="ui-body-d ui-shadow table-stroke ui-responsive">
                             <thead>
                                 <tr class="ui-bar-d">
+                                <th>Job ID</th>
+                                <td>Outcome</td>
+                                <td>Certification Status</td>
+                                <td>Execution Time</td>
+                                <td>I/O Log</td>
+                                <td>Comments</td>
                                 </tr>
                             </thead>
                             <tbody>
@@ -198,6 +328,7 @@
                                     {%- else %}
                                     <td style='width:10%'></td>
                                     {%- endif %}
+                                    <td style='width:10%'>{{ (job_state.result.execution_duration | default(0)) | round(1) }}s</td>
                                     {%- if job_state.result.io_log_as_flat_text != "" %}
                                     <td style='width:10%'><a href="#{{ mainloop.index }}-{{ loop.index }}-log">I/O log</a></td>
                                     {%- else %}

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
@@ -83,7 +83,7 @@
                     </ul>
                 {% endif %}
                 {% if system_information %}
-                    {% if system_information.image_info.success %}
+                    {% if system_information.image_info and system_information.image_info.success %}
                     <details>
                     <summary><h3>Image Information</h3></summary>
                     <table>

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/multi-page.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/multi-page.html
@@ -69,6 +69,7 @@
 {%- set state = manager.default_device_context.state -%}
 {%- set resource_map = state.resource_map -%}
 {%- set job_state_map = state.job_state_map -%}
+{%- set system_information = state.system_information -%}
 {%- set category_map = state.category_map_lite -%}
 {%- set category_outcome_map = state.category_outcome_map -%}
 {%- set resource_global_outcome = state.resource_global_outcome -%}
@@ -93,19 +94,20 @@
     </div><!-- /header -->
 
     <div role="main" class="ui-content jqm-content">
-        {%- if ns ~ 'system_info_json' in state.job_state_map and state.job_state_map[ns ~ 'system_info_json'].result.outcome == 'pass' %}
         <h2>System Information</h2>
+        <h3>Summary</h3>
+        {%- if ns ~ 'system_info_json' in state.job_state_map and state.job_state_map[ns ~ 'system_info_json'].result.outcome == 'pass' %}
         {%- set system_info_json = state.job_state_map[ns ~ 'system_info_json'].result.io_log_as_text_attachment.rstrip() %}
         {%- set system_info = system_info_json|json_load_ordered_dict %}
         <table data-role="table" id="system-info" data-mode="reflow" class="ui-body-d ui-responsive table-stroke">
             <thead><tr class="ui-bar-d"></tr></thead>
-            </tbody>
+            <tbody>
             {%- for section, section_data in system_info.items() %}
-                <tr style="margin-top: 0px; margin-bottom: 0px; padding-top: 0px; padding-bottom: 0px;">
-                <th style="margin-top: 0px; margin-bottom: 0px; padding-top: 0px; padding-bottom: 0px; vertical-align:top; font-size: 0.85em;">{{ section }}</th>
-                <td style="margin-top: 0px; margin-bottom: 0px; padding-top: 0px; padding-bottom: 0px; line-height: 1em;">
+                <tr>
+                <th>{{ section }}</th>
+                <td>
                 {%- for info in section_data %}
-                <p style="margin-top: 0px; margin-bottom: 0px; padding-top: 0px; padding-bottom: 0px; font-size: 0.85em">
+                <p>
                 {% autoescape false %}
                 {%- if section in ('System', 'Machine', 'CPU') %}
                 {{ info|highlight_keys }}
@@ -119,8 +121,130 @@
             {%- endfor %}
             </tbody>
         </table>
-        <br>
-        {%- endif %}
+        {% elif system_information %}
+            <ul>
+                {% if system_information.distribution and system_information.distribution.success %}
+                <li>Distribution: {{ system_information.distribution.outputs.payload.description }}</li>
+                {% endif %}
+                {% if system_information.uname and system_information.uname.success %}
+                <li>Kernel: {{ system_information.uname.outputs.payload.kernel }} ({{ system_information.uname.outputs.payload.architecture }})</li>
+                {% endif %}
+                {% if system_information.memory and system_information.memory.success %}
+                <li>Memory: {{ (system_information.memory.outputs.payload.total / 1024 / 1024 / 1024) | round(2) }} GiB</li>
+                {% endif %}
+            </ul>
+        {% endif %}
+        {% if system_information %}
+            {% if system_information.image_info and system_information.image_info.success %}
+            <details>
+            <summary><h3>Image Information</h3></summary>
+            <table>
+                <tbody>
+                    <tr>
+                        <th>Project</th>
+                        <td>{{ system_information.image_info.outputs.payload.project }}</td>
+                    </tr>
+                    <tr>
+                        <th>Series</th>
+                        <td>{{ system_information.image_info.outputs.payload.series }}</td>
+                    </tr>
+                    <tr>
+                        <th>Build Date</th>
+                        <td>{{ system_information.image_info.outputs.payload.build_date }}</td>
+                    </tr>
+                    <tr>
+                        <th>Build Number</th>
+                        <td>{{ system_information.image_info.outputs.payload.build_number }}</td>
+                    </tr>
+                    <tr>
+                        <th>Kernel</th>
+                        <td>{{ system_information.image_info.outputs.payload.kernel_type }} {{ system_information.image_info.outputs.payload.kernel_version }}</td>
+                    </tr>
+                    <tr>
+                        <th>Link</th>
+                        <td><a href="{{ system_information.image_info.outputs.payload.url }}">OEM Image</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            </details>
+            {% endif %}
+            {% if system_information.bios and system_information.bios.success %}
+            <details>
+            <summary><h3>BIOS</h3></summary>
+            <table>
+            {% for key, value in system_information.bios.outputs.payload.items() %}
+            <tr>
+                <th>{{ key }}</th>
+                <td>{{ value }}</td>
+            </tr>
+            {% endfor %}
+            </table>
+            </details>
+            {% endif %}
+            {% if system_information.machine_manifest and system_information.machine_manifest.success %}
+            <details>
+            <summary><h3>Machine Manifest</h3></summary>
+            <table>
+                <thead>
+                    <tr>
+                    <th>Name</th>
+                    <th>Value</th>
+                    </tr>
+                </thead>
+                {% for key, value in system_information.machine_manifest.outputs.payload.items() %}
+                <tr>
+                    <th>{{ key }}</th>
+                    <td>{{ value }}</td>
+                </tr>
+                {% endfor %}
+            </table>
+            </details>
+            {% endif %}
+            {% if system_information.snaps and system_information.snaps.success %}
+            <details>
+            <summary><h3>Snaps</h3></summary>
+            <table>
+                <thead>
+                    <tr>
+                    <th>Name</th>
+                    <th>Version</th>
+                    <th>Channel</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for snap in system_information.snaps.outputs.payload %}
+                    <tr>
+                    <th>{{ snap.name }}</th>
+                    <td>{{ snap.version }} (rev{{ snap.revision }})</td>
+                    <td>{{ snap.channel }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            </details>
+            {% endif %}
+            {% if system_information.debian_packages and system_information.debian_packages.success %}
+            <details>
+            <summary><h3>Debian Packages</h3></summary>
+            <table>
+                <thead>
+                    <tr>
+                    <th>Name</th>
+                    <th>Version</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for pkg in system_information.debian_packages.outputs.payload %}
+                    <tr>
+                    <th>{{ pkg.name }}</th>
+                    <td>{{ pkg.version }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            </details>
+            {% endif %}
+        {% endif %}
         <h2>Tests Results</h2>
             {%- if manager.test_plans %}
             <p>Test plan: {{ manager.test_plans[0] }}</p>
@@ -231,6 +355,12 @@
         <table data-role="table" id="{{ cat_id }}" data-filter="true" data-input="#filterTable-input{{ managerloop.index }}" class="ui-body-d ui-shadow table-stroke ui-responsive">
             <thead>
                 <tr class="ui-bar-d">
+                <th>Job ID</th>
+                <td>Outcome</td>
+                <td>Certification Status</td>
+                <td>Execution Time</td>
+                <td>I/O Log</td>
+                <td>Comments</td>
                 </tr>
             </thead>
             <tbody>
@@ -243,6 +373,7 @@
                     {%- else %}
                     <td style='width:10%'></td>
                     {%- endif %}
+                    <td style='width:10%'>{{ (job_state.result.execution_duration | default(0)) | round(1) }}s</td>
                     {%- if job_state.result.io_log_as_flat_text != "" %}
                     <td style='width:10%'><a href="#{{ managerloop.index }}-{{ mainloop.index }}-{{ loop.index }}-log">I/O log</a></td>
                     {%- else %}

--- a/checkbox-ng/plainbox/test-data/html-exporter/with_certification_blocker.html
+++ b/checkbox-ng/plainbox/test-data/html-exporter/with_certification_blocker.html
@@ -58,6 +58,62 @@
     src: local("Ubuntu Mono"), local("UbuntuMono-Regular"), url("https://fonts.gstatic.com/s/ubuntumono/v6/ViZhet7Ak-LRXZMXzuAfkYbN6UDyHWBl620a-IRfuBk.woff") format("woff");
 }
 
+html {
+    font-size: 62.5%; /* Sets base to 10px */
+}
+
+body {
+    font-size: 1.4em;
+}
+
+details {
+    padding-bottom: 1em;
+}
+
+summary>h3 {
+    color: #DD4815;
+    background-color: transparent;
+    font-size: 1.4em;
+    font-weight: 300;
+    margin: 0 0 1em;
+    display:inline;
+}
+
+summary {
+  list-style: none;
+  cursor: pointer;
+  &::before {
+    content: "+";
+    color: #DD4815;
+    padding: 0 0.5em 0 0;
+    margin-inline-start: 0.5em;
+  }
+  [open] &::before {
+    content: "–";
+  }
+}
+
+th {
+    text-align: left;
+}
+
+tbody tr:nth-child(odd) {
+  background-color: #eeeeee;
+}
+
+td > p {
+    padding: 0;
+    margin: 0;
+}
+
+.ui-table td {
+    padding: 0em;
+}
+
+td {
+    padding: 0.25em;
+}
+
 /* JQM Demos custom CSS */
 
 .ui-collapsible-content,
@@ -197,7 +253,7 @@
     line-height: 1.5;
 }
 .jqm-demos .jqm-content > ul:not(.jqm-list) li {
-    font-size: 1.2em;
+    font-size: 1em;
     line-height: 1.5;
 }
 .jqm-demos .jqm-content > p {
@@ -502,6 +558,9 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                     <h1>System Testing Report</h1>
                 </div><!-- /header -->
             <div role="main" class="ui-content jqm-content">
+                <h2>System Information</h2>
+                <h3>Summary</h3>
+                
                 <h2>Tests Results</h2>
                     <div id="canvas-holder" style="width:300px">
                         <canvas id="chart-area"></canvas>
@@ -601,6 +660,12 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                         <table data-role="table" id="com.canonical.plainbox::uncategorised" data-filter="true" data-input="#filterTable-input1" class="ui-body-d ui-shadow table-stroke ui-responsive">
                             <thead>
                                 <tr class="ui-bar-d">
+                                <th>Job ID</th>
+                                <td>Outcome</td>
+                                <td>Certification Status</td>
+                                <td>Execution Time</td>
+                                <td>I/O Log</td>
+                                <td>Comments</td>
                                 </tr>
                             </thead>
                             <tbody>
@@ -608,6 +673,7 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                                     <td data-filtertext="job_id1" style='width:35%'>job_id1</td>
                                     <td style='width:10%; font-weight: bold; color: #DC3912'>failed</td>
                                     <td style='width:10%'>blocker</td>
+                                    <td style='width:10%'>1.0s</td>
                                     <td style='width:10%'><a href="#1-1-log">I/O log</a></td>
                                     <td style='width:35%'></td>
                                 </tr>
@@ -615,6 +681,7 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                                     <td data-filtertext="job_id2" style='width:35%'>job_id2</td>
                                     <td style='width:10%; font-weight: bold; color: #6AA84F'>passed</td>
                                     <td style='width:10%'></td>
+                                    <td style='width:10%'>1.0s</td>
                                     <td style='width:10%'><a href="#1-2-log">I/O log</a></td>
                                     <td style='width:35%'>blah blah</td>
                                 </tr>
@@ -622,6 +689,7 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                                     <td data-filtertext="job_id3" style='width:35%'>job_id3</td>
                                     <td style='width:10%; font-weight: bold; color: #FF9900'>skipped</td>
                                     <td style='width:10%'></td>
+                                    <td style='width:10%'>1.0s</td>
                                     <td style='width:10%'></td>
                                     <td style='width:35%'>No such device</td>
                                 </tr>

--- a/checkbox-ng/plainbox/test-data/html-exporter/without_certification_status.html
+++ b/checkbox-ng/plainbox/test-data/html-exporter/without_certification_status.html
@@ -58,6 +58,62 @@
     src: local("Ubuntu Mono"), local("UbuntuMono-Regular"), url("https://fonts.gstatic.com/s/ubuntumono/v6/ViZhet7Ak-LRXZMXzuAfkYbN6UDyHWBl620a-IRfuBk.woff") format("woff");
 }
 
+html {
+    font-size: 62.5%; /* Sets base to 10px */
+}
+
+body {
+    font-size: 1.4em;
+}
+
+details {
+    padding-bottom: 1em;
+}
+
+summary>h3 {
+    color: #DD4815;
+    background-color: transparent;
+    font-size: 1.4em;
+    font-weight: 300;
+    margin: 0 0 1em;
+    display:inline;
+}
+
+summary {
+  list-style: none;
+  cursor: pointer;
+  &::before {
+    content: "+";
+    color: #DD4815;
+    padding: 0 0.5em 0 0;
+    margin-inline-start: 0.5em;
+  }
+  [open] &::before {
+    content: "–";
+  }
+}
+
+th {
+    text-align: left;
+}
+
+tbody tr:nth-child(odd) {
+  background-color: #eeeeee;
+}
+
+td > p {
+    padding: 0;
+    margin: 0;
+}
+
+.ui-table td {
+    padding: 0em;
+}
+
+td {
+    padding: 0.25em;
+}
+
 /* JQM Demos custom CSS */
 
 .ui-collapsible-content,
@@ -197,7 +253,7 @@
     line-height: 1.5;
 }
 .jqm-demos .jqm-content > ul:not(.jqm-list) li {
-    font-size: 1.2em;
+    font-size: 1em;
     line-height: 1.5;
 }
 .jqm-demos .jqm-content > p {
@@ -502,6 +558,9 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                     <h1>System Testing Report</h1>
                 </div><!-- /header -->
             <div role="main" class="ui-content jqm-content">
+                <h2>System Information</h2>
+                <h3>Summary</h3>
+                
                 <h2>Tests Results</h2>
                     <div id="canvas-holder" style="width:300px">
                         <canvas id="chart-area"></canvas>
@@ -601,6 +660,12 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                         <table data-role="table" id="com.canonical.plainbox::uncategorised" data-filter="true" data-input="#filterTable-input1" class="ui-body-d ui-shadow table-stroke ui-responsive">
                             <thead>
                                 <tr class="ui-bar-d">
+                                <th>Job ID</th>
+                                <td>Outcome</td>
+                                <td>Certification Status</td>
+                                <td>Execution Time</td>
+                                <td>I/O Log</td>
+                                <td>Comments</td>
                                 </tr>
                             </thead>
                             <tbody>
@@ -608,6 +673,7 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                                     <td data-filtertext="job_id1" style='width:35%'>job_id1</td>
                                     <td style='width:10%; font-weight: bold; color: #DC3912'>failed</td>
                                     <td style='width:10%'></td>
+                                    <td style='width:10%'>1.0s</td>
                                     <td style='width:10%'><a href="#1-1-log">I/O log</a></td>
                                     <td style='width:35%'></td>
                                 </tr>
@@ -615,6 +681,7 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                                     <td data-filtertext="job_id2" style='width:35%'>job_id2</td>
                                     <td style='width:10%; font-weight: bold; color: #6AA84F'>passed</td>
                                     <td style='width:10%'></td>
+                                    <td style='width:10%'>1.0s</td>
                                     <td style='width:10%'><a href="#1-2-log">I/O log</a></td>
                                     <td style='width:35%'>blah blah</td>
                                 </tr>
@@ -622,6 +689,7 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                                     <td data-filtertext="job_id3" style='width:35%'>job_id3</td>
                                     <td style='width:10%; font-weight: bold; color: #FF9900'>skipped</td>
                                     <td style='width:10%'></td>
+                                    <td style='width:10%'>1.0s</td>
                                     <td style='width:10%'></td>
                                     <td style='width:35%'>No such device</td>
                                 </tr>


### PR DESCRIPTION


## Description

Add the following to the default HTML report (used by Checkbox when
exporting to HTML and when using the `merge-submissions` subcommand) as well as the multi-page HTML report (used by the `merge-reports` subcommand):

- If `system_info_json` job has not been run, use some data from the
`system_information` collector instead (distribution, kernel, memory)
- Add more metadata from `system_information` collectors, if available
(these are collapsed tables by default and can be shown by clicking on
their title):
    - Image information
    - BIOS
    - Machine Manifest
    - Snaps
    - Debian Packages
- Add headers for each columns in the Tests Results
- Add execution times (in seconds) for each Test Result

A bug has been fixed in merge_reports.py to properly expose `system_information` to the templates.

The formatting of the HTML templates has been modified a bit.

Sample HTML report: [submission_2026-04-13T06.28.05.338628.zip](https://github.com/user-attachments/files/26667362/submission_2026-04-13T06.28.05.338628.zip)

Sample HTML report on UC16: [submission.html](https://github.com/user-attachments/files/26741504/submission.html) (it's run in a VM with a test plan that ends up not running any jobs, hence the lack of executed jobs).



When available, new sections appear (collapsed by default):

<img width="2066" height="1470" alt="image" src="https://github.com/user-attachments/assets/dedb4b8f-906f-4e9a-b608-0b245e7467b4" />

Each section can be clicked on to reveal the data:

<img width="1188" height="1077" alt="image" src="https://github.com/user-attachments/assets/54e5ed73-31b2-4b2e-8fc7-f24e360dfe1f" />

Test Results now include headers as well as execution time:

<img width="2039" height="367" alt="image" src="https://github.com/user-attachments/assets/80449a5c-9910-42ca-bdac-c54e3d14e02b" />


## Resolved issues

https://warthogs.atlassian.net/browse/CHECKBOX-2024

## Documentation



## Tests

- Ran checkbox-cli to generate an HTML report, and checked that all the data was there
- Used submissions created with previous versions of Checkbox to test the `merge-reports` and `merge-submissions` subcommands, both work as expected.
