### PR TITLE
Fix monitor/graphic/audio jobs duplicate and clean up for 26.04tp (Bugfix)

### DIFF
--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -366,7 +366,7 @@ command:
 _purpose:
     DisplayPort audio via USB Type-C port interface verification
 _steps:
-    1. Plug an external DisplayPort device with sound on a USB Type-C port using a "USB Typce-C to DisplayPort" adapter (Use only one HDMI/DisplayPort/Thunderbolt interface at a time for this test)
+    1. Plug an external DisplayPort device with sound on a USB Type-C port using a "USB Type-C to DisplayPort" adapter (Use only one HDMI/DisplayPort/Thunderbolt interface at a time for this test)
     2. Commence the test
 _verification:
     Did you hear the sound from the DisplayPort device?
@@ -401,7 +401,7 @@ command:
 _purpose:
     DisplayPort audio via USB Type-C port interface verification
 _steps:
-    1. Plug an external DisplayPort device with sound on a USB Type-C port using a "USB Typce-C to DisplayPort" adapter (Use only one HDMI/DisplayPort/Thunderbolt interface at a time for this test)
+    1. Plug an external DisplayPort device with sound on a USB Type-C port using a "USB Type-C to DisplayPort" adapter (Use only one HDMI/DisplayPort/Thunderbolt interface at a time for this test)
     2. Commence the test
 _verification:
     Did you hear the sound from the DisplayPort device?

--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -110,6 +110,41 @@ _steps:
 _verification:
     Did you hear the sound from the HDMI device?
 
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::audio
+id: audio/playback_hdmi
+estimated_duration: 30.0
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_hdmi == 'True'
+ manifest.has_audio_playback == 'True'
+ package.name == 'alsa-base'
+ package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
+ package.name in ['pulseaudio-utils', 'pipewire']
+flags: also-after-suspend
+command:
+  if check_audio_daemon.sh ; then
+    checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
+    checkbox-support-pipewire-utils gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --verbose --device=hdmi --volume=50
+    gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
+  exit $EXIT_CODE
+_purpose:
+    HDMI audio interface verification
+_steps:
+    1. Plug an external HDMI device with sound (Use only one HDMI/DisplayPort/Thunderbolt interface at a time for this test)
+    2. Commence the test
+_verification:
+    Did you hear the sound from the HDMI device?
+
 unit: template
 template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'
@@ -117,6 +152,41 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/{index}_playback_displayport_{product_slug}
 template-id: audio/index_playback_displayport_product_slug
+estimated_duration: 30.0
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_dp == 'True'
+ manifest.has_audio_playback == 'True'
+ package.name == 'alsa-base'
+ package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
+ package.name in ['pulseaudio-utils', 'pipewire']
+flags: also-after-suspend
+command:
+  if check_audio_daemon.sh ; then
+    checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
+    checkbox-support-pipewire-utils gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --verbose --device=hdmi --volume=50
+    gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
+  exit $EXIT_CODE
+_purpose:
+    DisplayPort audio interface verification
+_steps:
+    1. Plug an external DisplayPort device with sound (Use only one HDMI/DisplayPort/Thunderbolt interface at a time for this test)
+    2. Commence the test
+_verification:
+    Did you hear the sound from the DisplayPort device?
+
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::audio
+id: audio/playback_displayport
 estimated_duration: 30.0
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -227,6 +297,41 @@ _steps:
 _verification:
     Did you hear the sound from the Thunderbolt device?
 
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::audio
+id: audio/playback_thunderbolt3
+imports: from com.canonical.plainbox import manifest
+estimated_duration: 30.0
+requires:
+ manifest.has_thunderbolt3 == 'True'
+ manifest.has_audio_playback == 'True'
+ package.name == 'alsa-base'
+ package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
+ package.name in ['pulseaudio-utils', 'pipewire']
+flags: also-after-suspend
+command:
+  if check_audio_daemon.sh ; then
+    checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
+    checkbox-support-pipewire-utils gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --verbose --device=hdmi --volume=50
+    gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
+  exit $EXIT_CODE
+_purpose:
+    Thunderbolt audio interface verification
+_steps:
+    1. Plug an external Thunderbolt device with sound (Use only one HDMI/DisplayPort/Thunderbolt interface at a time for this test)
+    2. Commence the test
+_verification:
+    Did you hear the sound from the Thunderbolt device?
+
 unit: template
 template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'
@@ -266,6 +371,41 @@ _steps:
 _verification:
     Did you hear the sound from the DisplayPort device?
 
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::audio
+id: audio/playback_type-c_displayport
+imports: from com.canonical.plainbox import manifest
+estimated_duration: 30.0
+requires:
+ manifest.has_usbc_video == 'True'
+ manifest.has_audio_playback == 'True'
+ package.name == 'alsa-base'
+ package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
+ package.name in ['pulseaudio-utils', 'pipewire']
+flags: also-after-suspend
+command:
+  if check_audio_daemon.sh ; then
+    checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
+    checkbox-support-pipewire-utils gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --verbose --device=hdmi --volume=50
+    gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
+  exit $EXIT_CODE
+_purpose:
+    DisplayPort audio via USB Type-C port interface verification
+_steps:
+    1. Plug an external DisplayPort device with sound on a USB Type-C port using a "USB Typce-C to DisplayPort" adapter (Use only one HDMI/DisplayPort/Thunderbolt interface at a time for this test)
+    2. Commence the test
+_verification:
+    Did you hear the sound from the DisplayPort device?
+
 unit: template
 template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'
@@ -273,6 +413,43 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/{index}_playback_type-c_hdmi_{product_slug}
 template-id: audio/index_playback_type-c_hdmi_product_slug
