### PR TITLE
Add has usb type a entry (New)

### DIFF
--- a/.github/workflows/checkbox-promote-beta-to-candidate/resources/manifest.conf
+++ b/.github/workflows/checkbox-promote-beta-to-candidate/resources/manifest.conf
@@ -8,5 +8,6 @@ com.canonical.certification::has_thunderbolt3 = false
 com.canonical.certification::has_touchscreen = false
 com.canonical.certification::has_tpm2_chip = false
 com.canonical.certification::has_usb_storage = true
+com.canonical.certification::has_usb_type_a = true
 com.canonical.certification::has_usb_type_c = false
 com.canonical.certification::has_wlan_adapter = true

--- a/providers/base/units/usb/manifest.pxu
+++ b/providers/base/units/usb/manifest.pxu
@@ -17,3 +17,8 @@ unit: manifest entry
 id: has_usbc_otg
 _name: Does the platform support USB-C OTG?
 value-type: bool
+
+unit: manifest entry
+id: has_usb_type_a
+_name: USB Type-A port
+value-type: bool

--- a/providers/base/units/usb/test-plan.pxu
+++ b/providers/base/units/usb/test-plan.pxu
@@ -274,16 +274,6 @@ include:
     usb-c/storage-manual                       certification-status=blocker
     usb-c/c-to-ethernet-adapter-insert
 
-id: after-suspend-usb-c-cert-full
-unit: test plan
-_name: USB Type-C tests (after suspend)
-_description: USB Type-C tests (after suspend)
-include:
-    after-suspend-usb-c/c-to-a-adapter/hid                   certification-status=blocker
-    after-suspend-usb-c/c-to-a-adapter/storage-manual        certification-status=blocker
-    after-suspend-usb-c/storage-manual                       certification-status=blocker
-    after-suspend-usb-c/c-to-ethernet-adapter-insert
-
 id: usb-c-cert-manual
 unit: test plan
 _name: USB Type-C tests (Manual)
@@ -297,6 +287,16 @@ unit: test plan
 _name: USB Type-C tests (Automated)
 _description: USB Type-C tests (Automated)
 include:
+
+id: after-suspend-usb-c-cert-full
+unit: test plan
+_name: USB Type-C tests (after suspend)
+_description: USB Type-C tests (after suspend)
+include:
+    after-suspend-usb-c/c-to-a-adapter/hid                   certification-status=blocker
+    after-suspend-usb-c/c-to-a-adapter/storage-manual        certification-status=blocker
+    after-suspend-usb-c/storage-manual                       certification-status=blocker
+    after-suspend-usb-c/c-to-ethernet-adapter-insert
 
 id: after-suspend-usb-c-cert-manual
 unit: test plan

