### PR TITLE
Retry snap revision info (bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/retry.py
+++ b/checkbox-support/checkbox_support/helpers/retry.py
@@ -29,11 +29,13 @@ import time
 from unittest.mock import patch
 
 
-def run_with_retry(f, max_attempts, delay, *args, **kwargs):
+def run_with_retry(f, max_attempts, delay, print_logs=True, *args, **kwargs):
     """
     Run the f function. If it fails, retry for up to max_attempts times, adding
     a backoff and a jitter on top of a delay (in seconds). If none of the runs
-    succeed, raise the encountered exception.
+    succeed, raise the encountered exception. By default, it will print some
+    logs about its status (number of attempts, time to wait, etc.), unless
+    print_logs is set to False.
     """
     initial_delay = 1
     backoff_factor = 2
@@ -51,19 +53,22 @@ def run_with_retry(f, max_attempts, delay, *args, **kwargs):
         attempt_string = "Attempt {}/{} (function '{}')".format(
             attempt, max_attempts, f.__name__
         )
-        print()
-        print("=" * len(attempt_string))
-        print(attempt_string)
-        print("=" * len(attempt_string), flush=True)
+        if print_logs:
+            print()
+            print("=" * len(attempt_string))
+            print(attempt_string)
+            print("=" * len(attempt_string), flush=True)
         try:
             result = f(*args, **kwargs)
             return result
         except BaseException as e:
-            print("Attempt {} failed:".format(attempt))
-            print(e)
-            print(flush=True)
+            if print_logs:
+                print("Attempt {} failed:".format(attempt))
+                print(e)
+                print(flush=True)
             if attempt >= max_attempts:
-                print("All the attempts have failed!", flush=True)
+                if print_logs:
+                    print("All the attempts have failed!", flush=True)
                 raise
             min_delay = min(
                 initial_delay * (backoff_factor**attempt),
@@ -73,33 +78,40 @@ def run_with_retry(f, max_attempts, delay, *args, **kwargs):
                 0, delay * 0.5
             )  # Jitter: up to 50% of the delay
             total_delay = min_delay + jitter
-            print(
-                "Waiting {:.2f} seconds before retrying...".format(
-                    total_delay
-                ),
-                flush=True,
-            )
+            if print_logs:
+                print(
+                    "Waiting {:.2f} seconds before retrying...".format(
+                        total_delay
+                    ),
+                    flush=True,
+                )
             time.sleep(total_delay)
 
 
-def retry(max_attempts, delay):
+def retry(max_attempts, delay, print_logs=True):
     """
     Run the decorated function. If it fails, retry for up to max_attempts
     times, adding a backoff and a jitter on top of a delay (in seconds).
-    If none of the runs succeed, raise the encountered exception.
+    If none of the runs succeed, raise the encountered exception. By default,
+    it will print some logs about its status (number of attempts, time to wait,
+    etc.), unless print_logs is set to False.
     """
 
     def decorator_retry(f):
         @functools.wraps(f)
         def _f(*args, **kwargs):
-            return run_with_retry(f, max_attempts, delay, *args, **kwargs)
+            return run_with_retry(
+                f, max_attempts, delay, print_logs, *args, **kwargs
+            )
 
         return _f
 
     return decorator_retry
 
 
-def fake_run_with_retry(f, max_attempts, delay, *args, **kwargs):
+def fake_run_with_retry(
+    f, max_attempts, delay, print_logs=True, *args, **kwargs
+):
     return f(*args, **kwargs)
 
 

--- a/checkbox-support/checkbox_support/lxd_support.py
+++ b/checkbox-support/checkbox_support/lxd_support.py
@@ -168,6 +168,7 @@ class LXD:
                 self.run,
                 5,
                 2,
+                True,
                 "lxc image copy {}{} local: --alias {}".format(
                     self.remote, self.release, self.image_alias.hex
                 ),
@@ -263,6 +264,7 @@ class LXDVM(LXD):
                 self.run,
                 5,
                 15,
+                True,
                 "lxc image copy {}{} local: --alias {} --vm".format(
                     self.remote, self.release, self.image_alias.hex
                 ),

--- a/checkbox-support/checkbox_support/tests/test_retry.py
+++ b/checkbox-support/checkbox_support/tests/test_retry.py
@@ -53,6 +53,20 @@ class TestRetry(TestCase):
         self.assertIn("Attempt 7 failed", mock_stdout.getvalue())
         self.assertNotIn("Attempt 8 failed", mock_stdout.getvalue())
 
+    @patch("time.sleep")
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_decorator_max_attempts_no_print(self, mock_stdout, mock_sleep):
+        @retry(max_attempts=1, delay=10, print_logs=False)
+        def f():
+            return 1 / 0
+
+        with self.assertRaises(ZeroDivisionError):
+            f()
+        self.assertNotIn("Attempt 1 failed", mock_stdout.getvalue())
+        self.assertNotIn(
+            "All the attempts have failed!", mock_stdout.getvalue()
+        )
+
     def test_decorator_wrong_max_attempts(self):
         @retry(-1, 10)
         def f():
@@ -74,5 +88,6 @@ class TestRetry(TestCase):
             return (args, kwargs)
 
         self.assertEqual(
-            k(1, 2, 3, abc=10), fake_run_with_retry(k, 5, 10, 1, 2, 3, abc=10)
+            k(1, 2, 3, abc=10),
+            fake_run_with_retry(k, 5, 10, True, 1, 2, 3, abc=10),
         )

--- a/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/k8s_gpu_setup.py
+++ b/contrib/checkbox-dss-validation/checkbox-provider-dss/bin/k8s_gpu_setup.py
@@ -156,7 +156,9 @@ def setup_nvidia_gpu_operator(version: str, is_microk8s: bool) -> None:
         "ds/nvidia-operator-validator",
     ]:
         cmd = f"kubectl -n {ns} rollout status {daemonset}"