+imports: from com.canonical.plainbox import manifest
+estimated_duration: 30.0
+requires:
+ manifest.has_usbc_video == 'True'
+ manifest.has_audio_playback == 'True'
+ package.name == 'alsa-base'
+ package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
+ package.name in ['pulseaudio-utils', 'pipewire']
+flags: also-after-suspend
+command:
+  if check_audio_daemon.sh ; then
+    checkbox-support-pipewire-utils show -t audio
+    set -e
+    checkbox-support-pipewire-utils default_device_is_real -d audio-sink
+    checkbox-support-pipewire-utils gst -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+  else
+    audio_settings.py store --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+    audio_settings.py set --verbose --device=hdmi --volume=50
+    gst_pipeline_test.py -t 2 --device hdmi 'audiotestsrc wave=sine freq=512 ! audioconvert ! audioresample ! autoaudiosink'
+    EXIT_CODE=$?
+    audio_settings.py restore --verbose --file="$PLAINBOX_SESSION_SHARE"/pulseaudio_settings
+  fi
+  exit $EXIT_CODE
+_purpose:
+    HDMI audio via USB Type-C port interface verification
+_steps:
+    1. Plug an external HDMI device with sound into a USB Type-C port using a "USB Type-C to HDMI" adapter (Use only one HDMI/DisplayPort/Thunderbolt interface at a time for this test)
+    2. Begin the test
+_verification:
+    Did you hear the sound from the HDMI device?
+_summary:
+    Verify HDMI audio playback through the USB Type-C port using a "USB Type-C to HDMI" adapter and confirm sound output.
+
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::audio
+id: audio/playback_type-c_hdmi
 imports: from com.canonical.plainbox import manifest
 estimated_duration: 30.0
 requires:

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -291,7 +291,7 @@ command:
  # shellcheck disable=SC1091
  if [[ $XDG_CURRENT_DESKTOP == *"GNOME"* ]]
  then
-   randr_cycle.py -c resolution --prefix {index} --screenshot_dir="$PLAINBOX_SESSION_SHARE"
+   randr_cycle.py -c resolution --prefix primary --screenshot_dir="$PLAINBOX_SESSION_SHARE"
  else
    xrandr_cycle.py --screenshot-dir="$PLAINBOX_SESSION_SHARE"
  fi
@@ -343,7 +343,7 @@ command:
  # shellcheck disable=SC1091
  if [[ $XDG_CURRENT_DESKTOP == *"GNOME"* ]]
  then
-   randr_cycle.py -c transform --prefix {index} --screenshot_dir="$PLAINBOX_SESSION_SHARE"
+   randr_cycle.py -c transform --prefix primary --screenshot_dir="$PLAINBOX_SESSION_SHARE"
  else
    rotation_test.py
  fi

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -128,24 +128,6 @@ _purpose:
  resolution (800x600) on the {vendor} {product} graphics card. See here for details:
  https://help.ubuntu.com/community/Installation/SystemRequirements
 
-plugin: shell
-category_id: com.canonical.plainbox::graphics
-id: graphics/primary_minimum_resolution
-flags: also-after-suspend
-requires:
- desktop_session.desktop_session == 'True'
- device.category == 'VIDEO'
-command:
- # shellcheck disable=SC1091
- source graphics_env.sh {driver} {index}
- resolution_test.py --horizontal 800 --vertical 600
-estimated_duration: 0.331
-_summary: Test that {vendor} {product} meets minimum resolution requirement
-_purpose:
- Ensure the current resolution meets or exceeds the recommended minimum
- resolution (800x600) on the graphics card. See here for details:
- https://help.ubuntu.com/community/Installation/SystemRequirements
-
 unit: template
 template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -128,9 +128,6 @@ _purpose:
  resolution (800x600) on the {vendor} {product} graphics card. See here for details:
  https://help.ubuntu.com/community/Installation/SystemRequirements
 
-unit: template
-template-resource: graphics_card
-template-filter: graphics_card.prime_gpu_offload == 'Off'
 plugin: shell
 category_id: com.canonical.plainbox::graphics
 id: graphics/primary_minimum_resolution

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -162,11 +162,10 @@ command:
 estimated_duration: 10.0
 _summary: Test maximum supported resolution
 _purpose:
- This test will verify the maximum supported resolution on the graphics card.
+ This test will verify the maximum supported resolution on the primary graphics card.
 _steps:
- 1. Select the graphics card (a reboot may be necessary)
- 2. Consult the system's specifications and locate the screen's maximum supported resolution.
- 3. Click on Test to display the maximum resolution that can be used by Ubuntu on the current display.
+ 1. Consult the system's specifications and locate the screen's maximum supported resolution.
+ 2. Click on Test to display the maximum resolution that can be used by Ubuntu on the current display.
 _verification:
  Is this the maximum resolution for the display connected to the graphics card?
 
@@ -228,7 +227,6 @@ flags: also-after-suspend
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 requires:
- package.name == 'xorg'
  package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
 command:
  # shellcheck disable=SC1091

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -131,6 +131,27 @@ _purpose:
 unit: template
 template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'
+plugin: shell
+category_id: com.canonical.plainbox::graphics
+id: graphics/primary_minimum_resolution
+flags: also-after-suspend
+requires:
+ desktop_session.desktop_session == 'True'
+ device.category == 'VIDEO'
+command:
+ # shellcheck disable=SC1091
+ source graphics_env.sh {driver} {index}
+ resolution_test.py --horizontal 800 --vertical 600
+estimated_duration: 0.331
+_summary: Test that {vendor} {product} meets minimum resolution requirement
+_purpose:
+ Ensure the current resolution meets or exceeds the recommended minimum
+ resolution (800x600) on the graphics card. See here for details:
+ https://help.ubuntu.com/community/Installation/SystemRequirements
+
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.prime_gpu_offload == 'Off'
 id: graphics/{index}_maximum_resolution_{product_slug}
 template-id: graphics/index_maximum_resolution_product_slug
 flags: also-after-suspend
@@ -150,6 +171,25 @@ _steps:
  3. Click on Test to display the maximum resolution that can be used by Ubuntu on the current display.
 _verification:
  Is this the maximum resolution for the display connected to the {vendor} {product} graphics card?
+
+id: graphics/maximum_resolution_primary
+flags: also-after-suspend
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::graphics
+requires:
+ device.category == 'VIDEO'
+command:
+   graphics_max_resolution.py
+estimated_duration: 10.0
+_summary: Test maximum supported resolution
+_purpose:
+ This test will verify the maximum supported resolution on the graphics card.
+_steps:
+ 1. Select the graphics card (a reboot may be necessary)
+ 2. Consult the system's specifications and locate the screen's maximum supported resolution.
+ 3. Click on Test to display the maximum resolution that can be used by Ubuntu on the current display.
+_verification:
+ Is this the maximum resolution for the display connected to the graphics card?
 
 unit: template
 template-resource: graphics_card
