### PR TITLE
Use existing job result if session resumed after all jobs have run (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -514,6 +514,10 @@ class RemoteController(ReportsStage, MainLoopStage):
 
     def _resume_session(self, resume_params):
         metadata = self.sa.prepare_resume_session(resume_params.session_id)
+        # If there are no more jobs to run, resume. The empty dict is sent
+        # so that the last job result is not modified nor re-run.
+        if not metadata.remaining_todo_jobs:
+            return self.resume_by_id(resume_params.session_id, {})
         if "testplanless" not in metadata.flags:
             app_blob = json.loads(metadata.app_blob.decode("UTF-8"))
             test_plan_id = app_blob["testplan_id"]
@@ -626,6 +630,7 @@ class RemoteController(ReportsStage, MainLoopStage):
             (
                 candidate.id,
                 generate_resume_candidate_description(candidate),
+                candidate.metadata.remaining_todo_jobs,
             )
             for candidate in resumable_sessions
         ]

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -599,7 +599,7 @@ class Launcher(MainLoopStage, ReportsStage):
                 else:
                     result_dict["comments"] = newline_join(
                         result_dict["comments"],
-                        "Failed after resuming execution"
+                        "Failed after resuming execution",
                     )
             elif outcome == IJobResult.OUTCOME_SKIP:
                 if is_cert_blocker and not comments:
@@ -609,7 +609,7 @@ class Launcher(MainLoopStage, ReportsStage):
                 else:
                     result_dict["comments"] = newline_join(
                         result_dict["comments"],
-                        "Skipped after resuming execution"
+                        "Skipped after resuming execution",
                     )
             elif outcome == IJobResult.OUTCOME_CRASH:
                 if is_cert_blocker and not comments:
@@ -617,7 +617,7 @@ class Launcher(MainLoopStage, ReportsStage):
                 else:
                     result_dict["comments"] = newline_join(
                         result_dict["comments"],
-                        "Crashed after resuming execution"
+                        "Crashed after resuming execution",
                     )
             elif outcome == IJobResult.OUTCOME_UNDECIDED:
                 # if we don't call use_job_result it means we'll rerun the job

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -447,6 +447,7 @@ class Launcher(MainLoopStage, ReportsStage):
             (
                 candidate.id,
                 generate_resume_candidate_description(candidate),
+                candidate.metadata.remaining_todo_jobs,
             )
             for candidate in resume_candidates
         ]
@@ -504,12 +505,15 @@ class Launcher(MainLoopStage, ReportsStage):
                 return False
 
     def _resume_session_via_resume_params(self, resume_params):
-        outcome = {
-            "pass": IJobResult.OUTCOME_PASS,
-            "fail": IJobResult.OUTCOME_FAIL,
-            "skip": IJobResult.OUTCOME_SKIP,
-            "rerun": IJobResult.OUTCOME_UNDECIDED,
-        }[resume_params.action]
+        if resume_params.action:
+            outcome = {
+                "pass": IJobResult.OUTCOME_PASS,
+                "fail": IJobResult.OUTCOME_FAIL,
+                "skip": IJobResult.OUTCOME_SKIP,
+                "rerun": IJobResult.OUTCOME_UNDECIDED,
+            }[resume_params.action]
+        else:
+            outcome = None
         return self._resume_session(
             resume_params.session_id, outcome, resume_params.comments
         )
@@ -574,50 +578,56 @@ class Launcher(MainLoopStage, ReportsStage):
             if outcome is None:
                 outcome = self._get_autoresume_outcome_last_job(metadata)
 
