### PR TITLE
add workaround for eddystone_scanner (Bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/eddystone_scanner.py
+++ b/checkbox-support/checkbox_support/scripts/eddystone_scanner.py
@@ -38,7 +38,8 @@ def init_bluetooth():
         btctl.writeline("power on")
         time.sleep(3)
         # workaround for some intel bluetooth controller
-        # if we don't enable scan on via bluetoothctl first, the hci 'advertising scan enable' command would failed 
+        # if we don't enable scan on via bluetoothctl first,
+        #    the hci 'advertising scan enable' command would failed
         btctl.writeline("scan on")
         time.sleep(3)
         btctl.writeline("exit")

--- a/checkbox-support/checkbox_support/scripts/eddystone_scanner.py
+++ b/checkbox-support/checkbox_support/scripts/eddystone_scanner.py
@@ -37,6 +37,10 @@ def init_bluetooth():
     with InteractiveCommand("bluetoothctl") as btctl:
         btctl.writeline("power on")
         time.sleep(3)
+        # workaround for some intel bluetooth controller
+        # if we don't enable scan on via bluetoothctl first, the hci 'advertising scan enable' command would failed 
+        btctl.writeline("scan on")
+        time.sleep(3)
         btctl.writeline("exit")
         btctl.kill()
 

--- a/checkbox-support/checkbox_support/tests/test_eddystone_scanner.py
+++ b/checkbox-support/checkbox_support/tests/test_eddystone_scanner.py
@@ -105,3 +105,18 @@ class TestEddystoneScanner(unittest.TestCase):
         )
         mock_init.assert_called_once_with()
         mock_beacon_scan.assert_called_with(1, True)
+
+    @patch("time.sleep")
+    @patch("checkbox_support.scripts.eddystone_scanner.InteractiveCommand")
+    def test_initial_scripts(self, mock_command, mock_sleep):
+
+        mock_command_instance = mock_command.return_value
+        mock_btctl = MagicMock()
+        mock_command_instance.__enter__.return_value = mock_btctl
+
+        eddystone_scanner.init_bluetooth()
+        mock_command.assert_called_with("bluetoothctl")
+        mock_btctl.writeline.assert_any_call("power on")
+        mock_btctl.writeline.assert_any_call("scan on")
+        mock_btctl.writeline.assert_any_call("exit")
+        self.assertEqual(mock_sleep.call_count, 2)


### PR DESCRIPTION