@@ -204,6 +244,24 @@ _steps:
 _verification:
  Do you see color bars and static?
 
+id: graphics/video_primary
+flags: also-after-suspend
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::graphics
+requires:
+ package.name == 'xorg'
+ package.name == 'gir1.2-gst-plugins-base-0.10' or package.name == 'gir1.2-gst-plugins-base-1.0'
+command:
+ # shellcheck disable=SC1091
+ gst_pipeline_test.py -t 2 'videotestsrc ! videoconvert ! autovideosink' || gst_pipeline_test.py -t 2 'videotestsrc ! ffmpegcolorspace ! autovideosink'
+_summary: Test that video can be displayed
+_purpose:
+ This test will test the default display with a sample video
+_steps:
+ 1. Click "Test" to display a video test.
+_verification:
+ Do you see color bars and static?
+
 plugin: shell
 category_id: com.canonical.plainbox::graphics
 id: graphics/VESA_drivers_not_in_use
@@ -243,6 +301,31 @@ _steps:
 _verification:
      Did the screen appear to be working for each mode?
 
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::graphics
+id: graphics/cycle_resolution_primary
+flags: also-after-suspend
+requires: package.name == 'xorg'
+depends: graphics/VESA_drivers_not_in_use
+environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
+command:
+ # shellcheck disable=SC1091
+ if [[ $XDG_CURRENT_DESKTOP == *"GNOME"* ]]
+ then
+   randr_cycle.py -c resolution --prefix {index} --screenshot_dir="$PLAINBOX_SESSION_SHARE"
+ else
+   xrandr_cycle.py --screenshot-dir="$PLAINBOX_SESSION_SHARE"
+ fi
+estimated_duration: 250.000
+_summary: Test resolution cycling
+_description:
+_purpose:
+     This test cycles through the detected video modes for the graphics card
+_steps:
+     1. Click "Test" to start cycling through the video modes
+_verification:
+     Did the screen appear to be working for each mode?
+
 unit: template
 template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'
@@ -272,6 +355,30 @@ _steps:
 _verification:
  Did the display rotation take place without permanent screen corruption?
 
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::graphics
+id: graphics/rotation_primary
+flags: also-after-suspend
+environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
+command:
+ # shellcheck disable=SC1091
+ if [[ $XDG_CURRENT_DESKTOP == *"GNOME"* ]]
+ then
+   randr_cycle.py -c transform --prefix {index} --screenshot_dir="$PLAINBOX_SESSION_SHARE"
+ else
+   rotation_test.py
+ fi
+estimated_duration: 20.000
+_summary: Test rotation
+_purpose:
+ This test will test display rotation on the graphics card
+_steps:
+ 1. Click "Test" to test display rotation. The display will be rotated every 4 seconds.
+ 2. Try moving the mouse or try opening multiple terminals via ‘Ctrl+Alt+T’ every time the screen automatically turns.
+ 3. Check if all rotations (normal, right, inverted, left) took place without permanent screen corruption.
+_verification:
+ Did the display rotation take place without permanent screen corruption?
+
 unit: template
 template-resource: graphics_card
 plugin: shell
@@ -285,6 +392,18 @@ command:
 estimated_duration: 0.131
 _purpose: Check that {vendor} {product} hardware is able to run a desktop session (OpenGL)
 _summary: Test OpenGL support for {vendor} {product}
+user: root
+
+plugin: shell
+category_id: com.canonical.plainbox::graphics
+id: graphics/gl_support_primary
+flags: also-after-suspend
+environ: CHECKBOX_RUNTIME
+command:
+    gl_support.py
+estimated_duration: 0.131
+_purpose: Check that hardware is able to run a desktop session (OpenGL)
+_summary: Test OpenGL support
 user: root
 
 unit: template
@@ -313,6 +432,7 @@ template-resource: graphics_card
 plugin: shell
 category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_auto_glxgears_{product_slug}
+template-id: graphics/index_auto_glxgears_product_slug
 flags: also-after-suspend
 requires:
     executable.name == 'glxgears'
@@ -393,6 +513,7 @@ template-resource: graphics_card
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_valid_glxgears_{product_slug}
+template-id: graphics/index_valid_glxgears_product_slug
 flags: also-after-suspend
 requires:
     executable.name == 'glxgears'
@@ -422,6 +543,7 @@ template-resource: graphics_card
 plugin: shell
 category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_auto_glxgears_fullscreen_{product_slug}
+template-id: graphics/index_auto_glxgears_fullscreen_product_slug
 flags: also-after-suspend
 requires:
     executable.name == 'glxgears'
@@ -443,6 +565,7 @@ template-resource: graphics_card
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_valid_glxgears_fullscreen_{product_slug}
+template-id: graphics/index_valid_glxgears_fullscreen_product_slug
 flags: also-after-suspend
 requires:
     executable.name == 'glxgears'

--- a/providers/base/units/graphics/test-plan.pxu
+++ b/providers/base/units/graphics/test-plan.pxu
@@ -190,7 +190,7 @@ _description:
  Graphics tests (integrated GPU) (Manual)
 include:
  miscellanea/chvt
- graphics/1_maximum_resolution_.*           certiftemplate-id: monitor/hdmiication-status=blocker
+ graphics/1_maximum_resolution_.*           certification-status=blocker
  graphics/1_glxgears_.*                     certification-status=blocker
  graphics/1_rotation_.*                     certification-status=blocker
  graphics/1_video_.*                        certification-status=blocker
@@ -425,7 +425,7 @@ id: graphic-base-26-04-manual
 unit: test plan
 _name: Graphics for 26.04 (Manual)
 _description: Manual tests for graphics
-include:graphics-gpu-cert-26-04-manual
+include:
     keys/video-out
     after-suspend-keys/video-out
 nested_part:

--- a/providers/base/units/graphics/test-plan.pxu
+++ b/providers/base/units/graphics/test-plan.pxu
@@ -33,6 +33,27 @@ include:
 bootstrap_include:
     graphics_card
 