--- a/providers/base/units/usb/test-plan.pxu
+++ b/providers/base/units/usb/test-plan.pxu
@@ -1,227 +1,4 @@
-id: usb-cert-full
-unit: test plan
-_name: USB tests (Cert full)
-_description:
- USB tests
-include:
-nested_part:
- com.canonical.certification::usb-cert-manual
- com.canonical.certification::usb-cert-automated
-
-id: usb-cert-manual
-unit: test plan
-_name: USB tests (Manual)
-_description:
- USB tests (Manual)
-include:
- usb/hid                                    certification-status=blocker
- usb/storage-manual                         certification-status=blocker
-
-id: after-suspend-usb-cert-manual
-unit: test plan
-_name: USB tests after suspend (Manual)
-_description: USB tests after suspend (Manual)
-include:
- after-suspend-usb/hid                      certification-status=blocker
- after-suspend-usb/storage-manual           certification-status=blocker
-
-id: usb-cert-automated
-unit: test plan
-_name: USB tests (Automated)
-_description:
- USB tests (Automated)
-include:
- usb/detect                                 certification-status=blocker
- usb/storage-detect
- usb/storage-preinserted-.*
-
-id: after-suspend-usb-cert-automated
-unit: test plan
-_name: USB tests (Automated after suspend)
-_description:
- USB tests (Automated)
-include:
- after-suspend-usb/detect                                 certification-status=blocker
- after-suspend-usb/storage-detect
- after-suspend-usb/storage-preinserted-.*
-
-id: usb3-cert-full
-unit: test plan
-_name: USB3 tests (Cert full)
-_description:
- USB3 tests
-include:
-nested_part:
- com.canonical.certification::usb3-cert-manual
- com.canonical.certification::usb3-cert-automated
-
-id: usb3-cert-manual
-unit: test plan
-_name: USB3 tests (Manual)
-_description:
- USB3 tests (Manual)
-include:
- usb3/storage-manual                            certification-status=blocker
-
-id: after-suspend-usb3-cert-manual
-unit: test plan
-_name: USB3 tests after suspend (Manual)
-_description: USB3 tests after suspend (Manual)
-include:
- after-suspend-usb3/storage-manual              certification-status=blocker
-
-id: usb3-cert-automated
-unit: test plan
-_name: USB3 tests (Automated)
-_description:
- USB3 tests (Automated)
-include:
-
-id: after-suspend-usb3-cert-automated
-unit: test plan
-_name: USB3 tests after suspend (Automated)
-_description: USB3 tests after suspend (Automated)
-include:
-
-id: usb-c-cert-full
-unit: test plan
-_name: USB Type-C tests
-_description: USB Type-C tests
-include:
-    usb-c/c-to-a-adapter/hid                   certification-status=blocker
-    usb-c/c-to-a-adapter/storage-manual        certification-status=blocker
-    usb-c/storage-manual                       certification-status=blocker
-    usb-c/c-to-ethernet-adapter-insert
-
-id: after-suspend-usb-cert-full
-unit: test plan
-_name: USB tests (cert full after suspend)
-_description: USB tests (after suspend)
-include:
- after-suspend-usb/hid                                    certification-status=blocker
- after-suspend-usb/storage-manual                         certification-status=blocker
-
-id: after-suspend-usb3-cert-full
-unit: test plan
-_name: USB3 tests (cert full after suspend)
-_description: USB3 tests (after suspend)
-include:
- after-suspend-usb3/storage-manual                        certification-status=blocker
-
-id: after-suspend-usb-c-cert-full
-unit: test plan
-_name: USB Type-C tests (after suspend)
-_description: USB Type-C tests (after suspend)
-include:
-    after-suspend-usb-c/c-to-a-adapter/hid                   certification-status=blocker
-    after-suspend-usb-c/c-to-a-adapter/storage-manual        certification-status=blocker
-    after-suspend-usb-c/storage-manual                       certification-status=blocker
-    after-suspend-usb-c/c-to-ethernet-adapter-insert
-
-id: usb-cert-blockers
-unit: test plan
-_name: USB tests (certification blockers only)
-_description: USB tests (certification blockers only)
-include:
-    usb/detect                                 certification-status=blocker
-    usb/hid                                    certification-status=blocker
-    usb/storage-manual                         certification-status=blocker
-
-id: usb3-cert-blockers
-unit: test plan
-_name: USB3 tests (certification blockers only)
-_description: USB3 tests (certification blockers only)
-include:
-    usb3/storage-manual                        certification-status=blocker
-
-id: usb-c-cert-blockers
-unit: test plan
-_name: USB Type-C tests (certification blockers only)
-_description: USB Type-C tests (certification blockers only)
-include:
-    usb-c/c-to-a-adapter/hid                   certification-status=blocker
-    usb-c/c-to-a-adapter/storage-manual        certification-status=blocker
-    usb-c/storage-manual                       certification-status=blocker
-
-id: usb-c-cert-manual
-unit: test plan
-_name: USB Type-C tests (Manual)
-_description: USB Type-C tests (Manual)
-include:
-    usb-c/storage-manual                       certification-status=blocker
-    usb-c/c-to-ethernet-adapter-insert
-
-id: usb-c-cert-automated
-unit: test plan
-_name: USB Type-C tests (Automated)
-_description: USB Type-C tests (Automated)
-include:
-
-id: after-suspend-usb-c-cert-manual
-unit: test plan
-_name: USB Type-C tests after suspend (Manual)
-_description: USB Type-C tests after suspend (Manual)
-include:
-    after-suspend-usb-c/storage-manual                       certification-status=blocker
-    after-suspend-usb-c/c-to-ethernet-adapter-insert
-
-id: after-suspend-usb-c-cert-automated
-unit: test plan
-_name: USB Type-C tests (Automated)
-_description: USB Type-C tests (Automated)
-include:
-
-id: after-suspend-usb-cert-blockers
-unit: test plan
-_name: USB tests (after suspend, certification blockers only)
-_description: USB tests (after suspend, certification blockers only)
-include:
-    after-suspend-usb/hid                      certification-status=blocker
-    after-suspend-usb/storage-manual           certification-status=blocker
-
-id: after-suspend-usb3-cert-blockers
-unit: test plan
-_name: USB3 tests (after suspend, certification blockers only)
-_description: USB3 tests (after suspend, certification blockers only)
-include:
-    after-suspend-usb3/storage-manual          certification-status=blocker
-
-id: after-suspend-usb-c-cert-blockers
-unit: test plan
-_name: USB Type-C tests (after suspend, certification blockers only)
-_description: USB Type-C tests (after suspend, certification blockers only)
-include:
-    after-suspend-usb-c/c-to-a-adapter/hid                   certification-status=blocker
-    after-suspend-usb-c/c-to-a-adapter/storage-manual        certification-status=blocker
-    after-suspend-usb-c/storage-manual                       certification-status=blocker
-
-id: usb-preinserted
-unit: test plan
-_name: Automated USB write/read/compare tests on storage devices
-_description: Automated USB write/read/compare tests on storage devices
-include:
-    usb/storage-preinserted
-
-id: after-suspend-usb-preinserted
-unit: test plan
-_name: After suspend automated USB write/read/compare tests on storage devices
-_description: After suspend automated USB write/read/compare tests on storage devices
-include:
-    after-suspend-usb/storage-preinserted
-
-id: usb3-preinserted
-unit: test plan
-_name: Automated USB 3 write/read/compare tests on storage devices
-_description: Automated USB 3 write/read/compare tests on storage devices
-include:
-    usb3/storage-preinserted
-
-id: after-suspend-usb3-preinserted
-unit: test plan
-_name: After suspend automated USB 3 write/read/compare tests on storage devices
-_description: After suspend automated USB 3 write/read/compare tests on storage devices
-include:
-    after-suspend-usb3/storage-preinserted
+# Usb 2 tests
 
 id: usb-full
 unit: test plan
