### PR TITLE
Replaced integers for strings in requires fields (BugFix)

### DIFF
--- a/docs/how-to/migrate-away-jinja2.rst
+++ b/docs/how-to/migrate-away-jinja2.rst
@@ -146,8 +146,8 @@ Can be written as:
 
   requires:
     a.a == 'a'
-    environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or b.b == 'b'
-    environment.CHECKBOX_RUNNING_STRICT_SNAP == 1 or c.c == 'c'
+    environment.CHECKBOX_RUNNING_STRICT_SNAP != '1' or b.b == 'b'
+    environment.CHECKBOX_RUNNING_STRICT_SNAP == '1' or c.c == 'c'
 
 To remove usages of ``__checkbox_env__`` or ``__system_env__``:
 

--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -19,7 +19,7 @@ depends: bluetooth/detect
 template-engine: jinja2
 requires:
   package.name == 'bluez' or snap.name == 'bluez'
-  environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'bluez:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:bluez')
+  environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'bluez:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:bluez')
 command:
   bluez_list_adapters.py
 estimated_duration: 2s
@@ -267,7 +267,7 @@ category_id: com.canonical.plainbox::bluetooth
 estimated_duration: 30
 requires:
  package.name == 'bluez' or snap.name == 'bluez'
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'bluez:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:bluez')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'bluez:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:bluez')
 
 unit: template
 template-resource: device
@@ -286,7 +286,7 @@ category_id: com.canonical.plainbox::bluetooth
 estimated_duration: 10
 requires:
  package.name == 'bluez' or snap.name == 'bluez'
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'bluez:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:bluez')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'bluez:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:bluez')
 
 unit: template
 template-resource: bluez-internal-rfcomm-tests

--- a/providers/base/units/ethernet/jobs.pxu
+++ b/providers/base/units/ethernet/jobs.pxu
@@ -398,7 +398,7 @@ estimated_duration: 2s
 command: check_static.py nm {{ interface }}
 requires:
   net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
-  environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+  environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
   executable.name == 'nmcli'
 
 unit: template

--- a/providers/base/units/networking/jobs.pxu
+++ b/providers/base/units/networking/jobs.pxu
@@ -101,9 +101,9 @@ command: network_predictable_names.sh
 _summary: Verify that all network interfaces have predictable names.
 _purpose: Verify that all network interfaces have predictable names.
 requires:
-  environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or lsb.release >= '20'
-  environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or model_assertion.gadget != "pi"
-  environment.CHECKBOX_RUNNING_STRICT_SNAP == 1 or lsb.release >= '18'
+  environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or lsb.release >= '20'
+  environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or model_assertion.gadget != "pi"
+  environment.CHECKBOX_RUNNING_STRICT_SNAP == "1" or lsb.release >= '18'
 
 plugin: manual
 category_id: com.canonical.plainbox::networking

--- a/providers/base/units/wireless/jobs.pxu
+++ b/providers/base/units/wireless/jobs.pxu
@@ -29,7 +29,7 @@ _purpose:
  Check system can find a wireless network AP nearby
 flags: preserve-locale also-after-suspend
 requires:
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
  net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
  manifest.has_wlan_adapter == 'True'
 
@@ -53,7 +53,7 @@ category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
 flags: preserve-locale also-after-suspend
 requires:
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
  net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
 
 unit: template
@@ -76,7 +76,7 @@ category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
 flags: preserve-locale also-after-suspend
 requires:
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
  net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
 
 unit: template
@@ -99,7 +99,7 @@ category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
 flags: preserve-locale also-after-suspend
 requires:
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
  net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
 
 unit: template
@@ -122,7 +122,7 @@ category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
 flags: preserve-locale also-after-suspend
 requires:
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
  net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
 
 unit: template
@@ -146,7 +146,7 @@ estimated_duration: 30.0
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_ac == 'supported'
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
  net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
 
 unit: template
@@ -170,7 +170,7 @@ estimated_duration: 30.0
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_ac == 'supported'
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
  net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
 
 unit: template
@@ -194,7 +194,7 @@ estimated_duration: 30.0
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_ax == 'supported'
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
  net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
 
 unit: template
@@ -218,7 +218,7 @@ estimated_duration: 30.0
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_ax == 'supported'
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
  net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
 
 unit: template
@@ -242,7 +242,7 @@ estimated_duration: 30.0
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_ax == 'supported'
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
  net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
 
 unit: template
@@ -266,7 +266,7 @@ estimated_duration: 30.0
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_be == 'supported'
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
  net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
 
 unit: template
@@ -290,7 +290,7 @@ estimated_duration: 30.0
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_be == 'supported'
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
  net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
 
 unit: template
@@ -342,7 +342,7 @@ estimated_duration: 30.0
 flags: preserve-locale also-after-suspend
 requires:
  wireless_sta_protocol.{{ interface }}_be == 'supported'
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
  net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
 
 plugin: user-interact-verify

--- a/providers/base/units/wireless/nm-hotspot.pxu
+++ b/providers/base/units/wireless/nm-hotspot.pxu
@@ -18,7 +18,7 @@ flags: preserve-locale also-after-suspend
 requires:
  ( wifi_interface_mode.interface == '{{ interface }}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{{ interface }}' and net_if_management.master_mode_managed_by == 'NetworkManager'
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
  executable.name == 'nmcli'
 
 unit: template
@@ -40,5 +40,5 @@ flags: preserve-locale also-after-suspend
 requires:
  ( wifi_interface_mode.interface == '{{ interface }}' and wifi_interface_mode.AP == 'supported' )
  net_if_management.device == '{{ interface }}' and net_if_management.master_mode_managed_by == 'NetworkManager'
- environment.CHECKBOX_RUNNING_STRICT_SNAP != 1 or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
+ environment.CHECKBOX_RUNNING_STRICT_SNAP != "1" or (connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager')
  executable.name == 'nmcli'


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

[This PR](https://github.com/canonical/checkbox/pull/2430) included a typo in the requires field. The 
`environment.CHECKBOX_RUNNING_STRICT_SNAP` variable was compared against an integer instead of an string, 
and it was evaluated incorrectly.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
N/A

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->
Fixed also in the how-to.

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

TBD