### PR TITLE
fixed vp8 demux gst pipeline for imx8m (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_encoder_psnr.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_encoder_psnr.py
@@ -480,7 +480,7 @@ class NxpIMX8mProject(PipelineInterface):
             "{}p_{}fps_vp8.webm".format(self._height, self._framerate),
         )
         pipeline = (
-            "{} filesrc location={} ! qtdemux ! decodebin !"
+            "{} filesrc location={} ! matroskademux ! decodebin !"
             " imxvideoconvert_g2d ! videoconvert ! video/x-raw,format={} !"
             " v4l2vp8enc ! matroskamux ! filesink location={}"
         ).format(


### PR DESCRIPTION


<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
fixed vp8 demux gst pipeline issue for imx8m, there's wrong plugin has been put in the pipeline, so it fail to demux the vp8 video
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
```
ubuntu@ubuntu:~$ LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu LD_PLUGIN_PATH=/usr/lib/aarch64-linux-gnu/gstreamer-1.0 /usr/bin/gst-launch-1.0 filesrc location=/home/ubuntu/CodecCrafter/1080p_60fps_vp8.webm ! matroskademux ! decodebin ! imxvideoconvert_g2d ! videoconvert ! video/x-raw,format=I420 ! v4l2vp8enc ! matroskamux ! filesink location=test.vp8 
Setting pipeline to PAUSED ...

====== V4L2ENC: 1.24.7 build on Sep  7 2025 08:35:39. ======
Pipeline is PREROLLING ...

====== V4L2DEC: 1.24.7 build on Sep  7 2025 08:35:39. ======
Redistribute latency...
Redistribute latency...
Pipeline is PREROLLED ...
Setting pipeline to PLAYING ...
Redistribute latency...
New clock: GstSystemClock
Got EOS from element "pipeline0".
Execution ended after 0:02:54.004022390
Setting pipeline to NULL ...
Freeing pipeline ...
```

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
