### PR TITLE
Skip checking actual_brightness if brightness scaling is "non-linear" (Bugfix)

### DIFF
--- a/providers/base/bin/brightness_test.py
+++ b/providers/base/bin/brightness_test.py
@@ -150,7 +150,7 @@ def main():
             # since the naked-eye perceives brightness logarithmically
             # the BIOS might have already scaled the values,
             # which means the actual_brightness (raw register) value
-            # grows logarithmically i.e will not be max_brightness // 2
+            # grows logarithmically and will not be max_brightness / 2
             #
             # notably on AMD gpus, the 'scale' file explicitly says non-linear,
             # thus we should not be checking it unless there's a way to know

--- a/providers/base/bin/brightness_test.py
+++ b/providers/base/bin/brightness_test.py
@@ -114,7 +114,7 @@ class Brightness:
             return 0
 
     def get_scale(self, path) -> str:
-        return Path(path) / "scale"
+        return (Path(path) / "scale").read_text()
 
 
 def main():

--- a/providers/base/bin/brightness_test.py
+++ b/providers/base/bin/brightness_test.py
@@ -29,9 +29,10 @@ import os
 import time
 
 from glob import glob
+from pathlib import Path
 
 
-class Brightness(object):
+class Brightness:
     def __init__(self, path="/sys/class/backlight"):
         self.sysfs_path = path
         self.interfaces = self._get_interfaces_from_path()
@@ -112,6 +113,9 @@ class Brightness(object):
         else:
             return 0
 
+    def get_scale(self, path) -> str:
+        return Path(path) / "scale"
+
 
 def main():
     brightness = Brightness()
@@ -139,9 +143,23 @@ def main():
             max_brightness / 2, os.path.join(interface, "brightness")
         )
 
-        # Check that "actual_brightness" reports the same value we
-        # set "brightness" to
-        exit_status += brightness.was_brightness_applied(interface)
+        if brightness.get_scale(interface) != "non-linear":
+            # NOTE: the actual_brightness check
+            #       only makes sense if the scale is linear
+            #
+            # since the naked-eye perceives brightness logarithmically
+            # the BIOS might have already scaled the values,
+            # which means the actual_brightness (raw register) value
+            # grows logarithmically i.e will not be max_brightness // 2
+            #
+            # notably on AMD gpus, the 'scale' file explicitly says non-linear,
+            # thus we should not be checking it unless there's a way to know
+            # what that conversion formula is
+            #
+            # additionally, the scale file on intel gpus says "unknown"
+            # but behaves like "linear",
+            # so let's only exclude non-linear for now
+            exit_status += brightness.was_brightness_applied(interface)
 
         # Wait a little bit before going back to the original value
         time.sleep(2)

--- a/providers/base/bin/brightness_test.py
+++ b/providers/base/bin/brightness_test.py
@@ -114,7 +114,7 @@ class Brightness:
             return 0
 
     def get_scale(self, path) -> str:
-        return (Path(path) / "scale").read_text()
+        return (Path(path) / "scale").read_text().strip()
 
 
 def main():

