### PR TITLE
virtualization.py should pull from ubuntu-daily to get all the releases (bugfix)

### DIFF
--- a/providers/base/bin/virtualization.py
+++ b/providers/base/bin/virtualization.py
@@ -639,7 +639,7 @@ class LXDTest(object):
         self.template_tarball = None
         self.name = "testbed"
         self.image_alias = uuid4().hex
-        self.default_remote = "ubuntu:"
+        self.default_remote = "ubuntu-daily:"
         self.os_version = get_release_to_test()
 
     def run_command(self, cmd):
@@ -831,7 +831,7 @@ class LXDTest_vm(object):
         self.template_tarball = None
         self.name = "testbed"
         self.image_alias = uuid4().hex
-        self.default_remote = "ubuntu:"
+        self.default_remote = "ubuntu-daily:"
         self.os_version = get_release_to_test()
 
     def run_command(self, cmd, log_stderr=True):

--- a/providers/base/tests/test_virtualization.py
+++ b/providers/base/tests/test_virtualization.py
@@ -24,7 +24,10 @@ from virtualization import LXDTest, LXDTest_vm
 
 
 class TestLXDTest(TestCase):
-    def test_default_remote_is_ubuntu_daily(self):
+    @patch("virtualization.get_release_to_test", return_value="noble")
+    def test_default_remote_is_ubuntu_daily(
+        self, get_release_to_test_mock
+    ):
         lxd = LXDTest()
         self.assertEqual(lxd.default_remote, "ubuntu-daily:")
 

--- a/providers/base/tests/test_virtualization.py
+++ b/providers/base/tests/test_virtualization.py
@@ -20,7 +20,15 @@ import itertools
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
-from virtualization import LXDTest_vm
+from virtualization import LXDTest, LXDTest_vm
+
+
+class TestLXDTest(TestCase):
+    @patch("virtualization.get_release_to_test")
+    def test_default_remote_is_ubuntu_daily(self, mock_release):
+        mock_release.return_value = "24.04"
+        lxd = LXDTest()
+        self.assertEqual(lxd.default_remote, "ubuntu-daily:")
 
 
 class TestLXDTest_vm(TestCase):
@@ -207,6 +215,12 @@ class TestLXDTest_vm(TestCase):
         self.assertTrue(self_mock.setup.called)
         self.assertTrue(start_result)
         self.assertTrue(print_mock.called)
+
+    @patch("virtualization.get_release_to_test")
+    def test_default_remote_is_ubuntu_daily(self, mock_release):
+        mock_release.return_value = "24.04"
+        vm = LXDTest_vm()
+        self.assertEqual(vm.default_remote, "ubuntu-daily:")
 
     def test_setup_failure(self):
         self_mock = MagicMock()

--- a/providers/base/tests/test_virtualization.py
+++ b/providers/base/tests/test_virtualization.py
@@ -24,10 +24,8 @@ from virtualization import LXDTest, LXDTest_vm
 
 
 class TestLXDTest(TestCase):
-    @patch("virtualization.get_release_to_test", return_value="noble")
-    def test_default_remote_is_ubuntu_daily(
-        self, get_release_to_test_mock
-    ):
+    @patch("virtualization.get_release_to_test", return_value="24.04")
+    def test_default_remote_is_ubuntu_daily(self, _):
         lxd = LXDTest()
         self.assertEqual(lxd.default_remote, "ubuntu-daily:")
 

--- a/providers/base/tests/test_virtualization.py
+++ b/providers/base/tests/test_virtualization.py
@@ -24,9 +24,7 @@ from virtualization import LXDTest, LXDTest_vm
 
 
 class TestLXDTest(TestCase):
-    @patch("virtualization.get_release_to_test")
-    def test_default_remote_is_ubuntu_daily(self, mock_release):
-        mock_release.return_value = "24.04"
+    def test_default_remote_is_ubuntu_daily(self):
         lxd = LXDTest()
         self.assertEqual(lxd.default_remote, "ubuntu-daily:")
 


### PR DESCRIPTION
[BugFix] virtualization.py should pull from ubuntu-daily instead of ubuntu to ensure pre-release images can be tested. 

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

update virtualization.py to pull images from ubuntu-daily rather than ubuntu to ensure all images (including pre-release) are available

## Resolved issues
Fixes #2470 
Fixes CHECKBOX-2228
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

NA, one line change that modifies the image source, invisible to the user.

## Tests

tested by putting modified script on resolute and noble vms and `test-virtualization` run to verify this works on both pre-release (26.04) and released (24.04) Ubuntu versions.