+id: graphics-gpu-cert-26-04-automated
+unit: test plan
+_name: Graphics tests for 26.04 (Automated)
+_description:
+ Graphics tests (Automated)
+include:
+ graphics/VESA_drivers_not_in_use                           certification-status=blocker
+ graphics/index_driver_version_product_slug                 certification-status=blocker
+ graphics/gl_support_primary                                certification-status=blocker
+ graphics/index_minimum_resolution_product_slug             certification-status=blocker
+ graphics/index_auto_glxgears_product_slug                  certification-status=blocker
+ graphics/index_auto_glxgears_fullscreen_product_slug       certification-status=blocker
+ graphics/auto_glxgears                                     certification-status=blocker
+ graphics/auto_glxgears_fullscreen                          certification-status=blocker
+ suspend/resolution_before_suspend                          certification-status=blocker
+ graphics/index_vkcube_product_slug                         certification-status=blocker
+ graphics/vulkaninfo-debug                                  certification-status=blocker
+ graphics/vulkaninfo-api-version                            certification-status=blocker
+bootstrap_include:
+    graphics_card
+
 id: graphics-gpu-cert-manual
 unit: test plan
 _name: Graphics tests (Manual)
@@ -51,6 +72,24 @@ include:
 bootstrap_include:
     graphics_card
 
+id: graphics-gpu-cert-26-04-manual
+unit: test plan
+_name: Graphics tests for 26.04 (Manual)
+_description:
+ Graphics tests (Manual)
+include:
+ miscellanea/chvt
+ graphics/maximum_resolution_primary                     certification-status=blocker
+ graphics/rotation_primary                               certification-status=blocker
+ graphics/video_primary                                  certification-status=blocker
+ graphics/cycle_resolution_primary                       certification-status=blocker
+ graphics/index_valid_glxgears_product_slug              certification-status=blocker
+ graphics/index_valid_glxgears_fullscreen_product_slug   certification-status=blocker
+ graphics/valid_glxgears                                 certification-status=blocker
+ graphics/valid_glxgears_fullscreen                      certification-status=blocker
+bootstrap_include:
+    graphics_card
+
 id: after-suspend-graphics-gpu-cert-full
 unit: test plan
 _name: After suspend tests
@@ -59,6 +98,23 @@ include:
 nested_part:
  com.canonical.certification::after-suspend-graphics-gpu-cert-automated
  com.canonical.certification::after-suspend-graphics-gpu-cert-manual
+
+id: after-suspend-graphics-gpu-cert-26-04-automated
+unit: test plan
+_name: After suspend tests for 26.04 (GPU automated)
+_description: After suspend tests (GPU automated)
+include:
+ suspend/suspend-time-check                                               certification-status=non-blocker
+ suspend/suspend-single-log-attach                                        certification-status=non-blocker
+ after-suspend-graphics/VESA_drivers_not_in_use                           certification-status=blocker
+ after-suspend-graphics/index_driver_version_product_slug                 certification-status=blocker
+ after-suspend-graphics/gl_support_primary                                certification-status=blocker
+ after-suspend-graphics/index_minimum_resolution_product_slug             certification-status=blocker
+ after-suspend-graphics/index_auto_glxgears_product_slug                  certification-status=blocker
+ after-suspend-graphics/index_auto_glxgears_fullscreen_product_slug       certification-status=blocker
+ after-suspend-graphics/auto_glxgears                                     certification-status=blocker
+ after-suspend-graphics/auto_glxgears_fullscreen                          certification-status=blocker
+ suspend/resolution_after_suspend                                         certification-status=blocker
 
 id: after-suspend-graphics-gpu-cert-automated
 unit: test plan
@@ -96,6 +152,25 @@ include:
  after-suspend-graphics/valid_glxgears_fullscreen         certification-status=blocker
  suspend/1_xrandr_screens_after_suspend.tar.gz_auto
 
+id: after-suspend-graphics-gpu-cert-26-04-manual
+unit: test plan
+_name: After suspend tests for 26.04 (GPU manual)
+_description: After suspend tests (GPU manual)
+include:
+ power-management/lid_close_suspend_open                               certification-status=blocker
+ power-management/lid                                                  certification-status=blocker
+ after-suspend-miscellanea/chvt
+ suspend/display_after_suspend                                         certification-status=blocker
+ after-suspend-graphics/maximum_resolution_primary                     certification-status=blocker
+ after-suspend-graphics/rotation_primary                               certification-status=blocker
+ after-suspend-graphics/video_primary                                  certification-status=blocker
+ after-suspend-graphics/cycle_resolution_primary                       certification-status=blocker
+ after-suspend-graphics/index_valid_glxgears_product_slug              certification-status=blocker
+ after-suspend-graphics/index_valid_glxgears_fullscreen_product_slug   certification-status=blocker
+ after-suspend-graphics/valid_glxgears                                 certification-status=blocker
+ after-suspend-graphics/valid_glxgears_fullscreen                      certification-status=blocker
+ suspend/1_xrandr_screens_after_suspend.tar.gz_auto
+
 id: graphics-integrated-gpu-cert-full
 unit: test plan
 _name: Graphics tests (integrated GPU)
@@ -115,7 +190,7 @@ _description:
  Graphics tests (integrated GPU) (Manual)
 include:
  miscellanea/chvt
- graphics/1_maximum_resolution_.*           certification-status=blocker
+ graphics/1_maximum_resolution_.*           certiftemplate-id: monitor/hdmiication-status=blocker
  graphics/1_glxgears_.*                     certification-status=blocker
  graphics/1_rotation_.*                     certification-status=blocker
  graphics/1_video_.*                        certification-status=blocker
@@ -350,21 +425,16 @@ id: graphic-base-26-04-manual
 unit: test plan
 _name: Graphics for 26.04 (Manual)
 _description: Manual tests for graphics
-include:
+include:graphics-gpu-cert-26-04-manual
     keys/video-out
     after-suspend-keys/video-out
 nested_part:
     submission-cert-full
