### PR TITLE
Filter unopenable DEVPATH-derived disk resources (BugFix)

### DIFF
--- a/checkbox-ng/checkbox_ng/support/parsers/tests/test_udevadm.py
+++ b/checkbox-ng/checkbox_ng/support/parsers/tests/test_udevadm.py
@@ -18,6 +18,7 @@ import json
 
 from io import StringIO
 from unittest import TestCase
+from unittest.mock import patch
 from textwrap import dedent
 
 try:
@@ -113,81 +114,85 @@ class TestUdevadmParser(TestCase, UdevadmDataMixIn):
 
     def test_nvme_name_detection_without_devname(self):
         """Test NVMe device name extraction from DEVPATH when DEVNAME is missing."""
+        with patch(
+            "checkbox_ng.support.parsers.udevadm.has_dev_block_node",
+            return_value=True,
+        ):
 
-        # Test case 1: Virtual NVMe device (nvmeXcYnZ pattern)
-        stream = StringIO(dedent("""
-                P: /devices/virtual/nvme-subsystem/nvme-subsys0/nvme0c0n1
-                E: DEVPATH=/devices/virtual/nvme-subsystem/nvme-subsys0/nvme0c0n1
-                E: DEVTYPE=disk
-                E: DRIVER=nvme
-                E: SUBSYSTEM=nvme
-                E: ID_SERIAL=test-serial
-                """))
-        parser = UdevadmParser(stream)
-        devices = parser.run()
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(devices[0].name, "nvme0c0n1")
-        self.assertEqual(devices[0].category, "DISK")
+            # Test case 1: Virtual NVMe device (nvmeXcYnZ pattern)
+            stream = StringIO(dedent("""
+                    P: /devices/virtual/nvme-subsystem/nvme-subsys0/nvme0c0n1
+                    E: DEVPATH=/devices/virtual/nvme-subsystem/nvme-subsys0/nvme0c0n1
+                    E: DEVTYPE=disk
+                    E: DRIVER=nvme
+                    E: SUBSYSTEM=nvme
+                    E: ID_SERIAL=test-serial
+                    """))
+            parser = UdevadmParser(stream)
+            devices = parser.run()
+            self.assertEqual(len(devices), 1)
+            self.assertEqual(devices[0].name, "nvme0c0n1")
+            self.assertEqual(devices[0].category, "DISK")
 
-        # Test case 2: Standard namespace device (nvmeXnY pattern)
-        stream = StringIO(dedent("""
-                P: /devices/pci0000:00/0000:00:1d.0/nvme/nvme0/nvme0n1
-                E: DEVPATH=/devices/pci0000:00/0000:00:1d.0/nvme/nvme0/nvme0n1
-                E: DEVTYPE=disk
-                E: DRIVER=nvme
-                E: SUBSYSTEM=nvme
-                E: ID_SERIAL=test-serial
-                """))
-        parser = UdevadmParser(stream)
-        devices = parser.run()
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(devices[0].name, "nvme0n1")
-        self.assertEqual(devices[0].category, "DISK")
+            # Test case 2: Standard namespace device (nvmeXnY pattern)
+            stream = StringIO(dedent("""
+                    P: /devices/pci0000:00/0000:00:1d.0/nvme/nvme0/nvme0n1
+                    E: DEVPATH=/devices/pci0000:00/0000:00:1d.0/nvme/nvme0/nvme0n1
+                    E: DEVTYPE=disk
+                    E: DRIVER=nvme
+                    E: SUBSYSTEM=nvme
+                    E: ID_SERIAL=test-serial
+                    """))
+            parser = UdevadmParser(stream)
+            devices = parser.run()
+            self.assertEqual(len(devices), 1)
+            self.assertEqual(devices[0].name, "nvme0n1")
+            self.assertEqual(devices[0].category, "DISK")
 