-        last_job = metadata.running_job_name
-        is_cert_blocker = (
-            self.sa.get_job_state(last_job).effective_certification_status
-            == "blocker"
-        )
-        # If we resumed maybe not rerun the same, probably broken job
-        result_dict = {"comments": comments, "outcome": outcome}
-        if outcome == IJobResult.OUTCOME_PASS:
-            result_dict["comments"] = newline_join(
-                result_dict["comments"], "Passed after resuming execution"
+        # If there are more jobs to run, resume the session and modify the
+        # last job result.
+        if metadata.remaining_todo_jobs:
+            last_job = metadata.running_job_name
+            is_cert_blocker = (
+                self.sa.get_job_state(last_job).effective_certification_status
+                == "blocker"
             )
+            # If we resumed maybe not rerun the same, probably broken job
+            result_dict = {"comments": comments, "outcome": outcome}
+            if outcome == IJobResult.OUTCOME_PASS:
+                result_dict["comments"] = newline_join(
+                    result_dict["comments"], "Passed after resuming execution"
+                )
 
-        elif outcome == IJobResult.OUTCOME_FAIL:
-            if is_cert_blocker and not comments:
-                result_dict["comments"] = request_comment("why it failed")
+            elif outcome == IJobResult.OUTCOME_FAIL:
+                if is_cert_blocker and not comments:
+                    result_dict["comments"] = request_comment("why it failed")
+                else:
+                    result_dict["comments"] = newline_join(
+                        result_dict["comments"],
+                        "Failed after resuming execution"
+                    )
+            elif outcome == IJobResult.OUTCOME_SKIP:
+                if is_cert_blocker and not comments:
+                    result_dict["comments"] = request_comment(
+                        "why you want to skip it"
+                    )
+                else:
+                    result_dict["comments"] = newline_join(
+                        result_dict["comments"],
+                        "Skipped after resuming execution"
+                    )
+            elif outcome == IJobResult.OUTCOME_CRASH:
+                if is_cert_blocker and not comments:
+                    result_dict["comments"] = request_comment("why it failed")
+                else:
+                    result_dict["comments"] = newline_join(
+                        result_dict["comments"],
+                        "Crashed after resuming execution"
+                    )
+            elif outcome == IJobResult.OUTCOME_UNDECIDED:
+                # if we don't call use_job_result it means we'll rerun the job
+                return
             else:
-                result_dict["comments"] = newline_join(
-                    result_dict["comments"], "Failed after resuming execution"
+                raise ValueError(
+                    "Unsupported outcome for resume {}".format(outcome)
                 )
-        elif outcome == IJobResult.OUTCOME_SKIP:
-            if is_cert_blocker and not comments:
-                result_dict["comments"] = request_comment(
-                    "why you want to skip it"
-                )
-            else:
-                result_dict["comments"] = newline_join(
-                    result_dict["comments"], "Skipped after resuming execution"
-                )
-        elif outcome == IJobResult.OUTCOME_CRASH:
-            if is_cert_blocker and not comments:
-                result_dict["comments"] = request_comment("why it failed")
-            else:
-                result_dict["comments"] = newline_join(
-                    result_dict["comments"], "Crashed after resuming execution"
-                )
-        elif outcome == IJobResult.OUTCOME_UNDECIDED:
-            # if we don't call use_job_result it means we'll rerun the job
-            return
-        else:
-            raise ValueError(
-                "Unsupported outcome for resume {}".format(outcome)
-            )
-        result = MemoryJobResult(result_dict)
-        self.sa.use_job_result(last_job, result)
+            result = MemoryJobResult(result_dict)
+            self.sa.use_job_result(last_job, result)
         if self.sa.setting_up():
             self.setup()
             self.bootstrap()

--- a/checkbox-ng/checkbox_ng/resume_menu.py
+++ b/checkbox-ng/checkbox_ng/resume_menu.py
@@ -162,7 +162,7 @@ class ResumeMenu:
 
     def _create_menu_frame(self):
         """Create an urwid frame for the menu."""
-        menu_entries = [urwid.Button(id) for id, _ in self._entries]
+        menu_entries = [urwid.Button(id) for id, _, _ in self._entries]
 
         self._menu_body = ReactiveListBox(
             urwid.SimpleFocusListWalker(
@@ -251,8 +251,13 @@ class ResumeMenu:
         if key == "enter":
             self.chosen_session = self._entries[self.focused_index][0]
             # now let's show action menu, operator will chose what to do with
-            # the session
-            self.loop.widget = self._action_view
+            # the last job if there are still jobs to run in the todo list
+            if self._entries[self.focused_index][2]:
+                self.loop.widget = self._action_view
+            # otherwise, just continue (to the re-run screen or
+            # session finalization process)
+            else:
+                raise urwid.ExitMainLoop()
 
         elif key == "esc":
             self.chosen_session = None

--- a/checkbox-ng/checkbox_ng/utils.py
+++ b/checkbox-ng/checkbox_ng/utils.py
@@ -65,12 +65,18 @@ def generate_resume_candidate_description(candidate):
 
         Last job was started at:
             {last_job_start_time}
+
+        Are there still jobs to run?
+            {remaining_todo_jobs}
         """)
     app_blob = json.loads(candidate.metadata.app_blob.decode("UTF-8"))
     session_title = candidate.metadata.title or "Unknown"
     tp_id = app_blob.get("testplan_id", "Unknown")
     last_job_id = candidate.metadata.running_job_name or "Unknown"
     last_job_timestamp = candidate.metadata.last_job_start_time or None
+    remaining_todo_jobs = (
+        "Yes" if candidate.metadata.remaining_todo_jobs else "No"
+    )
     if last_job_timestamp:
         dt = datetime.datetime.fromtimestamp(
             last_job_timestamp, datetime.timezone.utc
@@ -83,6 +89,7 @@ def generate_resume_candidate_description(candidate):
         tp_id=tp_id,
         last_job_id=last_job_id,
         last_job_start_time=last_job_start_time,
+        remaining_todo_jobs=remaining_todo_jobs,
     )
 
 

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -795,6 +795,7 @@ class SessionAssistant:
             self.get_job: "to decide what result should be assigned",
             self.get_job_state: "to see if the job result was already decided",
             self.use_job_result: "to assign the decided result to the job",
+            self.get_dynamic_todo_list: "to see what is yet to be executed",
             self.start_setup: "to be called after setting the last job result",
         }
 
@@ -823,6 +824,7 @@ class SessionAssistant:
             self.run_job: "to run setup job",
             self.get_job: "to get the job definition by id",
             self.get_job_state: "to get the current state of a job",
+            self.get_dynamic_todo_list: "to see what is yet to be executed",
             self.finish_setup: "to finish setting up after running all jobs",
             self.get_session_id: "used internally by get_job",
             self.get_category: "used by UIs to represent a job",
@@ -865,6 +867,7 @@ class SessionAssistant:
             self.get_job_state: "to get the current state of a job",
             self.finish_bootstrap: "to finish bootstrapping after running all jobs",
             self.get_session_id: "used internally by get_job",
+            self.get_dynamic_todo_list: "to see what is yet to be executed",
             self.finalize_session: "to finalize the session",
         }
         return [job.id for job in self._context.state.run_list]

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -1457,6 +1457,9 @@ class SessionAssistant:
         """
         self._metadata.running_job_name = job["id"]
         self._metadata.last_job_start_time = time.time()
+        self._context.state.metadata.remaining_todo_jobs = bool(
+            self.get_dynamic_todo_list()
+        )
         self._manager.checkpoint()
 
     @raises(ValueError, TypeError, UnexpectedMethodCall)
@@ -1526,6 +1529,9 @@ class SessionAssistant:
         if job_state.can_start():
             ui.about_to_start_running(job, job_state)
             self._context.state.metadata.running_job_name = job.id
+            self._context.state.metadata.remaining_todo_jobs = bool(
+                self.get_dynamic_todo_list()
+            )
             self._manager.checkpoint()
             autorestart = (
                 self._restart_strategy is not None
@@ -1684,6 +1690,9 @@ class SessionAssistant:
             # happens when using `checkbox-cli run, or plainbox`, and with old,
             # legacy Launchers. They are not expected to do auto-retries.
             pass
+        self._context.state.metadata.remaining_todo_jobs = bool(
+            self.get_dynamic_todo_list()
+        )
         self._manager.checkpoint()
         # Set up expectations so that run_job() and use_job_result() must be
         # called in pairs and applications cannot just forget and call

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -857,6 +857,10 @@ class RemoteSessionAssistant:
     ):
         if not last_job_id:
             return
+        # If there are no more jobs to run, it means the last job already has
+        # a result, and does not need to be updated
+        if not self._sa._metadata.remaining_todo_jobs:
+            return
         if result_interactively_decided:
             result_dict = result_interactively_decided
         else:

--- a/checkbox-ng/plainbox/impl/session/resume.py
+++ b/checkbox-ng/plainbox/impl/session/resume.py
@@ -196,6 +196,7 @@ class SessionPeekHelper(EnvelopeUnpackMixIn):
             8: SessionPeekHelper8,
             9: SessionPeekHelper9,
             10: SessionPeekHelper10,
+            11: SessionPeekHelper11,
         }
         try:
             return version_peek_helper_map[version]().peek_json(json_repr)
@@ -322,6 +323,7 @@ class SessionResumeHelper(EnvelopeUnpackMixIn):
             8: SessionResumeHelper8,
             9: SessionResumeHelper9,
             10: SessionResumeHelper10,
+            11: SessionResumeHelper11,
         }
         try:
             helper_class = version_session_resume_map[version]
@@ -477,6 +479,16 @@ class MetaDataHelper7MixIn(MetaDataHelper6MixIn):
         )
 
 
+class MetaDataHelper11MixIn(MetaDataHelper7MixIn):
+    def _restore_SessionState_metadata(cls, metadata, session_repr):
+        super()._restore_SessionState_metadata(metadata, session_repr)
+        metadata.remaining_todo_jobs = _validate(
+            session_repr["metadata"],
+            key="remaining_todo_jobs",
+            value_type=bool,
+        )
+
+
 class SessionPeekHelper1(MetaDataHelper1MixIn):
     """
     Helper class for implementing session peek feature.
@@ -626,6 +638,19 @@ class SessionPeekHelper10(SessionPeekHelper9):
 
     This class works with data constructed by
     :class:`~plainbox.impl.session.suspend.SessionSuspendHelper10` which has
+    been pre-processed by :class:`SessionPeekHelper` (to strip the initial
+    envelope).
+
+    The only goal of this class is to reconstruct session state meta-data.
+    """
+
+
+class SessionPeekHelper11(MetaDataHelper11MixIn, SessionPeekHelper10):
+    """
+    Helper class for implementing session peek feature
+
+    This class works with data constructed by
+    :class:`~plainbox.impl.session.suspend.SessionSuspendHelper11` which has
     been pre-processed by :class:`SessionPeekHelper` (to strip the initial
     envelope).
 
@@ -1304,6 +1329,10 @@ class SessionResumeHelper9(SessionResumeHelper8):
 
 
 class SessionResumeHelper10(SessionResumeHelper9):
+    pass
+
+
+class SessionResumeHelper11(MetaDataHelper11MixIn, SessionResumeHelper10):
     pass
 
 

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -103,6 +103,7 @@ class SessionMetaData:
         app_blob=b"",
         app_id=None,
         custom_joblist=False,
+        remaining_todo_jobs=False,
     ):
         """Initialize a new session state meta-data object."""
         if flags is None:
@@ -115,14 +116,16 @@ class SessionMetaData:
         self._custom_joblist = custom_joblist
         self._rejected_jobs = []
         self._last_job_start_time = None
+        self._remaining_todo_jobs = remaining_todo_jobs
 
     def __repr__(self):
         """Get the representation of the session state meta-data."""
-        return "<{} title:{!r} flags:{!r} running_job_name:{!r}>".format(
+        return "<{} title:{!r} flags:{!r} running_job_name:{!r} remaining_todo_jobs:{!r}>".format(
             self.__class__.__name__,
             self.title,
             self.flags,
             self.running_job_name,
+            self.remaining_todo_jobs,
         )
 
     @property
@@ -165,6 +168,14 @@ class SessionMetaData:
     def title(self, title):
         """set the session title to the given value."""
         self._title = title
+
+    @property
+    def remaining_todo_jobs(self):
+        return self._remaining_todo_jobs
+
+    @remaining_todo_jobs.setter
+    def remaining_todo_jobs(self, remaining_todo_jobs: bool):
+        self._remaining_todo_jobs = remaining_todo_jobs
 
     def update_feature_flags(self, config):
         """

--- a/checkbox-ng/plainbox/impl/session/suspend.py
+++ b/checkbox-ng/plainbox/impl/session/suspend.py
@@ -711,5 +711,14 @@ class SessionSuspendHelper10(SessionSuspendHelper9):
         return data
 
 
+class SessionSuspendHelper11(SessionSuspendHelper10):
+    VERSION = 11
+
+    def _repr_SessionMetaData(self, obj, session_dir):
+        data = super()._repr_SessionMetaData(obj, session_dir)
+        data["remaining_todo_jobs"] = obj.remaining_todo_jobs
+        return data
+
+
 # Alias for the most recent version
-SessionSuspendHelper = SessionSuspendHelper10
+SessionSuspendHelper = SessionSuspendHelper11

--- a/metabox/metabox/metabox-provider/units/basic-tps.yaml
+++ b/metabox/metabox/metabox-provider/units/basic-tps.yaml
@@ -27,6 +27,14 @@ include:
   - stub/user-interact-verify
 ---
 unit: test plan
+id: basic-session-resume-manual
+name: Basic Manual (for Session Resume Scenario)
+include:
+  - basic-shell-passing
+  - basic-shell-failing
+  - stub/manual
+---
+unit: test plan
 id: display-manual
 name: Display Manual
 include:

--- a/metabox/metabox/scenarios/ui/remaining_todo.py
+++ b/metabox/metabox/scenarios/ui/remaining_todo.py
@@ -1,0 +1,145 @@
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+# Written by:
+#   Pierre Equoy <pierre.equoy@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox. If not, see <http://www.gnu.org/licenses/>.
+
+import metabox.core.keys as keys
+from metabox.core.actions import Expect, Send, Signal, Start, SelectTestPlan
+from metabox.core.scenario import Scenario
+from metabox.core.utils import tag
+
+
+@tag("manual", "resume")
+class RemainingTodoJobsLocal(Scenario):
+    """
+    Test that the remaining_todo_jobs metadata field is correctly displayed
+    in the resume menu. When there are still jobs to run, it should show
+    "Yes". When all jobs have been completed (only re-run screen remains),
+    it should:
+        - show "No"
+        - resume directly into the re-run screen (instead of asking what to do
+        with the last job)
+    """
+
+    modes = ["local"]
+
+    steps = [
+        # Step 1: Start session with bespoke test plan
+        Start(),
+        Expect("Select test plan"),
+        SelectTestPlan(
+            "2021.com.canonical.certification::basic-session-resume-manual"
+        ),
+        Send(keys.KEY_ENTER),
+        Expect("Press (T) to start"),
+        Send("t"),
+        # Step 2: Wait for manual job
+        Expect("Pick an action"),
+        # Step 3: Stop the session with Ctrl-C
+        Signal(keys.SIGINT),
+        # Step 4: Restart and resume - should show "Yes" for remaining jobs
+        Start(),
+        Expect("Resume session"),
+        Send("r"),
+        Expect("Incomplete sessions"),
+        Expect("Are there still jobs to run?"),
+        Expect("Yes"),
+        Send(keys.KEY_ENTER),
+        Expect("last job?"),
+        # Re-run the last job (smoke/manual)
+        Send("r"),
+        Expect("Pick an action"),
+        # Step 5: Set the job to pass - re-run screen is shown
+        Send("p" + keys.KEY_ENTER),
+        Expect("Select jobs to re-run"),
+        # Step 6: Stop the session again with Ctrl-C
+        Signal(keys.SIGINT),
+        # Resume again - should show "No" for remaining jobs
+        Start(),
+        Expect("Resume session"),
+        Send("r"),
+        Expect("Incomplete sessions"),
+        Expect("Are there still jobs to run?"),
+        Expect("No"),
+        Send(keys.KEY_ENTER),
+        # No action is shown, resumes directly in re-run screen
+        Expect("Select jobs to re-run"),
+    ]
+
+
+@tag("manual", "resume")
+class RemainingTodoJobsRemote(Scenario):
+    """
+    Test that the remaining_todo_jobs metadata field is correctly displayed
+    in the resume menu. When there are still jobs to run, it should show
+    "Yes". When all jobs have been completed (only re-run screen remains),
+    it should:
+        - show "No"
+        - resume directly into the re-run screen (instead of asking what to do
+        with the last job)
+    """
+
+    modes = ["remote"]
+    launcher = "# no launcher"
+
+    steps = [
+        # Step 1: Start session with bespoke test plan
+        Start(),
+        Expect("Select test plan"),
+        SelectTestPlan(
+            "2021.com.canonical.certification::basic-session-resume-manual"
+        ),
+        Send(keys.KEY_ENTER),
+        Expect("Press (T) to start"),
+        Send("t"),
+        # Step 2: Wait for manual job
+        Start(),
+        Expect("Pick an action"),
+        # Step 3: Stop the session with Ctrl-C, then Exit and stop the agent
+        Signal(keys.SIGINT),
+        Expect("(X) Nothing"),
+        Send(keys.KEY_DOWN * 3 + keys.KEY_SPACE + keys.KEY_ENTER),
+        # Step 4: Restart and resume - should show "Yes" for remaining jobs
+        Start(),
+        Expect("Resume session"),
+        Send("r"),
+        Expect("Incomplete sessions"),
+        Expect("Are there still jobs to run?"),
+        Expect("Yes"),
+        Send(keys.KEY_ENTER),
+        Expect("last job?"),
+        # Re-run the last job (smoke/manual)
+        Send("r"),
+        Expect("Pick an action"),
+        # Step 5: Set the job to pass - re-run screen is shown
+        Send("p" + keys.KEY_ENTER),
+        Expect("Select jobs to re-run"),
+        # Step 6: Stop the session again with Ctrl-C, then Exit and stop the
+        # agent
+        Signal(keys.SIGINT),
+        Expect("(X) Nothing"),
+        Send(keys.KEY_DOWN * 3 + keys.KEY_SPACE + keys.KEY_ENTER),
+        # Step 7: Resume again - should show "No" for remaining jobs
+        Start(),
+        Expect("Resume session"),
+        Send("r"),
+        Expect("Incomplete sessions"),
+        Expect("Are there still jobs to run?"),
+        Expect("No"),
+        Send(keys.KEY_ENTER),
+        # No action is shown, resumes directly in re-run screen
+        Expect("Select jobs to re-run"),
+    ]


### PR DESCRIPTION
## Description

If the session is interrupted and resumed when the final job is an interactive one, Checkbox would force the user to set the job outcome again, even if this job has been already run.

To prevent this, a new boolean attribute, `remaining_todo_jobs`, is added to the `SessionMetaData` and is used in:

- the UI to not show the submenu in that case
- the session resume process to not modify the job result and use the existing result

This allows to just continue to the re-run screen directly (or to the finalizing session process if there are no candidates for re-runs).

Since the session object is modified, a new version (version 11) is made available in `suspend.py` and `resume.py` that stores and restores the new `remaining_todo_jobs` attribute.

## Resolved issues

Fix #2535
Fix CHECKBOX-2262

## Tests

Tested successfully both in checkbox local and checkbox remote.

Steps followed:

1. Start a session and select the Smoke test plan
2. When the manual job (which is the last job in this test plan) is displayed, stop the session (`Ctrl-C` on local, and `Ctrl-C` then `Exit and stop the Checkbox agent on the testbed` on remote)
3. Restart Checkbox and resume the session by pressing `R` → when the session is highlighted, you can see "Are there still jobs to run? Yes". Select the session by pressing `Enter` and press `R` to re-run the last job (`smoke/manual`)
4. Set the job to `pass` → the re-run screen is shown
5. Stop the session again (like step 2), then resume it again (like in step 3) → This time, "Are there still jobs to run?" is "No". Select this session by pressing `Enter` → this time, no action is shown, and Checkbox resumes directly in the re-run screen.

***Note:*** at any point, you can check the content of the session metadata by going into the session directory in `/var/tmp/checkbox-ng/sessions/<session id>/` and checking the content of the `session` file which is a gzipped JSON doc: `zcat session | jq ".session.metadata"`
