### PR TITLE
Add Variable Refresh Rate (VRR) Test (New)

### DIFF
--- a/providers/base/data/vrr_rectangles_test.qml
+++ b/providers/base/data/vrr_rectangles_test.qml
@@ -47,7 +47,8 @@ Window {
         Repeater {
             model: rectCount
             Rectangle {
-                width: 50; height: 50
+                width: Screen.width * 0.05
+                height: Screen.width * 0.05
                 color: Qt.hsla(Math.random(), 0.6, 0.6, 0.9)
                 radius: 4
                 
@@ -61,8 +62,8 @@ Window {
 
                 // Custom function called by the Timer
                 function updatePosition() {
-                    x += vx/targetFps;
-                    y += vy/targetFps;
+                    x += vx / targetFps;
+                    y += vy / targetFps;
 
                     // Bounce logic
                     if (x <= 0 || x >= root.width - width) vx *= -1;
@@ -77,33 +78,42 @@ Window {
         id: "panel"
         anchors.bottom: parent.bottom
         anchors.horizontalCenter: parent.horizontalCenter
-        width: 600
-        height: 300
+        width: contentColumn.implicitWidth + 50
+        height: contentColumn.implicitHeight + 50
         color: "#cc000000"
-        radius: 10
+        radius: 12
         border.color: "white"
         anchors.margins: 20
 
         Column {
+            id: contentColumn
             anchors.centerIn: parent
             spacing: 5
             
             Text {
                 text: "Press Esc to quit"
-                color: "grey"
-                anchors.horizontalCenter: parent.horizontalCenter
+                color: "white"
+                font.bold: true
+                anchors.horizontalCenter: parent.horizontalLeft
             }
 
             Text {
                 text: "This test should be run at fullscreen"
                 color: "grey"
-                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.horizontalCenter: parent.horizontalLeft
             }
             
             Text {
                 text: "Set GALLIUM_HUD=fps vblank_mode=0"
                 color: "grey"
-                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.horizontalCenter: parent.horizontalLeft
+            }
+
+            Text {
+                text: "Look for tearing ONLY. Any stutter or fps mismatch is OK."
+                color: "red"
+                font.bold: true
+                anchors.horizontalCenter: parent.horizontalLeft
             }
 
             Text {
@@ -120,6 +130,24 @@ Window {
                 onValueChanged: {
                     targetFps = Math.floor(value)
                 }
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+
+            Text {
+                text: "Number of rectangles: " + rectCount
+                color: "white"
+                font.bold: true
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+
+            Slider {
+                minimumValue: 1
+                maximumValue: 10
+                value: rectCount
+                onValueChanged: {
+                    rectCount = value
+                }
+                anchors.horizontalCenter: parent.horizontalCenter
             }
         }
     }

--- a/providers/base/data/vrr_rectangles_test.qml
+++ b/providers/base/data/vrr_rectangles_test.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.0
 import QtQuick.Window 2.0
 import QtQuick.Controls 1.4
+import QtQuick.Layouts 1.2
 
 Window {
     id: root
@@ -12,6 +13,8 @@ Window {
 
     property int targetFps: 60
     property int rectCount: 5
+    property int minFps: 10
+    property int maxFps: 200    
 
     // old QT workaround, there's no 'Shortcuts' property on Window
     // in new QTs don't do this
@@ -95,7 +98,7 @@ Window {
         color: "#cc000000"
         radius: 12
         border.color: "white"
-        anchors.margins: 10
+        anchors.margins: 10    
 
         Column {
             id: contentColumn
@@ -135,14 +138,34 @@ Window {
                 anchors.horizontalCenter: parent.horizontalCenter
             }
 
-            Slider {
-                minimumValue: 10
-                maximumValue: 200
-                value: 60
-                onValueChanged: {
-                    targetFps = Math.floor(value)
-                }
+            RowLayout {
+                Layout.minimumHeight: 10
+                Layout.fillWidth: true
                 anchors.horizontalCenter: parent.horizontalCenter
+                Button {
+                    text: '-'
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    onClicked: {
+                        targetFps = Math.max(minFps, targetFps - 1)
+                    }
+                }
+                Slider {
+                    minimumValue: minFps
+                    maximumValue: maxFps
+                    value: targetFps
+                    onValueChanged: {
+                        targetFps = Math.floor(value)
+                    }
+                }
+                Button {
+                    text: '+'
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    onClicked: {
+                        targetFps = Math.min(maxFps, targetFps + 1)
+                    }
+                }
             }
 
             Text {
@@ -152,14 +175,34 @@ Window {
                 anchors.horizontalCenter: parent.horizontalCenter
             }
 
-            Slider {
-                minimumValue: 1
-                maximumValue: 10
-                value: rectCount
-                onValueChanged: {
-                    rectCount = Math.floor(value)
-                }
+            RowLayout {
+                Layout.minimumHeight: 10
+                Layout.fillWidth: true
                 anchors.horizontalCenter: parent.horizontalCenter
+                Button {
+                    text: '-'
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    onClicked: {
+                        rectCount = Math.max(1, rectCount - 1)
+                    }
+                }
+                Slider {
+                    minimumValue: 1
+                    maximumValue: 10
+                    value: rectCount
+                    onValueChanged: {
+                        rectCount = Math.floor(value)
+                    }
+                }
+                Button {
+                    text: '+'
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    onClicked: {
+                        rectCount = Math.min(10, rectCount + 1)
+                    }
+                }
             }
         }
     }

--- a/providers/base/data/vrr_rectangles_test.qml
+++ b/providers/base/data/vrr_rectangles_test.qml
@@ -10,8 +10,8 @@ Window {
     title: "Dynamic Refresh Rate Demo"
     color: "#1a1a1a"
 
-    property int targetFps: 10
-    property int rectCount: 10
+    property int targetFps: 60
+    property int rectCount: 5
 
     // old QT workaround, there's no 'Shortcuts' property on Window
     // in new QTs don't do this
@@ -47,13 +47,12 @@ Window {
         Repeater {
             model: rectCount
             Rectangle {
-                width: 30; height: 30
+                width: 50; height: 50
                 color: Qt.hsla(Math.random(), 0.6, 0.6, 0.9)
                 radius: 4
                 
-                // State variables for manual movement
-                property real vx: (Math.random() - 0.5) * 10
-                property real vy: (Math.random() - 0.5) * 10
+                property real vx: (Math.random() - 0.5) * 500
+                property real vy: (Math.random() - 0.5) * 500
 
                 Component.onCompleted: {
                     x = Math.random() * (root.width - width);
@@ -62,8 +61,8 @@ Window {
 
                 // Custom function called by the Timer
                 function updatePosition() {
-                    x += vx;
-                    y += vy;
+                    x += vx/targetFps;
+                    y += vy/targetFps;
 
                     // Bounce logic
                     if (x <= 0 || x >= root.width - width) vx *= -1;
@@ -78,8 +77,8 @@ Window {
         id: "panel"
         anchors.bottom: parent.bottom
         anchors.horizontalCenter: parent.horizontalCenter
-        width: 400
-        height: 180
+        width: 600
+        height: 300
         color: "#cc000000"
         radius: 10
         border.color: "white"
@@ -88,10 +87,21 @@ Window {
         Column {
             anchors.centerIn: parent
             spacing: 5
-            // anchors.margins: 5
             
             Text {
                 text: "Press Esc to quit"
+                color: "grey"
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+
+            Text {
+                text: "This test should be run at fullscreen"
+                color: "grey"
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+            
+            Text {
+                text: "Set GALLIUM_HUD=fps vblank_mode=0"
                 color: "grey"
                 anchors.horizontalCenter: parent.horizontalCenter
             }
@@ -104,10 +114,9 @@ Window {
             }
 
             Slider {
-                minimumValue: 48
-                maximumValue: 120
+                minimumValue: 20
+                maximumValue: 200
                 value: 60
-                // onMoved: targetFps = value
                 onValueChanged: {
                     targetFps = Math.floor(value)
                 }

--- a/providers/base/data/vrr_rectangles_test.qml
+++ b/providers/base/data/vrr_rectangles_test.qml
@@ -104,7 +104,7 @@ Window {
             }
             
             Text {
-                text: "Set GALLIUM_HUD=fps vblank_mode=0"
+                text: "Set GALLIUM_HUD=fps vblank_mode=0 MESA_VK_WSI_PRESENT_MODE=immediate"
                 color: "grey"
                 anchors.horizontalCenter: parent.horizontalLeft
             }

--- a/providers/base/data/vrr_rectangles_test.qml
+++ b/providers/base/data/vrr_rectangles_test.qml
@@ -32,8 +32,12 @@ Window {
 
     property int targetFps: 60
     property int rectCount: 5
+    
     property int minFps: 10
-    property int maxFps: 200    
+    property int maxFps: 200
+
+    property int minRectCount: 1
+    property int maxRectCount: 10
 
     // old QT workaround, there's no 'Shortcuts' property on Window
     // in new QTs don't do this
@@ -55,12 +59,12 @@ Window {
             // manually update the positions
             // this also implicitly changes the framerate to the requested one
             for (var i = 0; i < rectContainer.children.length; i++) {
-                // must use var here, even if it's the root of all evils in js
+                // must use 'var' here, not let/const like modern js
                 // otherwise older QT won't understand it
                 var rect = rectContainer.children[i]; 
                 // this QT version doesn't support optional chaining
                 // don't use rect?.updatePosition?.()
-                // this also must be checked
+                // method existence also must be checked
                 // since it doesn't exist on the very 1st frame
                 if (rect.updatePosition) {
                     rect.updatePosition();
@@ -205,7 +209,7 @@ Window {
                     Layout.fillHeight: true
                     Layout.fillWidth: true
                     onClicked: {
-                        rectCount = Math.max(1, rectCount - 1)
+                        rectCount = Math.max(minRectCount, rectCount - 1)
                     }
                 }
                 Slider {
@@ -221,7 +225,7 @@ Window {
                     Layout.fillHeight: true
                     Layout.fillWidth: true
                     onClicked: {
-                        rectCount = Math.min(10, rectCount + 1)
+                        rectCount = Math.min(maxRectCount, rectCount + 1)
                     }
                 }
             }

--- a/providers/base/data/vrr_rectangles_test.qml
+++ b/providers/base/data/vrr_rectangles_test.qml
@@ -54,8 +54,10 @@ Window {
         onTriggered: {
             // manually update the positions
             // this also implicitly changes the framerate to the requested one
-            for (let i = 0; i < rectContainer.children.length; i++) {
-                let rect = rectContainer.children[i];
+            for (var i = 0; i < rectContainer.children.length; i++) {
+                // must use var here, even if it's the root of all evils in js
+                // otherwise older QT won't understand it
+                var rect = rectContainer.children[i]; 
                 // this QT version doesn't support optional chaining
                 // don't use rect?.updatePosition?.()
                 // this also must be checked

--- a/providers/base/data/vrr_rectangles_test.qml
+++ b/providers/base/data/vrr_rectangles_test.qml
@@ -1,0 +1,96 @@
+import QtQuick 2.0
+import QtQuick.Window 2.0
+import QtQuick.Controls 1.4
+
+Window {
+    id: root
+    width: 800
+    height: 600
+    visible: true
+    title: "Dynamic Refresh Rate Demo"
+    color: "#1a1a1a"
+
+    property int targetFps: 10
+    property int rectCount: 10
+
+    Timer {
+        interval: 1000 / targetFps
+        running: true
+        repeat: true
+        onTriggered: {
+            for (let i = 0; i < rectContainer.children.length; i++) {
+                let rect = rectContainer.children[i];
+                if (rect.updatePosition) {
+                    rect.updatePosition();
+                }
+            }
+        }
+    }
+
+    // Container for the rectangles
+    Item {
+        id: rectContainer
+        anchors.fill: parent
+        
+        Repeater {
+            model: rectCount
+            Rectangle {
+                width: 30; height: 30
+                color: Qt.hsla(Math.random(), 0.6, 0.6, 0.9)
+                radius: 4
+                
+                // State variables for manual movement
+                property real vx: (Math.random() - 0.5) * 10
+                property real vy: (Math.random() - 0.5) * 10
+
+                Component.onCompleted: {
+                    x = Math.random() * (root.width - width);
+                    y = Math.random() * (root.height - height);
+                }
+
+                // Custom function called by the Timer
+                function updatePosition() {
+                    x += vx;
+                    y += vy;
+
+                    // Bounce logic
+                    if (x <= 0 || x >= root.width - width) vx *= -1;
+                    if (y <= 0 || y >= root.height - height) vy *= -1;
+                }
+            }
+        }
+    }
+
+    // Control Panel
+    Rectangle {
+        anchors.bottom: parent.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: 320; height: 80
+        color: "#cc000000"
+        radius: 10
+        border.color: "white"
+        anchors.margins: 20
+
+        Column {
+            anchors.centerIn: parent
+            spacing: 5
+            
+            Text {
+                text: "Refresh Rate: " + targetFps + " FPS"
+                color: "white"
+                font.bold: true
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+
+            Slider {
+                minimumValue: 48
+                maximumValue: 120
+                value: 60
+                // onMoved: targetFps = value
+                onValueChanged: {
+                    targetFps = Math.floor(value)
+                }
+            }
+        }
+    }
+}

--- a/providers/base/data/vrr_rectangles_test.qml
+++ b/providers/base/data/vrr_rectangles_test.qml
@@ -30,8 +30,14 @@ Window {
         running: true
         repeat: true
         onTriggered: {
+            // manually update the positions
+            // this also implicitly changes the framerate to the requested one
             for (let i = 0; i < rectContainer.children.length; i++) {
                 let rect = rectContainer.children[i];
+                // this QT version doesn't support optional chaining
+                // don't use rect?.updatePosition?.()
+                // this also must be checked
+                // since it doesn't exist on the very 1st frame
                 if (rect.updatePosition) {
                     rect.updatePosition();
                 }
@@ -52,6 +58,7 @@ Window {
                 color: Qt.hsla(Math.random(), 0.6, 0.6, 0.9)
                 radius: 4
                 
+                // velocity x and y
                 property real vx: (Math.random() - 0.5) * 500
                 property real vy: (Math.random() - 0.5) * 500
 
@@ -62,12 +69,17 @@ Window {
 
                 // Custom function called by the Timer
                 function updatePosition() {
+                    // normalize position change w.r.t. fps
                     x += vx / targetFps;
                     y += vy / targetFps;
 
-                    // Bounce logic
-                    if (x <= 0 || x >= root.width - width) vx *= -1;
-                    if (y <= 0 || y >= root.height - height) vy *= -1;
+                    // bounce at the walls
+                    if (x <= 0 || x >= root.width - width) {
+                        vx *= -1;
+                    }
+                    if (y <= 0 || y >= root.height - height) {
+                        vy *= -1
+                    }
                 }
             }
         }
@@ -104,7 +116,7 @@ Window {
             }
             
             Text {
-                text: "Set GALLIUM_HUD=fps vblank_mode=0 MESA_VK_WSI_PRESENT_MODE=immediate"
+                text: "Set GALLIUM_HUD=fps vblank_mode=3 MESA_VK_WSI_PRESENT_MODE=relaxed"
                 color: "grey"
                 anchors.horizontalCenter: parent.horizontalLeft
             }
@@ -124,7 +136,7 @@ Window {
             }
 
             Slider {
-                minimumValue: 20
+                minimumValue: 10
                 maximumValue: 200
                 value: 60
                 onValueChanged: {

--- a/providers/base/data/vrr_rectangles_test.qml
+++ b/providers/base/data/vrr_rectangles_test.qml
@@ -1,3 +1,22 @@
+/* This file is part of Checkbox.
+
+   Copyright 2026 Canonical Ltd.
+   Written by:
+     Zhongning Li <zhongning.li@canonical.com>
+
+   Checkbox is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License version 3,
+   as published by the Free Software Foundation.
+
+   Checkbox is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 import QtQuick 2.0
 import QtQuick.Window 2.0
 import QtQuick.Controls 1.4

--- a/providers/base/data/vrr_rectangles_test.qml
+++ b/providers/base/data/vrr_rectangles_test.qml
@@ -13,6 +13,18 @@ Window {
     property int targetFps: 10
     property int rectCount: 10
 
+    // old QT workaround, there's no 'Shortcuts' property on Window
+    // in new QTs don't do this
+    Item {
+        anchors.fill: parent
+        focus: true     
+        Keys.onPressed: {
+            if (event.key === Qt.Key_Escape) {
+                root.close()
+            }
+        }
+    }
+
     Timer {
         interval: 1000 / targetFps
         running: true
@@ -63,9 +75,11 @@ Window {
 
     // Control Panel
     Rectangle {
+        id: "panel"
         anchors.bottom: parent.bottom
         anchors.horizontalCenter: parent.horizontalCenter
-        width: 320; height: 80
+        width: 400
+        height: 180
         color: "#cc000000"
         radius: 10
         border.color: "white"
@@ -74,7 +88,14 @@ Window {
         Column {
             anchors.centerIn: parent
             spacing: 5
+            // anchors.margins: 5
             
+            Text {
+                text: "Press Esc to quit"
+                color: "grey"
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+
             Text {
                 text: "Refresh Rate: " + targetFps + " FPS"
                 color: "white"

--- a/providers/base/data/vrr_rectangles_test.qml
+++ b/providers/base/data/vrr_rectangles_test.qml
@@ -4,8 +4,8 @@ import QtQuick.Controls 1.4
 
 Window {
     id: root
-    width: 800
-    height: 600
+    width: 1280
+    height: 720
     visible: true
     title: "Dynamic Refresh Rate Demo"
     color: "#1a1a1a"
@@ -87,15 +87,15 @@ Window {
 
     // Control Panel
     Rectangle {
-        id: "panel"
+        id: panel
         anchors.bottom: parent.bottom
-        anchors.horizontalCenter: parent.horizontalLeft
+        anchors.horizontalCenter: parent.horizontalCenter
         width: contentColumn.implicitWidth + 50
         height: contentColumn.implicitHeight + 50
         color: "#cc000000"
         radius: 12
         border.color: "white"
-        anchors.margins: 20
+        anchors.margins: 10
 
         Column {
             id: contentColumn
@@ -106,26 +106,26 @@ Window {
                 text: "Press Esc to quit"
                 color: "white"
                 font.bold: true
-                anchors.horizontalCenter: parent.horizontalLeft
+                anchors.left: parent.left
             }
 
             Text {
                 text: "This test should be run at fullscreen"
                 color: "grey"
-                anchors.horizontalCenter: parent.horizontalLeft
+                anchors.left: parent.left
             }
             
             Text {
                 text: "Set GALLIUM_HUD=fps vblank_mode=3 MESA_VK_WSI_PRESENT_MODE=relaxed"
                 color: "grey"
-                anchors.horizontalCenter: parent.horizontalLeft
+                anchors.left: parent.left
             }
 
             Text {
                 text: "Look for tearing ONLY. Any stutter or fps mismatch is OK."
                 color: "red"
                 font.bold: true
-                anchors.horizontalCenter: parent.horizontalLeft
+                anchors.left: parent.left
             }
 
             Text {
@@ -157,7 +157,7 @@ Window {
                 maximumValue: 10
                 value: rectCount
                 onValueChanged: {
-                    rectCount = value
+                    rectCount = Math.floor(value)
                 }
                 anchors.horizontalCenter: parent.horizontalCenter
             }

--- a/providers/base/data/vrr_rectangles_test.qml
+++ b/providers/base/data/vrr_rectangles_test.qml
@@ -77,7 +77,7 @@ Window {
     Rectangle {
         id: "panel"
         anchors.bottom: parent.bottom
-        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.horizontalCenter: parent.horizontalLeft
         width: contentColumn.implicitWidth + 50
         height: contentColumn.implicitHeight + 50
         color: "#cc000000"
@@ -117,7 +117,7 @@ Window {
             }
 
             Text {
-                text: "Refresh Rate: " + targetFps + " FPS"
+                text: "Requested Refresh Rate: " + targetFps + " FPS"
                 color: "white"
                 font.bold: true
                 anchors.horizontalCenter: parent.horizontalCenter

--- a/providers/base/units/graphics/test-plan.pxu
+++ b/providers/base/units/graphics/test-plan.pxu
@@ -409,3 +409,9 @@ include:
 bootstrap_include:
     graphics_card
     executable
+
+id: vrr-test-plan
+unit: test plan
+_name: Sample Variable-Refresh-Rate Test Plan
+include:
+    graphics/variable-refresh-rate*

--- a/providers/base/units/graphics/test-plan.pxu
+++ b/providers/base/units/graphics/test-plan.pxu
@@ -412,6 +412,6 @@ bootstrap_include:
 
 id: vrr-test-plan
 unit: test plan
-_name: Sample Variable-Refresh-Rate Test Plan
+_name: Variable-Refresh-Rate Test Plan
 include:
     graphics/variable-refresh-rate.*

--- a/providers/base/units/graphics/test-plan.pxu
+++ b/providers/base/units/graphics/test-plan.pxu
@@ -414,4 +414,4 @@ id: vrr-test-plan
 unit: test plan
 _name: Sample Variable-Refresh-Rate Test Plan
 include:
-    graphics/variable-refresh-rate*
+    graphics/variable-refresh-rate.*

--- a/providers/base/units/graphics/vrr.yaml
+++ b/providers/base/units/graphics/vrr.yaml
@@ -9,7 +9,13 @@ imports:
 requires:
   - executable.name == 'qmlscene'
   - manifest.has_vrr_support == 'True'
-command: GALLIUM_HUD=fps vblank_mode=0 qmlscene vrr_rectangles_test.qml --fullscreen
+# the hud shows an fps graph over time
+# vblank turns off vsync for opengl
+# https://dri.freedesktop.org/wiki/ConfigurationOptions/
+# MESA_VK_WSI_PRESENT_MODE turns off vsync for vulkan
+# https://docs.mesa3d.org/envvars.html#envvar-MESA_VK_WSI_PRESENT_MODE
+# vblank is ignored by vulkan and the MESA_VK var is ignored by opengl => they don't conflict each other
+command: GALLIUM_HUD=fps MESA_VK_WSI_PRESENT_MODE=immediate vblank_mode=0 qmlscene vrr_rectangles_test.qml --fullscreen
 estimated_duration: "20s"
 summary: This test checks if Variable-Refresh-Rate (VRR) is working on the built-in display
 steps: |

--- a/providers/base/units/graphics/vrr.yaml
+++ b/providers/base/units/graphics/vrr.yaml
@@ -1,0 +1,28 @@
+unit: job
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::graphics
+id: graphics/variable-refresh-rate
+user: root
+flags:
+  - also-after-suspend
+imports:
+  - from com.canonical.plainbox import manifest
+requires:
+  - executable.name == 'qmlscene'
+  - manifest.has_vrr_support == 'True'
+command: GALLIUM_HUD=fps vblank_mode=0 qmlscene vrr_rectangles_test.qml --fullscreen
+estimated_duration: "3600s"
+summary: This test checks if Variable-Refresh-Rate (VRR) is working on the built-in display
+steps: |
+  1. Press Enter to start the test program
+  2. Inside the test program, you will see multiple rectangles bouncing inside the window. 
+     Adjust the FPS slider and look for screen tearing. 
+     It's OK for the fps meter to not match the requested FPS.
+  3. If the DUT appears to be struggling to render all the rectangles, 
+     use the bottom slider to adjust the number of squares.
+  4. Mark as pass if no tearing was observed, fail otherwise.
+---
+unit: manifest entry
+id: has_vrr_support
+name: Does the device have a built-in display with Variable-Refresh-Rate?
+value-type: bool

--- a/providers/base/units/graphics/vrr.yaml
+++ b/providers/base/units/graphics/vrr.yaml
@@ -11,7 +11,7 @@ requires:
   - executable.name == 'qmlscene'
   - manifest.has_vrr_support == 'True'
 command: GALLIUM_HUD=fps vblank_mode=0 qmlscene vrr_rectangles_test.qml --fullscreen
-estimated_duration: "3600s"
+estimated_duration: "20s"
 summary: This test checks if Variable-Refresh-Rate (VRR) is working on the built-in display
 steps: |
   1. Press Enter to start the test program

--- a/providers/base/units/graphics/vrr.yaml
+++ b/providers/base/units/graphics/vrr.yaml
@@ -17,12 +17,13 @@ steps: |
   1. Press Enter to start the test program
   2. Inside the test program, you will see multiple rectangles bouncing inside the window. 
      Adjust the FPS slider and look for screen tearing. 
-     It's OK for the fps meter to not match the requested FPS.
+     It's OK for the FPS meter to not match the requested FPS.
   3. If the DUT appears to be struggling to render all the rectangles, 
      use the bottom slider to adjust the number of squares.
-  4. Mark as pass if no tearing was observed, fail otherwise.
+  4. Press Esc to quit the program
+  5. Mark as pass if no tearing was observed, fail otherwise.
 ---
 unit: manifest entry
 id: has_vrr_support
-name: Does the device have a built-in display with Variable-Refresh-Rate?
+name: Does the device have a built-in display with Variable Refresh Rate (VRR)?
 value-type: bool

--- a/providers/base/units/graphics/vrr.yaml
+++ b/providers/base/units/graphics/vrr.yaml
@@ -10,12 +10,12 @@ requires:
   - executable.name == 'qmlscene'
   - manifest.has_vrr_support == 'True'
 # the hud shows an fps graph over time
-# vblank turns off vsync for opengl
+# vblank=3 forces vsync for opengl
 # https://dri.freedesktop.org/wiki/ConfigurationOptions/
-# MESA_VK_WSI_PRESENT_MODE turns off vsync for vulkan
+# MESA_VK_WSI_PRESENT_MODE=relaxed is the relaxed vsync for vulkan
 # https://docs.mesa3d.org/envvars.html#envvar-MESA_VK_WSI_PRESENT_MODE
 # vblank is ignored by vulkan and the MESA_VK var is ignored by opengl => they don't conflict each other
-command: GALLIUM_HUD=fps MESA_VK_WSI_PRESENT_MODE=immediate vblank_mode=0 qmlscene vrr_rectangles_test.qml --fullscreen
+command: GALLIUM_HUD=fps MESA_VK_WSI_PRESENT_MODE=relaxed vblank_mode=3 qmlscene vrr_rectangles_test.qml --fullscreen
 estimated_duration: "20s"
 summary: This test checks if Variable-Refresh-Rate (VRR) is working on the built-in display
 steps: |

--- a/providers/base/units/graphics/vrr.yaml
+++ b/providers/base/units/graphics/vrr.yaml
@@ -1,7 +1,7 @@
 unit: job
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
-id: graphics/variable-refresh-rate
+id: graphics/variable-refresh-rate-manual
 flags:
   - also-after-suspend
 imports:
@@ -9,6 +9,7 @@ imports:
 requires:
   - executable.name == 'qmlscene'
   - manifest.has_vrr_support == 'True'
+  - dmi.sane_product == 'portable' # don't run this if there's no built-in screen
 # the hud shows an fps graph over time
 # vblank_mode=3 forces vsync for opengl
 # https://dri.freedesktop.org/wiki/ConfigurationOptions/

--- a/providers/base/units/graphics/vrr.yaml
+++ b/providers/base/units/graphics/vrr.yaml
@@ -2,7 +2,6 @@ unit: job
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 id: graphics/variable-refresh-rate
-user: root
 flags:
   - also-after-suspend
 imports:
@@ -19,7 +18,7 @@ steps: |
      Adjust the FPS slider and look for screen tearing. 
      It's OK for the FPS meter to not match the requested FPS.
   3. If the DUT appears to be struggling to render all the rectangles, 
-     use the bottom slider to adjust the number of squares.
+     use the bottom slider to adjust the amount.
   4. Press Esc to quit the program
   5. Mark as pass if no tearing was observed, fail otherwise.
 ---

--- a/providers/base/units/graphics/vrr.yaml
+++ b/providers/base/units/graphics/vrr.yaml
@@ -10,12 +10,16 @@ requires:
   - executable.name == 'qmlscene'
   - manifest.has_vrr_support == 'True'
 # the hud shows an fps graph over time
-# vblank=3 forces vsync for opengl
+# vblank_mode=3 forces vsync for opengl
 # https://dri.freedesktop.org/wiki/ConfigurationOptions/
 # MESA_VK_WSI_PRESENT_MODE=relaxed is the relaxed vsync for vulkan
 # https://docs.mesa3d.org/envvars.html#envvar-MESA_VK_WSI_PRESENT_MODE
 # vblank is ignored by vulkan and the MESA_VK var is ignored by opengl => they don't conflict each other
-command: GALLIUM_HUD=fps MESA_VK_WSI_PRESENT_MODE=relaxed vblank_mode=3 qmlscene vrr_rectangles_test.qml --fullscreen
+command: >-
+  GALLIUM_HUD=fps
+  MESA_VK_WSI_PRESENT_MODE=relaxed
+  vblank_mode=3
+  qmlscene "$PLAINBOX_PROVIDER_DATA"/vrr_rectangles_test.qml --fullscreen
 estimated_duration: "20s"
 summary: This test checks if Variable-Refresh-Rate (VRR) is working on the built-in display
 steps: |


### PR DESCRIPTION
## Description

This PR adds a new manual test for the variable refresh rate support that was officially introduced in GNOME 50. The test launches a QT scene with some rectangles bouncing inside the window and the tester is supposed to look at the scene and look for screen tearing.

<img width="800" alt="image" src="https://github.com/user-attachments/assets/556544ec-41ed-423a-8c8c-c69c8ce46d9c" />


To run this without checkbox, use this command: `GALLIUM_HUD=fps MESA_VK_WSI_PRESENT_MODE=relaxed vblank_mode=3 qmlscene vrr_rectangles_test.qml --fullscreen` (requires QT installation, or run this inside checkbox.shell)
- The scene should launch even on xenial
- If you are running this on 25.10 or older, VRR has to be enabled in this dconf path, log out and back in, then the VRR button will appear in GNOME setting's Display page
<img width="800" alt="image" src="https://github.com/user-attachments/assets/68eb7ccd-63e1-4aa8-854f-f24b93ac19fb" />

## Resolved issues

Adds coverage for this GNOME feature in 26.04

## Documentation

Tbh this is largely experimental, I can only confirm that DUTs with VRR completely working will correctly respond to the requests FPS (i.e. the rectangles and the cursor will look like they are moving at 40fps if the requested FPS is 40).

1. This test should be run with VSync on, since it doesn't really make sense to go OVER the maximum refresh rate that the display supports
2. The way FPS changes are "requested" might rely on implicit QT behaviors. There's no explicit method in QML that sets the FPS, so the way it's done here is that we change the rectangle's position on a frame timer. Since there are no changes between each frame (i.e. change only happens every 16ms on 60FPS), QT will know, theoretically, that the scene is static and won't send any draw calls to the GPU. This seems consistent with the fps shown in GALLIUM_HUD.
3. Right now the test is only controlled by the manifest, but there should be another test that checks whether at least 1 monitor supports VRR. It's implemented in #2465 (it needs ctypes to do this check which is going to make 2464 too big, hence the separate PR)

## Tests

Eyeballs

C3: