### PR TITLE
Add scan parameters to beacontool (Bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/eddystone_scanner.py
+++ b/checkbox-support/checkbox_support/scripts/eddystone_scanner.py
@@ -27,6 +27,11 @@ from checkbox_support.vendor.beacontools import (
     BeaconScanner,
     EddystoneURLFrame,
 )
+from checkbox_support.vendor.beacontools.const import (
+    BluetoothAddressType,
+    ScanFilter,
+    ScanType,
+)
 from checkbox_support.helpers.timeout import timeout
 from checkbox_support.helpers.retry import retry
 from checkbox_support.interactive_cmd import InteractiveCommand
@@ -65,6 +70,13 @@ def beacon_scan(hci_device, debug=False):
         callback,
         bt_device_id=hci_device,
         packet_filter=EddystoneURLFrame,
+        scan_parameters={
+            "scan_type": ScanType.ACTIVE,
+            "interval_ms": 10,
+            "window_ms": 10,
+            "address_type": BluetoothAddressType.PUBLIC,
+            "filter_type": ScanFilter.ALL,
+        },
         debug=debug,
     )
 

--- a/checkbox-support/checkbox_support/scripts/eddystone_scanner.py
+++ b/checkbox-support/checkbox_support/scripts/eddystone_scanner.py
@@ -42,11 +42,6 @@ def init_bluetooth():
     with InteractiveCommand("bluetoothctl") as btctl:
         btctl.writeline("power on")
         time.sleep(3)
-        # workaround for some intel bluetooth controller
-        # if we don't enable scan on via bluetoothctl first,
-        #    the hci 'advertising scan enable' command would failed
-        btctl.writeline("scan on")
-        time.sleep(3)
         btctl.writeline("exit")
         btctl.kill()
 

--- a/checkbox-support/checkbox_support/tests/test_eddystone_scanner.py
+++ b/checkbox-support/checkbox_support/tests/test_eddystone_scanner.py
@@ -117,6 +117,5 @@ class TestEddystoneScanner(unittest.TestCase):
         eddystone_scanner.init_bluetooth()
         mock_command.assert_called_with("bluetoothctl")
         mock_btctl.writeline.assert_any_call("power on")
-        mock_btctl.writeline.assert_any_call("scan on")
         mock_btctl.writeline.assert_any_call("exit")
-        self.assertEqual(mock_sleep.call_count, 2)
+        self.assertEqual(mock_sleep.call_count, 1)


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
In PR #2260, it remove the `blutoothctl scan on`, and introduce issue #2466. In x86 enablement project also encounter similar issue [SOMERVILLE-4545](https://warthogs.atlassian.net/browse/SOMERVILLE-4545). From chip vendor's investigation, the root cause of this issue is scan with RANDOM address in scan parameter and not set the RANDOM address in advance, which had been addressed in [BT spec](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-f5242ce9-9acb-fff4-3e8f-8f6465b2f24c)  

> If Enable is set to 0x01, the scanning parameters' Own_Address_Type parameter is set to 0x01 or 0x03, and the random address for the device has not been initialized using the HCI_LE_Set_Random_Address command, the Controller shall return the error code Invalid HCI Command Parameters (0x12).

This PR change the scan type to PUBLIC which don't need to set RANDOM address in advance. And can revert the workaround introduced by #2475.


<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
Fixes #2466 
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
Install checkbox-support from [Test PPA](https://launchpad.net/~dirksu/+archive/ubuntu/checkbox-support-eddystone) and other checkbox packages from [checkbox-beta](https://launchpad.net/~checkbox-dev/+archive/ubuntu/beta). And run run test plan bluetooth-cert-automated on required machines
1. Origin platform: https://certification.canonical.com/hardware/202604-38592/submission/491156/test-results/
2. RPi3: https://certification.canonical.com/hardware/202311-32357/submission/491154/test-results/
3. RPi4: https://certification.canonical.com/hardware/202004-27866/submission/491373/test-results/
4. RPi5: https://certification.canonical.com/hardware/202512-38178/submission/491171/test-results/
<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->


[SOMERVILLE-4545]: https://warthogs.atlassian.net/browse/SOMERVILLE-4545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