### PR TITLE
Fix wrong python binary used in ce-oem-crypto tests (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/af_alg_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/af_alg_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import socket
 import argparse
 import unittest


### PR DESCRIPTION
## Description

contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/af_alg_test.py used in ce-oem-crypto tests was using the wrong python binary leading to the following dep issues on questing/resolute.

```
Fatal Python error: Failed to import encodings module
Python runtime state: core initialized
ModuleNotFoundError: No module named 'encodings'

Current thread 0x0000f5e54b086d80 (most recent call first):
  <no Python frame>
 ```

using /usr/bin/env python3 fixes the issue


## Resolved issues

Resolves: https://warthogs.atlassian.net/browse/PECA-1401

## Documentation

No changes required

## Tests

only the python binary is changed, tests need not to be updated.
