### PR TITLE
fix: Update ethernet/multi_iperf3_nic_device job to avoid virtual devices (BugFix)

### DIFF
--- a/providers/base/units/ethernet/jobs.pxu
+++ b/providers/base/units/ethernet/jobs.pxu
@@ -76,7 +76,7 @@ _purpose:
 
 unit: template
 template-resource: device
-template-filter: device.category == 'NETWORK' and device.interface != 'UNKNOWN'
+template-filter: device.category == 'NETWORK' and device.interface != 'UNKNOWN' and device.product_slug != 'Virtual_Ethernet_'
 plugin: shell
 category_id: com.canonical.plainbox::ethernet
 id: ethernet/multi_iperf3_nic_device{__index__}_{interface}


### PR DESCRIPTION
## Description

Updated the filter used by the `ethernet/multi_iperf3_nic_device...` job to avoid attempting to do iperf3 testing of virtual ethernet devices, which are typically used for administration of servers.

As seen in https://certification.canonical.com/certificates/request/2605-17514/

## Resolved issues

See above.

## Documentation

N/A

## Tests

Not tested