### PR TITLE
Reset job and category list when _populate_session_state() is called inside MergeReports (BugFix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/merge_reports.py
+++ b/checkbox-ng/checkbox_ng/launcher/merge_reports.py
@@ -128,7 +128,7 @@ class MergeReports:
     def _populate_session_state(self, job, state):
         self.job_list = []
         self.category_list = []
-        
+
         io_log = [
             IOLogRecord(count, "stdout", line.encode("utf-8"))
             for count, line in enumerate(

--- a/checkbox-ng/checkbox_ng/launcher/merge_reports.py
+++ b/checkbox-ng/checkbox_ng/launcher/merge_reports.py
@@ -35,7 +35,6 @@ from plainbox.impl.unit.category import CategoryUnit
 from plainbox.impl.providers.special import get_exporters
 from plainbox.impl.ctrl import gen_rfc822_records_from_io_log
 from plainbox.impl.session.system_information import (
-    CollectionOutput,
     CollectorOutputs,
 )
 
@@ -127,6 +126,9 @@ class MergeReports:
         return data["title"]
 
     def _populate_session_state(self, job, state):
+        self.job_list = []
+        self.category_list = []
+        
         io_log = [
             IOLogRecord(count, "stdout", line.encode("utf-8"))
             for count, line in enumerate(


### PR DESCRIPTION
## Description

Quick 2 line fix for #2572. Basically the `_populate_session_state()` function was appending to a non-empty list every time it was called which causes later `SessionManager.create_with_unit_list` calls to start with data that doesn't belong to the current submission file.

## Resolved issues

#2572 

## Documentation

Ideally, `_populate_session_state()` should be converted to a pure function that doesn't share a mutable state with subsequent calls. But I kinda want this fix to merge asap so I'll try to do that in a separate PR.

## Tests

The submissions in #2572 can now be merged successfully.
