### PR TITLE
Return actual effective certification status when running `expand` subcommand (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -1506,10 +1506,14 @@ class Expand:
             unit_id = unit.id
         for regex, override_field_list in self.override_list:
             if re.match(regex, unit_id):
-                for field, value in override_field_list:
-                    if field == "certification_status":
-                        effective_certification_status = value
-                return effective_certification_status
+                with contextlib.suppress(IndexError):
+                    cert_overrides = [
+                        value
+                        for (field, value) in override_field_list
+                        if field == "certification_status"
+                    ]
+                    # highest priority is last, list is in "inverse dept" order
+                    return cert_overrides[-1]
         if hasattr(unit, "certification_status"):
             return unit.certification_status
         return "non-blocker"

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -1493,6 +1493,12 @@ class Expand:
                         "Unknown unit type {}".format(obj["unit"])
                     )
 
+    # TODO: This function is a duplicate of
+    # plainbox.impl.session.state.SessionDeviceContext._override_update()
+    # which itself uses JobState.apply_overrides(). The reason is in expand,
+    # we cannot use anything from the job or the session state. This should
+    # probably be refactored, given that the overrides are available at test
+    # plan level and should not be part of the job state to begin with...
     def get_effective_certification_status(self, unit):
         if unit.unit == "template":
             unit_id = unit.template_id
@@ -1502,7 +1508,8 @@ class Expand:
             if re.match(regex, unit_id):
                 for field, value in override_field_list:
                     if field == "certification_status":
-                        return value
+                        effective_certification_status = value
+                return effective_certification_status
         if hasattr(unit, "certification_status"):
             return unit.certification_status
         return "non-blocker"

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -1215,8 +1215,14 @@ class TestExpand(TestCase):
             (
                 "^job2$",
                 [
-                    ("certification_status", "blocker"), # Usually inline override
-                    ("certification_status", "non-blocker"), # Usually top level section override
+                    (
+                        "certification_status",
+                        "blocker",
+                    ),  # Usually inline override
+                    (
+                        "certification_status",
+                        "non-blocker",
+                    ),  # Usually top level section override
                 ],
             ),
         ]
@@ -1224,7 +1230,8 @@ class TestExpand(TestCase):
             self.launcher.get_effective_certification_status(job1), "blocker"
         )
         self.assertEqual(
-            self.launcher.get_effective_certification_status(job2), "non-blocker"
+            self.launcher.get_effective_certification_status(job2),
+            "non-blocker",
         )
         self.assertEqual(
             self.launcher.get_effective_certification_status(template1),

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -1194,6 +1194,11 @@ class TestExpand(TestCase):
                 "id": "job1",
             }
         )
+        job2 = JobDefinition(
+            {
+                "id": "job2",
+            }
+        )
         template1 = TemplateUnit(
             {
                 "template-id": "template1",
@@ -1207,9 +1212,19 @@ class TestExpand(TestCase):
                     ("certification_status", "blocker"),
                 ],
             ),
+            (
+                "^job2$",
+                [
+                    ("certification_status", "blocker"), # Usually inline override
+                    ("certification_status", "non-blocker"), # Usually top level section override
+                ],
+            ),
         ]
         self.assertEqual(
             self.launcher.get_effective_certification_status(job1), "blocker"
+        )
+        self.assertEqual(
+            self.launcher.get_effective_certification_status(job2), "non-blocker"
         )
         self.assertEqual(
             self.launcher.get_effective_certification_status(template1),

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -1238,6 +1238,57 @@ class TestExpand(TestCase):
             "non-blocker",
         )
 
+    def test_get_effective_certificate_status_no_override(self):
+        job1 = JobDefinition(
+            {
+                "id": "job1",
+            }
+        )
+        template1 = TemplateUnit(
+            {
+                "template-id": "template1",
+                "id": "job-{res}",
+            }
+        )
+        self.launcher.override_list = []
+        self.assertEqual(
+            self.launcher.get_effective_certification_status(job1),
+            "non-blocker",
+        )
+        self.assertEqual(
+            self.launcher.get_effective_certification_status(template1),
+            "non-blocker",
+        )
+
+    def test_get_effective_certificate_status_no_certification_override(self):
+        job1 = JobDefinition(
+            {
+                "id": "job1",
+            }
+        )
+        template1 = TemplateUnit(
+            {
+                "template-id": "template1",
+                "id": "job-{res}",
+            }
+        )
+        self.launcher.override_list = [
+            (
+                "^job1$",
+                [
+                    ("category_id", "com.canonical.certification::test"),
+                ],
+            ),
+        ]
+        self.assertEqual(
+            self.launcher.get_effective_certification_status(job1),
+            "non-blocker",
+        )
+        self.assertEqual(
+            self.launcher.get_effective_certification_status(template1),
+            "non-blocker",
+        )
+
 
 class TestUtilsFunctions(TestCase):
     @patch("checkbox_ng.launcher.subcommands.Colorizer", new=MagicMock())

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -645,6 +645,9 @@ class SessionDeviceContext:
             job = job_state.job
             self._override_update(job)
 
+    # TODO: Overrides probably don't need to be at State level, since they
+    # are computed earlier. We could then move these functions to be reusable
+    # for things like the `expand` subcommand instead of duplicating code.
     def _override_update(self, job):
         """
         Apply overrides to job if they are directly related or apply to the


### PR DESCRIPTION

In Expand subcommand `get_effective_certification_status()`, the expectation was that there was only one override in the list:

```python
[
            (
                "^job1$",
                [
                    ("certification_status", "blocker"),
                ],
            ),
]
```

Therefore, as soon as the function found a `certification_status` item, it would return its associated value.

However, if there is more than one override, the list might contain more than one certification_status items:

```python
[
            (
                "^job2$",
                [
("certification_status", "blocker"), # Usually inline override
("certification_status", "non-blocker"), # Usually top level section override
                ],
            ),
        ]
```

This commit takes this case into account.

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->


## Resolved issues

- Fix #2480
- Fix https://warthogs.atlassian.net/browse/CHECKBOX-2235

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- Unit tests updated
- Expand command tested using the same steps as in [my comment in the bug report](https://github.com/canonical/checkbox/issues/2480#issuecomment-4288670651), and this time both job certification status are as expected.