@@ -250,6 +27,91 @@ include:
 bootstrap_include:
     removable_partition
 
+id: after-suspend-usb-full
+unit: test plan
+_name: USB tests (after suspend)
+_description: QA USB tests for Ubuntu Core devices
+include:
+nested_part:
+    after-suspend-usb-manual
+
+id: after-suspend-usb-manual
+unit: test plan
+_name: Manual USB tests (after suspend)
+_description: Manual USB tests for Ubuntu Core devices
+include:
+    after-suspend-usb/hid
+    after-suspend-usb/storage-manual
+
+id: after-suspend-usb-automated
+unit: test plan
+_name: Automated USB tests (after suspend)
+_description: Automated USB tests for Ubuntu Core devices
+include:
+    after-suspend-usb/storage-detect
+    after-suspend-usb/storage-preinserted-.*
+bootstrap_include:
+    removable_partition
+
+# Usb 2 tests (cert)
+
+id: usb-cert-full
+unit: test plan
+_name: USB tests (Cert full)
+_description:
+ USB tests
+include:
+nested_part:
+ com.canonical.certification::usb-cert-manual
+ com.canonical.certification::usb-cert-automated
+
+id: usb-cert-manual
+unit: test plan
+_name: USB tests (Manual)
+_description:
+ USB tests (Manual)
+include:
+ usb/hid                                    certification-status=blocker
+ usb/storage-manual                         certification-status=blocker
+
+id: usb-cert-automated
+unit: test plan
+_name: USB tests (Automated)
+_description:
+ USB tests (Automated)
+include:
+ usb/detect                                 certification-status=blocker
+ usb/storage-detect
+ usb/storage-preinserted-.*
+
+id: after-suspend-usb-cert-full
+unit: test plan
+_name: USB tests (cert full after suspend)
+_description: USB tests (after suspend)
+include:
+ after-suspend-usb/hid                                    certification-status=blocker
+ after-suspend-usb/storage-manual                         certification-status=blocker
+
+id: after-suspend-usb-cert-manual
+unit: test plan
+_name: USB tests after suspend (Manual)
+_description: USB tests after suspend (Manual)
+include:
+ after-suspend-usb/hid                      certification-status=blocker
+ after-suspend-usb/storage-manual           certification-status=blocker
+
+id: after-suspend-usb-cert-automated
+unit: test plan
+_name: USB tests (Automated after suspend)
+_description:
+ USB tests (Automated)
+include:
+ after-suspend-usb/detect                                 certification-status=blocker
+ after-suspend-usb/storage-detect
+ after-suspend-usb/storage-preinserted-.*
+
+# Usb 3 tests
+
 id: usb3-full
 unit: test plan
 _name: USB3 tests
