### PR TITLE
Explicitly get fork context as suggested (bugfix)

### DIFF
--- a/providers/base/bin/cpufreq_test.py
+++ b/providers/base/bin/cpufreq_test.py
@@ -465,7 +465,7 @@ class CpuFreqTest:
         for core in online_cores:
             affinity = [int(core)]
             affinity_dict = dict(affinity=affinity)
-            worker = multiprocessing.Process(
+            worker = multiprocessing.get_context("fork").Process(
                 target=run_worker_process,
                 args=(result_queue,),
                 kwargs=affinity_dict,


### PR DESCRIPTION
## Description

As suggested, 1 line change, same as the timeout decorator

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/2517
Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-2256

## Documentation

N/A

## Tests

<!--
Fantastic there are 300 words written in the fucking issue and nobody took a second to commit this one line. I fucking love this.

https://media1.tenor.com/m/IqnpCYlyWZ0AAAAd/roller-pepe-pepe-roller.gif
-->