-    graphics-gpu-cert-manual
-    monitor-gpu-cert-manual
-    after-suspend-graphics-gpu-cert-manual
-    after-suspend-monitor-gpu-cert-manual
+    graphics-gpu-cert-26-04-manual
+    monitor-gpu-cert-26-04-manual
+    after-suspend-graphics-gpu-cert-26-04-manual
+    after-suspend-monitor-gpu-cert-26-04-manual
     info-attachment-cert-full
-certification_status_overrides:
-    apply blocker to com.canonical.certification::graphics/1_cycle_resolution_.*
-    apply blocker to com.canonical.certification::graphics/2_cycle_resolution_.*
-    apply blocker to com.canonical.certification::after-suspend-graphics/1_cycle_resolution_.*
-    apply blocker to com.canonical.certification::after-suspend-graphics/2_cycle_resolution_.*
 
 id: graphic-base-26-04-automated
 unit: test plan
@@ -372,12 +442,8 @@ _name: Graphic for 26.04 (Automated)
 _description: Automated tests for graphic
 include:
 nested_part:
-    graphics-gpu-cert-automated
-    after-suspend-graphics-gpu-cert-automated
-certification_status_overrides:
-    apply blocker to com.canonical.certification::graphics/1_vkcube_.*
-    apply blocker to com.canonical.certification::graphics/2_vkcube_.*
-    apply blocker to com.canonical.certification::graphics/vulkaninfo.*
+    graphics-gpu-cert-26-04-automated
+    after-suspend-graphics-gpu-cert-26-04-automated
 
 id: opencl-core-test-plan
 unit: test plan

--- a/providers/base/units/graphics/test-plan.pxu
+++ b/providers/base/units/graphics/test-plan.pxu
@@ -169,7 +169,7 @@ include:
  after-suspend-graphics/index_valid_glxgears_fullscreen_product_slug   certification-status=blocker
  after-suspend-graphics/valid_glxgears                                 certification-status=blocker
  after-suspend-graphics/valid_glxgears_fullscreen                      certification-status=blocker
- suspend/1_xrandr_screens_after_suspend.tar.gz_auto
+ suspend/xrandr_screens_after_suspend_primary
 
 id: graphics-integrated-gpu-cert-full
 unit: test plan

--- a/providers/base/units/monitor/jobs.pxu
+++ b/providers/base/units/monitor/jobs.pxu
@@ -185,8 +185,45 @@ _verification:
 unit: template
 template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'
+flags: also-after-suspend
+id: monitor/powersaving
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::monitor
+command:
+  busctl --user call org.gnome.Shell /org/gnome/ScreenSaver org.gnome.ScreenSaver SetActive b true
+  sleep 5
+  busctl --user call org.gnome.Shell /org/gnome/ScreenSaver org.gnome.ScreenSaver SetActive b false
+_purpose:
+    This test will check your monitor power saving capabilities
+_steps:
+    1. Start the test to try the power saving capabilities of your monitor
+_verification:
+    Did the monitor go blank and turn on again after a few seconds?
+
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.prime_gpu_offload == 'Off'
 id: monitor/{index}_dim_brightness_{product_slug}
 template-id: monitor/index_dim_brightness_product_slug
+requires: dmi.display_type == "integrated"
+plugin: user-interact-verify
+category_id: com.canonical.plainbox::monitor
+user: root
+flags: also-after-suspend
+command: brightness_test.py
+_purpose:
+    This test will check changes to screen brightness.
+_steps:
+    1. Change screen brightness to maximum.
+    2. Click "Test" to attempt to dim the screen.
+    3. Check if the screen was dimmed approximately to half of the maximum brightness.
+    4. The screen will go back to the original brightness in 2 seconds.
+_verification:
+    Was your screen dimmed approximately to half of the maximum brightness?
+_summary:
+    Examine screen brightness adjustment capabilities.
+
+id: monitor/dim_brightness
 requires: dmi.display_type == "integrated"
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::monitor
@@ -251,6 +288,25 @@ _verification:
     Was the desktop displayed correctly with {vendor} {product} on the Thunderbolt-connected
     screen in every mode?
 
+id: monitor/thunderbolt3
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_thunderbolt3 == 'True'
+flags: also-after-suspend
+estimated_duration: 15.0
+plugin: manual
+category_id: com.canonical.plainbox::monitor
+_summary: Display connected via Thunderbolt 3
+_purpose:
+    This test will check your Thunderbolt 3 port as a monitor interconnect.
+_steps:
+    1. Connect a display (if not already connected) to the Thunderbolt 3 port on
+       your system
+    2. Switch display modes between in your Display Settings, check if it can be
+       set to mirrored, extended, displayed on external or onboard only
+_verification:
+    Was the desktop displayed correctly on the Thunderbolt-connected
+    screen in every mode?
+
 unit: template
 template-resource: graphics_card
 id: monitor/{index}_type-c_displayport_{product_slug}
@@ -273,6 +329,27 @@ _steps:
        set to mirrored, extended, displayed on external or onboard only.
 _verification:
     Was the desktop displayed correctly with {vendor} {product} on the screen
+    connected using a "USB Type-C to DisplayPort" adapter in every mode?
+
+id: monitor/type-c_displayport
+template-filter: graphics_card.prime_gpu_offload == 'Off'
+imports: from com.canonical.plainbox import manifest
+requires:
+  manifest.has_usbc_video == 'True'
+flags: also-after-suspend
+estimated_duration: 15.0
+plugin: manual
+category_id: com.canonical.plainbox::monitor
+_summary: Display connected via DisplayPort using a USB Type-C port
+_purpose:
+    This test will check the connection of a screen using a "USB Type-C to DisplayPort" adapter.
+_steps:
+    1. Connect a display (if not already connected) to the USB Type-C port on
+       your system using a "USB Type-C to DisplayPort" adapter.
+    2. Switch display modes within your Display Settings, check if it can be
+       set to mirrored, extended, displayed on external or onboard only.
+_verification:
+    Was the desktop displayed correctly on the screen
     connected using a "USB Type-C to DisplayPort" adapter in every mode?
 
 unit: template
@@ -299,6 +376,27 @@ _verification:
     Was the desktop displayed correctly with {vendor} {product} on the screen
     connected using a "USB Type-C to HDMI" adapter in every mode?
 
