### PR TITLE
update params in look_up_xtest (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/look_up_xtest.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/look_up_xtest.py
@@ -10,7 +10,7 @@ class ExtendSanpd(Snapd):
         super().__init__(task_timeout, poll_interval, verbose)
 
     def list_apps(self, snaps):
-        return self._get(self._apps, params={"names": snaps})
+        return self._get(self._apps, params=snaps)
 
 
 def look_up_app(target_app, snap_name=None):


### PR DESCRIPTION
Due to a change in function behavior in checkbox-support, we have updated our script accordingly.

Please refer to this [PR](https://github.com/canonical/checkbox/pull/2452/changes#diff-064b82b6a8989c595f23704bc986374a602a8b9b49d29b8a5034494663f1ec79) for more detail about the changes

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
Due to the `_get` function in snapd changed in [PR](https://github.com/canonical/checkbox/pull/2452/changes#diff-064b82b6a8989c595f23704bc986374a602a8b9b49d29b8a5034494663f1ec79). Update xtest look up script for fix error while running.
```
Traceback (most recent call last):
  File "/tmp/nest-ucn0p4qn.f1dfb4043b8477fc3e4871d77ff14931051b4b4c3adb901731bd28421cf86be3/optee_helper.py", line 207, in <module>
    main()
  File "/tmp/nest-ucn0p4qn.f1dfb4043b8477fc3e4871d77ff14931051b4b4c3adb901731bd28421cf86be3/optee_helper.py", line 203, in main
    raise SystemExit(launch_xtest(args.test_suite, args.test_id))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/nest-ucn0p4qn.f1dfb4043b8477fc3e4871d77ff14931051b4b4c3adb901731bd28421cf86be3/optee_helper.py", line 37, in launch_xtest
    test_utility = look_up_app("xtest", os.environ.get("XTEST"))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox-ce-oem/6686/providers/checkbox-provider-ce-oem/bin/look_up_xtest.py", line 18, in look_up_app
    apps = ExtendSanpd().list_apps(snap_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox-ce-oem/6686/providers/checkbox-provider-ce-oem/bin/look_up_xtest.py", line 13, in list_apps
    return self._get(self._apps, params={"names": snaps})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/current/lib/python3.12/site-packages/checkbox_ng/support/snap_utils/snapd.py", line 102, in _get
    return self._request("GET", path, params=params, decode=decode)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/checkbox24/current/lib/python3.12/site-packages/checkbox_ng/support/snap_utils/snapd.py", line 92, in _request
    conn.request(method, path, body=data, headers=headers)
  File "/snap/checkbox24/current/usr/lib/python3.12/http/client.py", line 1356, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/snap/checkbox24/current/usr/lib/python3.12/http/client.py", line 1367, in _send_request
    self.putrequest(method, url, **skips)
  File "/snap/checkbox24/current/usr/lib/python3.12/http/client.py", line 1201, in putrequest
    self._validate_path(url)
  File "/snap/checkbox24/current/usr/lib/python3.12/http/client.py", line 1301, in _validate_path
    raise InvalidURL(f"URL can't contain control characters. {url!r} "
http.client.InvalidURL: URL can't contain control characters. "/v2/apps?{'names': 'rzg2l-optee-xtest'}" (found at least ' ')
```


<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
Side load result
```
----------[ regression test - Session - user login for current user ]-----------
ID: com.canonical.contrib::ce-oem-optee/xtest-regression-xtest_tee_test_1027
Category: OP-TEE(Open Source - Trusted Execution Environment) test
--------------------------------------------------------------------------------
Looking for PID of tee-supplicant..
Running command: pgrep tee-supplicant
1330
Looking for TA path...
Attempting to install TA...
TA install succeeded!
Running command: rzg2l-optee-xtest.xtest -t regression 1027
Test ID: 1027
Run test suite with level=0

TEE test application started over default TEE instance
######################################################
#
# regression
#
######################################################
 
* regression_1027 Session: user login for current user
  regression_1027 OK
+-----------------------------------------------------
Result of testsuite regression filtered by "1027":
regression_1027 OK
+-----------------------------------------------------
6 subtests of which 0 failed
1 test case of which 0 failed
99 test cases were skipped
TEE test application done!
--------------------------------------------------------------------------------
Outcome: job passed
```

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
