### PR TITLE
Jinja templates spaces break translator (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/test_translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_translator.py
@@ -26,6 +26,7 @@ from functools import wraps
 from checkbox_ng.launcher.translator import (
     split_comment,
     split_string_values,
+    no_space_formatters,
     Translator,
     commentable_value,
     CommentedError,
@@ -103,6 +104,22 @@ class CommentedValueTranslatorTests(TestCase):
             _ = commentable_value("value # some comment")
         self.assertEqual("value", cm.exception.value)
         self.assertEqual("some comment", cm.exception.comment)
+
+
+class NoSpaceFormattersTests(TestCase):
+    def test_no_space_formatters(self):
+        self.assertEqual(
+            no_space_formatters(
+                "id_with_jinja_formatter{{ some_resource_key }}"
+            ),
+            "id_with_jinja_formatter{{some_resource_key}}",
+        )
+
+    def test_no_space_formatters_identity(self):
+        self.assertEqual(
+            no_space_formatters("id_with_jinja_formatter"),
+            "id_with_jinja_formatter",
+        )
 
 
 class TranslatorTestCase(TestCase):

--- a/checkbox-ng/checkbox_ng/launcher/translator.py
+++ b/checkbox-ng/checkbox_ng/launcher/translator.py
@@ -332,6 +332,20 @@ field_translators = {
 }
 
 
+def no_space_formatters(value):
+    """
+    Greedy replace all {{ jinja_template_values }} -> {{jinja_template_values}}
+
+    This is greedy and doesn't work in general but because these are used
+    relatively little and the cost to implementing this properly is very high
+    (need a new parser for space stringables) while this is rarely wrong, this
+    is a compromise.
+    """
+    if isinstance(value, str) and "{{" in value and "}}" in value:
+        return value.replace("{{ ", "{{").replace(" }}", "}}")
+    return value
+
+
 def translate_unit(unit_dict: dict) -> dict:
     from ruamel.yaml.comments import CommentedMap
 
@@ -343,6 +357,7 @@ def translate_unit(unit_dict: dict) -> dict:
     to_return = CommentedMap()
     for key, value in unit_dict.items():
         key = no_more_translations(key)
+        value = no_space_formatters(value)
         try:
             translated = field_translators[key](value)
             to_return[key] = translated


### PR DESCRIPTION
## Description

Currently if a value in a translated field contains a jinja template with a space within the formatters, it is broken into multiple fields, making the translation wrong.

This "resolves" the issue by removing all spaces within the formatters, it is not a perfect solution, as one would probably prefer to threat them semantically, but the translation is best effort and to do the correct solution it is significantly harder (some fields may contain these formatters we didnt anticipate, the current small parser for stringable values doesn't support them etc.)

## Resolved issues

Discovered while working on: https://warthogs.atlassian.net/browse/CHECKBOX-2200

## Documentation

N/A


## Tests

Added tests for the new function. To verify, translate any unit that depends/after/etc. an id with a formmater with a space. It will be broken into multiple lines.
