### PR TITLE
Core26 daily builds (infra)

### DIFF
--- a/.github/workflows/checkbox-daily-native-builds.yaml
+++ b/.github/workflows/checkbox-daily-native-builds.yaml
@@ -59,6 +59,7 @@ jobs:
           cd checkbox-core-snap/
           sudo apt update && sudo apt install -qq -y python3-setuptools-scm
           ./prepare.sh series${{ matrix.release }}
+          sudo snap refresh lxd --channel=6/beta
 
       - id: snap_build
         uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49

--- a/.github/workflows/checkbox-daily-native-builds.yaml
+++ b/.github/workflows/checkbox-daily-native-builds.yaml
@@ -62,7 +62,9 @@ jobs:
 
       - name: Refresh LXD to latest/beta
         if: matrix.release >= 26 # temporary workaround snapcraft 9 doesn't work on 5.x
-        run: sudo snap refresh lxd --channel=latest/beta
+        run: |
+          # Note: snapd bug, snap install always returns 0
+          sudo snap refresh lxd --channel=latest/beta || sudo snap install lxd --channel=latest/beta
 
       - id: snap_build
         uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49

--- a/.github/workflows/checkbox-daily-native-builds.yaml
+++ b/.github/workflows/checkbox-daily-native-builds.yaml
@@ -34,15 +34,15 @@ jobs:
           - arch: arm64
             tag: ARM64
           - release: 18
-            snapcraft_version: 7.x
+            snapcraft_version: 7.x/stable
           - release: 20
-            snapcraft_version: 7.x
+            snapcraft_version: 7.x/stable
           - release: 22
-            snapcraft_version: 8.x
+            snapcraft_version: 8.x/stable
           - release: 24
-            snapcraft_version: 8.x
+            snapcraft_version: 8.x/stable
           - release: 26
-            snapcraft_version: 8.x
+            snapcraft_version: 9.x/beta
     runs-on:
       group: "Canonical self-hosted runners"
       labels: ["self-hosted", "linux", "large", "${{ matrix.tag }}"]
@@ -70,7 +70,7 @@ jobs:
           attempt_limit: 5
           with: |
             path: checkbox-core-snap/series${{ matrix.release }}
