### PR TITLE
Split skip outcome into 4 possibilites (New)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -558,7 +558,7 @@ class RemoteController(ReportsStage, MainLoopStage):
                 result_dict["comments"] = newline_join(
                     result_dict["comments"], "Skipped after resuming execution"
                 )
-            result_dict["outcome"] = IJobResult.OUTCOME_SKIP
+            result_dict["outcome"] = IJobResult.OUTCOME_MANUAL_SKIP
         elif resume_params.action == "rerun":
             # if the job outcome is set to none it will be rerun
             result_dict["outcome"] = None

--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -130,7 +130,7 @@ class MainLoopStage(CheckboxUiStage):
                     "manual",
                 ):
                     result_builder = JobResultBuilder(
-                        outcome=IJobResult.OUTCOME_SKIP,
+                        outcome=IJobResult.OUTCOME_MANUAL_SKIP,
                         comments=_(
                             "Trying to run interactive job in a silent"
                             " session"
@@ -189,7 +189,7 @@ class MainLoopStage(CheckboxUiStage):
                             continue
                         else:
                             result_builder = JobResultBuilder(
-                                outcome=IJobResult.OUTCOME_SKIP,
+                                outcome=IJobResult.OUTCOME_MANUAL_SKIP,
                                 comments=_(
                                     "Explicitly skipped before execution"
                                 ),
@@ -230,7 +230,7 @@ class MainLoopStage(CheckboxUiStage):
             allowed_outcome = [
                 IJobResult.OUTCOME_PASS,
                 IJobResult.OUTCOME_FAIL,
-                IJobResult.OUTCOME_SKIP,
+                IJobResult.OUTCOME_MANUAL_SKIP,
             ]
         allowed_actions = [Action("c", _("add a comment"), "set-comments")]
         if IJobResult.OUTCOME_PASS in allowed_outcome:
@@ -253,7 +253,7 @@ class MainLoopStage(CheckboxUiStage):
                     "set-fail",
                 )
             )
-        if IJobResult.OUTCOME_SKIP in allowed_outcome:
+        if IJobResult.OUTCOME_MANUAL_SKIP in allowed_outcome:
             allowed_actions.append(
                 Action(
                     "s",
@@ -340,7 +340,7 @@ class MainLoopStage(CheckboxUiStage):
                     )
                     continue
                 else:
-                    result_builder.outcome = IJobResult.OUTCOME_SKIP
+                    result_builder.outcome = IJobResult.OUTCOME_MANUAL_SKIP
             elif cmd == "set-suggested":
                 result_builder.outcome = suggested_outcome
             elif cmd == "set-comments":

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -509,7 +509,7 @@ class Launcher(MainLoopStage, ReportsStage):
             outcome = {
                 "pass": IJobResult.OUTCOME_PASS,
                 "fail": IJobResult.OUTCOME_FAIL,
-                "skip": IJobResult.OUTCOME_SKIP,
+                "skip": IJobResult.OUTCOME_MANUAL_SKIP,
                 "rerun": IJobResult.OUTCOME_UNDECIDED,
             }[resume_params.action]
         else:
@@ -601,7 +601,7 @@ class Launcher(MainLoopStage, ReportsStage):
                         result_dict["comments"],
                         "Failed after resuming execution",
                     )
-            elif outcome == IJobResult.OUTCOME_SKIP:
+            elif outcome == IJobResult.OUTCOME_MANUAL_SKIP:
                 if is_cert_blocker and not comments:
                     result_dict["comments"] = request_comment(
                         "why you want to skip it"
@@ -870,7 +870,7 @@ class Launcher(MainLoopStage, ReportsStage):
                         result_dict["comments"] = _(
                             "Skipped after resuming execution"
                         )
-                    result_dict["outcome"] = IJobResult.OUTCOME_SKIP
+                    result_dict["outcome"] = IJobResult.OUTCOME_MANUAL_SKIP
                     result = MemoryJobResult(result_dict)
                     break
             elif cmd == "pass":

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -795,7 +795,7 @@ class ControllerTests(TestCase):
             "123",
             {
                 "comments": "Initial comment\nSkipped after resuming execution",
-                "outcome": mock_IJobResult.OUTCOME_SKIP,
+                "outcome": mock_IJobResult.OUTCOME_MANUAL_SKIP,
             },
         )
 
@@ -838,7 +838,7 @@ class ControllerTests(TestCase):
             "123",
             {
                 "comments": "comment requested from user",
-                "outcome": mock_IJobResult.OUTCOME_SKIP,
+                "outcome": mock_IJobResult.OUTCOME_MANUAL_SKIP,
             },
         )
 

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -484,7 +484,7 @@ class TestLauncher(TestCase):
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
-        self.assertEqual(result_dict["outcome"], IJobResult.OUTCOME_SKIP)
+        self.assertEqual(result_dict["outcome"], IJobResult.OUTCOME_MANUAL_SKIP)
         # given that no comment was in resume_params, the resume procedure asks for it
         self.assertTrue(request_comment_mock.called)
 
@@ -513,7 +513,7 @@ class TestLauncher(TestCase):
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
-        self.assertEqual(result_dict["outcome"], IJobResult.OUTCOME_SKIP)
+        self.assertEqual(result_dict["outcome"], IJobResult.OUTCOME_MANUAL_SKIP)
 
     @patch("checkbox_ng.launcher.subcommands.MemoryJobResult")
     @patch("checkbox_ng.launcher.subcommands.newline_join", new=MagicMock())

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -484,7 +484,9 @@ class TestLauncher(TestCase):
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
-        self.assertEqual(result_dict["outcome"], IJobResult.OUTCOME_MANUAL_SKIP)
+        self.assertEqual(
+            result_dict["outcome"], IJobResult.OUTCOME_MANUAL_SKIP
+        )
         # given that no comment was in resume_params, the resume procedure asks for it
         self.assertTrue(request_comment_mock.called)
 
@@ -513,7 +515,9 @@ class TestLauncher(TestCase):
 
         args, _ = memory_job_result_mock.call_args_list[-1]
         result_dict, *_ = args
-        self.assertEqual(result_dict["outcome"], IJobResult.OUTCOME_MANUAL_SKIP)
+        self.assertEqual(
+            result_dict["outcome"], IJobResult.OUTCOME_MANUAL_SKIP
+        )
 
     @patch("checkbox_ng.launcher.subcommands.MemoryJobResult")
     @patch("checkbox_ng.launcher.subcommands.newline_join", new=MagicMock())

--- a/checkbox-ng/checkbox_ng/urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/urwid_ui.py
@@ -496,7 +496,9 @@ class RerunWidget(CategoryWidget):
         IJobResult.OUTCOME_SKIP: _("Manually Skipped Jobs"),
         IJobResult.OUTCOME_CRASH: _("Crashed Jobs"),
         IJobResult.OUTCOME_NOT_SUPPORTED: _("Jobs with failed dependencies"),
-        IJobResult.OUTCOME_SKIPPED_DEPENDENCY: _("Jobs with failed dependencies"),
+        IJobResult.OUTCOME_SKIPPED_DEPENDENCY: _(
+            "Jobs with failed dependencies"
+        ),
         IJobResult.OUTCOME_SKIPPED_RESOURCE: _("Jobs with unmet resources"),
         IJobResult.OUTCOME_SKIPPED_MANIFEST: _("Jobs with unmet manifest"),
     }

--- a/checkbox-ng/checkbox_ng/urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/urwid_ui.py
@@ -493,9 +493,12 @@ class RerunWidget(CategoryWidget):
 
     section_names = {
         IJobResult.OUTCOME_FAIL: _("Failed Jobs"),
-        IJobResult.OUTCOME_SKIP: _("Skipped Jobs"),
+        IJobResult.OUTCOME_SKIP: _("Manually Skipped Jobs"),
         IJobResult.OUTCOME_CRASH: _("Crashed Jobs"),
         IJobResult.OUTCOME_NOT_SUPPORTED: _("Jobs with failed dependencies"),
+        IJobResult.OUTCOME_SKIPPED_DEPENDENCY: _("Jobs with failed dependencies"),
+        IJobResult.OUTCOME_SKIPPED_RESOURCE: _("Jobs with unmet resources"),
+        IJobResult.OUTCOME_SKIPPED_MANIFEST: _("Jobs with unmet manifest"),
     }
 
     def __init__(self, node):

