### PR TITLE
Migrate idle suspend test cases from manual to semi-auto(DC) and auto(AC) (New)

### DIFF
--- a/providers/base/bin/idle_suspend.py
+++ b/providers/base/bin/idle_suspend.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import glob
+import re
+import subprocess
+import time
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional, Tuple
+
+GSETTINGS_POWER = "org.gnome.settings-daemon.plugins.power"
+GSETTINGS_SESSION = "org.gnome.desktop.session"
+LOGGER_TAG = "idle_suspend_test"
+
+SUSPEND_PATTERNS = [
+    r"PM: suspend entry",
+    r"Suspending system",
+    r"Reached target.*[Ss]leep",
+]
+RESUME_PATTERNS = [
+    r"PM: suspend exit",
+    r"PM: resume",
+    r"Finished.*[Rr]esume",
+    r"ACPI: Waking",
+]
+
+AC_ONLINE_GLOBS = [
+    "/sys/class/power_supply/ADP*/online",
+    "/sys/class/power_supply/AC*/online",
+    "/sys/class/power_supply/ACAD*/online",
+]
+
+
+def run_cmd(cmd: List[str], check: bool = True) -> str:
+    """Run a shell command and return stdout as a stripped string."""
+    result = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError("Command {} failed: {}".format(cmd, result.stderr))
+    return result.stdout.strip()
+
+
+def _find_ac_online_path() -> Optional[str]:
+    """Return the first sysfs AC online path found, or None."""
+    for pattern in AC_ONLINE_GLOBS:
+        paths = glob.glob(pattern)
+        if paths:
+            return paths[0]
+    return None
+
+
+def check_power_mode(mode: str) -> None:
+    """Verify system is on the expected power mode.
+
+    Raises SystemExit if the requirement is not met.
+    """
+    ac_path = _find_ac_online_path()
+    if ac_path is None:
+        raise SystemExit("Cannot determine AC power status.")
+    try:
+        with open(ac_path) as fh:
+            ac_online = fh.read().strip() == "1"
+    except OSError as exc:
+        raise SystemExit("Cannot read power status: {}".format(exc))
+    if mode == "ac" and not ac_online:
+        raise SystemExit("Mode is 'ac' but system is running on battery.")
+    if mode == "battery" and ac_online:
+        raise SystemExit("Mode is 'battery' but system is on AC power.")
+
+
+def log_timestamp() -> datetime:
+    """Log a start timestamp to the system journal via logger.
+
+    Returns the captured naive UTC datetime.
+    """
+    now = datetime.now(timezone.utc)
+    message = "SUSPEND_TEST_START: {}".format(
+        now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+    run_cmd(["logger", "-t", LOGGER_TAG, message])
+    return now
+
+
+def get_journal_since(since: datetime) -> str:
+    """Retrieve journal entries since the given naive UTC datetime."""
+    since_str = since.strftime("%Y-%m-%d %H:%M:%S")
+    return run_cmd(
+        [
+            "journalctl",
+            "--since",
+            since_str,
+            "--no-pager",
+            "-o",
+            "short-iso",
+        ],
+        check=False,
+    )
+
+
+def _parse_ts(ts_str: str) -> Optional[datetime]:
+    """Parse a short-iso timestamp string to a naive UTC datetime.
+
+    Returns None on parse failure.
+    """
+    normalized = re.sub(r"([+-]\d{2}):(\d{2})$", r"\1\2", ts_str)
+    try:
+        dt = datetime.strptime(normalized, "%Y-%m-%dT%H:%M:%S%z")
+    except ValueError:
+        return None
+    return dt.replace(tzinfo=timezone.utc) - dt.utcoffset()
+
+
+def parse_journal_suspend_times(
+    journal_output: str,
+) -> Tuple[Optional[datetime], Optional[datetime]]:
+    """Parse journal output for the latest suspend and resume times.
+
+    Returns a tuple (suspend_utc, resume_utc) of naive UTC datetimes.
+    Either value may be None if not found.
+    """
+    suspend_utc = None
+    resume_utc = None
+    ts_re = re.compile(
+        r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2})"
+    )
+    for line in journal_output.splitlines():
+        match = ts_re.match(line)
+        if not match:
+            continue
+        ts = _parse_ts(match.group(1))
+        if ts is None:
+            continue
+        for pattern in SUSPEND_PATTERNS:
+            if re.search(pattern, line, re.IGNORECASE):
+                suspend_utc = ts
+                break
+        for pattern in RESUME_PATTERNS:
+            if re.search(pattern, line, re.IGNORECASE):
+                resume_utc = ts
+                break
+    return suspend_utc, resume_utc
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return the configured argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Test automatic idle suspend on Ubuntu GNOME."
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["ac", "battery"],
+        required=True,
+        help="Power mode to test: 'ac' or 'battery'.",
+    )
+    parser.add_argument(
+        "--suspend-time",
+        type=int,
+        default=15,
+        help="Automatic suspend delay in minutes (default: 15).",
+    )
+    parser.add_argument(
+        "--extra-percent",
+        type=float,
+        default=10.0,
+        help=("Extra wait percentage beyond suspend time " "(default: 10)."),
+    )
+    return parser
+
+
+def main() -> None:
+    """Main entry point."""
+    parser = build_parser()
+    args = parser.parse_args()
+
+    suspend_seconds = args.suspend_time * 60
+    extra_factor = 1.0 + args.extra_percent / 100.0
+    wait_seconds = suspend_seconds * extra_factor
+    allowed_delta = suspend_seconds * (args.extra_percent / 100.0)
+
+    check_power_mode(args.mode)
+
+    log_start_utc = log_timestamp()
+    print(
+        "Test started at (UTC): {}".format(
+            log_start_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+        ),
+        flush=True,
+    )
+    print(
+        "Waiting {:.0f}s for system to suspend and "
+        "resume...".format(wait_seconds),
+        flush=True,
+    )
+
+    time.sleep(wait_seconds)
+
+    journal_since = log_start_utc - timedelta(seconds=5)
+    journal_output = get_journal_since(journal_since)
+    suspend_utc, resume_utc = parse_journal_suspend_times(journal_output)
+
+    if suspend_utc is None:
+        raise SystemExit("FAIL: No suspend entry found in journal.")
+    if suspend_utc < log_start_utc:
+        raise SystemExit(
+            "FAIL: Suspend entry ({}) predates test start "
+            "({}).".format(
+                suspend_utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                log_start_utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            )
+        )
+
+    actual_delta = (suspend_utc - log_start_utc).total_seconds()
+    if abs(actual_delta - suspend_seconds) > allowed_delta:
+        raise SystemExit(
+            "FAIL: Suspend delay {:.1f}s vs expected {}s "
+            "(tolerance {:.1f}s).".format(
+                actual_delta, suspend_seconds, allowed_delta
+            )
+        )
+
+    print("Log at ({})".format(log_start_utc.strftime("%Y-%m-%dT%H:%M:%SZ")))
+    print("Suspend at ({})".format(suspend_utc.strftime("%Y-%m-%dT%H:%M:%SZ")))
+    print("Resume at ({})".format(resume_utc.strftime("%Y-%m-%dT%H:%M:%SZ")))
+    print(
+        "Suspend delay {:.1f}s vs expected {}s "
+        "(tolerance {:.1f}s).".format(
+            actual_delta, suspend_seconds, allowed_delta
+        )
+    )
+    print("PASS: Automatic suspend test passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/base/bin/idle_suspend.py
+++ b/providers/base/bin/idle_suspend.py
@@ -59,6 +59,15 @@ def check_power_mode(mode: str) -> None:
 
     Raises SystemExit if the requirement is not met.
     """
+    if not glob.glob("/sys/class/power_supply/*"):
+        # No power supply entries found; assume AC mode.
+        print(
+            "No power supply found under /sys/class/power_supply/; "
+            "Skip power mode verification.",
+            flush=True,
+        )
+        return
+
     ac_path = _find_ac_online_path()
     if ac_path is None:
         raise SystemExit("Cannot determine AC power status.")

--- a/providers/base/bin/idle_suspend.py
+++ b/providers/base/bin/idle_suspend.py
@@ -21,7 +21,6 @@ import re
 import subprocess
 import time
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional, Tuple
 
 GSETTINGS_POWER = "org.gnome.settings-daemon.plugins.power"
 GSETTINGS_SESSION = "org.gnome.desktop.session"
@@ -46,7 +45,7 @@ AC_ONLINE_GLOBS = [
 ]
 
 
-def run_cmd(cmd: List[str], check: bool = True) -> str:
+def run_cmd(cmd: "list[str]", check: bool = True) -> str:
     """Run a shell command and return stdout as a stripped string."""
     result = subprocess.run(
         cmd,
@@ -59,7 +58,7 @@ def run_cmd(cmd: List[str], check: bool = True) -> str:
     return result.stdout.strip()
 
 
-def _find_ac_online_path() -> Optional[str]:
+def _find_ac_online_path() -> "str | None":
     """Return the first sysfs AC online path found, or None."""
     for pattern in AC_ONLINE_GLOBS:
         paths = glob.glob(pattern)
@@ -116,7 +115,7 @@ def get_journal_since(since: datetime) -> str:
     )
 
 
-def _parse_ts(ts_str: str) -> Optional[datetime]:
+def _parse_ts(ts_str: str) -> "datetime | None":
     """Parse a short-iso timestamp string to a naive UTC datetime.
 
     Returns None on parse failure.
@@ -126,12 +125,12 @@ def _parse_ts(ts_str: str) -> Optional[datetime]:
         dt = datetime.strptime(normalized, "%Y-%m-%dT%H:%M:%S%z")
     except ValueError:
         return None
-    return dt.replace(tzinfo=timezone.utc) - dt.utcoffset()
+    return dt.replace(tzinfo=timezone.utc) - (dt.utcoffset() or timedelta())
 
 
 def parse_journal_suspend_times(
     journal_output: str,
-) -> Tuple[Optional[datetime], Optional[datetime]]:
+) -> ("datetime | None", "datetime | None"):
     """Parse journal output for the latest suspend and resume times.
 
     Returns a tuple (suspend_utc, resume_utc) of naive UTC datetimes.
@@ -239,7 +238,10 @@ def main() -> None:
 
     print("Log at ({})".format(log_start_utc.strftime("%Y-%m-%dT%H:%M:%SZ")))
     print("Suspend at ({})".format(suspend_utc.strftime("%Y-%m-%dT%H:%M:%SZ")))
-    print("Resume at ({})".format(resume_utc.strftime("%Y-%m-%dT%H:%M:%SZ")))
+    if resume_utc:
+        print(
+            "Resume at ({})".format(resume_utc.strftime("%Y-%m-%dT%H:%M:%SZ"))
+        )
     print(
         "Suspend delay {:.1f}s vs expected {}s "
         "(tolerance {:.1f}s).".format(

--- a/providers/base/bin/idle_suspend.py
+++ b/providers/base/bin/idle_suspend.py
@@ -116,7 +116,7 @@ def _parse_ts(ts_str: str) -> "datetime | None":
 
     Returns None on parse failure.
     """
