### PR TITLE
Fix merge reports submission parsing (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/merge_reports.py
+++ b/checkbox-ng/checkbox_ng/launcher/merge_reports.py
@@ -76,6 +76,7 @@ class MergeReports:
             for result in data["results"]:
                 result["plugin"] = "shell"  # Required so default to shell
                 result["summary"] = result["name"]
+                result["template-id"] = result["template_id"]
                 # 'id' field in json file only contains partial id
                 result["id"] = result.get("full_id", result["id"])
                 if "::" not in result["id"]:

--- a/checkbox-ng/checkbox_ng/launcher/merge_reports.py
+++ b/checkbox-ng/checkbox_ng/launcher/merge_reports.py
@@ -44,6 +44,11 @@ CERTIFICATION_NS = "com.canonical.certification::"
 
 
 class MergeReports:
+    def __init__(self):
+        self.job_list = []
+        self.category_list = []
+        self.system_information = []
+
     def register_arguments(self, parser):
         parser.add_argument(
             "submission",
@@ -59,12 +64,15 @@ class MergeReports:
             help="save combined test results to the specified FILE",
         )
 
-    def _parse_submission(self, submission, tmpdir, mode="list"):
+    def _get_submission_json(self, submission, tmpdir):
+        with tarfile.open(submission) as tar:
+            tar.extractall(tmpdir.name)
+            with open(os.path.join(tmpdir.name, "submission.json")) as f:
+                submission_json = json.load(f)
+        return submission_json
+
+    def _parse_submission(self, data, mode="list"):
         try:
-            with tarfile.open(submission) as tar:
-                tar.extractall(tmpdir.name)
-                with open(os.path.join(tmpdir.name, "submission.json")) as f:
-                    data = json.load(f)
             for result in data["results"]:
                 result["plugin"] = "shell"  # Required so default to shell
                 result["summary"] = result["name"]
@@ -183,10 +191,8 @@ class MergeReports:
         manager_list = []
         for submission in ctx.args.submission:
             tmpdir = TemporaryDirectory()
-            self.job_list = []
-            self.category_list = []
-            self.system_information = []
-            session_title = self._parse_submission(submission, tmpdir)
+            submission_json = self._get_submission_json(submission, tmpdir)
+            session_title = self._parse_submission(submission_json)
             manager = SessionManager.create_with_unit_list(
                 self.job_list + self.category_list
             )

--- a/checkbox-ng/checkbox_ng/launcher/merge_submissions.py
+++ b/checkbox-ng/checkbox_ng/launcher/merge_submissions.py
@@ -67,8 +67,9 @@ class MergeSubmissions(MergeReports):
         self.category_dict = {}
         self.system_information = {}
         for submission in ctx.args.submission:
+            submission_json = self._get_submission_json(submission, tmpdir)
             session_title = self._parse_submission(
-                submission, tmpdir, mode="dict"
+                submission_json, mode="dict"
             )
         manager = SessionManager.create_with_unit_list(
             list(self.job_dict.values()) + list(self.category_dict.values())

--- a/checkbox-ng/checkbox_ng/launcher/test_merge_reports.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_merge_reports.py
@@ -56,6 +56,7 @@ class MergeReportsTests(TestCase):
         basic_job_info = {
             "name": "test_name",
             "id": "test_id",  # note: no :: to fetch the default ns
+            "template_id": "test_template_id",
         }
         sub_to_read = {
             "title": "report title",
@@ -82,3 +83,28 @@ class MergeReportsTests(TestCase):
         self_mock = MagicMock()
         MergeReports._populate_session_state(self_mock, job_mock, state_mock)
         self.assertTrue(job_mock.get_record_value.called)
+
+    def test_parse_submission(self):
+        basic_job_info = {
+            "name": "test_name",
+            "id": "test_id",  # note: no :: to fetch the default ns
+            "template_id": "com.canonical.certification::test_template_id",
+        }
+        sub_to_read = {
+            "title": "report title",
+            "results": [basic_job_info],
+            "resource-results": [basic_job_info],
+            "attachment-results": [basic_job_info],
+            "category_map": {"test_category": "test_name"},
+            "system_information": {"version": 0},
+        }
+        mr = MergeReports()
+        mr._parse_submission(sub_to_read)
+        self.assertEqual(len(mr.job_list), 3)
+        self.assertEqual(
+            mr.job_list[0].id, "com.canonical.certification::test_id"
+        )
+        self.assertEqual(
+            mr.job_list[0].template_id,
+            "com.canonical.certification::test_template_id",
+        )


### PR DESCRIPTION


## Description

In the JSON report, the template field is called `template_id`, but in a `JobDefinition` it's `template-id`, therefore when the script tries to populate a session, it loses the template information...

I've also modified a bit the MergeReports and MergeSubmissions classes so that they're easier to test, and added some unit tests.

## Resolved issues

- https://warthogs.atlassian.net/browse/CHECKBOX-2246
- #2503 

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

- Unit test added
- Script tested by calling `merge-reports` and `merge-submissions` with a submission and making sure the JSON is the same.