### PR TITLE
VRR capable monitor detection (New)

### DIFF
--- a/providers/base/bin/detect_vrr.py
+++ b/providers/base/bin/detect_vrr.py
@@ -127,15 +127,16 @@ def get_vrr_capable_monitors(dri_card: Path) -> bool:
                 if not prop_ptr:
                     continue
 
-                prop_name = prop_ptr.contents.name.decode()
-                if prop_name == "vrr_capable":
-                    val = conn.prop_values[j]
-                    if val == 1:
-                        print(
-                            "Connection ID",
-                            conn_id,
-                            "is VRR capable",
-                        )
+                prop = prop_ptr.contents
+                if prop.name.decode() == "vrr_capable":
+                    # if we have the right name,
+                    # that means we are on the right index
+                    # use j to index into the value array
+                    if conn.prop_values[j] == 1:
+                        print("card:", str(dri_card))
+                        print("connection_id:", conn_id)
+                        print("vrr_supported: True")
+                        print()
                         # keep going, print the status for all connections
                         vrr_capable = True
                 drm.drmModeFreeProperty(prop_ptr)
@@ -151,11 +152,10 @@ if __name__ == "__main__":
     at_least_1_capable = False
     for path in Path("/dev/dri").iterdir():
         if os.path.basename(str(path)).startswith("card"):
-            print("Testing", path)
             at_least_1_capable = get_vrr_capable_monitors(path)
-            print("=" * 10)
 
     if not at_least_1_capable:
+        # fail here to allow fail-on-resource in the actual job
         raise SystemExit(
             "[ ERR ] None of the monitors connected to this DUT supports VRR"
         )

--- a/providers/base/bin/detect_vrr.py
+++ b/providers/base/bin/detect_vrr.py
@@ -24,6 +24,7 @@ import ctypes
 import ctypes.util
 import os
 from pathlib import Path
+from checkbox_support.helpers.slugify import slugify
 
 # this should find "libdrm.so.2"
 # works on xenial too, though we won't test vrr on that
@@ -133,7 +134,7 @@ def get_vrr_capable_monitors(dri_card: Path) -> bool:
                     # that means we are on the right index
                     # use j to index into the value array
                     if conn.prop_values[j] == 1:
-                        print("card:", str(dri_card))
+                        print("card_name:", slugify(str(dri_card)))
                         print("connection_id:", conn_id)
                         print("vrr_supported: True")
                         print()

--- a/providers/base/bin/detect_vrr.py
+++ b/providers/base/bin/detect_vrr.py
@@ -1,9 +1,32 @@
+#!/usr/bin/env python3
+#
+# This file is part of Checkbox.
+
+# Copyright 2026 Canonical Ltd.
+#
+# Authors:
+#   Zhongning Li <zhongning.li@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+
 import ctypes
 import ctypes.util
 import os
 from pathlib import Path
 
 # this should find "libdrm.so.2"
+# works on xenial too, though we won't test vrr on that
 libdrm_path = ctypes.util.find_library("drm")
 if not libdrm_path:
     raise ImportError("libdrm not found")
@@ -70,7 +93,7 @@ drm.drmModeGetConnector.restype = ctypes.POINTER(drmModeConnector)
 drm.drmModeGetProperty.restype = ctypes.POINTER(drmModePropertyRes)
 
 
-def get_vrr_capable(dri_card: Path):
+def get_vrr_capable_monitors(dri_card: Path) -> bool:
     """Checks if a /dev/dri/cardN is vrr capable
     A monitor must be connected and active for the result to be accurate
 
@@ -78,6 +101,7 @@ def get_vrr_capable(dri_card: Path):
     :raises RuntimeError: Failed to open /dev/driN
     :raises RuntimeError: drmModeGetResources returned nullptr
     """
+    vrr_capable = False
     with dri_card.open() as f:
         fd = f.fileno()
         if fd < 0:
@@ -100,22 +124,38 @@ def get_vrr_capable(dri_card: Path):
 
             for j in range(conn.count_props):
                 prop_ptr = drm.drmModeGetProperty(fd, conn.props[j])
-                if prop_ptr:
-                    prop_name = prop_ptr.contents.name.decode()
-                    print(prop_name)
-                    if prop_name == "vrr_capable":
-                        val = conn.prop_values[j]
-                        vrr_capable = val == 1
-                        print("Connector", conn_id, "capable", vrr_capable)
-                    drm.drmModeFreeProperty(prop_ptr)
+                if not prop_ptr:
+                    continue
+
+                prop_name = prop_ptr.contents.name.decode()
+                if prop_name == "vrr_capable":
+                    val = conn.prop_values[j]
+                    if val == 1:
+                        print(
+                            "Connection ID",
+                            conn_id,
+                            "is VRR capable",
+                        )
+                        # keep going, print the status for all connections
+                        vrr_capable = True
+                drm.drmModeFreeProperty(prop_ptr)
 
             drm.drmModeFreeConnector(conn_ptr)
+
         drm.drmModeFreeResources(res_ptr)
+
+    return vrr_capable
 
 
 if __name__ == "__main__":
+    at_least_1_capable = False
     for path in Path("/dev/dri").iterdir():
         if os.path.basename(str(path)).startswith("card"):
             print("Testing", path)
-            get_vrr_capable(path)
+            at_least_1_capable = get_vrr_capable_monitors(path)
             print("=" * 10)
+
+    if not at_least_1_capable:
+        raise SystemExit(
+            "[ ERR ] None of the monitors connected to this DUT supports VRR"
+        )

