### PR TITLE
Siblings handling wrong in YAML units (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/unit/__init__.py
+++ b/checkbox-ng/plainbox/impl/unit/__init__.py
@@ -61,8 +61,6 @@ def get_accessed_parameters(value, template_engine="default") -> frozenset:
         for value in values:
             to_r += list(get_accessed_parameters(value, template_engine))
     elif isinstance(value, dict):
-        # field + overrides
-        assert len(value.keys()) == 1, "Somethings very wrong here"
         to_r += list(
             get_accessed_parameters(next(iter(value.keys())), template_engine)
         )

--- a/checkbox-ng/plainbox/impl/unit/test_unit.py
+++ b/checkbox-ng/plainbox/impl/unit/test_unit.py
@@ -218,6 +218,23 @@ class TestUnitDefinition(TestCase):
         self.assertEqual(unit5.get_record_value("key", "default"), "default")
         self.assertEqual(unit6.get_record_value("key"), None)
         self.assertEqual(unit6.get_record_value("key", "default"), "default")
+        unit_sibling = Unit(
+            {
+                "id": "id_{a}",
+                "siblings": [{"id": "some"}],
+            },
+            parameters={"id": None},
+        )
+        self.assertEqual(
+            unit_sibling.get_record_value("siblings"), [{"id": "some"}]
+        )
+        unit_environ = Unit(
+            {"id": "some{a}", "environ": ["A", "B", "C"]},
+            parameters={"id": None},
+        )
+        self.assertEqual(
+            unit_environ.get_record_value("environ"), ["A", "B", "C"]
+        )
 
     def test_get_translated_data__typical(self):
         """

--- a/checkbox-ng/plainbox/impl/unit/unit.py
+++ b/checkbox-ng/plainbox/impl/unit/unit.py
@@ -718,6 +718,9 @@ class Unit(metaclass=UnitType):
             return {}
 
     def _get_record_value_leaf(self, name, value):
+        assert isinstance(
+            value, str
+        ), "Value '{}' is not leaf but type {} ({})".format(name, type(value), value)
         if self.template_engine == "jinja2":
             if self.is_parametric or self.unit != "template":
                 # Add the current system environment variables to the
@@ -741,6 +744,26 @@ class Unit(metaclass=UnitType):
                 raise MissingParam(self.template_id, name, value, e.args[0])
         return value
 
+    def _get_record_value(self, name, value):
+        """
+        Obtain the normalized version of the input value
+        """
+        if value is None:
+            return value
+        if isinstance(value, str):
+            return self._get_record_value_leaf(name, value)
+        elif isinstance(value, list):
+            f = partial(self._get_record_value, name)
+            return list(map(f, value))
+        elif isinstance(value, dict):
+            # Note: don't use get_record_value because it assumes name is in
+            #       self, but thats not true for sibling
+            return {
+                x: self._get_record_value(x, y) for (x, y) in value.items()
+            }
+        else:
+            return value
+
     @instance_method_lru_cache(maxsize=None)
     def get_record_value(self, name, default=None):
         """
@@ -757,14 +780,7 @@ class Unit(metaclass=UnitType):
         value = self._data.get("_{}".format(name))
         if value is None:
             value = self._data.get(name, default)
-        if value is None:
-            return value
-        if isinstance(value, str):
-            value = self._get_record_value_leaf(name, value)
-        elif isinstance(value, list):
-            f = partial(self._get_record_value_leaf, name)
-            value = list(map(f, value))
-        return value
+        return self._get_record_value(name, value)
 
     @instance_method_lru_cache(maxsize=None)
     def get_raw_record_value(self, name, default=None):

--- a/checkbox-ng/plainbox/impl/unit/unit.py
+++ b/checkbox-ng/plainbox/impl/unit/unit.py
@@ -720,7 +720,9 @@ class Unit(metaclass=UnitType):
     def _get_record_value_leaf(self, name, value):
         assert isinstance(
             value, str
-        ), "Value '{}' is not leaf but type {} ({})".format(name, type(value), value)
+        ), "Value '{}' is not leaf but type {} ({})".format(
+            name, type(value), value
+        )
         if self.template_engine == "jinja2":
             if self.is_parametric or self.unit != "template":
                 # Add the current system environment variables to the


### PR DESCRIPTION
## Description

Siblings were wrongly assumed to be a string, therefore passed into the _leaf function that only handles strings. Also, the other assert was wrongly assuming the values passed in would only be single keys, but that is not true for siblings.

## Resolved issues

Discovered while working on: https://warthogs.atlassian.net/browse/CHECKBOX-2200

## Documentation

N/A

## Tests

Added unit tests