-    # Python's %z directive in strptime() expects timezone offsets WITHOUT a colon
+    # Python %z directive in strptime expects timezone offsets WITHOUT a colon
     normalized = re.sub(r"([+-]\d{2}):(\d{2})$", r"\1\2", ts_str)
     try:
         dt = datetime.strptime(normalized, "%Y-%m-%dT%H:%M:%S%z")

--- a/providers/base/bin/idle_suspend.py
+++ b/providers/base/bin/idle_suspend.py
@@ -116,6 +116,7 @@ def _parse_ts(ts_str: str) -> "datetime | None":
 
     Returns None on parse failure.
     """
+    # Python's %z directive in strptime() expects timezone offsets WITHOUT a colon
     normalized = re.sub(r"([+-]\d{2}):(\d{2})$", r"\1\2", ts_str)
     try:
         dt = datetime.strptime(normalized, "%Y-%m-%dT%H:%M:%S%z")
@@ -126,7 +127,7 @@ def _parse_ts(ts_str: str) -> "datetime | None":
 
 def parse_journal_suspend_times(
     journal_output: str,
-) -> ("datetime | None", "datetime | None"):
+) -> "tuple[datetime | None, datetime | None]":
     """Parse journal output for the latest suspend and resume times.
 
     Returns a tuple (suspend_utc, resume_utc) of naive UTC datetimes.
