### PR TITLE
Ignore non existing paths in PATH (BugFix)

### DIFF
--- a/providers/resource/bin/executable_resource.py
+++ b/providers/resource/bin/executable_resource.py
@@ -11,7 +11,7 @@ def iter_if_accessible(path: Path):
 
 
 def main():
-    paths = {Path(x).resolve() for x in os.get_exec_path()}
+    paths = {Path(x).resolve() for x in os.get_exec_path() if Path(x).exists()}
     executables = set()
     for path in paths:
         all_files = filter(Path.is_file, iter_if_accessible(path))

--- a/providers/resource/tests/test_executable_resource.py
+++ b/providers/resource/tests/test_executable_resource.py
@@ -84,3 +84,21 @@ class TestExecutableResource(TestCase):
         self.assertIn("name: cat", lines)
         self.assertIn("name: custom_tool", lines)
         self.assertIn("name: ls", lines)
+
+    @patch("executable_resource.Path.exists", return_value=False)
+    @patch("executable_resource.print")
+    @patch("executable_resource.iter_if_accessible")
+    @patch("executable_resource.os.get_exec_path")
+    def test_main_skips_nonexistent_paths(
+        self,
+        get_exec_path_mock,
+        iter_mock,
+        print_mock,
+        exists_mock,
+    ):
+        get_exec_path_mock.return_value = ["/does/not/exist"]
+
+        executable_resource.main()
+
+        iter_mock.assert_not_called()
+        print_mock.assert_not_called()

--- a/providers/resource/tests/test_executable_resource.py
+++ b/providers/resource/tests/test_executable_resource.py
@@ -85,7 +85,7 @@ class TestExecutableResource(TestCase):
         self.assertIn("name: custom_tool", lines)
         self.assertIn("name: ls", lines)
 
-    @patch("executable_resource.Path.exists", return_value=False)
+    @patch("executable_resource.Path.resolve", side_effect=FileNotFoundError)
     @patch("executable_resource.print")
     @patch("executable_resource.iter_if_accessible")
     @patch("executable_resource.os.get_exec_path")
@@ -94,7 +94,7 @@ class TestExecutableResource(TestCase):
         get_exec_path_mock,
         iter_mock,
         print_mock,
-        exists_mock,
+        resolve_mock,
     ):
         get_exec_path_mock.return_value = ["/does/not/exist"]
 


### PR DESCRIPTION
## Description

I've noticed on an old machine this edge case, where a path in PATH does not exist, and `resolve` would fail.

```
$ python3 executable_resource.py 
Traceback (most recent call last):
  File "executable_resource.py", line 28, in <module>
    main()
  File "executable_resource.py", line 15, in main
    paths = {Path(x).resolve() for x in os.get_exec_path()}
  File "executable_resource.py", line 15, in <setcomp>
    paths = {Path(x).resolve() for x in os.get_exec_path()}
  File "/usr/lib/python3.5/pathlib.py", line 1109, in resolve
    s = self._flavour.resolve(self)
  File "/usr/lib/python3.5/pathlib.py", line 330, in resolve
    return _resolve(base, str(path)) or sep
  File "/usr/lib/python3.5/pathlib.py", line 315, in _resolve
    target = accessor.readlink(newpath)
  File "/usr/lib/python3.5/pathlib.py", line 422, in readlink
    return os.readlink(path)
FileNotFoundError: [Errno 2] No such file or directory: '/home/ubuntu/bin'
```

## Resolved issues

Executable resource job is failing.

## Documentation

N/A

## Tests

Append a non-existing path to PATH, and run the script.
