### PR TITLE
Check if the custom_frontend is non-empty (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/test_v1.py
@@ -1242,15 +1242,20 @@ class CustomFrontendPROVIDERPATHTest(TestCase):
         self.assertEqual(get_secure_custom_frontend_PROVIDERPATH_list(), [])
 
     @patch("plainbox.impl.secure.providers.v1.Path")
+    @patch("plainbox.impl.secure.providers.v1.logger")
     @patch("os.getenv", new=Mock(return_value="/snap/checkbox24/x1/current"))
-    def test_path_custom_frontend(self, mock_Path):
+    def test_path_custom_frontend(self, mock_logger, mock_Path):
         custom_frontends = mock_Path() / "custom_frontends"
         custom_frontends.exists.return_value = True
 
         # valid, has a custom_frontend/providers
         valid_custom_frontend = MagicMock()
+        valid_custom_frontend.iterdir.return_value = [
+            Path("providers"),
+            Path("bin"),
+        ]
         valid_custom_frontend_providers = valid_custom_frontend / "providers"
-        valid_custom_frontend_providers.exists = Mock(return_value=True)
+        valid_custom_frontend_providers.exists.return_value = True
         # frontend contains 2 providers
         valid_custom_frontend_providers.iterdir.return_value = [
             Path("a"),
@@ -1258,8 +1263,10 @@ class CustomFrontendPROVIDERPATHTest(TestCase):
         ]
 
         # invalid, doesn't have custom_frontend/providers
+        # but is non-empty
         invalid_custom_frontend = MagicMock()
         (invalid_custom_frontend / "providers").exists.return_value = False
+        invalid_custom_frontend.iterdir.return_value = [Path("bin")]
 
         custom_frontends.iterdir.return_value = [
             valid_custom_frontend,
@@ -1268,6 +1275,28 @@ class CustomFrontendPROVIDERPATHTest(TestCase):
         self.assertEqual(
             get_secure_custom_frontend_PROVIDERPATH_list(), ["a", "b"]
         )
+        self.assertTrue(mock_logger.error.called)
+
+    @patch("plainbox.impl.secure.providers.v1.Path")
+    @patch("plainbox.impl.secure.providers.v1.logger")
+    @patch("os.getenv", new=Mock(return_value="/snap/checkbox24/x1/current"))
+    def test_path_custom_frontend_default_ignored(
+        self, mock_logger, mock_Path
+    ):
+        custom_frontends = mock_Path() / "custom_frontends"
+        custom_frontends.exists.return_value = True
+
+        # invalid, doesn't have custom_frontend/providers
+        # but is non-empty
+        default_custom_frontend = MagicMock()
+        (default_custom_frontend / "providers").exists.return_value = False
+        default_custom_frontend.iterdir.return_value = []
+
+        custom_frontends.iterdir.return_value = [
+            default_custom_frontend,
+        ]
+        self.assertEqual(get_secure_custom_frontend_PROVIDERPATH_list(), [])
+        self.assertFalse(mock_logger.error.called)
 
 
 @patch("plainbox.impl.secure.providers.v1.logger")

--- a/checkbox-ng/plainbox/impl/secure/providers/v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/v1.py
@@ -2060,12 +2060,17 @@ def get_secure_custom_frontend_PROVIDERPATH_list():
     for custom_frontend_root in custom_frontends_path.iterdir():
         providers_path = custom_frontend_root / "providers"
         if not providers_path.exists():
-            logger.error(
-                "Custom frontend must have `providers` directory in root. "
-                "Invalid custom frontend found: {}".format(
-                    custom_frontend_root
+            # since core26, the target of all interfaces is always created even
+            # if the content interface is not plugged. This warning is supposed
+            # to notify if the custom frontend they plugged is invalid. This is
+            # why it checks if the dir is non-empty
+            if any(True for _ in custom_frontend_root.iterdir()):
+                logger.error(
+                    "Custom frontend must have `providers` directory in root. "
+                    "Invalid custom frontend found: {}".format(
+                        custom_frontend_root
+                    )
                 )
-            )
             continue
         providers_paths += providers_path.iterdir()
     return list(map(str, providers_paths))


### PR DESCRIPTION
## Description

This is necessary because the custom_frontend directory will now always exist on core26, even when unplugged. We have to check if it is non-empty before erroring else we spam errors for nothing.

## Resolved issues

Issue:
```
Custom frontend must have `providers` directory in root. Invalid custom frontend found: /snap/checkbox26/x1/custom_frontends/custom_frontend
Custom frontend must have `providers` directory in root. Invalid custom frontend found: /snap/checkbox26/x1/custom_frontends/custom_frontend
Custom frontend must have `providers` directory in root. Invalid custom frontend found: /snap/checkbox26/x1/custom_frontends/custom_frontend
Custom frontend must have `providers` directory in root. Invalid custom frontend found: /snap/checkbox26/x1/custom_frontends/custom_frontend
Custom frontend must have `providers` directory in root. Invalid custom frontend found: /snap/checkbox26/x1/custom_frontends/custom_frontend
Custom frontend must have `providers` directory in root. Invalid custom frontend found: /snap/checkbox26/x1/custom_frontends/custom_frontend
Custom frontend must have `providers` directory in root. Invalid custom frontend found: /snap/checkbox26/x1/custom_frontends/custom_frontend
Custom frontend must have `providers` directory in root. Invalid custom frontend found: /snap/checkbox26/x1/custom_frontends/custom_frontend
Custom frontend must have `providers` directory in root. Invalid custom frontend found: /snap/checkbox26/x1/custom_frontends/custom_frontend
Custom frontend must have `providers` directory in root. Invalid custom frontend found: /snap/checkbox26/x1/custom_frontends/custom_frontend
Custom frontend must have `providers` directory in root. Invalid custom frontend found: /snap/checkbox26/x1/custom_frontends/custom_frontend
Custom frontend must have `providers` directory in root. Invalid custom frontend found: /snap/checkbox26/x1/custom_frontends/custom_frontend
```

## Documentation

Added comment to explain why

## Tests

Added unit test for both present (invalid) and present (default created by snapd empty)
