### PR TITLE
Update cpuid.py with Clearwater Forest (New)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Copilot Instructions — Checkbox monorepo
 
-> **Global rules apply** — shell, git, secrets, destructive ops, and PR conventions are in `~/.github/copilot-instructions.md`.
+> Optional: you can add personal Copilot instructions in `~/.github/copilot-instructions.md`; this repository’s rules are defined below.
 
 ## Overview
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,6 @@
-# Copilot instructions — Checkbox monorepo
+# Copilot Instructions — Checkbox monorepo
+
+> **Global rules apply** — shell, git, secrets, destructive ops, and PR conventions are in `~/.github/copilot-instructions.md`.
 
 ## Overview
 

--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -191,51 +191,51 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
         "Hygon C86-4G 7490": ['0x900f41'],                               # 2024
 
         # Intel
-        "Penryn":            ['0x1067a'],                                 # 2007
-        "Nehalem":           ['0x106a', '0x106e5', '0x206e'],             # 2008
-        "Pineview":          ['0x106ca'],                                 # 2009
-        "Westmere":          ['0x2065', '0x206c', '0x206f'],              # 2010
-        "Sandy Bridge":      ['0x206a', '0x206d6', '0x206d7'],            # 2011
-        "Ivy Bridge":        ['0x306a', '0x306e'],                        # 2012
-        "Haswell":           ['0x306c', '0x4065', '0x4066', '0x306f'],    # 2013
-        "Broadwell":         ['0x4067', '0x306d4', '0x5066', '0x406f'],   # 2014
-        "Skylake":           ['0x406e3', '0x506e3', '0x50654',            # 2015
+        "Penryn":            ['0x1067a'],                                # 2007
+        "Nehalem":           ['0x106a', '0x106e5', '0x206e'],            # 2008
+        "Pineview":          ['0x106ca'],                                # 2009
+        "Westmere":          ['0x2065', '0x206c', '0x206f'],             # 2010
+        "Sandy Bridge":      ['0x206a', '0x206d6', '0x206d7'],           # 2011
+        "Ivy Bridge":        ['0x306a', '0x306e'],                       # 2012
+        "Haswell":           ['0x306c', '0x4065', '0x4066', '0x306f'],   # 2013
+        "Broadwell":         ['0x4067', '0x306d4', '0x5066', '0x406f'],  # 2014
+        "Skylake":           ['0x406e3', '0x506e3', '0x50654',           # 2015
                               '0x50652'],
-        "Knights Landing":   ['0x5067'],                                  # 2016
-        "Kaby Lake":         ['0x806e9', '0x906e9'],                      # 2016
+        "Knights Landing":   ['0x5067'],                                 # 2016
+        "Kaby Lake":         ['0x806e9', '0x906e9'],                     # 2016
         # Amber Lake Y (low power refresh of Kaby Lake) shares CPUID 0x806e9
-        "Apollo Lake":       ['0x506c9', '0x506ca'],                      # 2016
-        "Knights Mill":      ['0x8065'],                                  # 2017
-        "Coffee Lake":       ['0x806ea', '0x906ea', '0x906eb',            # 2017
+        "Apollo Lake":       ['0x506c9', '0x506ca'],                     # 2016
+        "Knights Mill":      ['0x8065'],                                 # 2017
+        "Coffee Lake":       ['0x806ea', '0x906ea', '0x906eb',           # 2017
                               '0x906ec', '0x906ed'],
-        "Gemini Lake":       ['0x706a1', '0x706a8'],                      # 2017
-        "Canon Lake":        ['0x6066'],                                  # 2018
-        "Whisky Lake":       ['0x806eb', '0x806ec'],                      # 2018
+        "Gemini Lake":       ['0x706a1', '0x706a8'],                     # 2017
+        "Canon Lake":        ['0x6066'],                                 # 2018
+        "Whisky Lake":       ['0x806eb', '0x806ec'],                     # 2018
         # Amber Lake Y shares CPUID 0x806ec and 0x806eb with Whisky Lake
-        "Amber Lake Y":      ['0x406e8'],                                 # 2018
-        "Cascade Lake":      ['0x50655', '0x50656', '0x50657'],           # 2019
-        "Ice Lake":          ['0x606e6', '0x606a6', '0x706e6',            # 2019
+        "Amber Lake Y":      ['0x406e8'],                                # 2018
+        "Cascade Lake":      ['0x50655', '0x50656', '0x50657'],          # 2019
+        "Ice Lake":          ['0x606e6', '0x606a6', '0x706e6',           # 2019
                               '0x606c1'],
-        "Comet Lake":        ['0x806ec', '0xa065'],                       # 2019
-        "Cooper Lake":       ['0x5065a', '0x5065b'],                      # 2020
-        "Tiger Lake":        ['0x806c1'],                                 # 2020
-        "Elkhart Lake":      ['0x90660', '0x90661'],                      # 2021
-        "Jasper Lake":       ['0x906c0'],                                 # 2021
-        "Rocket Lake":       ['0xa0671'],                                 # 2021
-        "Alder Lake":        ['0x906a4', '0x906a3', '0x90675',            # 2021
+        "Comet Lake":        ['0x806ec', '0xa065'],                      # 2019
+        "Cooper Lake":       ['0x5065a', '0x5065b'],                     # 2020
+        "Tiger Lake":        ['0x806c1'],                                # 2020
+        "Elkhart Lake":      ['0x90660', '0x90661'],                     # 2021
+        "Jasper Lake":       ['0x906c0'],                                # 2021
+        "Rocket Lake":       ['0xa0671'],                                # 2021
+        "Alder Lake":        ['0x906a4', '0x906a3', '0x90675',           # 2021
                               '0x90672'],
-        "Raptor Lake":       ['0xb0671', '0xb06f2', '0xb06f5',            # 2022
+        "Raptor Lake":       ['0xb0671', '0xb06f2', '0xb06f5',           # 2022
                               '0xb06a2'],
-        "Sapphire Rapids":   ['0x806f3', '0x806f6', '0x806f7',            # 2023
+        "Sapphire Rapids":   ['0x806f3', '0x806f6', '0x806f7',           # 2023
                               '0x806f8'],
-        "Emerald Rapids":    ['0xc06f2'],                                 # 2023
-        "Meteor Lake":       ['0xa06a4'],                                 # 2023
-        "Sierra Forest":     ['0xa06f3'],                                 # 2024
-        "Granite Rapids":    ['0xa06e0', '0xa06d0', '0xa06d1'],           # 2024
-        "Granite Rapids-D":  ['0xa06e1'],                                 # 2024
-        "Lunar Lake":        ['0xb06d1'],                                 # 2024
-        "Arrow Lake":        ['0xc0660', '0xc0652'],                      # 2024
-        "Panther Lake":      ['0xc06c0'],                                 # 2025
+        "Emerald Rapids":    ['0xc06f2'],                                # 2023
+        "Meteor Lake":       ['0xa06a4'],                                # 2023
+        "Sierra Forest":     ['0xa06f3'],                                # 2024
+        "Granite Rapids":    ['0xa06e0', '0xa06d0', '0xa06d1'],          # 2024
+        "Granite Rapids-D":  ['0xa06e1'],                                # 2024
+        "Lunar Lake":        ['0xb06d1'],                                # 2024
+        "Arrow Lake":        ['0xc0660', '0xc0652'],                     # 2024
+        "Panther Lake":      ['0xc06c0'],                                # 2025
         "Clearwater Forest": ['0xd06d1']                                 # 2026
     }
     for key in CPUIDS.keys():

--- a/providers/base/bin/cpuid.py
+++ b/providers/base/bin/cpuid.py
@@ -191,51 +191,52 @@ def cpuid_to_human_friendly(cpuid: str) -> str:
         "Hygon C86-4G 7490": ['0x900f41'],                               # 2024
 
         # Intel
-        "Penryn":           ['0x1067a'],                                 # 2007
-        "Nehalem":          ['0x106a', '0x106e5', '0x206e'],             # 2008
-        "Pineview":         ['0x106ca'],                                 # 2009
-        "Westmere":         ['0x2065', '0x206c', '0x206f'],              # 2010
-        "Sandy Bridge":     ['0x206a', '0x206d6', '0x206d7'],            # 2011
-        "Ivy Bridge":       ['0x306a', '0x306e'],                        # 2012
-        "Haswell":          ['0x306c', '0x4065', '0x4066', '0x306f'],    # 2013
-        "Broadwell":        ['0x4067', '0x306d4', '0x5066', '0x406f'],   # 2014
-        "Skylake":          ['0x406e3', '0x506e3', '0x50654',            # 2015
-                             '0x50652'],
-        "Knights Landing":  ['0x5067'],                                  # 2016
-        "Kaby Lake":        ['0x806e9', '0x906e9'],                      # 2016
+        "Penryn":            ['0x1067a'],                                 # 2007
+        "Nehalem":           ['0x106a', '0x106e5', '0x206e'],             # 2008
+        "Pineview":          ['0x106ca'],                                 # 2009
+        "Westmere":          ['0x2065', '0x206c', '0x206f'],              # 2010
+        "Sandy Bridge":      ['0x206a', '0x206d6', '0x206d7'],            # 2011
+        "Ivy Bridge":        ['0x306a', '0x306e'],                        # 2012
+        "Haswell":           ['0x306c', '0x4065', '0x4066', '0x306f'],    # 2013
+        "Broadwell":         ['0x4067', '0x306d4', '0x5066', '0x406f'],   # 2014
+        "Skylake":           ['0x406e3', '0x506e3', '0x50654',            # 2015
+                              '0x50652'],
+        "Knights Landing":   ['0x5067'],                                  # 2016
+        "Kaby Lake":         ['0x806e9', '0x906e9'],                      # 2016
         # Amber Lake Y (low power refresh of Kaby Lake) shares CPUID 0x806e9
-        "Apollo Lake":      ['0x506c9', '0x506ca'],                      # 2016
-        "Knights Mill":     ['0x8065'],                                  # 2017
-        "Coffee Lake":      ['0x806ea', '0x906ea', '0x906eb',            # 2017
-                             '0x906ec', '0x906ed'],
-        "Gemini Lake":      ['0x706a1', '0x706a8'],                      # 2017
-        "Canon Lake":       ['0x6066'],                                  # 2018
-        "Whisky Lake":      ['0x806eb', '0x806ec'],                      # 2018
+        "Apollo Lake":       ['0x506c9', '0x506ca'],                      # 2016
+        "Knights Mill":      ['0x8065'],                                  # 2017
+        "Coffee Lake":       ['0x806ea', '0x906ea', '0x906eb',            # 2017
+                              '0x906ec', '0x906ed'],
+        "Gemini Lake":       ['0x706a1', '0x706a8'],                      # 2017
+        "Canon Lake":        ['0x6066'],                                  # 2018
+        "Whisky Lake":       ['0x806eb', '0x806ec'],                      # 2018
         # Amber Lake Y shares CPUID 0x806ec and 0x806eb with Whisky Lake
-        "Amber Lake Y":     ['0x406e8'],                                 # 2018
-        "Cascade Lake":     ['0x50655', '0x50656', '0x50657'],           # 2019
-        "Ice Lake":         ['0x606e6', '0x606a6', '0x706e6',            # 2019
-                             '0x606c1'],
-        "Comet Lake":       ['0x806ec', '0xa065'],                       # 2019
-        "Cooper Lake":      ['0x5065a', '0x5065b'],                      # 2020
-        "Tiger Lake":       ['0x806c1'],                                 # 2020
-        "Elkhart Lake":     ['0x90660', '0x90661'],                      # 2021
-        "Jasper Lake":      ['0x906c0'],                                 # 2021
-        "Rocket Lake":      ['0xa0671'],                                 # 2021
-        "Alder Lake":       ['0x906a4', '0x906a3', '0x90675',            # 2021
-                             '0x90672'],
-        "Raptor Lake":      ['0xb0671', '0xb06f2', '0xb06f5',            # 2022
-                             '0xb06a2'],
-        "Sapphire Rapids":  ['0x806f3', '0x806f6', '0x806f7',            # 2023
-                             '0x806f8'],
-        "Emerald Rapids":   ['0xc06f2'],                                 # 2023
-        "Meteor Lake":      ['0xa06a4'],                                 # 2023
-        "Sierra Forest":    ['0xa06f3'],                                 # 2024
-        "Granite Rapids":   ['0xa06e0', '0xa06d0', '0xa06d1'],           # 2024
-        "Granite Rapids-D": ['0xa06e1'],                                 # 2024
-        "Lunar Lake":       ['0xb06d1'],                                 # 2024
-        "Arrow Lake":       ['0xc0660', '0xc0652'],                      # 2024
-        "Panther Lake":     ['0xc06c0']                                  # 2025
+        "Amber Lake Y":      ['0x406e8'],                                 # 2018
+        "Cascade Lake":      ['0x50655', '0x50656', '0x50657'],           # 2019
+        "Ice Lake":          ['0x606e6', '0x606a6', '0x706e6',            # 2019
+                              '0x606c1'],
+        "Comet Lake":        ['0x806ec', '0xa065'],                       # 2019
+        "Cooper Lake":       ['0x5065a', '0x5065b'],                      # 2020
+        "Tiger Lake":        ['0x806c1'],                                 # 2020
+        "Elkhart Lake":      ['0x90660', '0x90661'],                      # 2021
+        "Jasper Lake":       ['0x906c0'],                                 # 2021
+        "Rocket Lake":       ['0xa0671'],                                 # 2021
+        "Alder Lake":        ['0x906a4', '0x906a3', '0x90675',            # 2021
+                              '0x90672'],
+        "Raptor Lake":       ['0xb0671', '0xb06f2', '0xb06f5',            # 2022
+                              '0xb06a2'],
+        "Sapphire Rapids":   ['0x806f3', '0x806f6', '0x806f7',            # 2023
+                              '0x806f8'],
+        "Emerald Rapids":    ['0xc06f2'],                                 # 2023
+        "Meteor Lake":       ['0xa06a4'],                                 # 2023
+        "Sierra Forest":     ['0xa06f3'],                                 # 2024
+        "Granite Rapids":    ['0xa06e0', '0xa06d0', '0xa06d1'],           # 2024
+        "Granite Rapids-D":  ['0xa06e1'],                                 # 2024
+        "Lunar Lake":        ['0xb06d1'],                                 # 2024
+        "Arrow Lake":        ['0xc0660', '0xc0652'],                      # 2024
+        "Panther Lake":      ['0xc06c0'],                                 # 2025
+        "Clearwater Forest": ['0xd06d1']                                 # 2026
     }
     for key in CPUIDS.keys():
         for value in CPUIDS[key]:


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
Adds a CWF CPUid to the list of intel cpus in cpuid.py and adjusts the spacing so they all line up pretty like again since "Clearwater Forest" is such a long name.

While I was there, and playing with copilot cli, I learned that unlike Claude it cannot read a user level ~/.github/copilot-instructions.md automatically.  It can only read project level instructions files. BUT apparently referring to the userlevel one in the project level one seems to be a workaround. If the user does not have a global instruction file in ~/.github then copilot will just move on and use the local project instructions only.

## Resolved issues
resolves #2591
resolves CHECKBOX-2284
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

## Documentation

NA

## Tests

to test, just ran the script on the CWF system I have access to in the Locker:

from a cert test run on the machine before fix:
```
CPU Model: Intel(R) Xeon(R) 6960E+
Unable to determine CPU Family for this CPUID: 0xd06d1
```
modified script run on the machine later:
```
ubuntu@northrup-cwf-716346:~$ sudo ./cpuid.py 
CPU Model: Intel(R) Xeon(R) 6960E+
CPUID: 0xd06d1 which appears to be a Clearwater Forest processor
```
