### PR TITLE
Retry snap revision info stderr (bugfix)

### DIFF
--- a/checkbox-support/checkbox_support/helpers/retry.py
+++ b/checkbox-support/checkbox_support/helpers/retry.py
@@ -25,6 +25,7 @@ delay, backoff and jitter.
 
 import functools
 import random
+import sys
 import time
 from unittest.mock import patch
 
@@ -51,19 +52,23 @@ def run_with_retry(f, max_attempts, delay, *args, **kwargs):
         attempt_string = "Attempt {}/{} (function '{}')".format(
             attempt, max_attempts, f.__name__
         )
-        print()
-        print("=" * len(attempt_string))
-        print(attempt_string)
-        print("=" * len(attempt_string), flush=True)
+        print(file=sys.stderr)
+        print("=" * len(attempt_string), file=sys.stderr)
+        print(attempt_string, file=sys.stderr)
+        print("=" * len(attempt_string), file=sys.stderr, flush=True)
         try:
             result = f(*args, **kwargs)
             return result
         except BaseException as e:
-            print("Attempt {} failed:".format(attempt))
-            print(e)
-            print(flush=True)
+            print("Attempt {} failed:".format(attempt), file=sys.stderr)
+            print(e, file=sys.stderr)
+            print(file=sys.stderr, flush=True)
             if attempt >= max_attempts:
-                print("All the attempts have failed!", flush=True)
+                print(
+                    "All the attempts have failed!",
+                    file=sys.stderr,
+                    flush=True,
+                )
                 raise
             min_delay = min(
                 initial_delay * (backoff_factor**attempt),
@@ -77,6 +82,7 @@ def run_with_retry(f, max_attempts, delay, *args, **kwargs):
                 "Waiting {:.2f} seconds before retrying...".format(
                     total_delay
                 ),
+                file=sys.stderr,
                 flush=True,
             )
             time.sleep(total_delay)

--- a/checkbox-support/checkbox_support/helpers/retry.py
+++ b/checkbox-support/checkbox_support/helpers/retry.py
@@ -70,7 +70,11 @@ def run_with_retry(f, max_attempts, delay, *args, **kwargs):
             # order
             sys.stdout.flush()
             if attempt >= max_attempts:
-                print("All the attempts have failed!", file=sys.stderr, flush=True)
+                print(
+                    "All the attempts have failed!",
+                    file=sys.stderr,
+                    flush=True,
+                )
                 # also flush stdout to prevent messages being printed in the
                 # wrong order
                 sys.stdout.flush()

--- a/checkbox-support/checkbox_support/helpers/retry.py
+++ b/checkbox-support/checkbox_support/helpers/retry.py
@@ -56,6 +56,9 @@ def run_with_retry(f, max_attempts, delay, *args, **kwargs):
         print("=" * len(attempt_string), file=sys.stderr)
         print(attempt_string, file=sys.stderr)
         print("=" * len(attempt_string), file=sys.stderr, flush=True)
+        # also flush stdout to prevent messages being printed in the wrong
+        # order
+        sys.stdout.flush()
         try:
             result = f(*args, **kwargs)
             return result
@@ -63,12 +66,14 @@ def run_with_retry(f, max_attempts, delay, *args, **kwargs):
             print("Attempt {} failed:".format(attempt), file=sys.stderr)
             print(e, file=sys.stderr)
             print(file=sys.stderr, flush=True)
+            # also flush stdout to prevent messages being printed in the wrong
+            # order
+            sys.stdout.flush()
             if attempt >= max_attempts:
-                print(
-                    "All the attempts have failed!",
-                    file=sys.stderr,
-                    flush=True,
-                )
+                print("All the attempts have failed!", file=sys.stderr, flush=True)
+                # also flush stdout to prevent messages being printed in the
+                # wrong order
+                sys.stdout.flush()
                 raise
             min_delay = min(
                 initial_delay * (backoff_factor**attempt),
@@ -85,6 +90,9 @@ def run_with_retry(f, max_attempts, delay, *args, **kwargs):
                 file=sys.stderr,
                 flush=True,
             )
+            # also flush stdout to prevent messages being printed in the wrong
+            # order
+            sys.stdout.flush()
             time.sleep(total_delay)
 
 

--- a/checkbox-support/checkbox_support/tests/test_retry.py
+++ b/checkbox-support/checkbox_support/tests/test_retry.py
@@ -42,16 +42,16 @@ class TestRetry(TestCase):
             f()
 
     @patch("time.sleep")
-    @patch("sys.stdout", new_callable=StringIO)
-    def test_decorator_max_attempts(self, mock_stdout, mock_sleep):
+    @patch("sys.stderr", new_callable=StringIO)
+    def test_decorator_max_attempts(self, mock_stderr, mock_sleep):
         @retry(max_attempts=7, delay=10)
         def f():
             return 1 / 0
 
         with self.assertRaises(ZeroDivisionError):
             f()
-        self.assertIn("Attempt 7 failed", mock_stdout.getvalue())
-        self.assertNotIn("Attempt 8 failed", mock_stdout.getvalue())
+        self.assertIn("Attempt 7 failed", mock_stderr.getvalue())
+        self.assertNotIn("Attempt 8 failed", mock_stderr.getvalue())
 
     def test_decorator_wrong_max_attempts(self):
         @retry(-1, 10)

--- a/providers/base/bin/snap_update_test.py
+++ b/providers/base/bin/snap_update_test.py
@@ -25,6 +25,7 @@ import os
 import sys
 import time
 
+from checkbox_support.helpers.retry import retry
 from checkbox_support.snap_utils.snapd import Snapd
 from checkbox_support.snap_utils.snapd import AsyncException
 from checkbox_support.snap_utils.snapd import SnapdRequestError
@@ -63,6 +64,11 @@ def get_snaps_base_rev() -> dict:
     return base_rev_info
 
 
+@retry(max_attempts=3, delay=10)
+def find_snap(name):
+    return Snapd().find(name, exact=True)
+
+
 class SnapInfo:
     def __init__(self, name):
         snap = Snapd().list(name)
@@ -78,7 +84,7 @@ class SnapInfo:
         self.base_revision = get_snaps_base_rev().get(name, "")
 
         revisions = {}
-        for item in Snapd().find(name, exact=True):
+        for item in find_snap(name):
             for channel, info in item["channels"].items():
                 revisions[channel] = info["revision"]
 


### PR DESCRIPTION


## Description

Add a retry decorator to the function that makes a network call to retrieve revision information for a given snap. In order not to mess up the output of the resource job, the retry function is modified to spit out its informational logs to `stderr` instead of `stdout`.

Note: if network is **really** unavailable for the whole test execution, it will still fail with an exception printed out, but in that case this is expected: we want to investigate this.

## Resolved issues

https://warthogs.atlassian.net/browse/C3-1429

## Documentation



## Tests

- Modified unit tests
- Tested manually by calling `./snap_update_test.py --resource` while offline, waiting until second attempt and connecting back to the network. As you can see, the informational log is now red (`stderr`) while the actual resource output is green (`stdout`):

<img width="3707" height="1684" alt="image" src="https://github.com/user-attachments/assets/88860e26-9857-4507-b894-3ef1db3ca114" />

