### PR TITLE
Copy sibling fields to avoid changing parent unit (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -27,25 +27,26 @@ import json
 import logging
 import re
 import shutil
-
 from contextlib import suppress
+from copy import copy
 
 from plainbox.abc import IJobResult
 from plainbox.i18n import gettext as _
 from plainbox.impl import deprecated
-from plainbox.impl.depmgr import DependencyDuplicateError
-from plainbox.impl.depmgr import DependencyError
-from plainbox.impl.depmgr import DependencySolver
+from plainbox.impl.depmgr import (
+    DependencyDuplicateError,
+    DependencyError,
+    DependencySolver,
+)
 from plainbox.impl.secure.qualifiers import select_units
-from plainbox.impl.session.jobs import JobState
-from plainbox.impl.session.jobs import UndesiredJobReadinessInhibitor
+from plainbox.impl.session.jobs import JobState, UndesiredJobReadinessInhibitor
 from plainbox.impl.session.system_information import (
     collect as collect_system_information,
 )
 from plainbox.impl.unit.job import JobDefinition
-from plainbox.impl.unit.unit_with_id import UnitWithId
 from plainbox.impl.unit.testplan import TestPlanUnitSupport
 from plainbox.impl.unit.unit import on_ubuntucore
+from plainbox.impl.unit.unit_with_id import UnitWithId
 from plainbox.suspend_consts import Suspend
 from plainbox.vendor import morris
 
@@ -1217,7 +1218,7 @@ class SessionState:
             if suspend_flag not in new_job.get_flag_set():
                 continue
             data = {
-                key: value
+                key: copy(value)
                 for key, value in new_job._data.items()
                 if not key.endswith("siblings")
             }


### PR DESCRIPTION


## Description

Not copying is alway wrong here. It worked before because all mutations that we were doing were over string, which are immutable, so they automatically would copy. This leads to a funny bugs like flags of the parent unit being modified when sibiling unit is modified.

## Resolved issues

Discovered while working on: https://warthogs.atlassian.net/browse/CHECKBOX-2200

## Documentation

N/A

## Tests

N/A (Change is really small, I don't even know how to test it)
