### PR TITLE
Update gpu passthrough tests (BugFix)

### DIFF
--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -118,7 +118,6 @@ def test_lxd_gpu(args):
     """Tests GPU passthrough with a LXD container."""
     logging.info("Executing LXD GPU passthrough test")
 
-    instance = LXD(args.template, args.rootfs)
     with LXD(args.template, args.rootfs) as instance:
         logging.info("Launching container: %s", instance.name)
         instance.launch(

--- a/providers/gpgpu/bin/gpu_passthrough.py
+++ b/providers/gpgpu/bin/gpu_passthrough.py
@@ -50,20 +50,6 @@ GPU_VENDORS = {
 }
 """Mapping of supported vendor names to test configuration."""
 
-GPU_RUNS = 20
-"""How many times to run the GPU test.
-
-This can be overwritten by the `--count` option or by setting the environment
-variable `LXD_GPU_RUNS`. With priority in that order.
-"""
-
-GPU_THRESHOLD_SEC = 12.0
-"""The threshold for the GPU test to pass.
-
-This can be overwritten by the `--threshold` option or by setting the
-environment variable `LXD_GPU_THRESHOLD`. With priority in that order.
-"""
-
 QEMU_OPTS = ""
 """Any custom QEMU options required for passthrough on your platform
 
@@ -86,32 +72,14 @@ environment variable `VM_CPUS`. With priority in that order.
 """
 
 
-def run_gpu_test(
-    instance: LXD,
-    cmd: str,
-    run_count: int = GPU_RUNS,
-    threshold_sec: float = GPU_THRESHOLD_SEC,
-):
+def run_gpu_test(instance: LXD, cmd: str):
     """Executes GPU passthrough test."""
-    logging.info("Running GPU passthrough test %d times", run_count)
-    total_runtime_sec = 0.0
-    for i in range(run_count):
-        tic = time.time()
-        instance.run(cmd, on_guest=True)
-        toc = time.time()
-        runtime_sec = toc - tic
-        total_runtime_sec += runtime_sec
-        logging.debug("Runtime #%d (sec): %f", i, runtime_sec)
-
-    avg_runtime_sec = total_runtime_sec / run_count
-    logging.info("Average runtime (sec): %f", avg_runtime_sec)
-    if avg_runtime_sec >= threshold_sec:
-        logging.error(
-            "Average runtime %fs greater than threshold %fs",
-            avg_runtime_sec,
-            threshold_sec,
-        )
-        raise SystemExit(1)
+    logging.info("Running GPU passthrough test")
+    tic = time.time()
+    instance.run(cmd, on_guest=True)
+    toc = time.time()
+    runtime_sec = toc - tic
+    logging.debug("Runtime (sec): %f", runtime_sec)
 
 
 def test_lxd_gpu(args):
@@ -133,12 +101,7 @@ def test_lxd_gpu(args):
         logging.info("Installing mixbench snap")
         instance.run("snap install mixbench", on_guest=True)
 
-        run_gpu_test(
-            instance,
-            GPU_VENDORS[args.vendor]["test"],
-            args.count,
-            args.threshold,
-        )
+        run_gpu_test(instance, GPU_VENDORS[args.vendor]["test"])
 
 
 def test_lxdvm_gpu(args):
@@ -199,12 +162,7 @@ def test_lxdvm_gpu(args):
         logging.info("Installing mixbench snap")
         instance.run("snap install mixbench", on_guest=True)
 
-        run_gpu_test(
-            instance,
-            GPU_VENDORS[args.vendor]["test"],
-            args.count,
-            args.threshold,
-        )
+        run_gpu_test(instance, GPU_VENDORS[args.vendor]["test"])
 
 
 def parse_args():
@@ -220,20 +178,6 @@ def parse_args():
         default=logging.INFO,
         const=logging.DEBUG,
         help="Increase logging level",
-    )
-
-    test_group = parser.add_argument_group("test")
-    test_group.add_argument(
-        "--threshold",
-        type=float,
-        default=float(os.getenv("LXD_GPU_THRESHOLD") or GPU_THRESHOLD_SEC),
-        help="Threshold (sec) for GPU test",
-    )
-    test_group.add_argument(
-        "--count",
-        type=int,
-        default=int(os.getenv("LXD_GPU_RUNS") or GPU_RUNS),
-        help="Times to run GPU test",
     )
 
     gpu_group = parser.add_argument_group("gpu")