--- a/providers/base/tests/test_brightness_test.py
+++ b/providers/base/tests/test_brightness_test.py
@@ -1,0 +1,126 @@
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from brightness_test import Brightness
+
+SYSFS_PATH = "/sys/class/backlight"
+
+
+class TestGetMaxBrightness(unittest.TestCase):
+    def test_reads_max_brightness_file(self):
+        b = Brightness.__new__(Brightness)
+        with patch.object(b, "read_value", return_value=255) as mock_read:
+            result = b.get_max_brightness(
+                "/sys/class/backlight/intel_backlight"
+            )
+        mock_read.assert_called_once_with(
+            "/sys/class/backlight/intel_backlight/max_brightness"
+        )
+        self.assertEqual(result, 255)
+
+
+class TestGetActualBrightness(unittest.TestCase):
+    def test_reads_actual_brightness_file(self):
+        b = Brightness.__new__(Brightness)
+        with patch.object(b, "read_value", return_value=128) as mock_read:
+            result = b.get_actual_brightness(
+                "/sys/class/backlight/intel_backlight"
+            )
+        mock_read.assert_called_once_with(
+            "/sys/class/backlight/intel_backlight/actual_brightness"
+        )
+        self.assertEqual(result, 128)
+
+
+class TestGetLastSetBrightness(unittest.TestCase):
+    def test_reads_brightness_file(self):
+        b = Brightness.__new__(Brightness)
+        with patch.object(b, "read_value", return_value=64) as mock_read:
+            result = b.get_last_set_brightness(
+                "/sys/class/backlight/intel_backlight"
+            )
+        mock_read.assert_called_once_with(
+            "/sys/class/backlight/intel_backlight/brightness"
+        )
+        self.assertEqual(result, 64)
+
+
+class TestGetInterfacesFromPath(unittest.TestCase):
+    def test_returns_empty_list_when_path_does_not_exist(self):
+        with patch("brightness_test.os.path.isdir", return_value=False):
+            b = Brightness(path="/nonexistent")
+        self.assertEqual(b.interfaces, [])
+
+    def test_returns_subdirectory_interfaces(self):
+        dirs = [
+            "/sys/class/backlight/intel_backlight",
+            "/sys/class/backlight/acpi_video0",
+        ]
+        with (
+            patch("brightness_test.os.path.isdir", return_value=True),
+            patch(
+                "brightness_test.glob",
+                return_value=dirs,
+            ),
+        ):
+            b = Brightness(path=SYSFS_PATH)
+        self.assertEqual(b.interfaces, dirs)
+
+    def test_excludes_non_directory_entries(self):
+        entries = [
+            "/sys/class/backlight/intel_backlight",
+            "/sys/class/backlight/somefile",
+        ]
+
+        def _isdir(path):
+            return path != "/sys/class/backlight/somefile"
+
+        with (
+            patch("brightness_test.os.path.isdir", side_effect=_isdir),
+            patch(
+                "brightness_test.glob",
+                return_value=entries,
+            ),
+        ):
+            b = Brightness(path=SYSFS_PATH)
+        self.assertEqual(
+            b.interfaces, ["/sys/class/backlight/intel_backlight"]
+        )
+
+
+class TestWasBrightnessApplied(unittest.TestCase):
+    INTERFACE = "/sys/class/backlight/intel_backlight"
+
+    def _make_brightness(
+        self,
+        actual_brightness: int,
+        last_set_brightness: int,
+    ):
+        b = Brightness.__new__(Brightness)
+        b.get_actual_brightness = MagicMock(return_value=actual_brightness)
+        b.get_last_set_brightness = MagicMock(return_value=last_set_brightness)
+        return b
+
+    def test_happy_path(self):
+        b = self._make_brightness(100, 100)
+        self.assertEqual(b.was_brightness_applied(self.INTERFACE), 0)
+        b = self._make_brightness(101, 100)
+        self.assertEqual(b.was_brightness_applied(self.INTERFACE), 0)
+
+    def test_difference_greater_than_one(self):
+        b = self._make_brightness(103, 100)
+        self.assertEqual(b.was_brightness_applied(self.INTERFACE), 1)
+
+
+class TestGetScale(unittest.TestCase):
+    def test_returns_path_to_scale_file(self):
+        b = Brightness.__new__(Brightness)
+        result = b.get_scale("/sys/class/backlight/intel_backlight")
+        expected = Path("/sys/class/backlight/intel_backlight") / "scale"
+        self.assertEqual(result, expected)
+
+
+if __name__ == "__main__":
+    # verbosity=2 shows the test names when running locally
+    unittest.main(verbosity=2)

--- a/providers/base/tests/test_brightness_test.py
+++ b/providers/base/tests/test_brightness_test.py
@@ -13,7 +13,9 @@ class TestGetScale(unittest.TestCase):
 
     def test_reads_non_linear_scale(self):
         b = Brightness.__new__(Brightness)