@@ -270,6 +132,76 @@ unit: test plan
 _name: Automated USB3 tests
 _description: Manual USB3 tests for Ubuntu Core devices
 include:
+
+id: after-suspend-usb3-full
+unit: test plan
+_name: USB3 tests (after suspend)
+_description: QA USB3 tests for Ubuntu Core devices
+include:
+nested_part:
+    after-suspend-usb3-manual
+
+id: after-suspend-usb3-manual
+unit: test plan
+_name: Manual USB3 tests (after suspend)
+_description: Manual USB3 tests for Ubuntu Core devices
+include:
+    after-suspend-usb3/storage-manual
+
+id: after-suspend-usb3-automated
+unit: test plan
+_name: Automated USB3 tests (after suspend)
+_description: Automated USB3 tests for Ubuntu Core devices
+include:
+
+# Usb 3 tests (cert)
+
+id: usb3-cert-full
+unit: test plan
+_name: USB3 tests (Cert full)
+_description:
+ USB3 tests
+include:
+nested_part:
+ com.canonical.certification::usb3-cert-manual
+ com.canonical.certification::usb3-cert-automated
+
+id: usb3-cert-manual
+unit: test plan
+_name: USB3 tests (Manual)
+_description:
+ USB3 tests (Manual)
+include:
+ usb3/storage-manual                            certification-status=blocker
+
+id: usb3-cert-automated
+unit: test plan
+_name: USB3 tests (Automated)
+_description:
+ USB3 tests (Automated)
+include:
+
+id: after-suspend-usb3-cert-full
+unit: test plan
+_name: USB3 tests (cert full after suspend)
+_description: USB3 tests (after suspend)
+include:
+ after-suspend-usb3/storage-manual                        certification-status=blocker
+
+id: after-suspend-usb3-cert-manual
+unit: test plan
+_name: USB3 tests after suspend (Manual)
+_description: USB3 tests after suspend (Manual)
+include:
+ after-suspend-usb3/storage-manual              certification-status=blocker
+
+id: after-suspend-usb3-cert-automated
+unit: test plan
+_name: USB3 tests after suspend (Automated)
+_description: USB3 tests after suspend (Automated)
+include:
+
+# Usb Type-C tests
 
 id: usb-c-full
 unit: test plan
@@ -301,43 +233,6 @@ _name: Automated USB-C tests
 _description: Automated USB-C tests for Ubuntu Core devices
 include:
 
