### PR TITLE
Fix: Add validations to suspend_trigger (BugFix)

### DIFF
--- a/providers/base/bin/suspend_trigger.py
+++ b/providers/base/bin/suspend_trigger.py
@@ -67,6 +67,22 @@ def main(args=sys.argv[1:]):
             str(args.sleep_delay),
         ]
         suspend_cmd = ["systemctl", "suspend"]
+        list_jobs_cmd = ["systemctl", "list-jobs", "*suspend*"]
+        timeout = 10
+        while timeout > 0:
+            output = subprocess.check_output(
+                list_jobs_cmd,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+            ).strip()
+            if "No jobs running." in output or "No jobs listed." in output:
+                break
+            print("Suspend jobs ongoing, waiting...")
+            time.sleep(1)
+            timeout -= 1
+        else:
+            print("Timed out waiting for suspend jobs to finish")
+            return 1
         print("Running: {}".format(" ".join(rtcwake_cmd)))
         subprocess.check_call(rtcwake_cmd)
         print(
@@ -79,6 +95,8 @@ def main(args=sys.argv[1:]):
     if os.path.exists(log_path):
         print("Removing {}...".format(log_path))
         os.remove(log_path)
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/providers/base/bin/suspend_trigger.py
+++ b/providers/base/bin/suspend_trigger.py
@@ -8,6 +8,19 @@ import time
 import os
 
 from checkbox_support.scripts import fwts_test
+from checkbox_support.helpers.retry import retry
+
+
+@retry(max_attempts=10, delay=1)
+def wait_for_suspend_jobs_to_finish():
+    list_jobs_cmd = ["systemctl", "list-jobs", "*suspend*"]
+    output = subprocess.check_output(
+        list_jobs_cmd,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+    ).strip()
+    if "No jobs running." not in output and "No jobs listed." not in output:
+        raise RuntimeError("Suspend jobs ongoing")
 
 
 def main(args=sys.argv[1:]):
@@ -67,20 +80,9 @@ def main(args=sys.argv[1:]):
             str(args.sleep_delay),
         ]
         suspend_cmd = ["systemctl", "suspend"]
-        list_jobs_cmd = ["systemctl", "list-jobs", "*suspend*"]
-        timeout = 10
-        while timeout > 0:
-            output = subprocess.check_output(
-                list_jobs_cmd,
-                stderr=subprocess.STDOUT,
-                universal_newlines=True,
-            ).strip()
-            if "No jobs running." in output or "No jobs listed." in output:
-                break
-            print("Suspend jobs ongoing, waiting...")
-            time.sleep(1)
-            timeout -= 1
-        else:
+        try:
+            wait_for_suspend_jobs_to_finish()
+        except RuntimeError:
             raise SystemExit("Timed out waiting for suspend jobs to finish")
         print("Running: {}".format(" ".join(rtcwake_cmd)))
         subprocess.check_call(rtcwake_cmd)

--- a/providers/base/bin/suspend_trigger.py
+++ b/providers/base/bin/suspend_trigger.py
@@ -19,7 +19,7 @@ def wait_for_suspend_jobs_to_finish():
         stderr=subprocess.STDOUT,
         universal_newlines=True,
     ).strip()
-    if "No jobs running." not in output and "No jobs listed." not in output:
+    if output not in ("No jobs running.", "No jobs listed."):
         raise RuntimeError(
             "Suspend jobs ongoing.\n"
             f"Active jobs list:\n{output}"

--- a/providers/base/bin/suspend_trigger.py
+++ b/providers/base/bin/suspend_trigger.py
@@ -21,7 +21,7 @@ def wait_for_suspend_jobs_to_finish():
     ).strip()
     if output not in ("No jobs running.", "No jobs listed."):
         raise RuntimeError(
-            "Suspend jobs ongoing.\n" f"Active jobs list:\n{output}"
+            "Suspend jobs ongoing.\nActive jobs list:\n{}".format(output)
         )
 
 
