### PR TITLE
Remove type hints from ce-oem gst_resources_generator.py (bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_resources_generator.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gst_resources_generator.py
@@ -125,7 +125,7 @@ class GstResources:
         return returned_dict
 
     def gst_v4l2_video_decoder_md5_checksum_comparison(
-        self, scenario_data: list[dict]
+        self, scenario_data: "list[dict]"
     ) -> None:
         for item in scenario_data:
             self._resource_items.extend(
@@ -142,7 +142,7 @@ class GstResources:
                 ]
             )
 
-    def gst_encoder_psnr(self, scenario_data: list[dict]) -> None:
+    def gst_encoder_psnr(self, scenario_data: "list[dict]") -> None:
         # Iterate through each encoder plugin configuration
         for item in scenario_data:
             encoder_plugin = item.get("encoder_plugin")
@@ -198,7 +198,7 @@ class GstResources:
                 )
 
     def gst_video_decoder_performance_fakesink(
-        self, scenario_data: list[dict]
+        self, scenario_data: "list[dict]"
     ) -> None:
         for item in scenario_data:
             self._resource_items.append(
@@ -220,7 +220,9 @@ class GstResources:
                 }
             )
 
-    def gst_transform_rotate_and_flip(self, scenario_data: list[dict]) -> None:
+    def gst_transform_rotate_and_flip(
+        self, scenario_data: "list[dict]"
+    ) -> None:
         # Iterate through each encoder plugin configuration
         for item in scenario_data:
             encoder_plugin = item.get("encoder_plugin")
@@ -242,7 +244,7 @@ class GstResources:
                 }
                 self._resource_items.append(config)
 
-    def gst_transform_resize(self, scenario_data: list[dict]) -> None:
+    def gst_transform_resize(self, scenario_data: "list[dict]") -> None:
         # Iterate through each encoder plugin configuration
         for item in scenario_data:
             encoder_plugin = item.get("encoder_plugin")


### PR DESCRIPTION
## Description

This yields a type error on most versions of python we support.

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/C3-1431

## Documentation

N/A

## Tests

Tested on python3.5, now it crashes in an unrelated way
