### PR TITLE
Show skip reason on unsupported remote tests like local (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -109,6 +109,9 @@ class SimpleUI(NormalUI, MainLoopStage):
     def black_text(text, end="\n"):
         print(SimpleUI.C.BLACK(text), end=end, file=sys.stdout)
 
+    def yellow_text(text, end="\n"):
+        print(SimpleUI.C.YELLOW(text), end=end, file=sys.stderr)
+
     def horiz_line():
         print(SimpleUI.C.WHITE("-" * 80))
 
@@ -902,9 +905,17 @@ class RemoteController(ReportsStage, MainLoopStage):
                 self.finish_job()
                 break
 
-    def finish_job(self, result=None):
+    def finish_job(self, result=None, job_state=None):
         _logger.info("controller: Finishing job with a result: %s", result)
         job_result = self.sa.finish_job(result)
+        if (
+            job_state
+            and result
+            and result.outcome == IJobResult.OUTCOME_NOT_SUPPORTED
+        ):
+            print(_("Job cannot be started because:"))
+            for inhibitor in job_state.readiness_inhibitor_list:
+                SimpleUI.yellow_text(" - {}".format(inhibitor))
         SimpleUI.horiz_line()
         print(_("Outcome") + ": " + SimpleUI.C.result(job_result))
 
@@ -1097,7 +1108,8 @@ class RemoteController(ReportsStage, MainLoopStage):
                             break
                         else:
                             self.finish_job(
-                                interaction.extra._builder.get_result()
+                                interaction.extra._builder.get_result(),
+                                job_state,
                             )
                             next_job = True
                             break


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

There is no reason to hide this information, it is shown by checkbox local, I don't see a reason why we shouldn't show it in remote as well

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/579
Fixes: CHECKBOX-2059

## Documentation

N/A

## Tests

Output before this patch:
```
----------------------------[ Running job 19 / 20 ]-----------------------------
----------[ Verify job result status when requirements are not met. ]-----------
ID: com.canonical.certification::smoke/requirement/bad
Category: Uncategorised
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Outcome: job cannot be started
```

Output after the patch:
```
----------------------------[ Running job 19 / 20 ]-----------------------------
----------[ Verify job result status when requirements are not met. ]-----------
ID: com.canonical.certification::smoke/requirement/bad
Category: Uncategorised
--------------------------------------------------------------------------------
Job cannot be started because:
 - resource expression 'package.name == "unknown-package"' evaluates to false
--------------------------------------------------------------------------------
Outcome: job cannot be started
```