-        with patch("brightness_test.Path.read_text", return_value="non-linear\n"):
+        with patch(
+            "brightness_test.Path.read_text", return_value="non-linear\n"
+        ):
             result = b.get_scale("/sys/class/backlight/amdgpu_bl0")
         self.assertEqual(result, "non-linear\n")
 
@@ -41,27 +43,35 @@ class TestMainScaleBranch(unittest.TestCase):
         return ctx.exception.code
 
     def test_linear_scale_calls_check_and_exits_zero_on_success(self):
-        mock_b = self._make_mock_brightness("linear", was_applied_return_value=0)
+        mock_b = self._make_mock_brightness(
+            "linear", was_applied_return_value=0
+        )
         rv = self._run_main(mock_b)
         mock_b.was_brightness_applied.assert_called_once_with(self.INTERFACE)
         self.assertEqual(rv, 0)
 
     def test_linear_scale_calls_check_and_exits_one_on_failure(self):
-        mock_b = self._make_mock_brightness("linear", was_applied_return_value=1)
+        mock_b = self._make_mock_brightness(
+            "linear", was_applied_return_value=1
+        )
         rv = self._run_main(mock_b)
         mock_b.was_brightness_applied.assert_called_once_with(self.INTERFACE)
         self.assertEqual(rv, 1)
 
     def test_unknown_scale_calls_check_and_exits_zero(self):
         # intel case
-        mock_b = self._make_mock_brightness("unknown", was_applied_return_value=0)
+        mock_b = self._make_mock_brightness(
+            "unknown", was_applied_return_value=0
+        )
         rv = self._run_main(mock_b)
         mock_b.was_brightness_applied.assert_called_once_with(self.INTERFACE)
         self.assertEqual(rv, 0)
 
     def test_non_linear_scale_skips_check_and_exits_zero(self):
         # amd case
-        mock_b = self._make_mock_brightness("non-linear", was_applied_return_value=1)
+        mock_b = self._make_mock_brightness(
+            "non-linear", was_applied_return_value=1
+        )
         rv = self._run_main(mock_b)
         mock_b.was_brightness_applied.assert_not_called()
         self.assertEqual(rv, 0)