-        # Test case 3: Controller device (nvmeX pattern - should fallback to nvmeXn1)
-        stream = StringIO(dedent("""
-                P: /devices/pci0000:00/0000:00:1d.0/nvme/nvme0
-                E: DEVPATH=/devices/pci0000:00/0000:00:1d.0/nvme/nvme0
-                E: DEVTYPE=disk
-                E: DRIVER=nvme
-                E: SUBSYSTEM=nvme
-                E: ID_SERIAL=test-serial
-                """))
-        parser = UdevadmParser(stream)
-        devices = parser.run()
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(devices[0].name, "nvme0n1")
-        self.assertEqual(devices[0].category, "DISK")
+            # Test case 3: Controller device (nvmeX pattern -> nvmeXn1)
+            stream = StringIO(dedent("""
+                    P: /devices/pci0000:00/0000:00:1d.0/nvme/nvme0
+                    E: DEVPATH=/devices/pci0000:00/0000:00:1d.0/nvme/nvme0
+                    E: DEVTYPE=disk
+                    E: DRIVER=nvme
+                    E: SUBSYSTEM=nvme
+                    E: ID_SERIAL=test-serial
+                    """))
+            parser = UdevadmParser(stream)
+            devices = parser.run()
+            self.assertEqual(len(devices), 1)
+            self.assertEqual(devices[0].name, "nvme0n1")
+            self.assertEqual(devices[0].category, "DISK")
 
-        # Test case 4: Multiple digit numbers (nvme10c5n2)
-        stream = StringIO(dedent("""
-                P: /devices/virtual/nvme-subsystem/nvme-subsys10/nvme10c5n2
-                E: DEVPATH=/devices/virtual/nvme-subsystem/nvme-subsys10/nvme10c5n2
-                E: DEVTYPE=disk
-                E: DRIVER=nvme
-                E: SUBSYSTEM=nvme
-                E: ID_SERIAL=test-serial
-                """))
-        parser = UdevadmParser(stream)
-        devices = parser.run()
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(devices[0].name, "nvme10c5n2")
-        self.assertEqual(devices[0].category, "DISK")
+            # Test case 4: Multiple digit numbers (nvme10c5n2)
+            stream = StringIO(dedent("""
+                    P: /devices/virtual/nvme-subsystem/nvme-subsys10/nvme10c5n2
+                    E: DEVPATH=/devices/virtual/nvme-subsystem/nvme-subsys10/nvme10c5n2
+                    E: DEVTYPE=disk
+                    E: DRIVER=nvme
+                    E: SUBSYSTEM=nvme
+                    E: ID_SERIAL=test-serial
+                    """))
+            parser = UdevadmParser(stream)
+            devices = parser.run()
+            self.assertEqual(len(devices), 1)
+            self.assertEqual(devices[0].name, "nvme10c5n2")
+            self.assertEqual(devices[0].category, "DISK")
 