+id: monitor/type-c_hdmi
+template-filter: graphics_card.prime_gpu_offload == 'Off'
+imports: from com.canonical.plainbox import manifest
+requires:
+  manifest.has_usbc_video == 'True'
+flags: also-after-suspend
+estimated_duration: 15.0
+plugin: manual
+category_id: com.canonical.plainbox::monitor
+_summary: Display connection via HDMI using a USB Type-C port
+_purpose:
+    This test will check the connection of a display using a "USB Type-C to HDMI" adapter.
+_steps:
+    1. Connect a display (if not already connected) to the USB Type-C port on
+       your system using a "USB Type-C to HDMI" adapter.
+    2. Switch display modes in your Display Settings, check if it can be
+       set to mirrored, extended, displayed on external or onboard only.
+_verification:
+    Was the desktop displayed correctly on the screen
+    connected using a "USB Type-C to HDMI" adapter in every mode?
+
 unit: template
 template-resource: graphics_card
 id: monitor/{index}_type-c_vga_{product_slug}
@@ -321,6 +419,27 @@ _steps:
        set to mirrored, extended, displayed on external or onboard only
 _verification:
     Was the desktop displayed correctly with {vendor} {product} on the screen
+    connected using a "USB Type-C to VGA" adapter in every mode?
+
+id: monitor/type-c_vga
+template-filter: graphics_card.prime_gpu_offload == 'Off'
+imports: from com.canonical.plainbox import manifest
+requires:
+  manifest.has_usbc_video == 'True'
+flags: also-after-suspend
+estimated_duration: 15.0
+plugin: manual
+category_id: com.canonical.plainbox::monitor
+_summary: Display connected via VGA using an USB Type-C port
+_purpose:
+    This test will check the connection of a screen using a "USB Type-C to VGA" adapter.
+_steps:
+    1. Connect a display (if not already connected) to the USB Type-C port on
+       your system using a "USB Type-C to VGA" adapter
+    2. Switch display modes between in your Display Settings, check if it can be
+       set to mirrored, extended, displayed on external or onboard only
+_verification:
+    Was the desktop displayed correctly on the screen
     connected using a "USB Type-C to VGA" adapter in every mode?
 
 id: monitor/type-c-to-hdmi
@@ -363,53 +482,60 @@ _verification:
     Was the desktop displayed correctly with on the screen connected using a
     "USB Type-C to VGA" adapter in every mode?
 
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.prime_gpu_offload == 'Off'
 id: monitor/dvi
-_summary: Monitor works (DVI)
-_purpose:
- Check output to display through DVI port
-_steps:
- 1. Connect display to DVI port
- 2. Check the display
-_verification:
- Output to display works
-plugin: manual
-category_id: com.canonical.plainbox::monitor
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_dvi == 'True'
-estimated_duration: 300
 flags: also-after-suspend
+plugin: manual
+category_id: com.canonical.plainbox::monitor
+_purpose:
+    This test will check your DVI port as a monitor interconnect.
+_steps:
+    1. Connect a display (if not already connected) to the DVI port on your system.
+    2. Switch display modes within your Display Settings, check if it can be
+       set to mirrored, extended, display-only on external or onboard only.
+_verification:
+    Was the desktop displayed correctly on the DVI-connected
+    screen in every mode?
+_summary: Check DVI port functionality by connecting a display and verifying different display modes.
 
 id: monitor/hdmi
-_summary: Monitor works (HDMI)
-_purpose:
- Check output to display through HDMI port
-_steps:
- 1. Connect display to HDMI port
- 2. Check the display
-_verification:
- Output to display works
-plugin: manual
-category_id: com.canonical.plainbox::monitor
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_hdmi == 'True'
-estimated_duration: 300
 flags: also-after-suspend
-
-id: monitor/displayport
-_summary: Monitor works (DisplayPort)
-_purpose:
- Check output to display through DisplayPort
-_steps:
- 1. Connect display to DisplayPort
- 2. Check the display
-_verification:
- Output to display works
 plugin: manual
 category_id: com.canonical.plainbox::monitor
+_purpose:
+    This test will check your HDMI port as a monitor interconnect.
+_steps:
+    1. Connect a display (if not already connected) to the HDMI port on your system.
+    2. Switch display modes within your Display Settings, check if it can be
+    set to mirrored, extended, displayed on external or onboard only.
+_verification:
+    Was the desktop displayed correctly on the HDMI-connected
+    screen in every mode?
+_summary: Check HDMI port functionality as a monitor interconnect.
+
+id: monitor/displayport
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_dp == 'True'
-estimated_duration: 300
 flags: also-after-suspend
+plugin: manual
+category_id: com.canonical.plainbox::monitor
+_purpose:
+     This test will check your DisplayPort port as a monitor interconnect.
+_steps:
+     1. Connect a display (if not already connected) to the DisplayPort port on your system.
+     2. Switch display modes in your Display Settings; check if it can be
+     set to mirrored, extended, displayed on external or onboard only.
+_verification:
+    Was the desktop displayed correctly on the DisplayPort-connected
+    screen in every mode?
+_summary:
+    Test the DisplayPort port functionality with mirrored, extended, external, or onboard display modes.
 
 id: monitor/dvi-to-vga
 _summary: Monitor works (DVI-to-VGA)

--- a/providers/base/units/monitor/jobs.pxu
+++ b/providers/base/units/monitor/jobs.pxu
@@ -329,7 +329,6 @@ _verification:
     connected using a "USB Type-C to DisplayPort" adapter in every mode?
 
 id: monitor/type-c_displayport
-template-filter: graphics_card.prime_gpu_offload == 'Off'
 imports: from com.canonical.plainbox import manifest
 requires:
   manifest.has_usbc_video == 'True'
@@ -374,7 +373,6 @@ _verification:
     connected using a "USB Type-C to HDMI" adapter in every mode?
 
 id: monitor/type-c_hdmi
-template-filter: graphics_card.prime_gpu_offload == 'Off'
 imports: from com.canonical.plainbox import manifest
 requires:
   manifest.has_usbc_video == 'True'
