### PR TITLE
Fix pre-parsed certification status overrides (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/unit/test_testplan.py
+++ b/checkbox-ng/plainbox/impl/unit/test_testplan.py
@@ -52,6 +52,30 @@ class TestTestPlan(TestCase):
         self.provider = mock.Mock(name="provider", spec_set=IProvider1)
         self.provider.namespace = "ns"
 
+    def test__get_blocker_status_overrides_legacy(self):
+        self_mock = mock.Mock()
+        self_mock.get_nested_part.return_value = []
+        self_mock.certification_status_overrides = "apply blocker to Bar"
+        overrides = TestPlanUnitSupport._get_blocker_status_overrides(
+            self_mock, self_mock
+        )
+        self.assertEqual(len(overrides), 1)
+        _, field, value = overrides[0]
+        # here the pattern is enclosed in weirdness, lets not check it
+        self.assertEqual((field, value), ("certification_status", "blocker"))
+
+    def test__get_blocker_status_overrides(self):
+        self_mock = mock.Mock()
+        self_mock.get_nested_part.return_value = []
+        self_mock.certification_status_overrides = ["apply blocker to Bar"]
+        overrides = TestPlanUnitSupport._get_blocker_status_overrides(
+            self_mock, self_mock
+        )
+        self.assertEqual(len(overrides), 1)
+        _, field, value = overrides[0]
+        # here the pattern is enclosed in weirdness, lets not check it
+        self.assertEqual((field, value), ("certification_status", "blocker"))
+
     def test_name__default(self):
         unit = TestPlanUnit({}, provider=self.provider)
         self.assertEqual(unit.name, None)

--- a/checkbox-ng/plainbox/impl/unit/testplan.py
+++ b/checkbox-ng/plainbox/impl/unit/testplan.py
@@ -908,11 +908,18 @@ PatternMatcher('^job-[x-z]$'), inclusive=False)])
                         (pattern, "certification_status", blocker_status)
                     )
 
-            V().visit(
-                OverrideFieldList.parse(
+            if isinstance(testplan.certification_status_overrides, str):
+                # LEGACY: pxu compatibility, now certification_status_overrides
+                #         is a list
+                to_visit = OverrideFieldList.parse(
                     testplan.certification_status_overrides
                 )
-            )
+            else:
+                to_visit = OverrideFieldList.from_preparsed(
+                    testplan.certification_status_overrides
+                )
+
+            V().visit(to_visit)
         for tp_unit in testplan.get_nested_part():
             override_list.extend(self._get_blocker_status_overrides(tp_unit))
         return override_list

--- a/checkbox-ng/plainbox/impl/xparsers.py
+++ b/checkbox-ng/plainbox/impl/xparsers.py
@@ -456,6 +456,14 @@ class OverrideFieldList(Node):
             entries.append(FieldOverride.parse(line, lineno, col_offset))
         return OverrideFieldList(initial_lineno, col_offset, entries)
 
+    @staticmethod
+    def from_preparsed(override_lst):
+        return OverrideFieldList(
+            0,
+            0,
+            [FieldOverride.parse(override, 0, 0) for override in override_lst],
+        )
+
 
 class OverrideExpression(Node):
     """node representing a single override statement"""


### PR DESCRIPTION
## Description

Code didn't correctly handle the yaml certification status overrides as now they are no longer a string blob but a list of overrides. This crashes Checkbox if the field is used in YAML units.

## Resolved issues

Discovered while working on: https://warthogs.atlassian.net/browse/CHECKBOX-2200

## Documentation

N/A

## Tests

N/A