-        # Test case 5: Controller device with multi-digit number (nvme15 -> nvme15n1)
-        stream = StringIO(dedent("""
-                P: /devices/pci0000:00/0000:00:1d.0/nvme/nvme15
-                E: DEVPATH=/devices/pci0000:00/0000:00:1d.0/nvme/nvme15
-                E: DEVTYPE=disk
-                E: DRIVER=nvme
-                E: SUBSYSTEM=nvme
-                E: ID_SERIAL=test-serial
-                """))
-        parser = UdevadmParser(stream)
-        devices = parser.run()
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(devices[0].name, "nvme15n1")
-        self.assertEqual(devices[0].category, "DISK")
+            # Test case 5: Controller device with multi-digit number
+            stream = StringIO(dedent("""
+                    P: /devices/pci0000:00/0000:00:1d.0/nvme/nvme15
+                    E: DEVPATH=/devices/pci0000:00/0000:00:1d.0/nvme/nvme15
+                    E: DEVTYPE=disk
+                    E: DRIVER=nvme
+                    E: SUBSYSTEM=nvme
+                    E: ID_SERIAL=test-serial
+                    """))
+            parser = UdevadmParser(stream)
+            devices = parser.run()
+            self.assertEqual(len(devices), 1)
+            self.assertEqual(devices[0].name, "nvme15n1")
+            self.assertEqual(devices[0].category, "DISK")
 
         # Test case 6: NVMe device WITH DEVNAME should use DEVNAME
         stream = StringIO(dedent("""
@@ -205,6 +210,24 @@ class TestUdevadmParser(TestCase, UdevadmDataMixIn):
         self.assertEqual(len(devices), 1)
         self.assertEqual(devices[0].name, "nvme1n1")
         self.assertEqual(devices[0].category, "DISK")
+
+    def test_nvme_disk_without_devname_is_pruned_without_block_node(self):
+        """Test NVMe path objects are pruned when no block node exists."""
+
+        stream = StringIO(dedent("""
+                P: /devices/virtual/nvme-subsystem/nvme-subsys0/nvme0c0n1
+                E: DEVPATH=/devices/virtual/nvme-subsystem/nvme-subsys0/nvme0c0n1
+                E: DEVTYPE=disk
+                E: DRIVER=nvme
+                E: SUBSYSTEM=nvme
+                E: ID_SERIAL=test-serial
+                """))
+        with patch(
+            "checkbox_ng.support.parsers.udevadm.has_dev_block_node",
+            return_value=False,
+        ):
+            parser = UdevadmParser(stream)
+            self.assertEqual(parser.run(), [])
 
     def test_openfirmware_network(self):
         stream = StringIO(dedent("""
@@ -1170,62 +1193,34 @@ class TestUdevadmParser(TestCase, UdevadmDataMixIn):
         This test verifies that the NVMe name detection correctly handles
         both standard nvmeXnY pattern and virtual nvmeXcYnZ pattern.
         """
-        devices = self.parse("DISK_SAMSUNG_KIOXIA")
-        # Count total NVMe disks (2 standard + 8 virtual = 10)
-        nvme_disks = [
-            d
-            for d in devices
-            if d.category == "DISK" and d.name and d.name.startswith("nvme")
-        ]
-        self.assertEqual(
-            len(nvme_disks),
-            10,
-            "Expected 10 NVMe disks, found {}".format(len(nvme_disks)),
-        )
-
-        # Verify standard NVMe disk names are correctly detected
-        standard_nvme_names = [d.name for d in nvme_disks if "c" not in d.name]
-        self.assertIn(
+        expected_names = {
             "nvme0n1",
-            standard_nvme_names,
-            "Standard Samsung disk nvme0n1 should be detected",
-        )
-        self.assertIn(
             "nvme1n1",
-            standard_nvme_names,
-            "Standard Samsung disk nvme1n1 should be detected",
-        )
-
-        # Verify virtual NVMe disk names are correctly detected with controller notation
-        virtual_nvme_names = [d.name for d in nvme_disks if "c" in d.name]
-        expected_virtual_names = [
-            "nvme2c2n1",
-            "nvme3c3n1",
-            "nvme4c4n1",
-            "nvme5c5n1",
-            "nvme6c6n1",
-            "nvme7c7n1",
-            "nvme8c8n1",
-            "nvme9c9n1",
-        ]
-        for expected_name in expected_virtual_names:
-            self.assertIn(
-                expected_name,
-                virtual_nvme_names,
-                "Virtual Kioxia disk {} should be detected".format(
-                    expected_name
-                ),
+            "nvme2n1",
+            "nvme3n1",
+            "nvme4n1",
+            "nvme5n1",
+            "nvme6n1",
+            "nvme7n1",
+            "nvme8n1",
+            "nvme9n1",
+        }
+        with patch(
+            "checkbox_ng.support.parsers.udevadm.has_dev_block_node"
+        ) as mock_has_dev_block_node:
+            mock_has_dev_block_node.side_effect = (
+                lambda name: name in expected_names
             )
-
-        # Verify we have exactly 2 standard and 8 virtual NVMe disks
-        self.assertEqual(
-            len(standard_nvme_names), 2, "Should have 2 standard NVMe disks"
-        )
-        self.assertEqual(
-            len(virtual_nvme_names),
-            8,
-            "Should have 8 virtual NVMe disks with controller notation",
-        )
+            devices = self.parse("DISK_SAMSUNG_KIOXIA")
+            nvme_disks = [
+                d
+                for d in devices
+                if d.category == "DISK"
+                and d.name
+                and d.name.startswith("nvme")
+            ]
+            self.assertEqual(len(nvme_disks), 10)
+            self.assertEqual({d.name for d in nvme_disks}, expected_names)
 
     def test_SHUTTLE_DH170_WITH_USB_DISK(self):
         """DH170 with USB stick comparing pre and post reboot."""

--- a/checkbox-ng/checkbox_ng/support/parsers/tests/test_udevadm.py
+++ b/checkbox-ng/checkbox_ng/support/parsers/tests/test_udevadm.py
@@ -15,6 +15,7 @@
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
+import stat
 
 from io import StringIO
 from unittest import TestCase
@@ -34,6 +35,7 @@ from checkbox_ng.support.parsers.udevadm import (
     UdevadmParser,
     decode_id,
     find_pkname_is_root_mountpoint,
+    has_dev_block_node,
     is_readonly_partition,
     is_small_partition,
 )
@@ -83,6 +85,24 @@ class TestUdevadmParser(TestCase, UdevadmDataMixIn):
 
     def count(self, devices, category):
         return len([d for d in devices if d.category == category])
+
+    def test_has_dev_block_node(self):
+        class StatResult(object):
+            st_mode = stat.S_IFBLK
+
+        stat_result = StatResult()
+        with patch(
+            "checkbox_ng.support.parsers.udevadm.os.stat",
+            return_value=stat_result,
+        ):
+            self.assertTrue(has_dev_block_node("nvme0n1"))
+
+    def test_has_dev_block_node_returns_false_on_oserror(self):
+        with patch(
+            "checkbox_ng.support.parsers.udevadm.os.stat",
+            side_effect=OSError,
+        ):
+            self.assertFalse(has_dev_block_node("nvme0n1"))
 
     def test_mi300x_video(self):
         """Tests that AMD's MI300X accelerator is marked as a video device."""

--- a/checkbox-ng/checkbox_ng/support/parsers/udevadm.py
+++ b/checkbox-ng/checkbox_ng/support/parsers/udevadm.py
@@ -1384,6 +1384,15 @@ class UdevadmParser(object):
         # as disks (categorization is done elsewhere). Note that the *parent*
         # device will have no category, though it's not ignored per se.
         if device.bus in ("pci", "nvme") and device.driver == "nvme":
+            # Some platforms expose NVMe path objects as DISK devices without
+            # DEVNAME. Keep them only if the derived name resolves to an
+            # actual block device node.
+            if (
+                device.category == "DISK"
+                and "DEVNAME" not in device._environment
+                and device.name is None
+            ):
+                return True
             return False
         # Do not ignore eMMC drives (pad.lv/1522768)
         if (

--- a/checkbox-ng/checkbox_ng/support/parsers/udevadm.py
+++ b/checkbox-ng/checkbox_ng/support/parsers/udevadm.py
@@ -27,6 +27,7 @@ from subprocess import check_output, CalledProcessError
 import os
 import re
 import string
+import stat
 
 from checkbox_ng.support.helpers.slugify import slugify
 from checkbox_ng.support.lib.bit import get_bitmask
@@ -138,6 +139,14 @@ def is_small_partition(devname, lsblk=None):
     return False
 
 
+def has_dev_block_node(name):
+    """Return True if name resolves to a user-visible block-device node"""
+    try:
+        return stat.S_ISBLK(os.stat(os.path.join("/dev", name)).st_mode)
+    except (TypeError, OSError):
+        return False
+
+
 class UdevadmDevice(object):
     __slots__ = (
         "_environment",
@@ -213,20 +222,28 @@ class UdevadmDevice(object):
             and "DEVNAME" not in self._environment
         ):
             # Use DEVPATH
+            candidates = []
             devpath = self._environment.get("DEVPATH", "")
+
             # First try to match nvmeXcYnZ (virtual NVMe device)
             match = re.search(r"/(nvme\d+c\d+n\d+)(?:/|$)", devpath)
             if match:
-                return match.group(1)
+                candidates.append(match.group(1))
+
             # Then try to match nvmeXnY (standard namespace device)
             match = re.search(r"/(nvme\d+n\d+)(?:/|$)", devpath)
             if match:
-                return match.group(1)
+                candidates.append(match.group(1))
+
             # Fallback: match nvmeX (controller) and append n1
             match = re.search(r"/nvme/nvme(\d+)(?:/|$)", devpath)
             if match:
                 nvme_num = match.group(1)
-                return "nvme{}n1".format(nvme_num)
+                candidates.append("nvme{}n1".format(nvme_num))
+
+            for candidate in candidates:
+                if has_dev_block_node(candidate):
+                    return candidate
         return None
 
     @property


### PR DESCRIPTION
## Description

See https://github.com/canonical/checkbox/issues/2542 for more information.

This change prevents Checkbox from emitting `DEVPATH`-derived NVMe path objects as normal `device.category == DISK` resources unless the derived name resolves to a real `/dev` block-device node.

## Resolved issues

https://github.com/canonical/checkbox/issues/2542

#2160 added logic for NVMe disks categorized as `DISK` but lacking `DEVNAME` which derives a resource name from `DEVPATH`. However, on some platforms (e.g., DGX A100, 26.04), udev appears to expose NVMe path objects of the form `nvmeXcYnZ` with:
- `DEVTYPE=disk`, `SUBSYSTEM=block`
- no `DEVNAME`, no `MAJOR/MINOR`
- no `/sys/class/block/<name>/dev`, no `/dev/<name>`

The resource names it derives from the `DEVPATH` in these cases do not map to an openable `/dev` block device node, which leads to generated disk jobs targeting these unopenable `/dev` nodes.

## Documentation

None (minor bug fix)

## Tests

1. Provision an affected device (e.g., DGX A100) with Ubuntu 26.04
2. Clone checkbox and add checkbox-support and checkbox-ng to the PYTHONPATH
3. Compare the output from the following with and without this patch: `python3 ~/checkbox/providers/resource/bin/udev_resource.py --filter DISK`
4. Verify with `lsblk` and/or by inspecting `/dev`

Before: 
```
ubuntu@cortez:~/checkbox$ python3 ~/checkbox/providers/resource/bin/udev_resource.py --filter DISK
ERROR:root:Failed to retrieve checkbox-ng version
path: /devices/pci0000:00/0000:00:01.1/0000:01:00.0/0000:02:00.0/0000:03:00.0/0000:04:14.0/0000:09:00.0/nvme
name: nvme1c1n1
bus: nvme
category: DISK
driver: nvme
product_id: 43044
vendor_id: 5197
subproduct_id: 43009
subvendor_id: 5197
product: nvme1c1n1
vendor: Samsung Electronics Co Ltd
product_slug: nvme1c1n1
vendor_slug: Samsung_Electronics_Co_Ltd

path: /devices/pci0000:20/0000:20:03.2/0000:22:00.0/nvme
name: nvme0n1
bus: nvme
category: DISK
driver: nvme
product_id: 43016
vendor_id: 5197
subproduct_id: 43009
subvendor_id: 5197
product: nvme0n1
vendor: Samsung Electronics Co Ltd
product_slug: nvme0n1
vendor_slug: Samsung_Electronics_Co_Ltd

path: /devices/pci0000:20/0000:20:03.3/0000:23:00.0/nvme
name: nvme2n1
bus: nvme
category: DISK
driver: nvme
product_id: 43016
vendor_id: 5197
subproduct_id: 43009
subvendor_id: 5197
product: nvme2n1
vendor: Samsung Electronics Co Ltd
product_slug: nvme2n1
vendor_slug: Samsung_Electronics_Co_Ltd

path: /devices/pci0000:40/0000:40:01.1/0000:41:00.0/0000:42:08.0/0000:50:00.0/0000:51:00.0/0000:52:00.0/nvme
name: nvme4c4n1
bus: nvme
category: DISK
driver: nvme
product_id: 43044
vendor_id: 5197
subproduct_id: 43009
subvendor_id: 5197
product: nvme4c4n1
vendor: Samsung Electronics Co Ltd
product_slug: nvme4c4n1
vendor_slug: Samsung_Electronics_Co_Ltd

path: /devices/pci0000:80/0000:80:01.1/0000:81:00.0/0000:82:00.0/0000:83:00.0/0000:84:14.0/0000:8a:00.0/nvme
name: nvme5c5n1
bus: nvme
category: DISK
driver: nvme
product_id: 43044
vendor_id: 5197
subproduct_id: 43009
subvendor_id: 5197
product: nvme5c5n1
vendor: Samsung Electronics Co Ltd
product_slug: nvme5c5n1
vendor_slug: Samsung_Electronics_Co_Ltd

path: /devices/pci0000:b0/0000:b0:01.1/0000:b1:00.0/0000:b2:08.0/0000:be:00.0/0000:bf:04.0/0000:ca:00.0/nvme
name: nvme3c3n1
bus: nvme
category: DISK
driver: nvme
product_id: 43044
vendor_id: 5197
subproduct_id: 43009
subvendor_id: 5197
product: nvme3c3n1
vendor: Samsung Electronics Co Ltd
product_slug: nvme3c3n1
vendor_slug: Samsung_Electronics_Co_Ltd
```

After:
```
ubuntu@cortez:~/checkbox$ python3 ~/checkbox/providers/resource/bin/udev_resource.py --filter DISK
ERROR:root:Failed to retrieve checkbox-ng version
path: /devices/pci0000:00/0000:00:01.1/0000:01:00.0/0000:02:00.0/0000:03:00.0/0000:04:14.0/0000:09:00.0/nvme
name: nvme1n1
bus: nvme
category: DISK
driver: nvme
product_id: 43044
vendor_id: 5197
subproduct_id: 43009
subvendor_id: 5197
product: nvme1n1
vendor: Samsung Electronics Co Ltd
product_slug: nvme1n1
vendor_slug: Samsung_Electronics_Co_Ltd

path: /devices/pci0000:20/0000:20:03.2/0000:22:00.0/nvme
name: nvme0n1
bus: nvme
category: DISK
driver: nvme
product_id: 43016
vendor_id: 5197
subproduct_id: 43009
subvendor_id: 5197
product: nvme0n1
vendor: Samsung Electronics Co Ltd
product_slug: nvme0n1
vendor_slug: Samsung_Electronics_Co_Ltd

path: /devices/pci0000:20/0000:20:03.3/0000:23:00.0/nvme
name: nvme2n1
bus: nvme
category: DISK
driver: nvme
product_id: 43016
vendor_id: 5197
subproduct_id: 43009
subvendor_id: 5197
product: nvme2n1
vendor: Samsung Electronics Co Ltd
product_slug: nvme2n1
vendor_slug: Samsung_Electronics_Co_Ltd

path: /devices/pci0000:40/0000:40:01.1/0000:41:00.0/0000:42:08.0/0000:50:00.0/0000:51:00.0/0000:52:00.0/nvme
name: nvme4n1
bus: nvme
category: DISK
driver: nvme
product_id: 43044
vendor_id: 5197
subproduct_id: 43009
subvendor_id: 5197
product: nvme4n1
vendor: Samsung Electronics Co Ltd
product_slug: nvme4n1
vendor_slug: Samsung_Electronics_Co_Ltd

path: /devices/pci0000:80/0000:80:01.1/0000:81:00.0/0000:82:00.0/0000:83:00.0/0000:84:14.0/0000:8a:00.0/nvme
name: nvme5n1
bus: nvme
category: DISK
driver: nvme
product_id: 43044
vendor_id: 5197
subproduct_id: 43009
subvendor_id: 5197
product: nvme5n1
vendor: Samsung Electronics Co Ltd
product_slug: nvme5n1
vendor_slug: Samsung_Electronics_Co_Ltd

path: /devices/pci0000:b0/0000:b0:01.1/0000:b1:00.0/0000:b2:08.0/0000:be:00.0/0000:bf:04.0/0000:ca:00.0/nvme
name: nvme3n1
bus: nvme
category: DISK
driver: nvme
product_id: 43044
vendor_id: 5197
subproduct_id: 43009
subvendor_id: 5197
product: nvme3n1
vendor: Samsung Electronics Co Ltd
product_slug: nvme3n1
vendor_slug: Samsung_Electronics_Co_Ltd
```

Compare with `lsblk` and/or by inspecting `/dev`:
```
ubuntu@cortez:~/checkbox$ lsblk
NAME        MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda           8:0    1 29.3G  0 disk 
└─sda1        8:1    1 29.3G  0 part 
sr0          11:0    1 1024M  0 rom  
nvme2n1     259:0    0  1.7T  0 disk 
nvme0n1     259:1    0  1.7T  0 disk 
├─nvme0n1p1 259:2    0  512M  0 part /boot/efi
└─nvme0n1p2 259:3    0  1.7T  0 part /
nvme3n1     259:6    0  3.5T  0 disk 
nvme1n1     259:7    0  3.5T  0 disk 
nvme5n1     259:9    0  3.5T  0 disk 
nvme4n1     259:11   0  3.5T  0 disk 

ubuntu@cortez:~/checkbox$ ls /dev | grep nvme
nvme0
nvme0n1
nvme0n1p1
nvme0n1p2
nvme1
nvme1n1
nvme2
nvme2n1
nvme3
nvme3n1
nvme4
nvme4n1
nvme5
nvme5n1
```