--- a/providers/gpgpu/tests/test_gpu_passthrough.py
+++ b/providers/gpgpu/tests/test_gpu_passthrough.py
@@ -33,19 +33,18 @@ from gpu_passthrough import (
 
 @patch("gpu_passthrough.logging")
 class TestMain(TestCase):
-    @patch("time.time", side_effect=[0, 1])
-    def test_run_gpu_test_success(self, time_mock, logging_mock):
+    def test_run_gpu_test_success(self, logging_mock):
         instance = MagicMock()
         try:
-            run_gpu_test(instance, "test", run_count=1, threshold_sec=2)
+            run_gpu_test(instance, "test")
         except SystemExit:
             self.fail("run_gpu_test raised SystemExit")
 
-    @patch("time.time", side_effect=[0, 2])
-    def test_run_gpu_test_failure(self, time_mock, logging_mock):
+    def test_run_gpu_test_failure(self, logging_mock):
         instance = MagicMock()
+        instance.run.side_effect = SystemExit("failure running mixbench...")
         with self.assertRaises(SystemExit):
-            run_gpu_test(instance, "test", run_count=1, threshold_sec=1)
+            run_gpu_test(instance, "test")
 
     @patch("gpu_passthrough.run_gpu_test")
     @patch("gpu_passthrough.LXD")

--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -86,9 +86,8 @@ estimated_duration: 1m 45s
 environ:
     LXD_GPU_THRESHOLD
     LXD_GPU_RUNS
-    QEMU_OPTS
-    VM_RAM_MB
-    VM_CPUS
+    LXD_TEMPLATE
+    LXD_ROOTFS
 command: gpu_passthrough.py -v --vendor=nvidia --pci={pci_device_name} lxd
 _purpose: Creates a LXD container and passes {pci_device_name} GPU through
 _summary: Test LXD GPU passthrough on NVIDIA GPU {pci_device_name}
@@ -105,6 +104,14 @@ requires:
 category_id: gpgpu
 plugin: shell
 estimated_duration: 12m
+environ:
+    LXD_GPU_THRESHOLD
+    LXD_GPU_RUNS
+    LXD_TEMPLATE
+    KVM_IMAGE
+    QEMU_OPTS
+    VM_RAM_MB
+    VM_CPUS
 command: gpu_passthrough.py -v --vendor=nvidia --pci={pci_device_name} lxdvm
 _purpose: Creates a LXD virtual machine and passes {pci_device_name} GPU through
 _summary: Test LXD VM GPU passthrough on NVIDIA GPU {pci_device_name}

--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -84,8 +84,6 @@ category_id: gpgpu
 plugin: shell
 estimated_duration: 1m 45s
 environ:
-    LXD_GPU_THRESHOLD
-    LXD_GPU_RUNS
     LXD_TEMPLATE
     LXD_ROOTFS
 command: gpu_passthrough.py -v --vendor=nvidia --pci={pci_device_name} lxd
@@ -105,8 +103,6 @@ category_id: gpgpu
 plugin: shell
 estimated_duration: 12m
 environ:
-    LXD_GPU_THRESHOLD
-    LXD_GPU_RUNS
     LXD_TEMPLATE
     KVM_IMAGE
     QEMU_OPTS


### PR DESCRIPTION
## Description

- The GPU passthrough script uses environment variables to use local images or modify the VM options, but these are not defined in the `.pxu` jobs
- The tests have also been updated to run mixbench only once
  - Since mixbench scales with the hardware, there is no need to re-run it and time it; if the command works, the test passes

## Resolved issues

## Documentation

## Tests