-        run_with_retry(subprocess.run, 200, 3, shlex.split(cmd), check=True)
+        run_with_retry(
+            subprocess.run, 200, 3, True, shlex.split(cmd), check=True
+        )
     print("Finished NVIDIA GPU operator setup successfully", flush=True)
 
 
@@ -207,7 +209,9 @@ def setup_intel_gpu_plugin(version: str, is_microk8s: bool) -> None:
         "kubectl -n node-feature-discovery rollout status ds/nfd-worker",
         "kubectl -n default rollout status ds/intel-gpu-plugin",
     ]:
-        run_with_retry(subprocess.run, 100, 3, shlex.split(cmd), check=True)
+        run_with_retry(
+            subprocess.run, 100, 3, True, shlex.split(cmd), check=True
+        )
     print("Finished Intel GPU plugin setup successfully", flush=True)
 
 

--- a/providers/base/bin/snap_update_test.py
+++ b/providers/base/bin/snap_update_test.py
@@ -25,6 +25,7 @@ import os
 import sys
 import time
 
+from checkbox_support.helpers.retry import retry
 from checkbox_support.snap_utils.snapd import Snapd
 from checkbox_support.snap_utils.snapd import AsyncException
 from checkbox_support.snap_utils.snapd import SnapdRequestError
@@ -63,6 +64,11 @@ def get_snaps_base_rev() -> dict:
     return base_rev_info
 
 
+@retry(max_attempts=3, delay=10, print_logs=False)
+def find_snap(name):
+    return Snapd().find(name, exact=True)
+
+
 class SnapInfo:
     def __init__(self, name):
         snap = Snapd().list(name)
@@ -78,7 +84,7 @@ class SnapInfo:
         self.base_revision = get_snaps_base_rev().get(name, "")
 
         revisions = {}
-        for item in Snapd().find(name, exact=True):
+        for item in find_snap(name):
             for channel, info in item["channels"].items():
                 revisions[channel] = info["revision"]
 


### PR DESCRIPTION


## Description

Add a retry decorator to the function that uses the snapd `find` command to perform some online queries to retrieve the revisions of a given snap. This will help to prevent errors when there is a network hiccup. The job will still fail if no network is available, as it 100% requires network access to retrieve the revisions in order to run the snap update tests.

## Resolved issues

Fix https://warthogs.atlassian.net/browse/C3-1429

## Tests

Tested locally by running `./snap_update_test.py --resource` without any network connection for a while, then plugging back network. (if no network at all, the test will eventually fail as before)

Added unit tests to test the new `print_logs` param.
