### PR TITLE
Update snapcraft-multiarch to latest version (Infra)

### DIFF
--- a/.github/workflows/checkbox-ce-oem-daily-cross-builds.yaml
+++ b/.github/workflows/checkbox-ce-oem-daily-cross-builds.yaml
@@ -65,7 +65,7 @@ jobs:
         uses: Wandalen/wretry.action@df981d2bb22b26b5b23754bb516d0de8c1bfbbec
         with:
           attempt_limit: 5
-          action: canonical/snapcraft-multiarch-action@v1
+          action: canonical/snapcraft-multiarch-action@fb63b025e0775a87a0652bcec61107a34f272b74  # v1.10.2
           with: |
             architecture: ${{ matrix.arch }}
             path: contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_${{ matrix.type }}${{ matrix.release }}

--- a/.github/workflows/checkbox-daily-cross-builds.yaml
+++ b/.github/workflows/checkbox-daily-cross-builds.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: Wandalen/wretry.action@df981d2bb22b26b5b23754bb516d0de8c1bfbbec
         with:
           attempt_limit: 5
-          action: canonical/snapcraft-multiarch-action@v1
+          action: canonical/snapcraft-multiarch-action@fb63b025e0775a87a0652bcec61107a34f272b74  # v1.10.2
           with: |
             architecture: ${{ matrix.arch }}
             path: checkbox-core-snap/series${{ matrix.release }}
@@ -146,7 +146,7 @@ jobs:
         uses: Wandalen/wretry.action@df981d2bb22b26b5b23754bb516d0de8c1bfbbec
         with:
           attempt_limit: 5
-          action: canonical/snapcraft-multiarch-action@v1
+          action: canonical/snapcraft-multiarch-action@fb63b025e0775a87a0652bcec61107a34f272b74  # v1.10.2
           with: |
             architecture: ${{ matrix.arch }}
             path: checkbox-snap/series_${{ matrix.type }}${{ matrix.release }}


### PR DESCRIPTION
## Description

Snapcraft 9 is out, dropping support for core20. The cross-builder has already been update to handle this, and this is to pin the actions to the latest tagged version.

## Resolved issues

Current CI is failing, or it will soon enough

## Documentation

N/A

## Tests

CI will do.