--- a/providers/base/bin/detect_vrr.py
+++ b/providers/base/bin/detect_vrr.py
@@ -1,0 +1,121 @@
+import ctypes
+import ctypes.util
+import os
+from pathlib import Path
+
+# this should find "libdrm.so.2"
+libdrm_path = ctypes.util.find_library("drm")
+if not libdrm_path:
+    raise ImportError("libdrm not found")
+drm = ctypes.CDLL(libdrm_path)
+
+
+# https://github.com/CPFL/drm/blob/6f90b77ea903756c87ae614c093e3d816ebb26fc/xf86drmMode.h#L72
+DRM_MODE_PROP_NAME_LEN = 32
+
+
+class drmModePropertyRes(ctypes.Structure):
+    _fields_ = [
+        ("prop_id", ctypes.c_uint32),
+        ("flags", ctypes.c_uint32),
+        ("name", ctypes.c_char * DRM_MODE_PROP_NAME_LEN),
+        ("count_values", ctypes.c_uint32),
+        ("values", ctypes.POINTER(ctypes.c_uint64)),
+        ("count_enums", ctypes.c_uint32),
+        ("enums", ctypes.c_void_p),
+        ("count_blobs", ctypes.c_uint32),
+        ("blob_ids", ctypes.POINTER(ctypes.c_uint32)),
+    ]
+
+
+class drmModeConnector(ctypes.Structure):
+    _fields_ = [
+        ("connector_id", ctypes.c_uint32),
+        ("encoder_id", ctypes.c_uint32),
+        ("connector_type", ctypes.c_uint32),
+        ("connector_type_id", ctypes.c_uint32),
+        ("connection", ctypes.c_uint32),
+        ("mmWidth", ctypes.c_uint32),
+        ("mmHeight", ctypes.c_uint32),
+        ("subpixel", ctypes.c_uint32),
+        ("count_modes", ctypes.c_int),
+        ("modes", ctypes.c_void_p),
+        ("count_props", ctypes.c_int),
+        ("props", ctypes.POINTER(ctypes.c_uint32)),
+        ("prop_values", ctypes.POINTER(ctypes.c_uint64)),
+        ("count_encoders", ctypes.c_int),
+        ("encoders", ctypes.POINTER(ctypes.c_uint32)),
+    ]
+
+
+class drmModeRes(ctypes.Structure):
+    _fields_ = [
+        ("count_fbs", ctypes.c_int),
+        ("fbs", ctypes.c_void_p),
+        ("count_crtcs", ctypes.c_int),
+        ("crtcs", ctypes.c_void_p),
+        ("count_connectors", ctypes.c_int),
+        ("connectors", ctypes.POINTER(ctypes.c_uint32)),
+        ("count_encoders", ctypes.c_int),
+        ("encoders", ctypes.c_void_p),
+        ("min_width", ctypes.c_uint32),
+        ("max_width", ctypes.c_uint32),
+        ("min_height", ctypes.c_uint32),
+        ("max_height", ctypes.c_uint32),
+    ]
+
+
+drm.drmModeGetResources.restype = ctypes.POINTER(drmModeRes)
+drm.drmModeGetConnector.restype = ctypes.POINTER(drmModeConnector)
+drm.drmModeGetProperty.restype = ctypes.POINTER(drmModePropertyRes)
+
+
+def get_vrr_capable(dri_card: Path):
+    """Checks if a /dev/dri/cardN is vrr capable
+    A monitor must be connected and active for the result to be accurate
+
+    :param dri_card: _description_
+    :raises RuntimeError: Failed to open /dev/driN
+    :raises RuntimeError: drmModeGetResources returned nullptr
+    """
+    with dri_card.open() as f:
+        fd = f.fileno()
+        if fd < 0:
+            raise RuntimeError("Could not open DRM device")
+
+        res_ptr = drm.drmModeGetResources(fd)
+        if not res_ptr:
+            raise RuntimeError("Failed to get DRM resources")
+
+        res = res_ptr.contents
+        for i in range(res.count_connectors):
+            conn_id = res.connectors[i]
+            conn_ptr = drm.drmModeGetConnector(fd, conn_id)
+            if not conn_ptr:
+                continue
+
+            conn = conn_ptr.contents
+            if conn.connection != 1:  # ignore disconnected connectors
+                continue
+
+            for j in range(conn.count_props):
+                prop_ptr = drm.drmModeGetProperty(fd, conn.props[j])
+                if prop_ptr:
+                    prop_name = prop_ptr.contents.name.decode()
+                    print(prop_name)
+                    if prop_name == "vrr_capable":
+                        val = conn.prop_values[j]
+                        vrr_capable = val == 1
+                        print("Connector", conn_id, "capable", vrr_capable)
+                    drm.drmModeFreeProperty(prop_ptr)
+
+            drm.drmModeFreeConnector(conn_ptr)
+        drm.drmModeFreeResources(res_ptr)
+
+
+if __name__ == "__main__":
+    for path in Path("/dev/dri").iterdir():
+        if os.path.basename(str(path)).startswith("card"):
+            print("Testing", path)
+            get_vrr_capable(path)
+            print("=" * 10)

--- a/providers/base/bin/detect_vrr.py
+++ b/providers/base/bin/detect_vrr.py
@@ -26,7 +26,6 @@ import os
 from pathlib import Path
 from checkbox_support.helpers.slugify import slugify
 
-
 # https://github.com/CPFL/drm/blob/6f90b77ea903756c87ae614c093e3d816ebb26fc/xf86drmMode.h#L72
 DRM_MODE_PROP_NAME_LEN = 32
 drm = None  # type: ctypes.CDLL | None
@@ -158,7 +157,9 @@ def main():
     at_least_1_capable = False
     for path in Path("/dev/dri").iterdir():
         if os.path.basename(str(path)).startswith("card"):
-            at_least_1_capable = at_least_1_capable or get_vrr_capable_monitors(path)
+            at_least_1_capable = (
+                at_least_1_capable or get_vrr_capable_monitors(path)
+            )
 
     if not at_least_1_capable:
         # fail here to allow fail-on-resource in the actual job

--- a/providers/base/bin/detect_vrr.py
+++ b/providers/base/bin/detect_vrr.py
@@ -26,16 +26,10 @@ import os
 from pathlib import Path
 from checkbox_support.helpers.slugify import slugify
 
-# this should find "libdrm.so.2"
-# works on xenial too, though we won't test vrr on that
-libdrm_path = ctypes.util.find_library("drm")
-if not libdrm_path:
-    raise ImportError("libdrm not found")
-drm = ctypes.CDLL(libdrm_path)
-
 
 # https://github.com/CPFL/drm/blob/6f90b77ea903756c87ae614c093e3d816ebb26fc/xf86drmMode.h#L72
 DRM_MODE_PROP_NAME_LEN = 32