--- a/providers/base/tests/test_brightness_test.py
+++ b/providers/base/tests/test_brightness_test.py
@@ -1,124 +1,70 @@
 import unittest
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from brightness_test import Brightness
-
-SYSFS_PATH = "/sys/class/backlight"
-
-
-class TestGetMaxBrightness(unittest.TestCase):
-    def test_reads_max_brightness_file(self):
-        b = Brightness.__new__(Brightness)
-        with patch.object(b, "read_value", return_value=255) as mock_read:
-            result = b.get_max_brightness(
-                "/sys/class/backlight/intel_backlight"
-            )
-        mock_read.assert_called_once_with(
-            "/sys/class/backlight/intel_backlight/max_brightness"
-        )
-        self.assertEqual(result, 255)
-
-
-class TestGetActualBrightness(unittest.TestCase):
-    def test_reads_actual_brightness_file(self):
-        b = Brightness.__new__(Brightness)
-        with patch.object(b, "read_value", return_value=128) as mock_read:
-            result = b.get_actual_brightness(
-                "/sys/class/backlight/intel_backlight"
-            )
-        mock_read.assert_called_once_with(
-            "/sys/class/backlight/intel_backlight/actual_brightness"
-        )
-        self.assertEqual(result, 128)
-
-
-class TestGetLastSetBrightness(unittest.TestCase):
-    def test_reads_brightness_file(self):
-        b = Brightness.__new__(Brightness)
-        with patch.object(b, "read_value", return_value=64) as mock_read:
-            result = b.get_last_set_brightness(
-                "/sys/class/backlight/intel_backlight"
-            )
-        mock_read.assert_called_once_with(
-            "/sys/class/backlight/intel_backlight/brightness"
-        )
-        self.assertEqual(result, 64)
-
-
-class TestGetInterfacesFromPath(unittest.TestCase):
-    def test_returns_empty_list_when_path_does_not_exist(self):
-        with patch("brightness_test.os.path.isdir", return_value=False):
-            b = Brightness(path="/nonexistent")
-        self.assertEqual(b.interfaces, [])
-
-    def test_returns_subdirectory_interfaces(self):
-        dirs = [
-            "/sys/class/backlight/intel_backlight",
-            "/sys/class/backlight/acpi_video0",
-        ]
-        with (
-            patch("brightness_test.os.path.isdir", return_value=True),
-            patch(
-                "brightness_test.glob",
-                return_value=dirs,
-            ),
-        ):
-            b = Brightness(path=SYSFS_PATH)
-        self.assertEqual(b.interfaces, dirs)
-
-    def test_excludes_non_directory_entries(self):
-        entries = [
-            "/sys/class/backlight/intel_backlight",
-            "/sys/class/backlight/somefile",
-        ]
-
-        def _isdir(path):
-            return path != "/sys/class/backlight/somefile"
-
-        with (
-            patch("brightness_test.os.path.isdir", side_effect=_isdir),
-            patch(
-                "brightness_test.glob",
-                return_value=entries,
-            ),
-        ):
-            b = Brightness(path=SYSFS_PATH)
-        self.assertEqual(
-            b.interfaces, ["/sys/class/backlight/intel_backlight"]
-        )
-
-
-class TestWasBrightnessApplied(unittest.TestCase):
-    INTERFACE = "/sys/class/backlight/intel_backlight"
-
-    def _make_brightness(
-        self,
-        actual_brightness: int,
-        last_set_brightness: int,
-    ):
-        b = Brightness.__new__(Brightness)
-        b.get_actual_brightness = MagicMock(return_value=actual_brightness)
-        b.get_last_set_brightness = MagicMock(return_value=last_set_brightness)
-        return b
-
-    def test_happy_path(self):
-        b = self._make_brightness(100, 100)
-        self.assertEqual(b.was_brightness_applied(self.INTERFACE), 0)
-        b = self._make_brightness(101, 100)
-        self.assertEqual(b.was_brightness_applied(self.INTERFACE), 0)
-
-    def test_difference_greater_than_one(self):
-        b = self._make_brightness(103, 100)
-        self.assertEqual(b.was_brightness_applied(self.INTERFACE), 1)
+from brightness_test import Brightness, main
 
 
 class TestGetScale(unittest.TestCase):
-    def test_returns_path_to_scale_file(self):
+    def test_reads_scale_file_content(self):
         b = Brightness.__new__(Brightness)
