### PR TITLE
No return in finally (bugfix)

### DIFF
--- a/providers/base/bin/network_device_info.py
+++ b/providers/base/bin/network_device_info.py
@@ -96,8 +96,7 @@ class Utils:
                 file=sys.stderr,
             )
             ipv4_addr = "***NOT CONFIGURED***"
-        finally:
-            return ipv4_addr
+        return ipv4_addr
 
     @staticmethod
     def get_ipv6_address(interface):


### PR DESCRIPTION
## Description

This yields a warning on python3.14+ because the behaviour is counter intuitive

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/2516

## Documentation

N/A

## Tests

see:
```python
def f():
    try:
        return 1
    finally:
        return 2

print(f())
```