+drm = None  # type: ctypes.CDLL | None
 
 
 class drmModePropertyRes(ctypes.Structure):
@@ -89,11 +83,6 @@ class drmModeRes(ctypes.Structure):
     ]
 
 
-drm.drmModeGetResources.restype = ctypes.POINTER(drmModeRes)
-drm.drmModeGetConnector.restype = ctypes.POINTER(drmModeConnector)
-drm.drmModeGetProperty.restype = ctypes.POINTER(drmModePropertyRes)
-
-
 def get_vrr_capable_monitors(dri_card: Path) -> bool:
     """Checks if a /dev/dri/cardN is vrr capable
     A monitor must be connected and active for the result to be accurate
@@ -102,6 +91,10 @@ def get_vrr_capable_monitors(dri_card: Path) -> bool:
     :raises RuntimeError: Failed to open /dev/driN
     :raises RuntimeError: drmModeGetResources returned nullptr
     """
+
+    if not drm:
+        raise SystemExit("drm library was not initialized")
+
     vrr_capable = False
     with dri_card.open() as f:
         fd = f.fileno()
@@ -150,6 +143,18 @@ def get_vrr_capable_monitors(dri_card: Path) -> bool:
 
 
 def main():
+    # this should find "libdrm.so.2"
+    # works on xenial too, though we won't test vrr on that
+    libdrm_path = ctypes.util.find_library("drm")
+    if not libdrm_path:
+        raise ImportError("libdrm not found")
+
+    global drm
+    drm = ctypes.CDLL(libdrm_path)
+    drm.drmModeGetResources.restype = ctypes.POINTER(drmModeRes)
+    drm.drmModeGetConnector.restype = ctypes.POINTER(drmModeConnector)
+    drm.drmModeGetProperty.restype = ctypes.POINTER(drmModePropertyRes)
+
     at_least_1_capable = False
     for path in Path("/dev/dri").iterdir():
         if os.path.basename(str(path)).startswith("card"):

--- a/providers/base/bin/detect_vrr.py
+++ b/providers/base/bin/detect_vrr.py
@@ -153,7 +153,7 @@ def main():
     at_least_1_capable = False
     for path in Path("/dev/dri").iterdir():
         if os.path.basename(str(path)).startswith("card"):
-            at_least_1_capable = get_vrr_capable_monitors(path)
+            at_least_1_capable = at_least_1_capable or get_vrr_capable_monitors(path)
 
     if not at_least_1_capable:
         # fail here to allow fail-on-resource in the actual job

--- a/providers/base/bin/detect_vrr.py
+++ b/providers/base/bin/detect_vrr.py
@@ -127,7 +127,8 @@ def get_vrr_capable_monitors(dri_card: Path) -> bool:
                     # that means we are on the right index
                     # use j to index into the value array
                     if conn.prop_values[j] == 1:
-                        print("card_name:", slugify(str(dri_card)))
+                        # lstrip to avoid excessive underscores in names
+                        print("card_name:", slugify(str(dri_card)).lstrip("_"))
                         print("connection_id:", conn_id)
                         print("vrr_supported: True")
                         print()
@@ -158,9 +159,9 @@ def main():
     at_least_1_capable = False
     for path in Path("/dev/dri").iterdir():
         if os.path.basename(str(path)).startswith("card"):
-            at_least_1_capable = (
-                at_least_1_capable or get_vrr_capable_monitors(path)
-            )
+            # need to check every card
+            curr_card_is_vrr_capable = get_vrr_capable_monitors(path)
+            at_least_1_capable = at_least_1_capable or curr_card_is_vrr_capable
 
     if not at_least_1_capable:
         # fail here to allow fail-on-resource in the actual job

--- a/providers/base/bin/detect_vrr.py
+++ b/providers/base/bin/detect_vrr.py
@@ -149,7 +149,7 @@ def get_vrr_capable_monitors(dri_card: Path) -> bool:
     return vrr_capable
 
 
-if __name__ == "__main__":
+def main():
     at_least_1_capable = False
     for path in Path("/dev/dri").iterdir():
         if os.path.basename(str(path)).startswith("card"):
@@ -160,3 +160,7 @@ if __name__ == "__main__":
         raise SystemExit(
             "[ ERR ] None of the monitors connected to this DUT supports VRR"
         )
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/base/bin/detect_vrr.py
+++ b/providers/base/bin/detect_vrr.py
@@ -113,6 +113,7 @@ def get_vrr_capable_monitors(dri_card: Path) -> bool:
 
             conn = conn_ptr.contents
             if conn.connection != 1:  # ignore disconnected connectors
+                drm.drmModeFreeConnector(conn_ptr)
                 continue
 
             for j in range(conn.count_props):

--- a/providers/base/tests/test_detect_vrr.py
+++ b/providers/base/tests/test_detect_vrr.py
@@ -19,19 +19,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-_mock_slugify = MagicMock(side_effect=lambda x: x)
-sys.modules.setdefault("checkbox_support", MagicMock())
-sys.modules.setdefault("checkbox_support.helpers", MagicMock())
-sys.modules.setdefault(
-    "checkbox_support.helpers.slugify", MagicMock(slugify=_mock_slugify)
-)
-
-import detect_vrr  # noqa: E402
+import detect_vrr
 
 
 def _null_ptr():

--- a/providers/base/tests/test_detect_vrr.py
+++ b/providers/base/tests/test_detect_vrr.py
@@ -226,9 +226,15 @@ class TestGetVrrCapableMonitors(unittest.TestCase):
 
         self._call()
 
-        self.mock_drm.drmModeFreeProperty.assert_called_once_with(prop_ptr_mock)
-        self.mock_drm.drmModeFreeConnector.assert_called_once_with(conn_ptr_mock)
-        self.mock_drm.drmModeFreeResources.assert_called_once_with(res_ptr_mock)
+        self.mock_drm.drmModeFreeProperty.assert_called_once_with(
+            prop_ptr_mock
+        )
+        self.mock_drm.drmModeFreeConnector.assert_called_once_with(
+            conn_ptr_mock
+        )
+        self.mock_drm.drmModeFreeResources.assert_called_once_with(
+            res_ptr_mock
+        )
 
 
 class TestMain(unittest.TestCase):

