### PR TITLE
Revert "Add custom-frontend slot to checkbox-ce-oem (New)" (bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic24/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic24/snap/snapcraft.yaml
@@ -4,16 +4,9 @@ description: "Checkbox CE OEM test runner and public providers for 24.04 classic
 confinement: classic
 grade: stable
 
-version: '1.1-noble'
+version: '1.0-noble'
 
 base: core24
-
-slots:
-  custom-frontend:
-    interface: content
-    content: custom-frontend
-    read:
-      - /
 
 apps:
   checkbox-cli:


### PR DESCRIPTION
Reverts canonical/checkbox#2426

Issue: Build failure in checkbox-ce-oem (24.04 classic snap).
Cause: Snap Store upload failed due to "confinement 'classic' not allowed with plugs/slots" error introduced in the original PR.
Action: Reverting to restore release pipeline stability.