@@ -419,7 +417,6 @@ _verification:
     connected using a "USB Type-C to VGA" adapter in every mode?
 
 id: monitor/type-c_vga
-template-filter: graphics_card.prime_gpu_offload == 'Off'
 imports: from com.canonical.plainbox import manifest
 requires:
   manifest.has_usbc_video == 'True'

--- a/providers/base/units/monitor/jobs.pxu
+++ b/providers/base/units/monitor/jobs.pxu
@@ -182,9 +182,6 @@ _steps:
 _verification:
     Did the monitor go blank and turn on again after a few seconds?
 
-unit: template
-template-resource: graphics_card
-template-filter: graphics_card.prime_gpu_offload == 'Off'
 flags: also-after-suspend
 id: monitor/powersaving
 plugin: user-interact-verify
@@ -482,9 +479,6 @@ _verification:
     Was the desktop displayed correctly with on the screen connected using a
     "USB Type-C to VGA" adapter in every mode?
 
-unit: template
-template-resource: graphics_card
-template-filter: graphics_card.prime_gpu_offload == 'Off'
 id: monitor/dvi
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_dvi == 'True'

--- a/providers/base/units/monitor/test-plan.pxu
+++ b/providers/base/units/monitor/test-plan.pxu
@@ -45,6 +45,32 @@ include:
 bootstrap_include:
     graphics_card
 
+id: monitor-gpu-cert-26-04-manual
+unit: test plan
+_name: Monitor tests for 26.04 (GPU) (Manual)
+_description:
+ Monitor tests (GPU) (Manual)
+include:
+ monitor/powersaving                        certification-status=blocker
+ power-management/light_sensor              certification-status=blocker
+ monitor/dim_brightness                     certification-status=blocker
+ monitor/displayport                        certification-status=blocker
+ audio/playback_displayport                 certification-status=blocker
+ monitor/type-c_displayport                 certification-status=blocker
+ audio/playback_type-c_displayport          certification-status=blocker
+ monitor/type-c_hdmi                        certification-status=blocker
+ audio/playback_type-c_hdmi                 certification-status=blocker
+ monitor/type-c_vga                         certification-status=blocker
+ monitor/dvi                                certification-status=blocker
+ monitor/hdmi                               certification-status=blocker
+ audio/playback_hdmi                        certification-status=blocker
+ monitor/thunderbolt3                       certification-status=blocker
+ audio/playback_thunderbolt3                certification-status=blocker
+ thunderbolt3/daisy-chain                   certification-status=blocker
+ monitor/multi-head                         certification-status=blocker
+bootstrap_include:
+    graphics_card
+
 id: after-suspend-monitor-gpu-cert-full
 unit: test plan
 _name: Monitor tests (after suspend, GPU)
@@ -85,6 +111,32 @@ include:
  after-suspend-monitor/1_thunderbolt3_.*                  certification-status=non-blocker
  after-suspend-audio/1_playback_thunderbolt3_.*           certification-status=non-blocker
  after-suspend-thunderbolt3/daisy-chain                   certification-status=non-blocker
+ after-suspend-monitor/multi-head                         certification-status=blocker
+bootstrap_include:
+    graphics_card
+
+id: after-suspend-monitor-gpu-cert-26-04-manual
+unit: test plan
+_name: Monitor tests for 26.04 (after suspend, GPU) (Manual)
+_description:
+ Monitor tests (after suspend, GPU) (Manual)
+include:
+ after-suspend-monitor/powersaving                        certification-status=blocker
+ after-suspend-power-management/light_sensor              certification-status=blocker
+ after-suspend-monitor/dim_brightness                     certification-status=blocker
+ after-suspend-monitor/displayport                        certification-status=blocker
+ after-suspend-audio/playback_displayport                 certification-status=blocker
+ after-suspend-monitor/type-c_displayport                 certification-status=blocker
+ after-suspend-audio/playback_type-c_displayport          certification-status=blocker
+ after-suspend-monitor/type-c_hdmi                        certification-status=blocker
+ after-suspend-audio/playback_type-c_hdmi                 certification-status=blocker
+ after-suspend-monitor/type-c_vga                         certification-status=blocker
+ after-suspend-monitor/dvi                                certification-status=blocker
+ after-suspend-monitor/hdmi                               certification-status=blocker
+ after-suspend-audio/playback_hdmi                        certification-status=blocker
+ after-suspend-monitor/thunderbolt3                       certification-status=blocker
+ after-suspend-audio/playback_thunderbolt3                certification-status=blocker
+ after-suspend-thunderbolt3/daisy-chain                   certification-status=blocker
  after-suspend-monitor/multi-head                         certification-status=blocker
 bootstrap_include:
     graphics_card
@@ -394,22 +446,9 @@ _description: Manual tests for monitor
 include:
 nested_part:
     submission-cert-full
-    monitor-gpu-cert-manual
-    after-suspend-monitor-gpu-cert-manual
+    monitor-gpu-cert-26-04-manual
+    after-suspend-monitor-gpu-cert-26-04-manual
     info-attachment-cert-full
-certification_status_overrides:
-    apply blocker to com.canonical.certification::power-management/light_sensor
-    apply blocker to com.canonical.certification::monitor/1_thunderbolt3_.*
-    apply blocker to com.canonical.certification::audio/1_playback_thunderbolt3_.*
-    apply blocker to com.canonical.certification::monitor/2_thunderbolt3_.*
-    apply blocker to com.canonical.certification::audio/2_playback_thunderbolt3_.*
-    apply blocker to com.canonical.certification::thunderbolt3/daisy-chain
-    apply blocker to com.canonical.certification::after-suspend-power-management/light_sensor
-    apply blocker to com.canonical.certification::after-suspend-monitor/1_thunderbolt3_.*
-    apply blocker to com.canonical.certification::after-suspend-audio/1_playback_thunderbolt3_.*
-    apply blocker to com.canonical.certification::after-suspend-monitor/2_thunderbolt3_.*
-    apply blocker to com.canonical.certification::after-suspend-audio/2_playback_thunderbolt3_.*
-    apply blocker to com.canonical.certification::after-suspend-thunderbolt3/daisy-chain
 
 id: monitor-base-26-04-automated
 unit: test plan