--- a/providers/base/tests/test_detect_vrr.py
+++ b/providers/base/tests/test_detect_vrr.py
@@ -252,12 +252,11 @@ class TestMain(unittest.TestCase):
 
         with (
             patch("ctypes.util.find_library", return_value="libdrm.so.2"),
-            patch("ctypes.CDLL") as mock_cdll,
+            patch("ctypes.CDLL"),
             patch("os.path.basename", return_value="card0"),
             patch.object(Path, "iterdir", return_value=iter([card0])),
             patch("detect_vrr.get_vrr_capable_monitors", return_value=False),
         ):
-            mock_cdll.return_value = MagicMock()
             with self.assertRaises(SystemExit) as cm:
                 detect_vrr.main()
 
@@ -270,16 +269,15 @@ class TestMain(unittest.TestCase):
 
         with (
             patch("ctypes.util.find_library", return_value="libdrm.so.2"),
-            patch("ctypes.CDLL") as mock_cdll,
             patch("os.path.basename", return_value="card0"),
+            patch("ctypes.CDLL"),
             patch.object(Path, "iterdir", return_value=iter([card0])),
             patch("detect_vrr.get_vrr_capable_monitors", return_value=True),
         ):
-            mock_cdll.return_value = MagicMock()
-            # Should not raise
             detect_vrr.main()
 
-    def test_skips_non_card_entries_in_dri_dir(self):
+    @patch("detect_vrr.get_vrr_capable_monitors")
+    def test_skips_non_card_entries_in_dri_dir(self, mock_get_vrr: MagicMock):
         render0 = MagicMock(spec=Path)
         render0.__str__ = MagicMock(return_value="/dev/dri/renderD128")
 
@@ -288,7 +286,6 @@ class TestMain(unittest.TestCase):
             patch("ctypes.CDLL"),
             patch("os.path.basename", return_value="renderD128"),
             patch.object(Path, "iterdir", return_value=iter([render0])),
-            patch("detect_vrr.get_vrr_capable_monitors") as mock_get_vrr,
         ):
             with self.assertRaises(SystemExit):
                 detect_vrr.main()

--- a/providers/base/tests/test_detect_vrr.py
+++ b/providers/base/tests/test_detect_vrr.py
@@ -222,9 +222,15 @@ class TestGetVrrCapableMonitors(unittest.TestCase):
 
         self._call()
 
-        self.mock_drm.drmModeFreeProperty.assert_called_once_with(prop_ptr_mock)
-        self.mock_drm.drmModeFreeConnector.assert_called_once_with(conn_ptr_mock)
-        self.mock_drm.drmModeFreeResources.assert_called_once_with(res_ptr_mock)
+        self.mock_drm.drmModeFreeProperty.assert_called_once_with(
+            prop_ptr_mock
+        )
+        self.mock_drm.drmModeFreeConnector.assert_called_once_with(
+            conn_ptr_mock
+        )
+        self.mock_drm.drmModeFreeResources.assert_called_once_with(
+            res_ptr_mock
+        )
 
 
 class TestMain(unittest.TestCase):

--- a/providers/base/tests/test_detect_vrr.py
+++ b/providers/base/tests/test_detect_vrr.py
@@ -110,7 +110,9 @@ class TestGetVrrCapableMonitors(unittest.TestCase):
 
         self.assertFalse(result)
         # still need to free the pointer
-        self.mock_drm.drmModeFreeConnector.assert_called_once_with(self.mock_drm.drmModeGetConnector.return_value )
+        self.mock_drm.drmModeFreeConnector.assert_called_once_with(
+            self.mock_drm.drmModeGetConnector.return_value
+        )
 
     def test_skips_null_connector_pointer(self):
         self.mock_drm.drmModeGetResources.return_value = _ptr(_make_res([10]))

--- a/providers/base/tests/test_detect_vrr.py
+++ b/providers/base/tests/test_detect_vrr.py
@@ -35,14 +35,12 @@ import detect_vrr  # noqa: E402
 
 
 def _null_ptr():
-    """Return a MagicMock that evaluates as falsy (simulates a NULL pointer)."""
     ptr = MagicMock()
     ptr.__bool__ = MagicMock(return_value=False)
     return ptr
 
 
 def _ptr(contents):
-    """Return a MagicMock that evaluates as truthy with the given .contents."""
     ptr = MagicMock()
     ptr.__bool__ = MagicMock(return_value=True)
     ptr.contents = contents
@@ -58,7 +56,6 @@ def _make_res(connector_ids):
 
 
 def _make_conn(connection=1, props=None, prop_values=None):
-    """Build a mock drmModeConnector."""
     conn = MagicMock()
     conn.connection = connection
     props = props or []
@@ -69,15 +66,12 @@ def _make_conn(connection=1, props=None, prop_values=None):
 
 
 def _make_prop(name):
-    """Build a mock drmModePropertyRes with the given property name."""
     prop = MagicMock()
     prop.name.decode.return_value = name
     return prop
 
 
 class TestGetVrrCapableMonitors(unittest.TestCase):
-    """Tests for get_vrr_capable_monitors()."""
-
     def setUp(self):
         # Each test gets a fresh mock drm object.
         self.mock_drm = MagicMock()
@@ -242,8 +236,6 @@ class TestGetVrrCapableMonitors(unittest.TestCase):
 
 
 class TestMain(unittest.TestCase):
-    """Tests for main()."""
-
     def setUp(self):
         detect_vrr.drm = None
 
@@ -306,7 +298,7 @@ class TestMain(unittest.TestCase):
         mock_get_vrr.assert_not_called()
 
     def test_initializes_drm_restype_after_load(self):
-        """main() must set the restype for the three DRM getter functions."""
+
         import ctypes
 
         card0 = MagicMock(spec=Path)

--- a/providers/base/tests/test_detect_vrr.py
+++ b/providers/base/tests/test_detect_vrr.py
@@ -109,8 +109,8 @@ class TestGetVrrCapableMonitors(unittest.TestCase):
         result = self._call()
 
         self.assertFalse(result)
