### PR TITLE
Configure UnifiedRunner for ListBootstrapped (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -1513,6 +1513,10 @@ class ListBootstrapped:
     def sa(self):
         return self.ctx.sa
 
+    @lru_cache(maxsize=1)
+    def get_normal_user(self):
+        return self.ctx.args.normal_user or guess_normal_user()
+
     def register_arguments(self, parser):
         parser.add_argument(
             "--exact",
@@ -1532,10 +1536,21 @@ class ListBootstrapped:
                 )
             ),
         )
+        parser.add_argument(
+            "--normal-user",
+            help="Normal non-root user to use during bootstrap",
+        )
 
     def invoked(self, ctx):
         self.ctx = ctx
-        self.sa.start_new_session("checkbox-listing-ephemeral")
+        runner_kwargs = {
+            "normal_user_provider": self.get_normal_user,
+            "password_provider": sudo_password_provider.get_sudo_password,
+            "stdin": None,
+        }
+        self.sa.start_new_session(
+            "checkbox-listing-ephemeral", UnifiedRunner, runner_kwargs
+        )
 
         tps = self.sa.get_test_plans()
         testplan_id = get_testplan_id_by_id(


### PR DESCRIPTION


<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

If not configured, the runner won't work in snaps as the user will be None and plz-run will use it and blow up. 

## Resolved issues

Fixes: CHECKBOX-2232

## Documentation

N/A

## Tests

To try this:
```
snap download checkbox24 --edge
unsquashfs checkbox24*.snap
snap try --devmode squashfs-root
checkbox25.checkbox list-bootstrapped sru
# boom
# now patch the subcommands.py
# it should now work as intended
```