--- a/providers/base/units/suspend/suspend-graphics.pxu
+++ b/providers/base/units/suspend/suspend-graphics.pxu
@@ -127,6 +127,14 @@ command: [ -f "$PLAINBOX_SESSION_SHARE"/{index}_xrandr_screens_after_suspend.tgz
 _purpose: This attaches screenshots from the suspend/cycle_resolutions_after_suspend test to the results submission.
 _summary: Attach screenshots from suspend/cycle resolutions after suspend test to results.
 
+plugin: attachment
+category_id: com.canonical.plainbox::suspend
+id: suspend/xrandr_screens_after_suspend_primary
+depends: after-suspend-graphics/cycle_resolution_primary
+command: [ -f "$PLAINBOX_SESSION_SHARE"/primary_xrandr_screens_after_suspend.tgz ] && cat "$PLAINBOX_SESSION_SHARE"/primary_xrandr_screens_after_suspend.tgz
+_purpose: This attaches screenshots from the suspend/cycle_resolutions_after_suspend test to the results submission.
+_summary: Attach screenshots from suspend/cycle resolutions after suspend test to results.
+
 unit: template
 template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'

--- a/providers/base/units/suspend/suspend-graphics.pxu
+++ b/providers/base/units/suspend/suspend-graphics.pxu
@@ -122,7 +122,7 @@ plugin: attachment
 category_id: com.canonical.plainbox::suspend
 id: suspend/{index}_xrandr_screens_after_suspend.tar.gz_auto
 template-id: suspend/index_xrandr_screens_after_suspend.tar.gz_auto
-depends: after-suspend-graphics/cycle_resolution_primary | after-suspend-graphics/{index}_cycle_resolution_{product_slug}
+depends: after-suspend-graphics/{index}_cycle_resolution_{product_slug}
 command: [ -f "$PLAINBOX_SESSION_SHARE"/{index}_xrandr_screens_after_suspend.tgz ] && cat "$PLAINBOX_SESSION_SHARE"/{index}_xrandr_screens_after_suspend.tgz
 _purpose: This attaches screenshots from the suspend/cycle_resolutions_after_suspend test to the results submission.
 _summary: Attach screenshots from suspend/cycle resolutions after suspend test to results.

--- a/providers/base/units/suspend/suspend-graphics.pxu
+++ b/providers/base/units/suspend/suspend-graphics.pxu
@@ -130,7 +130,7 @@ _summary: Attach screenshots from suspend/cycle resolutions after suspend test t
 plugin: attachment
 category_id: com.canonical.plainbox::suspend
 id: suspend/xrandr_screens_after_suspend_primary
-depends: after-suspend-graphics/cycle_resolution_primary
+depends: com.canonical.certification::after-suspend-graphics/cycle_resolution_primary
 command: [ -f "$PLAINBOX_SESSION_SHARE"/primary_xrandr_screens_after_suspend.tgz ] && cat "$PLAINBOX_SESSION_SHARE"/primary_xrandr_screens_after_suspend.tgz
 _purpose: This attaches screenshots from the suspend/cycle_resolutions_after_suspend test to the results submission.
 _summary: Attach screenshots from suspend/cycle resolutions after suspend test to results.

--- a/providers/base/units/suspend/suspend-graphics.pxu
+++ b/providers/base/units/suspend/suspend-graphics.pxu
@@ -122,7 +122,7 @@ plugin: attachment
 category_id: com.canonical.plainbox::suspend
 id: suspend/{index}_xrandr_screens_after_suspend.tar.gz_auto
 template-id: suspend/index_xrandr_screens_after_suspend.tar.gz_auto
-depends: after-suspend-graphics/{index}_cycle_resolution_{product_slug}
+depends: after-suspend-graphics/cycle_resolution_primary | after-suspend-graphics/{index}_cycle_resolution_{product_slug}
 command: [ -f "$PLAINBOX_SESSION_SHARE"/{index}_xrandr_screens_after_suspend.tgz ] && cat "$PLAINBOX_SESSION_SHARE"/{index}_xrandr_screens_after_suspend.tgz
 _purpose: This attaches screenshots from the suspend/cycle_resolutions_after_suspend test to the results submission.
 _summary: Attach screenshots from suspend/cycle resolutions after suspend test to results.

--- a/providers/base/units/suspend/suspend-graphics.pxu
+++ b/providers/base/units/suspend/suspend-graphics.pxu
@@ -130,7 +130,7 @@ _summary: Attach screenshots from suspend/cycle resolutions after suspend test t
 plugin: attachment
 category_id: com.canonical.plainbox::suspend
 id: suspend/xrandr_screens_after_suspend_primary
-depends: com.canonical.certification::after-suspend-graphics/cycle_resolution_primary
+depends: graphics/cycle_resolution_primary
 command: [ -f "$PLAINBOX_SESSION_SHARE"/primary_xrandr_screens_after_suspend.tgz ] && cat "$PLAINBOX_SESSION_SHARE"/primary_xrandr_screens_after_suspend.tgz
 _purpose: This attaches screenshots from the suspend/cycle_resolutions_after_suspend test to the results submission.
 _summary: Attach screenshots from suspend/cycle resolutions after suspend test to results.


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
This PR cleans up the graphics, monitor, and audio test structures to support flat, clean names for the Ubuntu 26.04 lifecycle, while purposefully leaving specific templates unmapped by a template-id to support legacy test plans that explicitly require tracking unique hardware indexing.

Changes Made

Converted Standalone Tests: Changed tests like monitor/dim_brightness from templates to standard unit: job blocks since they do not rely on template brackets ({index} or {product_slug}), preventing unnecessary resource loops.

Added Flat Companion Jobs: Introduced distinct, static companion jobs (e.g., graphics/gl_support_primary) to provide clean, flat targets for the 26.04 suite without wildcards.
## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
Graphic_Base_Auto_Full: https://certification.canonical.com/hardware/202512-38234/submission/489839/
Graphic_Base_Manual_Full:https://certification.canonical.com/hardware/202512-38234/submission/489852/

05/28
https://certification.canonical.com/hardware/202512-38234/submission/490197/

https://certification.canonical.com/hardware/202512-38234/submission/490284/