-        # drmModeFreeConnector is not called when the connector is skipped
-        self.mock_drm.drmModeFreeConnector.assert_not_called()
+        # still need to free the pointer 
+        self.mock_drm.drmModeFreeConnector.assert_called_once()
 
     def test_skips_null_connector_pointer(self):
         self.mock_drm.drmModeGetResources.return_value = _ptr(_make_res([10]))

--- a/providers/base/tests/test_detect_vrr.py
+++ b/providers/base/tests/test_detect_vrr.py
@@ -110,7 +110,7 @@ class TestGetVrrCapableMonitors(unittest.TestCase):
 
         self.assertFalse(result)
         # still need to free the pointer
-        self.mock_drm.drmModeFreeConnector.assert_called_once()
+        self.mock_drm.drmModeFreeConnector.assert_called_once_with(self.mock_drm.drmModeGetConnector.return_value )
 
     def test_skips_null_connector_pointer(self):
         self.mock_drm.drmModeGetResources.return_value = _ptr(_make_res([10]))

--- a/providers/base/tests/test_detect_vrr.py
+++ b/providers/base/tests/test_detect_vrr.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+#
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+#
+# Authors:
+#   Zhongning Li <zhongning.li@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_mock_slugify = MagicMock(side_effect=lambda x: x)
+sys.modules.setdefault("checkbox_support", MagicMock())
+sys.modules.setdefault("checkbox_support.helpers", MagicMock())
+sys.modules.setdefault(
+    "checkbox_support.helpers.slugify", MagicMock(slugify=_mock_slugify)
+)
+
+import detect_vrr  # noqa: E402
+
+
+def _null_ptr():
+    """Return a MagicMock that evaluates as falsy (simulates a NULL pointer)."""
+    ptr = MagicMock()
+    ptr.__bool__ = MagicMock(return_value=False)
+    return ptr
+
+
+def _ptr(contents):
+    """Return a MagicMock that evaluates as truthy with the given .contents."""
+    ptr = MagicMock()
+    ptr.__bool__ = MagicMock(return_value=True)
+    ptr.contents = contents
+    return ptr
+
+
+def _make_res(connector_ids):
+    """Build a mock drmModeRes with the given list of connector IDs."""
+    res = MagicMock()
+    res.count_connectors = len(connector_ids)
+    res.connectors = connector_ids
+    return res
+
+
+def _make_conn(connection=1, props=None, prop_values=None):
+    """Build a mock drmModeConnector."""
+    conn = MagicMock()
+    conn.connection = connection
+    props = props or []
+    conn.count_props = len(props)
+    conn.props = props
+    conn.prop_values = prop_values or []
+    return conn
+
+
+def _make_prop(name):
+    """Build a mock drmModePropertyRes with the given property name."""
+    prop = MagicMock()
+    prop.name.decode.return_value = name
+    return prop
+
+
+class TestGetVrrCapableMonitors(unittest.TestCase):
+    """Tests for get_vrr_capable_monitors()."""
+
+    def setUp(self):
+        # Each test gets a fresh mock drm object.
+        self.mock_drm = MagicMock()
+        detect_vrr.drm = self.mock_drm
+
+    def tearDown(self):
+        detect_vrr.drm = None
+
+    def _call(self, path="/dev/dri/card0"):
+        """Call get_vrr_capable_monitors with a mocked file open."""
+        mock_file = MagicMock()
+        mock_file.__enter__ = MagicMock(return_value=mock_file)
+        mock_file.__exit__ = MagicMock(return_value=False)
+        mock_file.fileno.return_value = 5
+        with patch.object(Path, "open", return_value=mock_file):
+            return detect_vrr.get_vrr_capable_monitors(Path(path))
+
+    def test_raises_systemexit_when_drm_not_initialized(self):
+        detect_vrr.drm = None
+        with self.assertRaises(SystemExit):
+            detect_vrr.get_vrr_capable_monitors(Path("/dev/dri/card0"))
+
+    def test_raises_runtime_error_when_get_resources_returns_null(self):
+        self.mock_drm.drmModeGetResources.return_value = _null_ptr()
+        with self.assertRaises(RuntimeError):
+            self._call()
+
+    def test_returns_false_when_no_connectors(self):
+        self.mock_drm.drmModeGetResources.return_value = _ptr(_make_res([]))
+        result = self._call()
+        self.assertFalse(result)
+        self.mock_drm.drmModeFreeResources.assert_called_once()
+
+    def test_returns_false_for_disconnected_connector(self):
+        conn = _make_conn(connection=0)  # 0 = disconnected
+        self.mock_drm.drmModeGetResources.return_value = _ptr(_make_res([10]))
+        self.mock_drm.drmModeGetConnector.return_value = _ptr(conn)
+
+        result = self._call()
+
+        self.assertFalse(result)
+        # drmModeFreeConnector is not called when the connector is skipped
+        self.mock_drm.drmModeFreeConnector.assert_not_called()
+
+    def test_skips_null_connector_pointer(self):
+        self.mock_drm.drmModeGetResources.return_value = _ptr(_make_res([10]))
+        self.mock_drm.drmModeGetConnector.return_value = _null_ptr()
+
+        result = self._call()
+
+        self.assertFalse(result)
+        # drmModeFreeConnector must NOT be called for a NULL pointer
+        self.mock_drm.drmModeFreeConnector.assert_not_called()
+
+    def test_returns_false_when_connector_has_no_props(self):
+        conn = _make_conn(connection=1, props=[], prop_values=[])
+        self.mock_drm.drmModeGetResources.return_value = _ptr(_make_res([10]))
+        self.mock_drm.drmModeGetConnector.return_value = _ptr(conn)
+
+        result = self._call()
+
+        self.assertFalse(result)
+
+    def test_skips_null_property_pointer(self):
+        conn = _make_conn(connection=1, props=[100], prop_values=[0])
+        self.mock_drm.drmModeGetResources.return_value = _ptr(_make_res([10]))
+        self.mock_drm.drmModeGetConnector.return_value = _ptr(conn)
+        self.mock_drm.drmModeGetProperty.return_value = _null_ptr()
+
+        result = self._call()
+
+        self.assertFalse(result)
+        self.mock_drm.drmModeFreeProperty.assert_not_called()
+
+    def test_returns_false_when_vrr_capable_is_zero(self):
+        prop = _make_prop("vrr_capable")
+        conn = _make_conn(connection=1, props=[100], prop_values=[0])
+        self.mock_drm.drmModeGetResources.return_value = _ptr(_make_res([10]))
+        self.mock_drm.drmModeGetConnector.return_value = _ptr(conn)
+        self.mock_drm.drmModeGetProperty.return_value = _ptr(prop)
+
+        result = self._call()
+
+        self.assertFalse(result)
+
+    def test_returns_true_when_vrr_capable_is_one(self):
+        prop = _make_prop("vrr_capable")
+        conn = _make_conn(connection=1, props=[100], prop_values=[1])
+        self.mock_drm.drmModeGetResources.return_value = _ptr(_make_res([10]))
+        self.mock_drm.drmModeGetConnector.return_value = _ptr(conn)
+        self.mock_drm.drmModeGetProperty.return_value = _ptr(prop)
+
+        result = self._call()
+
+        self.assertTrue(result)
+
+    def test_prints_info_when_vrr_capable(self):
+        prop = _make_prop("vrr_capable")
+        conn = _make_conn(connection=1, props=[100], prop_values=[1])
+        conn.connector_id = 42
+        self.mock_drm.drmModeGetResources.return_value = _ptr(_make_res([42]))
+        self.mock_drm.drmModeGetConnector.return_value = _ptr(conn)
+        self.mock_drm.drmModeGetProperty.return_value = _ptr(prop)
+
+        with patch("builtins.print") as mock_print:
+            self._call("/dev/dri/card0")
+
+        mock_print.assert_any_call("vrr_supported: True")
+
+    def test_returns_false_for_unrelated_property(self):
+        prop = _make_prop("brightness")
+        conn = _make_conn(connection=1, props=[100], prop_values=[1])
+        self.mock_drm.drmModeGetResources.return_value = _ptr(_make_res([10]))
+        self.mock_drm.drmModeGetConnector.return_value = _ptr(conn)
+        self.mock_drm.drmModeGetProperty.return_value = _ptr(prop)
+
+        result = self._call()
+
+        self.assertFalse(result)
+
+    def test_returns_true_with_multiple_connectors_one_vrr_capable(self):
+        non_vrr_prop = _make_prop("brightness")
+        vrr_prop = _make_prop("vrr_capable")
+
+        # connector 10: connected, property "brightness" = 0 (not VRR)
+        conn_a = _make_conn(connection=1, props=[100], prop_values=[0])
+        # connector 20: connected, property "vrr_capable" = 1
+        conn_b = _make_conn(connection=1, props=[200], prop_values=[1])
+
+        res = _make_res([10, 20])
+        self.mock_drm.drmModeGetResources.return_value = _ptr(res)
+
+        def get_connector(fd, conn_id):
+            return _ptr(conn_a) if conn_id == 10 else _ptr(conn_b)
+
+        def get_property(fd, prop_id):
+            return _ptr(non_vrr_prop) if prop_id == 100 else _ptr(vrr_prop)
+
+        self.mock_drm.drmModeGetConnector.side_effect = get_connector
+        self.mock_drm.drmModeGetProperty.side_effect = get_property
+
+        result = self._call()
+
+        self.assertTrue(result)
+
+    def test_drm_free_calls_are_made(self):
+        prop = _make_prop("vrr_capable")
+        conn = _make_conn(connection=1, props=[100], prop_values=[1])
+        res_ptr_mock = _ptr(_make_res([10]))
+        conn_ptr_mock = _ptr(conn)
+        prop_ptr_mock = _ptr(prop)
+
+        self.mock_drm.drmModeGetResources.return_value = res_ptr_mock
+        self.mock_drm.drmModeGetConnector.return_value = conn_ptr_mock
+        self.mock_drm.drmModeGetProperty.return_value = prop_ptr_mock
+
+        self._call()
+
+        self.mock_drm.drmModeFreeProperty.assert_called_once_with(prop_ptr_mock)
+        self.mock_drm.drmModeFreeConnector.assert_called_once_with(conn_ptr_mock)
+        self.mock_drm.drmModeFreeResources.assert_called_once_with(res_ptr_mock)
+
+
+class TestMain(unittest.TestCase):
+    """Tests for main()."""
+
+    def setUp(self):
+        detect_vrr.drm = None
+
+    def tearDown(self):
+        detect_vrr.drm = None
+
+    def test_raises_import_error_when_libdrm_not_found(self):
+        with patch("ctypes.util.find_library", return_value=None):
+            with self.assertRaises(ImportError):
+                detect_vrr.main()
+
+    def test_raises_systemexit_when_no_vrr_capable_card(self):
+        card0 = MagicMock(spec=Path)
+        card0.__str__ = MagicMock(return_value="/dev/dri/card0")
+        card0.name = "card0"
+
+        with (
+            patch("ctypes.util.find_library", return_value="libdrm.so.2"),
+            patch("ctypes.CDLL") as mock_cdll,
+            patch("os.path.basename", return_value="card0"),
+            patch.object(Path, "iterdir", return_value=iter([card0])),
+            patch("detect_vrr.get_vrr_capable_monitors", return_value=False),
+        ):
+            mock_cdll.return_value = MagicMock()
+            with self.assertRaises(SystemExit) as cm:
+                detect_vrr.main()
+
+        self.assertIn("VRR", str(cm.exception))
+
+    def test_exits_cleanly_when_at_least_one_vrr_capable_card(self):
+        card0 = MagicMock(spec=Path)
+        card0.__str__ = MagicMock(return_value="/dev/dri/card0")
+        card0.name = "card0"
+
+        with (
+            patch("ctypes.util.find_library", return_value="libdrm.so.2"),
+            patch("ctypes.CDLL") as mock_cdll,
+            patch("os.path.basename", return_value="card0"),
+            patch.object(Path, "iterdir", return_value=iter([card0])),
+            patch("detect_vrr.get_vrr_capable_monitors", return_value=True),
+        ):
+            mock_cdll.return_value = MagicMock()
+            # Should not raise
+            detect_vrr.main()
+
+    def test_skips_non_card_entries_in_dri_dir(self):
+        render0 = MagicMock(spec=Path)
+        render0.__str__ = MagicMock(return_value="/dev/dri/renderD128")
+
+        with (
+            patch("ctypes.util.find_library", return_value="libdrm.so.2"),
+            patch("ctypes.CDLL"),
+            patch("os.path.basename", return_value="renderD128"),
+            patch.object(Path, "iterdir", return_value=iter([render0])),
+            patch("detect_vrr.get_vrr_capable_monitors") as mock_get_vrr,
+        ):
+            with self.assertRaises(SystemExit):
+                detect_vrr.main()
+
+        mock_get_vrr.assert_not_called()
+
+    def test_initializes_drm_restype_after_load(self):
+        """main() must set the restype for the three DRM getter functions."""
+        import ctypes
+
+        card0 = MagicMock(spec=Path)
+        card0.__str__ = MagicMock(return_value="/dev/dri/card0")
+
+        mock_lib = MagicMock()
+
+        with (
+            patch("ctypes.util.find_library", return_value="libdrm.so.2"),
+            patch("ctypes.CDLL", return_value=mock_lib),
+            patch("os.path.basename", return_value="card0"),
+            patch.object(Path, "iterdir", return_value=iter([card0])),
+            patch("detect_vrr.get_vrr_capable_monitors", return_value=True),
+        ):
+            detect_vrr.main()
+
+        self.assertEqual(
+            mock_lib.drmModeGetResources.restype,
+            ctypes.POINTER(detect_vrr.drmModeRes),
+        )
+        self.assertEqual(
+            mock_lib.drmModeGetConnector.restype,
+            ctypes.POINTER(detect_vrr.drmModeConnector),
+        )
+        self.assertEqual(
+            mock_lib.drmModeGetProperty.restype,
+            ctypes.POINTER(detect_vrr.drmModePropertyRes),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/providers/base/tests/test_detect_vrr.py
+++ b/providers/base/tests/test_detect_vrr.py
@@ -109,7 +109,7 @@ class TestGetVrrCapableMonitors(unittest.TestCase):
         result = self._call()
 
         self.assertFalse(result)
-        # still need to free the pointer 
+        # still need to free the pointer
         self.mock_drm.drmModeFreeConnector.assert_called_once()
 
     def test_skips_null_connector_pointer(self):

--- a/providers/base/tests/test_detect_vrr.py
+++ b/providers/base/tests/test_detect_vrr.py
@@ -78,8 +78,12 @@ class TestGetVrrCapableMonitors(unittest.TestCase):
         mock_file.__enter__ = MagicMock(return_value=mock_file)
         mock_file.__exit__ = MagicMock(return_value=False)
         mock_file.fileno.return_value = 5
-        with patch.object(Path, "open", return_value=mock_file):
+        patcher = patch.object(Path, "open", return_value=mock_file)
+        patcher.start()
+        try:
             return detect_vrr.get_vrr_capable_monitors(Path(path))
+        finally:
+            patcher.stop()
 
     def test_raises_systemexit_when_drm_not_initialized(self):
         detect_vrr.drm = None
@@ -95,7 +99,7 @@ class TestGetVrrCapableMonitors(unittest.TestCase):
         self.mock_drm.drmModeGetResources.return_value = _ptr(_make_res([]))
         result = self._call()
         self.assertFalse(result)
-        self.mock_drm.drmModeFreeResources.assert_called_once()
+        self.assertEqual(self.mock_drm.drmModeFreeResources.call_count, 1)
 
     def test_returns_false_for_disconnected_connector(self):
         conn = _make_conn(connection=0)  # 0 = disconnected
@@ -160,7 +164,8 @@ class TestGetVrrCapableMonitors(unittest.TestCase):
 
         self.assertTrue(result)
 
-    def test_prints_info_when_vrr_capable(self):
+    @patch("builtins.print")
+    def test_prints_info_when_vrr_capable(self, mock_print):
         prop = _make_prop("vrr_capable")
         conn = _make_conn(connection=1, props=[100], prop_values=[1])
         conn.connector_id = 42
@@ -168,8 +173,7 @@ class TestGetVrrCapableMonitors(unittest.TestCase):
         self.mock_drm.drmModeGetConnector.return_value = _ptr(conn)
         self.mock_drm.drmModeGetProperty.return_value = _ptr(prop)
 
-        with patch("builtins.print") as mock_print:
-            self._call("/dev/dri/card0")
+        self._call("/dev/dri/card0")
 
         mock_print.assert_any_call("vrr_supported: True")
 
@@ -222,15 +226,9 @@ class TestGetVrrCapableMonitors(unittest.TestCase):
 
         self._call()
 
-        self.mock_drm.drmModeFreeProperty.assert_called_once_with(
-            prop_ptr_mock
-        )
-        self.mock_drm.drmModeFreeConnector.assert_called_once_with(
-            conn_ptr_mock
-        )
-        self.mock_drm.drmModeFreeResources.assert_called_once_with(
-            res_ptr_mock
-        )
+        self.mock_drm.drmModeFreeProperty.assert_called_once_with(prop_ptr_mock)
+        self.mock_drm.drmModeFreeConnector.assert_called_once_with(conn_ptr_mock)
+        self.mock_drm.drmModeFreeResources.assert_called_once_with(res_ptr_mock)
 
 
 class TestMain(unittest.TestCase):
@@ -240,75 +238,77 @@ class TestMain(unittest.TestCase):
     def tearDown(self):
         detect_vrr.drm = None
 
-    def test_raises_import_error_when_libdrm_not_found(self):
-        with patch("ctypes.util.find_library", return_value=None):
-            with self.assertRaises(ImportError):
-                detect_vrr.main()
+    @patch("ctypes.util.find_library", return_value=None)
+    def test_raises_import_error_when_libdrm_not_found(self, mock_find):
+        with self.assertRaises(ImportError):
+            detect_vrr.main()
 
-    def test_raises_systemexit_when_no_vrr_capable_card(self):
+    @patch("detect_vrr.get_vrr_capable_monitors", return_value=False)
+    @patch.object(Path, "iterdir")
+    @patch("os.path.basename", return_value="card0")
+    @patch("ctypes.CDLL")
+    @patch("ctypes.util.find_library", return_value="libdrm.so.2")
+    def test_raises_systemexit_when_no_vrr_capable_card(
+        self, mock_find, mock_cdll, mock_basename, mock_iterdir, mock_get_vrr
+    ):
         card0 = MagicMock(spec=Path)
         card0.__str__ = MagicMock(return_value="/dev/dri/card0")
         card0.name = "card0"
+        mock_iterdir.return_value = iter([card0])
 
-        with (
-            patch("ctypes.util.find_library", return_value="libdrm.so.2"),
-            patch("ctypes.CDLL"),
-            patch("os.path.basename", return_value="card0"),
-            patch.object(Path, "iterdir", return_value=iter([card0])),
-            patch("detect_vrr.get_vrr_capable_monitors", return_value=False),
-        ):
-            with self.assertRaises(SystemExit) as cm:
-                detect_vrr.main()
+        with self.assertRaises(SystemExit) as cm:
+            detect_vrr.main()
 
         self.assertIn("VRR", str(cm.exception))
 
-    def test_exits_cleanly_when_at_least_one_vrr_capable_card(self):
+    @patch("detect_vrr.get_vrr_capable_monitors", return_value=True)
+    @patch.object(Path, "iterdir")
+    @patch("os.path.basename", return_value="card0")
+    @patch("ctypes.CDLL")
+    @patch("ctypes.util.find_library", return_value="libdrm.so.2")
+    def test_exits_cleanly_when_at_least_one_vrr_capable_card(
+        self, mock_find, mock_cdll, mock_basename, mock_iterdir, mock_get_vrr
+    ):
         card0 = MagicMock(spec=Path)
         card0.__str__ = MagicMock(return_value="/dev/dri/card0")
         card0.name = "card0"
-
-        with (
-            patch("ctypes.util.find_library", return_value="libdrm.so.2"),
-            patch("os.path.basename", return_value="card0"),
-            patch("ctypes.CDLL"),
-            patch.object(Path, "iterdir", return_value=iter([card0])),
-            patch("detect_vrr.get_vrr_capable_monitors", return_value=True),
-        ):
-            detect_vrr.main()
+        mock_iterdir.return_value = iter([card0])
+        detect_vrr.main()
 
     @patch("detect_vrr.get_vrr_capable_monitors")
-    def test_skips_non_card_entries_in_dri_dir(self, mock_get_vrr: MagicMock):
+    @patch.object(Path, "iterdir")
+    @patch("os.path.basename", return_value="renderD128")
+    @patch("ctypes.CDLL")
+    @patch("ctypes.util.find_library", return_value="libdrm.so.2")
+    def test_skips_non_card_entries_in_dri_dir(
+        self, mock_find, mock_cdll, mock_basename, mock_iterdir, mock_get_vrr
+    ):
         render0 = MagicMock(spec=Path)
         render0.__str__ = MagicMock(return_value="/dev/dri/renderD128")
+        mock_iterdir.return_value = iter([render0])
 
-        with (
-            patch("ctypes.util.find_library", return_value="libdrm.so.2"),
-            patch("ctypes.CDLL"),
-            patch("os.path.basename", return_value="renderD128"),
-            patch.object(Path, "iterdir", return_value=iter([render0])),
-        ):
-            with self.assertRaises(SystemExit):
-                detect_vrr.main()
+        with self.assertRaises(SystemExit):
+            detect_vrr.main()
 
         mock_get_vrr.assert_not_called()
 
-    def test_initializes_drm_restype_after_load(self):
-
+    @patch("detect_vrr.get_vrr_capable_monitors", return_value=True)
+    @patch.object(Path, "iterdir")
+    @patch("os.path.basename", return_value="card0")
+    @patch("ctypes.CDLL")
+    @patch("ctypes.util.find_library", return_value="libdrm.so.2")
+    def test_initializes_drm_restype_after_load(
+        self, mock_find, mock_cdll, mock_basename, mock_iterdir, mock_get_vrr
+    ):
         import ctypes
 
         card0 = MagicMock(spec=Path)
         card0.__str__ = MagicMock(return_value="/dev/dri/card0")
-
         mock_lib = MagicMock()
+        mock_cdll.return_value = mock_lib
+        mock_iterdir.return_value = iter([card0])
 
-        with (
-            patch("ctypes.util.find_library", return_value="libdrm.so.2"),
-            patch("ctypes.CDLL", return_value=mock_lib),
-            patch("os.path.basename", return_value="card0"),
-            patch.object(Path, "iterdir", return_value=iter([card0])),
-            patch("detect_vrr.get_vrr_capable_monitors", return_value=True),
-        ):
-            detect_vrr.main()
+        detect_vrr.main()
 
         self.assertEqual(
             mock_lib.drmModeGetResources.restype,


### PR DESCRIPTION
## Description

This PR implements a script that can detect whether the DUT is connected to any VRR capable monitors. This is supposed to act as the resource job for `graphics/variable-refresh-rate-manual` when `has_vrr` is set to true. See #2464 for more context. **#2464 and this PR can be merged in any order, they don't reference each other yet.** There will be 1 last PR after this one is merged to put everything together.

## Resolved issues

#2464 as it is right now doesn't actually check whether the DUT is connected to a VRR capable monitor. 

## Documentation

The basic idea is to mimic [what `modetest -connectors` does](https://github.com/grate-driver/libdrm/blob/master/tests/modetest/modetest.c) (this command comes from libdrm-tests). `modetest` will print these lines for a VRR capable monitor:

```
103 vrr_capable:
    flags: immutable range
    values: 0 1
    value: 1
```
If VRR is impossible, this property is either 0 or missing altogether. This script uses the same libdrm API calls to find this value.

[The exact lines we are mimicking](https://github.com/grate-driver/libdrm/blob/3e3c53ed85c30331a6c0ba2af349223654caa5dd/tests/modetest/modetest.c#L450-L457)

## Tests

Manually checked the output of this script against GNOME's output in gnome settings. 