### PR TITLE
Fix clocktest false failure on high CPU count systems (bugfix)

### DIFF
--- a/providers/base/src/clocktest.c
+++ b/providers/base/src/clocktest.c
@@ -24,7 +24,9 @@
 int test_clock_jitter(){
     cpu_set_t cpumask;
     struct timespec *time;
-    unsigned long nsec;
+    struct timespec t_before, t_after;
+    unsigned long loop_nsec, expected_nsec;
+    long adjusted, min_adjusted, max_adjusted;
     unsigned slow_cpu, fast_cpu;
     double jitter;
     double largest_jitter = 0.0;
@@ -50,6 +52,7 @@ int test_clock_jitter(){
     }
 
     for (iter=0; iter<ITERATIONS; iter++){
+        clock_gettime(CLOCK_REALTIME, &t_before);
         for (cpu=0; cpu < num_cpus; cpu++) {
             CPU_ZERO(&cpumask); CPU_SET(cpu,&cpumask);
             if (setaffinity(cpumask) < 0){
@@ -68,15 +71,24 @@ int test_clock_jitter(){
                 return 1;
             }
         }
+        clock_gettime(CLOCK_REALTIME, &t_after);
 
+         /* 
+          * Adjust for the time it takes to actually run the loop. On 
+          * high-core systems, the loop overhead itself creates enough 
+          * lag to look like clock skew, leading to false positives
+          */
+        loop_nsec = NSEC(t_after) - NSEC(t_before);
         slow_cpu = fast_cpu = 0;
+        min_adjusted = max_adjusted = (long)(NSEC(time[0]) - NSEC(t_before));
         for (cpu=0; cpu < num_cpus; cpu++) {
-            nsec = NSEC(time[cpu]);
-            if (nsec < NSEC(time[slow_cpu])) { slow_cpu = cpu; }
-            if (nsec > NSEC(time[fast_cpu])) { fast_cpu = cpu; }
+            expected_nsec = NSEC(t_before) +
+                (unsigned long)((double)cpu / (num_cpus - 1) * loop_nsec);
+            adjusted = (long)(NSEC(time[cpu]) - expected_nsec);
+            if (adjusted < min_adjusted) { min_adjusted = adjusted; slow_cpu = cpu; }
+            if (adjusted > max_adjusted) { max_adjusted = adjusted; fast_cpu = cpu; }
         }
-        jitter = ((double)(NSEC(time[fast_cpu]) - NSEC(time[slow_cpu]))
-                  / (double)NSEC_PER_SEC);
+        jitter = (double)(max_adjusted - min_adjusted) / (double)NSEC_PER_SEC;
 
 #ifdef DEBUG
         printf("DEBUG: max jitter for pass %u was %f (cpu %u,%u)\n",


### PR DESCRIPTION
On systems with many cores (e.g., 688), the cumulative time spent switching affinity and yielding exceeds MAX_JITTER (0.2s). This causes the test to misidentify loop overhead as clock skew.

This patch brackets the sampling loop and normalizes each CPU's timestamp against its relative position in the sequence. This isolates actual hardware jitter from the predictable delay of the measurement loop itself.

<!--
Example Title: Fixed bugged behavior of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This patch brackets the sampling loop and normalizes each CPU's timestamp against its relative position in the sequence. This isolates actual hardware jitter from the predictable delay of the measurement loop itself.
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
https://bugs.launchpad.net/hp/+bug/2143999
This issue was seen on 26.04 and also on 24.04 but only on systems with high core counts.
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