-id: after-suspend-usb-full
-unit: test plan
-_name: USB tests (after suspend)
-_description: QA USB tests for Ubuntu Core devices
-include:
-nested_part:
-    after-suspend-usb-manual
-
-id: after-suspend-usb-manual
-unit: test plan
-_name: Manual USB tests (after suspend)
-_description: Manual USB tests for Ubuntu Core devices
-include:
-    after-suspend-usb/hid
-    after-suspend-usb/storage-manual
-
-id: after-suspend-usb3-full
-unit: test plan
-_name: USB3 tests (after suspend)
-_description: QA USB3 tests for Ubuntu Core devices
-include:
-nested_part:
-    after-suspend-usb3-manual
-
-id: after-suspend-usb3-manual
-unit: test plan
-_name: Manual USB3 tests (after suspend)
-_description: Manual USB3 tests for Ubuntu Core devices
-include:
-    after-suspend-usb3/storage-manual
-
-id: after-suspend-usb3-automated
-unit: test plan
-_name: Automated USB3 tests (after suspend)
-_description: Automated USB3 tests for Ubuntu Core devices
-include:
-
 id: after-suspend-usb-c-full
 unit: test plan
 _name: USB-C tests (after suspend)
@@ -367,15 +262,57 @@ _name: Automated USB-C tests (after suspend)
 _description: Automated USB-C tests for Ubuntu Core devices
 include:
 
-id: after-suspend-usb-automated
+# Usb Type-C tests (cert)
+
+id: usb-c-cert-full
 unit: test plan
-_name: Automated USB tests (after suspend)
-_description: Automated USB tests for Ubuntu Core devices
+_name: USB Type-C tests
+_description: USB Type-C tests
 include:
-    after-suspend-usb/storage-detect
-    after-suspend-usb/storage-preinserted-.*
-bootstrap_include:
-    removable_partition
+    usb-c/c-to-a-adapter/hid                   certification-status=blocker
+    usb-c/c-to-a-adapter/storage-manual        certification-status=blocker
+    usb-c/storage-manual                       certification-status=blocker
+    usb-c/c-to-ethernet-adapter-insert
+
+id: after-suspend-usb-c-cert-full
+unit: test plan
+_name: USB Type-C tests (after suspend)
+_description: USB Type-C tests (after suspend)
+include:
+    after-suspend-usb-c/c-to-a-adapter/hid                   certification-status=blocker
+    after-suspend-usb-c/c-to-a-adapter/storage-manual        certification-status=blocker
+    after-suspend-usb-c/storage-manual                       certification-status=blocker
+    after-suspend-usb-c/c-to-ethernet-adapter-insert
+
+id: usb-c-cert-manual
+unit: test plan
+_name: USB Type-C tests (Manual)
+_description: USB Type-C tests (Manual)
+include:
+    usb-c/storage-manual                       certification-status=blocker
+    usb-c/c-to-ethernet-adapter-insert
+
+id: usb-c-cert-automated
+unit: test plan
+_name: USB Type-C tests (Automated)
+_description: USB Type-C tests (Automated)
+include:
+
+id: after-suspend-usb-c-cert-manual
+unit: test plan
+_name: USB Type-C tests after suspend (Manual)
+_description: USB Type-C tests after suspend (Manual)
+include:
+    after-suspend-usb-c/storage-manual                       certification-status=blocker
+    after-suspend-usb-c/c-to-ethernet-adapter-insert
+
+id: after-suspend-usb-c-cert-automated
+unit: test plan
+_name: USB Type-C tests (Automated)
+_description: USB Type-C tests (Automated)
+include:
+
+# Server test plan
 
 id: server-usb
 unit: test plan
@@ -385,6 +322,8 @@ include:
     usb/detect
     usb/storage-server      certification-status=blocker
     usb3/storage-server     certification-status=blocker
+
+# 26.04 test plan
 
 id: usb-base-26-04-manual
 unit: test plan
@@ -437,3 +376,87 @@ include:
 nested_part:
     usb-c-cert-automated
     after-suspend-usb-c-cert-automated
