### PR TITLE
Add AMD Sorano initial CPUID to cpuid.py (New)

### DIFF
--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -182,6 +182,7 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
         "AMD Genoa":        ['0xa10f11'],                                # 2022
         "AMD Bergamo":      ['0xaa0f01'],                                # 2023
         "AMD Siena SP6":    ['0xaa0f02'],                                # 2023
+        "AMD Sorano SP6":   ['0xb00f20'],                                # 2026
         "AMD Turin":        ['0xb00f21', '0xb10f10'],                    # 2024
         "AMD Grado":        ['0xb40f40'],                                # 2025
 


### PR DESCRIPTION


## Description
Add the initial CPUID for AMD Sorano to cpuid.py



## Resolved issues
NA


## Documentation
NA


## Tests
NA
