### PR TITLE
Filter out "PS/2 Generic Mouse" input jobs (bugfix)

### DIFF
--- a/providers/base/units/input/jobs.pxu
+++ b/providers/base/units/input/jobs.pxu
@@ -1,6 +1,8 @@
 unit: template
 template-resource: device
-template-filter: device.category == 'MOUSE' or device.category == 'TOUCHPAD' or device.category == 'TOUCHSCREEN'
+template-filter:
+    device.category == 'MOUSE' or device.category == 'TOUCHPAD' or device.category == 'TOUCHSCREEN'
+    device.product_slug != "PS_2_Generic_Mouse"
 plugin: manual
 category_id: com.canonical.plainbox::input
 id: input/pointing_{product_slug}_{category}_{__index__}
@@ -66,7 +68,9 @@ _summary: Test the accelerometer's detection and operation as a joystick device.
 
 unit: template
 template-resource: device
-template-filter: device.category == 'MOUSE' or device.category == 'TOUCHPAD'
+template-filter:
+    device.category == 'MOUSE' or device.category == 'TOUCHPAD'
+    device.product_slug != "PS_2_Generic_Mouse"
 plugin: manual
 category_id: com.canonical.plainbox::input
 id: input/clicking_{product_slug}_{category}_{__index__}


### PR DESCRIPTION
## Description

Modern devices have a trackpad that supports advanced features such as multitouch, pinch-to-zoom, etc. This is handled by recent input drivers. However, for backward compatbility, and to handle trackpads early on in the boot process, a more simple generic driver is often loaded. This driver is called "PS/2 Generic Mouse" because it does what mice were capable of in the PS/2 port era, namely moving the cursor and left-middle-right clicking.

Even if both drivers are loaded, the system will use the more advanced driver, and only keep the simple one for fallback in case something goes wrong.

When checking the udev database, Checkbox sees both, and creates entries for both, even though they represent *in fine* the same trackpad.

This means testers will see extra input jobs to run, even though they don't match anything they haven't tested yet.

This commit filters out these "extra" resources at template definition level for both `input/pointing` and `input/clicking` jobs.



## Resolved issues

Fix #2536
Fix CHECKBOX-2263

## Documentation

See commit message.

## Tests

I've used the output from udev from the [submission](https://certification.canonical.com/hardware/202512-38253/submission/475969/) mentioned in #2536, and modified the `device` resource job to use it instead of the udevadm from my laptop (using `udev_resource.py -c "cat /path/to/udev_attachment_from_submission"`).

I then ran the following command:

```shell
$ checkbox-cli list-bootstrapped --format json input-cert-manual | jq 'map({id})'
```

(the `input-cert-manual` nested part has to be modified to add a `bootstrap_include` section containing `device`)

Before the patch:

```json
[
  {
    "id": "device"
  },
  {
    "id": "input/accelerometer"
  },
  {
    "id": "input/pointing_VEN_06CB_00_06CB_D00B_Touchpad_TOUCHPAD_1"
  },
  {
    "id": "input/pointing_VEN_06CB_00_06CB_D00B_Mouse_MOUSE_2"
  },
  {
    "id": "input/pointing_PS_2_Generic_Mouse_MOUSE_3"
  },
  {
    "id": "input/clicking_VEN_06CB_00_06CB_D00B_Touchpad_TOUCHPAD_1"
  },
  {
    "id": "input/clicking_VEN_06CB_00_06CB_D00B_Mouse_MOUSE_2"
  },
  {
    "id": "input/clicking_PS_2_Generic_Mouse_MOUSE_3"
  },
  {
    "id": "input/keyboard"
  }
]
```

After the patch (not the removal of `input/[pointing|clicking]_PS_2_Generic_Mouse_MOUSE_3)`:

```json
[
  {
    "id": "device"
  },
  {
    "id": "input/accelerometer"
  },
  {
    "id": "input/pointing_VEN_06CB_00_06CB_D00B_Touchpad_TOUCHPAD_1"
  },
  {
    "id": "input/pointing_VEN_06CB_00_06CB_D00B_Mouse_MOUSE_2"
  },
  {
    "id": "input/clicking_VEN_06CB_00_06CB_D00B_Touchpad_TOUCHPAD_1"
  },
  {
    "id": "input/clicking_VEN_06CB_00_06CB_D00B_Mouse_MOUSE_2"
  },
  {
    "id": "input/keyboard"
  }
]
```