+
+# Deprecated (Not used in any test-plan)
+# Usb 2 tests
+
+id: usb-cert-blockers
+unit: test plan
+_name: USB tests (certification blockers only)
+_description: USB tests (certification blockers only)
+include:
+    usb/detect                                 certification-status=blocker
+    usb/hid                                    certification-status=blocker
+    usb/storage-manual                         certification-status=blocker
+
+id: after-suspend-usb-cert-blockers
+unit: test plan
+_name: USB tests (after suspend, certification blockers only)
+_description: USB tests (after suspend, certification blockers only)
+include:
+    after-suspend-usb/hid                      certification-status=blocker
+    after-suspend-usb/storage-manual           certification-status=blocker
+
+id: usb-preinserted
+unit: test plan
+_name: Automated USB write/read/compare tests on storage devices
+_description: Automated USB write/read/compare tests on storage devices
+include:
+    usb/storage-preinserted
+
+id: after-suspend-usb-preinserted
+unit: test plan
+_name: After suspend automated USB write/read/compare tests on storage devices
+_description: After suspend automated USB write/read/compare tests on storage devices
+include:
+    after-suspend-usb/storage-preinserted
+
+# Usb 3 tests
+
+id: usb3-cert-blockers
+unit: test plan
+_name: USB3 tests (certification blockers only)
+_description: USB3 tests (certification blockers only)
+include:
+    usb3/storage-manual                        certification-status=blocker
+
+id: after-suspend-usb3-cert-blockers
+unit: test plan
+_name: USB3 tests (after suspend, certification blockers only)
+_description: USB3 tests (after suspend, certification blockers only)
+include:
+    after-suspend-usb3/storage-manual          certification-status=blocker
+
+id: usb3-preinserted
+unit: test plan
+_name: Automated USB 3 write/read/compare tests on storage devices
+_description: Automated USB 3 write/read/compare tests on storage devices
+include:
+    usb3/storage-preinserted
+
+id: after-suspend-usb3-preinserted
+unit: test plan
+_name: After suspend automated USB 3 write/read/compare tests on storage devices
+_description: After suspend automated USB 3 write/read/compare tests on storage devices
+include:
+    after-suspend-usb3/storage-preinserted
+
+# Usb c tests
+
+id: usb-c-cert-blockers
+unit: test plan
+_name: USB Type-C tests (certification blockers only)
+_description: USB Type-C tests (certification blockers only)
+include:
+    usb-c/c-to-a-adapter/hid                   certification-status=blocker
+    usb-c/c-to-a-adapter/storage-manual        certification-status=blocker
+    usb-c/storage-manual                       certification-status=blocker
+
+id: after-suspend-usb-c-cert-blockers
+unit: test plan
+_name: USB Type-C tests (after suspend, certification blockers only)
+_description: USB Type-C tests (after suspend, certification blockers only)
+include:
+    after-suspend-usb-c/c-to-a-adapter/hid                   certification-status=blocker
+    after-suspend-usb-c/c-to-a-adapter/storage-manual        certification-status=blocker
+    after-suspend-usb-c/storage-manual                       certification-status=blocker

--- a/providers/base/units/usb/test-plan.pxu
+++ b/providers/base/units/usb/test-plan.pxu
@@ -279,6 +279,7 @@ unit: test plan
 _name: USB Type-C tests (Manual)
 _description: USB Type-C tests (Manual)
 include:
+    usb-c/c-to-a-adapter/hid                   certification-status=blocker
     usb-c/storage-manual                       certification-status=blocker
     usb-c/c-to-ethernet-adapter-insert
 
@@ -303,6 +304,7 @@ unit: test plan
 _name: USB Type-C tests after suspend (Manual)
 _description: USB Type-C tests after suspend (Manual)
 include:
+    after-suspend-usb-c/c-to-a-adapter/hid                   certification-status=blocker
     after-suspend-usb-c/storage-manual                       certification-status=blocker
     after-suspend-usb-c/c-to-ethernet-adapter-insert
 

--- a/providers/base/units/usb/usb.pxu
+++ b/providers/base/units/usb/usb.pxu
@@ -55,7 +55,7 @@ _verification:
 _summary: Verify USB HID devices functionality by performing specified actions.
 
 id: usb/storage-manual
-flags: also-after-suspend fail-on-resource
+flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_usb_type_a == 'True'

