### PR TITLE
Race condition on session creation deduplication (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/session/storage.py
+++ b/checkbox-ng/plainbox/impl/session/storage.py
@@ -232,7 +232,7 @@ class SessionStorage:
         """
         WellKnownDirsHelper.populate_base()
 
-        isoformat = "%Y-%m-%dT%H.%M.%S"
+        isoformat = "%Y-%m-%dT%H.%M.%S.%f"
         timestamp = datetime.datetime.now(datetime.timezone.utc).strftime(
             isoformat
         )


### PR DESCRIPTION
## Description

This doesn't 100% fix the issue but makes it basically impossible to trigger. If too many sessions are created at the same time (from a script for example) they clash and crash checkbox. 


## Resolved issues

Discovered while working on: https://warthogs.atlassian.net/browse/CHECKBOX-2200

## Documentation

N/A

## Tests

N/A 

You can try to trigger this with launching a few list-bootstrapped in parallel

