### PR TITLE
Avoid re-connecting every Ctrl+C (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -286,6 +286,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         while True:
             try:
                 if interrupted:
+                    # handling ctrl+c, assumes we are already connected
                     _logger.info("controller: Session interrupted")
                     interrupted = False  # we are handling the interruption ATM
                     # next line can raise exception due to connection being
@@ -294,47 +295,49 @@ class RemoteController(ReportsStage, MainLoopStage):
                     keep_running = self._handle_interrupt()
                     if not keep_running:
                         break
-                conn = rpyc.connect(host, port, config=config, keepalive=True)
-                keep_running = True
-
-                def quitter(msg):
-                    # this will be called when the agent decides to disconnect
-                    # this controller
-                    nonlocal server_msg
-                    nonlocal keep_running
-                    keep_running = False
-                    server_msg = msg
-
-                with contextlib.suppress(AttributeError):
-                    # TODO: REMOTE_API
-                    # when bumping the remote api make this bit obligatory
-                    # i.e. remove the suppressing
-                    conn.root.register_controller_blaster(quitter)
-                self._sa = conn.root.get_sa()
-                self.sa.conn = conn
-                # TODO: REMOTE API RAPI: Remove this API on the next RAPI bump
-                # the check and bailout is not needed if the agent as up to
-                # date as this controller, so after bumping RAPI we can assume
-                # that agent is always passwordless
-                if not self.sa.passwordless_sudo:
-                    raise SystemExit(
-                        _(
-                            "This version of Checkbox requires the agent"
-                            " to be run as root"
-                        )
+                else:
+                    # here we either connecting or re-connecting
+                    conn = rpyc.connect(
+                        host, port, config=config, keepalive=True
                     )
+                    keep_running = True
 
-                self.check_remote_api_match()
+                    def quitter(msg):
+                        # this will be called when the agent decides to disconnect
+                        # this controller
+                        nonlocal server_msg
+                        nonlocal keep_running
+                        keep_running = False
+                        server_msg = msg
 
-                state, payload = self.sa.whats_up()
-                _logger.info("controller: Main dispatch with state: %s", state)
-                if printed_reconnecting and ever_disconnected:
-                    print(
-                        "...\nReconnected (took: {}s)".format(
-                            int(time.time() - disconnection_time)
+                    with contextlib.suppress(AttributeError):
+                        # TODO: REMOTE_API
+                        # when bumping the remote api make this bit obligatory
+                        # i.e. remove the suppressing
+                        conn.root.register_controller_blaster(quitter)
+                    self._sa = conn.root.get_sa()
+                    self.sa.conn = conn
+                    # TODO: REMOTE API RAPI: Remove this API on the next RAPI bump
+                    # the check and bailout is not needed if the agent as up to
+                    # date as this controller, so after bumping RAPI we can assume
+                    # that agent is always passwordless
+                    if not self.sa.passwordless_sudo:
+                        raise SystemExit(
+                            _(
+                                "This version of Checkbox requires the agent"
+                                " to be run as root"
+                            )
                         )
-                    )
-                    printed_reconnecting = False
+
+                    self.check_remote_api_match()
+
+                    if printed_reconnecting and ever_disconnected:
+                        print(
+                            "...\nReconnected (took: {}s)".format(
+                                int(time.time() - disconnection_time)
+                            )
+                        )
+                        printed_reconnecting = False
                 keep_running = self.continue_session()
             except EOFError as exc:
                 if keep_running:

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -287,6 +287,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         while True:
             try:
                 if interrupted:
+                    # handling ctrl+c, assumes we are already connected
                     _logger.info("controller: Session interrupted")
                     interrupted = False  # we are handling the interruption ATM
                     # next line can raise exception due to connection being
@@ -295,47 +296,49 @@ class RemoteController(ReportsStage, MainLoopStage):
                     keep_running = self._handle_interrupt()
                     if not keep_running:
                         break
-                conn = rpyc.connect(host, port, config=config, keepalive=True)
-                keep_running = True
-
-                def quitter(msg):
-                    # this will be called when the agent decides to disconnect
-                    # this controller
-                    nonlocal server_msg
-                    nonlocal keep_running
-                    keep_running = False
-                    server_msg = msg
-
-                with contextlib.suppress(AttributeError):
-                    # TODO: REMOTE_API
-                    # when bumping the remote api make this bit obligatory
-                    # i.e. remove the suppressing
-                    conn.root.register_controller_blaster(quitter)
-                self._sa = conn.root.get_sa()
-                self.sa.conn = conn
-                # TODO: REMOTE API RAPI: Remove this API on the next RAPI bump
-                # the check and bailout is not needed if the agent as up to
-                # date as this controller, so after bumping RAPI we can assume
-                # that agent is always passwordless
-                if not self.sa.passwordless_sudo:
-                    raise SystemExit(
-                        _(
-                            "This version of Checkbox requires the agent"
-                            " to be run as root"
-                        )
+                else:
+                    # here we either connecting or re-connecting
+                    conn = rpyc.connect(
+                        host, port, config=config, keepalive=True
                     )
+                    keep_running = True
 
-                self.check_remote_api_match()
+                    def quitter(msg):
+                        # this will be called when the agent decides to disconnect
+                        # this controller
+                        nonlocal server_msg
+                        nonlocal keep_running
+                        keep_running = False
+                        server_msg = msg
 
-                state, payload = self.sa.whats_up()
-                _logger.info("controller: Main dispatch with state: %s", state)
-                if printed_reconnecting and ever_disconnected:
-                    print(
-                        "...\nReconnected (took: {}s)".format(
-                            int(time.time() - disconnection_time)
+                    with contextlib.suppress(AttributeError):
+                        # TODO: REMOTE_API
+                        # when bumping the remote api make this bit obligatory
+                        # i.e. remove the suppressing
+                        conn.root.register_controller_blaster(quitter)
+                    self._sa = conn.root.get_sa()
+                    self.sa.conn = conn
+                    # TODO: REMOTE API RAPI: Remove this API on the next RAPI bump
+                    # the check and bailout is not needed if the agent as up to
+                    # date as this controller, so after bumping RAPI we can assume
+                    # that agent is always passwordless
+                    if not self.sa.passwordless_sudo:
+                        raise SystemExit(
+                            _(
+                                "This version of Checkbox requires the agent"
+                                " to be run as root"
+                            )
                         )
-                    )
-                    printed_reconnecting = False
+
+                    self.check_remote_api_match()
+
+                    if printed_reconnecting and ever_disconnected:
+                        print(
+                            "...\nReconnected (took: {}s)".format(
+                                int(time.time() - disconnection_time)
+                            )
+                        )
+                        printed_reconnecting = False
                 keep_running = self.continue_session()
             except EOFError as exc:
                 if keep_running:

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -498,7 +498,7 @@ class UnifiedRunner(IJobRunner):
             logger.error("No job is currently running")
             return
         if not target_user:
-            os.kill(self._running_jobs_pid, signal)
+            os.killpg(self._running_jobs_pid, signal)
         else:
             # process used sudo, so sudo is needed to kill it
             in_r, in_w = os.pipe()

--- a/metabox/metabox/core/lxd_execute.py
+++ b/metabox/metabox/core/lxd_execute.py
@@ -90,9 +90,10 @@ class InteractiveWebsocket(SafeWebSocketClient):
         self._result_lock = threading.Lock()
 
     def received_message(self, message):
-        if len(message.data) == 0:
+        if message.data is None or len(message.data) == 0:
             self.close()
             self._connection_closed = True
+            return
         message_data_str = message.data.decode("utf-8", errors="ignore")
         raw_msg = message_data_str = self.ansi_escape.sub("", message_data_str)
         if self.verbose:

--- a/metabox/metabox/core/scenario.py
+++ b/metabox/metabox/core/scenario.py
@@ -170,9 +170,17 @@ class Scenario:
     def assertNotEqual(self, first, second):
         return first != second
 
-    def start(self, cmd="", interactive=False, timeout=0):
+    def start(self, cmd="", interactive=False, timeout=0, target="both"):
         if self.mode == "remote":
-            outcome = self.start_all(interactive=interactive, timeout=timeout)
+            if target == "both":
+                outcome = self.start_all(
+                    interactive=interactive, timeout=timeout
+                )
+            elif target == "agent":
+                self.start_agent()
+                return
+            elif target == "controller":
+                outcome = self.start_controller(interactive, timeout)
             if interactive:
                 self._pts = outcome
             else:

--- a/metabox/metabox/metabox-provider/units/basic-tps.yaml
+++ b/metabox/metabox/metabox-provider/units/basic-tps.yaml
@@ -77,3 +77,9 @@ bootstrap_include:
 include:
   - template_validation_invalid_fields
   - template_validation_missing_parameter
+---
+unit: test plan
+id: tired_test_plan
+name: Test plan that sleeps, terminates only
+include:
+  - sleep_1000s

--- a/metabox/metabox/metabox-provider/units/basic-tps.yaml
+++ b/metabox/metabox/metabox-provider/units/basic-tps.yaml
@@ -85,3 +85,9 @@ bootstrap_include:
 include:
   - template_validation_invalid_fields
   - template_validation_missing_parameter
+---
+unit: test plan
+id: tired_test_plan
+name: Test plan that sleeps, terminates only
+include:
+  - sleep_1000s

--- a/metabox/metabox/metabox-provider/units/basic-tps.yaml
+++ b/metabox/metabox/metabox-provider/units/basic-tps.yaml
@@ -91,3 +91,4 @@ id: tired_test_plan
 name: Test plan that sleeps, terminates only
 include:
   - sleep_1000s
+  - basic-shell-passing

--- a/metabox/metabox/scenarios/ui/interrupt_menu.py
+++ b/metabox/metabox/scenarios/ui/interrupt_menu.py
@@ -1,0 +1,73 @@
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox. If not, see <http://www.gnu.org/licenses/>.
+import textwrap
+
+import metabox.core.keys as keys
+from metabox.core.actions import Expect, Send, Start, Signal
+from metabox.core.scenario import Scenario
+from metabox.core.utils import tag
+
+
+@tag("ui", "interact")
+class CtrlCMenu(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::tired_test_plan
+        forced = yes
+        [test selection]
+        forced = yes
+        """)
+
+    steps = [
+        Start(),
+        Expect("ID: 2021.com.canonical.certification::sleep_1000s"),
+        Signal(keys.SIGINT),
+        Expect("Interruption"),
+        # Do nothing, go back to the test
+        Expect("(X) Nothing"),
+        Send(keys.KEY_ENTER),
+        Expect(
+            "In progress: 2021.com.canonical.certification::sleep_1000s (1/1)"
+        ),
+        Signal(keys.SIGINT),
+        Expect("Interruption!"),
+        Expect("Press <Enter> or <ESC> to continue"),
+        # we are now disconnecting the controller
+        Send(keys.KEY_DOWN),
+        Send(keys.KEY_DOWN),
+        Send(keys.KEY_SPACE),
+        Expect("(X) Pause"),
+        Send(keys.KEY_ENTER),
+        Start(target="controller"),
+        Expect(
+            "In progress: 2021.com.canonical.certification::sleep_1000s (1/1)"
+        ),
+        Signal(keys.SIGINT),
+        Expect("Interruption!"),
+        Expect("Press <Enter> or <ESC> to continue"),
+        # we are now crashing the test to continue the session
+        Send(keys.KEY_DOWN),
+        Send(keys.KEY_SPACE),
+        Expect("(X) Stop the test case in progress"),
+        Send(keys.KEY_ENTER),
+        Expect("Crashed Jobs"),
+    ]

--- a/metabox/metabox/scenarios/ui/interrupt_menu.py
+++ b/metabox/metabox/scenarios/ui/interrupt_menu.py
@@ -18,13 +18,13 @@
 import textwrap
 
 import metabox.core.keys as keys
-from metabox.core.actions import Expect, Send, Start, Signal
+from metabox.core.actions import Expect, Send, Start, Signal, RunCmd
 from metabox.core.scenario import Scenario
 from metabox.core.utils import tag
 
 
-@tag("ui", "interact")
-class CtrlCMenu(Scenario):
+@tag("ui", "interact", "interrupt")
+class CtrlCMenuNothing(Scenario):
     modes = ["remote"]
     launcher = textwrap.dedent("""
         [launcher]
@@ -40,34 +40,100 @@ class CtrlCMenu(Scenario):
     steps = [
         Start(),
         Expect("ID: 2021.com.canonical.certification::sleep_1000s"),
+        Expect("starting to sleep"),
         Signal(keys.SIGINT),
-        Expect("Interruption"),
-        # Do nothing, go back to the test
+        Expect("Interruption!"),
         Expect("(X) Nothing"),
         Send(keys.KEY_ENTER),
         Expect(
-            "In progress: 2021.com.canonical.certification::sleep_1000s (1/1)"
+            "In progress: 2021.com.canonical.certification::sleep_1000s (1/2)"
         ),
+    ]
+
+
+@tag("ui", "interact", "interrupt")
+class CtrlCMenuStopTestCase(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::tired_test_plan
+        forced = yes
+        [test selection]
+        forced = yes
+        """)
+
+    steps = [
+        Start(),
+        Expect("ID: 2021.com.canonical.certification::sleep_1000s"),
+        Expect("starting to sleep"),
         Signal(keys.SIGINT),
         Expect("Interruption!"),
-        Expect("Press <Enter> or <ESC> to continue"),
-        # we are now disconnecting the controller
-        Send(keys.KEY_DOWN),
-        Send(keys.KEY_DOWN),
-        Send(keys.KEY_SPACE),
+        Send(keys.KEY_DOWN + keys.KEY_SPACE),
+        Expect("(X) Stop the test case in progress"),
+        Send(keys.KEY_ENTER),
+        Expect("Outcome: job crashed"),
+        Expect("ID: 2021.com.canonical.certification::basic-shell-passing"),
+    ]
+
+
+@tag("ui", "interact", "interrupt")
+class CtrlCMenuPause(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::tired_test_plan
+        forced = yes
+        [test selection]
+        forced = yes
+        """)
+
+    steps = [
+        Start(),
+        Expect("ID: 2021.com.canonical.certification::sleep_1000s"),
+        Expect("starting to sleep"),
+        Signal(keys.SIGINT),
+        Expect("Interruption!"),
+        Send(keys.KEY_DOWN * 2 + keys.KEY_SPACE),
         Expect("(X) Pause"),
         Send(keys.KEY_ENTER),
         Start(target="controller"),
         Expect(
-            "In progress: 2021.com.canonical.certification::sleep_1000s (1/1)"
+            "In progress: 2021.com.canonical.certification::sleep_1000s (1/2)"
         ),
+    ]
+
+
+@tag("ui", "interact", "interrupt")
+class CtrlCMenuEndSession(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::tired_test_plan
+        forced = yes
+        [test selection]
+        forced = yes
+        """)
+
+    steps = [
+        Start(),
+        Expect("ID: 2021.com.canonical.certification::sleep_1000s"),
+        Expect("starting to sleep"),
         Signal(keys.SIGINT),
         Expect("Interruption!"),
-        Expect("Press <Enter> or <ESC> to continue"),
-        # we are now crashing the test to continue the session
-        Send(keys.KEY_DOWN),
-        Send(keys.KEY_SPACE),
-        Expect("(X) Stop the test case in progress"),
+        Send(keys.KEY_DOWN * 4 + keys.KEY_SPACE),
+        Expect("(X) End this test session"),
+        # Note: this is the session re-starting as we have an automated
+        #       launcher
         Send(keys.KEY_ENTER),
-        Expect("Crashed Jobs"),
+        Expect("ID: 2021.com.canonical.certification::sleep_1000s"),
+        Expect("starting to sleep"),
     ]


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This is a weird behaviour because regardless of what the user picks from the ctrl+c menu, we will always re-connect from scratch and sometimes mess up the session

<img width="929" height="393" alt="image" src="https://github.com/user-attachments/assets/927efe41-0336-4166-9e61-82dd55ead066" />


## Resolved issues

N/A (Ctrl+C didnt work, with this patch it does)

## Documentation

N/A

## Tests

Tested locally, before this patch, Ctrl+C always reconnects, so it basically never works.
