### PR TITLE
Add --stressor flag to run a single memory stressor (New)

### DIFF
--- a/providers/base/bin/stress_ng_test.py
+++ b/providers/base/bin/stress_ng_test.py
@@ -300,6 +300,39 @@ def stress_memory(args):
     # Low-thread-count stressors -- throttle to >8 threads...
     ltc_stressors = ["stack", "bigheap", "brk"]
 
+    if args.stressor is not None:
+        if args.stressor in crt_stressors:
+            sng_timeout, thread_count = args.base_time, 0
+        elif args.stressor in vrt_stressors:
+            sng_timeout, thread_count = vrt, 0
+        elif args.stressor in ltc_stressors:
+            sng_timeout, thread_count = vrt, 8
+        else:
+            print(
+                "** Unknown memory stressor '{}'. Valid options: {}".format(
+                    args.stressor,
+                    ", ".join(crt_stressors + vrt_stressors + ltc_stressors),
+                )
+            )
+            return 1
+        test_object = StressNg(
+            stressors=[args.stressor],
+            sng_timeout=sng_timeout,
+            wrapper_timeout=sng_timeout * 2,
+            thread_count=thread_count,
+            oom_avoid_bytes=oom_avoid_bytes,
+        )
+        retval = test_object.run()
+        print(test_object.results)
+        if my_swap is not None and args.keep_swap is False:
+            print("Deleting temporary swap file....")
+            cmd = "swapoff {}".format(my_swap)
+            Popen(
+                shlex.split(cmd), stderr=STDOUT, stdout=PIPE
+            ).communicate()[0]
+            os.remove(my_swap)
+        return retval
+
     est_runtime = (
         len(crt_stressors) * args.base_time + len(vrt_stressors) * vrt
     )
@@ -472,6 +505,13 @@ def main():
         type=str,
         help="OOM avoidance memory (default=10%%, 5%% for >255GB)",
         default=None,
+    )
+    memory_parser.add_argument(
+        "--stressor",
+        type=str,
+        default=None,
+        help="Run only the named stress-ng memory stressor (e.g. matrix, vm)"
+        " instead of the full suite",
     )
 
     # Disk parameters


### PR DESCRIPTION
Add a --stressor NAME option that runs just the named memory
stressor using the timeout and thread-count rules of the list it
belongs to, and errors out for unknown names.

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
- At times it is necessary to run a single stress-ng memory stress stressor for debugging purposes.  Rather than editing the code each time I created this patch.
- I created a patch to run an individual memory stressor
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