--- a/checkbox-ng/checkbox_ng/urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/urwid_ui.py
@@ -493,7 +493,7 @@ class RerunWidget(CategoryWidget):
 
     section_names = {
         IJobResult.OUTCOME_FAIL: _("Failed Jobs"),
-        IJobResult.OUTCOME_SKIP: _("Manually Skipped Jobs"),
+        IJobResult.OUTCOME_MANUAL_SKIP: _("Manually Skipped Jobs"),
         IJobResult.OUTCOME_CRASH: _("Crashed Jobs"),
         IJobResult.OUTCOME_NOT_SUPPORTED: _("Jobs with failed dependencies"),
         IJobResult.OUTCOME_SKIPPED_DEPENDENCY: _(

--- a/checkbox-ng/plainbox/abc.py
+++ b/checkbox-ng/plainbox/abc.py
@@ -204,10 +204,16 @@ class IJobResult(metaclass=ABCMeta):
     # skipped it. This is typically used for a manual job that is tedious or
     # was selected by accident.
     OUTCOME_SKIP = "skip"
-    # The not supported outcome is used when a job was about to run but a
-    # dependency or resource requirement prevent it from running.  XXX: perhaps
-    # this should be called "not available", not supported has the "unsupported
-    # code" feeling associated with it.
+    # The skipped outcomes are used when a job was about to run but could not
+    # start for various reasons (dependency failure, resource requirement, or
+    # manifest requirement). These outcomes replace the old OUTCOME_NOT_SUPPORTED
+    # to provide more granular information about why a job was skipped.
+    OUTCOME_SKIPPED_DEPENDENCY = "skipped-dependency"
+    OUTCOME_SKIPPED_RESOURCE = "skipped-resource"
+    OUTCOME_SKIPPED_MANIFEST = "skipped-manifest"
+    # /!\ The not supported outcome is DEPRECATED.
+    # Use OUTCOME_SKIPPED_DEPENDENCY, OUTCOME_SKIPPED_RESOURCE or
+    # OUTCOME_SKIPPED_MANIFEST instead.
     OUTCOME_NOT_SUPPORTED = "not-supported"
     # A temporary state that should be removed later on, used to indicate that
     # job runner is not implemented but the job "ran" so to speak.

--- a/checkbox-ng/plainbox/abc.py
+++ b/checkbox-ng/plainbox/abc.py
@@ -203,7 +203,7 @@ class IJobResult(metaclass=ABCMeta):
     # The skip outcome is used when the operator selected a job but then
     # skipped it. This is typically used for a manual job that is tedious or
     # was selected by accident.
-    OUTCOME_SKIP = "skip"
+    OUTCOME_MANUAL_SKIP = "skip"
     # The skipped outcomes are used when a job was about to run but could not
     # start for various reasons (dependency failure, resource requirement, or
     # manifest requirement). These outcomes replace the old OUTCOME_NOT_SUPPORTED

--- a/checkbox-ng/plainbox/impl/applogic.py
+++ b/checkbox-ng/plainbox/impl/applogic.py
@@ -75,7 +75,6 @@ def run_job_if_possible(session, runner, config, job, update=True, ui=None):
     return job_state, job_result
 
 
-
 def get_all_exporter_names():
     """
     Get the identifiers (names) of all the supported session state exporters.

--- a/checkbox-ng/plainbox/impl/applogic.py
+++ b/checkbox-ng/plainbox/impl/applogic.py
@@ -32,7 +32,6 @@ from plainbox.abc import IJobResult
 from plainbox.i18n import gettext as _
 from plainbox.impl.result import MemoryJobResult
 from plainbox.impl.result_utils import determine_outcome_and_skip_reason
-from plainbox.impl.secure import config
 from plainbox.impl.secure.qualifiers import select_units
 from plainbox.impl.session import SessionManager
 from plainbox.impl.session.jobs import InhibitionCause

--- a/checkbox-ng/plainbox/impl/applogic.py
+++ b/checkbox-ng/plainbox/impl/applogic.py
@@ -31,6 +31,7 @@ import os
 from plainbox.abc import IJobResult
 from plainbox.i18n import gettext as _
 from plainbox.impl.result import MemoryJobResult
+from plainbox.impl.result_utils import determine_outcome_and_skip_reason
 from plainbox.impl.secure import config
 from plainbox.impl.secure.qualifiers import select_units
 from plainbox.impl.session import SessionManager
@@ -58,27 +59,21 @@ def run_job_if_possible(session, runner, config, job, update=True, ui=None):
     if job_state.can_start():
         job_result = runner.run_job(job, job_state, config, ui)
     else:
-        # Set the outcome of jobs that cannot start to
-        # OUTCOME_NOT_SUPPORTED _except_ if any of the inhibitors point to
-        # a job with an OUTCOME_SKIP outcome, if that is the case mirror
-        # that outcome. This makes 'skip' stronger than 'not-supported'
-        outcome = IJobResult.OUTCOME_NOT_SUPPORTED
-        for inhibitor in job_state.readiness_inhibitor_list:
-            if inhibitor.cause != InhibitionCause.FAILED_DEP:
-                continue
-            related_job_state = session.job_state_map[inhibitor.related_job.id]
-            if related_job_state.result.outcome == IJobResult.OUTCOME_SKIP:
-                outcome = IJobResult.OUTCOME_SKIP
-        job_result = MemoryJobResult(
-            {
-                "outcome": outcome,
-                "comments": job_state.get_readiness_description(),
-            }
+        outcome, skip_reason = determine_outcome_and_skip_reason(
+            job_state, session.job_state_map
         )
+        result_data = {
+            "outcome": outcome,
+            "comments": job_state.get_readiness_description(),
+        }
+        if skip_reason:
+            result_data["skip_reason"] = skip_reason
+        job_result = MemoryJobResult(result_data)
     assert job_result is not None
     if update:
         session.update_job_result(job, job_result)
     return job_state, job_result
+
 
 
 def get_all_exporter_names():

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -150,14 +150,14 @@ class UnifiedRunner(IJobRunner):
                 )
             )
             return JobResultBuilder(
-                outcome=IJobResult.OUTCOME_SKIP,
+                outcome=IJobResult.OUTCOME_MANUAL_SKIP,
                 comments=_("Unsupported plugin type: {}".format(job.plugin)),
             ).get_result()
 
         # resource and attachment jobs are always run (even in dry runs)
         if self._dry_run and job.plugin not in ("resource", "attachment"):
             return JobResultBuilder(
-                outcome=IJobResult.OUTCOME_SKIP,
+                outcome=IJobResult.OUTCOME_MANUAL_SKIP,
                 comments=_("Job skipped in dry-run mode"),
             ).get_result()
 

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -150,7 +150,7 @@ class UnifiedRunner(IJobRunner):
                 )
             )
             return JobResultBuilder(
-                outcome=IJobResult.OUTCOME_MANUAL_SKIP,
+                outcome=IJobResult.OUTCOME_CRASH,
                 comments=_("Unsupported plugin type: {}".format(job.plugin)),
             ).get_result()
 

--- a/checkbox-ng/plainbox/impl/exporter/__init__.py
+++ b/checkbox-ng/plainbox/impl/exporter/__init__.py
@@ -273,12 +273,6 @@ class SessionStateExporterBase(ISessionStateExporter):
                     "comments"
                 ] = job_state.result.comments
 
-            # Add skip_reason if present
-            if job_state.result.skip_reason:
-                data["result_map"][job_id][
-                    "skip_reason"
-                ] = job_state.result.skip_reason
-
             # Add Job hash if requested
             if self.OPTION_WITH_JOB_HASH in self._option_list:
                 data["result_map"][job_id]["hash"] = job_state.job.checksum

--- a/checkbox-ng/plainbox/impl/exporter/__init__.py
+++ b/checkbox-ng/plainbox/impl/exporter/__init__.py
@@ -275,7 +275,9 @@ class SessionStateExporterBase(ISessionStateExporter):
 
             # Add skip_reason if present
             if job_state.result.skip_reason:
-                data["result_map"][job_id]["skip_reason"] = job_state.result.skip_reason
+                data["result_map"][job_id][
+                    "skip_reason"
+                ] = job_state.result.skip_reason
 
             # Add Job hash if requested
             if self.OPTION_WITH_JOB_HASH in self._option_list:

--- a/checkbox-ng/plainbox/impl/exporter/__init__.py
+++ b/checkbox-ng/plainbox/impl/exporter/__init__.py
@@ -273,6 +273,10 @@ class SessionStateExporterBase(ISessionStateExporter):
                     "comments"
                 ] = job_state.result.comments
 
+            # Add skip_reason if present
+            if job_state.result.skip_reason:
+                data["result_map"][job_id]["skip_reason"] = job_state.result.skip_reason
+
             # Add Job hash if requested
             if self.OPTION_WITH_JOB_HASH in self._option_list:
                 data["result_map"][job_id]["hash"] = job_state.job.checksum

--- a/checkbox-ng/plainbox/impl/exporter/test_html.py
+++ b/checkbox-ng/plainbox/impl/exporter/test_html.py
@@ -93,7 +93,7 @@ class HTMLExporterTests(TestCase):
         )
         self.result_skip = MemoryJobResult(
             {
-                "outcome": IJobResult.OUTCOME_SKIP,
+                "outcome": IJobResult.OUTCOME_MANUAL_SKIP,
                 "execution_duration": 1.0,
                 "comments": "No such device",
             }

--- a/checkbox-ng/plainbox/impl/exporter/xlsx.py
+++ b/checkbox-ng/plainbox/impl/exporter/xlsx.py
@@ -647,7 +647,7 @@ class XLSXSessionStateExporter(SessionStateExporterBase):
             ):
                 tmp_result_map[category][
                     "category_status"
-                ] = IJobResult.OUTCOME_SKIP
+                ] = IJobResult.OUTCOME_MANUAL_SKIP
         result_map.update(tmp_result_map)
         return res, 2
 

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
@@ -210,14 +210,14 @@
                                 datasets: [{
                                     data: [
                                         {%- for outcome, total in state.get_test_outcome_stats()|dictsort %}
-                                        {%- if outcome != 'not-supported' %}
+                                        {%- if outcome not in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] %}
                                         {{ total }},
                                         {%- endif %}
                                         {%- endfor %}
                                     ],
                                     backgroundColor: [
                                         {%- for outcome, total in state.get_test_outcome_stats()|dictsort %}
-                                        {%- if outcome != 'not-supported' %}
+                                        {%- if outcome not in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] %}
                                         "{{ OUTCOME_METADATA_MAP[outcome].color_hex }}",
                                         {%- endif %}
                                         {%- endfor %}
@@ -225,7 +225,7 @@
                                 }],
                                 labels: [
                                     {%- for outcome, total in state.get_test_outcome_stats()|dictsort %}
-                                    {%- if outcome != 'not-supported' %}
+                                    {%- if outcome not in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] %}
                                     "{{ OUTCOME_METADATA_MAP[outcome].tr_label }}",
                                     {%- endif %}
                                     {%- endfor %}
@@ -260,7 +260,7 @@
                                                     return {
                                                         // Instead of `text: label,`
                                                         // We add the value to the string
-                                                        text: label + " : " + value,
+                                                        text: label + ": " + value,
                                                         fillStyle: fill,
                                                         strokeStyle: stroke,
                                                         lineWidth: bw,
@@ -301,7 +301,7 @@
                     {%- for cat_id, cat_name in category_map|dictsort(false, 'value') %}
                     {% set mainloop = loop %}
                     {%- set has_supported = [] %}
-                    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.result.outcome != 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+                    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.result.outcome not in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
                         {%- if has_supported.append(1) %}{% endif %}
                     {%- endfor %}
                     {%- if has_supported|length > 0 %}
@@ -319,7 +319,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                            {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.result.outcome != 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+                            {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.result.outcome not in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
                                 <tr>
                                     <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%'>{{ job_id|strip_ns }}</td>
                                     <td style='width:10%; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
@@ -344,7 +344,7 @@
                     {%- endfor %}
                     <p></p>
                     {%- set has_any_not_supported = [] %}
-                    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome == 'not-supported' and job_state.job.plugin not in ("resource", "attachment") %}
+                    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] and job_state.job.plugin not in ("resource", "attachment") %}
                         {%- if has_any_not_supported.append(1) %}{% endif %}
                     {%- endfor %}
                     {%- if has_any_not_supported|length > 0 %}
@@ -353,7 +353,7 @@
                     {%- for cat_id, cat_name in category_map|dictsort(false, 'value') %}
                     {% set mainloop = loop %}
                     {%- set has_not_supported = [] %}
-                    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome == 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+                    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
                         {%- if has_not_supported.append(1) %}{% endif %}
                     {%- endfor %}
                     {%- if has_not_supported|length > 0 %}
@@ -365,7 +365,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                            {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome == 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+                            {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
                                 <tr>
                                     <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%'>{{ job_id|strip_ns }}</td>
                                     <td style='width:10%; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.json
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.json
@@ -61,6 +61,7 @@
             "category_id": "{{ job_state.effective_category_id }}",
             "status": "{{ job_state.result.outcome_meta().hexr_mapping }}",
             "outcome": "{{ job_state.result.outcome }}",
+            "skip_reason": {{ job_state.result.skip_reason | jsonify | safe }},
             "comments": {{ job_state.result.comments | jsonify | safe }},
             "io_log": {{ job_state.result.io_log_as_flat_text | jsonify | safe }},
             "type": "test",

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/multi-page.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/multi-page.html
@@ -260,14 +260,14 @@
                 datasets: [{
                     data: [
                         {%- for outcome, total in state.get_test_outcome_stats()|dictsort %}
-                        {%- if outcome != 'not-supported' %}
+                        {%- if outcome not in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] %}
                         {{ total }},
                         {%- endif %}
                         {%- endfor %}
                     ],
                     backgroundColor: [
                         {%- for outcome, total in state.get_test_outcome_stats()|dictsort %}
-                        {%- if outcome != 'not-supported' %}
+                        {%- if outcome not in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] %}
                         "{{ OUTCOME_METADATA_MAP[outcome].color_hex }}",
                         {%- endif %}
                         {%- endfor %}
@@ -275,7 +275,7 @@
                 }],
                 labels: [
                     {%- for outcome, total in state.get_test_outcome_stats()|dictsort %}
-                    {%- if outcome != 'not-supported' %}
+                    {%- if outcome not in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] %}
                     "{{ OUTCOME_METADATA_MAP[outcome].tr_label }}",
                     {%- endif %}
                     {%- endfor %}
@@ -310,7 +310,7 @@
                                     return {
                                         // Instead of `text: label,`
                                         // We add the value to the string
-                                        text: label + " : " + value,
+                                        text: label + ": " + value,
                                         fillStyle: fill,
                                         strokeStyle: stroke,
                                         lineWidth: bw,
@@ -346,7 +346,7 @@
     {%- for cat_id, cat_name in category_map|dictsort(false, 'value') %}
     {% set mainloop = loop %}
     {%- set has_supported = [] %}
-    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.result.outcome != 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.result.outcome not in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
         {%- if has_supported.append(1) %}{% endif %}
     {%- endfor %}
     {%- if has_supported|length > 0 %}
@@ -364,7 +364,7 @@
                 </tr>
             </thead>
             <tbody>
-            {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.result.outcome != 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+            {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.result.outcome not in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
                 <tr>
                     <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%'>{{ job_id|strip_ns }}</td>
                     <td style='width:10%; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>
@@ -389,7 +389,7 @@
     {%- endfor %}
     <p></p>
     {%- set has_any_not_supported = [] %}
-    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome == 'not-supported' and job_state.job.plugin not in ("resource", "attachment") %}
+    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] and job_state.job.plugin not in ("resource", "attachment") %}
         {%- if has_any_not_supported.append(1) %}{% endif %}
     {%- endfor %}
     {%- if has_any_not_supported|length > 0 %}
@@ -398,7 +398,7 @@
     {%- for cat_id, cat_name in category_map|dictsort(false, 'value') %}
     {% set mainloop = loop %}
     {%- set has_not_supported = [] %}
-    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome == 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
         {%- if has_not_supported.append(1) %}{% endif %}
     {%- endfor %}
     {%- if has_not_supported|length > 0 %}
@@ -410,7 +410,7 @@
                 </tr>
             </thead>
             <tbody>
-            {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome == 'not-supported' and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
+            {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome in ["not-supported", "skipped-dependency", "skipped-resource", "skipped-manifest"] and job_state.effective_category_id == cat_id and job_state.job.plugin not in ("resource", "attachment") %}
                 <tr>
                     <td data-filtertext="{{ job_id|strip_ns }}" style='width:35%'>{{ job_id|strip_ns }}</td>
                     <td style='width:10%; font-weight: bold; color: {{ job_state.result.outcome_meta().color_hex }}'>{{ job_state.result.outcome_meta().tr_label }}</td>

--- a/checkbox-ng/plainbox/impl/result.py
+++ b/checkbox-ng/plainbox/impl/result.py
@@ -155,7 +155,9 @@ OUTCOME_METADATA_MAP = {
     IJobResult.OUTCOME_SKIPPED_DEPENDENCY: OutcomeMetadata(
         value=IJobResult.OUTCOME_SKIPPED_DEPENDENCY,
         unicode_sigil="☐ ",
-        tr_outcome=C_("textual outcome", "job cannot be started (failed dependency)"),
+        tr_outcome=C_(
+            "textual outcome", "job cannot be started (failed dependency)"
+        ),
         tr_label=C_("chart label", "skipped"),
         color_ansi="\033[33;1m",
         color_hex="#FF9900",
@@ -164,7 +166,9 @@ OUTCOME_METADATA_MAP = {
     IJobResult.OUTCOME_SKIPPED_RESOURCE: OutcomeMetadata(
         value=IJobResult.OUTCOME_SKIPPED_RESOURCE,
         unicode_sigil="☐ ",
-        tr_outcome=C_("textual outcome", "job cannot be started (unmet resource)"),
+        tr_outcome=C_(
+            "textual outcome", "job cannot be started (unmet resource)"
+        ),
         tr_label=C_("chart label", "skipped"),
         color_ansi="\033[33;1m",
         color_hex="#FF9900",
@@ -173,7 +177,9 @@ OUTCOME_METADATA_MAP = {
     IJobResult.OUTCOME_SKIPPED_MANIFEST: OutcomeMetadata(
         value=IJobResult.OUTCOME_SKIPPED_MANIFEST,
         unicode_sigil="☐ ",
-        tr_outcome=C_("textual outcome", "job cannot be started (unmet manifest)"),
+        tr_outcome=C_(
+            "textual outcome", "job cannot be started (unmet manifest)"
+        ),
         tr_label=C_("chart label", "skipped"),
         color_ansi="\033[33;1m",
         color_hex="#FF9900",

--- a/checkbox-ng/plainbox/impl/result.py
+++ b/checkbox-ng/plainbox/impl/result.py
@@ -146,7 +146,34 @@ OUTCOME_METADATA_MAP = {
     IJobResult.OUTCOME_SKIP: OutcomeMetadata(
         value=IJobResult.OUTCOME_SKIP,
         unicode_sigil="☐ ",
-        tr_outcome=C_("textual outcome", "job skipped"),
+        tr_outcome=C_("textual outcome", "job manually skipped"),
+        tr_label=C_("chart label", "skipped"),
+        color_ansi="\033[33;1m",
+        color_hex="#FF9900",
+        hexr_mapping="skip",
+    ),
+    IJobResult.OUTCOME_SKIPPED_DEPENDENCY: OutcomeMetadata(
+        value=IJobResult.OUTCOME_SKIPPED_DEPENDENCY,
+        unicode_sigil="☐ ",
+        tr_outcome=C_("textual outcome", "job cannot be started (failed dependency)"),
+        tr_label=C_("chart label", "skipped"),
+        color_ansi="\033[33;1m",
+        color_hex="#FF9900",
+        hexr_mapping="skip",
+    ),
+    IJobResult.OUTCOME_SKIPPED_RESOURCE: OutcomeMetadata(
+        value=IJobResult.OUTCOME_SKIPPED_RESOURCE,
+        unicode_sigil="☐ ",
+        tr_outcome=C_("textual outcome", "job cannot be started (unmet resource)"),
+        tr_label=C_("chart label", "skipped"),
+        color_ansi="\033[33;1m",
+        color_hex="#FF9900",
+        hexr_mapping="skip",
+    ),
+    IJobResult.OUTCOME_SKIPPED_MANIFEST: OutcomeMetadata(
+        value=IJobResult.OUTCOME_SKIPPED_MANIFEST,
+        unicode_sigil="☐ ",
+        tr_outcome=C_("textual outcome", "job cannot be started (unmet manifest)"),
         tr_label=C_("chart label", "skipped"),
         color_ansi="\033[33;1m",
         color_hex="#FF9900",
@@ -250,6 +277,12 @@ class JobResultBuilder(pod.POD):
     io_log_filename = pod.Field(
         "path to a structured I/O log file of the (optional) test process",
         str,
+        pod.UNSET,
+        assign_filter_list=[pod.unset_or_typed],
+    )
+    skip_reason = pod.Field(
+        "list of inhibitors (reasons why a job could not start)",
+        dict,
         pod.UNSET,
         assign_filter_list=[pod.unset_or_typed],
     )
@@ -516,6 +549,18 @@ class _JobResultBase(IJobResult):
         :class:`plainbox.impl.session.suspend.SessionSuspendHelper4`.
         """
         return not bool(self._data)
+
+    @property
+    def skip_reason(self):
+        """
+        Get the skip_reason list that explains why a job could not start.
+
+        This is a list of inhibitor dicts with keys like:
+        - related_dependencies: list of job ids
+        - related_resources: list of resource expressions
+        - related_manifests: list of manifest expressions
+        """
+        return self._data.get("skip_reason")
 
 
 class MemoryJobResult(_JobResultBase):

--- a/checkbox-ng/plainbox/impl/result.py
+++ b/checkbox-ng/plainbox/impl/result.py
@@ -287,7 +287,7 @@ class JobResultBuilder(pod.POD):
         assign_filter_list=[pod.unset_or_typed],
     )
     skip_reason = pod.Field(
-        "list of inhibitors (reasons why a job could not start)",
+        "dict of inhibitors (reasons why a job could not start)",
         dict,
         pod.UNSET,
         assign_filter_list=[pod.unset_or_typed],
@@ -559,12 +559,23 @@ class _JobResultBase(IJobResult):
     @property
     def skip_reason(self):
         """
-        Get the skip_reason list that explains why a job could not start.
+        Dictionary that explains why a job could not start.
 
-        This is a list of inhibitor dicts with keys like:
-        - related_dependencies: list of job ids
-        - related_resources: list of resource expressions
-        - related_manifests: list of manifest expressions
+        This is a dict of inhibitor lists that looks like this:
+
+        {
+            'related_dependencies': ['com.canonical.certification::smoke/false'],
+            'related_manifests': ["manifest.doesnt_exist == 'True'"],
+            'related_resources': []
+        }
+
+        or
+
+        {
+            'related_dependencies': [],
+            'related_manifests': [],
+            'related_resources': ['package.name == "missing-program"']
+        }
         """
         return self._data.get("skip_reason")
 

--- a/checkbox-ng/plainbox/impl/result.py
+++ b/checkbox-ng/plainbox/impl/result.py
@@ -147,7 +147,7 @@ OUTCOME_METADATA_MAP = {
         value=IJobResult.OUTCOME_SKIP,
         unicode_sigil="☐ ",
         tr_outcome=C_("textual outcome", "job manually skipped"),
-        tr_label=C_("chart label", "skipped"),
+        tr_label=C_("chart label", "manually skipped"),
         color_ansi="\033[33;1m",
         color_hex="#FF9900",
         hexr_mapping="skip",
@@ -158,7 +158,7 @@ OUTCOME_METADATA_MAP = {
         tr_outcome=C_(
             "textual outcome", "job cannot be started (failed dependency)"
         ),
-        tr_label=C_("chart label", "skipped"),
+        tr_label=C_("chart label", "skipped (failed dependency)"),
         color_ansi="\033[33;1m",
         color_hex="#FF9900",
         hexr_mapping="skip",
@@ -169,7 +169,7 @@ OUTCOME_METADATA_MAP = {
         tr_outcome=C_(
             "textual outcome", "job cannot be started (unmet resource)"
         ),
-        tr_label=C_("chart label", "skipped"),
+        tr_label=C_("chart label", "skipped (unmet resource)"),
         color_ansi="\033[33;1m",
         color_hex="#FF9900",
         hexr_mapping="skip",
@@ -180,7 +180,7 @@ OUTCOME_METADATA_MAP = {
         tr_outcome=C_(
             "textual outcome", "job cannot be started (unmet manifest)"
         ),
-        tr_label=C_("chart label", "skipped"),
+        tr_label=C_("chart label", "skipped (unmet manifest)"),
         color_ansi="\033[33;1m",
         color_hex="#FF9900",
         hexr_mapping="skip",

--- a/checkbox-ng/plainbox/impl/result.py
+++ b/checkbox-ng/plainbox/impl/result.py
@@ -143,8 +143,8 @@ OUTCOME_METADATA_MAP = {
         color_hex="#DC3912",
         hexr_mapping="fail",
     ),
-    IJobResult.OUTCOME_SKIP: OutcomeMetadata(
-        value=IJobResult.OUTCOME_SKIP,
+    IJobResult.OUTCOME_MANUAL_SKIP: OutcomeMetadata(
+        value=IJobResult.OUTCOME_MANUAL_SKIP,
         unicode_sigil="☐ ",
         tr_outcome=C_("textual outcome", "job manually skipped"),
         tr_label=C_("chart label", "manually skipped"),

--- a/checkbox-ng/plainbox/impl/result_utils.py
+++ b/checkbox-ng/plainbox/impl/result_utils.py
@@ -80,13 +80,12 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
             has_failed_dep = True
             # Check if the dependency was manually skipped
             if inhibitor.related_job:
-                related_job_state = job_state_map.get(
-                    inhibitor.related_job.id
-                )
+                related_job_state = job_state_map.get(inhibitor.related_job.id)
                 if (
                     related_job_state
                     and related_job_state.result
-                    and related_job_state.result.outcome == IJobResult.OUTCOME_SKIP
+                    and related_job_state.result.outcome
+                    == IJobResult.OUTCOME_SKIP
                 ):
                     outcome = IJobResult.OUTCOME_SKIP
                 else:
@@ -109,7 +108,9 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
 
     # If we found a manual skip, use that outcome
     if outcome == IJobResult.OUTCOME_SKIP:
-        return outcome, skip_reason if skip_reason["related_dependencies"] else None
+        return outcome, (
+            skip_reason if skip_reason["related_dependencies"] else None
+        )
 
     # Determine outcome based on priority:
     # FAILED_MANIFEST > FAILED_DEP > FAILED_RESOURCE
@@ -131,4 +132,3 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
         return outcome, skip_reason
     else:
         return outcome, None
-

--- a/checkbox-ng/plainbox/impl/result_utils.py
+++ b/checkbox-ng/plainbox/impl/result_utils.py
@@ -1,0 +1,134 @@
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+# Written by:
+#   Pierre Equoy <pierre.equoy@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Utilities for handling job results and skip reasons.
+
+:mod:`plainbox.impl.result_utils` -- result utilities
+=====================================================
+
+This module provides utilities for working with job results, particularly
+for determining skip outcomes and extracting skip reason information from
+job readiness inhibitors.
+"""
+
+from plainbox.abc import IJobResult
+from plainbox.impl.session.jobs import InhibitionCause
+
+
+def determine_outcome_and_skip_reason(job_state, job_state_map):
+    """
+    Determine the correct outcome and skip_reason for a job that cannot start.
+
+    This function examines the job's readiness inhibitors and determines:
+    1. The most appropriate outcome (SKIPPED_DEPENDENCY, SKIPPED_RESOURCE, or
+       SKIPPED_MANIFEST), with special handling for manual skip outcomes
+    2. A skip_reason dict containing structured information about why the job
+       cannot start
+
+    Outcome determination follows this priority:
+    - If any dependency was manually skipped, outcome is OUTCOME_SKIP
+    - Else if there are failed manifest expressions, outcome is OUTCOME_SKIPPED_MANIFEST
+    - Else if there are FAILED_DEP inhibitors, outcome is OUTCOME_SKIPPED_DEPENDENCY
+    - Else if there are failed resource expressions, outcome is OUTCOME_SKIPPED_RESOURCE
+    - Else outcome is OUTCOME_NOT_SUPPORTED
+
+    :param job_state:
+        A JobState object containing readiness_inhibitor_list and result info
+    :param job_state_map:
+        A mapping of job ids to JobState objects (from session)
+    :returns:
+        A tuple of (outcome: str, skip_reason: dict or None)
+        where skip_reason is a dict with optional keys:
+        - related_dependencies: list of job ids that failed
+        - related_resources: list of resource expressions that failed
+        - related_manifests: list of manifest expressions that failed
+    """
+    if not job_state.readiness_inhibitor_list:
+        return IJobResult.OUTCOME_NOT_SUPPORTED, None
+
+    # Check for manual skip outcome and collect all inhibitors
+    outcome = None
+    skip_reason = {
+        "related_dependencies": [],
+        "related_resources": [],
+        "related_manifests": [],
+    }
+
+    # Track what we've seen to build skip_reason
+    has_failed_dep = False
+    has_failed_resource = False
+    has_failed_manifest = False
+
+    for inhibitor in job_state.readiness_inhibitor_list:
+        if inhibitor.cause == InhibitionCause.FAILED_DEP:
+            has_failed_dep = True
+            # Check if the dependency was manually skipped
+            if inhibitor.related_job:
+                related_job_state = job_state_map.get(
+                    inhibitor.related_job.id
+                )
+                if (
+                    related_job_state
+                    and related_job_state.result
+                    and related_job_state.result.outcome == IJobResult.OUTCOME_SKIP
+                ):
+                    outcome = IJobResult.OUTCOME_SKIP
+                else:
+                    skip_reason["related_dependencies"].append(
+                        inhibitor.related_job.id
+                    )
+        elif inhibitor.cause == InhibitionCause.FAILED_RESOURCE:
+            has_failed_resource = True
+            if inhibitor.related_expression:
+                # Check if this is a manifest expression
+                if inhibitor.related_expression.manifest_id_list:
+                    has_failed_manifest = True
+                    skip_reason["related_manifests"].append(
+                        inhibitor.related_expression.text
+                    )
+                else:
+                    skip_reason["related_resources"].append(
+                        inhibitor.related_expression.text
+                    )
+
+    # If we found a manual skip, use that outcome
+    if outcome == IJobResult.OUTCOME_SKIP:
+        return outcome, skip_reason if skip_reason["related_dependencies"] else None
+
+    # Determine outcome based on priority:
+    # FAILED_MANIFEST > FAILED_DEP > FAILED_RESOURCE
+    if has_failed_manifest:
+        outcome = IJobResult.OUTCOME_SKIPPED_MANIFEST
+    elif has_failed_dep:
+        outcome = IJobResult.OUTCOME_SKIPPED_DEPENDENCY
+    elif has_failed_resource:
+        outcome = IJobResult.OUTCOME_SKIPPED_RESOURCE
+    else:
+        outcome = IJobResult.OUTCOME_NOT_SUPPORTED
+
+    # Return skip_reason only if we have any inhibitors to report
+    if (
+        skip_reason["related_dependencies"]
+        or skip_reason["related_resources"]
+        or skip_reason["related_manifests"]
+    ):
+        return outcome, skip_reason
+    else:
+        return outcome, None
+

--- a/checkbox-ng/plainbox/impl/result_utils.py
+++ b/checkbox-ng/plainbox/impl/result_utils.py
@@ -96,10 +96,6 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
                     )
         elif inhibitor.cause == InhibitionCause.FAILED_RESOURCE:
             has_failed_resource = True
-            # Special handling for fail-on-resource flag
-            if "fail-on-resource" in job_state.job.get_flag_set():
-                outcome = IJobResult.OUTCOME_FAIL
-                break
             if inhibitor.related_expression:
                 # Check if this is a manifest expression
                 if inhibitor.related_expression.manifest_id_list:
@@ -125,7 +121,10 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
     elif has_failed_dep:
         outcome = IJobResult.OUTCOME_SKIPPED_DEPENDENCY
     elif has_failed_resource:
-        outcome = IJobResult.OUTCOME_SKIPPED_RESOURCE
+        if "fail-on-resource" in job_state.job.get_flag_set():
+            outcome = IJobResult.OUTCOME_FAIL
+        else:
+            outcome = IJobResult.OUTCOME_SKIPPED_RESOURCE
 
     # Return skip_reason only if we have any inhibitors to report
     if (

--- a/checkbox-ng/plainbox/impl/result_utils.py
+++ b/checkbox-ng/plainbox/impl/result_utils.py
@@ -64,9 +64,6 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
         - related_resources: list of resource expressions that failed
         - related_manifests: list of manifest expressions that failed
     """
-    if not job_state.readiness_inhibitor_list:
-        return IJobResult.OUTCOME_NOT_SUPPORTED, None
-
     # Check for manual skip outcome and collect all inhibitors
     outcome = None
     skip_reason = {
@@ -129,8 +126,6 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
         outcome = IJobResult.OUTCOME_SKIPPED_DEPENDENCY
     elif has_failed_resource:
         outcome = IJobResult.OUTCOME_SKIPPED_RESOURCE
-    else:
-        outcome = IJobResult.OUTCOME_NOT_SUPPORTED
 
     # Return skip_reason only if we have any inhibitors to report
     if (

--- a/checkbox-ng/plainbox/impl/result_utils.py
+++ b/checkbox-ng/plainbox/impl/result_utils.py
@@ -36,16 +36,21 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
     Determine the correct outcome and skip_reason for a job that cannot start.
 
     This function examines the job's readiness inhibitors and determines:
-    1. The most appropriate outcome (SKIPPED_DEPENDENCY, SKIPPED_RESOURCE, or
-       SKIPPED_MANIFEST), with special handling for manual skip outcomes
+    1. The most appropriate outcome (SKIPPED_DEPENDENCY, SKIPPED_RESOURCE,
+       SKIPPED_MANIFEST or FAILED), with special handling for manual skip
+       outcomes
     2. A skip_reason dict containing structured information about why the job
        cannot start
 
     Outcome determination follows this priority:
     - If any dependency was manually skipped, outcome is OUTCOME_SKIP
-    - Else if there are failed manifest expressions, outcome is OUTCOME_SKIPPED_MANIFEST
-    - Else if there are FAILED_DEP inhibitors, outcome is OUTCOME_SKIPPED_DEPENDENCY
-    - Else if there are failed resource expressions, outcome is OUTCOME_SKIPPED_RESOURCE
+    - Else if there are failed manifest expressions, outcome is
+    OUTCOME_SKIPPED_MANIFEST
+    - Else if there are FAILED_DEP inhibitors, outcome is
+    OUTCOME_SKIPPED_DEPENDENCY
+    - Else if there are failed resource expressions, outcome is
+    OUTCOME_SKIPPED_RESOURCE, except if `fail-on-resource` flag is used, in
+    which case outcome is OUTCOME_FAIL
     - Else outcome is OUTCOME_NOT_SUPPORTED
 
     :param job_state:
@@ -94,6 +99,10 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
                     )
         elif inhibitor.cause == InhibitionCause.FAILED_RESOURCE:
             has_failed_resource = True
+            # Special handling for fail-on-resource flag
+            if "fail-on-resource" in job_state.job.get_flag_set():
+                outcome = IJobResult.OUTCOME_FAIL
+                break
             if inhibitor.related_expression:
                 # Check if this is a manifest expression
                 if inhibitor.related_expression.manifest_id_list:

--- a/checkbox-ng/plainbox/impl/result_utils.py
+++ b/checkbox-ng/plainbox/impl/result_utils.py
@@ -51,7 +51,6 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
     - Else if there are failed resource expressions, outcome is
     OUTCOME_SKIPPED_RESOURCE, except if `fail-on-resource` flag is used, in
     which case outcome is OUTCOME_FAIL
-    - Else outcome is OUTCOME_NOT_SUPPORTED
 
     :param job_state:
         A JobState object containing readiness_inhibitor_list and result info

--- a/checkbox-ng/plainbox/impl/result_utils.py
+++ b/checkbox-ng/plainbox/impl/result_utils.py
@@ -43,7 +43,7 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
        cannot start
 
     Outcome determination follows this priority:
-    - If any dependency was manually skipped, outcome is OUTCOME_SKIP
+    - If any dependency was manually skipped, outcome is OUTCOME_MANUAL_SKIP
     - Else if there are failed manifest expressions, outcome is
     OUTCOME_SKIPPED_MANIFEST
     - Else if there are FAILED_DEP inhibitors, outcome is
@@ -90,9 +90,9 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
                     related_job_state
                     and related_job_state.result
                     and related_job_state.result.outcome
-                    == IJobResult.OUTCOME_SKIP
+                    == IJobResult.OUTCOME_MANUAL_SKIP
                 ):
-                    outcome = IJobResult.OUTCOME_SKIP
+                    outcome = IJobResult.OUTCOME_MANUAL_SKIP
                 else:
                     skip_reason["related_dependencies"].append(
                         inhibitor.related_job.id
@@ -116,7 +116,7 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
                     )
 
     # If we found a manual skip, use that outcome
-    if outcome == IJobResult.OUTCOME_SKIP:
+    if outcome == IJobResult.OUTCOME_MANUAL_SKIP:
         return outcome, (
             skip_reason if skip_reason["related_dependencies"] else None
         )

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -51,6 +51,7 @@ from plainbox.impl.developer import (
 )
 from plainbox.impl.providers import get_providers
 from plainbox.impl.result import JobResultBuilder, MemoryJobResult
+from plainbox.impl.result_utils import determine_outcome_and_skip_reason
 from plainbox.impl.runner import JobRunnerUIDelegate
 from plainbox.impl.secure.origin import Origin
 from plainbox.impl.secure.qualifiers import (
@@ -1647,11 +1648,8 @@ class SessionAssistant:
             self._manager.checkpoint()
             ui.finished_running(job, job_state, builder.get_result())
         else:
-            # Set the outcome of jobs that cannot start to
-            # OUTCOME_NOT_SUPPORTED _except_ if any of the inhibitors point to
-            # a job with an OUTCOME_SKIP outcome, if that is the case mirror
-            # that outcome. This makes 'skip' stronger than 'not-supported'
-            outcome = IJobResult.OUTCOME_NOT_SUPPORTED
+            # Special handling for fail-on-resource flag
+            outcome = None
             for inhibitor in job_state.readiness_inhibitor_list:
                 if (
                     inhibitor.cause == InhibitionCause.FAILED_RESOURCE
@@ -1659,16 +1657,15 @@ class SessionAssistant:
                 ):
                     outcome = IJobResult.OUTCOME_FAIL
                     break
-                elif inhibitor.cause != InhibitionCause.FAILED_DEP:
-                    continue
-                related_job_state = self._context.state.job_state_map[
-                    inhibitor.related_job.id
-                ]
-                if related_job_state.result.outcome == IJobResult.OUTCOME_SKIP:
-                    outcome = IJobResult.OUTCOME_SKIP
+            # If fail-on-resource doesn't apply, determine the outcome from inhibitors
+            outcome, skip_reason = determine_outcome_and_skip_reason(
+                job_state, self._context.state.job_state_map
+            )
             builder = JobResultBuilder(
                 outcome=outcome, comments=job_state.get_readiness_description()
             )
+            if skip_reason:
+                builder.skip_reason = skip_reason
             ui.job_cannot_start(job, job_state, builder.get_result())
         ui.finished(job, job_state, builder.get_result())
         # Set up expectations so that run_job() and use_job_result() must be
@@ -1756,6 +1753,9 @@ class SessionAssistant:
                     IJobResult.OUTCOME_CRASH,
                     IJobResult.OUTCOME_SKIP,
                     IJobResult.OUTCOME_NOT_SUPPORTED,
+                    IJobResult.OUTCOME_SKIPPED_DEPENDENCY,
+                    IJobResult.OUTCOME_SKIPPED_RESOURCE,
+                    IJobResult.OUTCOME_SKIPPED_MANIFEST,
                 ):
                     rerun_candidates.append(self.get_job(job_id))
             if session_type == "auto":
@@ -1767,7 +1767,10 @@ class SessionAssistant:
                 if job_state.effective_auto_retry == "no":
                     continue
                 if job_state.result.outcome in (
-                    IJobResult.OUTCOME_NOT_SUPPORTED
+                    IJobResult.OUTCOME_NOT_SUPPORTED,
+                    IJobResult.OUTCOME_SKIPPED_DEPENDENCY,
+                    IJobResult.OUTCOME_SKIPPED_RESOURCE,
+                    IJobResult.OUTCOME_SKIPPED_MANIFEST,
                 ):
                     for inhibitor in job_state.readiness_inhibitor_list:
                         if inhibitor.cause == InhibitionCause.FAILED_DEP:

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -1617,16 +1617,7 @@ class SessionAssistant:
             self._manager.checkpoint()
             ui.finished_running(job, job_state, builder.get_result())
         else:
-            # Special handling for fail-on-resource flag
             outcome = None
-            for inhibitor in job_state.readiness_inhibitor_list:
-                if (
-                    inhibitor.cause == InhibitionCause.FAILED_RESOURCE
-                    and "fail-on-resource" in job.get_flag_set()
-                ):
-                    outcome = IJobResult.OUTCOME_FAIL
-                    break
-            # If fail-on-resource doesn't apply, determine the outcome from inhibitors
             outcome, skip_reason = determine_outcome_and_skip_reason(
                 job_state, self._context.state.job_state_map
             )

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -51,6 +51,7 @@ from plainbox.impl.developer import (
 )
 from plainbox.impl.providers import get_providers
 from plainbox.impl.result import JobResultBuilder, MemoryJobResult
+from plainbox.impl.result_utils import determine_outcome_and_skip_reason
 from plainbox.impl.runner import JobRunnerUIDelegate
 from plainbox.impl.secure.origin import Origin
 from plainbox.impl.secure.qualifiers import (
@@ -1616,11 +1617,8 @@ class SessionAssistant:
             self._manager.checkpoint()
             ui.finished_running(job, job_state, builder.get_result())
         else:
-            # Set the outcome of jobs that cannot start to
-            # OUTCOME_NOT_SUPPORTED _except_ if any of the inhibitors point to
-            # a job with an OUTCOME_SKIP outcome, if that is the case mirror
-            # that outcome. This makes 'skip' stronger than 'not-supported'
-            outcome = IJobResult.OUTCOME_NOT_SUPPORTED
+            # Special handling for fail-on-resource flag
+            outcome = None
             for inhibitor in job_state.readiness_inhibitor_list:
                 if (
                     inhibitor.cause == InhibitionCause.FAILED_RESOURCE
@@ -1628,16 +1626,15 @@ class SessionAssistant:
                 ):
                     outcome = IJobResult.OUTCOME_FAIL
                     break
-                elif inhibitor.cause != InhibitionCause.FAILED_DEP:
-                    continue
-                related_job_state = self._context.state.job_state_map[
-                    inhibitor.related_job.id
-                ]
-                if related_job_state.result.outcome == IJobResult.OUTCOME_SKIP:
-                    outcome = IJobResult.OUTCOME_SKIP
+            # If fail-on-resource doesn't apply, determine the outcome from inhibitors
+            outcome, skip_reason = determine_outcome_and_skip_reason(
+                job_state, self._context.state.job_state_map
+            )
             builder = JobResultBuilder(
                 outcome=outcome, comments=job_state.get_readiness_description()
             )
+            if skip_reason:
+                builder.skip_reason = skip_reason
             ui.job_cannot_start(job, job_state, builder.get_result())
         ui.finished(job, job_state, builder.get_result())
         # Set up expectations so that run_job() and use_job_result() must be
@@ -1728,6 +1725,9 @@ class SessionAssistant:
                     IJobResult.OUTCOME_CRASH,
                     IJobResult.OUTCOME_SKIP,
                     IJobResult.OUTCOME_NOT_SUPPORTED,
+                    IJobResult.OUTCOME_SKIPPED_DEPENDENCY,
+                    IJobResult.OUTCOME_SKIPPED_RESOURCE,
+                    IJobResult.OUTCOME_SKIPPED_MANIFEST,
                 ):
                     rerun_candidates.append(self.get_job(job_id))
             if session_type == "auto":
@@ -1739,7 +1739,10 @@ class SessionAssistant:
                 if job_state.effective_auto_retry == "no":
                     continue
                 if job_state.result.outcome in (
-                    IJobResult.OUTCOME_NOT_SUPPORTED
+                    IJobResult.OUTCOME_NOT_SUPPORTED,
+                    IJobResult.OUTCOME_SKIPPED_DEPENDENCY,
+                    IJobResult.OUTCOME_SKIPPED_RESOURCE,
+                    IJobResult.OUTCOME_SKIPPED_MANIFEST,
                 ):
                     for inhibitor in job_state.readiness_inhibitor_list:
                         if inhibitor.cause == InhibitionCause.FAILED_DEP:

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -1714,7 +1714,7 @@ class SessionAssistant:
                 if job_state.result.outcome in (
                     IJobResult.OUTCOME_FAIL,
                     IJobResult.OUTCOME_CRASH,
-                    IJobResult.OUTCOME_SKIP,
+                    IJobResult.OUTCOME_MANUAL_SKIP,
                     IJobResult.OUTCOME_NOT_SUPPORTED,
                     IJobResult.OUTCOME_SKIPPED_DEPENDENCY,
                     IJobResult.OUTCOME_SKIPPED_RESOURCE,

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -42,6 +42,7 @@ from plainbox.impl.session.storage import WellKnownDirsHelper
 from plainbox.impl.secure.sudo_broker import is_passwordless_sudo
 from plainbox.impl.result import JobResultBuilder
 from plainbox.impl.result import MemoryJobResult
+from plainbox.impl.result_utils import determine_outcome_and_skip_reason
 from plainbox.abc import IJobResult
 
 from checkbox_ng.config import load_configs
@@ -557,7 +558,10 @@ class RemoteSessionAssistant:
         job_state = self._sa.get_job_state(job_id)
 
         if not job_state.can_start():
-            outcome = IJobResult.OUTCOME_NOT_SUPPORTED
+            outcome, skip_reason = determine_outcome_and_skip_reason(
+                job_state, self._sa._context.state.job_state_map
+            )
+            # Override with FAIL for fail-on-resource flag
             for inhibitor in job_state.readiness_inhibitor_list:
                 if (
                     inhibitor.cause == InhibitionCause.FAILED_RESOURCE
@@ -565,19 +569,14 @@ class RemoteSessionAssistant:
                 ):
                     outcome = IJobResult.OUTCOME_FAIL
                     break
-                elif inhibitor.cause != InhibitionCause.FAILED_DEP:
-                    continue
-                related_job_state = self._sa._context.state.job_state_map[
-                    inhibitor.related_job.id
-                ]
-                if related_job_state.result.outcome == IJobResult.OUTCOME_SKIP:
-                    outcome = IJobResult.OUTCOME_SKIP
 
             def cant_start_builder(*args, **kwargs):
                 result_builder = JobResultBuilder(
                     outcome=outcome,
                     comments=job_state.get_readiness_description(),
                 )
+                if skip_reason:
+                    result_builder.skip_reason = skip_reason
                 return result_builder
 
             self._be = BackgroundExecutor(self, job_id, cant_start_builder)

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -561,14 +561,6 @@ class RemoteSessionAssistant:
             outcome, skip_reason = determine_outcome_and_skip_reason(
                 job_state, self._sa._context.state.job_state_map
             )
-            # Override with FAIL for fail-on-resource flag
-            for inhibitor in job_state.readiness_inhibitor_list:
-                if (
-                    inhibitor.cause == InhibitionCause.FAILED_RESOURCE
-                    and "fail-on-resource" in job.get_flag_set()
-                ):
-                    outcome = IJobResult.OUTCOME_FAIL
-                    break
 
             def cant_start_builder(*args, **kwargs):
                 result_builder = JobResultBuilder(

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -600,7 +600,7 @@ class RemoteSessionAssistant:
 
                 def skipped_builder(*args, **kwargs):
                     result_builder = JobResultBuilder(
-                        outcome=IJobResult.OUTCOME_SKIP
+                        outcome=IJobResult.OUTCOME_MANUAL_SKIP
                     )
                     if self._current_comments != "":
                         result_builder.comments = self._current_comments

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -1477,7 +1477,7 @@ class SessionState:
             # Generate categories status
             child_status = job_state.result.outcome
             if category not in tmp_result_map:
-                tmp_result_map[category] = IJobResult.OUTCOME_SKIP
+                tmp_result_map[category] = IJobResult.OUTCOME_MANUAL_SKIP
             if child_status in (
                 IJobResult.OUTCOME_FAIL,
                 IJobResult.OUTCOME_CRASH,
@@ -1492,12 +1492,12 @@ class SessionState:
                 IJobResult.OUTCOME_PASS,
                 IJobResult.OUTCOME_FAIL,
             ):
-                tmp_result_map[category] = IJobResult.OUTCOME_SKIP
+                tmp_result_map[category] = IJobResult.OUTCOME_MANUAL_SKIP
         return tmp_result_map
 
     @property
     def resource_global_outcome(self):
-        global_outcome = IJobResult.OUTCOME_SKIP
+        global_outcome = IJobResult.OUTCOME_MANUAL_SKIP
         for job_state in self.job_state_map.values():
             if (
                 job_state.job.plugin != "resource"
@@ -1520,12 +1520,12 @@ class SessionState:
                 IJobResult.OUTCOME_PASS,
                 IJobResult.OUTCOME_FAIL,
             ):
-                global_outcome = IJobResult.OUTCOME_SKIP
+                global_outcome = IJobResult.OUTCOME_MANUAL_SKIP
         return global_outcome
 
     @property
     def attachment_global_outcome(self):
-        global_outcome = IJobResult.OUTCOME_SKIP
+        global_outcome = IJobResult.OUTCOME_MANUAL_SKIP
         for job_state in self.job_state_map.values():
             if (
                 job_state.job.plugin != "attachment"
@@ -1548,7 +1548,7 @@ class SessionState:
                 IJobResult.OUTCOME_PASS,
                 IJobResult.OUTCOME_FAIL,
             ):
-                global_outcome = IJobResult.OUTCOME_SKIP
+                global_outcome = IJobResult.OUTCOME_MANUAL_SKIP
         return global_outcome
 
     def get_certification_status_map(

--- a/checkbox-ng/plainbox/impl/session/test_resume.py
+++ b/checkbox-ng/plainbox/impl/session/test_resume.py
@@ -999,8 +999,9 @@ class JobResultResumeMixIn:
             str(boom.exception),
             (
                 "Value for key 'outcome' not in allowed set ['crash', 'fail',"
-                " None, 'not-implemented', 'not-supported', 'pass', 'skip', "
-                "'undecided']"
+                " None, 'not-implemented', 'not-supported', 'pass', 'skip',"
+                " 'skipped-dependency', 'skipped-manifest',"
+                " 'skipped-resource', 'undecided']"
             ),
         )
 

--- a/checkbox-ng/plainbox/impl/session/test_state.py
+++ b/checkbox-ng/plainbox/impl/session/test_state.py
@@ -175,7 +175,9 @@ class RegressionTests(TestCase):
             {"a": IJobResult.OUTCOME_FAIL},
         )
 
-        result_skip = MemoryJobResult({"outcome": IJobResult.OUTCOME_MANUAL_SKIP})
+        result_skip = MemoryJobResult(
+            {"outcome": IJobResult.OUTCOME_MANUAL_SKIP}
+        )
         state.update_job_result(job_a, result_skip)
         self.assertEqual(
             state.category_outcome_map,

--- a/checkbox-ng/plainbox/impl/session/test_state.py
+++ b/checkbox-ng/plainbox/impl/session/test_state.py
@@ -175,11 +175,11 @@ class RegressionTests(TestCase):
             {"a": IJobResult.OUTCOME_FAIL},
         )
 
-        result_skip = MemoryJobResult({"outcome": IJobResult.OUTCOME_SKIP})
+        result_skip = MemoryJobResult({"outcome": IJobResult.OUTCOME_MANUAL_SKIP})
         state.update_job_result(job_a, result_skip)
         self.assertEqual(
             state.category_outcome_map,
-            {"a": IJobResult.OUTCOME_SKIP},
+            {"a": IJobResult.OUTCOME_MANUAL_SKIP},
         )
 
         # Test different outcomes for non valid jobs

--- a/checkbox-ng/plainbox/impl/test_applogic.py
+++ b/checkbox-ng/plainbox/impl/test_applogic.py
@@ -26,7 +26,10 @@ Test definitions for plainbox.impl.applogic module
 
 from unittest import TestCase
 
-from plainbox.impl.applogic import get_matching_job_list
+from plainbox.abc import IJobResult
+from plainbox.impl.applogic import get_matching_job_list, run_job_if_possible
+from plainbox.impl.job import JobDefinition
+from plainbox.impl.result import MemoryJobResult
 from plainbox.impl.secure.origin import Origin
 from plainbox.impl.secure.qualifiers import RegExpJobQualifier
 from plainbox.impl.testing_utils import make_job
@@ -42,3 +45,75 @@ class FunctionTests(TestCase):
             get_matching_job_list(job_list, RegExpJobQualifier("f.*", origin)),
             [make_job("foo"), make_job("froz")],
         )
+
+
+class RunJobIfPossibleTests(TestCase):
+    """Tests for run_job_if_possible function."""
+
+    def setUp(self):
+        self.job = JobDefinition({"id": "test-job", "plugin": "shell"})
+        self.job_state = mock.Mock()
+        self.session = mock.Mock()
+        self.session.job_state_map = {"test-job": self.job_state}
+        self.runner = mock.Mock()
+        self.config = mock.Mock()
+
+    def test_job_can_start(self):
+        """When job can start, runner.run_job is called."""
+        self.job_state.can_start.return_value = True
+        job_result = MemoryJobResult({"outcome": IJobResult.OUTCOME_PASS})
+        self.runner.run_job.return_value = job_result
+
+        state, result = run_job_if_possible(
+            self.session, self.runner, self.config, self.job
+        )
+
+        self.runner.run_job.assert_called_once_with(
+            self.job, self.job_state, self.config, None
+        )
+        self.assertEqual(result, job_result)
+        self.session.update_job_result.assert_called_once_with(self.job, job_result)
+        self.assertEqual(state, self.job_state)
+
+    def test_job_cannot_start_no_skip_reason(self):
+        """When job cannot start without skip_reason."""
+        self.job_state.can_start.return_value = False
+        self.job_state.get_readiness_description.return_value = "Not ready"
+
+        with mock.patch(
+            "plainbox.impl.applogic.determine_outcome_and_skip_reason"
+        ) as mock_determine:
+            mock_determine.return_value = (IJobResult.OUTCOME_NOT_SUPPORTED, None)
+            state, result = run_job_if_possible(
+                self.session, self.runner, self.config, self.job
+            )
+
+            self.assertEqual(result.outcome, IJobResult.OUTCOME_NOT_SUPPORTED)
+            self.assertIsNone(result.skip_reason)
+            self.assertEqual(result.comments, "Not ready")
+            self.runner.run_job.assert_not_called()
+
+    def test_job_cannot_start_with_skip_reason(self):
+        """When job cannot start with skip_reason."""
+        self.job_state.can_start.return_value = False
+        self.job_state.get_readiness_description.return_value = "Skipped"
+        skip_reason = {
+            "related_dependencies": ["dep-job"],
+            "related_resources": [],
+            "related_manifests": [],
+        }
+
+        with mock.patch(
+            "plainbox.impl.applogic.determine_outcome_and_skip_reason"
+        ) as mock_determine:
+            mock_determine.return_value = (
+                IJobResult.OUTCOME_SKIPPED_DEPENDENCY,
+                skip_reason,
+            )
+            state, result = run_job_if_possible(
+                self.session, self.runner, self.config, self.job
+            )
+
+            self.assertEqual(result.outcome, IJobResult.OUTCOME_SKIPPED_DEPENDENCY)
+            self.assertEqual(result.skip_reason, skip_reason)
+            self.assertEqual(result.comments, "Skipped")

--- a/checkbox-ng/plainbox/impl/test_applogic.py
+++ b/checkbox-ng/plainbox/impl/test_applogic.py
@@ -72,7 +72,9 @@ class RunJobIfPossibleTests(TestCase):
             self.job, self.job_state, self.config, None
         )
         self.assertEqual(result, job_result)
-        self.session.update_job_result.assert_called_once_with(self.job, job_result)
+        self.session.update_job_result.assert_called_once_with(
+            self.job, job_result
+        )
         self.assertEqual(state, self.job_state)
 
     def test_job_cannot_start_no_skip_reason(self):
@@ -83,7 +85,10 @@ class RunJobIfPossibleTests(TestCase):
         with mock.patch(
             "plainbox.impl.applogic.determine_outcome_and_skip_reason"
         ) as mock_determine:
-            mock_determine.return_value = (IJobResult.OUTCOME_NOT_SUPPORTED, None)
+            mock_determine.return_value = (
+                IJobResult.OUTCOME_NOT_SUPPORTED,
+                None,
+            )
             state, result = run_job_if_possible(
                 self.session, self.runner, self.config, self.job
             )
@@ -114,6 +119,8 @@ class RunJobIfPossibleTests(TestCase):
                 self.session, self.runner, self.config, self.job
             )
 
-            self.assertEqual(result.outcome, IJobResult.OUTCOME_SKIPPED_DEPENDENCY)
+            self.assertEqual(
+                result.outcome, IJobResult.OUTCOME_SKIPPED_DEPENDENCY
+            )
             self.assertEqual(result.skip_reason, skip_reason)
             self.assertEqual(result.comments, "Skipped")

--- a/checkbox-ng/plainbox/impl/test_result_utils.py
+++ b/checkbox-ng/plainbox/impl/test_result_utils.py
@@ -1,0 +1,390 @@
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+# Written by:
+#   Pierre Equoy <pierre.equoy@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import Mock
+
+from plainbox.abc import IJobResult
+from plainbox.impl.result_utils import determine_outcome_and_skip_reason
+from plainbox.impl.session.jobs import InhibitionCause
+
+
+class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
+    """Tests for the determine_outcome_and_skip_reason function."""
+
+    def test_no_inhibitors(self):
+        """Test with no readiness inhibitors."""
+        job_state = Mock()
+        job_state.readiness_inhibitor_list = []
+
+        outcome, skip_reason = determine_outcome_and_skip_reason(
+            job_state, {}
+        )
+
+        self.assertEqual(outcome, IJobResult.OUTCOME_NOT_SUPPORTED)
+        self.assertIsNone(skip_reason)
+
+    def test_single_failed_dep_inhibitor(self):
+        """Test with a single FAILED_DEP inhibitor."""
+        related_job = Mock()
+        related_job.id = "job1"
+
+        inhibitor = Mock()
+        inhibitor.cause = InhibitionCause.FAILED_DEP
+        inhibitor.related_job = related_job
+
+        job_state = Mock()
+        job_state.readiness_inhibitor_list = [inhibitor]
+
+        job_state_map = {"job1": Mock(result=Mock(outcome="fail"))}
+
+        outcome, skip_reason = determine_outcome_and_skip_reason(
+            job_state, job_state_map
+        )
+
+        self.assertEqual(outcome, IJobResult.OUTCOME_SKIPPED_DEPENDENCY)
+        self.assertIsNotNone(skip_reason)
+        self.assertIn("job1", skip_reason["related_dependencies"])
+        self.assertEqual(skip_reason["related_resources"], [])
+        self.assertEqual(skip_reason["related_manifests"], [])
+
+    def test_multiple_failed_deps(self):
+        """Test with multiple FAILED_DEP inhibitors."""
+        job1 = Mock()
+        job1.id = "job1"
+        job2 = Mock()
+        job2.id = "job2"
+
+        inhibitor1 = Mock()
+        inhibitor1.cause = InhibitionCause.FAILED_DEP
+        inhibitor1.related_job = job1
+
+        inhibitor2 = Mock()
+        inhibitor2.cause = InhibitionCause.FAILED_DEP
+        inhibitor2.related_job = job2
+
+        job_state = Mock()
+        job_state.readiness_inhibitor_list = [inhibitor1, inhibitor2]
+
+        job_state_map = {
+            "job1": Mock(result=Mock(outcome="fail")),
+            "job2": Mock(result=Mock(outcome="fail")),
+        }
+
+        outcome, skip_reason = determine_outcome_and_skip_reason(
+            job_state, job_state_map
+        )
+
+        self.assertEqual(outcome, IJobResult.OUTCOME_SKIPPED_DEPENDENCY)
+        self.assertIn("job1", skip_reason["related_dependencies"])
+        self.assertIn("job2", skip_reason["related_dependencies"])
+
+    def test_failed_resource_inhibitor(self):
+        """Test with a FAILED_RESOURCE inhibitor."""
+        expr = Mock()
+        expr.text = "cpuinfo.count > 2"
+        expr.manifest_id_list = []
+
+        inhibitor = Mock()
+        inhibitor.cause = InhibitionCause.FAILED_RESOURCE
+        inhibitor.related_expression = expr
+
+        job_state = Mock()
+        job_state.readiness_inhibitor_list = [inhibitor]
+
+        outcome, skip_reason = determine_outcome_and_skip_reason(
+            job_state, {}
+        )
+
+        self.assertEqual(outcome, IJobResult.OUTCOME_SKIPPED_RESOURCE)
+        self.assertIsNotNone(skip_reason)
+        self.assertIn("cpuinfo.count > 2", skip_reason["related_resources"])
+        self.assertEqual(skip_reason["related_dependencies"], [])
+        self.assertEqual(skip_reason["related_manifests"], [])
+
+    def test_failed_manifest_inhibitor(self):
+        """Test with a FAILED_RESOURCE inhibitor for a manifest."""
+        expr = Mock()
+        expr.text = "manifest.has_thunderbolt3 == 'True'"
+        expr.manifest_id_list = ["com.canonical.plainbox::manifest-id"]
+
+        inhibitor = Mock()
+        inhibitor.cause = InhibitionCause.FAILED_RESOURCE
+        inhibitor.related_expression = expr
+
+        job_state = Mock()
+        job_state.readiness_inhibitor_list = [inhibitor]
+
+        outcome, skip_reason = determine_outcome_and_skip_reason(
+            job_state, {}
+        )
+
+        self.assertEqual(outcome, IJobResult.OUTCOME_SKIPPED_MANIFEST)
+        self.assertIsNotNone(skip_reason)
+        self.assertIn(
+            "manifest.has_thunderbolt3 == 'True'",
+            skip_reason["related_manifests"],
+        )
+        self.assertEqual(skip_reason["related_dependencies"], [])
+        self.assertEqual(skip_reason["related_resources"], [])
+
+    def test_multiple_failed_resources(self):
+        """Test with multiple FAILED_RESOURCE inhibitors."""
+        expr1 = Mock()
+        expr1.text = "package.name == 'pkg1'"
+        expr1.manifest_id_list = []
+
+        expr2 = Mock()
+        expr2.text = "package.name == 'pkg2'"
+        expr2.manifest_id_list = []
+
+        inhibitor1 = Mock()
+        inhibitor1.cause = InhibitionCause.FAILED_RESOURCE
+        inhibitor1.related_expression = expr1
+
+        inhibitor2 = Mock()
+        inhibitor2.cause = InhibitionCause.FAILED_RESOURCE
+        inhibitor2.related_expression = expr2
+
+        job_state = Mock()
+        job_state.readiness_inhibitor_list = [inhibitor1, inhibitor2]
+
+        outcome, skip_reason = determine_outcome_and_skip_reason(
+            job_state, {}
+        )
+
+        self.assertEqual(outcome, IJobResult.OUTCOME_SKIPPED_RESOURCE)
+        self.assertIn("package.name == 'pkg1'", skip_reason["related_resources"])
+        self.assertIn("package.name == 'pkg2'", skip_reason["related_resources"])
+
+    def test_mixed_inhibitors_dep_priority(self):
+        """Test that FAILED_DEP takes priority over FAILED_RESOURCE."""
+        dep_job = Mock()
+        dep_job.id = "job1"
+
+        dep_inhibitor = Mock()
+        dep_inhibitor.cause = InhibitionCause.FAILED_DEP
+        dep_inhibitor.related_job = dep_job
+
+        expr = Mock()
+        expr.text = "cpuinfo.count > 2"
+        expr.manifest_id_list = []
+
+        res_inhibitor = Mock()
+        res_inhibitor.cause = InhibitionCause.FAILED_RESOURCE
+        res_inhibitor.related_expression = expr
+
+        job_state = Mock()
+        job_state.readiness_inhibitor_list = [res_inhibitor, dep_inhibitor]
+
+        job_state_map = {"job1": Mock(result=Mock(outcome="fail"))}
+
+        outcome, skip_reason = determine_outcome_and_skip_reason(
+            job_state, job_state_map
+        )
+
+        # FAILED_DEP should take priority
+        self.assertEqual(outcome, IJobResult.OUTCOME_SKIPPED_DEPENDENCY)
+        # But skip_reason should include both
+        self.assertIn("job1", skip_reason["related_dependencies"])
+        self.assertIn("cpuinfo.count > 2", skip_reason["related_resources"])
+
+    def test_mixed_inhibitors_manifest_priority(self):
+        """Test that FAILED_MANIFEST takes priority over FAILED_RESOURCE."""
+        manifest_expr = Mock()
+        manifest_expr.text = "manifest.has_feature == 'True'"
+        manifest_expr.manifest_id_list = ["com.canonical.plainbox::manifest-id"]
+
+        manifest_inhibitor = Mock()
+        manifest_inhibitor.cause = InhibitionCause.FAILED_RESOURCE
+        manifest_inhibitor.related_expression = manifest_expr
+
+        resource_expr = Mock()
+        resource_expr.text = "cpuinfo.count > 2"
+        resource_expr.manifest_id_list = []
+
+        resource_inhibitor = Mock()
+        resource_inhibitor.cause = InhibitionCause.FAILED_RESOURCE
+        resource_inhibitor.related_expression = resource_expr
+
+        job_state = Mock()
+        job_state.readiness_inhibitor_list = [
+            resource_inhibitor,
+            manifest_inhibitor,
+        ]
+
+        outcome, skip_reason = determine_outcome_and_skip_reason(
+            job_state, {}
+        )
+
+        # FAILED_MANIFEST should take priority over other FAILED_RESOURCE
+        self.assertEqual(outcome, IJobResult.OUTCOME_SKIPPED_MANIFEST)
+        # But skip_reason should include both
+        self.assertIn(
+            "manifest.has_feature == 'True'", skip_reason["related_manifests"]
+        )
+        self.assertIn("cpuinfo.count > 2", skip_reason["related_resources"])
+
+    def test_manual_skip_of_dependency(self):
+        """Test that manual skip of a dependency results in OUTCOME_SKIP."""
+        related_job = Mock()
+        related_job.id = "job1"
+
+        inhibitor = Mock()
+        inhibitor.cause = InhibitionCause.FAILED_DEP
+        inhibitor.related_job = related_job
+
+        job_state = Mock()
+        job_state.readiness_inhibitor_list = [inhibitor]
+
+        # The related job was manually skipped
+        skipped_result = Mock()
+        skipped_result.outcome = IJobResult.OUTCOME_SKIP
+
+        job_state_map = {"job1": Mock(result=skipped_result)}
+
+        outcome, skip_reason = determine_outcome_and_skip_reason(
+            job_state, job_state_map
+        )
+
+        self.assertEqual(outcome, IJobResult.OUTCOME_SKIP)
+        # skip_reason should not include the dependency since it was manually skipped
+        self.assertIsNone(skip_reason)
+
+    def test_undesired_inhibitor_ignored(self):
+        """Test that UNDESIRED inhibitor is ignored."""
+        inhibitor = Mock()
+        inhibitor.cause = InhibitionCause.UNDESIRED
+        inhibitor.related_job = None
+
+        job_state = Mock()
+        job_state.readiness_inhibitor_list = [inhibitor]
+
+        outcome, skip_reason = determine_outcome_and_skip_reason(
+            job_state, {}
+        )
+
+        # UNDESIRED should not affect the outcome
+        self.assertEqual(outcome, IJobResult.OUTCOME_NOT_SUPPORTED)
+        self.assertIsNone(skip_reason)
+
+    def test_pending_resource_inhibitor_ignored(self):
+        """Test that PENDING_RESOURCE inhibitor is ignored."""
+        expr = Mock()
+        expr.text = "cpuinfo.count > 2"
+
+        inhibitor = Mock()
+        inhibitor.cause = InhibitionCause.PENDING_RESOURCE
+        inhibitor.related_expression = expr
+
+        job_state = Mock()
+        job_state.readiness_inhibitor_list = [inhibitor]
+
+        outcome, skip_reason = determine_outcome_and_skip_reason(
+            job_state, {}
+        )
+
+        # PENDING_RESOURCE should not affect the outcome
+        self.assertEqual(outcome, IJobResult.OUTCOME_NOT_SUPPORTED)
+        self.assertIsNone(skip_reason)
+
+    def test_skip_reason_structure(self):
+        """Test that skip_reason has the correct structure."""
+        related_job = Mock()
+        related_job.id = "job1"
+
+        inhibitor = Mock()
+        inhibitor.cause = InhibitionCause.FAILED_DEP
+        inhibitor.related_job = related_job
+
+        job_state = Mock()
+        job_state.readiness_inhibitor_list = [inhibitor]
+
+        job_state_map = {"job1": Mock(result=Mock(outcome="fail"))}
+
+        outcome, skip_reason = determine_outcome_and_skip_reason(
+            job_state, job_state_map
+        )
+
+        # Check structure
+        self.assertIsInstance(skip_reason, dict)
+        self.assertIn("related_dependencies", skip_reason)
+        self.assertIn("related_resources", skip_reason)
+        self.assertIn("related_manifests", skip_reason)
+        self.assertIsInstance(skip_reason["related_dependencies"], list)
+        self.assertIsInstance(skip_reason["related_resources"], list)
+        self.assertIsInstance(skip_reason["related_manifests"], list)
+
+    def test_complex_scenario(self):
+        """Test a complex scenario with multiple inhibitors of different types."""
+        # Create inhibitors
+        job1 = Mock()
+        job1.id = "job1"
+        job2 = Mock()
+        job2.id = "job2"
+
+        dep_inhibitor1 = Mock()
+        dep_inhibitor1.cause = InhibitionCause.FAILED_DEP
+        dep_inhibitor1.related_job = job1
+
+        dep_inhibitor2 = Mock()
+        dep_inhibitor2.cause = InhibitionCause.FAILED_DEP
+        dep_inhibitor2.related_job = job2
+
+        resource_expr = Mock()
+        resource_expr.text = "cpuinfo.count > 4"
+        resource_expr.manifest_id_list = []
+
+        resource_inhibitor = Mock()
+        resource_inhibitor.cause = InhibitionCause.FAILED_RESOURCE
+        resource_inhibitor.related_expression = resource_expr
+
+        manifest_expr = Mock()
+        manifest_expr.text = "manifest.has_touchpad == 'True'"
+        manifest_expr.manifest_id_list = ["has_touchpad"]
+
+        manifest_inhibitor = Mock()
+        manifest_inhibitor.cause = InhibitionCause.FAILED_RESOURCE
+        manifest_inhibitor.related_expression = manifest_expr
+
+        job_state = Mock()
+        job_state.readiness_inhibitor_list = [
+            dep_inhibitor1,
+            resource_inhibitor,
+            dep_inhibitor2,
+            manifest_inhibitor,
+        ]
+
+        job_state_map = {
+            "job1": Mock(result=Mock(outcome="fail")),
+            "job2": Mock(result=Mock(outcome="fail")),
+        }
+
+        outcome, skip_reason = determine_outcome_and_skip_reason(
+            job_state, job_state_map
+        )
+
+        # FAILED_MANIFEST should take priority
+        self.assertEqual(outcome, IJobResult.OUTCOME_SKIPPED_MANIFEST)
+        # But skip_reason should include all inhibitors
+        self.assertIn("job1", skip_reason["related_dependencies"])
+        self.assertIn("job2", skip_reason["related_dependencies"])
+        self.assertIn("cpuinfo.count > 4", skip_reason["related_resources"])
+        self.assertIn(
+            "manifest.has_touchpad == 'True'", skip_reason["related_manifests"]
+        )

--- a/checkbox-ng/plainbox/impl/test_result_utils.py
+++ b/checkbox-ng/plainbox/impl/test_result_utils.py
@@ -32,9 +32,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
         job_state = Mock()
         job_state.readiness_inhibitor_list = []
 
-        outcome, skip_reason = determine_outcome_and_skip_reason(
-            job_state, {}
-        )
+        outcome, skip_reason = determine_outcome_and_skip_reason(job_state, {})
 
         self.assertEqual(outcome, IJobResult.OUTCOME_NOT_SUPPORTED)
         self.assertIsNone(skip_reason)
@@ -107,9 +105,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
         job_state = Mock()
         job_state.readiness_inhibitor_list = [inhibitor]
 
-        outcome, skip_reason = determine_outcome_and_skip_reason(
-            job_state, {}
-        )
+        outcome, skip_reason = determine_outcome_and_skip_reason(job_state, {})
 
         self.assertEqual(outcome, IJobResult.OUTCOME_SKIPPED_RESOURCE)
         self.assertIsNotNone(skip_reason)
@@ -130,9 +126,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
         job_state = Mock()
         job_state.readiness_inhibitor_list = [inhibitor]
 
-        outcome, skip_reason = determine_outcome_and_skip_reason(
-            job_state, {}
-        )
+        outcome, skip_reason = determine_outcome_and_skip_reason(job_state, {})
 
         self.assertEqual(outcome, IJobResult.OUTCOME_SKIPPED_MANIFEST)
         self.assertIsNotNone(skip_reason)
@@ -164,13 +158,15 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
         job_state = Mock()
         job_state.readiness_inhibitor_list = [inhibitor1, inhibitor2]
 
-        outcome, skip_reason = determine_outcome_and_skip_reason(
-            job_state, {}
-        )
+        outcome, skip_reason = determine_outcome_and_skip_reason(job_state, {})
 
         self.assertEqual(outcome, IJobResult.OUTCOME_SKIPPED_RESOURCE)
-        self.assertIn("package.name == 'pkg1'", skip_reason["related_resources"])
-        self.assertIn("package.name == 'pkg2'", skip_reason["related_resources"])
+        self.assertIn(
+            "package.name == 'pkg1'", skip_reason["related_resources"]
+        )
+        self.assertIn(
+            "package.name == 'pkg2'", skip_reason["related_resources"]
+        )
 
     def test_mixed_inhibitors_dep_priority(self):
         """Test that FAILED_DEP takes priority over FAILED_RESOURCE."""
@@ -208,7 +204,9 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
         """Test that FAILED_MANIFEST takes priority over FAILED_RESOURCE."""
         manifest_expr = Mock()
         manifest_expr.text = "manifest.has_feature == 'True'"
-        manifest_expr.manifest_id_list = ["com.canonical.plainbox::manifest-id"]
+        manifest_expr.manifest_id_list = [
+            "com.canonical.plainbox::manifest-id"
+        ]
 
         manifest_inhibitor = Mock()
         manifest_inhibitor.cause = InhibitionCause.FAILED_RESOURCE
@@ -228,9 +226,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
             manifest_inhibitor,
         ]
 
-        outcome, skip_reason = determine_outcome_and_skip_reason(
-            job_state, {}
-        )
+        outcome, skip_reason = determine_outcome_and_skip_reason(job_state, {})
 
         # FAILED_MANIFEST should take priority over other FAILED_RESOURCE
         self.assertEqual(outcome, IJobResult.OUTCOME_SKIPPED_MANIFEST)
@@ -275,9 +271,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
         job_state = Mock()
         job_state.readiness_inhibitor_list = [inhibitor]
 
-        outcome, skip_reason = determine_outcome_and_skip_reason(
-            job_state, {}
-        )
+        outcome, skip_reason = determine_outcome_and_skip_reason(job_state, {})
 
         # UNDESIRED should not affect the outcome
         self.assertEqual(outcome, IJobResult.OUTCOME_NOT_SUPPORTED)
@@ -295,9 +289,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
         job_state = Mock()
         job_state.readiness_inhibitor_list = [inhibitor]
 
-        outcome, skip_reason = determine_outcome_and_skip_reason(
-            job_state, {}
-        )
+        outcome, skip_reason = determine_outcome_and_skip_reason(job_state, {})
 
         # PENDING_RESOURCE should not affect the outcome
         self.assertEqual(outcome, IJobResult.OUTCOME_NOT_SUPPORTED)

--- a/checkbox-ng/plainbox/impl/test_result_utils.py
+++ b/checkbox-ng/plainbox/impl/test_result_utils.py
@@ -27,16 +27,6 @@ from plainbox.impl.session.jobs import InhibitionCause
 class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
     """Tests for the determine_outcome_and_skip_reason function."""
 
-    def test_no_inhibitors(self):
-        """Test with no readiness inhibitors."""
-        job_state = Mock()
-        job_state.readiness_inhibitor_list = []
-
-        outcome, skip_reason = determine_outcome_and_skip_reason(job_state, {})
-
-        self.assertEqual(outcome, IJobResult.OUTCOME_NOT_SUPPORTED)
-        self.assertIsNone(skip_reason)
-
     def test_single_failed_dep_inhibitor(self):
         """Test with a single FAILED_DEP inhibitor."""
         related_job = Mock()
@@ -265,39 +255,6 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
 
         self.assertEqual(outcome, IJobResult.OUTCOME_MANUAL_SKIP)
         # skip_reason should not include the dependency since it was manually skipped
-        self.assertIsNone(skip_reason)
-
-    def test_undesired_inhibitor_ignored(self):
-        """Test that UNDESIRED inhibitor is ignored."""
-        inhibitor = Mock()
-        inhibitor.cause = InhibitionCause.UNDESIRED
-        inhibitor.related_job = None
-
-        job_state = Mock()
-        job_state.readiness_inhibitor_list = [inhibitor]
-
-        outcome, skip_reason = determine_outcome_and_skip_reason(job_state, {})
-
-        # UNDESIRED should not affect the outcome
-        self.assertEqual(outcome, IJobResult.OUTCOME_NOT_SUPPORTED)
-        self.assertIsNone(skip_reason)
-
-    def test_pending_resource_inhibitor_ignored(self):
-        """Test that PENDING_RESOURCE inhibitor is ignored."""
-        expr = Mock()
-        expr.text = "cpuinfo.count > 2"
-
-        inhibitor = Mock()
-        inhibitor.cause = InhibitionCause.PENDING_RESOURCE
-        inhibitor.related_expression = expr
-
-        job_state = Mock()
-        job_state.readiness_inhibitor_list = [inhibitor]
-
-        outcome, skip_reason = determine_outcome_and_skip_reason(job_state, {})
-
-        # PENDING_RESOURCE should not affect the outcome
-        self.assertEqual(outcome, IJobResult.OUTCOME_NOT_SUPPORTED)
         self.assertIsNone(skip_reason)
 
     def test_skip_reason_structure(self):

--- a/checkbox-ng/plainbox/impl/test_result_utils.py
+++ b/checkbox-ng/plainbox/impl/test_result_utils.py
@@ -242,7 +242,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
         self.assertIn("cpuinfo.count > 2", skip_reason["related_resources"])
 
     def test_manual_skip_of_dependency(self):
-        """Test that manual skip of a dependency results in OUTCOME_SKIP."""
+        """Test that manual skip of a dependency results in OUTCOME_MANUAL_SKIP."""
         related_job = Mock()
         related_job.id = "job1"
 
@@ -255,7 +255,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
 
         # The related job was manually skipped
         skipped_result = Mock()
-        skipped_result.outcome = IJobResult.OUTCOME_SKIP
+        skipped_result.outcome = IJobResult.OUTCOME_MANUAL_SKIP
 
         job_state_map = {"job1": Mock(result=skipped_result)}
 
@@ -263,7 +263,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
             job_state, job_state_map
         )
 
-        self.assertEqual(outcome, IJobResult.OUTCOME_SKIP)
+        self.assertEqual(outcome, IJobResult.OUTCOME_MANUAL_SKIP)
         # skip_reason should not include the dependency since it was manually skipped
         self.assertIsNone(skip_reason)
 

--- a/checkbox-ng/plainbox/impl/test_result_utils.py
+++ b/checkbox-ng/plainbox/impl/test_result_utils.py
@@ -104,6 +104,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
 
         job_state = Mock()
         job_state.readiness_inhibitor_list = [inhibitor]
+        job_state.job.get_flag_set.return_value = set()
 
         outcome, skip_reason = determine_outcome_and_skip_reason(job_state, {})
 
@@ -125,6 +126,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
 
         job_state = Mock()
         job_state.readiness_inhibitor_list = [inhibitor]
+        job_state.job.get_flag_set.return_value = set()
 
         outcome, skip_reason = determine_outcome_and_skip_reason(job_state, {})
 
@@ -157,6 +159,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
 
         job_state = Mock()
         job_state.readiness_inhibitor_list = [inhibitor1, inhibitor2]
+        job_state.job.get_flag_set.return_value = set()
 
         outcome, skip_reason = determine_outcome_and_skip_reason(job_state, {})
 
@@ -187,6 +190,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
 
         job_state = Mock()
         job_state.readiness_inhibitor_list = [res_inhibitor, dep_inhibitor]
+        job_state.job.get_flag_set.return_value = set()
 
         job_state_map = {"job1": Mock(result=Mock(outcome="fail"))}
 
@@ -225,6 +229,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
             resource_inhibitor,
             manifest_inhibitor,
         ]
+        job_state.job.get_flag_set.return_value = set()
 
         outcome, skip_reason = determine_outcome_and_skip_reason(job_state, {})
 
@@ -361,6 +366,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
             dep_inhibitor2,
             manifest_inhibitor,
         ]
+        job_state.job.get_flag_set.return_value = set()
 
         job_state_map = {
             "job1": Mock(result=Mock(outcome="fail")),

--- a/checkbox-ng/plainbox/impl/test_result_utils.py
+++ b/checkbox-ng/plainbox/impl/test_result_utils.py
@@ -104,6 +104,28 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
         self.assertEqual(skip_reason["related_dependencies"], [])
         self.assertEqual(skip_reason["related_manifests"], [])
 
+    def test_failed_resource_inhibitor_fail_on_resource_flag(self):
+        """FAILED_RESOURCE inhibitor when fail-on-resource flag used."""
+        expr = Mock()
+        expr.text = "cpuinfo.count > 2"
+        expr.manifest_id_list = []
+
+        inhibitor = Mock()
+        inhibitor.cause = InhibitionCause.FAILED_RESOURCE
+        inhibitor.related_expression = expr
+
+        job_state = Mock()
+        job_state.readiness_inhibitor_list = [inhibitor]
+        job_state.job.get_flag_set.return_value = {"fail-on-resource"}
+
+        outcome, skip_reason = determine_outcome_and_skip_reason(job_state, {})
+
+        self.assertEqual(outcome, IJobResult.OUTCOME_FAIL)
+        self.assertIsNotNone(skip_reason)
+        self.assertIn("cpuinfo.count > 2", skip_reason["related_resources"])
+        self.assertEqual(skip_reason["related_dependencies"], [])
+        self.assertEqual(skip_reason["related_manifests"], [])
+
     def test_failed_manifest_inhibitor(self):
         """Test with a FAILED_RESOURCE inhibitor for a manifest."""
         expr = Mock()

--- a/checkbox-ng/plainbox/test-data/html-exporter/with_certification_blocker.html
+++ b/checkbox-ng/plainbox/test-data/html-exporter/with_certification_blocker.html
@@ -584,7 +584,7 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                                 labels: [
                                     "failed",
                                     "passed",
-                                    "skipped",
+                                    "manually skipped",
                                 ]
                             },
                             options: {
@@ -616,7 +616,7 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                                                     return {
                                                         // Instead of `text: label,`
                                                         // We add the value to the string
-                                                        text: label + " : " + value,
+                                                        text: label + ": " + value,
                                                         fillStyle: fill,
                                                         strokeStyle: stroke,
                                                         lineWidth: bw,
@@ -687,7 +687,7 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                                 </tr>
                                 <tr>
                                     <td data-filtertext="job_id3" style='width:35%'>job_id3</td>
-                                    <td style='width:10%; font-weight: bold; color: #FF9900'>skipped</td>
+                                    <td style='width:10%; font-weight: bold; color: #FF9900'>manually skipped</td>
                                     <td style='width:10%'></td>
                                     <td style='width:10%'>1.0s</td>
                                     <td style='width:10%'></td>

--- a/checkbox-ng/plainbox/test-data/html-exporter/without_certification_status.html
+++ b/checkbox-ng/plainbox/test-data/html-exporter/without_certification_status.html
@@ -584,7 +584,7 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                                 labels: [
                                     "failed",
                                     "passed",
-                                    "skipped",
+                                    "manually skipped",
                                 ]
                             },
                             options: {
@@ -616,7 +616,7 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                                                     return {
                                                         // Instead of `text: label,`
                                                         // We add the value to the string
-                                                        text: label + " : " + value,
+                                                        text: label + ": " + value,
                                                         fillStyle: fill,
                                                         strokeStyle: stroke,
                                                         lineWidth: bw,
@@ -687,7 +687,7 @@ b.matchMedia=b.matchMedia||(function(k,l){var i,g=k.documentElement,h=g.firstEle
                                 </tr>
                                 <tr>
                                     <td data-filtertext="job_id3" style='width:35%'>job_id3</td>
-                                    <td style='width:10%; font-weight: bold; color: #FF9900'>skipped</td>
+                                    <td style='width:10%; font-weight: bold; color: #FF9900'>manually skipped</td>
                                     <td style='width:10%'></td>
                                     <td style='width:10%'>1.0s</td>
                                     <td style='width:10%'></td>

--- a/docs/reference/units/job.rst
+++ b/docs/reference/units/job.rst
@@ -330,7 +330,8 @@ Following fields may be used by the job unit:
     .. option:: fail-on-resource
         
         This flag makes Checkbox fail the job if one of the resource
-        requirements evaluates to False.
+        requirements evaluates to False. This does not apply to manifest
+        entries.
 
     .. option:: also-after-suspend
         

--- a/metabox/metabox/scenarios/ui/resume_menu.py
+++ b/metabox/metabox/scenarios/ui/resume_menu.py
@@ -116,7 +116,7 @@ class ResumeMenuMarkSkip(Scenario):
         Expect("Skipped Jobs"),
         Expect("Finish"),
         Send("f"),
-        Expect(_re("(☐|job skipped).*User-interact")),
+        Expect(_re("(☐|job manually skipped).*User-interact")),
     ]
 
 


### PR DESCRIPTION
## Description

Instead of having OUTCOME_SKIP for manually skipped jobs and OUTCOME_NOT_SUPPORTED for any job that is skipped for a specific reason (failed dependencies, failed resources, unmet manifest), 3 new outcomes are created:

- `OUTCOME_SKIPPED_DEPENDENCY`
- `OUTCOME_SKIPPED_RESOURCE`
- `OUTCOME_SKIPPED_MANIFEST`

`OUTCOME_NOT_SUPPORTED` is deprecated but kept for backward compatibility (when using `merge-submissions` with subs made with older versions of Checkbox, for instance).

Finally, `OUTCOME_SKIP` is renamed `OUTCOME_MANUAL_SKIP` to indicate its real nature.

Then the reason why the job was automatically skipped is indicated in the JSON report in the `skip_reason` section.

The HTML report is also updated to take these modifications into account.

**Important:** the "status" is still mapped to `skip` for all of these new outcomes, so that we don't break C3 processing for the moment.

For more information, see the original specification document [CR139](https://docs.google.com/document/d/1kPp2PB_X0ENH1wkBbjUF6Dci4ehDEl8z9g8u67tWeLA/edit?tab=t.0).


## Resolved issues

Fix CHECKBOX-1337

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

- Tested manually by running a few test plans, including the smoke test plan ([submission.zip](https://github.com/user-attachments/files/27141117/submission_2026-04-27T20.27.43.163620.zip) that contains the HTML and the JSON reports)
- Unit tests adjusted
- New unit tests created