-            snapcraft-channel: ${{ matrix.snapcraft_version }}/stable
+            snapcraft-channel: ${{ matrix.snapcraft_version }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         name: Upload logs on failure
@@ -120,7 +120,7 @@ jobs:
             snapcraft_version: 8.x
     runs-on:
       group: "Canonical self-hosted runners"
-      labels: ["self-hosted", "linux", "jammy", "large", "${{ matrix.tag }}"]
+      labels: ["self-hosted", "linux", "large", "${{ matrix.tag }}"]
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     name: Frontend ${{ matrix.type }}${{ matrix.release }} (${{matrix.arch}})
     steps:

--- a/.github/workflows/checkbox-daily-native-builds.yaml
+++ b/.github/workflows/checkbox-daily-native-builds.yaml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         # other confs cross-built by checkbox-daily-cross-build.yaml
-        release: [18, 20, 22, 24]
+        release: [18, 20, 22, 24, 26]
         arch: [amd64, arm64]
         include:
           - arch: amd64
@@ -40,6 +40,8 @@ jobs:
           - release: 22
             snapcraft_version: 8.x
           - release: 24
+            snapcraft_version: 8.x
+          - release: 26
             snapcraft_version: 8.x
     runs-on:
       group: "Canonical self-hosted runners"

--- a/.github/workflows/checkbox-daily-native-builds.yaml
+++ b/.github/workflows/checkbox-daily-native-builds.yaml
@@ -59,7 +59,10 @@ jobs:
           cd checkbox-core-snap/
           sudo apt update && sudo apt install -qq -y python3-setuptools-scm
           ./prepare.sh series${{ matrix.release }}
-          sudo snap refresh lxd --channel=6/beta
+
+      - name: Refresh LXD to latest/beta
+        if: matrix.release >= 26 # temporary workaround snapcraft 9 doesn't work on 5.x
+        run: sudo snap refresh lxd --channel=latest/beta
 
       - id: snap_build
         uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -291,7 +291,7 @@ parts:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
       cd src && autoreconf -i && cd -
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -311,7 +311,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -422,7 +422,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -438,7 +438,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -454,7 +454,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -468,7 +468,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -482,7 +482,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -496,7 +496,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -510,7 +510,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -524,7 +524,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.12/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build

--- a/checkbox-core-snap/series26/.gitignore
+++ b/checkbox-core-snap/series26/.gitignore
@@ -1,0 +1,21 @@
+*.pyc
+*.snap
+__pycache__
+build/mo/*
+dist/*.tar.gz
+parts/
+snap/.snapcraft
+snap/gui/
+stage/
+prime/
+
+# following files are populated by the prepare.sh script and should be ignored
+config/
+checkbox-ng/
+checkbox-support/
+providers/
+version.txt
+
+# following files are the result of the build process
+checkbox*.txt
+checkbox*.snap

--- a/checkbox-core-snap/series26/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series26/snap/snapcraft.yaml
@@ -1,0 +1,565 @@
+name: checkbox26
+summary: Checkbox runtime and public providers
+description: "Checkbox runtime and public providers"
+confinement: strict
+
+adopt-info: version-calculator
+
+grade: devel
+build-base: devel
+base: core26
+
+# Don't forget to add a new slot if a new provider part is added in the parts
+# section below.
+slots:
+  provider-resource:
+    interface: content
+    read:
+      - $SNAP/providers/checkbox-provider-resource
+  provider-checkbox:
+    interface: content
+    read:
+      - $SNAP/providers/checkbox-provider-base
+  provider-docker:
+    interface: content
+    read:
+      - $SNAP/providers/checkbox-provider-docker
+  provider-tpm2:
+    interface: content
+    read:
+      - $SNAP/providers/checkbox-provider-tpm2
+  provider-iiotg:
+    interface: content
+    read:
+      - $SNAP/providers/checkbox-provider-iiotg
+  provider-engineering-tests:
+    interface: content
+    read:
+      - $SNAP/providers/checkbox-provider-engineering-tests
+  provider-sru:
+    interface: content
+    read:
+      - $SNAP/providers/checkbox-provider-sru
+  provider-gpgpu:
+    interface: content
+    read:
+      - $SNAP/providers/checkbox-provider-gpgpu
+  provider-certification-client:
+    interface: content
+    read:
+      - $SNAP/providers/checkbox-provider-certification-client
+  provider-certification-server:
+    interface: content
+    read:
+      - $SNAP/providers/checkbox-provider-certification-server
+  provider-tutorial:
+    interface: content
+    read:
+      - $SNAP/providers/checkbox-provider-tutorial
+  checkbox-runtime:
+    interface: content
+    read:
+      - /
+
+plugs:
+  custom-frontend:
+    interface: content
+    content: custom-frontend
+    target: $SNAP/custom_frontends/custom_frontend
+
+apps:
+  checkbox:
+    command: bin/checkbox-cli
+    plugs: &standard [home, network-bind, hardware-observe, bluez, bluetooth-control,
+      gpio, modem-manager, mount-observe, network-manager, pulseaudio, serial-port,
+      system-observe, tpm, udisks2, account-control, accounts-service,
+      login-session-control, login-session-observe]
+    environment:
+      PYTHONPATH: $SNAP/lib/python3.14/site-packages/:$SNAP/lib64/python3.14/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+  agent:
+    command: bin/checkbox-cli run-agent
+    daemon: simple
+    restart-condition: always
+    restart-delay: 1s
+    plugs: *standard
+    install-mode: disable
+    environment:
+      PYTHONPATH: $SNAP/lib/python3.14/site-packages/:$SNAP/lib64/python3.14/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+
+package-repositories:
+  - type: apt
+    ppa: colin-king/stress-ng
+  - type: apt
+    ppa: colin-king/ppa
+
+parts:
+  version-calculator:
+    plugin: dump
+    source: .
+    override-pull: |
+      craftctl default
+      # version.txt created by prepare.sh
+      export version=`cat $CRAFT_PART_SRC/version.txt`
+      [ $version ] || exit 1
+      craftctl set version=$version
+    stage:
+      - version.txt
+  ################################################################################
+  extra-path-environment:
+    plugin: nil
+    override-build: |
+      echo "#fwts is in /lib/fwts instead of /lib
+      LD_LIBRARY_PATH+=/lib/fwts
+      # lapack and blas are pulled by opencv and install libraries in a directory
+      LD_LIBRARY_PATH+=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack
+      LD_LIBRARY_PATH+=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas
+      # GLIB object paths are ofc. not default as well
+      GI_TYPELIB_PATH+=/usr/lib/girepository-1.0
+      GI_TYPELIB_PATH+=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0
+      " >> $CRAFT_PART_INSTALL/extra_path_environment
+    stage:
+      - extra_path_environment
+  ################################################################################
+  plz-run:
+    plugin: go
+    source: https://github.com/Hook25/plz-run.git
+    build-snaps:
+      - go/latest/stable
+  ################################################################################
+  # statically linked nsenter as plz-run launches nsenter outside of the namespace
+  # so if the user is using a different base / os with a different version of
+  # glibc, nsenter won't work at all.
+  static-nsenter:
+    plugin: nil
+    source-tag: "v2.41.1"
+    source-depth: 1
+    source: https://github.com/util-linux/util-linux.git
+    build-packages:
+      - build-essential
+      - libcap-ng-dev
+      - git
+      - autoconf
+      - automake
+      - libtool
+      - gettext
+      - bison
+      - pkg-config
+      - flex
+      - autopoint
+    override-build: |
+      craftctl default
+      ./autogen.sh
+      ./configure --disable-all-programs --enable-nsenter --enable-setpriv \
+        --enable-static-programs=nsenter
+      make LDFLAGS="-static -all-static"
+      install -D -m 755 nsenter.static "$CRAFT_PART_INSTALL/usr/bin/nsenter.static"
+  ################################################################################
+  fwts:
+    source-tag: "V26.03.00"
+    source-depth: 1
+    plugin: autotools
+    source: https://github.com/fwts/fwts.git
+    # needed because default is /usr/local
+    # if you change this update LD_LIBRARY_PATH
+    autotools-configure-parameters:
+      - --prefix=/
+    stage-packages:
+      - libfdt1
+      - libbsd0
+      - libpci3
+    build-packages:
+      - gcc
+      - make
+      - autoconf
+      - automake
+      - libtool
+      - flex
+      - bison
+      - dh-autoreconf
+      - libglib2.0-dev
+      - libfdt-dev
+      - libbsd-dev
+    after: [version-calculator]
+  ################################################################################
+  stress-ng:
+    plugin: nil
+    stage-packages:
+      - stress-ng
+    after: [fwts]
+  ################################################################################
+  acpi-tools:
+    plugin: nil
+    stage-packages:
+      - acpica-tools
+    after: [stress-ng]
+  ################################################################################
+  checkbox-support:
+    plugin: python
+    source: checkbox-support
+    source-type: local
+    stage-packages:
+      # actual requirements
+      - python3-bluez
+      - libsystemd0
+      - v4l-utils
+      # added to stage python:
+      - libpython3-stdlib
+      - libpython3.14-stdlib
+      - libpython3.14-minimal
+      - python3-pip
+      - python3-setuptools
+      - python3-wheel
+      - python3-venv
+      - python3-minimal
+      - python3-pkg-resources
+      - python3.14-minimal
+    build-packages:
+      - libbluetooth-dev
+      - python3-dev
+    python-packages:
+      - pynmea2
+    after: [acpi-tools]
+    stage:
+      - -pyvenv.cfg
+      - -bin/activate*
+      - -**/RECORD
+      - -**/__pycache__
+      - -debian
+    build-environment:
+      - C_INCLUDE_PATH: /usr/include/python3.14
+      - PYTHONPATH: $CRAFT_PART_INSTALL/usr/lib/python3/dist-packages:${PYTHONPATH:-}
+      - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $CRAFT_STAGE/version.txt)"
+    override-build: |
+      craftctl default
+  ################################################################################
+  checkbox-ng:
+    plugin: python
+    source: checkbox-ng
+    source-type: local
+    build-packages:
+      - zlib1g-dev
+      - build-essential
+    stage-packages:
+      - perl
+      - python3-markupsafe
+      - python3-jinja2
+      - python3-packaging
+      - python3-pyparsing
+      - python3-urwid
+      - python3-xlsxwriter
+      # added to stage python:
+      - libpython3-stdlib
+      - libpython3.14-stdlib
+      - libpython3.14-minimal
+      - python3-pip
+      - python3-setuptools
+      - python3-wheel
+      - python3-venv
+      - python3-minimal
+      - python3-pkg-resources
+      - python3.14-minimal
+      - python3-yaml
+    python-packages:
+      - requests-oauthlib
+      - tqdm
+      - picamera # p-p-c dep that wouldnt install in another part
+    after: [checkbox-support]
+    stage:
+      - -pyvenv.cfg
+      - -bin/activate*
+      - -**/RECORD
+      - -**/__pycache__
+      - -debian
+    build-environment:
+      - PYTHONPATH: $CRAFT_PART_INSTALL/usr/lib/python3/dist-packages:${PYTHONPATH:-}
+      - READTHEDOCS: "True" # simplifies picamera install
+      - SETUPTOOLS_SCM_PRETEND_VERSION: "$(cat $CRAFT_STAGE/version.txt)"
+    override-build: |
+      craftctl default
+  ################################################################################
+  checkbox-provider-resource:
+    plugin: dump
+    source: providers/resource
+    source-type: local
+    stage-packages:
+      - cpu-checker
+      - dpkg
+      - dmidecode
+      - libjson-xs-perl
+      - pciutils
+      - smartmontools
+    build-environment:
+      - PYTHONPYCACHEPREFIX: "/tmp"
+    override-build: |
+      cd src && autoreconf -i && cd -
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      python3 manage.py validate
+      python3 manage.py build
+      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-resource --root="$CRAFT_PART_INSTALL"
+    build-packages:
+      - autoconf
+      - automake
+      - libnl-3-dev
+      - libnl-genl-3-dev
+      - pkg-config
+    after: [checkbox-ng]
+  ################################################################################
+  checkbox-provider-base:
+    plugin: dump
+    source: providers/base
+    source-type: local
+    build-environment:
+      - PYTHONPYCACHEPREFIX: "/tmp"
+    override-build: |
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
+      python3 manage.py validate
+      python3 manage.py build
+      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-base --root="$CRAFT_PART_INSTALL"
+    stage-packages:
+      - python3-opencv
+      - bc
+      - bonnie++
+      - bpftrace
+      - cryptsetup-bin
+      - dbus
+      - debsums
+      - dmidecode
+      - dmsetup
+      - efibootmgr
+      - ethtool
+      - freeipmi-tools
+      - fscrypt
+      - fswebcam
+      - glmark2
+      - glmark2-es2
+      - glmark2-wayland
+      - glmark2-es2-wayland
+      - gnome-screenshot
+      - gstreamer1.0-tools
+      - gstreamer1.0-plugins-bad
+      - gstreamer1.0-pulseaudio
+      - hdparm
+      - i2c-tools
+      - ipmitool
+      - iperf
+      - iperf3
+      - iw
+      - jq
+      - kmod
+      - libasound2t64
+      - libcap2-bin
+      - libfdt1
+      - libsvm3
+      - lsb-release
+      - lshw
+      - mesa-utils
+      - mokutil
+      - net-tools
+      - nmap
+      - nux-tools
+      - nvme-cli
+      - obexftp
+      - parted
+      - pciutils
+      - pyotherside-doc
+      - pyotherside-tests
+      - qml-module-io-thp-pyotherside
+      - qml6-module-io-thp-pyotherside
+      - python3-dbus
+      - python3-evdev
+      - python3-gi
+      - python3-natsort
+      - python3-pil
+      - python3-psutil
+      - python3-serial
+      - python3-yaml
+      - python3-pyscard
+      - python3-zbar
+      - qml-module-qtquick-controls
+      - qml-module-qtquick-layouts
+      - qmlscene
+      - smartmontools
+      - usbutils
+      - util-linux
+      - uuid-runtime
+      - wget
+      - wmctrl
+      - xz-utils
+      - rt-tests # For realtime performance test
+      - mdadm
+      - on armhf:
+          - python3-rpi.gpio # only in focal
+      - on arm64:
+          - python3-rpi.gpio # only in focal
+    build-packages:
+      - libasound2-dev
+      - libcap-dev
+    organize:
+      usr/lib/lib*.so*: usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/
+    after: [checkbox-provider-resource]
+  ################################################################################
+  checkbox-provider-docker:
+    plugin: dump
+    source: providers/docker
+    source-type: local
+    build-environment:
+      - PYTHONPYCACHEPREFIX: "/tmp"
+    override-build: |
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
+      python3 manage.py validate
+      python3 manage.py build
+      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-docker --root="$CRAFT_PART_INSTALL"
+    stage-packages:
+      - apache2-utils
+    after: [checkbox-provider-base]
+  ################################################################################
+  checkbox-provider-tpm2:
+    plugin: dump
+    source: providers/tpm2
+    source-type: local
+    build-environment:
+      - PYTHONPYCACHEPREFIX: "/tmp"
+    override-build: |
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
+      python3 manage.py validate
+      python3 manage.py build
+      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-tpm2 --root="$CRAFT_PART_INSTALL"
+    stage-packages:
+      - clevis-tpm2
+    after: [checkbox-provider-docker]
+  ################################################################################
+  checkbox-provider-iiotg:
+    plugin: dump
+    source: providers/iiotg
+    source-type: local
+    build-environment:
+      - PYTHONPYCACHEPREFIX: "/tmp"
+    override-build: |
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
+      python3 manage.py validate
+      python3 manage.py build
+      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-iiotg --root="$CRAFT_PART_INSTALL"
+    after: [checkbox-provider-tpm2]
+  ################################################################################
+  checkbox-provider-sru:
+    plugin: dump
+    source: providers/sru
+    source-type: local
+    build-environment:
+      - PYTHONPYCACHEPREFIX: "/tmp"
+    override-build: |
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
+      python3 manage.py validate
+      python3 manage.py build
+      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-sru --root="$CRAFT_PART_INSTALL"
+    after: [checkbox-provider-iiotg]
+  ################################################################################
+  checkbox-provider-gpgpu:
+    plugin: dump
+    source: providers/gpgpu
+    source-type: local
+    build-environment:
+      - PYTHONPYCACHEPREFIX: "/tmp"
+    override-build: |
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
+      python3 manage.py validate
+      python3 manage.py build
+      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-gpgpu --root="$CRAFT_PART_INSTALL"
+    after: [checkbox-provider-sru]
+  ################################################################################
+  checkbox-provider-certification-client:
+    plugin: dump
+    source: providers/certification-client
+    source-type: local
+    build-environment:
+      - PYTHONPYCACHEPREFIX: "/tmp"
+    override-build: |
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
+      python3 manage.py validate
+      python3 manage.py build
+      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-certification-client --root="$CRAFT_PART_INSTALL"
+    after: [checkbox-provider-gpgpu]
+  ################################################################################
+  checkbox-provider-certification-server:
+    plugin: dump
+    source: providers/certification-server
+    source-type: local
+    build-environment:
+      - PYTHONPYCACHEPREFIX: "/tmp"
+    override-build: |
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
+      python3 manage.py validate
+      python3 manage.py build
+      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-certification-server --root="$CRAFT_PART_INSTALL"
+    after: [checkbox-provider-certification-client]
+  ################################################################################
+  checkbox-provider-tutorial:
+    plugin: dump
+    source: providers/tutorial
+    source-type: local
+    build-environment:
+      - PYTHONPYCACHEPREFIX: "/tmp"
+    override-build: |
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
+      python3 manage.py validate
+      python3 manage.py build
+      python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-tutorial --root="$CRAFT_PART_INSTALL"
+    after: [checkbox-provider-base]
+  ################################################################################
+  rpi-support-binaries:
+    plugin: nil
+    stage-packages:
+      - on armhf:
+          - libraspberrypi0
+      - on arm64:
+          - libraspberrypi0
+    organize:
+      usr/lib/lib*.so: usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/
+  ################################################################################
+  lk-boot-env:
+    plugin: nil
+    source: .
+    override-pull: |
+      craftctl default
+      wget https://raw.githubusercontent.com/snapcore/snapd/master/include/lk/snappy_boot_common.h
+      wget https://raw.githubusercontent.com/snapcore/snapd/master/include/lk/snappy_boot_v2.h
+      wget https://raw.githubusercontent.com/kubiko/dragonboard-gadget/20-lk/snap-boot-sel/lk-boot-env.c
+    build-packages:
+      - wget
+      - on amd64 to armhf:
+          - gcc-arm-linux-gnueabihf:amd64
+      - on amd64 to arm64:
+          - gcc-aarch64-linux-gnu:amd64
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/bin
+      if [ "${CRAFT_ARCH_TRIPLET_BUILD_FOR}" = "arm-linux-gnueabihf" ]; then
+          arm-linux-gnueabihf-gcc lk-boot-env.c -I/usr/include/ -Iapp/aboot -o ${CRAFT_PART_INSTALL}/bin/lk-boot-env
+      elif [ "${CRAFT_ARCH_TRIPLET_BUILD_FOR}" = "aarch64-linux-gnu" ]; then
+          aarch64-linux-gnu-gcc lk-boot-env.c -I/usr/include/ -Iapp/aboot -o ${CRAFT_PART_INSTALL}/bin/lk-boot-env
+      else
+          # native build
+          gcc lk-boot-env.c -I/usr/include/ -Iapp/aboot -o ${CRAFT_PART_INSTALL}/bin/lk-boot-env
+      fi
+  ################################################################################
+  parts-meta-info:
+    plugin: nil
+    build-environment:
+      - RUNTIME_VERSION: "$(cat $CRAFT_STAGE/version.txt)"
+    override-build: |
+      craftctl default
+      echo "checkbox-runtime:" >> $CRAFT_PART_INSTALL/parts_meta_info
+      echo "$RUNTIME_VERSION" >> $CRAFT_PART_INSTALL/parts_meta_info
+    after: [checkbox-provider-certification-server]
+  ################################################################################
+  common-config:
+    plugin: dump
+    source: config/

