### PR TITLE
Expand templates in list-bootstrapped (infra)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -1572,15 +1572,23 @@ class ListBootstrapped:
             raise SystemExit("Test plan not found")
         self.sa.select_test_plan(testplan_id)
         self.sa.bootstrap()
+
         jobs = []
         for job in self.sa.get_static_todo_list():
             job_unit = self.sa.get_job(job)
-            attrs = job_unit._raw_data.copy()
+
+            # use get_record_value to apply template expansions else all values
+            # beside id and partial_id would be un-templated in the output
+            attrs = {
+                field: job_unit.get_record_value(field)
+                for field in job_unit._raw_data
+            }
             attrs["full_id"] = job_unit.id
             attrs["id"] = job_unit.partial_id
             attrs["certification_status"] = self.ctx.sa.get_job_state(
                 job
             ).effective_certification_status
+
             jobs.append(attrs)
         if ctx.args.format == "?":
             all_keys = set()

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -984,43 +984,46 @@ class TestLauncherReturnCodes(TestCase):
         self.assertEqual(self.launcher.invoked(self.ctx), 1)
 
 
-class TestLListBootstrapped(TestCase):
+class TestListBootstrapped(TestCase):
     def setUp(self):
         self.launcher = ListBootstrapped()
         self.ctx = Mock()
         self.ctx.args = Mock(TEST_PLAN="", format="")
+
+        def identity(self, name):
+            return self._raw_data[name]
+
+        job_1 = Mock(
+            _raw_data={
+                "id": "namespace1::test-job1",
+                "summary": "fake-job1",
+                "plugin": "manual",
+                "description": "fake-description1",
+                "certification_status": "non-blocker",
+            },
+            id="namespace1::test-job1",
+            partial_id="test-job1",
+        )
+        job_2 = Mock(
+            _raw_data={
+                "id": "namespace2::test-job2",
+                "summary": "fake-job2",
+                "plugin": "shell",
+                "command": "ls",
+                "certification_status": "non-blocker",
+            },
+            id="namespace2::test-job2",
+            partial_id="test-job2",
+        )
+        job_1.get_record_value = partial(identity, job_1)
+        job_2.get_record_value = partial(identity, job_2)
         self.ctx.sa = Mock(
             start_new_session=Mock(),
             get_test_plans=Mock(return_value=["test-plan1", "test-plan2"]),
             select_test_plan=Mock(),
             bootstrap=Mock(),
             get_static_todo_list=Mock(return_value=["test-job1", "test-job2"]),
-            get_job=Mock(
-                side_effect=[
-                    Mock(
-                        _raw_data={
-                            "id": "namespace1::test-job1",
-                            "summary": "fake-job1",
-                            "plugin": "manual",
-                            "description": "fake-description1",
-                            "certification_status": "non-blocker",
-                        },
-                        id="namespace1::test-job1",
-                        partial_id="test-job1",
-                    ),
-                    Mock(
-                        _raw_data={
-                            "id": "namespace2::test-job2",
-                            "summary": "fake-job2",
-                            "plugin": "shell",
-                            "command": "ls",
-                            "certification_status": "non-blocker",
-                        },
-                        id="namespace2::test-job2",
-                        partial_id="test-job2",
-                    ),
-                ]
-            ),
+            get_job=Mock(side_effect=[job_1, job_2]),
             get_job_state=Mock(
                 return_value=Mock(effective_certification_status="blocker")
             ),


### PR DESCRIPTION
## Description

List bootstrapped is used to get the concrete test plan, so it doesn't make sense to return the pre-templated values for unit fields. This is most likely a bug because the class was written without taking into consideration templates and then patched using the attribute getters for id and full_id because someone noticed that was wrong.

## Resolved issues

N/A

## Documentation

Added a comment to explain why we use get_record_value

## Tests

This is the json of sru (on my machine) before and after the patch: 
[sru_json_prepatch.json](https://github.com/user-attachments/files/27010295/sru_json_prepatch.json)
[sru_json.json](https://github.com/user-attachments/files/27010298/sru_json.json)

Example of the change:
Pre patch
```
  {
    "unit": "job",
    "id": "bluetooth4/beacon_eddystone_url_hci0",
    "_summary": "Test system can get beacon EddyStone URL advertisements on the {{ interface }} adapter",
    "command": "checkbox-support-eddystone_scanner -D {{ interface }}",
    "plugin": "shell",
    "user": "root",
    "flags": "also-after-suspend fail-on-resource",
    "category_id": "com.canonical.plainbox::bluetooth",
    "estimated_duration": "10",
    "requires": "package.name == 'bluez' or snap.name == 'bluez'\nenvironment.CHECKBOX_RUNNING_STRICT_SNAP != \"1\" or (connections.slot == 'bluez:service' and connections.plug == '{{ __system_env__[\"SNAP_NAME\"] }}:bluez')",
    "template-engine": "jinja2",
    "template-id": "com.canonical.certification::bluetooth4/beacon_eddystone_url_interface",
    "full_id": "com.canonical.certification::bluetooth4/beacon_eddystone_url_hci0",
    "certification_status": "blocker"
  },
```
Post patch
```
  {
    "unit": "job",
    "id": "bluetooth4/beacon_eddystone_url_hci0",
    "_summary": "Test system can get beacon EddyStone URL advertisements on the hci0 adapter",
    "command": "checkbox-support-eddystone_scanner -D hci0",
    "plugin": "shell",
    "user": "root",
    "flags": "also-after-suspend fail-on-resource",
    "category_id": "com.canonical.plainbox::bluetooth",
    "estimated_duration": "10",
    "requires": "package.name == 'bluez' or snap.name == 'bluez'\nenvironment.CHECKBOX_RUNNING_STRICT_SNAP != \"1\" or (connections.slot == 'bluez:service' and connections.plug == ':bluez')",
    "template-engine": "jinja2",
    "template-id": "com.canonical.certification::bluetooth4/beacon_eddystone_url_interface",
    "full_id": "com.canonical.certification::bluetooth4/beacon_eddystone_url_hci0",
    "certification_status": "blocker"
  },
```

