### PR TITLE
Create RVS snap common directory if it does not exist (BugFix)

### DIFF
--- a/providers/gpgpu/bin/rvs.py
+++ b/providers/gpgpu/bin/rvs.py
@@ -51,6 +51,7 @@ class ModuleRunner:
         # CHECKBOX-2021: Snap confinement prevents access to /usr/share
         snap_bins = ["/snap/bin/rvs", "/snap/bin/rocm-validation-suite"]
         if any(rvs.match(p) for p in snap_bins):
+            RVS_SNAP_COMMON.mkdir(parents=True, exist_ok=True)
             shutil.copy(config, RVS_SNAP_COMMON)
             self.config = RVS_SNAP_COMMON / config.name
 

--- a/providers/gpgpu/units/jobs.pxu
+++ b/providers/gpgpu/units/jobs.pxu
@@ -37,6 +37,7 @@ _siblings: [
 id: gpgpu/rvs-gpup
 category_id: gpgpu
 plugin: shell
+user: root
 estimated_duration: 4
 requires:
     graphics_card.vendor == 'Advanced Micro Devices, Inc. [AMD/ATI]'


### PR DESCRIPTION
## Description

- The RVS snap doesn't seem to create the common directory when it's installed
- The RVS tests also require elevation to root user

## Resolved issues

## Documentation

## Tests

https://certification.canonical.com/hardware/202606-38900/submission/494795/test-results/pass/