--- a/checkbox-core-snap/series26/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series26/snap/snapcraft.yaml
@@ -122,7 +122,7 @@ parts:
   ################################################################################
   plz-run:
     plugin: go
-    source: https://github.com/Hook25/plz-run.git
+    source: https://github.com/canonical/plz-run.git
     build-snaps:
       - go/latest/stable
   ################################################################################

--- a/checkbox-core-snap/series26/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series26/snap/snapcraft.yaml
@@ -292,7 +292,7 @@ parts:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
       cd src && autoreconf -i && cd -
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       python3 manage.py validate
       python3 manage.py build
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-resource --root="$CRAFT_PART_INSTALL"
@@ -311,7 +311,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -406,7 +406,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -422,7 +422,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -438,7 +438,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -452,7 +452,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -466,7 +466,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -480,7 +480,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -494,7 +494,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build
@@ -508,7 +508,7 @@ parts:
     build-environment:
       - PYTHONPYCACHEPREFIX: "/tmp"
     override-build: |
-      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$SNAPCRAFT_STAGE/usr/lib/python3/dist-packages
+      export PYTHONPATH=$CRAFT_STAGE/lib/python3.14/site-packages:$CRAFT_STAGE/usr/lib/python3/dist-packages
       for path in $(find "$CRAFT_STAGE/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       python3 manage.py validate
       python3 manage.py build

--- a/checkbox-core-snap/series26/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series26/snap/snapcraft.yaml
@@ -513,16 +513,6 @@ parts:
       python3 manage.py install --layout=relocatable --prefix=/providers/checkbox-provider-tutorial --root="$CRAFT_PART_INSTALL"
     after: [checkbox-provider-base]
   ################################################################################
-  rpi-support-binaries:
-    plugin: nil
-    stage-packages:
-      - on armhf:
-          - libraspberrypi0
-      - on arm64:
-          - libraspberrypi0
-    organize:
-      usr/lib/lib*.so: usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/
-  ################################################################################
   lk-boot-env:
     plugin: nil
     source: .

--- a/checkbox-core-snap/series26/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series26/snap/snapcraft.yaml
@@ -331,8 +331,6 @@ parts:
       - freeipmi-tools
       - fscrypt
       - fswebcam
-      - glmark2
-      - glmark2-es2
       - glmark2-wayland
       - glmark2-es2-wayland
       - gnome-screenshot


### PR DESCRIPTION
## Description

This adds the core26 runtime snap and the daily builds for it. This will need five followups:
1. To remove the lxd workaround once snapcraft9 is stable
2. To change the build base and to stable
3. To change the promotion workflow for both beta and stable (right now we won't do it)
4. Frontend snaps once we get the channels
5. riscv builds, this is pending actual support from the action

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-2178

## Documentation

Differences from core24 snap:
1. build base/name/python version
2. SNAPCRAFT -> CRAFT + snapcraftctl -> craftctl: names are now deprecated, this is the new name
3. rpi-support-binaries removed: this part installs a library that is long deprecated that is used for camera compatibility on the ancient video stack, it was completely removed in resolute
4. stage package gir1.2* removed, package is long deprecated and now dead, if tests depend on it (which I couldn't figure out) we are going to figure out a replacement
6. stage package: glmark2 + glmark2-es2 removed, packages are x11 specific, the wayland variant remains
7. execstack hack, probably could be removed in 24 as well, execstack is no longer in the repos and the upload is not blocked, so it is not needed anymore

This also lands a change in the core24 recipe: SNAPCRAFT -> CRAFT as the old name was deprecated but not removed and it remained in the yaml due to sloppy `:%s` (forgot a `/g`)

To double check my diff: (surprisingly readable)
```
diff series24/snap/snapcraft.yaml series26/snap/snapcraft.yaml
```

## Tests

The snap is up in the store right now built using this pipeline
