### PR TITLE
Fix bug in the environment resource (bugfix)

### DIFF
--- a/providers/resource/bin/environment_resource.py
+++ b/providers/resource/bin/environment_resource.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+import os
+
+
+def no_newlines(s: str):
+    # newlines break resource output
+    return s.replace("\n", "\\n")
+
+
+def main():
+    for key, value in os.environ.items():
+        print("{}: {}".format(key, no_newlines(value)))
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/resource/jobs/resource.pxu
+++ b/providers/resource/jobs/resource.pxu
@@ -246,11 +246,7 @@ estimated_duration: 0.11
 plugin: resource
 category_id: information_gathering
 _summary: Create resource info for environment variables
-command:
- IFS=$'\n'
- for e in $(env | sed 's/=/:/g'); do
-     echo "$e" | awk -F':' '{print $1 ": " $2}'
- done
+command: environment_resource.py
 
 id: mobilebroadband
 estimated_duration: 0.38

--- a/providers/resource/tests/test_environment_resource.py
+++ b/providers/resource/tests/test_environment_resource.py
@@ -1,0 +1,37 @@
+import unittest
+from textwrap import dedent
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import environment_resource
+
+
+class TestEnvironmentResource(TestCase):
+
+    @patch("environment_resource.print")
+    @patch("os.environ")
+    def test_main(self, environ_mock, print_mock):
+        text = ""
+
+        def store(*args, **kwargs):
+            nonlocal text
+            text += " ".join(args) + "\n"
+
+        print_mock.side_effect = store
+        environ = {
+            "SOME": "1",
+            "OTHER": dedent("""
+            multiline environment
+            variable
+            """).strip(),
+            # non-regression, this was a bug in the old resource
+            "LAST": "bug:somevalue",
+        }
+        environ_mock.items = environ.items
+
+        environment_resource.main()
+
+        self.assertIn("SOME: 1", text.strip())
+        self.assertIn("LAST: bug:somevalue", text.strip())
+        # newlines shouldn't break the resource
+        self.assertEqual(len(text.splitlines()), len(environ))


### PR DESCRIPTION
## Description

The environent resource is bugged and when a envvar contains a `:` it is wrongfully truncated. Similarly if a envvar contains a `\n`, it breaks the resource output.

This fixes the bugs while also translating the script to python and testing it

## Resolved issues

Fixes: CHECKBOX-2280

## Documentation

N/A

## Tests

Adds unit tests. To reproduce the issue run this:
```
BUG="value:with :" checkbox-cli run "environment" | grep BUG
```

Before:
```
BUG: value
```

After:
```
BUG: value:with :
```
