### PR TITLE
Added hidden manifest entry for cold/warm reboot loop tests (New)

### DIFF
--- a/providers/base/units/stress/boot.pxu
+++ b/providers/base/units/stress/boot.pxu
@@ -40,6 +40,8 @@ _purpose: This creates baseline data sets which will be considered the master
  includes network status, SSID, and USB device.
 unit: job
 plugin: shell
+imports: from com.canonical.plainbox import manifest
+requires: manifest._ignore_reboot_loop_tests == 'False'
 command:
   reboot_check_test.py -d "$PLAINBOX_SESSION_SHARE/before_reboot"
 environ: LD_LIBRARY_PATH

--- a/providers/base/units/stress/manifest.pxu
+++ b/providers/base/units/stress/manifest.pxu
@@ -2,7 +2,6 @@ unit: manifest entry
 id: _ignore_reboot_loop_tests
 _name: Ignore reboot loop (warm-boot and cold-boot stress) tests
 value-type: bool
-hidden-reason: Reboot loop stress tests should be run during certification.
-  However, in some lab or regression environments these long-running reboot
-  cycles are not feasible, so this flag allows them to be skipped without
-  affecting the rest of the test plan.
+hidden-reason: The reboot loop stress tests should be run only for 
+  certification and they must be skipped. Since we don't have a separate stress
+  test plan for odm, we will use this manifest entry.

--- a/providers/base/units/stress/manifest.pxu
+++ b/providers/base/units/stress/manifest.pxu
@@ -1,0 +1,8 @@
+unit: manifest entry
+id: _ignore_reboot_loop_tests
+_name: Ignore reboot loop (warm-boot and cold-boot stress) tests
+value-type: bool
+hidden-reason: Reboot loop stress tests should be run during certification.
+  However, in some lab or regression environments these long-running reboot
+  cycles are not feasible, so this flag allows them to be skipped without
+  affecting the rest of the test plan.


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->


Introduces a new hidden manifest entry _ignore_reboot_loop_tests that allows warm-boot and cold-boot stress tests to be skipped in client-cert-odm (and other) test plans without affecting the rest of the run.

The flag gates both reboot-run-generator and init-boot-loop-data, which are the root resource/dependency for all warm-boot-loop-* and cold-boot-loop-* jobs 

This requires 

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

https://warthogs.atlassian.net/browse/RTW-594


## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->

Tested on the failing device (ADVANTECH - UNO-2271G v2):
with this launcher:
```
[launcher]
launcher_version = 1

[test plan]
unit = com.canonical.certification::warm-boot-stress-test

[manifest]
com.canonical.certification::_ignore_reboot_loop_tests = true

[environment]
STRESS_BOOT_ITERATIONS=2
```

before:
```
...
 ☑ : Generate the baseline data set to test against
 ☑ : Perform warm reboot 1
 ☒ : Warm boot system configuration test 1
 ☑ : Perform warm reboot 2
 ☒ : Compare system data after warm boot with baseline data
```

after:
```
...
 ☐ : Generate the baseline data set to test against
 ☐ : Perform warm reboot 1
 ☐ : Warm boot system configuration test 1
 ☐ : Perform warm reboot 2
 ☐ : Compare system data after warm boot with baseline data
```