--- a/providers/base/units/usb/usb.pxu
+++ b/providers/base/units/usb/usb.pxu
@@ -38,6 +38,9 @@ category_id: com.canonical.plainbox::usb
 id: usb/HID
 flags: also-after-suspend
 depends: usb/detect
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_usb_type_a == 'True'
 estimated_duration: 1.0
 command: keyboard_test.py
 _description:
@@ -53,6 +56,9 @@ _summary: Verify USB HID devices functionality by performing specified actions.
 
 id: usb/storage-manual
 flags: also-after-suspend fail-on-resource
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_usb_type_a == 'True'
 _summary: Test USB 2.0 storage device insertion + read/write + removal.
 _purpose:
     Check system can detect insertion of a USB 2.0 storage device.
@@ -80,8 +86,10 @@ estimated_duration: 120
 
 id: usb3/storage-manual
 flags: also-after-suspend
+imports: from com.canonical.plainbox import manifest
 requires:
  usb.usb3 == 'supported'
+ manifest.has_usb_type_a == 'True'
 _summary: Test USB 3.0 storage device insertion + read/write + removal.
 _purpose:
     Check system can detect insertion of a USB 3.0 storage device.
@@ -257,6 +265,9 @@ _purpose:
 depends: usb/storage-detect
 
 id: usb/hid
+imports: from com.canonical.plainbox import manifest
+requires:
+ manifest.has_usb_type_a == 'True'
 _summary: USB keyboard works
 _purpose:
  Check USB input device works

--- a/tools/lab_dispatch/resources/manifest.conf
+++ b/tools/lab_dispatch/resources/manifest.conf
@@ -8,5 +8,6 @@ com.canonical.certification::has_thunderbolt3 = false
 com.canonical.certification::has_touchscreen = false
 com.canonical.certification::has_tpm2_chip = false
 com.canonical.certification::has_usb_storage = true
+com.canonical.certification::has_usb_type_a = true
 com.canonical.certification::has_usb_type_c = false
 com.canonical.certification::has_wlan_adapter = true


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

There are some devices that don’t come with any USB-A port, and their usb tests have to be manually skipped:

https://certification.canonical.com/hardware/202510-38027/submission/456469/test-results/?term=usb%2F

Since there are already specific tests for USB-C ports, we should add a manifest entry so the tests are not executed

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

This issue was common while reviewing certificates, since that's the only place where we run the manual tests. [This   submission](https://certification.canonical.com/hardware/202510-38027/submission/456469/test-results/?term=usb%2F) is from a certificate request.

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

N/A
## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->

Tested locally with different manifests:
"com.canonical.certification::has_usb_type_a": true
"com.canonical.certification::has_usbc_data": true

usb-manual:
```
 ☑ : Hardware Manifest
 ☑ : USB keyboard works
 ☑ : Test USB 2.0 storage device insertion + read/write + removal.
```
usb3-manual:
```
 ☑ : Collect information about supported types of USB
 ☑ : Hardware Manifest
 ☑ : Test USB 3.0 storage device insertion + read/write + removal.
```
usb-c-manual: 
```
 ☑ : Hardware Manifest
 ☑ : USB HID work on USB Type-C port using a "USB Type-C to Type-A" adapter
 ☑ : Collect information about supported types of USB
 ☑ : USB 3.0 storage device insertion + read/write + removal on USB Type-C port
...
```
"com.canonical.certification::has_usb_type_a": false
"com.canonical.certification::has_usbc_data": true

usb-manual:
```
 ☑ : Hardware Manifest
 ☐ : USB keyboard works
 ☐ : Test USB 2.0 storage device insertion + read/write + removal.
```
usb3-manual:
```
 ☑ : Collect information about supported types of USB
 ☑ : Hardware Manifest
 ☐ : Test USB 3.0 storage device insertion + read/write + removal.
```
usb-c-manual: 
```
 ☑ : Hardware Manifest
 ☑ : USB HID work on USB Type-C port using a "USB Type-C to Type-A" adapter
 ☑ : Collect information about supported types of USB
 ☑ : USB 3.0 storage device insertion + read/write + removal on USB Type-C port
...
```
