### PR TITLE
Fix regex in benchmarks cpu/disk_on_idle (BugFix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 
 venv
+
+CLAUDE.md

--- a/providers/base/bin/iostat_benchmark.py
+++ b/providers/base/bin/iostat_benchmark.py
@@ -24,10 +24,7 @@ import sys
 
 
 def parse_iostat_column(output, column):
-    values = [
-        float(n)
-        for n in re.findall(rf"{column}\n.*?(\S+)\n", output)
-    ]
+    values = [float(n) for n in re.findall(rf"{column}\n.*?(\S+)\n", output)]
     if not values:
         print(
             f"ERROR: No '{column}' values found in iostat output",
@@ -48,10 +45,11 @@ def main():
         help="Which metric to report: 'cpu' (idle %%) or 'disk' (util %%)",
     )
     parser.add_argument(
-        "-t","--time",
+        "-t",
+        "--time",
         action="store",
         default=10,
-        help="Time in seconds to run iostat. (default: %(default)s)"
+        help="Time in seconds to run iostat. (default: %(default)s)",
     )
     args = parser.parse_args()
 

--- a/providers/base/bin/iostat_benchmark.py
+++ b/providers/base/bin/iostat_benchmark.py
@@ -60,8 +60,9 @@ def main():
     try:
         result = subprocess.run(
             ["iostat", "-x", "-m", "1", str(args.time)],
-            capture_output=True,
-            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
             check=True,
         )
     except subprocess.CalledProcessError as e:

--- a/providers/base/bin/iostat_benchmark.py
+++ b/providers/base/bin/iostat_benchmark.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+# Written by:
+#   Jeff Lane <jeff@ubuntu.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import re
+import subprocess
+import sys
+
+
+def parse_iostat_column(output, column):
+    values = [
+        float(n)
+        for n in re.findall(rf"{column}\n.*?(\S+)\n", output)
+    ]
+    if not values:
+        print(
+            f"ERROR: No '{column}' values found in iostat output",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"{sum(values) / len(values):.2f}%")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Measure average CPU or disk utilization from iostat."
+    )
+    parser.add_argument(
+        "metric",
+        choices=["cpu", "disk"],
+        help="Which metric to report: 'cpu' (idle %%) or 'disk' (util %%)",
+    )
+    parser.add_argument(
+        "-t","--time",
+        action="store",
+        default=10,
+        help="Time in seconds to run iostat. (default: %(default)s)"
+    )
+    args = parser.parse_args()
+
+    column = "idle" if args.metric == "cpu" else "util"
+
+    try:
+        result = subprocess.run(
+            ["iostat", "-x", "-m", "1", str(args.time)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: iostat failed: {e}", file=sys.stderr)
+        return 1
+
+    return parse_iostat_column(result.stdout, column)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/providers/base/bin/iostat_benchmark.py
+++ b/providers/base/bin/iostat_benchmark.py
@@ -24,14 +24,14 @@ import sys
 
 
 def parse_iostat_column(output, column):
-    values = [float(n) for n in re.findall(rf"{column}\n.*?(\S+)\n", output)]
+    values = [float(n) for n in re.findall(column + r"\n.*?(\S+)\n", output)]
     if not values:
         print(
-            f"ERROR: No '{column}' values found in iostat output",
+            "ERROR: No '{}' values found in iostat output".format(column),
             file=sys.stderr,
         )
         return 1
-    print(f"{sum(values) / len(values):.2f}%")
+    print("{:.2f}%".format(sum(values) / len(values)))
     return 0
 
 
@@ -64,7 +64,7 @@ def main():
             check=True,
         )
     except subprocess.CalledProcessError as e:
-        print(f"ERROR: iostat failed: {e}", file=sys.stderr)
+        print("ERROR: iostat failed: {}".format(e), file=sys.stderr)
         return 1
 
     return parse_iostat_column(result.stdout, column)

--- a/providers/base/tests/test_iostat_benchmark.py
+++ b/providers/base/tests/test_iostat_benchmark.py
@@ -1,0 +1,102 @@
+import subprocess
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+import iostat_benchmark
+
+
+IOSTAT_OUTPUT = """\
+Linux 6.8.0-57-generic (hostname)	04/27/2026	_x86_64_	(8 CPU)
+
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           0.50    0.00    0.25    0.10    0.00   99.15
+
+Device            r/s     rMB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wMB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dMB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              0.10      0.00     0.00   0.00    0.50    10.00    1.00      0.01     0.50  33.33    5.00    10.24    0.00      0.00     0.00   0.00    0.00     0.00    0.00    0.00    0.01   0.10
+
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           0.60    0.00    0.30    0.05    0.00   99.05
+
+Device            r/s     rMB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wMB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dMB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              0.00      0.00     0.00   0.00    0.00     0.00    0.50      0.00     0.25  33.33    4.00     8.00    0.00      0.00     0.00   0.00    0.00     0.00    0.00    0.00    0.00   0.20
+
+"""
+
+
+class TestParseIostatColumn(unittest.TestCase):
+    def test_cpu_idle_average(self):
+        out = StringIO()
+        with patch("sys.stdout", out):
+            ret = iostat_benchmark.parse_iostat_column(IOSTAT_OUTPUT, "idle")
+        self.assertEqual(ret, 0)
+        # (99.15 + 99.05) / 2 = 99.1
+        self.assertIn("99.1", out.getvalue())
+
+    def test_disk_util_average(self):
+        out = StringIO()
+        with patch("sys.stdout", out):
+            ret = iostat_benchmark.parse_iostat_column(IOSTAT_OUTPUT, "util")
+        self.assertEqual(ret, 0)
+        # (0.10 + 0.20) / 2 = 0.15
+        self.assertIn("0.15", out.getvalue())
+
+    def test_missing_column_returns_error(self):
+        err = StringIO()
+        with patch("sys.stderr", err):
+            ret = iostat_benchmark.parse_iostat_column("no output here", "idle")
+        self.assertEqual(ret, 1)
+        self.assertIn("idle", err.getvalue())
+
+
+class TestMain(unittest.TestCase):
+    @patch(
+        "iostat_benchmark.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=IOSTAT_OUTPUT
+        ),
+    )
+    def test_main_cpu(self, mock_run):
+        out = StringIO()
+        with patch("sys.stdout", out), patch(
+            "sys.argv", ["iostat_benchmark.py", "cpu"]
+        ):
+            ret = iostat_benchmark.main()
+        self.assertEqual(ret, 0)
+        mock_run.assert_called_once_with(
+            ["iostat", "-x", "-m", "1", "10"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    @patch(
+        "iostat_benchmark.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=IOSTAT_OUTPUT
+        ),
+    )
+    def test_main_disk(self, mock_run):
+        out = StringIO()
+        with patch("sys.stdout", out), patch(
+            "sys.argv", ["iostat_benchmark.py", "disk"]
+        ):
+            ret = iostat_benchmark.main()
+        self.assertEqual(ret, 0)
+
+    @patch(
+        "iostat_benchmark.subprocess.run",
+        side_effect=subprocess.CalledProcessError(1, "iostat"),
+    )
+    def test_main_iostat_failure(self, _mock_run):
+        err = StringIO()
+        with patch("sys.stderr", err), patch(
+            "sys.argv", ["iostat_benchmark.py", "cpu"]
+        ):
+            ret = iostat_benchmark.main()
+        self.assertEqual(ret, 1)
+        self.assertIn("iostat failed", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/providers/base/tests/test_iostat_benchmark.py
+++ b/providers/base/tests/test_iostat_benchmark.py
@@ -63,11 +63,20 @@ class TestMain(unittest.TestCase):
         ):
             ret = iostat_benchmark.main()
         self.assertEqual(ret, 0)
-        mock_run.assert_called_once_with(
-            ["iostat", "-x", "-m", "1", "10"],
-            capture_output=True,
-            text=True,
-            check=True,
+        mock_run.assert_called_once()
+        args, kwargs = mock_run.call_args
+        self.assertEqual(args[0], ["iostat", "-x", "-m", "1", "10"])
+        self.assertTrue(kwargs.get("check"))
+        self.assertTrue(
+            (
+                kwargs.get("capture_output") is True
+                and kwargs.get("text") is True
+            )
+            or (
+                kwargs.get("stdout") == subprocess.PIPE
+                and kwargs.get("stderr") == subprocess.PIPE
+                and kwargs.get("universal_newlines") is True
+            )
         )
 
     @patch(

--- a/providers/base/tests/test_iostat_benchmark.py
+++ b/providers/base/tests/test_iostat_benchmark.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 import iostat_benchmark
 
-
 IOSTAT_OUTPUT = """\
 Linux 6.8.0-57-generic (hostname)	04/27/2026	_x86_64_	(8 CPU)
 
@@ -44,7 +43,9 @@ class TestParseIostatColumn(unittest.TestCase):
     def test_missing_column_returns_error(self):
         err = StringIO()
         with patch("sys.stderr", err):
-            ret = iostat_benchmark.parse_iostat_column("no output here", "idle")
+            ret = iostat_benchmark.parse_iostat_column(
+                "no output here", "idle"
+            )
         self.assertEqual(ret, 1)
         self.assertIn("idle", err.getvalue())
 

--- a/providers/base/tests/test_iostat_benchmark.py
+++ b/providers/base/tests/test_iostat_benchmark.py
@@ -64,7 +64,7 @@ class TestMain(unittest.TestCase):
         ):
             ret = iostat_benchmark.main()
         self.assertEqual(ret, 0)
-        mock_run.assert_called_once()
+        self.assertEqual(mock_run.call_count, 1)
         args, kwargs = mock_run.call_args
         self.assertEqual(args[0], ["iostat", "-x", "-m", "1", "10"])
         self.assertTrue(kwargs.get("check"))

--- a/providers/base/units/benchmarks/jobs.pxu
+++ b/providers/base/units/benchmarks/jobs.pxu
@@ -88,7 +88,7 @@ category_id: com.canonical.plainbox::benchmarks
 id: benchmarks/system/cpu_on_idle
 estimated_duration: 10.0
 requires: package.name == 'sysstat'
-command: iostat -x -m 1 10 | python3 -c 'import sys, re; lines="".join(sys.stdin.readlines()); l=[float(n) for n in (re.findall("idle\n.*?(\S+)\n", lines))]; print(sum(l)/len(l),"%")'
+command: iostat -x -m 1 10 | python3 -c 'import sys, re; lines="".join(sys.stdin.readlines()); l=[float(n) for n in (re.findall(r"idle\n.*?(\S+)\n", lines))]; print(sum(l)/len(l),"%")'
 _purpose: CPU utilization on an idle system.
 _summary: Measure CPU utilization on an idle system.
 
@@ -97,7 +97,7 @@ category_id: com.canonical.plainbox::benchmarks
 id: benchmarks/system/disk_on_idle
 estimated_duration: 10.0
 requires: package.name == 'sysstat'
-command: iostat -x -m 1 10 | python3 -c 'import sys, re; lines="".join(sys.stdin.readlines()); l=[float(n) for n in (re.findall("util\n.*?(\S+)\n", lines))]; print(sum(l)/len(l),"%")'
+command: iostat -x -m 1 10 | python3 -c 'import sys, re; lines="".join(sys.stdin.readlines()); l=[float(n) for n in (re.findall(r"util\n.*?(\S+)\n", lines))]; print(sum(l)/len(l),"%")'
 _purpose: Disk utilization on an idle system.
 _summary: Measure disk utilization on an idle system.
 

--- a/providers/base/units/benchmarks/jobs.pxu
+++ b/providers/base/units/benchmarks/jobs.pxu
@@ -88,7 +88,7 @@ category_id: com.canonical.plainbox::benchmarks
 id: benchmarks/system/cpu_on_idle
 estimated_duration: 10.0
 requires: package.name == 'sysstat'
-command: iostat -x -m 1 10 | python3 -c 'import sys, re; lines="".join(sys.stdin.readlines()); l=[float(n) for n in (re.findall(r"idle\n.*?(\S+)\n", lines))]; print(sum(l)/len(l),"%")'
+command: iostat_benchmark.py cpu
 _purpose: CPU utilization on an idle system.
 _summary: Measure CPU utilization on an idle system.
 
@@ -97,7 +97,7 @@ category_id: com.canonical.plainbox::benchmarks
 id: benchmarks/system/disk_on_idle
 estimated_duration: 10.0
 requires: package.name == 'sysstat'
-command: iostat -x -m 1 10 | python3 -c 'import sys, re; lines="".join(sys.stdin.readlines()); l=[float(n) for n in (re.findall(r"util\n.*?(\S+)\n", lines))]; print(sum(l)/len(l),"%")'
+command: iostat_benchmark.py disk
 _purpose: Disk utilization on an idle system.
 _summary: Measure disk utilization on an idle system.
 


### PR DESCRIPTION


<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
 * for disk_on_idle and cpu_on_idle, fix regex to resolve warning about invalid escape char in newer python3 versions. (older Python3 just silently passed it)
 * Also added CLAUDE.md to gitignore to avoid accidentally pulling in Claude instructions when making commits. Fixes #2477
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
Resolves #2477
Resolves CHECKBOX-2238
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

## Documentation

NA 
## Tests

Tested on a fresh Bionic install to verify rawstrings does work back that far:
```
u@bionic-tester:~$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 18.04 LTS
Release:        18.04
Codename:       bionic
u@bionic-tester:~$ python3 --version
Python 3.6.5
u@bionic-tester:~$ iostat -x -m 1 10 | python3 -c 'import sys, re; lines="".join(sys.stdin.readlines()); l=[float(n) for n in (re.findall(r"idle\n.*?(\S+)\n", lines))]; print(sum(l)/len(l),"%")'
99.787 %
u@bionic-tester:~$ iostat -x -m 1 10 | python3 -c 'import sys, re; lines="".join(sys.stdin.readlines()); l=[float(n) for n in (re.findall(r"util\n.*?(\S+)\n", lines))]; print(sum(l)/len(l),"%")'
0.013000000000000001 %
```

For comparison, this is Resolute where the initial warnings appeared for me, showing before and after:
```
bladernr@resolute-test:~$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu Resolute Raccoon (development branch)
Release:        26.04
Codename:       resolute
bladernr@resolute-test:~$ python3 --version
Python 3.14.4
bladernr@resolute-test:~$ iostat -x -m 1 10 | python3 -c 'import sys, re; lines="".join(sys.stdin.readlines()); l=[float(n) for n in (re.findall("idle\n.*?(\S+)\n", lines))]; print(sum(l)/len(l),"%")'
<string>:1: SyntaxWarning: "\S" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\S"? A raw string is also an option.
98.978 %
bladernr@resolute-test:~$ iostat -x -m 1 10 | python3 -c 'import sys, re; lines="".join(sys.stdin.readlines()); l=[float(n) for n in (re.findall(r"idle\n.*?(\S+)\n", lines))]; print(sum(l)/len(l),"%")'
98.829 %
bladernr@resolute-test:~$ iostat -x -m 1 10 | python3 -c 'import sys, re; lines="".join(sys.stdin.readlines()); l=[float(n) for n in (re.findall("util\n.*?(\S+)\n", lines))]; print(sum(l)/len(l),"%")'
<string>:1: SyntaxWarning: "\S" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\S"? A raw string is also an option.
0.0 %
bladernr@resolute-test:~$ iostat -x -m 1 10 | python3 -c 'import sys, re; lines="".join(sys.stdin.readlines()); l=[float(n) for n in (re.findall(r"util\n.*?(\S+)\n", lines))]; print(sum(l)/len(l),"%")'
0.0 %
```
