### PR TITLE
Ignore gnome-screenshot errors (Bugfix)

### DIFF
--- a/checkbox-core-snap/series26/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series26/snap/snapcraft.yaml
@@ -332,7 +332,6 @@ parts:
       - fswebcam
       - glmark2-wayland
       - glmark2-es2-wayland
-      - gnome-screenshot
       - gstreamer1.0-tools
       - gstreamer1.0-plugins-bad
       - gstreamer1.0-pulseaudio

--- a/providers/base/bin/randr_cycle.py
+++ b/providers/base/bin/randr_cycle.py
@@ -142,7 +142,7 @@ def action(filename, **kwargs):
     if shutil.which("gnome-screenshot"):
         # gnome-screenshot no longer works on 26.04+
         # until we find an alternative, ignore screenshot errors for now
-        
+
         # also make sure this doesn't hang forever
         with suppress(subprocess.TimeoutExpired):
             subprocess.run(

--- a/providers/base/bin/randr_cycle.py
+++ b/providers/base/bin/randr_cycle.py
@@ -137,6 +137,8 @@ def action(filename, **kwargs):
         path_and_filename = "{}.jpg".format(filename)
     time.sleep(5)
     if shutil.which("gnome-screenshot"):
+        # gnome-screenshot no longer works on 26.04+
+        # until we find an alternative, ignore screenshot errors for now
         subprocess.run(["gnome-screenshot", "-f", path_and_filename])
     else:
         print(

--- a/providers/base/bin/randr_cycle.py
+++ b/providers/base/bin/randr_cycle.py
@@ -19,6 +19,8 @@
 # along with Checkbox. If not, see <http://www.gnu.org/licenses/>.
 
 
+import shutil
+
 from checkbox_support.dbus.gnome_monitor import MutterDisplayMode as Mode
 from checkbox_support.helpers import display_info
 from collections import namedtuple
@@ -41,9 +43,7 @@ def _is_too_small(mode: Mode) -> bool:
     :param mode:  The Mode that defined in checkbox_support.dbus.gnome_monitor
     """
     aspect = Fraction(mode.width, mode.height)
-    return (
-        mode.width < MIN_RESOLUTION.w or mode.width / aspect < MIN_RESOLUTION.h
-    )
+    return mode.width < MIN_RESOLUTION.w or mode.width / aspect < MIN_RESOLUTION.h
 
 
 def _is_duplicate_resolution(mode: Mode, processed_resolutions: list):
@@ -136,7 +136,13 @@ def action(filename, **kwargs):
     else:
         path_and_filename = "{}.jpg".format(filename)
     time.sleep(5)
-    subprocess.check_output(["gnome-screenshot", "-f", path_and_filename])
+    if shutil.which("gnome-screenshot"):
+        subprocess.run(["gnome-screenshot", "-f", path_and_filename])
+    else:
+        print(
+            "gnome-screenshot is not installed. Not taking any screenshots.",
+            "This is expected for 26.04 onwards",
+        )
 
 
 class MonitorTest:
@@ -222,8 +228,7 @@ class MonitorTest:
             "--screenshot_dir",
             default=os.getenv("HOME", "~"),
             help=(
-                "Specify a directory to store screenshots in. "
-                "(default: %(default)s)"
+                "Specify a directory to store screenshots in. (default: %(default)s)"
             ),
         )
 

--- a/providers/base/bin/randr_cycle.py
+++ b/providers/base/bin/randr_cycle.py
@@ -232,7 +232,8 @@ class MonitorTest:
             "--screenshot_dir",
             default=os.getenv("HOME", "~"),
             help=(
-                "Specify a directory to store screenshots in. (default: %(default)s)"
+                "Specify a directory to store screenshots in. "
+                + "(default: %(default)s)"
             ),
         )
 

--- a/providers/base/bin/randr_cycle.py
+++ b/providers/base/bin/randr_cycle.py
@@ -146,7 +146,7 @@ def action(filename, **kwargs):
         # also make sure this doesn't hang forever
         with suppress(subprocess.TimeoutExpired):
             subprocess.run(
-                ["gnome-screenshot", "-f", path_and_filename], timeout=10
+                ["gnome-screenshot", "-f", path_and_filename], timeout=5
             )
     else:
         print(

--- a/providers/base/bin/randr_cycle.py
+++ b/providers/base/bin/randr_cycle.py
@@ -19,6 +19,7 @@
 # along with Checkbox. If not, see <http://www.gnu.org/licenses/>.
 
 
+from contextlib import suppress
 import shutil
 
 from checkbox_support.dbus.gnome_monitor import MutterDisplayMode as Mode
@@ -141,7 +142,12 @@ def action(filename, **kwargs):
     if shutil.which("gnome-screenshot"):
         # gnome-screenshot no longer works on 26.04+
         # until we find an alternative, ignore screenshot errors for now
-        subprocess.run(["gnome-screenshot", "-f", path_and_filename])
+        
+        # also make sure this doesn't hang forever
+        with suppress(subprocess.TimeoutExpired):
+            subprocess.run(
+                ["gnome-screenshot", "-f", path_and_filename], timeout=10
+            )
     else:
         print(
             "gnome-screenshot is not installed. Not taking any screenshots.",

--- a/providers/base/bin/randr_cycle.py
+++ b/providers/base/bin/randr_cycle.py
@@ -43,7 +43,9 @@ def _is_too_small(mode: Mode) -> bool:
     :param mode:  The Mode that defined in checkbox_support.dbus.gnome_monitor
     """
     aspect = Fraction(mode.width, mode.height)
-    return mode.width < MIN_RESOLUTION.w or mode.width / aspect < MIN_RESOLUTION.h
+    return (
+        mode.width < MIN_RESOLUTION.w or mode.width / aspect < MIN_RESOLUTION.h
+    )
 
 
 def _is_duplicate_resolution(mode: Mode, processed_resolutions: list):

--- a/providers/base/tests/test_randr_cycle.py
+++ b/providers/base/tests/test_randr_cycle.py
@@ -189,6 +189,22 @@ class TestActionFunction(unittest.TestCase):
         )
         mock_sleep.assert_called_once_with(5)
 
+    @patch("shutil.which")
+    @patch("subprocess.run")
+    @patch("time.sleep")
+    def test_action_without_gnome_screenshot_installed(
+        self,
+        mock_sleep: MagicMock,
+        mock_subprocess: MagicMock,
+        mock_which: MagicMock,
+    ):
+        filename = "monitor_1920x1080_normal_"
+        mock_which.return_value = False
+        action(filename)
+
+        mock_subprocess.assert_not_called()
+        mock_sleep.assert_called_once_with(5)
+
 
 class GenScreenshotPath(unittest.TestCase):
     """

--- a/providers/base/tests/test_randr_cycle.py
+++ b/providers/base/tests/test_randr_cycle.py
@@ -176,7 +176,9 @@ class TestActionFunction(unittest.TestCase):
     @patch("shutil.which")
     @patch("subprocess.run")
     @patch("time.sleep")
-    def test_action_without_path(self, mock_sleep, mock_subprocess, mock_which):
+    def test_action_without_path(
+        self, mock_sleep, mock_subprocess, mock_which
+    ):
         filename = "monitor_1920x1080_normal_"
         mock_which.return_value = True
         action(filename)
@@ -233,7 +235,9 @@ class GenScreenshotPath(unittest.TestCase):
             mt.gen_screenshot_path("1", "key", "test"),
             "test/1_xrandr_screens_key",
         )
-        mock_mkdir.assert_called_with("test/1_xrandr_screens_key", exist_ok=True)
+        mock_mkdir.assert_called_with(
+            "test/1_xrandr_screens_key", exist_ok=True
+        )
 
 
 class TestScreenshotTarring(unittest.TestCase):
@@ -255,8 +259,12 @@ class TestScreenshotTarring(unittest.TestCase):
 
         mock_tar_open.assert_called_once_with("screenshots.tgz", "w:gz")
         self.assertEqual(mock_tar.add.call_count, 2)
-        mock_tar.add.assert_any_call("screenshots/screenshot1.png", "screenshot1.png")
-        mock_tar.add.assert_any_call("screenshots/screenshot2.png", "screenshot2.png")
+        mock_tar.add.assert_any_call(
+            "screenshots/screenshot1.png", "screenshot1.png"
+        )
+        mock_tar.add.assert_any_call(
+            "screenshots/screenshot2.png", "screenshot2.png"
+        )
 
     @patch("os.listdir")
     @patch("tarfile.open")
@@ -270,7 +278,9 @@ class TestScreenshotTarring(unittest.TestCase):
 
         try:
             mt.tar_screenshot_dir(path)
-            result = True  # If no exception is raised, we consider it successful.
+            result = (
+                True  # If no exception is raised, we consider it successful.
+            )
         except Exception:
             result = False
 
@@ -335,7 +345,9 @@ class MainTests(unittest.TestCase):
     @patch("checkbox_support.helpers.display_info.get_monitor_config")
     @patch("randr_cycle.MonitorTest.gen_screenshot_path")
     @patch("randr_cycle.MonitorTest.tar_screenshot_dir")
-    def test_cycle_both(self, mock_dir, mock_path, mock_config, mock_parse_args):
+    def test_cycle_both(
+        self, mock_dir, mock_path, mock_config, mock_parse_args
+    ):
         args_mock = MagicMock()
         args_mock.cycle = "both"
         args_mock.keyword = ""
@@ -362,7 +374,9 @@ class MainTests(unittest.TestCase):
     @patch("checkbox_support.helpers.display_info.get_monitor_config")
     @patch("randr_cycle.MonitorTest.gen_screenshot_path")
     @patch("randr_cycle.MonitorTest.tar_screenshot_dir")
-    def test_cycle_resolution(self, mock_dir, mock_path, mock_config, mock_parse_args):
+    def test_cycle_resolution(
+        self, mock_dir, mock_path, mock_config, mock_parse_args
+    ):
         args_mock = MagicMock()
         args_mock.cycle = "resolution"
         args_mock.keyword = ""
@@ -389,7 +403,9 @@ class MainTests(unittest.TestCase):
     @patch("checkbox_support.helpers.display_info.get_monitor_config")
     @patch("randr_cycle.MonitorTest.gen_screenshot_path")
     @patch("randr_cycle.MonitorTest.tar_screenshot_dir")
-    def test_cycle_transform(self, mock_dir, mock_path, mock_config, mock_parse_args):
+    def test_cycle_transform(
+        self, mock_dir, mock_path, mock_config, mock_parse_args
+    ):
         args_mock = MagicMock()
         args_mock.cycle = "transform"
         args_mock.keyword = ""
@@ -422,8 +438,11 @@ class MainTests(unittest.TestCase):
         mock_parse_args.return_value = args_mock
 
         mock_config.side_effect = ValueError("Error")
-        with self.assertRaisesRegex(SystemExit, "Current host is not support: Error"):
+        with self.assertRaisesRegex(
+            SystemExit, "Current host is not support: Error"
+        ):
             MonitorTest().main()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/providers/base/tests/test_randr_cycle.py
+++ b/providers/base/tests/test_randr_cycle.py
@@ -158,11 +158,13 @@ class TestResolutionFilter(unittest.TestCase):
 
 
 class TestActionFunction(unittest.TestCase):
-    @patch("subprocess.check_output")
+    @patch("shutil.which")
+    @patch("subprocess.run")
     @patch("time.sleep")
-    def test_action_with_path(self, mock_sleep, mock_subprocess):
+    def test_action_with_path(self, mock_sleep, mock_subprocess, mock_which):
         filename = "monitor_1920x1080_normal_"
         path = "/tmp/screenshots"
+        mock_which.return_value = True
         action(filename, path=path)
 
         expected_path_and_filename = "{}/{}.jpg".format(path, filename)
@@ -171,10 +173,12 @@ class TestActionFunction(unittest.TestCase):
         )
         mock_sleep.assert_called_once_with(5)
 
-    @patch("subprocess.check_output")
+    @patch("shutil.which")
+    @patch("subprocess.run")
     @patch("time.sleep")
-    def test_action_without_path(self, mock_sleep, mock_subprocess):
+    def test_action_without_path(self, mock_sleep, mock_subprocess, mock_which):
         filename = "monitor_1920x1080_normal_"
+        mock_which.return_value = True
         action(filename)
 
         expected_path_and_filename = filename + ".jpg"
@@ -182,17 +186,6 @@ class TestActionFunction(unittest.TestCase):
             ["gnome-screenshot", "-f", expected_path_and_filename]
         )
         mock_sleep.assert_called_once_with(5)
-
-    @patch("subprocess.check_output")
-    @patch("time.sleep")
-    def test_action_subprocess_error(self, mock_sleep, mock_subprocess):
-        filename = "monitor_1920x1080_normal_"
-        mock_subprocess.side_effect = subprocess.CalledProcessError(
-            1, "gnome-screenshot"
-        )
-
-        with self.assertRaises(subprocess.CalledProcessError):
-            action(filename)
 
 
 class GenScreenshotPath(unittest.TestCase):
@@ -240,9 +233,7 @@ class GenScreenshotPath(unittest.TestCase):
             mt.gen_screenshot_path("1", "key", "test"),
             "test/1_xrandr_screens_key",
         )
-        mock_mkdir.assert_called_with(
-            "test/1_xrandr_screens_key", exist_ok=True
-        )
+        mock_mkdir.assert_called_with("test/1_xrandr_screens_key", exist_ok=True)
 
 
 class TestScreenshotTarring(unittest.TestCase):
@@ -264,12 +255,8 @@ class TestScreenshotTarring(unittest.TestCase):
 
         mock_tar_open.assert_called_once_with("screenshots.tgz", "w:gz")
         self.assertEqual(mock_tar.add.call_count, 2)
-        mock_tar.add.assert_any_call(
-            "screenshots/screenshot1.png", "screenshot1.png"
-        )
-        mock_tar.add.assert_any_call(
-            "screenshots/screenshot2.png", "screenshot2.png"
-        )
+        mock_tar.add.assert_any_call("screenshots/screenshot1.png", "screenshot1.png")
+        mock_tar.add.assert_any_call("screenshots/screenshot2.png", "screenshot2.png")
 
     @patch("os.listdir")
     @patch("tarfile.open")
@@ -283,9 +270,7 @@ class TestScreenshotTarring(unittest.TestCase):
 
         try:
             mt.tar_screenshot_dir(path)
-            result = (
-                True  # If no exception is raised, we consider it successful.
-            )
+            result = True  # If no exception is raised, we consider it successful.
         except Exception:
             result = False
 
@@ -350,9 +335,7 @@ class MainTests(unittest.TestCase):
     @patch("checkbox_support.helpers.display_info.get_monitor_config")
     @patch("randr_cycle.MonitorTest.gen_screenshot_path")
     @patch("randr_cycle.MonitorTest.tar_screenshot_dir")
-    def test_cycle_both(
-        self, mock_dir, mock_path, mock_config, mock_parse_args
-    ):
+    def test_cycle_both(self, mock_dir, mock_path, mock_config, mock_parse_args):
         args_mock = MagicMock()
         args_mock.cycle = "both"
         args_mock.keyword = ""
@@ -379,9 +362,7 @@ class MainTests(unittest.TestCase):
     @patch("checkbox_support.helpers.display_info.get_monitor_config")
     @patch("randr_cycle.MonitorTest.gen_screenshot_path")
     @patch("randr_cycle.MonitorTest.tar_screenshot_dir")
-    def test_cycle_resolution(
-        self, mock_dir, mock_path, mock_config, mock_parse_args
-    ):
+    def test_cycle_resolution(self, mock_dir, mock_path, mock_config, mock_parse_args):
         args_mock = MagicMock()
         args_mock.cycle = "resolution"
         args_mock.keyword = ""
@@ -408,9 +389,7 @@ class MainTests(unittest.TestCase):
     @patch("checkbox_support.helpers.display_info.get_monitor_config")
     @patch("randr_cycle.MonitorTest.gen_screenshot_path")
     @patch("randr_cycle.MonitorTest.tar_screenshot_dir")
-    def test_cycle_transform(
-        self, mock_dir, mock_path, mock_config, mock_parse_args
-    ):
+    def test_cycle_transform(self, mock_dir, mock_path, mock_config, mock_parse_args):
         args_mock = MagicMock()
         args_mock.cycle = "transform"
         args_mock.keyword = ""
@@ -443,7 +422,8 @@ class MainTests(unittest.TestCase):
         mock_parse_args.return_value = args_mock
 
         mock_config.side_effect = ValueError("Error")
-        with self.assertRaisesRegex(
-            SystemExit, "Current host is not support: Error"
-        ):
+        with self.assertRaisesRegex(SystemExit, "Current host is not support: Error"):
             MonitorTest().main()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/providers/base/tests/test_randr_cycle.py
+++ b/providers/base/tests/test_randr_cycle.py
@@ -169,7 +169,7 @@ class TestActionFunction(unittest.TestCase):
 
         expected_path_and_filename = "{}/{}.jpg".format(path, filename)
         mock_subprocess.assert_called_once_with(
-            ["gnome-screenshot", "-f", expected_path_and_filename], timeout=10
+            ["gnome-screenshot", "-f", expected_path_and_filename], timeout=5
         )
         mock_sleep.assert_called_once_with(5)
 
@@ -185,7 +185,7 @@ class TestActionFunction(unittest.TestCase):
 
         expected_path_and_filename = filename + ".jpg"
         mock_subprocess.assert_called_once_with(
-            ["gnome-screenshot", "-f", expected_path_and_filename], timeout=10
+            ["gnome-screenshot", "-f", expected_path_and_filename], timeout=5
         )
         mock_sleep.assert_called_once_with(5)
 

--- a/providers/base/tests/test_randr_cycle.py
+++ b/providers/base/tests/test_randr_cycle.py
@@ -169,7 +169,7 @@ class TestActionFunction(unittest.TestCase):
 
         expected_path_and_filename = "{}/{}.jpg".format(path, filename)
         mock_subprocess.assert_called_once_with(
-            ["gnome-screenshot", "-f", expected_path_and_filename]
+            ["gnome-screenshot", "-f", expected_path_and_filename], timeout=10
         )
         mock_sleep.assert_called_once_with(5)
 
@@ -185,7 +185,7 @@ class TestActionFunction(unittest.TestCase):
 
         expected_path_and_filename = filename + ".jpg"
         mock_subprocess.assert_called_once_with(
-            ["gnome-screenshot", "-f", expected_path_and_filename]
+            ["gnome-screenshot", "-f", expected_path_and_filename], timeout=10
         )
         mock_sleep.assert_called_once_with(5)
 

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -256,7 +256,6 @@ category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_cycle_resolution_{product_slug}
 template-id: graphics/index_cycle_resolution_product_slug
 flags: also-after-suspend
-requires: package.name == 'xorg'
 depends: graphics/VESA_drivers_not_in_use
 environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 command:
@@ -282,7 +281,6 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 id: graphics/cycle_resolution_primary
 flags: also-after-suspend
-requires: package.name == 'xorg'
 depends: graphics/VESA_drivers_not_in_use
 environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 command:

--- a/providers/base/units/suspend/suspend-graphics.pxu
+++ b/providers/base/units/suspend/suspend-graphics.pxu
@@ -89,7 +89,6 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::suspend
 id: suspend/{{ index }}_cycle_resolutions_after_suspend_{{ product_slug }}_graphics
 template-id: suspend/index_cycle_resolutions_after_suspend_product_slug_graphics
-requires: package.name == 'xorg'
 depends:
  {%- if gpu_count > "1" %}
   suspend/{{ index }}_suspend_after_switch_to_card_{{ product_slug }}_auto

--- a/providers/base/units/suspend/suspend.pxu
+++ b/providers/base/units/suspend/suspend.pxu
@@ -1151,7 +1151,6 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::suspend
 id: suspend/cycle_resolutions_after_suspend
 estimated_duration: 120.0
-requires: package.name == 'xorg'
 depends: suspend/suspend_advanced_auto
 environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 command:
@@ -1176,7 +1175,6 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::suspend
 id: suspend/{index}_cycle_resolutions_after_suspend_{product_slug}
 template-id: suspend/index_cycle_resolutions_after_suspend_product_slug
-requires: package.name == 'xorg'
 depends: suspend/{index}_suspend_after_switch_to_card_{product_slug}
 environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 estimated_duration: 120.0
@@ -1199,7 +1197,6 @@ plugin: shell
 category_id: com.canonical.plainbox::suspend
 id: suspend/cycle_resolutions_after_suspend_auto
 estimated_duration: 1.2
-requires: package.name == 'xorg'
 depends: suspend/suspend_advanced_auto
 environ: XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 _purpose:


### PR DESCRIPTION
## Description

gnome-screenshot doesn't work anymore after the removal of xorg in 26.04. It technically never should have worked in a wayland session, but since we used to have the xorg package in 24.04 and older, gnome-screenshot was able to use that as a fallback and take screenshots.

## Resolved issues

Part of #2508 

## Documentation

## Tests
C3: https://certification.canonical.com/hardware/201812-26713/submission/497211/