@@ -134,8 +135,9 @@ def parse_journal_suspend_times(
     """
     suspend_utc = None
     resume_utc = None
+    # The timezone format is different between ubuntu 22.04 and 24.04.
     ts_re = re.compile(
-        r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2})"
+        r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:?\d{2})"
     )
     for line in journal_output.splitlines():
         match = ts_re.match(line)

--- a/providers/base/bin/idle_suspend.py
+++ b/providers/base/bin/idle_suspend.py
@@ -45,19 +45,6 @@ AC_ONLINE_GLOBS = [
 ]
 
 
-def run_cmd(cmd: "list[str]", check: bool = True) -> str:
-    """Run a shell command and return stdout as a stripped string."""
-    result = subprocess.run(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        universal_newlines=True,
-    )
-    if check and result.returncode != 0:
-        raise RuntimeError("Command {} failed: {}".format(cmd, result.stderr))
-    return result.stdout.strip()
-
-
 def _find_ac_online_path() -> "str | None":
     """Return the first sysfs AC online path found, or None."""
     for pattern in AC_ONLINE_GLOBS:
@@ -95,24 +82,24 @@ def log_timestamp() -> datetime:
     message = "SUSPEND_TEST_START: {}".format(
         now.strftime("%Y-%m-%dT%H:%M:%SZ")
     )
-    run_cmd(["logger", "-t", LOGGER_TAG, message])
+    subprocess.check_output(
+        ["logger", "-t", LOGGER_TAG, message],
+        stderr=subprocess.STDOUT,
+    )
     return now
 
 
 def get_journal_since(since: datetime) -> str:
     """Retrieve journal entries since the given naive UTC datetime."""
     since_str = since.strftime("%Y-%m-%d %H:%M:%S")
-    return run_cmd(
-        [
-            "journalctl",
-            "--since",
-            since_str,
-            "--no-pager",
-            "-o",
-            "short-iso",
-        ],
-        check=False,
-    )
+    cmd = ["journalctl", "--since", since_str, "--no-pager", "-o", "short-iso"]
+    try:
+        output = subprocess.check_output(
+            cmd, stderr=subprocess.DEVNULL, universal_newlines=True
+        )
+    except subprocess.CalledProcessError as exc:
+        output = exc.output or ""
+    return output.strip()
 
 
 def _parse_ts(ts_str: str) -> "datetime | None":

--- a/providers/base/tests/test_idle_suspend.py
+++ b/providers/base/tests/test_idle_suspend.py
@@ -574,7 +574,7 @@ class TestMain(unittest.TestCase):
         with ExitStack() as stack:
             mocks = self._enter_patches(stack)
             idle_suspend.main()
-        mocks["sleep"].assert_called_once()
+        self.assertEqual(mocks["sleep"].call_count, 1)
         sleep_arg = mocks["sleep"].call_args[0][0]
         self.assertAlmostEqual(sleep_arg, 990.0)
 

--- a/providers/base/tests/test_idle_suspend.py
+++ b/providers/base/tests/test_idle_suspend.py
@@ -1,0 +1,597 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import subprocess
+import unittest
+from contextlib import ExitStack
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, mock_open, patch
+
+import idle_suspend
+from idle_suspend import (
+    _find_ac_online_path,
+    _parse_ts,
+    build_parser,
+    check_power_mode,
+    get_journal_since,
+    log_timestamp,
+    parse_journal_suspend_times,
+    run_cmd,
+)
+
+UTC = timezone.utc
+
+_UNSET = object()
+
+# Reusable timestamp fixtures
+_TS1 = "2026-04-17T03:00:00+00:00"
+_TS2 = "2026-04-17T03:05:00+00:00"
+_TS3 = "2026-04-17T03:10:00+00:00"
+_TS1_DT = datetime(2026, 4, 17, 3, 0, 0, tzinfo=UTC)
+_TS2_DT = datetime(2026, 4, 17, 3, 5, 0, tzinfo=UTC)
+_TS3_DT = datetime(2026, 4, 17, 3, 10, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# run_cmd
+# ---------------------------------------------------------------------------
+
+
+class TestRunCmd(unittest.TestCase):
+    def _make_result(self, returncode=0, stdout="", stderr=""):
+        r = MagicMock()
+        r.returncode = returncode
+        r.stdout = stdout
+        r.stderr = stderr
+        return r
+
+    def test_success_returns_stripped_stdout(self):
+        with patch(
+            "subprocess.run",
+            return_value=self._make_result(stdout="  hello  \n"),
+        ):
+            self.assertEqual(run_cmd(["echo", "hello"]), "hello")
+
+    def test_failure_raises_runtime_error_when_check_true(self):
+        with patch(
+            "subprocess.run",
+            return_value=self._make_result(returncode=1, stderr="oops"),
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                run_cmd(["false"])
+        self.assertIn("oops", str(ctx.exception))
+
+    def test_failure_no_raise_when_check_false(self):
+        with patch(
+            "subprocess.run",
+            return_value=self._make_result(returncode=1, stdout="  out  "),
+        ):
+            self.assertEqual(run_cmd(["false"], check=False), "out")
+
+    def test_subprocess_called_with_correct_kwargs(self):
+        with patch(
+            "subprocess.run",
+            return_value=self._make_result(),
+        ) as mock_run:
+            run_cmd(["ls"])
+        _, kwargs = mock_run.call_args
+        self.assertEqual(kwargs["stdout"], subprocess.PIPE)
+        self.assertEqual(kwargs["stderr"], subprocess.PIPE)
+        self.assertTrue(kwargs["universal_newlines"])
+
+    def test_empty_stdout_returns_empty_string(self):
+        with patch(
+            "subprocess.run", return_value=self._make_result(stdout="")
+        ):
+            self.assertEqual(run_cmd(["true"]), "")
+
+
+# ---------------------------------------------------------------------------
+# _find_ac_online_path
+# ---------------------------------------------------------------------------
+
+
+class TestFindAcOnlinePath(unittest.TestCase):
+    def test_returns_first_match_from_first_glob(self):
+        def fake_glob(pattern):
+            if "ADP*" in pattern:
+                return ["/sys/class/power_supply/ADP0/online"]
+            return []
+
+        with patch("idle_suspend.glob.glob", side_effect=fake_glob):
+            self.assertEqual(
+                _find_ac_online_path(),
+                "/sys/class/power_supply/ADP0/online",
+            )
+
+    def test_falls_through_to_second_pattern(self):
+        def fake_glob(pattern):
+            if "AC*" in pattern and "ADP*" not in pattern:
+                return ["/sys/class/power_supply/AC0/online"]
+            return []
+
+        with patch("idle_suspend.glob.glob", side_effect=fake_glob):
+            self.assertEqual(
+                _find_ac_online_path(),
+                "/sys/class/power_supply/AC0/online",
+            )
+
+    def test_returns_none_when_no_glob_matches(self):
+        with patch("idle_suspend.glob.glob", return_value=[]):
+            self.assertIsNone(_find_ac_online_path())
+
+    def test_returns_first_of_multiple_matches(self):
+        paths = [
+            "/sys/class/power_supply/ADP0/online",
+            "/sys/class/power_supply/ADP1/online",
+        ]
+        with patch("idle_suspend.glob.glob", return_value=paths):
+            self.assertEqual(_find_ac_online_path(), paths[0])
+
+
+# ---------------------------------------------------------------------------
+# check_power_mode
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPowerMode(unittest.TestCase):
+    def _patch_path(self, path):
+        return patch("idle_suspend._find_ac_online_path", return_value=path)
+
+    def test_no_ac_path_raises_systemexit(self):
+        with self._patch_path(None):
+            with self.assertRaises(SystemExit) as ctx:
+                check_power_mode("ac")
+        self.assertIn("Cannot determine", str(ctx.exception))
+
+    def test_oserror_reading_file_raises_systemexit(self):
+        with self._patch_path("/fake/path"):
+            with patch("builtins.open", side_effect=OSError("no perm")):
+                with self.assertRaises(SystemExit) as ctx:
+                    check_power_mode("ac")
+        self.assertIn("Cannot read power status", str(ctx.exception))
+
+    def test_ac_mode_on_ac_does_not_raise(self):
+        with self._patch_path("/fake/path"):
+            with patch("builtins.open", mock_open(read_data="1\n")):
+                check_power_mode("ac")  # must not raise
+
+    def test_ac_mode_on_battery_raises(self):
+        with self._patch_path("/fake/path"):
+            with patch("builtins.open", mock_open(read_data="0\n")):
+                with self.assertRaises(SystemExit) as ctx:
+                    check_power_mode("ac")
+        self.assertIn("battery", str(ctx.exception))
+
+    def test_battery_mode_on_battery_does_not_raise(self):
+        with self._patch_path("/fake/path"):
+            with patch("builtins.open", mock_open(read_data="0\n")):
+                check_power_mode("battery")  # must not raise
+
+    def test_battery_mode_on_ac_raises(self):
+        with self._patch_path("/fake/path"):
+            with patch("builtins.open", mock_open(read_data="1\n")):
+                with self.assertRaises(SystemExit) as ctx:
+                    check_power_mode("battery")
+        self.assertIn("AC power", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# log_timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestLogTimestamp(unittest.TestCase):
+    def test_returns_aware_utc_datetime(self):
+        with patch("idle_suspend.run_cmd"):
+            result = log_timestamp()
+        self.assertIsInstance(result, datetime)
+        self.assertEqual(result.tzinfo, UTC)
+
+    def test_calls_logger_with_tag(self):
+        with patch("idle_suspend.run_cmd") as mock_run:
+            log_timestamp()
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("logger", cmd)
+        self.assertIn("-t", cmd)
+        self.assertIn(idle_suspend.LOGGER_TAG, cmd)
+
+    def test_message_contains_start_marker(self):
+        with patch("idle_suspend.run_cmd") as mock_run:
+            log_timestamp()
+        cmd = mock_run.call_args[0][0]
+        self.assertTrue(any("SUSPEND_TEST_START" in arg for arg in cmd))
+
+    def test_timestamp_in_message_matches_returned_value(self):
+        with patch("idle_suspend.run_cmd") as mock_run:
+            result = log_timestamp()
+        cmd = mock_run.call_args[0][0]
+        ts_str = result.strftime("%Y-%m-%dT%H:%M:%SZ")
+        self.assertTrue(any(ts_str in arg for arg in cmd))
+
+
+# ---------------------------------------------------------------------------
+# get_journal_since
+# ---------------------------------------------------------------------------
+
+
+class TestGetJournalSince(unittest.TestCase):
+    _since = datetime(2026, 4, 17, 3, 0, 0, tzinfo=UTC)
+
+    def test_calls_journalctl_with_since_arg(self):
+        with patch("idle_suspend.run_cmd", return_value="") as mock_run:
+            get_journal_since(self._since)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("journalctl", cmd)
+        self.assertIn("--since", cmd)
+        idx = cmd.index("--since")
+        self.assertEqual(cmd[idx + 1], "2026-04-17 03:00:00")
+
+    def test_uses_check_false(self):
+        with patch("idle_suspend.run_cmd", return_value="") as mock_run:
+            get_journal_since(self._since)
+        kwargs = mock_run.call_args[1]
+        self.assertFalse(kwargs.get("check", True))
+
+    def test_returns_run_cmd_output(self):
+        with patch("idle_suspend.run_cmd", return_value="journal output"):
+            result = get_journal_since(self._since)
+        self.assertEqual(result, "journal output")
+
+    def test_short_iso_format_requested(self):
+        with patch("idle_suspend.run_cmd", return_value="") as mock_run:
+            get_journal_since(self._since)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("short-iso", cmd)
+
+
+# ---------------------------------------------------------------------------
+# _parse_ts
+# ---------------------------------------------------------------------------
+
+
+class TestParseTs(unittest.TestCase):
+    def test_utc_zero_offset(self):
+        result = _parse_ts("2026-04-17T03:00:00+00:00")
+        self.assertEqual(result, _TS1_DT)
+
+    def test_positive_offset_converted_to_utc(self):
+        # 08:30+05:30 == 03:00 UTC
+        result = _parse_ts("2026-04-17T08:30:00+05:30")
+        self.assertEqual(result, _TS1_DT)
+
+    def test_negative_offset_converted_to_utc(self):
+        # 22:00-05:00 == 03:00 UTC next day
+        result = _parse_ts("2026-04-16T22:00:00-05:00")
+        self.assertEqual(result, _TS1_DT)
+
+    def test_invalid_string_returns_none(self):
+        self.assertIsNone(_parse_ts("not-a-timestamp"))
+
+    def test_date_only_returns_none(self):
+        self.assertIsNone(_parse_ts("2026-04-17"))
+
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(_parse_ts(""))
+
+    def test_result_is_datetime(self):
+        result = _parse_ts("2026-04-17T03:00:00+00:00")
+        self.assertIsInstance(result, datetime)
+
+
+# ---------------------------------------------------------------------------
+# parse_journal_suspend_times
+# ---------------------------------------------------------------------------
+
+
+def _jline(ts, msg):
+    """Build a fake journal line with the given timestamp and message."""
+    return "{} hostname kernel: {}".format(ts, msg)
+
+
+class TestParseJournalSuspendTimes(unittest.TestCase):
+    def test_empty_input_returns_none_none(self):
+        s, r = parse_journal_suspend_times("")
+        self.assertIsNone(s)
+        self.assertIsNone(r)
+
+    def test_no_matching_keywords_returns_none_none(self):
+        output = _jline(_TS1, "some random kernel message")
+        s, r = parse_journal_suspend_times(output)
+        self.assertIsNone(s)
+        self.assertIsNone(r)
+
+    def test_line_without_timestamp_is_skipped(self):
+        output = "no-ts-here PM: suspend entry"
+        s, r = parse_journal_suspend_times(output)
+        self.assertIsNone(s)
+        self.assertIsNone(r)
+
+    # --- suspend patterns ---
+
+    def test_suspend_entry_pattern(self):
+        s, _ = parse_journal_suspend_times(_jline(_TS1, "PM: suspend entry"))
+        self.assertEqual(s, _TS1_DT)
+
+    def test_suspending_system_pattern(self):
+        s, _ = parse_journal_suspend_times(_jline(_TS1, "Suspending system"))
+        self.assertEqual(s, _TS1_DT)
+
+    def test_reached_target_sleep_pattern(self):
+        s, _ = parse_journal_suspend_times(
+            _jline(_TS1, "Reached target Sleep")
+        )
+        self.assertEqual(s, _TS1_DT)
+
+    def test_reached_target_sleep_lowercase(self):
+        s, _ = parse_journal_suspend_times(
+            _jline(_TS1, "Reached target sleep")
+        )
+        self.assertEqual(s, _TS1_DT)
+
+    # --- resume patterns ---
+
+    def test_suspend_exit_pattern(self):
+        _, r = parse_journal_suspend_times(_jline(_TS2, "PM: suspend exit"))
+        self.assertEqual(r, _TS2_DT)
+
+    def test_pm_resume_pattern(self):
+        _, r = parse_journal_suspend_times(_jline(_TS2, "PM: resume"))
+        self.assertEqual(r, _TS2_DT)
+
+    def test_finished_resume_pattern(self):
+        _, r = parse_journal_suspend_times(_jline(_TS2, "Finished Resume"))
+        self.assertEqual(r, _TS2_DT)
+
+    def test_finished_resume_lowercase(self):
+        _, r = parse_journal_suspend_times(_jline(_TS2, "Finished resume"))
+        self.assertEqual(r, _TS2_DT)
+
+    def test_acpi_waking_pattern(self):
+        _, r = parse_journal_suspend_times(_jline(_TS2, "ACPI: Waking"))
+        self.assertEqual(r, _TS2_DT)
+
+    # --- combined / ordering ---
+
+    def test_both_suspend_and_resume_detected(self):
+        lines = "\n".join(
+            [
+                _jline(_TS1, "PM: suspend entry"),
+                _jline(_TS2, "PM: suspend exit"),
+            ]
+        )
+        s, r = parse_journal_suspend_times(lines)
+        self.assertEqual(s, _TS1_DT)
+        self.assertEqual(r, _TS2_DT)
+
+    def test_last_suspend_occurrence_wins(self):
+        lines = "\n".join(
+            [
+                _jline(_TS1, "PM: suspend entry"),
+                _jline(_TS3, "Suspending system"),
+            ]
+        )
+        s, _ = parse_journal_suspend_times(lines)
+        self.assertEqual(s, _TS3_DT)
+
+    def test_last_resume_occurrence_wins(self):
+        lines = "\n".join(
+            [
+                _jline(_TS1, "PM: suspend exit"),
+                _jline(_TS3, "ACPI: Waking"),
+            ]
+        )
+        _, r = parse_journal_suspend_times(lines)
+        self.assertEqual(r, _TS3_DT)
+
+    def test_non_timestamp_lines_interspersed(self):
+        lines = "\n".join(
+            [
+                "-- Journal begins --",
+                _jline(_TS1, "PM: suspend entry"),
+                "some log line without timestamp",
+                _jline(_TS2, "PM: suspend exit"),
+            ]
+        )
+        s, r = parse_journal_suspend_times(lines)
+        self.assertEqual(s, _TS1_DT)
+        self.assertEqual(r, _TS2_DT)
+
+    def test_unparseable_timestamp_line_is_skipped(self):
+        line = "2026-13-17T03:00:00+00:00 hostname kernel: PM: suspend entry"
+        s, r = parse_journal_suspend_times(line)
+        self.assertIsNone(s)
+        self.assertIsNone(r)
+
+
+# ---------------------------------------------------------------------------
+# build_parser
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParser(unittest.TestCase):
+    def setUp(self):
+        self.parser = build_parser()
+
+    def test_returns_argument_parser(self):
+        self.assertIsInstance(self.parser, argparse.ArgumentParser)
+
+    def test_mode_required(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args([])
+
+    def test_mode_ac_accepted(self):
+        args = self.parser.parse_args(["--mode", "ac"])
+        self.assertEqual(args.mode, "ac")
+
+    def test_mode_battery_accepted(self):
+        args = self.parser.parse_args(["--mode", "battery"])
+        self.assertEqual(args.mode, "battery")
+
+    def test_mode_invalid_raises(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(["--mode", "usb"])
+
+    def test_default_suspend_time_is_15(self):
+        args = self.parser.parse_args(["--mode", "ac"])
+        self.assertEqual(args.suspend_time, 15)
+
+    def test_custom_suspend_time(self):
+        args = self.parser.parse_args(["--mode", "ac", "--suspend-time", "30"])
+        self.assertEqual(args.suspend_time, 30)
+
+    def test_suspend_time_is_int(self):
+        args = self.parser.parse_args(["--mode", "ac"])
+        self.assertIsInstance(args.suspend_time, int)
+
+    def test_default_extra_percent_is_10(self):
+        args = self.parser.parse_args(["--mode", "ac"])
+        self.assertAlmostEqual(args.extra_percent, 10.0)
+
+    def test_custom_extra_percent(self):
+        args = self.parser.parse_args(
+            ["--mode", "ac", "--extra-percent", "20.5"]
+        )
+        self.assertAlmostEqual(args.extra_percent, 20.5)
+
+    def test_extra_percent_is_float(self):
+        args = self.parser.parse_args(["--mode", "ac"])
+        self.assertIsInstance(args.extra_percent, float)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain(unittest.TestCase):
+    """Tests for the main() orchestration function."""
+
+    _LOG_START = datetime(2026, 4, 17, 3, 0, 0, tzinfo=UTC)
+    _SUSPEND_ON_TIME = datetime(2026, 4, 17, 3, 15, 0, tzinfo=UTC)
+    _RESUME_ON_TIME = datetime(2026, 4, 17, 3, 20, 0, tzinfo=UTC)
+
+    def _enter_patches(
+        self, stack, argv=None, suspend_utc=_UNSET, resume_utc=None
+    ):
+        """Push all main() side-effect patches into *stack*.
+
+        Returns a dict of named mocks for assertions.
+        suspend_utc defaults to _SUSPEND_ON_TIME when not supplied.
+        Pass None explicitly to simulate no suspend found.
+        """
+        if argv is None:
+            argv = ["prog", "--mode", "ac"]
+        if suspend_utc is _UNSET:
+            suspend_utc = self._SUSPEND_ON_TIME
+        if resume_utc is None:
+            resume_utc = self._RESUME_ON_TIME
+        stack.enter_context(patch("sys.argv", argv))
+        mocks = {}
+        mocks["check"] = stack.enter_context(
+            patch("idle_suspend.check_power_mode")
+        )
+        stack.enter_context(
+            patch(
+                "idle_suspend.log_timestamp",
+                return_value=self._LOG_START,
+            )
+        )
+        mocks["sleep"] = stack.enter_context(patch("idle_suspend.time.sleep"))
+        stack.enter_context(
+            patch("idle_suspend.get_journal_since", return_value="")
+        )
+        stack.enter_context(
+            patch(
+                "idle_suspend.parse_journal_suspend_times",
+                return_value=(suspend_utc, resume_utc),
+            )
+        )
+        return mocks
+
+    # --- failure branches ---
+
+    def test_no_suspend_entry_raises_systemexit(self):
+        with ExitStack() as stack:
+            self._enter_patches(stack, suspend_utc=None)
+            with self.assertRaises(SystemExit) as ctx:
+                idle_suspend.main()
+        self.assertIn("No suspend entry", str(ctx.exception))
+
+    def test_suspend_predates_start_raises_systemexit(self):
+        before = self._LOG_START - timedelta(seconds=1)
+        with ExitStack() as stack:
+            self._enter_patches(stack, suspend_utc=before)
+            with self.assertRaises(SystemExit) as ctx:
+                idle_suspend.main()
+        self.assertIn("predates", str(ctx.exception))
+
+    def test_suspend_delay_out_of_tolerance_raises_systemexit(self):
+        # 900 s expected, tolerance 90 s; 1800 s actual is way outside.
+        very_late = self._LOG_START + timedelta(seconds=1800)
+        with ExitStack() as stack:
+            self._enter_patches(stack, suspend_utc=very_late)
+            with self.assertRaises(SystemExit) as ctx:
+                idle_suspend.main()
+        self.assertIn("Suspend delay", str(ctx.exception))
+
+    # --- success path ---
+
+    def test_pass_succeeds_without_exception(self):
+        with ExitStack() as stack:
+            self._enter_patches(stack)
+            idle_suspend.main()  # must not raise
+
+    def test_pass_prints_pass_message(self):
+        with ExitStack() as stack:
+            self._enter_patches(stack)
+            with patch("builtins.print") as mock_print:
+                idle_suspend.main()
+        printed = " ".join(
+            str(a) for call in mock_print.call_args_list for a in call[0]
+        )
+        self.assertIn("PASS", printed)
+
+    # --- interactions ---
+
+    def test_sleep_called_with_correct_wait_seconds(self):
+        # suspend-time 15 min, extra-percent 10 → wait = 900 * 1.1 = 990 s
+        with ExitStack() as stack:
+            mocks = self._enter_patches(stack)
+            idle_suspend.main()
+        mocks["sleep"].assert_called_once()
+        sleep_arg = mocks["sleep"].call_args[0][0]
+        self.assertAlmostEqual(sleep_arg, 990.0)
+
+    def test_check_power_mode_called_with_ac(self):
+        with ExitStack() as stack:
+            mocks = self._enter_patches(stack, argv=["prog", "--mode", "ac"])
+            idle_suspend.main()
+        mocks["check"].assert_called_once_with("ac")
+
+    def test_check_power_mode_called_with_battery(self):
+        with ExitStack() as stack:
+            mocks = self._enter_patches(
+                stack, argv=["prog", "--mode", "battery"]
+            )
+            idle_suspend.main()
+        mocks["check"].assert_called_once_with("battery")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/providers/base/tests/test_idle_suspend.py
+++ b/providers/base/tests/test_idle_suspend.py
@@ -31,7 +31,6 @@ from idle_suspend import (
     get_journal_since,
     log_timestamp,
     parse_journal_suspend_times,
-    run_cmd,
 )
 
 UTC = timezone.utc
@@ -45,60 +44,6 @@ _TS3 = "2026-04-17T03:10:00+00:00"
 _TS1_DT = datetime(2026, 4, 17, 3, 0, 0, tzinfo=UTC)
 _TS2_DT = datetime(2026, 4, 17, 3, 5, 0, tzinfo=UTC)
 _TS3_DT = datetime(2026, 4, 17, 3, 10, 0, tzinfo=UTC)
-
-
-# ---------------------------------------------------------------------------
-# run_cmd
-# ---------------------------------------------------------------------------
-
-
-class TestRunCmd(unittest.TestCase):
-    def _make_result(self, returncode=0, stdout="", stderr=""):
-        r = MagicMock()
-        r.returncode = returncode
-        r.stdout = stdout
-        r.stderr = stderr
-        return r
-
-    def test_success_returns_stripped_stdout(self):
-        with patch(
-            "subprocess.run",
-            return_value=self._make_result(stdout="  hello  \n"),
-        ):
-            self.assertEqual(run_cmd(["echo", "hello"]), "hello")
-
-    def test_failure_raises_runtime_error_when_check_true(self):
-        with patch(
-            "subprocess.run",
-            return_value=self._make_result(returncode=1, stderr="oops"),
-        ):
-            with self.assertRaises(RuntimeError) as ctx:
-                run_cmd(["false"])
-        self.assertIn("oops", str(ctx.exception))
-
-    def test_failure_no_raise_when_check_false(self):
-        with patch(
-            "subprocess.run",
-            return_value=self._make_result(returncode=1, stdout="  out  "),
-        ):
-            self.assertEqual(run_cmd(["false"], check=False), "out")
-
-    def test_subprocess_called_with_correct_kwargs(self):
-        with patch(
-            "subprocess.run",
-            return_value=self._make_result(),
-        ) as mock_run:
-            run_cmd(["ls"])
-        _, kwargs = mock_run.call_args
-        self.assertEqual(kwargs["stdout"], subprocess.PIPE)
-        self.assertEqual(kwargs["stderr"], subprocess.PIPE)
-        self.assertTrue(kwargs["universal_newlines"])
-
-    def test_empty_stdout_returns_empty_string(self):
-        with patch(
-            "subprocess.run", return_value=self._make_result(stdout="")
-        ):
-            self.assertEqual(run_cmd(["true"]), "")
 
 
 # ---------------------------------------------------------------------------
@@ -198,29 +143,29 @@ class TestCheckPowerMode(unittest.TestCase):
 
 class TestLogTimestamp(unittest.TestCase):
     def test_returns_aware_utc_datetime(self):
-        with patch("idle_suspend.run_cmd"):
+        with patch("subprocess.check_output"):
             result = log_timestamp()
         self.assertIsInstance(result, datetime)
         self.assertEqual(result.tzinfo, UTC)
 
     def test_calls_logger_with_tag(self):
-        with patch("idle_suspend.run_cmd") as mock_run:
+        with patch("subprocess.check_output") as mock_co:
             log_timestamp()
-        cmd = mock_run.call_args[0][0]
+        cmd = mock_co.call_args[0][0]
         self.assertIn("logger", cmd)
         self.assertIn("-t", cmd)
         self.assertIn(idle_suspend.LOGGER_TAG, cmd)
 
     def test_message_contains_start_marker(self):
-        with patch("idle_suspend.run_cmd") as mock_run:
+        with patch("subprocess.check_output") as mock_co:
             log_timestamp()
-        cmd = mock_run.call_args[0][0]
+        cmd = mock_co.call_args[0][0]
         self.assertTrue(any("SUSPEND_TEST_START" in arg for arg in cmd))
 
     def test_timestamp_in_message_matches_returned_value(self):
-        with patch("idle_suspend.run_cmd") as mock_run:
+        with patch("subprocess.check_output") as mock_co:
             result = log_timestamp()
-        cmd = mock_run.call_args[0][0]
+        cmd = mock_co.call_args[0][0]
         ts_str = result.strftime("%Y-%m-%dT%H:%M:%SZ")
         self.assertTrue(any(ts_str in arg for arg in cmd))
 
@@ -234,29 +179,29 @@ class TestGetJournalSince(unittest.TestCase):
     _since = datetime(2026, 4, 17, 3, 0, 0, tzinfo=UTC)
 
     def test_calls_journalctl_with_since_arg(self):
-        with patch("idle_suspend.run_cmd", return_value="") as mock_run:
+        with patch("subprocess.check_output", return_value="") as mock_co:
             get_journal_since(self._since)
-        cmd = mock_run.call_args[0][0]
+        cmd = mock_co.call_args[0][0]
         self.assertIn("journalctl", cmd)
         self.assertIn("--since", cmd)
         idx = cmd.index("--since")
         self.assertEqual(cmd[idx + 1], "2026-04-17 03:00:00")
 
-    def test_uses_check_false(self):
-        with patch("idle_suspend.run_cmd", return_value="") as mock_run:
-            get_journal_since(self._since)
-        kwargs = mock_run.call_args[1]
-        self.assertFalse(kwargs.get("check", True))
+    def test_called_process_error_is_suppressed(self):
+        exc = subprocess.CalledProcessError(1, "journalctl", output="partial")
+        with patch("subprocess.check_output", side_effect=exc):
+            result = get_journal_since(self._since)
+        self.assertEqual(result, "partial")
 
-    def test_returns_run_cmd_output(self):
-        with patch("idle_suspend.run_cmd", return_value="journal output"):
+    def test_returns_output(self):
+        with patch("subprocess.check_output", return_value="journal output"):
             result = get_journal_since(self._since)
         self.assertEqual(result, "journal output")
 
     def test_short_iso_format_requested(self):
-        with patch("idle_suspend.run_cmd", return_value="") as mock_run:
+        with patch("subprocess.check_output", return_value="") as mock_co:
             get_journal_since(self._since)
-        cmd = mock_run.call_args[0][0]
+        cmd = mock_co.call_args[0][0]
         self.assertIn("short-iso", cmd)
 
 

--- a/providers/base/tests/test_idle_suspend.py
+++ b/providers/base/tests/test_idle_suspend.py
@@ -98,41 +98,61 @@ class TestCheckPowerMode(unittest.TestCase):
     def _patch_path(self, path):
         return patch("idle_suspend._find_ac_online_path", return_value=path)
 
+    def _patch_glob(self, entries):
+        """Patch glob.glob used inside check_power_mode for the directory check."""
+        return patch("idle_suspend.glob.glob", return_value=entries)
+
+    def test_no_power_supply_dir_assumes_ac_and_does_not_raise(self):
+        with self._patch_glob([]):
+            check_power_mode("ac")  # must not raise
+
+    def test_no_power_supply_dir_assumes_ac_for_battery_mode_does_not_raise(
+        self,
+    ):
+        with self._patch_glob([]):
+            check_power_mode("battery")  # must not raise (silently assumes AC)
+
     def test_no_ac_path_raises_systemexit(self):
-        with self._patch_path(None):
-            with self.assertRaises(SystemExit) as ctx:
-                check_power_mode("ac")
+        with self._patch_glob(["/sys/class/power_supply/BAT0"]):
+            with self._patch_path(None):
+                with self.assertRaises(SystemExit) as ctx:
+                    check_power_mode("ac")
         self.assertIn("Cannot determine", str(ctx.exception))
 
     def test_oserror_reading_file_raises_systemexit(self):
-        with self._patch_path("/fake/path"):
-            with patch("builtins.open", side_effect=OSError("no perm")):
-                with self.assertRaises(SystemExit) as ctx:
-                    check_power_mode("ac")
+        with self._patch_glob(["/sys/class/power_supply/AC0"]):
+            with self._patch_path("/fake/path"):
+                with patch("builtins.open", side_effect=OSError("no perm")):
+                    with self.assertRaises(SystemExit) as ctx:
+                        check_power_mode("ac")
         self.assertIn("Cannot read power status", str(ctx.exception))
 
     def test_ac_mode_on_ac_does_not_raise(self):
-        with self._patch_path("/fake/path"):
-            with patch("builtins.open", mock_open(read_data="1\n")):
-                check_power_mode("ac")  # must not raise
+        with self._patch_glob(["/sys/class/power_supply/AC0"]):
+            with self._patch_path("/fake/path"):
+                with patch("builtins.open", mock_open(read_data="1\n")):
+                    check_power_mode("ac")  # must not raise
 
     def test_ac_mode_on_battery_raises(self):
-        with self._patch_path("/fake/path"):
-            with patch("builtins.open", mock_open(read_data="0\n")):
-                with self.assertRaises(SystemExit) as ctx:
-                    check_power_mode("ac")
+        with self._patch_glob(["/sys/class/power_supply/AC0"]):
+            with self._patch_path("/fake/path"):
+                with patch("builtins.open", mock_open(read_data="0\n")):
+                    with self.assertRaises(SystemExit) as ctx:
+                        check_power_mode("ac")
         self.assertIn("battery", str(ctx.exception))
 
     def test_battery_mode_on_battery_does_not_raise(self):
-        with self._patch_path("/fake/path"):
-            with patch("builtins.open", mock_open(read_data="0\n")):
-                check_power_mode("battery")  # must not raise
+        with self._patch_glob(["/sys/class/power_supply/BAT0"]):
+            with self._patch_path("/fake/path"):
+                with patch("builtins.open", mock_open(read_data="0\n")):
+                    check_power_mode("battery")  # must not raise
 
     def test_battery_mode_on_ac_raises(self):
-        with self._patch_path("/fake/path"):
-            with patch("builtins.open", mock_open(read_data="1\n")):
-                with self.assertRaises(SystemExit) as ctx:
-                    check_power_mode("battery")
+        with self._patch_glob(["/sys/class/power_supply/AC0"]):
+            with self._patch_path("/fake/path"):
+                with patch("builtins.open", mock_open(read_data="1\n")):
+                    with self.assertRaises(SystemExit) as ctx:
+                        check_power_mode("battery")
         self.assertIn("AC power", str(ctx.exception))
 
 

--- a/providers/base/units/power-management/idle_suspend.yaml
+++ b/providers/base/units/power-management/idle_suspend.yaml
@@ -31,7 +31,7 @@ group: group_suspend_on_battery_power
 estimated_duration: '360.0'
 command: |
   echo "Make sure system running on battery power, then press Enter"
-  read
+  read -r
   idle_suspend.py --mode battery --suspend-time 5 --extra-percent 20
 ---
 category_id: com.canonical.plainbox::power-management

--- a/providers/base/units/power-management/idle_suspend.yaml
+++ b/providers/base/units/power-management/idle_suspend.yaml
@@ -14,7 +14,7 @@ group: group_suspend_on_battery_power
 estimated_duration: '5.0'
 command: |
   echo "Backup all dbus settings"
-  dconf dump / > $PLAINBOX_SESSION_SHARE/dc-env-for-restore-dconf
+  dconf dump / > "$PLAINBOX_SESSION_SHARE"/dc-env-for-restore-dconf
   echo "Enable "On battery Power" under Automatic Suspend with a delay of 5 minutes"
   gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-battery-type 'suspend'
   gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-battery-timeout 300
@@ -31,7 +31,7 @@ group: group_suspend_on_battery_power
 estimated_duration: '360.0'
 command: |
   echo "Make sure system running on battery power, then press Enter"
-  read ignore
+  read
   idle_suspend.py --mode battery --suspend-time 5 --extra-percent 20
 ---
 category_id: com.canonical.plainbox::power-management
@@ -45,7 +45,7 @@ group: group_suspend_on_battery_power
 estimated_duration: '5.0'
 command: |
   echo "Restore all dbus settings"
-  dconf load / < $PLAINBOX_SESSION_SHARE/dc-env-for-restore-dconf
+  dconf load / < "$PLAINBOX_SESSION_SHARE"/dc-env-for-restore-dconf
 ---
 category_id: com.canonical.plainbox::power-management
 id: power-management/suspend-on-AC-power-setup
@@ -62,7 +62,7 @@ group: group_suspend_on_ac_power
 estimated_duration: '5.0'
 command: |
   echo "Backup all dbus settings"
-  dconf dump / > $PLAINBOX_SESSION_SHARE/ac-env-for-restore-dconf
+  dconf dump / > "$PLAINBOX_SESSION_SHARE"/ac-env-for-restore-dconf
   echo "Enable "Plugged in" under Automatic Suspend with a delay of 5 minutes"
   gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type 'suspend'
   gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-timeout 300
@@ -92,4 +92,4 @@ group: group_suspend_on_ac_power
 estimated_duration: '5.0'
 command: |
   echo "Restore all dbus settings"
-  dconf load / < $PLAINBOX_SESSION_SHARE/ac-env-for-restore-dconf
+  dconf load / < "$PLAINBOX_SESSION_SHARE"/ac-env-for-restore-dconf

--- a/providers/base/units/power-management/idle_suspend.yaml
+++ b/providers/base/units/power-management/idle_suspend.yaml
@@ -1,0 +1,95 @@
+category_id: com.canonical.plainbox::power-management
+id: power-management/suspend-on-battery-power-setup
+plugin: shell
+environ:
+  - PLAINBOX_SESSION_SHARE
+depends:
+  - com.canonical.certification::suspend/suspend_advanced_auto
+imports:
+  - from com.canonical.plainbox import manifest
+requires:
+  - manifest.has_dc_mode == 'True'
+  - manifest.has_suspend_support == 'True'
+group: group_suspend_on_battery_power
+estimated_duration: '5.0'
+command: |
+  echo "Backup all dbus settings"
+  dconf dump / > $PLAINBOX_SESSION_SHARE/dc-env-for-restore-dconf
+  echo "Enable "On battery Power" under Automatic Suspend with a delay of 5 minutes"
+  gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-battery-type 'suspend'
+  gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-battery-timeout 300
+  echo "Set Screen Blank for 1 minute in power settings"
+  gsettings set org.gnome.desktop.session idle-delay 60
+---
+category_id: com.canonical.plainbox::power-management
+id: power-management/suspend-on-battery-power-test
+plugin: user-interact-verify
+user: root
+depends:
+  - power-management/suspend-on-battery-power-setup
+group: group_suspend_on_battery_power
+estimated_duration: '360.0'
+command: |
+  echo "Make sure system running on battery power, then press Enter"
+  read ignore
+  idle_suspend.py --mode battery --suspend-time 5 --extra-percent 20
+---
+category_id: com.canonical.plainbox::power-management
+id: power-management/suspend-on-battery-power-teardown
+plugin: shell
+depends:
+  - power-management/suspend-on-battery-power-setup
+after:
+  - power-management/suspend-on-battery-power-test
+group: group_suspend_on_battery_power
+estimated_duration: '5.0'
+command: |
+  echo "Restore all dbus settings"
+  dconf load / < $PLAINBOX_SESSION_SHARE/dc-env-for-restore-dconf
+---
+category_id: com.canonical.plainbox::power-management
+id: power-management/suspend-on-AC-power-setup
+plugin: shell
+environ:
+  - PLAINBOX_SESSION_SHARE
+depends:
+  - com.canonical.certification::suspend/suspend_advanced_auto
+imports:
+  - from com.canonical.plainbox import manifest
+requires:
+  - manifest.has_suspend_support == 'True'
+group: group_suspend_on_ac_power
+estimated_duration: '5.0'
+command: |
+  echo "Backup all dbus settings"
+  dconf dump / > $PLAINBOX_SESSION_SHARE/ac-env-for-restore-dconf
+  echo "Enable "Plugged in" under Automatic Suspend with a delay of 5 minutes"
+  gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type 'suspend'
+  gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-timeout 300
+  echo "Set Screen Blank for 1 minute in power settings"
+  gsettings set org.gnome.desktop.session idle-delay 60
+---
+category_id: com.canonical.plainbox::power-management
+id: power-management/suspend-on-AC-power-test
+plugin: shell
+user: root
+depends:
+  - power-management/suspend-on-AC-power-setup
+group: group_suspend_on_ac_power
+estimated_duration: '360.0'
+command: |
+  rtcwake -m no -s 360
+  idle_suspend.py --mode ac --suspend-time 5 --extra-percent 20
+---
+category_id: com.canonical.plainbox::power-management
+id: power-management/suspend-on-AC-power-teardown
+plugin: shell
+depends:
+  - power-management/suspend-on-AC-power-setup
+after:
+  - power-management/suspend-on-AC-power-test
+group: group_suspend_on_ac_power
+estimated_duration: '5.0'
+command: |
+  echo "Restore all dbus settings"
+  dconf load / < $PLAINBOX_SESSION_SHARE/ac-env-for-restore-dconf


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
This PR is going to migrate the manual test cases to semi-auto and auto:
1. `id: power-management/suspend-on-AC-power` to Auto test case
2. `id: power-management/suspend-on-battery-power` to semi-auto test case

The new test groups three test cases
1. setup: for setting dbus configurations of idle to suspend behavior and backup the configurations
2.  test: 
    2.1. Set the rtc wake for full auto AC test only
    2.2. Ensure the system is in the correct power supply mode. (DC/AC)
    2.3. Verifying the suspend is starting at the right timing or not
4. teardown: restore the configurations

At this point, the tolerance is higher for collecting more data to fine tune the gate in the future. 

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
Test
laptop:
    22.04: https://certification.canonical.com/hardware/202001-27667/submission/489824/
    24.04: https://certification.canonical.com/hardware/202001-27667/submission/489823/
desktop: https://certification.canonical.com/hardware/202603-38566/submission/486631/