### PR TITLE
Better snap_test.py logging (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/support/snap_utils/snapd.py
+++ b/checkbox-ng/checkbox_ng/support/snap_utils/snapd.py
@@ -19,6 +19,7 @@
 
 import http.client
 import json
+import logging
 import socket
 import time
 
@@ -27,6 +28,12 @@ class AsyncException(Exception):
     def __init__(self, message, abort_message=""):
         self.message = message
         self.abort_message = abort_message
+
+    def __str__(self):
+        message = self.message
+        if self.abort_message:
+            message += "\n\n" + self.abort_message
+        return message
 
 
 class SnapdRequestError(Exception):
@@ -73,14 +80,32 @@ class Snapd:
     _interfaces = "/v2/interfaces"
     _assertions = "/v2/assertions"
 
-    def __init__(self, task_timeout=30, poll_interval=1, verbose=False):
+    def __init__(
+        self, task_timeout=30, poll_interval=1, verbose=False, logger=None
+    ):
         self._task_timeout = task_timeout
         self._poll_interval = poll_interval
         self._verbose = verbose
+        self._logger = self._get_logger(logger, verbose)
+
+    def _get_logger(self, in_logger, verbose):
+        # verbose is here for backward compatibility
+        if in_logger:
+            return in_logger
+        logger = logging.getLogger("snapd")
+        logger.handlers.clear()
+        if verbose:
+            handler = logging.StreamHandler()
+            handler.setFormatter(logging.Formatter("(info) %(message)s"))
+            logger.addHandler(handler)
+            logger.setLevel(logging.INFO)
+        else:
+            logger.addHandler(logging.NullHandler())
+            logger.setLevel(logging.CRITICAL)
+        return logger
 
     def _info(self, msg):
-        if self._verbose:
-            print("(info) {}".format(msg), flush=True)
+        self._logger.info(msg)
 
     def _request(self, method, path, data=None, params=None, decode=True):
         if params:
@@ -115,7 +140,14 @@ class Snapd:
                 return True
             if time.time() > maxtime:
                 abort_result = self._abort_change(change_id)
-                raise AsyncException(status, abort_result)
+                raise AsyncException(
+                    "Task Failed: Timed out waiting for change (timeout: {}s)."
+                    " Final task status: '{}'".format(
+                        self._task_timeout, status
+                    ),
+                    "Aborting task to try to get back the device to normal. "
+                    "Abort result: {}".format(abort_result),
+                )
             for task in self.tasks(change_id):
                 if task["status"] == "Doing":
                     if task["progress"]["label"]:
@@ -139,7 +171,9 @@ class Snapd:
                     self._info(
                         "({}) {}".format(task["status"], task["summary"])
                     )
-                    raise AsyncException(task.get("log"))
+                    raise AsyncException(
+                        "Task failed: Error log: {}".format(task.get("log"))
+                    )
             time.sleep(self._poll_interval)
 
     def _abort_change(self, change_id):

--- a/providers/base/bin/snap_tests.py
+++ b/providers/base/bin/snap_tests.py
@@ -6,10 +6,12 @@
 #    Authors: Jonathan Cave <jonathan.cave@canonical.com>
 
 import argparse
+import logging
 import os
 import sys
+from functools import wraps, partial
 
-from checkbox_support.snap_utils.snapd import Snapd
+from checkbox_support.snap_utils.snapd import Snapd, AsyncException
 
 # Requirements for the test snap:
 #  - the snap must be strictly confined (no classic or devmode flags)
@@ -34,13 +36,55 @@ except KeyError:
 SNAPD_TASK_TIMEOUT = int(os.getenv("SNAPD_TASK_TIMEOUT", 30))
 SNAPD_POLL_INTERVAL = int(os.getenv("SNAPD_POLL_INTERVAL", 1))
 
+print = partial(print, flush=True)
+
+
+def pretty_exit_async_exception(f):
+    """
+    Snapd functions raise AsyncException on failure. Users may assume that a
+    traceback is a test issue. This gets rid of the traceback.
+    """
+
+    @wraps(f)
+    def _f(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except AsyncException as e:
+            raise SystemExit(str(e))
+
+    return _f
+
+
+def remove_if_present(snapd, snap_name):
+    if snapd.list(TEST_SNAP):
+        print(
+            "Test snap '{}' is already installed. Removing it...".format(
+                snap_name
+            )
+        )
+        snapd.remove(TEST_SNAP)
+
+
+def get_snapd_client():
+    logger = logging.getLogger("snapd")
+    logger.handlers.clear()
+    # here we are printing to sys.stdout so that progress flushes the correct stream
+    handler = logging.StreamHandler(sys.stdout)
+    # double space makes it easier to tell what is test progress and what is
+    # logs
+    handler.setFormatter(logging.Formatter("  (snapd) %(message)s"))
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    return Snapd(SNAPD_TASK_TIMEOUT, SNAPD_POLL_INTERVAL, logger=logger)
+
 
 class SnapList:
     """snap list sub-command."""
 
     def invoked(self):
         """snap list should show the core package is installed."""
-        data = Snapd().list()
+        data = get_snapd_client().list()
         for snap in data:
             if snap["name"] in (
                 "core",
@@ -61,7 +105,7 @@ class SnapSearch:
 
     def invoked(self):
         """snap search for TEST_SNAP."""
-        data = Snapd().find(
+        data = get_snapd_client().find(
             TEST_SNAP,
         )
         for snap in data:
@@ -80,18 +124,17 @@ class SnapInstall:
         parser = argparse.ArgumentParser()
         parser.add_argument("channel", help="channel to install from")
         args = parser.parse_args(sys.argv[2:])
-        print("Install {}...".format(TEST_SNAP))
-        s = Snapd(SNAPD_TASK_TIMEOUT, SNAPD_POLL_INTERVAL, verbose=True)
-        if s.list(TEST_SNAP):
-            print("{} already installed. Removing".format(TEST_SNAP))
-            s.remove(TEST_SNAP)
+        s = get_snapd_client()
+        remove_if_present(s, TEST_SNAP)
+        print("Installing '{}'...".format(TEST_SNAP))
         s.install(TEST_SNAP, args.channel)
-        print("Confirm in snap list...")
+        print("Confirming '{}' is in the snap list...".format(TEST_SNAP))
         data = s.list()
         for snap in data:
             if snap["name"] == TEST_SNAP:
+                print("Pass: Test snap is in the snap list")
                 return 0
-        print(" not in snap list")
+        print("Fail: '{}' is not in the snap list".format(TEST_SNAP))
         return 1
 
 
@@ -100,21 +143,20 @@ class SnapRefresh:
 
     def invoked(self):
         """Test refresh of test-snapd-tools snap."""
-        s = Snapd(SNAPD_TASK_TIMEOUT, SNAPD_POLL_INTERVAL)
-        if s.list(TEST_SNAP):
-            print("Remove previously installed revision")
-            s.remove(TEST_SNAP)
-        print("Install starting revision...")
+        s = get_snapd_client()
+        remove_if_present(s, TEST_SNAP)
+        print("Installing stable revision...")
         s.install(TEST_SNAP, "stable")
         start_rev = s.list(TEST_SNAP)["revision"]
-        print("  revision:", start_rev)
-        print("Refresh to edge...")
+        print("Stable revision is:", start_rev)
+        print("Refreshing to edge...")
         s.refresh(TEST_SNAP, "edge")
-        print("Get new revision...")
         new_rev = s.list(TEST_SNAP)["revision"]
-        print("  revision:", new_rev)
+        print("New revision is:", new_rev)
         if new_rev == start_rev:
+            print("Fail: Snap revision didn't change")
             return 1
+        print("Pass: Snap revision changed")
         return 0
 
 
@@ -123,29 +165,32 @@ class SnapRevert:
 
     def invoked(self):
         """Test revert of test-snapd-tools snap."""
-        s = Snapd(SNAPD_TASK_TIMEOUT, SNAPD_POLL_INTERVAL)
-        if s.list(TEST_SNAP):
-            s.remove(TEST_SNAP)
-        print("Install stable revision")
+        s = get_snapd_client()
+        remove_if_present(s, TEST_SNAP)
+        print("Installing stable revision...")
         s.install(TEST_SNAP)
-        print("Refresh to edge")
+        print("Refreshing to edge...")
         s.refresh(TEST_SNAP, "edge")
         print("Get stable channel revision from store...")
         r = s.info(TEST_SNAP)
         stable_rev = r["channels"]["latest/stable"]["revision"]
         r = s.list(TEST_SNAP)
         installed_rev = r["revision"]  # should be edge revision
-        print("Reverting snap {}...".format(TEST_SNAP))
+        print("Reverting test snap '{}'...".format(TEST_SNAP))
         s.revert(TEST_SNAP)
-        print("Get new installed revision...")
         r = s.list(TEST_SNAP)
         rev = r["revision"]
         if rev != stable_rev:
-            print("Not stable revision number")
+            print(
+                "Fail: Failed to revert to stable revision ({}), got: {}".format(
+                    stable_rev, rev
+                )
+            )
             return 1
         if rev == installed_rev:
-            print("Identical revision number")
+            print("Fail: Failed to revert, revisions match ({})".format(rev))
             return 1
+        print("Pass: Snap refreshed and reverted correctly")
         return 0
 
 
@@ -154,25 +199,29 @@ class SnapReupdate:
 
     def invoked(self):
         """Test re-update of test-snapd-tools snap."""
-        s = Snapd(SNAPD_TASK_TIMEOUT, SNAPD_POLL_INTERVAL)
+        s = get_snapd_client()
+        remove_if_present(s, TEST_SNAP)
         print("Get edge channel revision from store...")
-        if s.list(TEST_SNAP):
-            s.remove(TEST_SNAP)
         s.install(TEST_SNAP)
         s.refresh(TEST_SNAP, "edge")
         s.revert(TEST_SNAP)
         r = s.info(TEST_SNAP)
         edge_rev = r["channels"]["latest/edge"]["revision"]
-        print("Remove edge revision...")
+        print("Removing edge revision...")
         s.remove(TEST_SNAP, edge_rev)
-        print("Refresh to edge channel...")
+        print("Refreshing to edge channel...")
         s.refresh(TEST_SNAP, "edge")
-        print("Get new installed revision...")
+        print("Getting new installed revision...")
         r = s.list(TEST_SNAP)
         rev = r["revision"]
         if rev != edge_rev:
-            print("Not edge revision number")
+            print(
+                "Fail: Failed to refresh to edge, expected revision: {}, got {}".format(
+                    edge_rev, rev
+                )
+            )
             return 1
+        print("Pass: Snap re-updated correctly")
 
 
 class SnapRemove:
@@ -180,24 +229,25 @@ class SnapRemove:
 
     def invoked(self):
         """Test remove of test-snapd-tools snap."""
-        print("Remove {}...".format(TEST_SNAP))
-        s = Snapd(SNAPD_TASK_TIMEOUT, SNAPD_POLL_INTERVAL)
+        s = get_snapd_client()
         if not s.list(TEST_SNAP):
-            print("{} not found. Installing".format(TEST_SNAP))
+            print("Test snap '{}' not found. Installing".format(TEST_SNAP))
             s.install(TEST_SNAP)
+        print("Removing '{}'...".format(TEST_SNAP))
         s.remove(TEST_SNAP)
-        print("Check not in snap list")
         data = s.list()
         for snap in data:
             if snap["name"] == TEST_SNAP:
-                print(" found in snap list")
+                print("Fail: Snap '{}' found in snap list".format(TEST_SNAP))
                 return 1
+        print("Pass: Snap '{}' succesfully removed".format(TEST_SNAP))
         return 0
 
 
 class Snap:
     """Fake snap like command."""
 
+    @pretty_exit_async_exception
     def main(self):
         sub_commands = {
             "list": SnapList,

--- a/providers/base/bin/snap_tests.py
+++ b/providers/base/bin/snap_tests.py
@@ -56,13 +56,13 @@ def pretty_exit_async_exception(f):
 
 
 def remove_if_present(snapd, snap_name):
-    if snapd.list(TEST_SNAP):
+    if snapd.list(snap_name):
         print(
             "Test snap '{}' is already installed. Removing it...".format(
                 snap_name
             )
         )
-        snapd.remove(TEST_SNAP)
+        snapd.remove(snap_name)
 
 
 def get_snapd_client():

--- a/providers/base/bin/snap_tests.py
+++ b/providers/base/bin/snap_tests.py
@@ -68,7 +68,8 @@ def remove_if_present(snapd, snap_name):
 def get_snapd_client():
     logger = logging.getLogger("snapd")
     logger.handlers.clear()
-    # here we are printing to sys.stdout so that progress flushes the correct stream
+    # here we are printing to sys.stdout so that progress flushes the correct
+    # stream
     handler = logging.StreamHandler(sys.stdout)
     # double space makes it easier to tell what is test progress and what is
     # logs
@@ -182,9 +183,8 @@ class SnapRevert:
         rev = r["revision"]
         if rev != stable_rev:
             print(
-                "Fail: Failed to revert to stable revision ({}), got: {}".format(
-                    stable_rev, rev
-                )
+                "Fail: Failed to revert to stable revision ({}), "
+                "got: {}".format(stable_rev, rev)
             )
             return 1
         if rev == installed_rev:
@@ -216,9 +216,8 @@ class SnapReupdate:
         rev = r["revision"]
         if rev != edge_rev:
             print(
-                "Fail: Failed to refresh to edge, expected revision: {}, got {}".format(
-                    edge_rev, rev
-                )
+                "Fail: Failed to refresh to edge, expected revision: {}"
+                ", got {}".format(edge_rev, rev)
             )
             return 1
         print("Pass: Snap re-updated correctly")

--- a/providers/base/tests/test_snap_tests.py
+++ b/providers/base/tests/test_snap_tests.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+#
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+# Written by:
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import os
+from pathlib import Path
+import unittest
+from unittest.mock import patch, MagicMock
+
+import snap_tests
+
+
+class SnapTestsUtilityTests(unittest.TestCase):
+    def test_pretty_exit(self):
+
+        @snap_tests.pretty_exit_async_exception
+        def f():
+            raise snap_tests.AsyncException("Test text")
+
+        with self.assertRaises(SystemExit) as e:
+            f()
+        self.assertIn("Test text", str(e.exception))
+
+    def test_remove_if_present(self):
+        snapd_mock = MagicMock()
+        snapd_mock.list.return_value = True
+        snap_tests.remove_if_present(snapd_mock, "snap_name")
+        self.assertTrue(snapd_mock.remove.called)
+
+        snapd_mock = MagicMock()
+        snapd_mock.list.return_value = None
+        snap_tests.remove_if_present(snapd_mock, "snap_name")
+        self.assertFalse(snapd_mock.remove.called)
+
+    @patch("snap_tests.Snapd")
+    def test_get_snapd_client(self, Snapd_mock):
+        snapd = snap_tests.get_snapd_client()
+        self.assertTrue(Snapd_mock.called)
+        self.assertEqual(Snapd_mock(), snapd)
+
+
+class SnapCommandsTests(unittest.TestCase):
+    @patch("snap_tests.Snapd")
+    def test_snap_search(self, Snapd_mock):
+        s = Snapd_mock()
+        s.find.return_value = [
+            {
+                "id": "some_id",
+                "name": "some_name",
+                "developer": "some_developer",
+            }
+        ]
+
+        self.assertEqual(snap_tests.SnapSearch().invoked(), 0)
+
+        s.find.return_value = []
+        self.assertEqual(snap_tests.SnapSearch().invoked(), 1)
+
+    @patch("snap_tests.Snapd")
+    @patch("sys.argv")
+    @patch("argparse.ArgumentParser")
+    def test_snap_install(self, AP_mock, argv_mock, Snapd_mock):
+        s = Snapd_mock()
+        s.list.return_value = [{"name": snap_tests.TEST_SNAP}]
+
+        self.assertEqual(snap_tests.SnapInstall().invoked(), 0)
+
+        s.list.return_value = []
+        self.assertEqual(snap_tests.SnapInstall().invoked(), 1)
+
+    @patch("snap_tests.Snapd")
+    def test_snap_refresh(self, Snapd_mock):
+        s = Snapd_mock()
+        s.list.return_value = {"revision": "100"}
+        self.assertEqual(snap_tests.SnapRefresh().invoked(), 1)
+
+        s.list.side_effect = [None, {"revision": "1"}, {"revision": "2"}]
+        self.assertEqual(snap_tests.SnapRefresh().invoked(), 0)
+
+    @patch("snap_tests.Snapd")
+    def test_snap_revert(self, Snapd_mock):
+        s = Snapd_mock()
+        s.list.side_effect = [
+            None,
+            {"revision": "2"},
+            {"revision": "1"},
+        ]
+        s.info.return_value = {
+            "channels": {"latest/stable": {"revision": "1"}}
+        }
+        self.assertEqual(snap_tests.SnapRevert().invoked(), 0)
+
+        s.list.side_effect = [
+            None,
+            {"revision": "2"},
+            {"revision": "2"},
+        ]
+        self.assertEqual(snap_tests.SnapRevert().invoked(), 1)
+
+    @patch("snap_tests.Snapd")
+    def test_snap_remove(self, Snapd_mock):
+        s = Snapd_mock()
+        s.list.side_effect = [True, []]
+        self.assertEqual(snap_tests.SnapRemove().invoked(), 0)
+
+        s.list.side_effect = [True, [{"name": snap_tests.TEST_SNAP}]]
+        self.assertEqual(snap_tests.SnapRemove().invoked(), 1)
+
+    @patch("snap_tests.Snapd")
+    def test_snap_reupdate(self, Snapd_mock):
+        s = Snapd_mock()
+        s.list.side_effect = [None]
+        s.info.return_value = {"channels": {"latest/edge": {"revision": "5"}}}
+        s.list.side_effect = [None, {"revision": "5"}]
+        self.assertIsNone(snap_tests.SnapReupdate().invoked())
+
+        s.list.side_effect = [None, {"revision": "99"}]
+        self.assertEqual(snap_tests.SnapReupdate().invoked(), 1)


### PR DESCRIPTION
## Description

People are cofused by the snap_test log. This is due to:
1. on timeout it explodes with a traceback and people assume this is a test error
2. the traceback test is gibberish
3. overall the log is useless and not informative (in some cases we hide the changes and therefore loose valuable information for no reason)
4. print("(info)...) sigh

## Resolved issues

Fixes: CHECKBOX-2249
Fixes: https://github.com/canonical/checkbox/issues/2506

## Documentation

Commented where appropriate

## Tests

Lowering the timeout to two seconds here is the before:
```
Install starting revision...
  revision: 1
Refresh to edge...
Traceback (most recent call last):
  File "/tmp/nest-sgn1anwp.5d8fa8fda43408dada8ebcff2a38ab289bec28ba04eca96bb2acc6340d969209/snap_tests.py", line 218, in <module>
    sys.exit(Snap().main())
  File "/tmp/nest-sgn1anwp.5d8fa8fda43408dada8ebcff2a38ab289bec28ba04eca96bb2acc6340d969209/snap_tests.py", line 214, in main
    return sub_commands[args.subcommand]().invoked()
  File "/tmp/nest-sgn1anwp.5d8fa8fda43408dada8ebcff2a38ab289bec28ba04eca96bb2acc6340d969209/snap_tests.py", line 112, in invoked
    s.refresh(TEST_SNAP, "edge")
  File "/snap/checkbox-nuremberg/34/checkbox-runtime/lib/python3.8/site-packages/checkbox_ng/support/snap_utils/snapd.py", line 199, in refresh
    self._poll_change(r["change"])
  File "/snap/checkbox-nuremberg/34/checkbox-runtime/lib/python3.8/site-packages/checkbox_ng/support/snap_utils/snapd.py", line 118, in _poll_change
    raise AsyncException(status, abort_result)
checkbox_ng.support.snap_utils.snapd.AsyncException: ('Doing', 'Abort')
```
And here is the after:
```
root in providers/base/bin on  main [#!?] via 🐍 v3.14.5 (venv) 
❯ TEST_SNAP=test-snapd-tools-core24 python snap_tests.py refresh
Test snap 'test-snapd-tools-core24' is already installed. Removing it...
  (info) (Doing) Remove snap "test-snapd-tools-core24" (2) from the system
Installing stable revision...
  (info) (Doing) Process delayed security backend side effects for affected snaps
  (info) (Doing) Mount snap "test-snapd-tools-core24" (1)
  (info) (Doing) Process delayed security backend side effects for affected snaps
Task Failed: Timed out waiting for change (timeout: 2s). Final task status: 'Doing'

Aborting task to try to get back the device to normal. Abort result: Abort
```

This similarly improves all logs including all changes (tabbed in for clarity) and unifying the output format (doing... before doing a thing, clear Pass or Fail and the reason why something is considered pass or fail)

See for example:
```
❯ TEST_SNAP=test-snapd-tools-core24 python snap_tests.py reupdate
Test snap 'test-snapd-tools-core24' is already installed. Removing it...
  (snapd) (Doing) Stop snap "test-snapd-tools-core24" services
  (snapd) (Doing) Remove snap "test-snapd-tools-core24" (1) from the system
  (snapd) (Doing) Remove snap "test-snapd-tools-core24" (2) from the system
Get edge channel revision from store...
  (snapd) (Doing) Process delayed security backend side effects for affected snaps
  (snapd) (Doing) Mount snap "test-snapd-tools-core24" (1)
  (snapd) (Doing) Process delayed security backend side effects for affected snaps
  (snapd) (Doing) Process delayed security backend side effects for affected snaps
  (snapd) (Doing) Ensure prerequisites for "test-snapd-tools-core24" are available
  (snapd) (Doing) Monitoring snap "test-snapd-tools-core24" to determine whether extra refresh steps are required
  (snapd) (Doing) Process delayed security backend side effects for affected snaps
  (snapd) (Doing) Mount snap "test-snapd-tools-core24" (2)
  (snapd) (Doing) Monitoring snap "test-snapd-tools-core24" to determine whether extra refresh steps are required
  (snapd) (Doing) Process delayed security backend side effects for affected snaps
  (snapd) (Doing) Setup snap "test-snapd-tools-core24" (2) security profiles
  (snapd) (Doing) Monitoring snap "test-snapd-tools-core24" to determine whether extra refresh steps are required
  (snapd) (Doing) Process delayed security backend side effects for affected snaps
  (snapd) (Doing) Run health check of "test-snapd-tools-core24" snap
  (snapd) (Doing) Monitoring snap "test-snapd-tools-core24" to determine whether extra refresh steps are required
  (snapd) (Doing) Process delayed security backend side effects for affected snaps
  (snapd) (Doing) Monitoring snap "test-snapd-tools-core24" to determine whether extra refresh steps are required
  (snapd) (Doing) Ensure prerequisites for "test-snapd-tools-core24" are available
Removing edge revision...
  (snapd) (Doing) Remove data for snap "test-snapd-tools-core24" (2)
Refreshing to edge channel...
  (snapd) (Doing) Monitoring snap "test-snapd-tools-core24" to determine whether extra refresh steps are required
  (snapd) (Doing) Process delayed security backend side effects for affected snaps
  (snapd) (Doing) Mount snap "test-snapd-tools-core24" (2)
  (snapd) (Doing) Monitoring snap "test-snapd-tools-core24" to determine whether extra refresh steps are required
  (snapd) (Doing) Process delayed security backend side effects for affected snaps
  (snapd) (Doing) Setup snap "test-snapd-tools-core24" (2) security profiles
  (snapd) (Doing) Monitoring snap "test-snapd-tools-core24" to determine whether extra refresh steps are required
  (snapd) (Doing) Process delayed security backend side effects for affected snaps
  (snapd) (Doing) Monitoring snap "test-snapd-tools-core24" to determine whether extra refresh steps are required
  (snapd) (Doing) Process delayed security backend side effects for affected snaps
  (snapd) (Doing) Monitoring snap "test-snapd-tools-core24" to determine whether extra refresh steps are required
Getting new installed revision...
Pass: Snap re-updated correctly
```
