### PR TITLE
Stop lstopo from hanging in 26.04 (BugFix)

### DIFF
--- a/providers/base/units/info/jobs.pxu
+++ b/providers/base/units/info/jobs.pxu
@@ -532,7 +532,7 @@ command:
 id: lstopo_verbose_attachment
 plugin: attachment
 category_id: com.canonical.plainbox::info
-command: lstopo -v
+command: HWLOC_COMPONENTS=-gl lstopo --output-format console
 estimated_duration: 0.015
 requires: executable.name == 'lstopo'
 _purpose: Attaches the system topology as presented by the lstopo command

--- a/providers/base/units/info/jobs.pxu
+++ b/providers/base/units/info/jobs.pxu
@@ -532,7 +532,7 @@ command:
 id: lstopo_verbose_attachment
 plugin: attachment
 category_id: com.canonical.plainbox::info
-command: HWLOC_COMPONENTS=-gl lstopo-no-graphics
+command: HWLOC_COMPONENTS=-gl lstopo-no-graphics -v
 estimated_duration: 0.015
 requires: executable.name == 'lstopo-no-graphics'
 _purpose: Attaches the system topology as presented by the lstopo command
@@ -546,7 +546,7 @@ requires: executable.name == 'lstopo'
 _purpose: Attaches the system topology as presented by the lstopo command
 _summary: Attach the output of lstopo command to present system topology.
 command:
- lstopo "$PLAINBOX_SESSION_SHARE"/lstopo_visual.png; \
+ HWLOC_COMPONENTS=-gl lstopo "$PLAINBOX_SESSION_SHARE"/lstopo_visual.png; \
  [ -e "$PLAINBOX_SESSION_SHARE/lstopo_visual.png" ] && \
  cat "$PLAINBOX_SESSION_SHARE/lstopo_visual.png"
 

--- a/providers/base/units/info/jobs.pxu
+++ b/providers/base/units/info/jobs.pxu
@@ -534,7 +534,7 @@ plugin: attachment
 category_id: com.canonical.plainbox::info
 command: HWLOC_COMPONENTS=-gl lstopo-no-graphics
 estimated_duration: 0.015
-requires: executable.name == 'lstopo'
+requires: executable.name == 'lstopo-no-graphics'
 _purpose: Attaches the system topology as presented by the lstopo command
 _summary: Attach the output of lstopo
 

--- a/providers/base/units/info/jobs.pxu
+++ b/providers/base/units/info/jobs.pxu
@@ -532,7 +532,7 @@ command:
 id: lstopo_verbose_attachment
 plugin: attachment
 category_id: com.canonical.plainbox::info
-command: HWLOC_COMPONENTS=-gl lstopo --output-format console
+command: HWLOC_COMPONENTS=-gl lstopo-no-graphics
 estimated_duration: 0.015
 requires: executable.name == 'lstopo'
 _purpose: Attaches the system topology as presented by the lstopo command


### PR DESCRIPTION

## WARNING: This modifies com.canonical.certification::sru-server

## Description

A quick 1-line fix to stop lstopo from hanging forever. The solution comes from here https://github.com/open-mpi/ompi/issues/13838#issuecomment-4294194268.

This PR also changes `lstopo` to `lstopo-no-graphics` as discussed in the office hours. 

## Resolved issues

lstopo hanging in 26.04

## Documentation

https://github.com/open-mpi/hwloc/issues/517

## Tests

Ran `HWLOC_COMPONENTS=-gl lstopo-no-graphics` in 16.04~26.04 and they all successfully finish.

https://certification.canonical.com/hardware/201812-26713/submission/486967/