@@ -86,7 +86,8 @@ def main(args=sys.argv[1:]):
             wait_for_suspend_jobs_to_finish()
         except RuntimeError as e:
             raise SystemExit(
-                f"Timed out waiting for suspend jobs to finish.\nDetails: {e}"
+                "Timed out waiting for suspend jobs to finish."
+                "\nDetails: {}".format(e)
             )
         print("Running: {}".format(" ".join(rtcwake_cmd)))
         subprocess.check_call(rtcwake_cmd)

--- a/providers/base/bin/suspend_trigger.py
+++ b/providers/base/bin/suspend_trigger.py
@@ -20,7 +20,10 @@ def wait_for_suspend_jobs_to_finish():
         universal_newlines=True,
     ).strip()
     if "No jobs running." not in output and "No jobs listed." not in output:
-        raise RuntimeError("Suspend jobs ongoing")
+        raise RuntimeError(
+            "Suspend jobs ongoing.\n"
+            f"Active jobs list:\n{output}"
+        )
 
 
 def main(args=sys.argv[1:]):

--- a/providers/base/bin/suspend_trigger.py
+++ b/providers/base/bin/suspend_trigger.py
@@ -85,8 +85,10 @@ def main(args=sys.argv[1:]):
         suspend_cmd = ["systemctl", "suspend"]
         try:
             wait_for_suspend_jobs_to_finish()
