### PR TITLE
Override maximum expected ethernet speed with an environment variable in network.py (New)

### DIFF
--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -369,7 +369,7 @@ class IPerfPerformanceTest(object):
                         "The expected maximum speed of '{}' ".format(
                             self.iface.interface
                         )
-                        + "was manually overridden to '{}'".format(
+                        + "was manually overridden to '{}' Mbps".format(
                             self.expected_max_speed,
                         )
                     )
@@ -722,7 +722,7 @@ def run_test(args, test_target, expected_max_speed: "int | None" = None):
     if expected_max_speed:
         logging.warning(
             "Expected maximum transfer speed of "
-            + "'{}' was overridden to: {}".format(
+            + "'{}' was overridden to: {} Mbps".format(
                 args.interface, expected_max_speed
             )
         )

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -672,7 +672,9 @@ def get_test_parameters(args: Namespace, environ: "MutableMapping[str, str]"):
     if args.target:
         params["test_target_iperf"] = args.target
     if args.max_expected_speed_override:
-        params["max_expected_speed_override"] = args.max_expected_speed_override
+        params["max_expected_speed_override"] = (
+            args.max_expected_speed_override
+        )
 
     return params
 

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -202,9 +202,8 @@ class IPerfPerformanceTest(object):
         # to iperf3, thus disabling NUMA features.
         if node_num == -1:
             logging.warning(
-                "WARNING: Could not find the NUMA node associated with {}!".format(
-                    device
-                )
+                "WARNING: Could not find the NUMA node"
+                + " associated with {}!".format(device)
             )
         else:
             logging.info("NUMA node of {} is {}....".format(device, node_num))
@@ -262,8 +261,8 @@ class IPerfPerformanceTest(object):
         # if max_speed is 0, assume it's wifi and move on
         if self.iface.max_speed == 0:
             logging.warning(
-                "No max speed (from ethtool) detected, assuming Wireless device "
-                "and continuing with test."
+                "No max speed (from ethtool) detected, "
+                + "assuming Wireless device and continuing with test."
             )
 
         threads = self.num_threads
@@ -367,8 +366,10 @@ class IPerfPerformanceTest(object):
                 if self.expected_max_speed != self.iface.max_speed:
                     logging.warning("MANUAL OVERRIDE WAS USED".center(80, "-"))
                     logging.warning(
-                        "The expected maximum speed of '{}' was manually overridden to '{}'".format(
-                            self.iface.interface,
+                        "The expected maximum speed of '{}' ".format(
+                            self.iface.interface
+                        )
+                        + "was manually overridden to '{}'".format(
                             self.expected_max_speed,
                         )
                     )
@@ -718,7 +719,8 @@ def run_test(args, test_target, expected_max_speed: "int | None" = None):
 
     if expected_max_speed:
         logging.warning(
-            "Expected maximum transfer speed of '{}' was overridden to: {}".format(
+            "Expected maximum transfer speed of "
+            + "'{}' was overridden to: {}".format(
                 args.interface, expected_max_speed
             )
         )
@@ -933,15 +935,16 @@ def check_underspeed(iface):
         and network_if.max_speed != 0
     ):
         logging.error(
-            "Detected link speed ({}) is lower than detected max speed ({})".format(
-                network_if.link_speed, network_if.max_speed
+            "Detected link speed ({}) ".format(network_if.link_speed)
+            + "is lower than detected max speed ({})".format(
+                network_if.max_speed
             )
         )
         logging.error("Check your device configuration and try again.")
         logging.error(
-            "If you want to override and test despite this under-speed link, use"
+            "If you want to override and test despite this under-speed link,"
         )
-        logging.error("the --underspeed-ok option.")
+        logging.error("use the --underspeed-ok option.")
         return True
     return False
 
@@ -1100,7 +1103,8 @@ def interface_test(args: Namespace):
         )
         logging.error("target in /etc/xdg/canonical-certification.conf")
         logging.error(
-            "Please run this script with -h to see more details on how to configure"
+            "Please run this script with -h "
+            + "to see more details on how to configure"
         )
         sys.exit(1)
 

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -1075,14 +1075,14 @@ def interface_test(args: Namespace):
         test_targets_list = make_target_list(
             args.interface, test_targets, True
         )
-        if test_parameters["max_expected_speed_override"]:
-            max_expected_speed_override = (
+        if test_parameters.get("max_expected_speed_override"):
+            max_expected_speed_override_dict = (
                 make_max_expected_speed_override_dict(
                     test_parameters["max_expected_speed_override"]
                 )
             )
         else:
-            max_expected_speed_override = {}
+            max_expected_speed_override_dict = {}
 
     # Validate that we got reasonable values
     if not test_targets_list or "example.com" in test_targets:
@@ -1125,7 +1125,7 @@ def interface_test(args: Namespace):
                 error_number = run_test(
                     args,
                     test_target,
-                    max_expected_speed_override.get(args.interface),
+                    max_expected_speed_override_dict.get(args.interface),
                 )
                 elapsed_seconds = (
                     datetime.datetime.now() - start_time

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -983,7 +983,7 @@ def interface_test_initialize(
             raise CalledProcessError(3, "restore network failed")
 
 
-def interface_test(args):
+def interface_test(args: Namespace):
     if not ("test_type" in vars(args)):
         return
 
@@ -1278,9 +1278,6 @@ TEST_TARGET_IPERF = iperf-server.example.com
     info_parser.set_defaults(func=interface_info)
 
     args = parser.parse_args()
-
-    print(args)
-    return
 
     if (
         args.func.__name__ is interface_test

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -107,7 +107,9 @@ class IPerfPerformanceTest(object):
                 # other return value means something did fail
                 if "unable to connect to server" in iperf_exception.output:
                     logging.error(
-                        "Unable to connect to server on port {}".format(port_num)
+                        "Unable to connect to server on port {}".format(
+                            port_num
+                        )
                     )
                     if port_num == 5202:
                         # 5202 is 2nd port in high-speed configs
@@ -118,8 +120,12 @@ class IPerfPerformanceTest(object):
                         logging.warning("more information.")
                 else:
                     # Unknown error; log it....
-                    logging.error("Failed executing iperf on port {}.".format(port_num))
-                    logging.error("Output is '{}'".format(iperf_exception.output))
+                    logging.error(
+                        "Failed executing iperf on port {}.".format(port_num)
+                    )
+                    logging.error(
+                        "Output is '{}'".format(iperf_exception.output)
+                    )
                 return iperf_exception.returncode
             else:
                 # this is normal so we "except" this exception and we
@@ -148,10 +154,14 @@ class IPerfPerformanceTest(object):
                     )
                 )
                 logging.debug(
-                    "Min Transfer speed for thread {}: {} Mb/s".format(n, min(speeds))
+                    "Min Transfer speed for thread {}: {} Mb/s".format(
+                        n, min(speeds)
+                    )
                 )
                 logging.debug(
-                    "Max Transfer speed for thread {}: {} Mb/s".format(n, max(speeds))
+                    "Max Transfer speed for thread {}: {} Mb/s".format(
+                        n, max(speeds)
+                    )
                 )
                 n = n + 1
         return total_throughput
@@ -170,7 +180,9 @@ class IPerfPerformanceTest(object):
             )
             if new_cpu:
                 float_cpu = float(new_cpu[0])
-                logging.debug("CPU load for thread {}: {}%".format(n, float_cpu))
+                logging.debug(
+                    "CPU load for thread {}: {}%".format(n, float_cpu)
+                )
                 sum_cpu = sum_cpu + float_cpu
                 n = n + 1
             if n > 0:
@@ -327,7 +339,9 @@ class IPerfPerformanceTest(object):
                 full_cmd = cmd
             port_num = start_port + thread_num
             t.append(
-                threading.Thread(target=self.run_one_thread, args=(full_cmd, port_num))
+                threading.Thread(
+                    target=self.run_one_thread, args=(full_cmd, port_num)
+                )
             )
             t[thread_num].start()
         for thread_num in range(0, python_threads):
@@ -337,9 +351,28 @@ class IPerfPerformanceTest(object):
         invalid_speed = False
         try:
             if self.expected_max_speed is None:
-                percent = throughput / int(self.iface.max_speed) * 100
+                percent = (throughput / self.iface.max_speed) * 100
+                logging.info(
+                    "{:03.2f}% of theoretical max {} Mb/s".format(
+                        percent, int(self.iface.max_speed)
+                    )
+                )
             else:
                 percent = throughput / self.expected_max_speed * 100
+                logging.info(
+                    "{:03.2f}% of expected max {} Mb/s".format(
+                        percent, int(self.expected_max_speed)
+                    )
+                )
+                if self.expected_max_speed != self.iface.max_speed:
+                    logging.warning("MANUAL OVERRIDE WAS USED".center(80, "-"))
+                    logging.warning(
+                        "The expected maximum speed of '{}' was manually overridden to '{}'".format(
+                            self.iface.interface,
+                            self.expected_max_speed,
+                        )
+                    )
+                    logging.warning("-" * 80)
         except (ZeroDivisionError, TypeError):
             # Catches a condition where the interface functions fine but
             # ethtool fails to properly report max speed. In this case
@@ -355,30 +388,39 @@ class IPerfPerformanceTest(object):
             logging.warning("Unable to obtain maximum speed.")
             logging.warning("Considering the test as passed.")
             return 0
+
         # Below is guaranteed to not throw an exception because we'll
         # have exited above if it did.
-        logging.info(
-            "{:03.2f}% of theoretical max {} Mb/s".format(
-                percent, int(self.iface.max_speed)
-            )
-        )
-
         if self.iperf3:
             cpu_load = self.summarize_cpu()
-            logging.info("Average CPU utilization: {}%".format(round(cpu_load, 1)))
+            logging.info(
+                "Average CPU utilization: {}%".format(round(cpu_load, 1))
+            )
         else:
             cpu_load = 0
-        if percent < self.fail_threshold or cpu_load > self.cpu_load_fail_threshold:
+        if (
+            percent < self.fail_threshold
+            or cpu_load > self.cpu_load_fail_threshold
+        ):
             logging.warning(
-                "The network test against {} failed because:".format(self.target)
+                "The network test against {} failed because:".format(
+                    self.target
+                )
             )
             if percent < self.fail_threshold:
                 logging.error("  Transfer speed: {} Mb/s".format(throughput))
-                logging.error(
-                    "  {:03.2f}% of theoretical max {} Mb/s\n".format(
-                        percent, int(self.iface.max_speed)
+                if self.expected_max_speed:
+                    logging.error(
+                        "  {:03.2f}% of expected max {} Mb/s\n".format(
+                            percent, int(self.expected_max_speed)
+                        )
                     )
-                )
+                else:
+                    logging.error(
+                        "  {:03.2f}% of theoretical max {} Mb/s\n".format(
+                            percent, int(self.iface.max_speed)
+                        )
+                    )
             if cpu_load > self.cpu_load_fail_threshold:
                 logging.error("  CPU load: {}%".format(cpu_load))
                 logging.error(
@@ -425,7 +467,9 @@ class IPerfPerformanceTest(object):
         self.run_time = orig_run_time
         self.scan_timeout = orig_scan_timeout
         self.num_threads = int(max_multiple * orig_num_threads)
-        logging.info("Setting number of threads to {}.".format(self.num_threads))
+        logging.info(
+            "Setting number of threads to {}.".format(self.num_threads)
+        )
 
 
 class StressPerformanceTest:
@@ -436,9 +480,13 @@ class StressPerformanceTest:
 
     def run(self):
         if self.iperf3:
-            iperf_cmd = "timeout -k 1 320 iperf3 -c {} -t 300".format(self.target)
+            iperf_cmd = "timeout -k 1 320 iperf3 -c {} -t 300".format(
+                self.target
+            )
         else:
-            iperf_cmd = "timeout -k 1 320 iperf -c {} -t 300".format(self.target)
+            iperf_cmd = "timeout -k 1 320 iperf -c {} -t 300".format(
+                self.target
+            )
         print("Running iperf...")
         iperf = subprocess.Popen(shlex.split(iperf_cmd))
 
@@ -656,18 +704,22 @@ def run_test(args, test_target, expected_max_speed: "int | None" = None):
     logging.info("Testing {} against {}".format(args.interface, test_target))
     if can_ping(args.interface, test_target):
         logging.info(
-            "Have successfully pinged {} on {}".format(test_target, args.interface)
+            "Have successfully pinged {} on {}".format(
+                test_target, args.interface
+            )
         )
     else:
         logging.error(
-            "Can't ping test server {} on {}".format(test_target, args.interface)
+            "Can't ping test server {} on {}".format(
+                test_target, args.interface
+            )
         )
         return 1
 
     if expected_max_speed:
         logging.warning(
-            "Expected maximum transfer speed was overridden to: {}".format(
-                expected_max_speed
+            "Expected maximum transfer speed of '{}' was overridden to: {}".format(
+                args.interface, expected_max_speed
             )
         )
 
@@ -682,7 +734,7 @@ def run_test(args, test_target, expected_max_speed: "int | None" = None):
             args.iperf3,
             args.num_threads,
             args.reverse,
-            expected_max_speed=expected_max_speed
+            expected_max_speed=expected_max_speed,
         )
         if args.datasize:
             iperf_benchmark.data_size = args.datasize
@@ -732,7 +784,9 @@ def make_target_list(iface, test_targets, log_warnings):
     test_targets_list = test_targets.split(",")
     try:
         net = ipaddress.IPv4Network(
-            "{}/{}".format(Interface(iface).ipaddress, Interface(iface).netmask),
+            "{}/{}".format(
+                Interface(iface).ipaddress, Interface(iface).netmask
+            ),
             False,
         )
     except ipaddress.AddressValueError as e:
@@ -764,7 +818,9 @@ def make_target_list(iface, test_targets, log_warnings):
                     return_list.remove(test_target)
             except ValueError:
                 if log_warnings:
-                    logging.warning("Invalid address: {}; skipping".format(test_target))
+                    logging.warning(
+                        "Invalid address: {}; skipping".format(test_target)
+                    )
                 return_list.remove(test_target)
     return_list.reverse()
     if return_list == [""]:
@@ -872,7 +928,10 @@ def check_underspeed(iface):
     # UNLESS --underspeed-ok option was used or max_speed is 0
     # (which indicates a probable WiFi link)
     network_if = Interface(iface)
-    if network_if.link_speed < network_if.max_speed and network_if.max_speed != 0:
+    if (
+        network_if.link_speed < network_if.max_speed
+        and network_if.max_speed != 0
+    ):
         logging.error(
             "Detected link speed ({}) is lower than detected max speed ({})".format(
                 network_if.link_speed, network_if.max_speed
@@ -897,11 +956,15 @@ def setup_network_ifaces(
     if target_if_attrs["status"] == "down" and not turn_up_network(
         target_network, timeout
     ):
-        raise SystemExit("Failed to bring up {} interface".format(target_network))
+        raise SystemExit(
+            "Failed to bring up {} interface".format(target_network)
+        )
 
     if not underspeed_ok and check_underspeed(target_network):
         raise SystemExit(
-            "the network speed is incorrect for {} interface".format(target_network)
+            "the network speed is incorrect for {} interface".format(
+                target_network
+            )
         )
 
     if (
@@ -934,7 +997,9 @@ def setup_network_ifaces(
         # Shutdown other network interfaces
         for iface, attrs in network_info.items():
             if attrs["status"] == "up" and not turn_down_network(iface):
-                raise SystemExit("Failed to shutdown {} interface".format(iface))
+                raise SystemExit(
+                    "Failed to shutdown {} interface".format(iface)
+                )
 
 
 def restore_network_ifaces(cur_network_info, origin_network_info, timeout):
@@ -961,7 +1026,9 @@ def interface_test_initialize(
         # Back up routing table, since network down/up process
         # tends to trash it....
         logging.debug("Backup routing table")
-        check_call(["ip", "route", "save", "table", "all"], stdout=tempfile_route)
+        check_call(
+            ["ip", "route", "save", "table", "all"], stdout=tempfile_route
+        )
         setup_network_ifaces(
             network_info,
             target_dev,
@@ -1005,10 +1072,14 @@ def interface_test(args: Namespace):
 
     if args.test_type.lower() == "iperf" or args.test_type.lower() == "stress":
         test_targets = test_parameters["test_target_iperf"]
-        test_targets_list = make_target_list(args.interface, test_targets, True)
-        if args.max_expected_speed_override:
-            max_expected_speed_override = make_max_expected_speed_override_dict(
-                args.max_expected_speed_override
+        test_targets_list = make_target_list(
+            args.interface, test_targets, True
+        )
+        if test_parameters["max_expected_speed_override"]:
+            max_expected_speed_override = (
+                make_max_expected_speed_override_dict(
+                    test_parameters["max_expected_speed_override"]
+                )
             )
         else:
             max_expected_speed_override = {}
@@ -1017,10 +1088,16 @@ def interface_test(args: Namespace):
     if not test_targets_list or "example.com" in test_targets:
         # Default values found in config file
         logging.error("Valid target server has not been supplied.")
-        logging.error("Configuration settings can be configured 3 different ways:")
-        logging.error("1- If calling the script directly, pass the --target option")
+        logging.error(
+            "Configuration settings can be configured 3 different ways:"
+        )
+        logging.error(
+            "1- If calling the script directly, pass the --target option"
+        )
         logging.error("2- Define the TEST_TARGET_IPERF environment variable")
-        logging.error("3- If running the test via checkbox/plainbox, define the ")
+        logging.error(
+            "3- If running the test via checkbox/plainbox, define the "
+        )
         logging.error("target in /etc/xdg/canonical-certification.conf")
         logging.error(
             "Please run this script with -h to see more details on how to configure"
@@ -1036,7 +1113,9 @@ def interface_test(args: Namespace):
             args.dont_toggle_ifaces,
             args.iface_timeout,
         ):
-            logging.debug("Start Iperf testing with %s iperf server", test_targets_list)
+            logging.debug(
+                "Start Iperf testing with %s iperf server", test_targets_list
+            )
             start_time = datetime.datetime.now()
             first_loop = True
             # Keep testing until a success
@@ -1044,21 +1123,29 @@ def interface_test(args: Namespace):
             while test_targets_list:
                 test_target = test_targets_list.pop().strip()
                 error_number = run_test(
-                    args, test_target, max_expected_speed_override.get(args.interface)
+                    args,
+                    test_target,
+                    max_expected_speed_override.get(args.interface),
                 )
-                elapsed_seconds = (datetime.datetime.now() - start_time).seconds
+                elapsed_seconds = (
+                    datetime.datetime.now() - start_time
+                ).seconds
                 if (
                     elapsed_seconds > args.scan_timeout and not first_loop
                 ) or not error_number:
                     break
                 if not test_targets_list:
                     logging.warning(
-                        " Exhausted test target list; trying again ".center(60, "=")
+                        " Exhausted test target list; trying again ".center(
+                            60, "="
+                        )
                     )
                     test_targets_list = make_target_list(
                         args.interface, test_targets, False
                     )
-                    time.sleep(30)  # Wait to give server(s) time to come online
+                    time.sleep(
+                        30
+                    )  # Wait to give server(s) time to come online
                     first_loop = False
 
         return error_number
@@ -1140,7 +1227,9 @@ TEST_TARGET_IPERF = iperf-server.example.com
     subparsers = parser.add_subparsers()
 
     # Main cli options
-    test_parser = subparsers.add_parser("test", help=("Run network performance test"))
+    test_parser = subparsers.add_parser(
+        "test", help=("Run network performance test")
+    )
     info_parser = subparsers.add_parser("info", help=("Gather network info"))
 
     # Sub test options
@@ -1275,13 +1364,21 @@ TEST_TARGET_IPERF = iperf-server.example.com
     # Sub info options
     info_parser.add_argument("-i", "--interface", type=str, required=True)
     info_parser.add_argument("--all", default=False, action="store_true")
-    info_parser.add_argument("--duplex-mode", default=False, action="store_true")
-    info_parser.add_argument("--link-speed", default=False, action="store_true")
+    info_parser.add_argument(
+        "--duplex-mode", default=False, action="store_true"
+    )
+    info_parser.add_argument(
+        "--link-speed", default=False, action="store_true"
+    )
     info_parser.add_argument("--max-speed", default=False, action="store_true")
     info_parser.add_argument("--ipaddress", default=False, action="store_true")
     info_parser.add_argument("--netmask", default=False, action="store_true")
-    info_parser.add_argument("--device-name", default=False, action="store_true")
-    info_parser.add_argument("--macaddress", default=False, action="store_true")
+    info_parser.add_argument(
+        "--device-name", default=False, action="store_true"
+    )
+    info_parser.add_argument(
+        "--macaddress", default=False, action="store_true"
+    )
     info_parser.add_argument(
         "--status",
         default=False,
@@ -1305,7 +1402,9 @@ TEST_TARGET_IPERF = iperf-server.example.com
         and not args.cpu_load_fail_threshold != 100
         and not args.iperf3
     ):
-        parser.error("--cpu-load-fail-threshold can only be set with --iperf3.")
+        parser.error(
+            "--cpu-load-fail-threshold can only be set with --iperf3."
+        )
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from argparse import ArgumentParser, RawTextHelpFormatter
+from argparse import ArgumentParser, RawTextHelpFormatter, Namespace
 import datetime
 import fcntl
 import ipaddress
@@ -46,6 +46,7 @@ from contextlib import contextmanager, suppress
 from pathlib import Path
 import sys
 import time
+from collections.abc import MutableMapping
 
 # Global results[] variable to pass results from multiple threads....
 results = []
@@ -199,8 +200,9 @@ class IPerfPerformanceTest(object):
         # to iperf3, thus disabling NUMA features.
         if node_num == -1:
             logging.warning(
-                "WARNING: Could not find the NUMA node "
-                "associated with {}!".format(device)
+                "WARNING: Could not find the NUMA node associated with {}!".format(
+                    device
+                )
             )
         else:
             logging.info("NUMA node of {} is {}....".format(device, node_num))
@@ -445,7 +447,6 @@ class IPerfPerformanceTest(object):
 
 
 class StressPerformanceTest:
-
     def __init__(self, interface, target, iperf3):
         self.interface = interface
         self.target = target
@@ -611,23 +612,40 @@ class Interface(socket.socket):
         return self._read_data("phys_switch_id")
 
 
-def get_test_parameters(args, environ):
-    # Decide the actual values for test parameters, which can come
-    # from one of two possible sources: command-line
-    # arguments, or environment variables.
-    # - If command-line args were given, they take precedence
-    # - Next come environment variables, if set.
+def get_test_parameters(args: Namespace, environ: "MutableMapping[str, str]"):
+    """
+    Decide the actual values for test parameters, which can come
+    from one of two possible sources: command-line
+    arguments, or environment variables.
+    - If command-line args were given, they take precedence
+    - Next come environment variables, if set.
 
-    params = {"test_target_iperf": None}
+    :param args: args from argparser
+    :param environ: environment variable dict, usually os.environ
+    :return: test params dict, see the params variable
+    """
+
+    params = {
+        # test_target_iperf is a comma separated list of ip addresses
+        # example: TEST_TARGET_IPERF=10.102.10.1,10.102.10.2,10.102.10.3
+        "test_target_iperf": None,
+        # max_speed_override is a comma separated list of INTERFACE:SPEED pairs
+        # where INTERFACE is the interface shown in ethtool like eno1
+        # and SPEED is an integer string like 200000 (unit is Megabytes)
+        # example: MAX_EXPECTED_SPEED_OVERRIDE=eno1:1000,enp1s1:2500
+        "max_expected_speed_override": None,
+    }  # type: dict[str, str | None]
 
     # See if we have environment variables
     for key in params.keys():
-        params[key] = os.environ.get(key.upper(), "")
+        params[key] = environ.get(key.upper())  # preserve None
 
     # Finally, see if we have the command-line arguments that are the ultimate
     # override.
     if args.target:
         params["test_target_iperf"] = args.target
+    if args.max_expected_speed_override:
+        params["max_expected_speed_override"] = args.max_speed_override
 
     return params
 
@@ -847,13 +865,13 @@ def check_underspeed(iface):
         and network_if.max_speed != 0
     ):
         logging.error(
-            "Detected link speed ({}) is lower than detected max "
-            "speed ({})".format(network_if.link_speed, network_if.max_speed)
+            "Detected link speed ({}) is lower than detected max speed ({})".format(
+                network_if.link_speed, network_if.max_speed
+            )
         )
         logging.error("Check your device configuration and try again.")
         logging.error(
-            "If you want to override and test despite this "
-            "under-speed link, use"
+            "If you want to override and test despite this under-speed link, use"
         )
         logging.error("the --underspeed-ok option.")
         return True
@@ -995,19 +1013,18 @@ def interface_test(args):
         # Default values found in config file
         logging.error("Valid target server has not been supplied.")
         logging.error(
-            "Configuration settings can be configured 3 different " "ways:"
+            "Configuration settings can be configured 3 different ways:"
         )
         logging.error(
-            "1- If calling the script directly, pass the --target " "option"
+            "1- If calling the script directly, pass the --target option"
         )
         logging.error("2- Define the TEST_TARGET_IPERF environment variable")
         logging.error(
-            "3- If running the test via checkbox/plainbox, define " "the "
+            "3- If running the test via checkbox/plainbox, define the "
         )
         logging.error("target in /etc/xdg/canonical-certification.conf")
         logging.error(
-            "Please run this script with -h to see more details on "
-            "how to configure"
+            "Please run this script with -h to see more details on how to configure"
         )
         sys.exit(1)
 
@@ -1158,6 +1175,7 @@ TEST_TARGET_IPERF = iperf-server.example.com
         ),
     )
     test_parser.add_argument("--target", type=str)
+    test_parser.add_argument("--max-expected-speed-override", type=str)
     action.add_argument(
         "--datasize",
         type=str,
@@ -1298,13 +1316,17 @@ TEST_TARGET_IPERF = iperf-server.example.com
     info_parser.set_defaults(func=interface_info)
 
     args = parser.parse_args()
+
+    print(args)
+    return
+
     if (
         args.func.__name__ is interface_test
         and not args.cpu_load_fail_threshold != 100
         and not args.iperf3
     ):
         parser.error(
-            "--cpu-load-fail-threshold can only be set with " "--iperf3."
+            "--cpu-load-fail-threshold can only be set with --iperf3."
         )
 
     if args.debug:

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -68,6 +68,7 @@ class IPerfPerformanceTest(object):
         reverse,
         protocol="tcp",
         data_size="1",
+        expected_max_speed: "int | None" = None,
         run_time=None,
         scan_timeout=3600,
         iface_timeout=120,
@@ -82,6 +83,7 @@ class IPerfPerformanceTest(object):
         self.iperf3 = iperf3
         self.num_threads = num_threads
         self.data_size = data_size
+        self.expected_max_speed = expected_max_speed
         self.run_time = run_time
         self.scan_timeout = scan_timeout
         self.iface_timeout = iface_timeout
@@ -248,7 +250,7 @@ class IPerfPerformanceTest(object):
         # if max_speed is 0, assume it's wifi and move on
         if self.iface.max_speed == 0:
             logging.warning(
-                "No max speed detected, assuming Wireless device "
+                "No max speed (from ethtool) detected, assuming Wireless device "
                 "and continuing with test."
             )
 
@@ -334,7 +336,10 @@ class IPerfPerformanceTest(object):
         throughput = self.summarize_speeds()
         invalid_speed = False
         try:
-            percent = throughput / int(self.iface.max_speed) * 100
+            if self.expected_max_speed is None:
+                percent = throughput / int(self.iface.max_speed) * 100
+            else:
+                percent = throughput / self.expected_max_speed * 100
         except (ZeroDivisionError, TypeError):
             # Catches a condition where the interface functions fine but
             # ethtool fails to properly report max speed. In this case
@@ -645,7 +650,7 @@ def can_ping(the_interface, test_target):
     return working_interface
 
 
-def run_test(args, test_target):
+def run_test(args, test_target, expected_max_speed: "int | None" = None):
     # Ensure that interface is fully up by waiting until it can
     # ping the test server
     logging.info("Testing {} against {}".format(args.interface, test_target))
@@ -659,6 +664,13 @@ def run_test(args, test_target):
         )
         return 1
 
+    if expected_max_speed:
+        logging.warning(
+            "Expected maximum transfer speed was overridden to: {}".format(
+                expected_max_speed
+            )
+        )
+
     # Execute requested networking test
     if args.test_type.lower() == "iperf":
         error_number = 0
@@ -670,6 +682,7 @@ def run_test(args, test_target):
             args.iperf3,
             args.num_threads,
             args.reverse,
+            expected_max_speed=expected_max_speed
         )
         if args.datasize:
             iperf_benchmark.data_size = args.datasize
@@ -993,6 +1006,12 @@ def interface_test(args: Namespace):
     if args.test_type.lower() == "iperf" or args.test_type.lower() == "stress":
         test_targets = test_parameters["test_target_iperf"]
         test_targets_list = make_target_list(args.interface, test_targets, True)
+        if args.max_expected_speed_override:
+            max_expected_speed_override = make_max_expected_speed_override_dict(
+                args.max_expected_speed_override
+            )
+        else:
+            max_expected_speed_override = {}
 
     # Validate that we got reasonable values
     if not test_targets_list or "example.com" in test_targets:
@@ -1024,7 +1043,9 @@ def interface_test(args: Namespace):
             # or we run out of both targets and time
             while test_targets_list:
                 test_target = test_targets_list.pop().strip()
-                error_number = run_test(args, test_target)
+                error_number = run_test(
+                    args, test_target, max_expected_speed_override.get(args.interface)
+                )
                 elapsed_seconds = (datetime.datetime.now() - start_time).seconds
                 if (
                     elapsed_seconds > args.scan_timeout and not first_loop

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -672,7 +672,7 @@ def get_test_parameters(args: Namespace, environ: "MutableMapping[str, str]"):
     if args.target:
         params["test_target_iperf"] = args.target
     if args.max_expected_speed_override:
-        params["max_expected_speed_override"] = args.max_speed_override
+        params["max_expected_speed_override"] = args.max_expected_speed_override
 
     return params
 

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -105,9 +105,7 @@ class IPerfPerformanceTest(object):
                 # other return value means something did fail
                 if "unable to connect to server" in iperf_exception.output:
                     logging.error(
-                        "Unable to connect to server on port {}".format(
-                            port_num
-                        )
+                        "Unable to connect to server on port {}".format(port_num)
                     )
                     if port_num == 5202:
                         # 5202 is 2nd port in high-speed configs
@@ -118,12 +116,8 @@ class IPerfPerformanceTest(object):
                         logging.warning("more information.")
                 else:
                     # Unknown error; log it....
-                    logging.error(
-                        "Failed executing iperf on port {}.".format(port_num)
-                    )
-                    logging.error(
-                        "Output is '{}'".format(iperf_exception.output)
-                    )
+                    logging.error("Failed executing iperf on port {}.".format(port_num))
+                    logging.error("Output is '{}'".format(iperf_exception.output))
                 return iperf_exception.returncode
             else:
                 # this is normal so we "except" this exception and we
@@ -152,14 +146,10 @@ class IPerfPerformanceTest(object):
                     )
                 )
                 logging.debug(
-                    "Min Transfer speed for thread {}: {} Mb/s".format(
-                        n, min(speeds)
-                    )
+                    "Min Transfer speed for thread {}: {} Mb/s".format(n, min(speeds))
                 )
                 logging.debug(
-                    "Max Transfer speed for thread {}: {} Mb/s".format(
-                        n, max(speeds)
-                    )
+                    "Max Transfer speed for thread {}: {} Mb/s".format(n, max(speeds))
                 )
                 n = n + 1
         return total_throughput
@@ -178,9 +168,7 @@ class IPerfPerformanceTest(object):
             )
             if new_cpu:
                 float_cpu = float(new_cpu[0])
-                logging.debug(
-                    "CPU load for thread {}: {}%".format(n, float_cpu)
-                )
+                logging.debug("CPU load for thread {}: {}%".format(n, float_cpu))
                 sum_cpu = sum_cpu + float_cpu
                 n = n + 1
             if n > 0:
@@ -337,9 +325,7 @@ class IPerfPerformanceTest(object):
                 full_cmd = cmd
             port_num = start_port + thread_num
             t.append(
-                threading.Thread(
-                    target=self.run_one_thread, args=(full_cmd, port_num)
-                )
+                threading.Thread(target=self.run_one_thread, args=(full_cmd, port_num))
             )
             t[thread_num].start()
         for thread_num in range(0, python_threads):
@@ -374,19 +360,12 @@ class IPerfPerformanceTest(object):
 
         if self.iperf3:
             cpu_load = self.summarize_cpu()
-            logging.info(
-                "Average CPU utilization: {}%".format(round(cpu_load, 1))
-            )
+            logging.info("Average CPU utilization: {}%".format(round(cpu_load, 1)))
         else:
             cpu_load = 0
-        if (
-            percent < self.fail_threshold
-            or cpu_load > self.cpu_load_fail_threshold
-        ):
+        if percent < self.fail_threshold or cpu_load > self.cpu_load_fail_threshold:
             logging.warning(
-                "The network test against {} failed because:".format(
-                    self.target
-                )
+                "The network test against {} failed because:".format(self.target)
             )
             if percent < self.fail_threshold:
                 logging.error("  Transfer speed: {} Mb/s".format(throughput))
@@ -441,9 +420,7 @@ class IPerfPerformanceTest(object):
         self.run_time = orig_run_time
         self.scan_timeout = orig_scan_timeout
         self.num_threads = int(max_multiple * orig_num_threads)
-        logging.info(
-            "Setting number of threads to {}.".format(self.num_threads)
-        )
+        logging.info("Setting number of threads to {}.".format(self.num_threads))
 
 
 class StressPerformanceTest:
@@ -454,13 +431,9 @@ class StressPerformanceTest:
 
     def run(self):
         if self.iperf3:
-            iperf_cmd = "timeout -k 1 320 iperf3 -c {} -t 300".format(
-                self.target
-            )
+            iperf_cmd = "timeout -k 1 320 iperf3 -c {} -t 300".format(self.target)
         else:
-            iperf_cmd = "timeout -k 1 320 iperf -c {} -t 300".format(
-                self.target
-            )
+            iperf_cmd = "timeout -k 1 320 iperf -c {} -t 300".format(self.target)
         print("Running iperf...")
         iperf = subprocess.Popen(shlex.split(iperf_cmd))
 
@@ -678,15 +651,11 @@ def run_test(args, test_target):
     logging.info("Testing {} against {}".format(args.interface, test_target))
     if can_ping(args.interface, test_target):
         logging.info(
-            "Have successfully pinged {} on {}".format(
-                test_target, args.interface
-            )
+            "Have successfully pinged {} on {}".format(test_target, args.interface)
         )
     else:
         logging.error(
-            "Can't ping test server {} on {}".format(
-                test_target, args.interface
-            )
+            "Can't ping test server {} on {}".format(test_target, args.interface)
         )
         return 1
 
@@ -750,9 +719,7 @@ def make_target_list(iface, test_targets, log_warnings):
     test_targets_list = test_targets.split(",")
     try:
         net = ipaddress.IPv4Network(
-            "{}/{}".format(
-                Interface(iface).ipaddress, Interface(iface).netmask
-            ),
+            "{}/{}".format(Interface(iface).ipaddress, Interface(iface).netmask),
             False,
         )
     except ipaddress.AddressValueError as e:
@@ -784,14 +751,46 @@ def make_target_list(iface, test_targets, log_warnings):
                     return_list.remove(test_target)
             except ValueError:
                 if log_warnings:
-                    logging.warning(
-                        "Invalid address: {}; skipping".format(test_target)
-                    )
+                    logging.warning("Invalid address: {}; skipping".format(test_target))
                 return_list.remove(test_target)
     return_list.reverse()
     if return_list == [""]:
         del return_list[0]
     return return_list
+
+
+def make_max_expected_speed_override_dict(max_expected_speed_override: str):
+    """Convert the max_expected_speed_override env var string to a dict
+
+    Example: MAX_EXPECTED_SPEED_OVERRIDE=eno1:1000,enp1s1:2500
+
+    This string doesn't have to have all the interfaces. If an interface is
+    not specified, its speed reported by ethtool will be used.
+
+    :param max_expected_speed_override: string from the environment variable
+    :return: dict[str, int], key is interface, value is max speed in megabytes
+    """
+    out = {}  # type: dict[str, int]
+    try:
+        iface_speed_words = max_expected_speed_override.strip().split(",")
+        for iface_speed_word in iface_speed_words:
+            words = iface_speed_word.split(":")
+            if len(words) != 2:
+                raise ValueError(
+                    "Expected string of the form 'eno1:1000', "
+                    + "but got '{}'".format(iface_speed_word)
+                )
+
+            out[words[0]] = int(words[1])
+    except Exception as e:
+        logging.error(
+            "Failed to parse MAX_EXPECTED_SPEED_OVERRIDE, error: '{}'".format(
+                e,
+            )
+        )
+        raise e
+
+    return out
 
 
 # Wait until the specified interface comes up, or until iface_timeout.
@@ -860,10 +859,7 @@ def check_underspeed(iface):
     # UNLESS --underspeed-ok option was used or max_speed is 0
     # (which indicates a probable WiFi link)
     network_if = Interface(iface)
-    if (
-        network_if.link_speed < network_if.max_speed
-        and network_if.max_speed != 0
-    ):
+    if network_if.link_speed < network_if.max_speed and network_if.max_speed != 0:
         logging.error(
             "Detected link speed ({}) is lower than detected max speed ({})".format(
                 network_if.link_speed, network_if.max_speed
@@ -888,15 +884,11 @@ def setup_network_ifaces(
     if target_if_attrs["status"] == "down" and not turn_up_network(
         target_network, timeout
     ):
-        raise SystemExit(
-            "Failed to bring up {} interface".format(target_network)
-        )
+        raise SystemExit("Failed to bring up {} interface".format(target_network))
 
     if not underspeed_ok and check_underspeed(target_network):
         raise SystemExit(
-            "the network speed is incorrect for {} interface".format(
-                target_network
-            )
+            "the network speed is incorrect for {} interface".format(target_network)
         )
 
     if (
@@ -929,9 +921,7 @@ def setup_network_ifaces(
         # Shutdown other network interfaces
         for iface, attrs in network_info.items():
             if attrs["status"] == "up" and not turn_down_network(iface):
-                raise SystemExit(
-                    "Failed to shutdown {} interface".format(iface)
-                )
+                raise SystemExit("Failed to shutdown {} interface".format(iface))
 
 
 def restore_network_ifaces(cur_network_info, origin_network_info, timeout):
@@ -958,9 +948,7 @@ def interface_test_initialize(
         # Back up routing table, since network down/up process
         # tends to trash it....
         logging.debug("Backup routing table")
-        check_call(
-            ["ip", "route", "save", "table", "all"], stdout=tempfile_route
-        )
+        check_call(["ip", "route", "save", "table", "all"], stdout=tempfile_route)
         setup_network_ifaces(
             network_info,
             target_dev,
@@ -1004,24 +992,16 @@ def interface_test(args):
 
     if args.test_type.lower() == "iperf" or args.test_type.lower() == "stress":
         test_targets = test_parameters["test_target_iperf"]
-        test_targets_list = make_target_list(
-            args.interface, test_targets, True
-        )
+        test_targets_list = make_target_list(args.interface, test_targets, True)
 
     # Validate that we got reasonable values
     if not test_targets_list or "example.com" in test_targets:
         # Default values found in config file
         logging.error("Valid target server has not been supplied.")
-        logging.error(
-            "Configuration settings can be configured 3 different ways:"
-        )
-        logging.error(
-            "1- If calling the script directly, pass the --target option"
-        )
+        logging.error("Configuration settings can be configured 3 different ways:")
+        logging.error("1- If calling the script directly, pass the --target option")
         logging.error("2- Define the TEST_TARGET_IPERF environment variable")
-        logging.error(
-            "3- If running the test via checkbox/plainbox, define the "
-        )
+        logging.error("3- If running the test via checkbox/plainbox, define the ")
         logging.error("target in /etc/xdg/canonical-certification.conf")
         logging.error(
             "Please run this script with -h to see more details on how to configure"
@@ -1037,9 +1017,7 @@ def interface_test(args):
             args.dont_toggle_ifaces,
             args.iface_timeout,
         ):
-            logging.debug(
-                "Start Iperf testing with %s iperf server", test_targets_list
-            )
+            logging.debug("Start Iperf testing with %s iperf server", test_targets_list)
             start_time = datetime.datetime.now()
             first_loop = True
             # Keep testing until a success
@@ -1047,25 +1025,19 @@ def interface_test(args):
             while test_targets_list:
                 test_target = test_targets_list.pop().strip()
                 error_number = run_test(args, test_target)
-                elapsed_seconds = (
-                    datetime.datetime.now() - start_time
-                ).seconds
+                elapsed_seconds = (datetime.datetime.now() - start_time).seconds
                 if (
                     elapsed_seconds > args.scan_timeout and not first_loop
                 ) or not error_number:
                     break
                 if not test_targets_list:
                     logging.warning(
-                        " Exhausted test target list; trying again ".center(
-                            60, "="
-                        )
+                        " Exhausted test target list; trying again ".center(60, "=")
                     )
                     test_targets_list = make_target_list(
                         args.interface, test_targets, False
                     )
-                    time.sleep(
-                        30
-                    )  # Wait to give server(s) time to come online
+                    time.sleep(30)  # Wait to give server(s) time to come online
                     first_loop = False
 
         return error_number
@@ -1147,9 +1119,7 @@ TEST_TARGET_IPERF = iperf-server.example.com
     subparsers = parser.add_subparsers()
 
     # Main cli options
-    test_parser = subparsers.add_parser(
-        "test", help=("Run network performance test")
-    )
+    test_parser = subparsers.add_parser("test", help=("Run network performance test"))
     info_parser = subparsers.add_parser("info", help=("Gather network info"))
 
     # Sub test options
@@ -1284,21 +1254,13 @@ TEST_TARGET_IPERF = iperf-server.example.com
     # Sub info options
     info_parser.add_argument("-i", "--interface", type=str, required=True)
     info_parser.add_argument("--all", default=False, action="store_true")
-    info_parser.add_argument(
-        "--duplex-mode", default=False, action="store_true"
-    )
-    info_parser.add_argument(
-        "--link-speed", default=False, action="store_true"
-    )
+    info_parser.add_argument("--duplex-mode", default=False, action="store_true")
+    info_parser.add_argument("--link-speed", default=False, action="store_true")
     info_parser.add_argument("--max-speed", default=False, action="store_true")
     info_parser.add_argument("--ipaddress", default=False, action="store_true")
     info_parser.add_argument("--netmask", default=False, action="store_true")
-    info_parser.add_argument(
-        "--device-name", default=False, action="store_true"
-    )
-    info_parser.add_argument(
-        "--macaddress", default=False, action="store_true"
-    )
+    info_parser.add_argument("--device-name", default=False, action="store_true")
+    info_parser.add_argument("--macaddress", default=False, action="store_true")
     info_parser.add_argument(
         "--status",
         default=False,
@@ -1325,9 +1287,7 @@ TEST_TARGET_IPERF = iperf-server.example.com
         and not args.cpu_load_fail_threshold != 100
         and not args.iperf3
     ):
-        parser.error(
-            "--cpu-load-fail-threshold can only be set with --iperf3."
-        )
+        parser.error("--cpu-load-fail-threshold can only be set with --iperf3.")
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)

--- a/providers/base/tests/test_network.py
+++ b/providers/base/tests/test_network.py
@@ -740,9 +740,7 @@ class InterfaceTestWithMaxSpeedOverrideTests(unittest.TestCase):
             network.interface_test(args)
 
         mock_make_override_dict.assert_called_once_with("eth0:5000")
-        mock_run.assert_called_once_with(
-            args, "192.168.1.1", 5000
-        )
+        mock_run.assert_called_once_with(args, "192.168.1.1", 5000)
 
     @patch("time.sleep")
     @patch("network.run_test")
@@ -803,5 +801,5 @@ class InterfaceClassTest(unittest.TestCase):
         self.assertEqual(self.obj_intf.phys_switch_id, "test")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/providers/base/tests/test_network.py
+++ b/providers/base/tests/test_network.py
@@ -639,6 +639,145 @@ class NetworkTests(unittest.TestCase):
         self.assertEqual(mock_logging.call_count, 7)
 
 
+class MakeMaxExpectedSpeedOverrideDictTests(unittest.TestCase):
+    def test_single_entry_happy_path(self):
+        result = network.make_max_expected_speed_override_dict("eno1:1000")
+        self.assertEqual(result, {"eno1": 1000})
+
+    def test_multiple_entries_happy_path(self):
+        result = network.make_max_expected_speed_override_dict(
+            "eno1:1000,enp1s1:2500"
+        )
+        self.assertEqual(result, {"eno1": 1000, "enp1s1": 2500})
+
+    def test_leading_trailing_whitespace_stripped(self):
+        result = network.make_max_expected_speed_override_dict("  eno1:1000  ")
+        self.assertEqual(result, {"eno1": 1000})
+
+    def test_invalid_no_colon_raises(self):
+        with self.assertRaises(ValueError):
+            network.make_max_expected_speed_override_dict("eno1")
+
+    def test_invalid_non_integer_speed_raises(self):
+        with self.assertRaises(ValueError):
+            network.make_max_expected_speed_override_dict("eno1:notanumber")
+
+    def test_invalid_extra_colon_raises(self):
+        with self.assertRaises(ValueError):
+            network.make_max_expected_speed_override_dict("eno1:1000:extra")
+
+
+class GetTestParametersTests(unittest.TestCase):
+    def _make_args(self, target=None, max_expected_speed_override=None):
+        return Namespace(
+            target=target,
+            max_expected_speed_override=max_expected_speed_override,
+        )
+
+    def test_no_env_vars_no_args_returns_none(self):
+        result = network.get_test_parameters(self._make_args(), {})
+        self.assertIsNone(result["test_target_iperf"])
+        self.assertIsNone(result["max_expected_speed_override"])
+
+    def test_env_var_test_target_iperf(self):
+        environ = {"TEST_TARGET_IPERF": "192.168.1.1"}
+        result = network.get_test_parameters(self._make_args(), environ)
+        self.assertEqual(result["test_target_iperf"], "192.168.1.1")
+        self.assertIsNone(result["max_expected_speed_override"])
+
+    def test_env_var_max_expected_speed_override(self):
+        environ = {"MAX_EXPECTED_SPEED_OVERRIDE": "eno1:1000,enp1s1:2500"}
+        result = network.get_test_parameters(self._make_args(), environ)
+        self.assertEqual(
+            result["max_expected_speed_override"], "eno1:1000,enp1s1:2500"
+        )
+
+    def test_cli_target_overrides_env(self):
+        environ = {"TEST_TARGET_IPERF": "192.168.1.1"}
+        args = self._make_args(target="10.0.0.1")
+        result = network.get_test_parameters(args, environ)
+        self.assertEqual(result["test_target_iperf"], "10.0.0.1")
+
+    def test_missing_env_var_preserves_none(self):
+        result = network.get_test_parameters(self._make_args(), {})
+        self.assertIsNone(result["test_target_iperf"])
+
+
+class InterfaceTestWithMaxSpeedOverrideTests(unittest.TestCase):
+    @patch("time.sleep")
+    @patch("network.make_max_expected_speed_override_dict")
+    @patch("network.run_test")
+    @patch("network.interface_test_initialize")
+    @patch("network.make_target_list")
+    @patch("network.get_test_parameters")
+    def test_interface_test_passes_override_speed_to_run_test(
+        self,
+        mock_get_test_params,
+        mock_mk_targets,
+        mock_net_init,
+        mock_run,
+        mock_make_override_dict,
+        mock_sleep,
+    ):
+        """run_test receives the overridden speed for the given interface."""
+        args = Namespace(
+            test_type="iperf",
+            interface="eth0",
+            scan_timeout=4,
+            underspeed_ok=True,
+            dont_toggle_ifaces=True,
+            iface_timeout=1,
+        )
+        mock_get_test_params.return_value = {
+            "test_target_iperf": "127.0.0.1",
+            "max_expected_speed_override": "eth0:5000",
+        }
+        mock_make_override_dict.return_value = {"eth0": 5000}
+        mock_mk_targets.return_value = ["192.168.1.1"]
+        mock_run.return_value = 0
+
+        with redirect_stderr(StringIO()):
+            network.interface_test(args)
+
+        mock_make_override_dict.assert_called_once_with("eth0:5000")
+        mock_run.assert_called_once_with(
+            args, "192.168.1.1", 5000
+        )
+
+    @patch("time.sleep")
+    @patch("network.run_test")
+    @patch("network.interface_test_initialize")
+    @patch("network.make_target_list")
+    @patch("network.get_test_parameters")
+    def test_interface_test_no_override_passes_none_to_run_test(
+        self,
+        mock_get_test_params,
+        mock_mk_targets,
+        mock_net_init,
+        mock_run,
+        mock_sleep,
+    ):
+        args = Namespace(
+            test_type="iperf",
+            interface="eth0",
+            scan_timeout=4,
+            underspeed_ok=True,
+            dont_toggle_ifaces=True,
+            iface_timeout=1,
+        )
+        mock_get_test_params.return_value = {
+            "test_target_iperf": "127.0.0.1",
+            "max_expected_speed_override": None,
+        }
+        mock_mk_targets.return_value = ["192.168.1.1"]
+        mock_run.return_value = 0
+
+        with redirect_stderr(StringIO()):
+            network.interface_test(args)
+
+        mock_run.assert_called_once_with(args, "192.168.1.1", None)
+
+
 class InterfaceClassTest(unittest.TestCase):
 
     @patch("network.Interface.__init__", Mock(return_value=None))
@@ -662,3 +801,7 @@ class InterfaceClassTest(unittest.TestCase):
         mock_read.return_value = "test"
 
         self.assertEqual(self.obj_intf.phys_switch_id, "test")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

This PR adds the relevant logic in network.py to accept a new environment variable `MAX_EXPECTED_SPEED_OVERRIDE`. 

If this environment variable is specified, the logs will show this block:

```
INFO:root:92.85% of expected max 200000 Mb/s
WARNING:root:----------------------------MANUAL OVERRIDE WAS USED----------------------------
WARNING:root:The expected maximum speed of 'enP1p3s0f0np0' was manually overridden to '200000'
WARNING:root:--------------------------------------------------------------------------------
```

indicating that this needs extra attention during review time.

Implements #2568 

## Resolved issues

Some network cards like Nvidia CX8 doesn't support its maximum theoretical speed without special configuration which is the expected behavior. Adding this environment variable will allow these special cards to pass the iperf tests.

There's unfortunately a bit of formatting changes mixed in because the original script won't pass black and flake8 checks.

## Documentation



## Tests

C3: 