-        result = b.get_scale("/sys/class/backlight/intel_backlight")
-        expected = Path("/sys/class/backlight/intel_backlight") / "scale"
-        self.assertEqual(result, expected)
+        with patch("brightness_test.Path.read_text", return_value="linear\n"):
+            result = b.get_scale("/sys/class/backlight/intel_backlight")
+        self.assertEqual(result, "linear\n")
+
+    def test_reads_non_linear_scale(self):
+        b = Brightness.__new__(Brightness)
+        with patch("brightness_test.Path.read_text", return_value="non-linear\n"):
+            result = b.get_scale("/sys/class/backlight/amdgpu_bl0")
+        self.assertEqual(result, "non-linear\n")
+
+
+class TestMainScaleBranch(unittest.TestCase):
+    INTERFACE = "/sys/class/backlight/amdgpu_bl0"
+
+    def _make_mock_brightness(self, scale_value, was_applied_return_value=0):
+        mock_b = MagicMock()
+        mock_b.interfaces = [self.INTERFACE]
+        mock_b.get_actual_brightness.return_value = 100
+        mock_b.get_max_brightness.return_value = 255
+        mock_b.get_scale.return_value = scale_value
+        mock_b.was_brightness_applied.return_value = was_applied_return_value
+        return mock_b
+
+    def _run_main(self, mock_b):
+        with (
+            patch("brightness_test.Brightness", return_value=mock_b),
+            patch("brightness_test.os.geteuid", return_value=0),
+            patch("brightness_test.time.sleep"),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+        return ctx.exception.code
+
+    def test_linear_scale_calls_check_and_exits_zero_on_success(self):
+        mock_b = self._make_mock_brightness("linear", was_applied_return_value=0)
+        rv = self._run_main(mock_b)
+        mock_b.was_brightness_applied.assert_called_once_with(self.INTERFACE)
+        self.assertEqual(rv, 0)
+
+    def test_linear_scale_calls_check_and_exits_one_on_failure(self):
+        mock_b = self._make_mock_brightness("linear", was_applied_return_value=1)
+        rv = self._run_main(mock_b)
+        mock_b.was_brightness_applied.assert_called_once_with(self.INTERFACE)
+        self.assertEqual(rv, 1)
+
+    def test_unknown_scale_calls_check_and_exits_zero(self):
+        # intel case
+        mock_b = self._make_mock_brightness("unknown", was_applied_return_value=0)
+        rv = self._run_main(mock_b)
+        mock_b.was_brightness_applied.assert_called_once_with(self.INTERFACE)
+        self.assertEqual(rv, 0)
+
+    def test_non_linear_scale_skips_check_and_exits_zero(self):
+        # amd case
+        mock_b = self._make_mock_brightness("non-linear", was_applied_return_value=1)
+        rv = self._run_main(mock_b)
+        mock_b.was_brightness_applied.assert_not_called()
+        self.assertEqual(rv, 0)
 
 
 if __name__ == "__main__":

--- a/providers/base/tests/test_brightness_test.py
+++ b/providers/base/tests/test_brightness_test.py
@@ -9,7 +9,7 @@ class TestGetScale(unittest.TestCase):
         b = Brightness.__new__(Brightness)
         with patch("brightness_test.Path.read_text", return_value="linear\n"):
             result = b.get_scale("/sys/class/backlight/intel_backlight")
-        self.assertEqual(result, "linear\n")
+        self.assertEqual(result, "linear")
 
     def test_reads_non_linear_scale(self):
         b = Brightness.__new__(Brightness)
@@ -17,7 +17,7 @@ class TestGetScale(unittest.TestCase):
             "brightness_test.Path.read_text", return_value="non-linear\n"
         ):
             result = b.get_scale("/sys/class/backlight/amdgpu_bl0")
-        self.assertEqual(result, "non-linear\n")
+        self.assertEqual(result, "non-linear")
 
 
 class TestMainScaleBranch(unittest.TestCase):

--- a/providers/base/tests/test_brightness_test.py
+++ b/providers/base/tests/test_brightness_test.py
@@ -33,11 +33,9 @@ class TestMainScaleBranch(unittest.TestCase):
         return mock_b
 
     def _run_main(self, mock_b):
-        with (
-            patch("brightness_test.Brightness", return_value=mock_b),
-            patch("brightness_test.os.geteuid", return_value=0),
-            patch("brightness_test.time.sleep"),
-        ):
+        with patch("brightness_test.Brightness", return_value=mock_b), patch(
+            "brightness_test.os.geteuid", return_value=0
+        ), patch("brightness_test.time.sleep"):
             with self.assertRaises(SystemExit) as ctx:
                 main()
         return ctx.exception.code


### PR DESCRIPTION
## Description

In the current brightness test there's a check where after writing to the `brightness` file, the script checks if `actual_brightness` reports a value close to `max_brightness / 2`. This PR changes it to only test when brightness scaling is not `non-linear`.

## Resolved issues

The current brightness test will always return non-zero on devices that don't use linear brightness scaling. It can be confusing when the physical brightness changes correctly.

Technically we can do an [R^2 test](https://en.wikipedia.org/wiki/Coefficient_of_determination) for linearity, but I feel like that's overcomplicated for a manual test case.

## Documentation

Documented in the python comment, but the idea is that the `actual_brightness` value is often times the raw register value which isn't always scaled linearly. Checking it directly against `max_brightness / 2` isn't correct in this case.

## Tests
