### PR TITLE
This fix TypeError: FakeJobRunner.run_job() got an unexpected keyword (Bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -524,8 +524,8 @@ class FakeJobRunner(UnifiedRunner):
     """
 
     def run_job(
-            self, job, job_state, environ=None, ui=None, as_systemd_unit=False
-            ):
+        self, job, job_state, environ=None, ui=None, as_systemd_unit=False
+    ):
         """
         Only one resouce object is created from this runner.
         Exception: 'graphics_card' resource job creates two objects to
@@ -534,7 +534,7 @@ class FakeJobRunner(UnifiedRunner):
         if job.plugin != "resource":
             return super().run_job(
                 job, job_state, environ, ui, as_systemd_unit
-                )
+            )
         builder = JobResultBuilder()
         if job.partial_id == "graphics_card":
             builder.io_log = [

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -523,14 +523,18 @@ class FakeJobRunner(UnifiedRunner):
     Special runner that creates fake resource objects.
     """
 
-    def run_job(self, job, job_state, environ=None, ui=None):
+    def run_job(
+            self, job, job_state, environ=None, ui=None, as_systemd_unit=False
+            ):
         """
         Only one resouce object is created from this runner.
         Exception: 'graphics_card' resource job creates two objects to
         simulate hybrid graphics.
         """
         if job.plugin != "resource":
-            return super().run_job(job, job_state, environ, ui)
+            return super().run_job(
+                job, job_state, environ, ui, as_systemd_unit
+                )
         builder = JobResultBuilder()
         if job.partial_id == "graphics_card":
             builder.io_log = [

--- a/checkbox-ng/plainbox/impl/test_execution.py
+++ b/checkbox-ng/plainbox/impl/test_execution.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from unittest import TestCase, mock
 
 from plainbox.impl.execution import (
+    FakeJobRunner,
     MountingStrategy,
     UnifiedRunner,
     add_to_environment,
@@ -520,3 +521,139 @@ class TestGetExecutionEnvironment(TestCase):
         )
 
         self.assertEqual(env["EXISTING_VAR"], "original_value")
+
+
+@mock.patch("plainbox.impl.execution.dangerous_nsenter", new=empty_context)
+class FakeJobRunnerTests(TestCase):
+    def test_run_job_non_resource_as_systemd_unit_false(self):
+        """Test FakeJobRunner passes as_systemd_unit=False to parent for non-resource jobs."""
+        fake_runner = FakeJobRunner(
+            session_id="test-session",
+            provider_list=[],
+            jobs_io_log_dir=None,
+        )
+
+        job = mock.MagicMock()
+        job.plugin = "shell"
+        job_state = mock.MagicMock()
+
+        with mock.patch.object(
+            UnifiedRunner, "run_job", return_value=mock.MagicMock()
+        ) as mock_parent_run_job:
+            fake_runner.run_job(job, job_state, as_systemd_unit=False)
+
+            mock_parent_run_job.assert_called_once_with(
+                job, job_state, None, None, False
+            )
+
+    def test_run_job_non_resource_as_systemd_unit_true(self):
+        """Test FakeJobRunner passes as_systemd_unit=True to parent for non-resource jobs."""
+        fake_runner = FakeJobRunner(
+            session_id="test-session",
+            provider_list=[],
+            jobs_io_log_dir=None,
+        )
+
+        job = mock.MagicMock()
+        job.plugin = "shell"
+        job_state = mock.MagicMock()
+
+        with mock.patch.object(
+            UnifiedRunner, "run_job", return_value=mock.MagicMock()
+        ) as mock_parent_run_job:
+            fake_runner.run_job(job, job_state, as_systemd_unit=True)
+
+            mock_parent_run_job.assert_called_once_with(
+                job, job_state, None, None, True
+            )
+
+    def test_run_job_resource_default_as_systemd_unit(self):
+        """Test FakeJobRunner creates fake resource for resource jobs (default as_systemd_unit)."""
+        fake_runner = FakeJobRunner(
+            session_id="test-session",
+            provider_list=[],
+            jobs_io_log_dir=None,
+        )
+
+        job = mock.MagicMock()
+        job.plugin = "resource"
+        job.partial_id = "some_resource"
+        job_state = mock.MagicMock()
+
+        result = fake_runner.run_job(job, job_state)
+
+        self.assertEqual(result.outcome, "pass")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.io_log), 1)
+        self.assertEqual(result.io_log[0].stream_name, "stdout")
+        self.assertEqual(result.io_log[0].data, b"a: b\n")
+
+    def test_run_job_graphics_card_resource(self):
+        """Test FakeJobRunner creates two resource objects for graphics_card."""
+        fake_runner = FakeJobRunner(
+            session_id="test-session",
+            provider_list=[],
+            jobs_io_log_dir=None,
+        )
+
+        job = mock.MagicMock()
+        job.plugin = "resource"
+        job.partial_id = "graphics_card"
+        job_state = mock.MagicMock()
+
+        result = fake_runner.run_job(job, job_state)
+
+        self.assertEqual(result.outcome, "pass")
+        self.assertEqual(result.return_code, 0)
+        self.assertEqual(len(result.io_log), 3)
+        self.assertEqual(result.io_log[0].stream_name, "stdout")
+        self.assertEqual(result.io_log[0].data, b"a: b\n")
+        self.assertEqual(result.io_log[1].stream_name, "stdout")
+        self.assertEqual(result.io_log[1].data, b"\n")
+        self.assertEqual(result.io_log[2].stream_name, "stdout")
+        self.assertEqual(result.io_log[2].data, b"a: c\n")
+
+    def test_run_job_resource_with_environ_and_ui(self):
+        """Test FakeJobRunner creates fake resource with environ and ui parameters."""
+        fake_runner = FakeJobRunner(
+            session_id="test-session",
+            provider_list=[],
+            jobs_io_log_dir=None,
+        )
+
+        job = mock.MagicMock()
+        job.plugin = "resource"
+        job.partial_id = "test_resource"
+        job_state = mock.MagicMock()
+        environ = {"TEST": "value"}
+        ui = mock.MagicMock()
+
+        result = fake_runner.run_job(job, job_state, environ, ui)
+
+        self.assertEqual(result.outcome, "pass")
+        self.assertEqual(result.return_code, 0)
+
+    def test_run_job_non_resource_with_all_parameters(self):
+        """Test FakeJobRunner passes all parameters correctly to parent."""
+        fake_runner = FakeJobRunner(
+            session_id="test-session",
+            provider_list=[],
+            jobs_io_log_dir=None,
+        )
+
+        job = mock.MagicMock()
+        job.plugin = "shell"
+        job_state = mock.MagicMock()
+        environ = {"TEST": "value"}
+        ui = mock.MagicMock()
+
+        with mock.patch.object(
+            UnifiedRunner, "run_job", return_value=mock.MagicMock()
+        ) as mock_parent_run_job:
+            fake_runner.run_job(
+                job, job_state, environ, ui, as_systemd_unit=True
+            )
+
+            mock_parent_run_job.assert_called_once_with(
+                job, job_state, environ, ui, True
+            )


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
This PR fix the error while running command `tp-export`
```
rick.wu@canonical.com@rickwu:~$ checkbox.checkbox-cli tp-export com.canonical.contrib::ce-oem-iot-server-24-04
We are deprecating the classic frontend Checkbox snaps
Consider switching to the strict frontend

$PROVIDERPATH is defined, so following provider sources are ignored ['/home/rick.wu@canonical.com/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Using sideloaded provider: checkbox-provider-ce-oem, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-ce-oem
Using sideloaded provider: checkbox-provider-ce-oem, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-ce-oem
unable to find nested part: com.canonical.contrib::ce-oem-caam-manual
unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-caam-manual
unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-iio-sensors-manual
Undeclared exception TypeError raised from bootstrap
Traceback (most recent call last):
  File "/snap/checkbox24/current/bin/checkbox-cli", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/snap/checkbox24/current/lib/python3.12/site-packages/checkbox_ng/launcher/checkbox_cli.py", line 185, in main
    return subcmd.invoked(ctx)
           ^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/current/lib/python3.12/site-packages/checkbox_ng/launcher/subcommands.py", line 1608, in invoked
    self.sa.bootstrap()
  File "/snap/checkbox24/current/lib/python3.12/site-packages/plainbox/impl/decorators.py", line 154, in wrapper
    raise exc
  File "/snap/checkbox24/current/lib/python3.12/site-packages/plainbox/impl/decorators.py", line 146, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/current/lib/python3.12/site-packages/plainbox/impl/session/assistant.py", line 903, in bootstrap
    rb = self.run_job(job.id, "silent", False)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/current/lib/python3.12/site-packages/plainbox/impl/decorators.py", line 154, in wrapper
    raise exc
  File "/snap/checkbox24/current/lib/python3.12/site-packages/plainbox/impl/decorators.py", line 146, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/current/lib/python3.12/site-packages/plainbox/impl/session/assistant.py", line 1631, in run_job
    result = self._runner.run_job(
             ^^^^^^^^^^^^^^^^^^^^^
TypeError: FakeJobRunner.run_job() got an unexpected keyword argument 'as_systemd_unit'
```

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
Test with the sideload checkbox24
```
rick.wu@canonical.com@rickwu:~$ checkbox.checkbox-cli tp-export com.canonical.contrib::ce-oem-iot-server-24-04
We are deprecating the classic frontend Checkbox snaps
Consider switching to the strict frontend

$PROVIDERPATH is defined, so following provider sources are ignored ['/home/rick.wu@canonical.com/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Using sideloaded provider: checkbox-provider-ce-oem, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-ce-oem
Using sideloaded provider: checkbox-provider-ce-oem, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-ce-oem
unable to find nested part: com.canonical.contrib::ce-oem-caam-manual
unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-caam-manual
unable to find nested part: com.canonical.contrib::after-suspend-ce-oem-iio-sensors-manual
warning: /snap/checkbox24/current/providers/checkbox-provider-base/units/optical/jobs.pxu:75-88: job 'optical/cdrom-write-automated_NAME', field 'summary', please stay under 80 characters
warning: /snap/checkbox24/current/providers/checkbox-provider-base/units/suspend/suspend.pxu:659-675: job 'suspend/iperf_after_suspend_ether_auto_device1_INTERFACE', field 'summary', please stay under 80 characters
warning: /snap/checkbox24/current/providers/checkbox-provider-base/units/wireless/wifi-ap.pxu:1007-1042: job 'wireless/wifi_ap_across_reboot_INTERFACE_setup_manual', field 'summary', please stay under 80 characters
warning: /snap/checkbox24/current/providers/checkbox-provider-base/units/wireless/wifi-ap.pxu:1044-1075: job 'wireless/wifi_ap_across_reboot_INTERFACE_check', field 'summary', please stay under 80 characters
warning: /snap/checkbox24/current/providers/checkbox-provider-base/units/stress/suspend_cycles_reboot.pxu:135: job 'stress-tests/suspend_cycles_SUSPEND_ID_rebootSUSPEND_REBOOT_ID', field 'summary', please stay under 80 characters
Dependency problem: missing dependency: 'com.canonical.certification::warm-boot-loop-testREBOOT_ID_PREVIOUS' (after)
Dependency problem: missing dependency: 'com.canonical.certification::warm-boot-loop-rebootREBOOT_ID' (depends)
Dependency problem: missing dependency: 'com.canonical.certification::cold-boot-loop-testREBOOT_ID_PREVIOUS' (after)
Dependency problem: missing dependency: 'com.canonical.certification::cold-boot-loop-rebootREBOOT_ID' (depends)
Dependency problem: missing dependency: 'com.canonical.certification::stress-tests/suspend_cycles_rebootSUSPEND_REBOOT_PREVIOUS' (after)
Dependency problem: missing dependency: 'com.canonical.certification::stress-tests/suspend_cycles_SUSPEND_ID_PREVIOUS_rebootSUSPEND_REBOOT_ID' (after)
Dependency problem: missing dependency: 'com.canonical.certification::stress-tests/suspend_cycles_S3_ITERATIONS_rebootSUSPEND_REBOOT_ID' (after)
Dependency problem: missing dependency: 'com.canonical.certification::stress-tests/suspend_cycles_rebootREBOOT_ITERATIONS' (after)
Dependency problem: missing dependency: 'com.canonical.certification::stress-tests/suspend_cycles_rebootREBOOT_ITERATIONS' (after)
Dependency problem: missing dependency: 'com.canonical.contrib::ce-oem-post-cold-boot-loop-by-pdu-rebootREBOOT_ID_PREVIOUS' (after)
Dependency problem: missing dependency: 'com.canonical.contrib::ce-oem-cold-boot-loop-by-pdu-rebootREBOOT_ID' (depends)
/var/tmp/checkbox-ng/sessions/tp-export-ephemeral-2026-04-09T07.47.58.session/CE-OEM-IOT_-_Full_manual___automated_OEMQA_tests_for_Ubuntu_Server_24.04.xlsx
```

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