-        except RuntimeError:
-            raise SystemExit("Timed out waiting for suspend jobs to finish")
+        except RuntimeError as e:
+            raise SystemExit(
+                f"Timed out waiting for suspend jobs to finish.\nDetails: {e}"
+            )
         print("Running: {}".format(" ".join(rtcwake_cmd)))
         subprocess.check_call(rtcwake_cmd)
         print(

--- a/providers/base/bin/suspend_trigger.py
+++ b/providers/base/bin/suspend_trigger.py
@@ -81,8 +81,7 @@ def main(args=sys.argv[1:]):
             time.sleep(1)
             timeout -= 1
         else:
-            print("Timed out waiting for suspend jobs to finish")
-            return 1
+            raise SystemExit("Timed out waiting for suspend jobs to finish")
         print("Running: {}".format(" ".join(rtcwake_cmd)))
         subprocess.check_call(rtcwake_cmd)
         print(
@@ -95,8 +94,6 @@ def main(args=sys.argv[1:]):
     if os.path.exists(log_path):
         print("Removing {}...".format(log_path))
         os.remove(log_path)
-
-    return 0
 
 
 if __name__ == "__main__":

--- a/providers/base/bin/suspend_trigger.py
+++ b/providers/base/bin/suspend_trigger.py
@@ -21,8 +21,7 @@ def wait_for_suspend_jobs_to_finish():
     ).strip()
     if output not in ("No jobs running.", "No jobs listed."):
         raise RuntimeError(
-            "Suspend jobs ongoing.\n"
-            f"Active jobs list:\n{output}"
+            "Suspend jobs ongoing.\n" f"Active jobs list:\n{output}"
         )
 
 

--- a/providers/base/bin/suspend_trigger.py
+++ b/providers/base/bin/suspend_trigger.py
@@ -11,7 +11,7 @@ from checkbox_support.scripts import fwts_test
 from checkbox_support.helpers.retry import retry
 
 
-@retry(max_attempts=10, delay=1)
+@retry(max_attempts=10, delay=4)
 def wait_for_suspend_jobs_to_finish():
     list_jobs_cmd = ["systemctl", "list-jobs", "*suspend*"]
     output = subprocess.check_output(

--- a/providers/base/tests/test_suspend_trigger.py
+++ b/providers/base/tests/test_suspend_trigger.py
@@ -74,6 +74,7 @@ class TestSuspendTriggerFWTS(unittest.TestCase):
 
 
 @patch("suspend_trigger.fwts_test")
+@patch("suspend_trigger.subprocess.check_output")
 @patch("suspend_trigger.subprocess.check_call")
 @patch("suspend_trigger.platform.machine")
 @patch("os.remove")
@@ -85,12 +86,14 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         mock_remove,
         mock_machine,
         mock_check_call,
+        mock_check_output,
         mock_fwts_test,
     ):
         """
         Tests the rtcwake/systemctl path on aarch64 with custom arguments.
         """
         mock_machine.return_value = "aarch64"
+        mock_check_output.return_value = "No jobs listed."
 
         suspend_trigger.main(
             ["--sleep-delay", "25", "--rtc-device", "/dev/my_rtc"]
@@ -108,12 +111,19 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
             "25",
         ]
         expected_suspend_cmd = ["systemctl", "suspend"]
+        expected_list_cmd = ["systemctl", "list-jobs", "*suspend*"]
+        mock_check_output.assert_called_with(
+            expected_list_cmd,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
         subprocess_calls = [
             call(expected_rtcwake_cmd),
             call(expected_suspend_cmd),
         ]
         mock_check_call.assert_has_calls(subprocess_calls)
         self.assertEqual(mock_check_call.call_count, 2)
+        self.assertEqual(mock_check_output.call_count, 1)
 
     def test_rtcwake_path_with_defaults(
         self,
@@ -121,12 +131,14 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         mock_remove,
         mock_machine,
         mock_check_call,
+        mock_check_output,
         mock_fwts_test,
     ):
         """
         Tests the rtcwake/systemctl path without any argument.
         """
         mock_machine.return_value = "riscv64"
+        mock_check_output.return_value = "No jobs listed."
 
         suspend_trigger.main([])
 
@@ -141,11 +153,74 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
             "30",
         ]
         expected_suspend_cmd = ["systemctl", "suspend"]
+        expected_list_cmd = ["systemctl", "list-jobs", "*suspend*"]
+        mock_check_output.assert_called_with(
+            expected_list_cmd,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
         subprocess_calls = [
             call(expected_rtcwake_cmd),
             call(expected_suspend_cmd),
         ]
         mock_check_call.assert_has_calls(subprocess_calls)
+
+    def test_list_command_failure(
+        self,
+        mock_exists,
+        mock_remove,
+        mock_machine,
+        mock_check_call,
+        mock_check_output,
+        mock_fwts_test,
+    ):
+        """
+        Tests the case where the systemctl list-jobs *suspend* fails.
+        """
+        mock_machine.return_value = "aarch64"
+        # Simulate a command failure
+        error = subprocess.CalledProcessError(
+            returncode=1,
+            cmd="systemctl list-jobs *suspend*",
+            output="Timed out waiting for suspend jobs to finish",
+        )
+        mock_check_output.side_effect = error
+
+        # The script should propagate the exception
+        with self.assertRaises(subprocess.CalledProcessError):
+            suspend_trigger.main([])
+
+        # Verify that only the first command was attempted
+        self.assertTrue(mock_check_output.called)
+        called_args = mock_check_output.call_args[0][0]
+        self.assertEqual(called_args[0], "systemctl")
+        self.assertEqual(called_args[1], "list-jobs")
+
+    def test_wait_for_jobs_timeout(
+        self,
+        mock_exists,
+        mock_remove,
+        mock_machine,
+        mock_check_call,
+        mock_check_output,
+        mock_fwts_test,
+    ):
+        """
+        Tests the case where systemctl list-jobs *suspend* times out.
+        """
+        mock_machine.return_value = "aarch64"
+
+        mock_check_output.return_value = "1 jobs listed. (suspend ongoing)"
+
+        result = suspend_trigger.main([])
+
+        self.assertEqual(result, 1)
+
+        # Verify that check_output was called exactly 10 times (your loop limit).
+        self.assertEqual(mock_check_output.call_count, 10)
+
+        # Verify that rtcwake was NEVER called (because of the timeout).
+        self.assertFalse(mock_check_call.called)
 
     def test_rtcwake_command_failure(
         self,
@@ -153,12 +228,14 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         mock_remove,
         mock_machine,
         mock_check_call,
+        mock_check_output,
         mock_fwts_test,
     ):
         """
         Tests the case where the rtcwake command fails.
         """
         mock_machine.return_value = "aarch64"
+        mock_check_output.return_value = "No jobs listed."
         # Simulate a command failure
         error = subprocess.CalledProcessError(
             returncode=1, cmd="rtcwake", output="Error from rtcwake"
@@ -169,7 +246,8 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         with self.assertRaises(subprocess.CalledProcessError):
             suspend_trigger.main([])
 
-        # Verify that only the first command (rtcwake) was attempted
+        # Verify that only the first 2 commands were attempted
+        self.assertTrue(mock_check_output.called)
         self.assertTrue(mock_check_call.called)
         self.assertIn("rtcwake", mock_check_call.call_args[0][0])
 
@@ -179,12 +257,14 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         mock_remove,
         mock_machine,
         mock_check_call,
+        mock_check_output,
         mock_fwts_test,
     ):
         """
         Tests the case where the systemctl suspend command fails.
         """
         mock_machine.return_value = "aarch64"
+        mock_check_output.return_value = "No jobs listed."
         suspend_error = subprocess.CalledProcessError(
             returncode=1, cmd="systemctl suspend", output="Error from suspend"
         )
@@ -195,6 +275,7 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
             suspend_trigger.main([])
 
         # Verify both commands were attempted
+        self.assertTrue(mock_check_output.called)
         self.assertEqual(mock_check_call.call_count, 2)
         self.assertIn("rtcwake", mock_check_call.call_args_list[0][0][0])
         self.assertIn("systemctl", mock_check_call.call_args_list[1][0][0])
@@ -205,6 +286,7 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         mock_remove,
         mock_machine,
         mock_check_call,
+        mock_check_output,
         mock_fwts_test,
     ):
         """
@@ -214,10 +296,17 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         mock_machine.return_value = "aarch64"
         mock_exists.return_value = True  # Simulate file exists
         mock_check_call.side_effect = [None, None]
+        mock_check_output.return_value = "No jobs listed."
 
         suspend_trigger.main([])
 
         # Verify commands were called
+        expected_list_cmd = ["systemctl", "list-jobs", "*suspend*"]
+        mock_check_output.assert_called_with(
+            expected_list_cmd,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
         expected_rtcwake_cmd = [
             "rtcwake",
             "--verbose",
@@ -246,6 +335,7 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         mock_remove,
         mock_machine,
         mock_check_call,
+        mock_check_output,
         mock_fwts_test,
     ):
         """
@@ -254,6 +344,7 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         mock_machine.return_value = "aarch64"
         mock_exists.return_value = False  # Simulate file missing
         mock_check_call.side_effect = [None, None]
+        mock_check_output.return_value = "No jobs listed."
 
         suspend_trigger.main([])
         # Verify remove was never called

--- a/providers/base/tests/test_suspend_trigger.py
+++ b/providers/base/tests/test_suspend_trigger.py
@@ -187,7 +187,9 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         mock_check_output.side_effect = error
 
         # The script should propagate the exception
-        with patch("checkbox_support.helpers.retry.time.sleep", return_value=None):
+        with patch(
+            "checkbox_support.helpers.retry.time.sleep", return_value=None
+        ):
             with self.assertRaises(subprocess.CalledProcessError):
                 suspend_trigger.main([])
 

--- a/providers/base/tests/test_suspend_trigger.py
+++ b/providers/base/tests/test_suspend_trigger.py
@@ -187,8 +187,9 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
         mock_check_output.side_effect = error
 
         # The script should propagate the exception
-        with self.assertRaises(subprocess.CalledProcessError):
-            suspend_trigger.main([])
+        with patch("checkbox_support.helpers.retry.time.sleep", return_value=None):
+            with self.assertRaises(subprocess.CalledProcessError):
+                suspend_trigger.main([])
 
         # Verify that only the first command was attempted
         self.assertTrue(mock_check_output.called)

--- a/providers/base/tests/test_suspend_trigger.py
+++ b/providers/base/tests/test_suspend_trigger.py
@@ -215,11 +215,14 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
 
         mock_check_output.return_value = "1 jobs listed. (suspend ongoing)"
 
-        with self.assertRaises(SystemExit) as cm:
-            suspend_trigger.main([])
+        with patch(
+            "checkbox_support.helpers.retry.time.sleep", return_value=None
+        ):
+            with self.assertRaises(SystemExit) as cm:
+                suspend_trigger.main([])
 
-        self.assertEqual(
-            str(cm.exception), "Timed out waiting for suspend jobs to finish"
+        self.assertIn(
+            "Timed out waiting for suspend jobs to finish", str(cm.exception)
         )
 
         # Verify that check_output was called exactly 10 times (loop limit).

--- a/providers/base/tests/test_suspend_trigger.py
+++ b/providers/base/tests/test_suspend_trigger.py
@@ -212,11 +212,14 @@ class TestSuspendTriggerRTCWake(unittest.TestCase):
 
         mock_check_output.return_value = "1 jobs listed. (suspend ongoing)"
 
-        result = suspend_trigger.main([])
+        with self.assertRaises(SystemExit) as cm:
+            suspend_trigger.main([])
 
-        self.assertEqual(result, 1)
+        self.assertEqual(
+            str(cm.exception), "Timed out waiting for suspend jobs to finish"
+        )
 
-        # Verify that check_output was called exactly 10 times (your loop limit).
+        # Verify that check_output was called exactly 10 times (loop limit).
         self.assertEqual(mock_check_output.call_count, 10)
 
         # Verify that rtcwake was NEVER called (because of the timeout).

--- a/providers/base/units/stress/suspend_cycles_reboot.pxu
+++ b/providers/base/units/stress/suspend_cycles_reboot.pxu
@@ -79,6 +79,7 @@ estimated_duration: 75.0
 environ: PLAINBOX_SESSION_SHARE STRESS_S3_INIT_DELAY STRESS_S3_SLEEP_DELAY STRESS_S3_WAIT_DELAY LD_LIBRARY_PATH RTC_DEVICE_FILE
 user: root
 command:
+   set -o pipefail
    echo "Current boot ID is: $(tr -d - < /proc/sys/kernel/random/boot_id)"
    suspend_trigger.py --wait "${STRESS_S3_INIT_DELAY:-120}" --check-delay "${STRESS_S3_WAIT_DELAY:-45}" --sleep-delay "${STRESS_S3_SLEEP_DELAY:-30}" --rtc-device "${RTC_DEVICE_FILE:-/dev/rtc0}" 2>&1 | tee -a "$PLAINBOX_SESSION_SHARE"/suspend_cycles_with_reboot_total.log
 summary:
@@ -105,6 +106,7 @@ environ: PLAINBOX_SESSION_SHARE STRESS_S3_INIT_DELAY STRESS_S3_SLEEP_DELAY STRES
 after: stress-tests/suspend_cycles_reboot{{suspend_reboot_previous}}
 user: root
 command:
+ set -o pipefail
  echo "Current boot ID is: $(tr -d - < /proc/sys/kernel/random/boot_id)"
  suspend_trigger.py --wait "${STRESS_S3_INIT_DELAY:-120}" --check-delay "${STRESS_S3_WAIT_DELAY:-45}" --sleep-delay "${STRESS_S3_SLEEP_DELAY:-30}" --rtc-device "${RTC_DEVICE_FILE:-/dev/rtc0}" 2>&1 | tee -a "$PLAINBOX_SESSION_SHARE"/suspend_cycles_with_reboot_total.log
 summary:
@@ -129,6 +131,7 @@ environ: PLAINBOX_SESSION_SHARE STRESS_S3_INIT_DELAY STRESS_S3_SLEEP_DELAY STRES
 after: stress-tests/suspend_cycles_{{suspend_id_previous}}_reboot{{suspend_reboot_id}}
 user: root
 command:
+ set -o pipefail
  echo "Current boot ID is: $(tr -d - < /proc/sys/kernel/random/boot_id)"
  suspend_trigger.py --check-delay "${STRESS_S3_WAIT_DELAY:-45}" --sleep-delay "${STRESS_S3_SLEEP_DELAY:-30}" --rtc-device "${RTC_DEVICE_FILE:-/dev/rtc0}" 2>&1 | tee -a "$PLAINBOX_SESSION_SHARE"/suspend_cycles_with_reboot_total.log
 summary:


### PR DESCRIPTION
## Description

The following jobs were executed as part of the NVIDIA Riverside Stress test plans.
1. [Job 1](http://10.102.156.15:8080/job/partner-engineering/job/riverside/view/orin-nano/job/jetson-orin-nano-latest-server-22.04-daily-kernel-full-stress/91/console)
2. [Job 2](http://10.102.156.15:8080/job/partner-engineering/job/riverside/view/orin-nano/job/jetson-orin-nano-latest-server-22.04-daily-kernel-full-stress/86/console)
3. [Job 3](http://10.102.156.15:8080/job/partner-engineering/job/riverside/view/orin-nano/job/jetson-orin-nano-latest-server-22.04-daily-kernel-full-stress/75/console)

As can be seen the following error is commonly displayed.

```
Failed to suspend system via logind: There's already a shutdown or sleep operation in progress
Running: rtcwake --verbose --device /dev/rtc0 --mode no --seconds 60
Running: systemctl suspend to suspend the system
Traceback (most recent call last):
  File "/tmp/nest-l6gc9hfq.539cd33af75a03c6be23305220f4d9eb9436c26514c6041892099f42a977f924/suspend_trigger.py", line 85, in <module>
     sys.exit(main())
   File "/tmp/nest-l6gc9hfq.539cd33af75a03c6be23305220f4d9eb9436c26514c6041892099f42a977f924/suspend_trigger.py", line 75, in main
     subprocess.check_call(suspend_cmd)
   File "/snap/checkbox22/current/usr/lib/python3.10/subprocess.py", line 369, in check_call
     raise CalledProcessError(retcode, cmd)
 subprocess.CalledProcessError: Command '['systemctl', 'suspend']' returned non-zero exit status 1.
 --------------------------------------------------------------------------------
 Outcome: job passed
```

Even though the suspend command failed, the job is marked as `Outcome: job passed`, and the error is printed cyclically in further iterations.

This PR proposes some validations for the `suspend_trigger.py` script to make the `stress-tests/suspend_cycles_{{suspend_id}}_reboot{{suspend_reboot_id}}` test cases more robust.

 * Run `systemctl list-jobs *suspend*` to check if there are suspend jobs running before running one more.
 * If `systemctl list-jobs *suspend*` detects suspend jobs running, the job will wait before proceeding.
 * Set `set -o pipefail` on the Checkbox job definition for the job to be marked as "failed" when exiting on error.
 * Update the corresponding Python unit tests to support the `systemctl list-jobs *suspend*` calls.

## Resolved issues

https://warthogs.atlassian.net/browse/PERI-1367

## Documentation

## Tests

I ran the `com.canonical.certification::suspend-cycles-stress-test` test plan two times on a `nvidia-jetson-orin-nano` DUT.

1. [On this Checkbox submission](https://github.com/user-attachments/files/27628616/test-12-05-2026.zip) there can be seen cases, such as the `stress-tests/suspend_cycles_27_reboot1` there where suspend jobs still on-going when trying to suspend the device once more, but the test case waited until being able to send the corresponding commands.
<img width="452" height="361" alt="image" src="https://github.com/user-attachments/assets/d9e2d5af-a5f8-4f02-a004-ef467ffb22cc" />

2. I've set a maximum 40 seconds delay (spitted in 10 maximum attempts with a 4 second delay between each one). On the attached tests there were 300 suspend/resume cycles.

* 248 suspend/resume cycles ran properly at the first attempt.
* 31 suspend/resume cycles needed 2 reattempts (+8 seconds) to run.
* 18 suspend/resume cycles needed 3 reattempts (+12 seconds)  to run.
* 2 suspend/resume cycles needed 4 reattempts (+16 seconds)  to run.
* 1 suspend/resume cycle needed 5 reattempts (+20 seconds) to run.


