### PR TITLE
miscellanea/screen-pkg-not-public failed on 2604 (BugFix)

### DIFF
--- a/contrib/pc-sanity/bin/screen-pkg.py
+++ b/contrib/pc-sanity/bin/screen-pkg.py
@@ -85,6 +85,8 @@ def get_platform() -> Platform:
         oem_ubuntu_codename = "jellyfish"
     elif sys_ubuntu_codename == "noble":
         oem_ubuntu_codename = "numbat"
+    elif sys_ubuntu_codename == "resolute":
+        oem_ubuntu_codename = "raccoon"
     if oem_ubuntu_codename is None:
         raise Exception("oem ubuntu codename is empty.")
 


### PR DESCRIPTION
## Description

[Sanity] miscellanea/screen-pkg-not-public failed
```
Traceback (most recent call last):
  File "/tmp/nest-7g17olx4.ae598f1c8afeb07802c7bc9d11fe714c67441b2c62dcac4b124ee4a9a7662bf6/screen-pkg.py", line 532, in <module>
    check_public(args)
    ~~~~~~~~~~~~^^^^^^
  File "/tmp/nest-7g17olx4.ae598f1c8afeb07802c7bc9d11fe714c67441b2c62dcac4b124ee4a9a7662bf6/screen-pkg.py", line 464, in check_public
    platform = get_platform()
  File "/tmp/nest-7g17olx4.ae598f1c8afeb07802c7bc9d11fe714c67441b2c62dcac4b124ee4a9a7662bf6/screen-pkg.py", line 89, in get_platform
    raise Exception("oem ubuntu codename is empty.")
Exception: oem ubuntu codename is empty.

```
## Resolved issues

https://warthogs.atlassian.net/browse/SUTTON-5342

## Documentation


## Tests

On 26.04 run the command below.
```
$ checkbox-cli run com.canonical.certification::miscellanea/screen-pkg-not-public
```