<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
add workaround for eddystone_scanner
for some intel bluetooth controller, the 'advertising scan enable' command would failed if we don't enable scan via bluetoothctl.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
https://github.com/canonical/checkbox/issues/2466
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
Tested on a HP laptop
```
# Test with built-in checkbox-support library
ubuntu@38204:~$ sudo python3 /usr/lib/python3/dist-packages/checkbox_support/scripts/eddystone_scanner.py -D hci0

====================================
Attempt 1/3 (function 'beacon_scan')
====================================
# Checking the LE Extended advertising capability
Received response from controller.
Raw 8-byte LE feature mask: fd fd ff ff be 0 0 0
# Extended advertising support: True
# Checking the LE Extended advertising length
# Max advertising data length: 756
# Issue LE Set Extended Scan Enable to 'False' by hci command
# Issue LE Set Extended Scan Parameters by hci command
# Issue LE Set Extended Scan Enable to 'True' by hci command
Warning: HCI Command failed. Error code: 0x12, Payload: b'\x04\x0e\x04\x01B \x12'
# Issue LE Set Extended Scan Enable to 'False' by hci command
Attempt 1 failed:
No EddyStone URL advertisement detected!

Waiting 3.30 seconds before retrying...

====================================
Attempt 2/3 (function 'beacon_scan')
====================================
# Checking the LE Extended advertising capability
Received response from controller.
Raw 8-byte LE feature mask: fd fd ff ff be 0 0 0
# Extended advertising support: True
# Checking the LE Extended advertising length
# Max advertising data length: 756
# Issue LE Set Extended Scan Enable to 'False' by hci command
# Issue LE Set Extended Scan Parameters by hci command
# Issue LE Set Extended Scan Enable to 'True' by hci command
Warning: HCI Command failed. Error code: 0x12, Payload: b'\x04\x0e\x04\x01B \x12'
# Issue LE Set Extended Scan Enable to 'False' by hci command
Attempt 2 failed:
No EddyStone URL advertisement detected!

Waiting 4.07 seconds before retrying...

====================================
Attempt 3/3 (function 'beacon_scan')
====================================
# Checking the LE Extended advertising capability
Received response from controller.
Raw 8-byte LE feature mask: fd fd ff ff be 0 0 0
# Extended advertising support: True
# Checking the LE Extended advertising length
# Max advertising data length: 756
# Issue LE Set Extended Scan Enable to 'False' by hci command
# Issue LE Set Extended Scan Parameters by hci command
# Issue LE Set Extended Scan Enable to 'True' by hci command
Warning: HCI Command failed. Error code: 0x12, Payload: b'\x04\x0e\x04\x01B \x12'
# Issue LE Set Extended Scan Enable to 'False' by hci command
Attempt 3 failed:
No EddyStone URL advertisement detected!

All the attempts have failed!
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/checkbox_support/scripts/eddystone_scanner.py", line 118, in <module>
    raise SystemExit(main(sys.argv[1:]))
                     ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/checkbox_support/helpers/timeout.py", line 180, in _f
    return run_with_timeout(f, timeout_s, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/checkbox_support/helpers/timeout.py", line 155, in run_with_timeout
    raise exception_queue.get_nowait()
RuntimeError: No EddyStone URL advertisement detected!
ubuntu@38204:~$ sudo PYTHONPATH=checkbox-support/ python3 checkbox-support/checkbox_support/scripts/eddystone_scanner.py -D hci0

# Test with checkbox-support library with workaround

====================================
Attempt 1/3 (function 'beacon_scan')
====================================
# Checking the LE Extended advertising capability
Received response from controller.
Raw 8-byte LE feature mask: fd fd ff ff be 0 0 0
# Extended advertising support: True
# Checking the LE Extended advertising length
# Max advertising data length: 756
# Issue LE Set Extended Scan Enable to 'False' by hci command
# Issue LE Set Extended Scan Parameters by hci command
# Issue LE Set Extended Scan Enable to 'True' by hci command
  Found an eddystone report
# Issue LE Set Extended Scan Enable to 'False' by hci command
Eddystone beacon detected: [Adv Report Type: LE_EXT_ADVERTISING_REPORT(13)] URL: http://www.ubuntu.com <mac: 4c:80:93:cc:ac:21> <rssi: -74>
ubuntu@38204:~$ 
```
<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
Tested on RPi5
```
ubuntu@ubuntu:~$ ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute 
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 2c:cf:67:b6:b1:48 brd ff:ff:ff:ff:ff:ff
    inet 10.102.164.107/22 metric 100 brd 10.102.167.255 scope global dynamic eth0
       valid_lft 388sec preferred_lft 388sec
    inet6 fe80::2ecf:67ff:feb6:b148/64 scope link 
       valid_lft forever preferred_lft forever
3: wlan0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether 2c:cf:67:b6:b1:49 brd ff:ff:ff:ff:ff:ff
ubuntu@ubuntu:~$ sudo PYTHONPATH=checkbox-support/ python3 checkbox-support/checkbox_support/scripts/eddystone_scanner.py -D hci0

====================================
Attempt 1/3 (function 'beacon_scan')
====================================
# Checking the LE Extended advertising capability
Received response from controller.
Raw 8-byte LE feature mask: 3f 0 0 8 0 0 0 0
# Extended advertising support: False
# Checking the LE Extended advertising length
HCI command failed with status 0x01.
Failed to get the max_advertising_data_length from controller, return '255'
# Max advertising data length: 255
# Issue LE Set Scan Enable to 'False' by hci command
# Issue LE Set Scan Parameters by hci command
# Issue LE Set Scan Enable to 'True' by hci command
Warning: HCI Command failed. Error code: 0xc, Payload: b'\x04\x0e\x04\x01\x0c \x0c'
  Found an eddystone report
# Issue LE Set Scan Enable to 'False' by hci command
Eddystone beacon detected: [Adv Report Type: LE_ADVERTISING_REPORT(2)] URL: http://www.ubuntu.com.com/ <mac: d6:5a:23:65:e3:43> <rssi: -69>
ubuntu@ubuntu:~$ 
```
Tested on RPi4
```
ubuntu@ubuntu:~$ ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute 
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether d8:3a:dd:3e:3e:4e brd ff:ff:ff:ff:ff:ff
    inet 10.102.164.137/22 metric 100 brd 10.102.167.255 scope global dynamic eth0
       valid_lft 322sec preferred_lft 322sec
    inet6 fe80::da3a:ddff:fe3e:3e4e/64 scope link 
       valid_lft forever preferred_lft forever
3: wlan0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether d8:3a:dd:3e:3e:50 brd ff:ff:ff:ff:ff:ff
ubuntu@ubuntu:~$ hciconfig
hci0:	Type: Primary  Bus: UART
	BD Address: D8:3A:DD:3E:3E:52  ACL MTU: 1021:8  SCO MTU: 64:1
	UP RUNNING 
	RX bytes:4419 acl:0 sco:0 events:427 errors:0
	TX bytes:67154 acl:0 sco:0 commands:427 errors:0

ubuntu@ubuntu:~$ sudo PYTHONPATH=checkbox-support/ python3 checkbox-support/checkbox_support/scripts/eddystone_scanner.py -D hci0

====================================
Attempt 1/3 (function 'beacon_scan')
====================================
# Checking the LE Extended advertising capability
Received response from controller.
Raw 8-byte LE feature mask: 3f 0 0 8 0 0 0 0
# Extended advertising support: False
# Checking the LE Extended advertising length
HCI command failed with status 0x01.
Failed to get the max_advertising_data_length from controller, return '255'
# Max advertising data length: 255
# Issue LE Set Scan Enable to 'False' by hci command
# Issue LE Set Scan Parameters by hci command
# Issue LE Set Scan Enable to 'True' by hci command
Warning: HCI Command failed. Error code: 0xc, Payload: b'\x04\x0e\x04\x01\x0c \x0c'
  Found an eddystone report
# Issue LE Set Scan Enable to 'False' by hci command
Eddystone beacon detected: [Adv Report Type: LE_ADVERTISING_REPORT(2)] URL: https://www.ubuntu.com.com/ <mac: db:c0:8d:75:1d:80> <rssi: -68>
```