### PR TITLE
Gpiod gpio test for simple and loopback (New)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_python.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_python.py
@@ -391,7 +391,7 @@ def emit_records(records: list[dict[str, object]], fmt: str) -> None:
         return
     for record in records:
         for key, value in record.items():
-            print(f"{key}={value}")
+            print(f"{key}: {value}")
         print()
 
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_python.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_python.py
@@ -8,47 +8,36 @@ human-readable progress blocks while keeping ``GPIO_TEST_RESULT=...`` available
 for Checkbox parsing.
 """
 
-from __future__ import annotations
-
 import argparse
 import glob
 import json
 import re
 import sys
 import time
-from dataclasses import dataclass
+from collections import namedtuple
 from pathlib import Path
 
 CONSUMER = "gpio-test"
 
+# Description of one GPIO line discovered from the Python gpiod API.
+GpioLine = namedtuple(
+    "GpioLine",
+    ["chip", "offset", "name", "used", "direction", "active_low"],
+)
 
-@dataclass(frozen=True)
-class GpioLine:
-    """Description of one GPIO line discovered from the Python gpiod API."""
+# Cached Python gpiod module, API style and GPIO discovery data.
+TestState = namedtuple("TestState", ["gpiod", "style", "lines"])
 
-    chip: str
-    offset: int
-    name: str
-    used: bool
-    direction: str | None
-    active_low: bool
-
-
-@dataclass(frozen=True)
-class TestState:
-    """Cached Python gpiod module, API style and GPIO discovery data."""
-
-    gpiod: object
-    style: str
-    lines: dict[str, GpioLine]
+# Original line state used to restore GPIO direction and value.
+SavedLineState = namedtuple("SavedLineState", ["line", "value"])
 
 
-@dataclass(frozen=True)
-class SavedLineState:
-    """Original line state used to restore GPIO direction and value."""
+def strip_prefix(text, prefix):
+    """Return ``text`` without ``prefix`` (str.removeprefix for Python 3.5)."""
 
-    line: GpioLine
-    value: int | None
+    if text.startswith(prefix):
+        return text[len(prefix) :]
+    return text
 
 
 class GpioTestError(Exception):
@@ -60,49 +49,48 @@ class GpioTestError(Exception):
 class StepError(GpioTestError):
     """Exception that records the human-readable step that failed."""
 
-    def __init__(self, step: str, message: str) -> None:
+    def __init__(self, step, message):
         super().__init__(message)
         self.step = step
         self.message = message
 
 
-def print_step(message: str) -> str:
+def print_step(message):
     """Print and return a human-readable progress step."""
 
     print()
-    print(f"[INFO] {message}")
+    print("[INFO] {}".format(message))
     return message
 
 
-def print_detail(key: str, value: object) -> None:
+def print_detail(key, value):
     """Print an indented key/value detail line under the current step."""
 
-    print(f"       {key}: {value}")
+    print("       {}: {}".format(key, value))
 
 
-def print_test_header(name: str, target: str) -> None:
+def print_test_header(name, target):
     """Print the test name and target line or line pair."""
 
-    print(f"TEST: {name}")
-    print(f"TARGET: {target}")
+    print("TEST: {}".format(name))
+    print("TARGET: {}".format(target))
 
 
-def print_result(status: str) -> None:
+def print_result(status):
     """Print the human and machine-readable final test result."""
 
     upper = status.upper()
     print()
-    print(f"RESULT: {upper}")
-    print(f"GPIO_TEST_RESULT={status}")
+    print("RESULT: {}".format(upper))
+    print("GPIO_TEST_RESULT={}".format(status))
 
 
-def python_gpiod_error(action: str, line: str, exc: Exception) -> str:
+def python_gpiod_error(action, line, exc):
     """Format Python gpiod operation failures as user-facing messages."""
 
     return (
-        f"Python gpiod failed to {action} {line}: {exc} "
-        "(kernel/libgpiod operation error)"
-    )
+        "Python gpiod failed to {} {}: {} " "(kernel/libgpiod operation error)"
+    ).format(action, line, exc)
 
 
 def import_gpiod():
@@ -113,11 +101,11 @@ def import_gpiod():
     except (
         Exception
     ) as exc:  # pragma: no cover - depends on target environment.
-        raise GpioTestError(f"failed to import gpiod: {exc}") from exc
+        raise GpioTestError("failed to import gpiod: {}".format(exc)) from exc
     return gpiod
 
 
-def api_style(gpiod) -> str:
+def api_style(gpiod):
     """Detect whether the imported gpiod module exposes v1 or v2 APIs."""
 
     if hasattr(gpiod, "request_lines") and hasattr(gpiod, "LineSettings"):
@@ -127,7 +115,7 @@ def api_style(gpiod) -> str:
     raise GpioTestError("unsupported Python gpiod API")
 
 
-def gpiod_version(gpiod) -> str:
+def gpiod_version(gpiod):
     """Return the best available Python gpiod version string."""
 
     for attr in ("__version__", "version"):
@@ -139,35 +127,35 @@ def gpiod_version(gpiod) -> str:
     return "unknown"
 
 
-def chip_path(chip: str) -> str:
+def chip_path(chip):
     """Return a /dev path for a chip when that path exists."""
 
     path = Path("/dev") / chip
     return str(path) if path.exists() else chip
 
 
-def chip_names() -> list[str]:
+def chip_names():
     """Return sorted GPIO chip names from /dev."""
 
     names = [Path(path).name for path in glob.glob("/dev/gpiochip*")]
     return sorted(
         names,
         key=lambda item: (
-            int(item.removeprefix("gpiochip"))
-            if item.removeprefix("gpiochip").isdigit()
+            int(strip_prefix(item, "gpiochip"))
+            if strip_prefix(item, "gpiochip").isdigit()
             else item
         ),
     )
 
 
-def value_attr(obj, name: str):
+def value_attr(obj, name):
     """Read an attribute that may be exposed as a value or method."""
 
     attr = getattr(obj, name, None)
     return attr() if callable(attr) else attr
 
 
-def normalized_direction(direction) -> str | None:
+def normalized_direction(direction):
     """Normalize gpiod direction constants to input/output strings."""
 
     if direction is None:
@@ -182,7 +170,7 @@ def normalized_direction(direction) -> str | None:
     return text
 
 
-def line_info_v1(gpiod, chip_name: str, offset: int) -> GpioLine:
+def line_info_v1(gpiod, chip_name, offset):
     """Read one line description using the Python gpiod v1 API."""
 
     chip = gpiod.Chip(chip_name)
@@ -202,14 +190,16 @@ def line_info_v1(gpiod, chip_name: str, offset: int) -> GpioLine:
             close()
 
 
-def line_count_v1(gpiod, chip_name: str) -> int:
+def line_count_v1(gpiod, chip_name):
     """Return a chip line count using the Python gpiod v1 API."""
 
     chip = gpiod.Chip(chip_name)
     try:
         count = value_attr(chip, "num_lines")
         if count is None:
-            raise GpioTestError(f"cannot determine line count for {chip_name}")
+            raise GpioTestError(
+                "cannot determine line count for {}".format(chip_name)
+            )
         return int(count)
     finally:
         close = getattr(chip, "close", None)
@@ -217,7 +207,7 @@ def line_count_v1(gpiod, chip_name: str) -> int:
             close()
 
 
-def line_info_v2(gpiod, chip_name: str, offset: int) -> GpioLine:
+def line_info_v2(gpiod, chip_name, offset):
     """Read one line description using the Python gpiod v2 API."""
 
     chip = gpiod.Chip(chip_path(chip_name))
@@ -236,7 +226,7 @@ def line_info_v2(gpiod, chip_name: str, offset: int) -> GpioLine:
             close()
 
 
-def line_count_v2(gpiod, chip_name: str) -> int:
+def line_count_v2(gpiod, chip_name):
     """Return a chip line count using the Python gpiod v2 API."""
 
     chip = gpiod.Chip(chip_path(chip_name))
@@ -244,7 +234,9 @@ def line_count_v2(gpiod, chip_name: str) -> int:
         info = chip.get_info()
         count = value_attr(info, "num_lines")
         if count is None:
-            raise GpioTestError(f"cannot determine line count for {chip_name}")
+            raise GpioTestError(
+                "cannot determine line count for {}".format(chip_name)
+            )
         return int(count)
     finally:
         close = getattr(chip, "close", None)
@@ -252,7 +244,7 @@ def line_count_v2(gpiod, chip_name: str) -> int:
             close()
 
 
-def load_lines(chip: str | None = None) -> dict[str, GpioLine]:
+def load_lines(chip=None):
     """Discover GPIO lines, optionally limited to one chip."""
 
     gpiod = import_gpiod()
@@ -261,7 +253,7 @@ def load_lines(chip: str | None = None) -> dict[str, GpioLine]:
     if not names:
         raise GpioTestError("no GPIO chips found under /dev")
 
-    lines: dict[str, GpioLine] = {}
+    lines = {}
     for chip_name in names:
         count = (
             line_count_v2(gpiod, chip_name)
@@ -274,35 +266,34 @@ def load_lines(chip: str | None = None) -> dict[str, GpioLine]:
                 if style == "v2"
                 else line_info_v1(gpiod, chip_name, offset)
             )
-            lines[f"{line.chip}-{line.offset}"] = line
+            lines["{}-{}".format(line.chip, line.offset)] = line
     return lines
 
 
-def print_gpio_inventory(lines: dict[str, GpioLine]) -> None:
+def print_gpio_inventory(lines):
     """Print all discovered GPIO lines in a human-readable format."""
 
-    by_chip: dict[str, list[GpioLine]] = {}
+    by_chip = {}
     for line in lines.values():
         by_chip.setdefault(line.chip, []).append(line)
 
     for chip in sorted(
-        by_chip, key=lambda item: int(item.removeprefix("gpiochip"))
+        by_chip, key=lambda item: int(strip_prefix(item, "gpiochip"))
     ):
         chip_lines = sorted(by_chip[chip], key=lambda line: line.offset)
-        print(f"       {chip} - {len(chip_lines)} lines:")
+        print("       {} - {} lines:".format(chip, len(chip_lines)))
         for line in chip_lines:
-            name = f'"{line.name}"' if line.name else "unnamed"
+            name = '"{}"'.format(line.name) if line.name else "unnamed"
             used = "used" if line.used else "unused"
             direction = line.direction or "unknown"
             active = "active-low" if line.active_low else "active-high"
-            line_text = (
-                f"         line {line.offset:3}: {name:18} "
-                f"{used:6} {direction:7} {active}"
+            line_text = "         line {:3}: {:18} {:6} {:7} {}".format(
+                line.offset, name, used, direction, active
             )
             print(line_text)
 
 
-def initialize_test_state() -> TestState:
+def initialize_test_state():
     """Collect and cache API version and full GPIO discovery for one test."""
 
     print_step("Get Python gpiod version")
@@ -317,7 +308,7 @@ def initialize_test_state() -> TestState:
     return TestState(gpiod=gpiod, style=style, lines=lines)
 
 
-def parse_line_id(identifier: str) -> tuple[str, int]:
+def parse_line_id(identifier):
     """Parse ``gpiochipN-LINE`` into chip name and line offset."""
 
     parts = identifier.strip().split("-", 1)
@@ -326,11 +317,13 @@ def parse_line_id(identifier: str) -> tuple[str, int]:
         or not parts[0].startswith("gpiochip")
         or not parts[1].isdigit()
     ):
-        raise GpioTestError(f"invalid GPIO line identifier: {identifier}")
+        raise GpioTestError(
+            "invalid GPIO line identifier: {}".format(identifier)
+        )
     return parts[0], int(parts[1])
 
 
-def parse_ignore(value: str | None, lines: dict[str, GpioLine]) -> set[str]:
+def parse_ignore(value, lines):
     """Expand ignore expressions into concrete ``gpiochipN-LINE`` keys.
 
     Supported input forms are ``gpiochipN-LINE``, ``gpiochipN-START..END``,
@@ -340,7 +333,7 @@ def parse_ignore(value: str | None, lines: dict[str, GpioLine]) -> set[str]:
     if not value:
         return set()
 
-    ignored: set[str] = set()
+    ignored = set()
     for raw_item in value.split(","):
         item = raw_item.strip()
         if not item:
@@ -360,24 +353,25 @@ def parse_ignore(value: str | None, lines: dict[str, GpioLine]) -> set[str]:
             start = int(range_match.group(2))
             end = int(range_match.group(3))
             if start > end:
-                raise GpioTestError(f"invalid ignore range: {item}")
+                raise GpioTestError("invalid ignore range: {}".format(item))
             ignored.update(
-                f"{chip}-{offset}" for offset in range(start, end + 1)
+                "{}-{}".format(chip, offset)
+                for offset in range(start, end + 1)
             )
             continue
 
         chip, offset = parse_line_id(item)
-        ignored.add(f"{chip}-{offset}")
+        ignored.add("{}-{}".format(chip, offset))
     return ignored
 
 
-def parse_pairs(value: str) -> list[tuple[str, int, str, int]]:
+def parse_pairs(value):
     """Parse comma-separated loopback pairs in ``INPUT:OUTPUT`` format."""
 
     pairs = []
     for item in value.split(","):
         if ":" not in item:
-            raise GpioTestError(f"invalid loopback pair: {item}")
+            raise GpioTestError("invalid loopback pair: {}".format(item))
         input_, output = item.split(":", 1)
         in_chip, in_line = parse_line_id(input_)
         out_chip, out_line = parse_line_id(output)
@@ -385,7 +379,7 @@ def parse_pairs(value: str) -> list[tuple[str, int, str, int]]:
     return pairs
 
 
-def emit_records(records: list[dict[str, object]], fmt: str) -> None:
+def emit_records(records, fmt):
     """Emit Checkbox resource records as text or JSON."""
 
     if fmt == "json":
@@ -393,18 +387,18 @@ def emit_records(records: list[dict[str, object]], fmt: str) -> None:
         return
     for record in records:
         for key, value in record.items():
-            print(f"{key}: {value}")
+            print("{}: {}".format(key, value))
         print()
 
 
-def sort_key(identifier: str) -> tuple[int, int]:
+def sort_key(identifier):
     """Return a numeric sort key for ``gpiochipN-LINE`` identifiers."""
 
     chip, offset = identifier.split("-", 1)
-    return int(chip.removeprefix("gpiochip")), int(offset)
+    return int(strip_prefix(chip, "gpiochip")), int(offset)
 
 
-def resource_simple(args: argparse.Namespace) -> int:
+def resource_simple(args):
     """Generate unused GPIO line resources for simple input/output jobs."""
 
     lines = load_lines()
@@ -419,26 +413,32 @@ def resource_simple(args: argparse.Namespace) -> int:
     return 0
 
 
-def resource_loopback(args: argparse.Namespace) -> int:
+def resource_loopback(args):
     """Generate validated GPIO loopback resources from pair definitions."""
 
     lines = load_lines()
     records = []
     for out_chip, out_line, in_chip, in_line in parse_pairs(args.pairs):
-        out_key = f"{out_chip}-{out_line}"
-        in_key = f"{in_chip}-{in_line}"
+        out_key = "{}-{}".format(out_chip, out_line)
+        in_key = "{}-{}".format(in_chip, in_line)
         if out_key == in_key:
             raise GpioTestError(
-                f"loopback output and input are the same line: {out_key}"
+                "loopback output and input are the same line: {}".format(
+                    out_key
+                )
             )
         if out_key not in lines:
-            raise GpioTestError(f"output line not found: {out_key}")
+            raise GpioTestError("output line not found: {}".format(out_key))
         if in_key not in lines:
-            raise GpioTestError(f"input line not found: {in_key}")
+            raise GpioTestError("input line not found: {}".format(in_key))
         if lines[out_key].used:
-            raise GpioTestError(f"output line is already used: {out_key}")
+            raise GpioTestError(
+                "output line is already used: {}".format(out_key)
+            )
         if lines[in_key].used:
-            raise GpioTestError(f"input line is already used: {in_key}")
+            raise GpioTestError(
+                "input line is already used: {}".format(in_key)
+            )
         records.append(
             {
                 "GPIO_OUTPUT_CHIP": out_chip,
@@ -451,63 +451,68 @@ def resource_loopback(args: argparse.Namespace) -> int:
     return 0
 
 
-def get_line_or_raise(chip: str, offset: int, purpose: str = "") -> GpioLine:
+def get_line_or_raise(chip, offset, purpose=""):
     """Find a line from fresh discovery or raise a step-aware error."""
 
-    label = f"{chip}-{offset}"
-    print_step(f"Find {purpose + ' ' if purpose else ''}{label}")
+    label = "{}-{}".format(chip, offset)
+    print_step("Find {}{}".format(purpose + " " if purpose else "", label))
     lines = load_lines(chip)
     if label not in lines:
-        raise StepError(f"Find {label}", f"GPIO line not found: {label}")
+        raise StepError(
+            "Find {}".format(label), "GPIO line not found: {}".format(label)
+        )
     return lines[label]
 
 
 def get_line_from_state_or_raise(
-    state: TestState,
-    chip: str,
-    offset: int,
-    purpose: str = "",
-) -> GpioLine:
+    state,
+    chip,
+    offset,
+    purpose="",
+):
     """Find a line in cached test state or raise a step-aware error."""
 
-    label = f"{chip}-{offset}"
-    print_step(f"Find {purpose + ' ' if purpose else ''}{label}")
+    label = "{}-{}".format(chip, offset)
+    print_step("Find {}{}".format(purpose + " " if purpose else "", label))
     if label not in state.lines:
-        raise StepError(f"Find {label}", f"GPIO line not found: {label}")
+        raise StepError(
+            "Find {}".format(label), "GPIO line not found: {}".format(label)
+        )
     return state.lines[label]
 
 
-def get_loopback_lines_or_raise(
-    args: argparse.Namespace, state: TestState
-) -> tuple[GpioLine, GpioLine]:
+def get_loopback_lines_or_raise(args, state):
     """Return output and input lines for a loopback test."""
 
-    out_label = f"{args.out_chip}-{args.out_line}"
-    in_label = f"{args.in_chip}-{args.in_line}"
-    print_step(f"Find input {in_label}")
-    print_step(f"Find output {out_label}")
+    out_label = "{}-{}".format(args.out_chip, args.out_line)
+    in_label = "{}-{}".format(args.in_chip, args.in_line)
+    print_step("Find input {}".format(in_label))
+    print_step("Find output {}".format(out_label))
     if out_label not in state.lines:
         raise StepError(
-            f"Find output {out_label}", f"GPIO line not found: {out_label}"
+            "Find output {}".format(out_label),
+            "GPIO line not found: {}".format(out_label),
         )
     if in_label not in state.lines:
         raise StepError(
-            f"Find input {in_label}", f"GPIO line not found: {in_label}"
+            "Find input {}".format(in_label),
+            "GPIO line not found: {}".format(in_label),
         )
     return state.lines[out_label], state.lines[in_label]
 
 
-def ensure_unused(line: GpioLine) -> None:
+def ensure_unused(line):
     """Fail the current step if a line is already requested."""
 
-    step = print_step(f"Check {line.chip}-{line.offset} is unused")
+    step = print_step("Check {}-{} is unused".format(line.chip, line.offset))
     if line.used:
         raise StepError(
-            step, f"GPIO line is already used: {line.chip}-{line.offset}"
+            step,
+            "GPIO line is already used: {}-{}".format(line.chip, line.offset),
         )
 
 
-def request_input_v1(gpiod, chip_name: str, offset: int):
+def request_input_v1(gpiod, chip_name, offset):
     """Request one line as input through the Python gpiod v1 API."""
 
     chip = gpiod.Chip(chip_name)
@@ -516,7 +521,7 @@ def request_input_v1(gpiod, chip_name: str, offset: int):
     return chip, line
 
 
-def request_output_v1(gpiod, chip_name: str, offset: int, value: int):
+def request_output_v1(gpiod, chip_name, offset, value):
     """Request one line as output through the Python gpiod v1 API."""
 
     chip = gpiod.Chip(chip_name)
@@ -527,7 +532,7 @@ def request_output_v1(gpiod, chip_name: str, offset: int, value: int):
     return chip, line
 
 
-def release_v1(handle) -> None:
+def release_v1(handle):
     """Release a Python gpiod v1 line handle and close its chip."""
 
     chip, line = handle
@@ -539,7 +544,7 @@ def release_v1(handle) -> None:
             close()
 
 
-def request_input_v2(gpiod, chip_name: str, offset: int):
+def request_input_v2(gpiod, chip_name, offset):
     """Request one line as input through the Python gpiod v2 API."""
 
     settings = gpiod.LineSettings(direction=gpiod.line.Direction.INPUT)
@@ -548,7 +553,7 @@ def request_input_v2(gpiod, chip_name: str, offset: int):
     )
 
 
-def request_output_v2(gpiod, chip_name: str, offset: int, value: int):
+def request_output_v2(gpiod, chip_name, offset, value):
     """Request one line as output through the Python gpiod v2 API."""
 
     output_value = (
@@ -562,7 +567,7 @@ def request_output_v2(gpiod, chip_name: str, offset: int, value: int):
     )
 
 
-def read_handle(gpiod, style: str, handle, offset: int) -> int:
+def read_handle(gpiod, style, handle, offset):
     """Read a value from an active Python gpiod line request."""
 
     if style == "v2":
@@ -571,9 +576,7 @@ def read_handle(gpiod, style: str, handle, offset: int) -> int:
     return int(handle[1].get_value())
 
 
-def set_handle_value(
-    gpiod, style: str, handle, offset: int, value: int
-) -> None:
+def set_handle_value(gpiod, style, handle, offset, value):
     """Set a value on an active Python gpiod line request."""
 
     if style == "v2":
@@ -585,7 +588,7 @@ def set_handle_value(
     handle[1].set_value(value)
 
 
-def release_handle(style: str, handle) -> None:
+def release_handle(style, handle):
     """Release a Python gpiod v1 or v2 request handle."""
 
     if style == "v2":
@@ -594,7 +597,7 @@ def release_handle(style: str, handle) -> None:
         release_v1(handle)
 
 
-def request_input(gpiod, style: str, chip_name: str, offset: int):
+def request_input(gpiod, style, chip_name, offset):
     """Dispatch input requests to the detected Python gpiod API."""
 
     return (
@@ -604,7 +607,7 @@ def request_input(gpiod, style: str, chip_name: str, offset: int):
     )
 
 
-def request_output(gpiod, style: str, chip_name: str, offset: int, value: int):
+def request_output(gpiod, style, chip_name, offset, value):
     """Dispatch output requests to the detected Python gpiod API."""
 
     return (
@@ -614,7 +617,7 @@ def request_output(gpiod, style: str, chip_name: str, offset: int, value: int):
     )
 
 
-def save_line_state(state: TestState, line: GpioLine) -> SavedLineState:
+def save_line_state(state, line):
     """Save the original direction and readable output value."""
 
     value = None
@@ -629,7 +632,7 @@ def save_line_state(state: TestState, line: GpioLine) -> SavedLineState:
     return SavedLineState(line=line, value=value)
 
 
-def restore_line_state(state: TestState, saved: SavedLineState) -> None:
+def restore_line_state(state, saved):
     """Restore one line to its original direction and saved value."""
 
     line = saved.line
@@ -650,9 +653,7 @@ def restore_line_state(state: TestState, saved: SavedLineState) -> None:
     release_handle(state.style, handle)
 
 
-def recover_saved_states(
-    state: TestState | None, states: list[SavedLineState]
-) -> None:
+def recover_saved_states(state, states):
     """Best-effort restoration for all saved line states."""
 
     if state is None:
@@ -661,23 +662,27 @@ def recover_saved_states(
         try:
             restore_line_state(state, saved)
         except Exception as exc:
-            line_id = f"{saved.line.chip}-{saved.line.offset}"
+            line_id = "{}-{}".format(saved.line.chip, saved.line.offset)
             print(
-                f"GPIO_RECOVERY_ERROR={line_id}: {exc}",
+                "GPIO_RECOVERY_ERROR={}: {}".format(line_id, exc),
                 file=sys.stderr,
             )
 
 
-def test_simple_input(args: argparse.Namespace) -> int:
+def test_simple_input(args):
     """Run the simple input test for one GPIO line."""
 
     handle = None
     try:
-        print_test_header("GPIO simple input", f"{args.chip}-{args.line}")
+        print_test_header(
+            "GPIO simple input", "{}-{}".format(args.chip, args.line)
+        )
         state = initialize_test_state()
         line = get_line_from_state_or_raise(state, args.chip, args.line)
         ensure_unused(line)
-        step = print_step(f"Request {args.chip}-{args.line} as input")
+        step = print_step(
+            "Request {}-{} as input".format(args.chip, args.line)
+        )
         print_detail(
             "note", "Python gpiod API requests the line as input here"
         )
@@ -689,21 +694,23 @@ def test_simple_input(args: argparse.Namespace) -> int:
             raise StepError(
                 step,
                 python_gpiod_error(
-                    "request input", f"{args.chip}-{args.line}", exc
+                    "request input", "{}-{}".format(args.chip, args.line), exc
                 ),
             ) from exc
-        step = print_step(f"Read value from {args.chip}-{args.line}")
+        step = print_step("Read value from {}-{}".format(args.chip, args.line))
         try:
             value = read_handle(state.gpiod, state.style, handle, args.line)
         except Exception as exc:
             raise StepError(
                 step,
-                python_gpiod_error("read", f"{args.chip}-{args.line}", exc),
+                python_gpiod_error(
+                    "read", "{}-{}".format(args.chip, args.line), exc
+                ),
             ) from exc
-        print_step(f"Release {args.chip}-{args.line}")
+        print_step("Release {}-{}".format(args.chip, args.line))
         release_handle(state.style, handle)
         handle = None
-        print(f"GPIO_VALUE={value}")
+        print("GPIO_VALUE={}".format(value))
         print_result("pass")
         return 0
     except Exception as exc:
@@ -715,20 +722,26 @@ def test_simple_input(args: argparse.Namespace) -> int:
         return fail_current_step(exc)
 
 
-def test_simple_output(args: argparse.Namespace) -> int:
+def test_simple_output(args):
     """Run the simple output low/high test for one GPIO line."""
 
     handle = None
-    state: TestState | None = None
-    saved: SavedLineState | None = None
+    state = None
+    saved = None
     try:
-        print_test_header("GPIO simple output", f"{args.chip}-{args.line}")
+        print_test_header(
+            "GPIO simple output", "{}-{}".format(args.chip, args.line)
+        )
         state = initialize_test_state()
         line = get_line_from_state_or_raise(state, args.chip, args.line)
         ensure_unused(line)
-        print_step(f"Save original state for {args.chip}-{args.line}")
+        print_step(
+            "Save original state for {}-{}".format(args.chip, args.line)
+        )
         saved = save_line_state(state, line)
-        step = print_step(f"Request {args.chip}-{args.line} as output")
+        step = print_step(
+            "Request {}-{} as output".format(args.chip, args.line)
+        )
         print_detail(
             "note", "Python gpiod API requests the line as output here"
         )
@@ -744,32 +757,36 @@ def test_simple_output(args: argparse.Namespace) -> int:
             raise StepError(
                 step,
                 python_gpiod_error(
-                    "request output", f"{args.chip}-{args.line}", exc
+                    "request output", "{}-{}".format(args.chip, args.line), exc
                 ),
             ) from exc
-        step = print_step(f"Set {args.chip}-{args.line} low")
+        step = print_step("Set {}-{} low".format(args.chip, args.line))
         try:
             set_handle_value(state.gpiod, state.style, handle, args.line, 0)
         except Exception as exc:
             raise StepError(
                 step,
-                python_gpiod_error("set low", f"{args.chip}-{args.line}", exc),
+                python_gpiod_error(
+                    "set low", "{}-{}".format(args.chip, args.line), exc
+                ),
             ) from exc
-        step = print_step(f"Set {args.chip}-{args.line} high")
+        step = print_step("Set {}-{} high".format(args.chip, args.line))
         try:
             set_handle_value(state.gpiod, state.style, handle, args.line, 1)
         except Exception as exc:
             raise StepError(
                 step,
                 python_gpiod_error(
-                    "set high", f"{args.chip}-{args.line}", exc
+                    "set high", "{}-{}".format(args.chip, args.line), exc
                 ),
             ) from exc
-        print_step(f"Recover original state for {args.chip}-{args.line}")
+        print_step(
+            "Recover original state for {}-{}".format(args.chip, args.line)
+        )
         release_handle(state.style, handle)
         handle = None
         restore_line_state(state, saved)
-        print_step(f"Release {args.chip}-{args.line}")
+        print_step("Release {}-{}".format(args.chip, args.line))
         print_result("pass")
         return 0
     except Exception as exc:
@@ -779,24 +796,26 @@ def test_simple_output(args: argparse.Namespace) -> int:
             except Exception:
                 pass
         if saved is not None:
-            print_step(f"Recover original state for {args.chip}-{args.line}")
+            print_step(
+                "Recover original state for {}-{}".format(args.chip, args.line)
+            )
             recover_saved_states(state, [saved])
         return fail_current_step(exc)
 
 
-def test_loopback(args: argparse.Namespace) -> int:
+def test_loopback(args):
     """Run a physical loopback test using an input/output line pair."""
 
     out_handle = None
     in_handle = None
-    state: TestState | None = None
-    saved_states: list[SavedLineState] = []
+    state = None
+    saved_states = []
     try:
-        in_id = f"{args.in_chip}-{args.in_line}"
-        out_id = f"{args.out_chip}-{args.out_line}"
+        in_id = "{}-{}".format(args.in_chip, args.in_line)
+        out_id = "{}-{}".format(args.out_chip, args.out_line)
         print_test_header(
             "GPIO loopback",
-            f"input={in_id} output={out_id}",
+            "input={} output={}".format(in_id, out_id),
         )
         state = initialize_test_state()
         output, input_ = get_loopback_lines_or_raise(args, state)
@@ -805,18 +824,18 @@ def test_loopback(args: argparse.Namespace) -> int:
                 "Check loopback lines", "output and input line are the same"
             )
 
-        step = print_step(f"Check {out_id} and {in_id} are unused")
+        step = print_step("Check {} and {} are unused".format(out_id, in_id))
         if output.used or input_.used:
             raise StepError(
                 step, "one or both loopback lines are already used"
             )
 
-        print_step(f"Save original state for {out_id} and {in_id}")
+        print_step("Save original state for {} and {}".format(out_id, in_id))
         saved_states = [
             save_line_state(state, output),
             save_line_state(state, input_),
         ]
-        step = print_step(f"Request {out_id} as output")
+        step = print_step("Request {} as output".format(out_id))
         print_detail("note", "Python gpiod API requests the output line here")
         try:
             out_handle = request_output(
@@ -827,7 +846,7 @@ def test_loopback(args: argparse.Namespace) -> int:
                 step,
                 python_gpiod_error("request output", out_id, exc),
             ) from exc
-        step = print_step(f"Request {in_id} as input")
+        step = print_step("Request {} as input".format(in_id))
         print_detail("note", "Python gpiod API requests the input line here")
         try:
             in_handle = request_input(
@@ -840,7 +859,7 @@ def test_loopback(args: argparse.Namespace) -> int:
             ) from exc
 
         for _ in range(args.repeat):
-            step = print_step(f"Set {out_id} low")
+            step = print_step("Set {} low".format(out_id))
             try:
                 set_handle_value(
                     state.gpiod, state.style, out_handle, args.out_line, 0
@@ -851,7 +870,7 @@ def test_loopback(args: argparse.Namespace) -> int:
                     python_gpiod_error("set low", out_id, exc),
                 ) from exc
             time.sleep(args.delay)
-            step = print_step(f"Verify {in_id} reads low")
+            step = print_step("Verify {} reads low".format(in_id))
             try:
                 input_value = read_handle(
                     state.gpiod, state.style, in_handle, args.in_line
@@ -863,11 +882,11 @@ def test_loopback(args: argparse.Namespace) -> int:
                 ) from exc
             if input_value != 0:
                 raise StepError(
-                    f"Verify {in_id} reads low",
+                    "Verify {} reads low".format(in_id),
                     "input did not read low",
                 )
 
-            step = print_step(f"Set {out_id} high")
+            step = print_step("Set {} high".format(out_id))
             try:
                 set_handle_value(
                     state.gpiod, state.style, out_handle, args.out_line, 1
@@ -878,7 +897,7 @@ def test_loopback(args: argparse.Namespace) -> int:
                     python_gpiod_error("set high", out_id, exc),
                 ) from exc
             time.sleep(args.delay)
-            step = print_step(f"Verify {in_id} reads high")
+            step = print_step("Verify {} reads high".format(in_id))
             try:
                 input_value = read_handle(
                     state.gpiod, state.style, in_handle, args.in_line
@@ -890,17 +909,19 @@ def test_loopback(args: argparse.Namespace) -> int:
                 ) from exc
             if input_value != 1:
                 raise StepError(
-                    f"Verify {in_id} reads high",
+                    "Verify {} reads high".format(in_id),
                     "input did not read high",
                 )
 
-        print_step(f"Recover original state for {out_id} and {in_id}")
+        print_step(
+            "Recover original state for {} and {}".format(out_id, in_id)
+        )
         release_handle(state.style, out_handle)
         release_handle(state.style, in_handle)
         out_handle = None
         in_handle = None
         recover_saved_states(state, saved_states)
-        print_step(f"Release {out_id} and {in_id}")
+        print_step("Release {} and {}".format(out_id, in_id))
         print_result("pass")
         return 0
     except Exception as exc:
@@ -911,29 +932,31 @@ def test_loopback(args: argparse.Namespace) -> int:
                 except Exception:
                     pass
         if saved_states:
-            print_step(f"Recover original state for {out_id} and {in_id}")
+            print_step(
+                "Recover original state for {} and {}".format(out_id, in_id)
+            )
             recover_saved_states(state, saved_states)
         return fail_current_step(exc)
 
 
-def fail_current_step(exc: Exception) -> int:
+def fail_current_step(exc):
     """Print a failed result and return a Checkbox-compatible exit code."""
 
     if isinstance(exc, StepError):
         print()
-        print(f"[FAIL] {exc.step}")
+        print("[FAIL] {}".format(exc.step))
         print_detail("error", exc.message)
-        print(f"GPIO_ERROR={exc.message}", file=sys.stderr)
+        print("GPIO_ERROR={}".format(exc.message), file=sys.stderr)
     else:
         print()
         print("[FAIL] GPIO test failed")
         print_detail("error", exc)
-        print(f"GPIO_ERROR={exc}", file=sys.stderr)
+        print("GPIO_ERROR={}".format(exc), file=sys.stderr)
     print_result("fail")
     return 1
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser():
     """Create the command-line parser for resources and tests."""
 
     formatter = argparse.RawDescriptionHelpFormatter
@@ -1050,7 +1073,7 @@ def build_parser() -> argparse.ArgumentParser:
 class PythonGpioApplication:
     """Command-line application for Python gpiod GPIO validation."""
 
-    def __init__(self, parser: argparse.ArgumentParser) -> None:
+    def __init__(self, parser):
         """Initialize the application with an argument parser.
 
         Args:
@@ -1059,7 +1082,7 @@ class PythonGpioApplication:
 
         self._parser = parser
 
-    def run(self, argv: list[str] | None = None) -> int:
+    def run(self, argv=None):
         """Parse arguments and run the selected resource or test command.
 
         Args:
@@ -1073,11 +1096,11 @@ class PythonGpioApplication:
         try:
             return args.func(args)
         except GpioTestError as exc:
-            print(f"GPIO_ERROR={exc}", file=sys.stderr)
+            print("GPIO_ERROR={}".format(exc), file=sys.stderr)
             return 1
 
 
-def main() -> int:
+def main():
     """Parse arguments and dispatch to the selected subcommand."""
 
     return PythonGpioApplication(build_parser()).run()

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_python.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_python.py
@@ -1,0 +1,958 @@
+#!/usr/bin/env python3
+"""GPIO validation using the Python gpiod binding."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import re
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+CONSUMER = "gpio-test"
+
+
+@dataclass(frozen=True)
+class GpioLine:
+    chip: str
+    offset: int
+    name: str
+    used: bool
+    direction: str | None
+    active_low: bool
+
+
+@dataclass(frozen=True)
+class TestState:
+    gpiod: object
+    style: str
+    lines: dict[str, GpioLine]
+
+
+@dataclass(frozen=True)
+class SavedLineState:
+    line: GpioLine
+    value: int | None
+
+
+class GpioTestError(Exception):
+    pass
+
+
+class StepError(GpioTestError):
+    def __init__(self, step: str, message: str) -> None:
+        super().__init__(message)
+        self.step = step
+        self.message = message
+
+
+def print_step(message: str) -> str:
+    print()
+    print(f"[INFO] {message}")
+    return message
+
+
+def print_detail(key: str, value: object) -> None:
+    print(f"       {key}: {value}")
+
+
+def print_test_header(name: str, target: str) -> None:
+    print(f"TEST: {name}")
+    print(f"TARGET: {target}")
+
+
+def print_result(status: str) -> None:
+    upper = status.upper()
+    print()
+    print(f"RESULT: {upper}")
+    print(f"GPIO_TEST_RESULT={status}")
+
+
+def python_gpiod_error(action: str, line: str, exc: Exception) -> str:
+    return (
+        f"Python gpiod failed to {action} {line}: {exc} "
+        "(kernel/libgpiod operation error)"
+    )
+
+
+def import_gpiod():
+    try:
+        import gpiod  # type: ignore
+    except (
+        Exception
+    ) as exc:  # pragma: no cover - depends on target environment.
+        raise GpioTestError(f"failed to import gpiod: {exc}") from exc
+    return gpiod
+
+
+def api_style(gpiod) -> str:
+    if hasattr(gpiod, "request_lines") and hasattr(gpiod, "LineSettings"):
+        return "v2"
+    if hasattr(gpiod, "Chip"):
+        return "v1"
+    raise GpioTestError("unsupported Python gpiod API")
+
+
+def gpiod_version(gpiod) -> str:
+    for attr in ("__version__", "version"):
+        value = getattr(gpiod, attr, None)
+        if callable(value):
+            value = value()
+        if value:
+            return str(value)
+    return "unknown"
+
+
+def chip_path(chip: str) -> str:
+    path = Path("/dev") / chip
+    return str(path) if path.exists() else chip
+
+
+def chip_names() -> list[str]:
+    names = [Path(path).name for path in glob.glob("/dev/gpiochip*")]
+    return sorted(
+        names,
+        key=lambda item: (
+            int(item.removeprefix("gpiochip"))
+            if item.removeprefix("gpiochip").isdigit()
+            else item
+        ),
+    )
+
+
+def value_attr(obj, name: str):
+    attr = getattr(obj, name, None)
+    return attr() if callable(attr) else attr
+
+
+def normalized_direction(direction) -> str | None:
+    if direction is None:
+        return None
+    if isinstance(direction, int):
+        return {1: "input", 2: "output"}.get(direction, str(direction))
+    text = str(direction).lower()
+    if "input" in text:
+        return "input"
+    if "output" in text:
+        return "output"
+    return text
+
+
+def line_info_v1(gpiod, chip_name: str, offset: int) -> GpioLine:
+    chip = gpiod.Chip(chip_name)
+    try:
+        line = chip.get_line(offset)
+        name = value_attr(line, "name") or ""
+        consumer = value_attr(line, "consumer")
+        is_used = value_attr(line, "is_used")
+        used = bool(is_used) if is_used is not None else bool(consumer)
+        direction = normalized_direction(value_attr(line, "direction"))
+        active_state = value_attr(line, "active_state")
+        active_low = "low" in str(active_state).lower()
+        return GpioLine(chip_name, offset, name, used, direction, active_low)
+    finally:
+        close = getattr(chip, "close", None)
+        if callable(close):
+            close()
+
+
+def line_count_v1(gpiod, chip_name: str) -> int:
+    chip = gpiod.Chip(chip_name)
+    try:
+        count = value_attr(chip, "num_lines")
+        if count is None:
+            raise GpioTestError(f"cannot determine line count for {chip_name}")
+        return int(count)
+    finally:
+        close = getattr(chip, "close", None)
+        if callable(close):
+            close()
+
+
+def line_info_v2(gpiod, chip_name: str, offset: int) -> GpioLine:
+    chip = gpiod.Chip(chip_path(chip_name))
+    try:
+        info = chip.get_line_info(offset)
+        name = value_attr(info, "name") or ""
+        consumer = value_attr(info, "consumer")
+        direction = normalized_direction(value_attr(info, "direction"))
+        active_low = bool(value_attr(info, "active_low"))
+        return GpioLine(
+            chip_name, offset, name, bool(consumer), direction, active_low
+        )
+    finally:
+        close = getattr(chip, "close", None)
+        if callable(close):
+            close()
+
+
+def line_count_v2(gpiod, chip_name: str) -> int:
+    chip = gpiod.Chip(chip_path(chip_name))
+    try:
+        info = chip.get_info()
+        count = value_attr(info, "num_lines")
+        if count is None:
+            raise GpioTestError(f"cannot determine line count for {chip_name}")
+        return int(count)
+    finally:
+        close = getattr(chip, "close", None)
+        if callable(close):
+            close()
+
+
+def load_lines(chip: str | None = None) -> dict[str, GpioLine]:
+    gpiod = import_gpiod()
+    style = api_style(gpiod)
+    names = [chip] if chip else chip_names()
+    if not names:
+        raise GpioTestError("no GPIO chips found under /dev")
+
+    lines: dict[str, GpioLine] = {}
+    for chip_name in names:
+        count = (
+            line_count_v2(gpiod, chip_name)
+            if style == "v2"
+            else line_count_v1(gpiod, chip_name)
+        )
+        for offset in range(count):
+            line = (
+                line_info_v2(gpiod, chip_name, offset)
+                if style == "v2"
+                else line_info_v1(gpiod, chip_name, offset)
+            )
+            lines[f"{line.chip}-{line.offset}"] = line
+    return lines
+
+
+def print_gpio_inventory(lines: dict[str, GpioLine]) -> None:
+    by_chip: dict[str, list[GpioLine]] = {}
+    for line in lines.values():
+        by_chip.setdefault(line.chip, []).append(line)
+
+    for chip in sorted(
+        by_chip, key=lambda item: int(item.removeprefix("gpiochip"))
+    ):
+        chip_lines = sorted(by_chip[chip], key=lambda line: line.offset)
+        print(f"       {chip} - {len(chip_lines)} lines:")
+        for line in chip_lines:
+            name = f'"{line.name}"' if line.name else "unnamed"
+            used = "used" if line.used else "unused"
+            direction = line.direction or "unknown"
+            active = "active-low" if line.active_low else "active-high"
+            print(
+                f"         line {line.offset:3}: {name:18} {used:6} {direction:7} {active}"
+            )
+
+
+def initialize_test_state() -> TestState:
+    print_step("Get Python gpiod version")
+    gpiod = import_gpiod()
+    style = api_style(gpiod)
+    print_detail("python-gpiod-version", gpiod_version(gpiod))
+    print_detail("python-gpiod-api", style)
+
+    print_step("List all GPIO chips and lines")
+    lines = load_lines()
+    print_gpio_inventory(lines)
+    return TestState(gpiod=gpiod, style=style, lines=lines)
+
+
+def parse_line_id(identifier: str) -> tuple[str, int]:
+    parts = identifier.strip().split("-", 1)
+    if (
+        len(parts) != 2
+        or not parts[0].startswith("gpiochip")
+        or not parts[1].isdigit()
+    ):
+        raise GpioTestError(f"invalid GPIO line identifier: {identifier}")
+    return parts[0], int(parts[1])
+
+
+def parse_ignore(value: str | None, lines: dict[str, GpioLine]) -> set[str]:
+    if not value:
+        return set()
+
+    ignored: set[str] = set()
+    for raw_item in value.split(","):
+        item = raw_item.strip()
+        if not item:
+            continue
+
+        chip_match = re.fullmatch(r"(gpiochip\d+)(?:-\*)?", item)
+        if chip_match:
+            chip = chip_match.group(1)
+            ignored.update(
+                key for key, line in lines.items() if line.chip == chip
+            )
+            continue
+
+        range_match = re.fullmatch(r"(gpiochip\d+)-(\d+)\.\.(\d+)", item)
+        if range_match:
+            chip = range_match.group(1)
+            start = int(range_match.group(2))
+            end = int(range_match.group(3))
+            if start > end:
+                raise GpioTestError(f"invalid ignore range: {item}")
+            ignored.update(
+                f"{chip}-{offset}" for offset in range(start, end + 1)
+            )
+            continue
+
+        chip, offset = parse_line_id(item)
+        ignored.add(f"{chip}-{offset}")
+    return ignored
+
+
+def parse_pairs(value: str) -> list[tuple[str, int, str, int]]:
+    pairs = []
+    for item in value.split(","):
+        if ":" not in item:
+            raise GpioTestError(f"invalid loopback pair: {item}")
+        input_, output = item.split(":", 1)
+        in_chip, in_line = parse_line_id(input_)
+        out_chip, out_line = parse_line_id(output)
+        pairs.append((out_chip, out_line, in_chip, in_line))
+    return pairs
+
+
+def emit_records(records: list[dict[str, object]], fmt: str) -> None:
+    if fmt == "json":
+        print(json.dumps(records, indent=2, sort_keys=True))
+        return
+    for record in records:
+        for key, value in record.items():
+            print(f"{key}={value}")
+        print()
+
+
+def sort_key(identifier: str) -> tuple[int, int]:
+    chip, offset = identifier.split("-", 1)
+    return int(chip.removeprefix("gpiochip")), int(offset)
+
+
+def resource_simple(args: argparse.Namespace) -> int:
+    lines = load_lines()
+    ignored = parse_ignore(args.ignore, lines)
+    candidates = []
+    for key in sorted(lines, key=sort_key):
+        line = lines[key]
+        if line.used or key in ignored:
+            continue
+        candidates.append({"GPIO_CHIP": line.chip, "GPIO_LINE": line.offset})
+    emit_records(candidates, args.format)
+    return 0
+
+
+def resource_loopback(args: argparse.Namespace) -> int:
+    lines = load_lines()
+    records = []
+    for out_chip, out_line, in_chip, in_line in parse_pairs(args.pairs):
+        out_key = f"{out_chip}-{out_line}"
+        in_key = f"{in_chip}-{in_line}"
+        if out_key == in_key:
+            raise GpioTestError(
+                f"loopback output and input are the same line: {out_key}"
+            )
+        if out_key not in lines:
+            raise GpioTestError(f"output line not found: {out_key}")
+        if in_key not in lines:
+            raise GpioTestError(f"input line not found: {in_key}")
+        if lines[out_key].used:
+            raise GpioTestError(f"output line is already used: {out_key}")
+        if lines[in_key].used:
+            raise GpioTestError(f"input line is already used: {in_key}")
+        records.append(
+            {
+                "GPIO_OUTPUT_CHIP": out_chip,
+                "GPIO_OUTPUT_LINE": out_line,
+                "GPIO_INPUT_CHIP": in_chip,
+                "GPIO_INPUT_LINE": in_line,
+            }
+        )
+    emit_records(records, args.format)
+    return 0
+
+
+def get_line_or_raise(chip: str, offset: int, purpose: str = "") -> GpioLine:
+    label = f"{chip}-{offset}"
+    print_step(f"Find {purpose + ' ' if purpose else ''}{label}")
+    lines = load_lines(chip)
+    if label not in lines:
+        raise StepError(f"Find {label}", f"GPIO line not found: {label}")
+    return lines[label]
+
+
+def get_line_from_state_or_raise(
+    state: TestState,
+    chip: str,
+    offset: int,
+    purpose: str = "",
+) -> GpioLine:
+    label = f"{chip}-{offset}"
+    print_step(f"Find {purpose + ' ' if purpose else ''}{label}")
+    if label not in state.lines:
+        raise StepError(f"Find {label}", f"GPIO line not found: {label}")
+    return state.lines[label]
+
+
+def get_loopback_lines_or_raise(
+    args: argparse.Namespace, state: TestState
+) -> tuple[GpioLine, GpioLine]:
+    out_label = f"{args.out_chip}-{args.out_line}"
+    in_label = f"{args.in_chip}-{args.in_line}"
+    print_step(f"Find input {in_label}")
+    print_step(f"Find output {out_label}")
+    if out_label not in state.lines:
+        raise StepError(
+            f"Find output {out_label}", f"GPIO line not found: {out_label}"
+        )
+    if in_label not in state.lines:
+        raise StepError(
+            f"Find input {in_label}", f"GPIO line not found: {in_label}"
+        )
+    return state.lines[out_label], state.lines[in_label]
+
+
+def ensure_unused(line: GpioLine) -> None:
+    step = print_step(f"Check {line.chip}-{line.offset} is unused")
+    if line.used:
+        raise StepError(
+            step, f"GPIO line is already used: {line.chip}-{line.offset}"
+        )
+
+
+def request_input_v1(gpiod, chip_name: str, offset: int):
+    chip = gpiod.Chip(chip_name)
+    line = chip.get_line(offset)
+    line.request(consumer=CONSUMER, type=gpiod.LINE_REQ_DIR_IN)
+    return chip, line
+
+
+def request_output_v1(gpiod, chip_name: str, offset: int, value: int):
+    chip = gpiod.Chip(chip_name)
+    line = chip.get_line(offset)
+    line.request(
+        consumer=CONSUMER, type=gpiod.LINE_REQ_DIR_OUT, default_vals=[value]
+    )
+    return chip, line
+
+
+def release_v1(handle) -> None:
+    chip, line = handle
+    try:
+        line.release()
+    finally:
+        close = getattr(chip, "close", None)
+        if callable(close):
+            close()
+
+
+def request_input_v2(gpiod, chip_name: str, offset: int):
+    settings = gpiod.LineSettings(direction=gpiod.line.Direction.INPUT)
+    return gpiod.request_lines(
+        chip_path(chip_name), consumer=CONSUMER, config={offset: settings}
+    )
+
+
+def request_output_v2(gpiod, chip_name: str, offset: int, value: int):
+    output_value = (
+        gpiod.line.Value.ACTIVE if value else gpiod.line.Value.INACTIVE
+    )
+    settings = gpiod.LineSettings(
+        direction=gpiod.line.Direction.OUTPUT, output_value=output_value
+    )
+    return gpiod.request_lines(
+        chip_path(chip_name), consumer=CONSUMER, config={offset: settings}
+    )
+
+
+def read_handle(gpiod, style: str, handle, offset: int) -> int:
+    if style == "v2":
+        value = handle.get_value(offset)
+        return 1 if value == gpiod.line.Value.ACTIVE else 0
+    return int(handle[1].get_value())
+
+
+def set_handle_value(
+    gpiod, style: str, handle, offset: int, value: int
+) -> None:
+    if style == "v2":
+        output_value = (
+            gpiod.line.Value.ACTIVE if value else gpiod.line.Value.INACTIVE
+        )
+        handle.set_value(offset, output_value)
+        return
+    handle[1].set_value(value)
+
+
+def release_handle(style: str, handle) -> None:
+    if style == "v2":
+        handle.release()
+    else:
+        release_v1(handle)
+
+
+def request_input(gpiod, style: str, chip_name: str, offset: int):
+    return (
+        request_input_v2(gpiod, chip_name, offset)
+        if style == "v2"
+        else request_input_v1(gpiod, chip_name, offset)
+    )
+
+
+def request_output(gpiod, style: str, chip_name: str, offset: int, value: int):
+    return (
+        request_output_v2(gpiod, chip_name, offset, value)
+        if style == "v2"
+        else request_output_v1(gpiod, chip_name, offset, value)
+    )
+
+
+def save_line_state(state: TestState, line: GpioLine) -> SavedLineState:
+    value = None
+    if line.direction == "output":
+        handle = request_input(
+            state.gpiod, state.style, line.chip, line.offset
+        )
+        try:
+            value = read_handle(state.gpiod, state.style, handle, line.offset)
+        finally:
+            release_handle(state.style, handle)
+    return SavedLineState(line=line, value=value)
+
+
+def restore_line_state(state: TestState, saved: SavedLineState) -> None:
+    line = saved.line
+    if line.direction == "input":
+        handle = request_input(
+            state.gpiod, state.style, line.chip, line.offset
+        )
+    elif line.direction == "output":
+        handle = request_output(
+            state.gpiod,
+            state.style,
+            line.chip,
+            line.offset,
+            saved.value if saved.value is not None else 0,
+        )
+    else:
+        return
+    release_handle(state.style, handle)
+
+
+def recover_saved_states(
+    state: TestState | None, states: list[SavedLineState]
+) -> None:
+    if state is None:
+        return
+    for saved in states:
+        try:
+            restore_line_state(state, saved)
+        except Exception as exc:
+            print(
+                f"GPIO_RECOVERY_ERROR={saved.line.chip}-{saved.line.offset}: {exc}",
+                file=sys.stderr,
+            )
+
+
+def test_simple_input(args: argparse.Namespace) -> int:
+    handle = None
+    try:
+        print_test_header("GPIO simple input", f"{args.chip}-{args.line}")
+        state = initialize_test_state()
+        line = get_line_from_state_or_raise(state, args.chip, args.line)
+        ensure_unused(line)
+        step = print_step(f"Request {args.chip}-{args.line} as input")
+        print_detail(
+            "note", "Python gpiod API requests the line as input here"
+        )
+        try:
+            handle = request_input(
+                state.gpiod, state.style, args.chip, args.line
+            )
+        except Exception as exc:
+            raise StepError(
+                step,
+                python_gpiod_error(
+                    "request input", f"{args.chip}-{args.line}", exc
+                ),
+            ) from exc
+        step = print_step(f"Read value from {args.chip}-{args.line}")
+        try:
+            value = read_handle(state.gpiod, state.style, handle, args.line)
+        except Exception as exc:
+            raise StepError(
+                step,
+                python_gpiod_error("read", f"{args.chip}-{args.line}", exc),
+            ) from exc
+        print_step(f"Release {args.chip}-{args.line}")
+        release_handle(state.style, handle)
+        handle = None
+        print(f"GPIO_VALUE={value}")
+        print_result("pass")
+        return 0
+    except Exception as exc:
+        if handle is not None:
+            try:
+                release_handle(api_style(import_gpiod()), handle)
+            except Exception:
+                pass
+        return fail_current_step(exc)
+
+
+def test_simple_output(args: argparse.Namespace) -> int:
+    handle = None
+    state: TestState | None = None
+    saved: SavedLineState | None = None
+    try:
+        print_test_header("GPIO simple output", f"{args.chip}-{args.line}")
+        state = initialize_test_state()
+        line = get_line_from_state_or_raise(state, args.chip, args.line)
+        ensure_unused(line)
+        print_step(f"Save original state for {args.chip}-{args.line}")
+        saved = save_line_state(state, line)
+        step = print_step(f"Request {args.chip}-{args.line} as output")
+        print_detail(
+            "note", "Python gpiod API requests the line as output here"
+        )
+        try:
+            handle = request_output(
+                state.gpiod,
+                state.style,
+                args.chip,
+                args.line,
+                int(args.initial or 0),
+            )
+        except Exception as exc:
+            raise StepError(
+                step,
+                python_gpiod_error(
+                    "request output", f"{args.chip}-{args.line}", exc
+                ),
+            ) from exc
+        step = print_step(f"Set {args.chip}-{args.line} low")
+        try:
+            set_handle_value(state.gpiod, state.style, handle, args.line, 0)
+        except Exception as exc:
+            raise StepError(
+                step,
+                python_gpiod_error("set low", f"{args.chip}-{args.line}", exc),
+            ) from exc
+        step = print_step(f"Set {args.chip}-{args.line} high")
+        try:
+            set_handle_value(state.gpiod, state.style, handle, args.line, 1)
+        except Exception as exc:
+            raise StepError(
+                step,
+                python_gpiod_error(
+                    "set high", f"{args.chip}-{args.line}", exc
+                ),
+            ) from exc
+        print_step(f"Recover original state for {args.chip}-{args.line}")
+        release_handle(state.style, handle)
+        handle = None
+        restore_line_state(state, saved)
+        print_step(f"Release {args.chip}-{args.line}")
+        print_result("pass")
+        return 0
+    except Exception as exc:
+        if handle is not None:
+            try:
+                release_handle(api_style(import_gpiod()), handle)
+            except Exception:
+                pass
+        if saved is not None:
+            print_step(f"Recover original state for {args.chip}-{args.line}")
+            recover_saved_states(state, [saved])
+        return fail_current_step(exc)
+
+
+def test_loopback(args: argparse.Namespace) -> int:
+    out_handle = None
+    in_handle = None
+    state: TestState | None = None
+    saved_states: list[SavedLineState] = []
+    try:
+        print_test_header(
+            "GPIO loopback",
+            f"input={args.in_chip}-{args.in_line} output={args.out_chip}-{args.out_line}",
+        )
+        state = initialize_test_state()
+        output, input_ = get_loopback_lines_or_raise(args, state)
+        if (args.out_chip, args.out_line) == (args.in_chip, args.in_line):
+            raise StepError(
+                "Check loopback lines", "output and input line are the same"
+            )
+
+        step = print_step(
+            f"Check {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line} are unused"
+        )
+        if output.used or input_.used:
+            raise StepError(
+                step, "one or both loopback lines are already used"
+            )
+
+        print_step(
+            f"Save original state for {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
+        )
+        saved_states = [
+            save_line_state(state, output),
+            save_line_state(state, input_),
+        ]
+        step = print_step(f"Request {args.out_chip}-{args.out_line} as output")
+        print_detail("note", "Python gpiod API requests the output line here")
+        try:
+            out_handle = request_output(
+                state.gpiod, state.style, args.out_chip, args.out_line, 0
+            )
+        except Exception as exc:
+            raise StepError(
+                step,
+                python_gpiod_error(
+                    "request output", f"{args.out_chip}-{args.out_line}", exc
+                ),
+            ) from exc
+        step = print_step(f"Request {args.in_chip}-{args.in_line} as input")
+        print_detail("note", "Python gpiod API requests the input line here")
+        try:
+            in_handle = request_input(
+                state.gpiod, state.style, args.in_chip, args.in_line
+            )
+        except Exception as exc:
+            raise StepError(
+                step,
+                python_gpiod_error(
+                    "request input", f"{args.in_chip}-{args.in_line}", exc
+                ),
+            ) from exc
+
+        for _ in range(args.repeat):
+            step = print_step(f"Set {args.out_chip}-{args.out_line} low")
+            try:
+                set_handle_value(
+                    state.gpiod, state.style, out_handle, args.out_line, 0
+                )
+            except Exception as exc:
+                raise StepError(
+                    step,
+                    python_gpiod_error(
+                        "set low", f"{args.out_chip}-{args.out_line}", exc
+                    ),
+                ) from exc
+            time.sleep(args.delay)
+            step = print_step(
+                f"Verify {args.in_chip}-{args.in_line} reads low"
+            )
+            try:
+                input_value = read_handle(
+                    state.gpiod, state.style, in_handle, args.in_line
+                )
+            except Exception as exc:
+                raise StepError(
+                    step,
+                    python_gpiod_error(
+                        "read", f"{args.in_chip}-{args.in_line}", exc
+                    ),
+                ) from exc
+            if input_value != 0:
+                raise StepError(
+                    f"Verify {args.in_chip}-{args.in_line} reads low",
+                    "input did not read low",
+                )
+
+            step = print_step(f"Set {args.out_chip}-{args.out_line} high")
+            try:
+                set_handle_value(
+                    state.gpiod, state.style, out_handle, args.out_line, 1
+                )
+            except Exception as exc:
+                raise StepError(
+                    step,
+                    python_gpiod_error(
+                        "set high", f"{args.out_chip}-{args.out_line}", exc
+                    ),
+                ) from exc
+            time.sleep(args.delay)
+            step = print_step(
+                f"Verify {args.in_chip}-{args.in_line} reads high"
+            )
+            try:
+                input_value = read_handle(
+                    state.gpiod, state.style, in_handle, args.in_line
+                )
+            except Exception as exc:
+                raise StepError(
+                    step,
+                    python_gpiod_error(
+                        "read", f"{args.in_chip}-{args.in_line}", exc
+                    ),
+                ) from exc
+            if input_value != 1:
+                raise StepError(
+                    f"Verify {args.in_chip}-{args.in_line} reads high",
+                    "input did not read high",
+                )
+
+        print_step(
+            f"Recover original state for {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
+        )
+        release_handle(state.style, out_handle)
+        release_handle(state.style, in_handle)
+        out_handle = None
+        in_handle = None
+        recover_saved_states(state, saved_states)
+        print_step(
+            f"Release {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
+        )
+        print_result("pass")
+        return 0
+    except Exception as exc:
+        for handle in (out_handle, in_handle):
+            if handle is not None:
+                try:
+                    release_handle(api_style(import_gpiod()), handle)
+                except Exception:
+                    pass
+        if saved_states:
+            print_step(
+                f"Recover original state for {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
+            )
+            recover_saved_states(state, saved_states)
+        return fail_current_step(exc)
+
+
+def fail_current_step(exc: Exception) -> int:
+    if isinstance(exc, StepError):
+        print()
+        print(f"[FAIL] {exc.step}")
+        print_detail("error", exc.message)
+        print(f"GPIO_ERROR={exc.message}", file=sys.stderr)
+    else:
+        print()
+        print("[FAIL] GPIO test failed")
+        print_detail("error", exc)
+        print(f"GPIO_ERROR={exc}", file=sys.stderr)
+    print_result("fail")
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    formatter = argparse.RawDescriptionHelpFormatter
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=formatter
+    )
+    subparsers = parser.add_subparsers(dest="category", required=True)
+
+    resource = subparsers.add_parser("resource", formatter_class=formatter)
+    resource_sub = resource.add_subparsers(
+        dest="resource_command", required=True
+    )
+    simple_resource = resource_sub.add_parser(
+        "simple",
+        formatter_class=formatter,
+        epilog=(
+            "Examples:\n"
+            "  gpio_test_python.py resource simple\n"
+            "  gpio_test_python.py resource simple --ignore gpiochip0-2,gpiochip1-14\n"
+            "  gpio_test_python.py resource simple --ignore gpiochip14,gpiochip16-0..4\n"
+            "  gpio_test_python.py resource simple --ignore gpiochip14-*,gpiochip16-0..1,gpiochip16-2..4\n"
+            "  gpio_test_python.py resource simple --allow-named --format json\n"
+        ),
+    )
+    simple_resource.add_argument(
+        "--ignore",
+        metavar="IDS",
+        help=(
+            "Comma-separated GPIO lines, ranges, or chips to exclude. Supports "
+            "gpiochipN-LINE, gpiochipN-START..END, gpiochipN, and gpiochipN-*. "
+            "Examples: gpiochip0-2,gpiochip14,gpiochip16-0..4."
+        ),
+    )
+    simple_resource.add_argument(
+        "--allow-named",
+        action="store_true",
+        help=(
+            "Compatibility option. Named unused GPIO lines are included by "
+            "default; use --ignore to exclude unsafe platform lines."
+        ),
+    )
+    simple_resource.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format. Default: text.",
+    )
+    simple_resource.set_defaults(func=resource_simple)
+
+    loopback_resource = resource_sub.add_parser(
+        "loopback",
+        formatter_class=formatter,
+        epilog=(
+            "Examples:\n"
+            "  gpio_test_python.py resource loopback --pairs gpiochip0-100:gpiochip0-0\n"
+            "  gpio_test_python.py resource loopback --pairs gpiochip0-100:gpiochip0-0,gpiochip1-2:gpiochip1-1\n"
+            "\n"
+            "Pair format is INPUT:OUTPUT.\n"
+        ),
+    )
+    loopback_resource.add_argument(
+        "--pairs",
+        required=True,
+        help="Comma-separated loopback pairs in INPUT:OUTPUT format.",
+    )
+    loopback_resource.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format. Default: text.",
+    )
+    loopback_resource.set_defaults(func=resource_loopback)
+
+    test = subparsers.add_parser("test", formatter_class=formatter)
+    test_sub = test.add_subparsers(dest="test_command", required=True)
+    simple_test = test_sub.add_parser("simple", formatter_class=formatter)
+    simple_test_sub = simple_test.add_subparsers(
+        dest="direction", required=True
+    )
+
+    input_test = simple_test_sub.add_parser("input")
+    input_test.add_argument("chip")
+    input_test.add_argument("line", type=int)
+    input_test.add_argument(
+        "--bias", choices=("pull-up", "pull-down", "disabled")
+    )
+    input_test.set_defaults(func=test_simple_input)
+
+    output_test = simple_test_sub.add_parser("output")
+    output_test.add_argument("chip")
+    output_test.add_argument("line", type=int)
+    output_test.add_argument("--initial", choices=("0", "1"))
+    output_test.set_defaults(func=test_simple_output)
+
+    loopback_test = test_sub.add_parser("loopback")
+    loopback_test.add_argument("in_chip")
+    loopback_test.add_argument("in_line", type=int)
+    loopback_test.add_argument("out_chip")
+    loopback_test.add_argument("out_line", type=int)
+    loopback_test.add_argument("--repeat", type=int, default=3)
+    loopback_test.add_argument("--delay", type=float, default=0.05)
+    loopback_test.set_defaults(func=test_loopback)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return args.func(args)
+    except GpioTestError as exc:
+        print(f"GPIO_ERROR={exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_python.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_python.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""GPIO validation using the Python gpiod binding."""
+"""GPIO validation using the Python gpiod binding.
+
+This script is the Python API implementation of the CE OEM gpiod GPIO tests.
+It discovers GPIO lines through ``import gpiod`` and performs line requests
+without calling the libgpiod command-line tools.  Test commands print
+human-readable progress blocks while keeping ``GPIO_TEST_RESULT=...`` available
+for Checkbox parsing.
+"""
 
 from __future__ import annotations
 
@@ -17,6 +24,8 @@ CONSUMER = "gpio-test"
 
 @dataclass(frozen=True)
 class GpioLine:
+    """Description of one GPIO line discovered from the Python gpiod API."""
+
     chip: str
     offset: int
     name: str
@@ -27,6 +36,8 @@ class GpioLine:
 
 @dataclass(frozen=True)
 class TestState:
+    """Cached Python gpiod module, API style and GPIO discovery data."""
+
     gpiod: object
     style: str
     lines: dict[str, GpioLine]
@@ -34,15 +45,21 @@ class TestState:
 
 @dataclass(frozen=True)
 class SavedLineState:
+    """Original line state used to restore GPIO direction and value."""
+
     line: GpioLine
     value: int | None
 
 
 class GpioTestError(Exception):
+    """Base exception for expected GPIO test failures."""
+
     pass
 
 
 class StepError(GpioTestError):
+    """Exception that records the human-readable step that failed."""
+
     def __init__(self, step: str, message: str) -> None:
         super().__init__(message)
         self.step = step
@@ -50,21 +67,29 @@ class StepError(GpioTestError):
 
 
 def print_step(message: str) -> str:
+    """Print and return a human-readable progress step."""
+
     print()
     print(f"[INFO] {message}")
     return message
 
 
 def print_detail(key: str, value: object) -> None:
+    """Print an indented key/value detail line under the current step."""
+
     print(f"       {key}: {value}")
 
 
 def print_test_header(name: str, target: str) -> None:
+    """Print the test name and target line or line pair."""
+
     print(f"TEST: {name}")
     print(f"TARGET: {target}")
 
 
 def print_result(status: str) -> None:
+    """Print the human and machine-readable final test result."""
+
     upper = status.upper()
     print()
     print(f"RESULT: {upper}")
@@ -72,6 +97,8 @@ def print_result(status: str) -> None:
 
 
 def python_gpiod_error(action: str, line: str, exc: Exception) -> str:
+    """Format Python gpiod operation failures as user-facing messages."""
+
     return (
         f"Python gpiod failed to {action} {line}: {exc} "
         "(kernel/libgpiod operation error)"
@@ -79,6 +106,8 @@ def python_gpiod_error(action: str, line: str, exc: Exception) -> str:
 
 
 def import_gpiod():
+    """Import and return the Python gpiod module."""
+
     try:
         import gpiod  # type: ignore
     except (
@@ -89,6 +118,8 @@ def import_gpiod():
 
 
 def api_style(gpiod) -> str:
+    """Detect whether the imported gpiod module exposes v1 or v2 APIs."""
+
     if hasattr(gpiod, "request_lines") and hasattr(gpiod, "LineSettings"):
         return "v2"
     if hasattr(gpiod, "Chip"):
@@ -97,6 +128,8 @@ def api_style(gpiod) -> str:
 
 
 def gpiod_version(gpiod) -> str:
+    """Return the best available Python gpiod version string."""
+
     for attr in ("__version__", "version"):
         value = getattr(gpiod, attr, None)
         if callable(value):
@@ -107,11 +140,15 @@ def gpiod_version(gpiod) -> str:
 
 
 def chip_path(chip: str) -> str:
+    """Return a /dev path for a chip when that path exists."""
+
     path = Path("/dev") / chip
     return str(path) if path.exists() else chip
 
 
 def chip_names() -> list[str]:
+    """Return sorted GPIO chip names from /dev."""
+
     names = [Path(path).name for path in glob.glob("/dev/gpiochip*")]
     return sorted(
         names,
@@ -124,11 +161,15 @@ def chip_names() -> list[str]:
 
 
 def value_attr(obj, name: str):
+    """Read an attribute that may be exposed as a value or method."""
+
     attr = getattr(obj, name, None)
     return attr() if callable(attr) else attr
 
 
 def normalized_direction(direction) -> str | None:
+    """Normalize gpiod direction constants to input/output strings."""
+
     if direction is None:
         return None
     if isinstance(direction, int):
@@ -142,6 +183,8 @@ def normalized_direction(direction) -> str | None:
 
 
 def line_info_v1(gpiod, chip_name: str, offset: int) -> GpioLine:
+    """Read one line description using the Python gpiod v1 API."""
+
     chip = gpiod.Chip(chip_name)
     try:
         line = chip.get_line(offset)
@@ -160,6 +203,8 @@ def line_info_v1(gpiod, chip_name: str, offset: int) -> GpioLine:
 
 
 def line_count_v1(gpiod, chip_name: str) -> int:
+    """Return a chip line count using the Python gpiod v1 API."""
+
     chip = gpiod.Chip(chip_name)
     try:
         count = value_attr(chip, "num_lines")
@@ -173,6 +218,8 @@ def line_count_v1(gpiod, chip_name: str) -> int:
 
 
 def line_info_v2(gpiod, chip_name: str, offset: int) -> GpioLine:
+    """Read one line description using the Python gpiod v2 API."""
+
     chip = gpiod.Chip(chip_path(chip_name))
     try:
         info = chip.get_line_info(offset)
@@ -190,6 +237,8 @@ def line_info_v2(gpiod, chip_name: str, offset: int) -> GpioLine:
 
 
 def line_count_v2(gpiod, chip_name: str) -> int:
+    """Return a chip line count using the Python gpiod v2 API."""
+
     chip = gpiod.Chip(chip_path(chip_name))
     try:
         info = chip.get_info()
@@ -204,6 +253,8 @@ def line_count_v2(gpiod, chip_name: str) -> int:
 
 
 def load_lines(chip: str | None = None) -> dict[str, GpioLine]:
+    """Discover GPIO lines, optionally limited to one chip."""
+
     gpiod = import_gpiod()
     style = api_style(gpiod)
     names = [chip] if chip else chip_names()
@@ -228,6 +279,8 @@ def load_lines(chip: str | None = None) -> dict[str, GpioLine]:
 
 
 def print_gpio_inventory(lines: dict[str, GpioLine]) -> None:
+    """Print all discovered GPIO lines in a human-readable format."""
+
     by_chip: dict[str, list[GpioLine]] = {}
     for line in lines.values():
         by_chip.setdefault(line.chip, []).append(line)
@@ -248,6 +301,8 @@ def print_gpio_inventory(lines: dict[str, GpioLine]) -> None:
 
 
 def initialize_test_state() -> TestState:
+    """Collect and cache API version and full GPIO discovery for one test."""
+
     print_step("Get Python gpiod version")
     gpiod = import_gpiod()
     style = api_style(gpiod)
@@ -261,6 +316,8 @@ def initialize_test_state() -> TestState:
 
 
 def parse_line_id(identifier: str) -> tuple[str, int]:
+    """Parse ``gpiochipN-LINE`` into chip name and line offset."""
+
     parts = identifier.strip().split("-", 1)
     if (
         len(parts) != 2
@@ -272,6 +329,12 @@ def parse_line_id(identifier: str) -> tuple[str, int]:
 
 
 def parse_ignore(value: str | None, lines: dict[str, GpioLine]) -> set[str]:
+    """Expand ignore expressions into concrete ``gpiochipN-LINE`` keys.
+
+    Supported input forms are ``gpiochipN-LINE``, ``gpiochipN-START..END``,
+    ``gpiochipN`` and ``gpiochipN-*``.
+    """
+
     if not value:
         return set()
 
@@ -307,6 +370,8 @@ def parse_ignore(value: str | None, lines: dict[str, GpioLine]) -> set[str]:
 
 
 def parse_pairs(value: str) -> list[tuple[str, int, str, int]]:
+    """Parse comma-separated loopback pairs in ``INPUT:OUTPUT`` format."""
+
     pairs = []
     for item in value.split(","):
         if ":" not in item:
@@ -319,6 +384,8 @@ def parse_pairs(value: str) -> list[tuple[str, int, str, int]]:
 
 
 def emit_records(records: list[dict[str, object]], fmt: str) -> None:
+    """Emit Checkbox resource records as text or JSON."""
+
     if fmt == "json":
         print(json.dumps(records, indent=2, sort_keys=True))
         return
@@ -329,11 +396,15 @@ def emit_records(records: list[dict[str, object]], fmt: str) -> None:
 
 
 def sort_key(identifier: str) -> tuple[int, int]:
+    """Return a numeric sort key for ``gpiochipN-LINE`` identifiers."""
+
     chip, offset = identifier.split("-", 1)
     return int(chip.removeprefix("gpiochip")), int(offset)
 
 
 def resource_simple(args: argparse.Namespace) -> int:
+    """Generate unused GPIO line resources for simple input/output jobs."""
+
     lines = load_lines()
     ignored = parse_ignore(args.ignore, lines)
     candidates = []
@@ -347,6 +418,8 @@ def resource_simple(args: argparse.Namespace) -> int:
 
 
 def resource_loopback(args: argparse.Namespace) -> int:
+    """Generate validated GPIO loopback resources from pair definitions."""
+
     lines = load_lines()
     records = []
     for out_chip, out_line, in_chip, in_line in parse_pairs(args.pairs):
@@ -377,6 +450,8 @@ def resource_loopback(args: argparse.Namespace) -> int:
 
 
 def get_line_or_raise(chip: str, offset: int, purpose: str = "") -> GpioLine:
+    """Find a line from fresh discovery or raise a step-aware error."""
+
     label = f"{chip}-{offset}"
     print_step(f"Find {purpose + ' ' if purpose else ''}{label}")
     lines = load_lines(chip)
@@ -391,6 +466,8 @@ def get_line_from_state_or_raise(
     offset: int,
     purpose: str = "",
 ) -> GpioLine:
+    """Find a line in cached test state or raise a step-aware error."""
+
     label = f"{chip}-{offset}"
     print_step(f"Find {purpose + ' ' if purpose else ''}{label}")
     if label not in state.lines:
@@ -401,6 +478,8 @@ def get_line_from_state_or_raise(
 def get_loopback_lines_or_raise(
     args: argparse.Namespace, state: TestState
 ) -> tuple[GpioLine, GpioLine]:
+    """Return output and input lines for a loopback test."""
+
     out_label = f"{args.out_chip}-{args.out_line}"
     in_label = f"{args.in_chip}-{args.in_line}"
     print_step(f"Find input {in_label}")
@@ -417,6 +496,8 @@ def get_loopback_lines_or_raise(
 
 
 def ensure_unused(line: GpioLine) -> None:
+    """Fail the current step if a line is already requested."""
+
     step = print_step(f"Check {line.chip}-{line.offset} is unused")
     if line.used:
         raise StepError(
@@ -425,6 +506,8 @@ def ensure_unused(line: GpioLine) -> None:
 
 
 def request_input_v1(gpiod, chip_name: str, offset: int):
+    """Request one line as input through the Python gpiod v1 API."""
+
     chip = gpiod.Chip(chip_name)
     line = chip.get_line(offset)
     line.request(consumer=CONSUMER, type=gpiod.LINE_REQ_DIR_IN)
@@ -432,6 +515,8 @@ def request_input_v1(gpiod, chip_name: str, offset: int):
 
 
 def request_output_v1(gpiod, chip_name: str, offset: int, value: int):
+    """Request one line as output through the Python gpiod v1 API."""
+
     chip = gpiod.Chip(chip_name)
     line = chip.get_line(offset)
     line.request(
@@ -441,6 +526,8 @@ def request_output_v1(gpiod, chip_name: str, offset: int, value: int):
 
 
 def release_v1(handle) -> None:
+    """Release a Python gpiod v1 line handle and close its chip."""
+
     chip, line = handle
     try:
         line.release()
@@ -451,6 +538,8 @@ def release_v1(handle) -> None:
 
 
 def request_input_v2(gpiod, chip_name: str, offset: int):
+    """Request one line as input through the Python gpiod v2 API."""
+
     settings = gpiod.LineSettings(direction=gpiod.line.Direction.INPUT)
     return gpiod.request_lines(
         chip_path(chip_name), consumer=CONSUMER, config={offset: settings}
@@ -458,6 +547,8 @@ def request_input_v2(gpiod, chip_name: str, offset: int):
 
 
 def request_output_v2(gpiod, chip_name: str, offset: int, value: int):
+    """Request one line as output through the Python gpiod v2 API."""
+
     output_value = (
         gpiod.line.Value.ACTIVE if value else gpiod.line.Value.INACTIVE
     )
@@ -470,6 +561,8 @@ def request_output_v2(gpiod, chip_name: str, offset: int, value: int):
 
 
 def read_handle(gpiod, style: str, handle, offset: int) -> int:
+    """Read a value from an active Python gpiod line request."""
+
     if style == "v2":
         value = handle.get_value(offset)
         return 1 if value == gpiod.line.Value.ACTIVE else 0
@@ -479,6 +572,8 @@ def read_handle(gpiod, style: str, handle, offset: int) -> int:
 def set_handle_value(
     gpiod, style: str, handle, offset: int, value: int
 ) -> None:
+    """Set a value on an active Python gpiod line request."""
+
     if style == "v2":
         output_value = (
             gpiod.line.Value.ACTIVE if value else gpiod.line.Value.INACTIVE
@@ -489,6 +584,8 @@ def set_handle_value(
 
 
 def release_handle(style: str, handle) -> None:
+    """Release a Python gpiod v1 or v2 request handle."""
+
     if style == "v2":
         handle.release()
     else:
@@ -496,6 +593,8 @@ def release_handle(style: str, handle) -> None:
 
 
 def request_input(gpiod, style: str, chip_name: str, offset: int):
+    """Dispatch input requests to the detected Python gpiod API."""
+
     return (
         request_input_v2(gpiod, chip_name, offset)
         if style == "v2"
@@ -504,6 +603,8 @@ def request_input(gpiod, style: str, chip_name: str, offset: int):
 
 
 def request_output(gpiod, style: str, chip_name: str, offset: int, value: int):
+    """Dispatch output requests to the detected Python gpiod API."""
+
     return (
         request_output_v2(gpiod, chip_name, offset, value)
         if style == "v2"
@@ -512,6 +613,8 @@ def request_output(gpiod, style: str, chip_name: str, offset: int, value: int):
 
 
 def save_line_state(state: TestState, line: GpioLine) -> SavedLineState:
+    """Save the original direction and readable output value."""
+
     value = None
     if line.direction == "output":
         handle = request_input(
@@ -525,6 +628,8 @@ def save_line_state(state: TestState, line: GpioLine) -> SavedLineState:
 
 
 def restore_line_state(state: TestState, saved: SavedLineState) -> None:
+    """Restore one line to its original direction and saved value."""
+
     line = saved.line
     if line.direction == "input":
         handle = request_input(
@@ -546,6 +651,8 @@ def restore_line_state(state: TestState, saved: SavedLineState) -> None:
 def recover_saved_states(
     state: TestState | None, states: list[SavedLineState]
 ) -> None:
+    """Best-effort restoration for all saved line states."""
+
     if state is None:
         return
     for saved in states:
@@ -559,6 +666,8 @@ def recover_saved_states(
 
 
 def test_simple_input(args: argparse.Namespace) -> int:
+    """Run the simple input test for one GPIO line."""
+
     handle = None
     try:
         print_test_header("GPIO simple input", f"{args.chip}-{args.line}")
@@ -604,6 +713,8 @@ def test_simple_input(args: argparse.Namespace) -> int:
 
 
 def test_simple_output(args: argparse.Namespace) -> int:
+    """Run the simple output low/high test for one GPIO line."""
+
     handle = None
     state: TestState | None = None
     saved: SavedLineState | None = None
@@ -671,6 +782,8 @@ def test_simple_output(args: argparse.Namespace) -> int:
 
 
 def test_loopback(args: argparse.Namespace) -> int:
+    """Run a physical loopback test using an input/output line pair."""
+
     out_handle = None
     in_handle = None
     state: TestState | None = None
@@ -825,6 +938,8 @@ def test_loopback(args: argparse.Namespace) -> int:
 
 
 def fail_current_step(exc: Exception) -> int:
+    """Print a failed result and return a Checkbox-compatible exit code."""
+
     if isinstance(exc, StepError):
         print()
         print(f"[FAIL] {exc.step}")
@@ -840,6 +955,8 @@ def fail_current_step(exc: Exception) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser for resources and tests."""
+
     formatter = argparse.RawDescriptionHelpFormatter
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=formatter
@@ -945,6 +1062,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main() -> int:
+    """Parse arguments and dispatch to the selected subcommand."""
+
     parser = build_parser()
     args = parser.parse_args()
     try:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_python.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_python.py
@@ -295,9 +295,11 @@ def print_gpio_inventory(lines: dict[str, GpioLine]) -> None:
             used = "used" if line.used else "unused"
             direction = line.direction or "unknown"
             active = "active-low" if line.active_low else "active-high"
-            print(
-                f"         line {line.offset:3}: {name:18} {used:6} {direction:7} {active}"
+            line_text = (
+                f"         line {line.offset:3}: {name:18} "
+                f"{used:6} {direction:7} {active}"
             )
+            print(line_text)
 
 
 def initialize_test_state() -> TestState:
@@ -659,8 +661,9 @@ def recover_saved_states(
         try:
             restore_line_state(state, saved)
         except Exception as exc:
+            line_id = f"{saved.line.chip}-{saved.line.offset}"
             print(
-                f"GPIO_RECOVERY_ERROR={saved.line.chip}-{saved.line.offset}: {exc}",
+                f"GPIO_RECOVERY_ERROR={line_id}: {exc}",
                 file=sys.stderr,
             )
 
@@ -789,9 +792,11 @@ def test_loopback(args: argparse.Namespace) -> int:
     state: TestState | None = None
     saved_states: list[SavedLineState] = []
     try:
+        in_id = f"{args.in_chip}-{args.in_line}"
+        out_id = f"{args.out_chip}-{args.out_line}"
         print_test_header(
             "GPIO loopback",
-            f"input={args.in_chip}-{args.in_line} output={args.out_chip}-{args.out_line}",
+            f"input={in_id} output={out_id}",
         )
         state = initialize_test_state()
         output, input_ = get_loopback_lines_or_raise(args, state)
@@ -800,22 +805,18 @@ def test_loopback(args: argparse.Namespace) -> int:
                 "Check loopback lines", "output and input line are the same"
             )
 
-        step = print_step(
-            f"Check {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line} are unused"
-        )
+        step = print_step(f"Check {out_id} and {in_id} are unused")
         if output.used or input_.used:
             raise StepError(
                 step, "one or both loopback lines are already used"
             )
 
-        print_step(
-            f"Save original state for {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
-        )
+        print_step(f"Save original state for {out_id} and {in_id}")
         saved_states = [
             save_line_state(state, output),
             save_line_state(state, input_),
         ]
-        step = print_step(f"Request {args.out_chip}-{args.out_line} as output")
+        step = print_step(f"Request {out_id} as output")
         print_detail("note", "Python gpiod API requests the output line here")
         try:
             out_handle = request_output(
@@ -824,11 +825,9 @@ def test_loopback(args: argparse.Namespace) -> int:
         except Exception as exc:
             raise StepError(
                 step,
-                python_gpiod_error(
-                    "request output", f"{args.out_chip}-{args.out_line}", exc
-                ),
+                python_gpiod_error("request output", out_id, exc),
             ) from exc
-        step = print_step(f"Request {args.in_chip}-{args.in_line} as input")
+        step = print_step(f"Request {in_id} as input")
         print_detail("note", "Python gpiod API requests the input line here")
         try:
             in_handle = request_input(
@@ -837,13 +836,11 @@ def test_loopback(args: argparse.Namespace) -> int:
         except Exception as exc:
             raise StepError(
                 step,
-                python_gpiod_error(
-                    "request input", f"{args.in_chip}-{args.in_line}", exc
-                ),
+                python_gpiod_error("request input", in_id, exc),
             ) from exc
 
         for _ in range(args.repeat):
-            step = print_step(f"Set {args.out_chip}-{args.out_line} low")
+            step = print_step(f"Set {out_id} low")
             try:
                 set_handle_value(
                     state.gpiod, state.style, out_handle, args.out_line, 0
@@ -851,14 +848,10 @@ def test_loopback(args: argparse.Namespace) -> int:
             except Exception as exc:
                 raise StepError(
                     step,
-                    python_gpiod_error(
-                        "set low", f"{args.out_chip}-{args.out_line}", exc
-                    ),
+                    python_gpiod_error("set low", out_id, exc),
                 ) from exc
             time.sleep(args.delay)
-            step = print_step(
-                f"Verify {args.in_chip}-{args.in_line} reads low"
-            )
+            step = print_step(f"Verify {in_id} reads low")
             try:
                 input_value = read_handle(
                     state.gpiod, state.style, in_handle, args.in_line
@@ -866,17 +859,15 @@ def test_loopback(args: argparse.Namespace) -> int:
             except Exception as exc:
                 raise StepError(
                     step,
-                    python_gpiod_error(
-                        "read", f"{args.in_chip}-{args.in_line}", exc
-                    ),
+                    python_gpiod_error("read", in_id, exc),
                 ) from exc
             if input_value != 0:
                 raise StepError(
-                    f"Verify {args.in_chip}-{args.in_line} reads low",
+                    f"Verify {in_id} reads low",
                     "input did not read low",
                 )
 
-            step = print_step(f"Set {args.out_chip}-{args.out_line} high")
+            step = print_step(f"Set {out_id} high")
             try:
                 set_handle_value(
                     state.gpiod, state.style, out_handle, args.out_line, 1
@@ -884,14 +875,10 @@ def test_loopback(args: argparse.Namespace) -> int:
             except Exception as exc:
                 raise StepError(
                     step,
-                    python_gpiod_error(
-                        "set high", f"{args.out_chip}-{args.out_line}", exc
-                    ),
+                    python_gpiod_error("set high", out_id, exc),
                 ) from exc
             time.sleep(args.delay)
-            step = print_step(
-                f"Verify {args.in_chip}-{args.in_line} reads high"
-            )
+            step = print_step(f"Verify {in_id} reads high")
             try:
                 input_value = read_handle(
                     state.gpiod, state.style, in_handle, args.in_line
@@ -899,27 +886,21 @@ def test_loopback(args: argparse.Namespace) -> int:
             except Exception as exc:
                 raise StepError(
                     step,
-                    python_gpiod_error(
-                        "read", f"{args.in_chip}-{args.in_line}", exc
-                    ),
+                    python_gpiod_error("read", in_id, exc),
                 ) from exc
             if input_value != 1:
                 raise StepError(
-                    f"Verify {args.in_chip}-{args.in_line} reads high",
+                    f"Verify {in_id} reads high",
                     "input did not read high",
                 )
 
-        print_step(
-            f"Recover original state for {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
-        )
+        print_step(f"Recover original state for {out_id} and {in_id}")
         release_handle(state.style, out_handle)
         release_handle(state.style, in_handle)
         out_handle = None
         in_handle = None
         recover_saved_states(state, saved_states)
-        print_step(
-            f"Release {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
-        )
+        print_step(f"Release {out_id} and {in_id}")
         print_result("pass")
         return 0
     except Exception as exc:
@@ -930,9 +911,7 @@ def test_loopback(args: argparse.Namespace) -> int:
                 except Exception:
                     pass
         if saved_states:
-            print_step(
-                f"Recover original state for {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
-            )
+            print_step(f"Recover original state for {out_id} and {in_id}")
             recover_saved_states(state, saved_states)
         return fail_current_step(exc)
 
@@ -973,18 +952,23 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=(
             "Examples:\n"
             "  gpio_test_python.py resource simple\n"
-            "  gpio_test_python.py resource simple --ignore gpiochip0-2,gpiochip1-14\n"
-            "  gpio_test_python.py resource simple --ignore gpiochip14,gpiochip16-0..4\n"
-            "  gpio_test_python.py resource simple --ignore gpiochip14-*,gpiochip16-0..1,gpiochip16-2..4\n"
-            "  gpio_test_python.py resource simple --allow-named --format json\n"
+            "  gpio_test_python.py resource simple "
+            "--ignore gpiochip0-2,gpiochip1-14\n"
+            "  gpio_test_python.py resource simple "
+            "--ignore gpiochip14,gpiochip16-0..4\n"
+            "  gpio_test_python.py resource simple "
+            "--ignore gpiochip14-*,gpiochip16-0..1,gpiochip16-2..4\n"
+            "  gpio_test_python.py resource simple "
+            "--allow-named --format json\n"
         ),
     )
     simple_resource.add_argument(
         "--ignore",
         metavar="IDS",
         help=(
-            "Comma-separated GPIO lines, ranges, or chips to exclude. Supports "
-            "gpiochipN-LINE, gpiochipN-START..END, gpiochipN, and gpiochipN-*. "
+            "Comma-separated GPIO lines, ranges, or chips to exclude. "
+            "Supports gpiochipN-LINE, gpiochipN-START..END, gpiochipN, "
+            "and gpiochipN-*. "
             "Examples: gpiochip0-2,gpiochip14,gpiochip16-0..4."
         ),
     )
@@ -1009,8 +993,10 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=formatter,
         epilog=(
             "Examples:\n"
-            "  gpio_test_python.py resource loopback --pairs gpiochip0-100:gpiochip0-0\n"
-            "  gpio_test_python.py resource loopback --pairs gpiochip0-100:gpiochip0-0,gpiochip1-2:gpiochip1-1\n"
+            "  gpio_test_python.py resource loopback "
+            "--pairs gpiochip0-100:gpiochip0-0\n"
+            "  gpio_test_python.py resource loopback "
+            "--pairs gpiochip0-100:gpiochip0-0,gpiochip1-2:gpiochip1-1\n"
             "\n"
             "Pair format is INPUT:OUTPUT.\n"
         ),
@@ -1061,16 +1047,40 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+class PythonGpioApplication:
+    """Command-line application for Python gpiod GPIO validation."""
+
+    def __init__(self, parser: argparse.ArgumentParser) -> None:
+        """Initialize the application with an argument parser.
+
+        Args:
+            parser: Parser that attaches a callable ``func`` to parsed args.
+        """
+
+        self._parser = parser
+
+    def run(self, argv: list[str] | None = None) -> int:
+        """Parse arguments and run the selected resource or test command.
+
+        Args:
+            argv: Optional argument list for tests. ``None`` reads sys.argv.
+
+        Returns:
+            Process exit status.
+        """
+
+        args = self._parser.parse_args(argv)
+        try:
+            return args.func(args)
+        except GpioTestError as exc:
+            print(f"GPIO_ERROR={exc}", file=sys.stderr)
+            return 1
+
+
 def main() -> int:
     """Parse arguments and dispatch to the selected subcommand."""
 
-    parser = build_parser()
-    args = parser.parse_args()
-    try:
-        return args.func(args)
-    except GpioTestError as exc:
-        print(f"GPIO_ERROR={exc}", file=sys.stderr)
-        return 1
+    return PythonGpioApplication(build_parser()).run()
 
 
 if __name__ == "__main__":

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_subprocess.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_subprocess.py
@@ -578,8 +578,9 @@ def recover_saved_states(
         try:
             restore_line_state(saved, major)
         except Exception as exc:
+            line_id = f"{saved.line.chip}-{saved.line.offset}"
             print(
-                f"GPIO_RECOVERY_ERROR={saved.line.chip}-{saved.line.offset}: {exc}",
+                f"GPIO_RECOVERY_ERROR={line_id}: {exc}",
                 file=sys.stderr,
             )
 
@@ -698,9 +699,11 @@ def test_loopback(args: argparse.Namespace) -> int:
     saved_states: list[SavedLineState] = []
     major: int | None = None
     try:
+        in_id = f"{args.in_chip}-{args.in_line}"
+        out_id = f"{args.out_chip}-{args.out_line}"
         print_test_header(
             "GPIO loopback",
-            f"input={args.in_chip}-{args.in_line} output={args.out_chip}-{args.out_line}",
+            f"input={in_id} output={out_id}",
         )
         state = initialize_test_state()
         major = state.major
@@ -710,27 +713,20 @@ def test_loopback(args: argparse.Namespace) -> int:
                 "Check loopback lines", "output and input line are the same"
             )
 
-        step = print_step(
-            f"Check {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line} are unused"
-        )
+        step = print_step(f"Check {out_id} and {in_id} are unused")
         if output.used or input_.used:
             raise StepError(
                 step, "one or both loopback lines are already used"
             )
 
-        print_step(
-            f"Save original state for {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
-        )
+        print_step(f"Save original state for {out_id} and {in_id}")
         saved_states = [
             save_line_state(output, state.major),
             save_line_state(input_, state.major),
         ]
-        print_step(f"Request {args.out_chip}-{args.out_line} as output")
-        print_detail(
-            "note",
-            "gpioset requests and holds the output line while verification runs",
-        )
-        print_step(f"Request {args.in_chip}-{args.in_line} as input")
+        print_step(f"Request {out_id} as output")
+        print_detail("note", "gpioset requests and holds output during read")
+        print_step(f"Request {in_id} as input")
         print_detail(
             "note",
             "gpioget requests the input line when each read command runs",
@@ -738,52 +734,46 @@ def test_loopback(args: argparse.Namespace) -> int:
 
         held: subprocess.Popen[str] | None = None
         for _ in range(args.repeat):
-            print_step(f"Set {args.out_chip}-{args.out_line} low")
+            print_step(f"Set {out_id} low")
             held = start_held_value(
                 args.out_chip, args.out_line, 0, state.major
             )
             try:
                 time.sleep(args.delay)
-                print_step(f"Verify {args.in_chip}-{args.in_line} reads low")
+                print_step(f"Verify {in_id} reads low")
                 if read_value(args.in_chip, args.in_line, state.major) != 0:
                     raise StepError(
-                        f"Verify {args.in_chip}-{args.in_line} reads low",
+                        f"Verify {in_id} reads low",
                         "input did not read low",
                     )
             finally:
                 stop_held_value(held)
                 held = None
 
-            print_step(f"Set {args.out_chip}-{args.out_line} high")
+            print_step(f"Set {out_id} high")
             held = start_held_value(
                 args.out_chip, args.out_line, 1, state.major
             )
             try:
                 time.sleep(args.delay)
-                print_step(f"Verify {args.in_chip}-{args.in_line} reads high")
+                print_step(f"Verify {in_id} reads high")
                 if read_value(args.in_chip, args.in_line, state.major) != 1:
                     raise StepError(
-                        f"Verify {args.in_chip}-{args.in_line} reads high",
+                        f"Verify {in_id} reads high",
                         "input did not read high",
                     )
             finally:
                 stop_held_value(held)
                 held = None
 
-        print_step(
-            f"Recover original state for {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
-        )
+        print_step(f"Recover original state for {out_id} and {in_id}")
         recover_saved_states(saved_states, state.major)
-        print_step(
-            f"Release {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
-        )
+        print_step(f"Release {out_id} and {in_id}")
         print_result("pass")
         return 0
     except Exception as exc:
         if saved_states:
-            print_step(
-                f"Recover original state for {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
-            )
+            print_step(f"Recover original state for {out_id} and {in_id}")
             recover_saved_states(saved_states, major)
         return fail_current_step(exc)
 
@@ -824,18 +814,23 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=(
             "Examples:\n"
             "  gpio_test_subprocess.py resource simple\n"
-            "  gpio_test_subprocess.py resource simple --ignore gpiochip0-2,gpiochip1-14\n"
-            "  gpio_test_subprocess.py resource simple --ignore gpiochip14,gpiochip16-0..4\n"
-            "  gpio_test_subprocess.py resource simple --ignore gpiochip14-*,gpiochip16-0..1,gpiochip16-2..4\n"
-            "  gpio_test_subprocess.py resource simple --allow-named --format json\n"
+            "  gpio_test_subprocess.py resource simple "
+            "--ignore gpiochip0-2,gpiochip1-14\n"
+            "  gpio_test_subprocess.py resource simple "
+            "--ignore gpiochip14,gpiochip16-0..4\n"
+            "  gpio_test_subprocess.py resource simple "
+            "--ignore gpiochip14-*,gpiochip16-0..1,gpiochip16-2..4\n"
+            "  gpio_test_subprocess.py resource simple "
+            "--allow-named --format json\n"
         ),
     )
     simple_resource.add_argument(
         "--ignore",
         metavar="IDS",
         help=(
-            "Comma-separated GPIO lines, ranges, or chips to exclude. Supports "
-            "gpiochipN-LINE, gpiochipN-START..END, gpiochipN, and gpiochipN-*. "
+            "Comma-separated GPIO lines, ranges, or chips to exclude. "
+            "Supports gpiochipN-LINE, gpiochipN-START..END, gpiochipN, "
+            "and gpiochipN-*. "
             "Examples: gpiochip0-2,gpiochip14,gpiochip16-0..4."
         ),
     )
@@ -860,8 +855,10 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=formatter,
         epilog=(
             "Examples:\n"
-            "  gpio_test_subprocess.py resource loopback --pairs gpiochip0-100:gpiochip0-0\n"
-            "  gpio_test_subprocess.py resource loopback --pairs gpiochip0-100:gpiochip0-0,gpiochip1-2:gpiochip1-1\n"
+            "  gpio_test_subprocess.py resource loopback "
+            "--pairs gpiochip0-100:gpiochip0-0\n"
+            "  gpio_test_subprocess.py resource loopback "
+            "--pairs gpiochip0-100:gpiochip0-0,gpiochip1-2:gpiochip1-1\n"
             "\n"
             "Pair format is INPUT:OUTPUT.\n"
         ),
@@ -912,16 +909,40 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+class SubprocessGpioApplication:
+    """Command-line application for subprocess-based GPIO validation."""
+
+    def __init__(self, parser: argparse.ArgumentParser) -> None:
+        """Initialize the application with an argument parser.
+
+        Args:
+            parser: Parser that attaches a callable ``func`` to parsed args.
+        """
+
+        self._parser = parser
+
+    def run(self, argv: list[str] | None = None) -> int:
+        """Parse arguments and run the selected resource or test command.
+
+        Args:
+            argv: Optional argument list for tests. ``None`` reads sys.argv.
+
+        Returns:
+            Process exit status.
+        """
+
+        args = self._parser.parse_args(argv)
+        try:
+            return args.func(args)
+        except GpioTestError as exc:
+            print(f"GPIO_ERROR={exc}", file=sys.stderr)
+            return 1
+
+
 def main() -> int:
     """Parse arguments and dispatch to the selected subcommand."""
 
-    parser = build_parser()
-    args = parser.parse_args()
-    try:
-        return args.func(args)
-    except GpioTestError as exc:
-        print(f"GPIO_ERROR={exc}", file=sys.stderr)
-        return 1
+    return SubprocessGpioApplication(build_parser()).run()
 
 
 if __name__ == "__main__":

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_subprocess.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_subprocess.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""GPIO validation using libgpiod command-line tools."""
+"""GPIO validation using libgpiod command-line tools.
+
+This script is the command-line-tool implementation of the CE OEM gpiod GPIO
+tests.  It discovers GPIO lines with ``gpioinfo`` and performs requests through
+``gpioget`` and ``gpioset``.  The test commands print human-readable progress
+blocks while keeping ``GPIO_TEST_RESULT=...`` available for Checkbox parsing.
+"""
 
 from __future__ import annotations
 
@@ -19,6 +25,8 @@ _DETECTED_MAJOR: int | None = None
 
 @dataclass(frozen=True)
 class GpioLine:
+    """Description of one GPIO line discovered from ``gpioinfo``."""
+
     chip: str
     offset: int
     name: str
@@ -29,6 +37,8 @@ class GpioLine:
 
 @dataclass(frozen=True)
 class CommandResult:
+    """Captured output and return code from a subprocess command."""
+
     stdout: str
     stderr: str
     returncode: int
@@ -36,21 +46,29 @@ class CommandResult:
 
 @dataclass(frozen=True)
 class TestState:
+    """Cached discovery state shared by all steps in one test command."""
+
     major: int
     lines: dict[str, GpioLine]
 
 
 @dataclass(frozen=True)
 class SavedLineState:
+    """Original line state used to restore GPIO direction and value."""
+
     line: GpioLine
     value: int | None
 
 
 class GpioTestError(Exception):
+    """Base exception for expected GPIO test failures."""
+
     pass
 
 
 class StepError(GpioTestError):
+    """Exception that records the human-readable step that failed."""
+
     def __init__(self, step: str, message: str) -> None:
         super().__init__(message)
         self.step = step
@@ -58,21 +76,29 @@ class StepError(GpioTestError):
 
 
 def print_step(message: str) -> str:
+    """Print and return a human-readable progress step."""
+
     print()
     print(f"[INFO] {message}")
     return message
 
 
 def print_detail(key: str, value: object) -> None:
+    """Print an indented key/value detail line under the current step."""
+
     print(f"       {key}: {value}")
 
 
 def print_test_header(name: str, target: str) -> None:
+    """Print the test name and target line or line pair."""
+
     print(f"TEST: {name}")
     print(f"TARGET: {target}")
 
 
 def print_block(label: str, content: str) -> None:
+    """Print multi-line command output under an indented label."""
+
     if not content:
         return
     print(f"       {label}:")
@@ -81,6 +107,8 @@ def print_block(label: str, content: str) -> None:
 
 
 def print_result(status: str) -> None:
+    """Print the human and machine-readable final test result."""
+
     upper = status.upper()
     print()
     print(f"RESULT: {upper}")
@@ -88,10 +116,14 @@ def print_result(status: str) -> None:
 
 
 def print_command(command: list[str]) -> None:
+    """Print the exact subprocess command before it runs."""
+
     print_detail("command", " ".join(command))
 
 
 def print_command_output(result: CommandResult) -> None:
+    """Print stdout/stderr from a command result when output exists."""
+
     if not result.stdout and not result.stderr:
         return
 
@@ -107,6 +139,8 @@ def print_command_output(result: CommandResult) -> None:
 
 
 def run_command(command: list[str], log: bool = True) -> CommandResult:
+    """Run a subprocess command and raise ``GpioTestError`` on failure."""
+
     if log:
         print_command(command)
     proc = subprocess.run(command, text=True, capture_output=True, check=False)
@@ -122,6 +156,8 @@ def run_command(command: list[str], log: bool = True) -> CommandResult:
 
 
 def filter_gpioinfo_output(output: str, offsets: set[int]) -> str:
+    """Limit displayed ``gpioinfo`` output to selected line offsets."""
+
     if not offsets:
         return output
 
@@ -143,6 +179,8 @@ def filter_gpioinfo_output(output: str, offsets: set[int]) -> str:
 def run_gpioinfo(
     command: list[str], log: bool, focus_offsets: set[int] | None = None
 ) -> CommandResult:
+    """Run ``gpioinfo`` and optionally filter only the logged output."""
+
     if not log:
         return run_command(command, log=False)
 
@@ -164,6 +202,8 @@ def run_gpioinfo(
 
 
 def detect_major_version(log: bool = True) -> int:
+    """Return the detected libgpiod command-line major version."""
+
     global _DETECTED_MAJOR
     if _DETECTED_MAJOR is not None:
         return _DETECTED_MAJOR
@@ -185,6 +225,8 @@ def detect_major_version(log: bool = True) -> int:
 
 
 def require_commands() -> None:
+    """Ensure all required libgpiod command-line tools are available."""
+
     missing = [
         cmd
         for cmd in ("gpiodetect", "gpioinfo", "gpioget", "gpioset")
@@ -197,6 +239,8 @@ def require_commands() -> None:
 
 
 def parse_line(chip: str, line: str, major: int) -> GpioLine | None:
+    """Parse one ``gpioinfo`` line for libgpiod v1 or v2 output."""
+
     match = re.match(r"\s*line\s+(\d+):\s*(.*)$", line)
     if not match:
         return None
@@ -224,6 +268,8 @@ def parse_line(chip: str, line: str, major: int) -> GpioLine | None:
 
 
 def parse_gpioinfo(output: str, major: int) -> dict[str, GpioLine]:
+    """Parse complete ``gpioinfo`` output into GPIO line objects."""
+
     lines: dict[str, GpioLine] = {}
     chip: str | None = None
     for raw_line in output.splitlines():
@@ -244,6 +290,8 @@ def load_lines(
     log: bool = True,
     focus_offsets: set[int] | None = None,
 ) -> dict[str, GpioLine]:
+    """Discover GPIO lines, optionally limited to one chip."""
+
     require_commands()
     major = detect_major_version(log=log)
     command = ["gpioinfo"]
@@ -257,6 +305,8 @@ def load_lines(
 
 
 def initialize_test_state() -> TestState:
+    """Collect and cache version and full GPIO discovery for one test."""
+
     require_commands()
     print_step("Get libgpiod version")
     major = detect_major_version(log=True)
@@ -266,6 +316,8 @@ def initialize_test_state() -> TestState:
 
 
 def parse_line_id(identifier: str) -> tuple[str, int]:
+    """Parse ``gpiochipN-LINE`` into chip name and line offset."""
+
     match = re.fullmatch(r"(gpiochip\d+)-(\d+)", identifier.strip())
     if not match:
         raise GpioTestError(f"invalid GPIO line identifier: {identifier}")
@@ -273,6 +325,12 @@ def parse_line_id(identifier: str) -> tuple[str, int]:
 
 
 def parse_ignore(value: str | None, lines: dict[str, GpioLine]) -> set[str]:
+    """Expand ignore expressions into concrete ``gpiochipN-LINE`` keys.
+
+    Supported input forms are ``gpiochipN-LINE``, ``gpiochipN-START..END``,
+    ``gpiochipN`` and ``gpiochipN-*``.
+    """
+
     if not value:
         return set()
 
@@ -308,6 +366,8 @@ def parse_ignore(value: str | None, lines: dict[str, GpioLine]) -> set[str]:
 
 
 def parse_pairs(value: str) -> list[tuple[str, int, str, int]]:
+    """Parse comma-separated loopback pairs in ``INPUT:OUTPUT`` format."""
+
     pairs = []
     for item in value.split(","):
         if ":" not in item:
@@ -320,6 +380,8 @@ def parse_pairs(value: str) -> list[tuple[str, int, str, int]]:
 
 
 def emit_records(records: list[dict[str, object]], fmt: str) -> None:
+    """Emit Checkbox resource records as text or JSON."""
+
     if fmt == "json":
         print(json.dumps(records, indent=2, sort_keys=True))
         return
@@ -330,6 +392,8 @@ def emit_records(records: list[dict[str, object]], fmt: str) -> None:
 
 
 def resource_simple(args: argparse.Namespace) -> int:
+    """Generate unused GPIO line resources for simple input/output jobs."""
+
     lines = load_lines(log=False)
     ignored = parse_ignore(args.ignore, lines)
     candidates = []
@@ -349,6 +413,8 @@ def resource_simple(args: argparse.Namespace) -> int:
 
 
 def resource_loopback(args: argparse.Namespace) -> int:
+    """Generate validated GPIO loopback resources from pair definitions."""
+
     lines = load_lines(log=False)
     records = []
     for out_chip, out_line, in_chip, in_line in parse_pairs(args.pairs):
@@ -379,6 +445,8 @@ def resource_loopback(args: argparse.Namespace) -> int:
 
 
 def get_line_or_raise(chip: str, offset: int, purpose: str = "") -> GpioLine:
+    """Find a line from fresh discovery or raise a step-aware error."""
+
     label = f"{chip}-{offset}"
     print_step(f"Find {purpose + ' ' if purpose else ''}{label}")
     lines = load_lines(chip, log=True, focus_offsets={offset})
@@ -393,6 +461,8 @@ def get_line_from_state_or_raise(
     offset: int,
     purpose: str = "",
 ) -> GpioLine:
+    """Find a line in cached test state or raise a step-aware error."""
+
     label = f"{chip}-{offset}"
     print_step(f"Find {purpose + ' ' if purpose else ''}{label}")
     if label not in state.lines:
@@ -403,6 +473,8 @@ def get_line_from_state_or_raise(
 def get_loopback_lines_or_raise(
     args: argparse.Namespace, state: TestState
 ) -> tuple[GpioLine, GpioLine]:
+    """Return output and input lines for a loopback test."""
+
     out_label = f"{args.out_chip}-{args.out_line}"
     in_label = f"{args.in_chip}-{args.in_line}"
 
@@ -421,6 +493,8 @@ def get_loopback_lines_or_raise(
 
 
 def ensure_unused(line: GpioLine) -> None:
+    """Fail the current step if a line is already requested."""
+
     step = print_step(f"Check {line.chip}-{line.offset} is unused")
     if line.used:
         raise StepError(
@@ -429,12 +503,16 @@ def ensure_unused(line: GpioLine) -> None:
 
 
 def cmd_gpioget(chip: str, offset: int, major: int) -> list[str]:
+    """Build the version-specific ``gpioget`` command."""
+
     if major == 2:
         return ["gpioget", "--numeric", "--chip", chip, str(offset)]
     return ["gpioget", chip, str(offset)]
 
 
 def cmd_gpioset(chip: str, offset: int, value: int, major: int) -> list[str]:
+    """Build the version-specific non-holding ``gpioset`` command."""
+
     if major == 2:
         return [
             "gpioset",
@@ -448,6 +526,8 @@ def cmd_gpioset(chip: str, offset: int, value: int, major: int) -> list[str]:
 
 
 def read_value(chip: str, offset: int, major: int) -> int:
+    """Read a GPIO value through ``gpioget``."""
+
     result = run_command(cmd_gpioget(chip, offset, major))
     output = result.stdout.strip()
     if output not in ("0", "1"):
@@ -456,10 +536,14 @@ def read_value(chip: str, offset: int, major: int) -> int:
 
 
 def set_value(chip: str, offset: int, value: int, major: int) -> None:
+    """Set a GPIO value through non-holding ``gpioset``."""
+
     run_command(cmd_gpioset(chip, offset, value, major))
 
 
 def save_line_state(line: GpioLine, major: int) -> SavedLineState:
+    """Save the original direction and readable output value."""
+
     value = (
         read_value(line.chip, line.offset, major)
         if line.direction == "output"
@@ -469,6 +553,8 @@ def save_line_state(line: GpioLine, major: int) -> SavedLineState:
 
 
 def restore_line_state(saved: SavedLineState, major: int) -> None:
+    """Restore one line to its original direction and saved value."""
+
     line = saved.line
     if line.direction == "input":
         read_value(line.chip, line.offset, major)
@@ -484,6 +570,8 @@ def restore_line_state(saved: SavedLineState, major: int) -> None:
 def recover_saved_states(
     states: list[SavedLineState], major: int | None
 ) -> None:
+    """Best-effort restoration for all saved line states."""
+
     if major is None:
         return
     for saved in states:
@@ -499,6 +587,8 @@ def recover_saved_states(
 def cmd_gpioset_hold(
     chip: str, offset: int, value: int, major: int
 ) -> list[str]:
+    """Build a ``gpioset`` command that holds the requested value."""
+
     if major == 2:
         return ["gpioset", "--chip", chip, f"{offset}={value}"]
     return ["gpioset", "--mode=signal", chip, f"{offset}={value}"]
@@ -507,6 +597,8 @@ def cmd_gpioset_hold(
 def start_held_value(
     chip: str, offset: int, value: int, major: int
 ) -> subprocess.Popen[str]:
+    """Start ``gpioset`` and keep the output value asserted."""
+
     command = cmd_gpioset_hold(chip, offset, value, major)
     print_command(command)
     proc = subprocess.Popen(
@@ -526,6 +618,8 @@ def start_held_value(
 
 
 def stop_held_value(proc: subprocess.Popen[str]) -> None:
+    """Terminate a held ``gpioset`` process and print any output."""
+
     proc.send_signal(signal.SIGTERM)
     try:
         stdout, stderr = proc.communicate(timeout=2)
@@ -536,10 +630,14 @@ def stop_held_value(proc: subprocess.Popen[str]) -> None:
 
 
 def release_line(chip: str, offset: int) -> None:
+    """Log release of a line after a one-shot command has exited."""
+
     print_step(f"Release {chip}-{offset}")
 
 
 def test_simple_input(args: argparse.Namespace) -> int:
+    """Run the simple input test for one GPIO line."""
+
     try:
         print_test_header("GPIO simple input", f"{args.chip}-{args.line}")
         state = initialize_test_state()
@@ -561,6 +659,8 @@ def test_simple_input(args: argparse.Namespace) -> int:
 
 
 def test_simple_output(args: argparse.Namespace) -> int:
+    """Run the simple output low/high test for one GPIO line."""
+
     saved: SavedLineState | None = None
     major: int | None = None
     try:
@@ -593,6 +693,8 @@ def test_simple_output(args: argparse.Namespace) -> int:
 
 
 def test_loopback(args: argparse.Namespace) -> int:
+    """Run a physical loopback test using an input/output line pair."""
+
     saved_states: list[SavedLineState] = []
     major: int | None = None
     try:
@@ -687,6 +789,8 @@ def test_loopback(args: argparse.Namespace) -> int:
 
 
 def fail_current_step(exc: Exception) -> int:
+    """Print a failed result and return a Checkbox-compatible exit code."""
+
     if isinstance(exc, StepError):
         print()
         print(f"[FAIL] {exc.step}")
@@ -702,6 +806,8 @@ def fail_current_step(exc: Exception) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser for resources and tests."""
+
     formatter = argparse.RawDescriptionHelpFormatter
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=formatter
@@ -807,6 +913,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main() -> int:
+    """Parse arguments and dispatch to the selected subcommand."""
+
     parser = build_parser()
     args = parser.parse_args()
     try:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_subprocess.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_subprocess.py
@@ -1,0 +1,820 @@
+#!/usr/bin/env python3
+"""GPIO validation using libgpiod command-line tools."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+
+CONSUMER = "gpio-test"
+_DETECTED_MAJOR: int | None = None
+
+
+@dataclass(frozen=True)
+class GpioLine:
+    chip: str
+    offset: int
+    name: str
+    used: bool
+    direction: str | None
+    active_low: bool
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    stdout: str
+    stderr: str
+    returncode: int
+
+
+@dataclass(frozen=True)
+class TestState:
+    major: int
+    lines: dict[str, GpioLine]
+
+
+@dataclass(frozen=True)
+class SavedLineState:
+    line: GpioLine
+    value: int | None
+
+
+class GpioTestError(Exception):
+    pass
+
+
+class StepError(GpioTestError):
+    def __init__(self, step: str, message: str) -> None:
+        super().__init__(message)
+        self.step = step
+        self.message = message
+
+
+def print_step(message: str) -> str:
+    print()
+    print(f"[INFO] {message}")
+    return message
+
+
+def print_detail(key: str, value: object) -> None:
+    print(f"       {key}: {value}")
+
+
+def print_test_header(name: str, target: str) -> None:
+    print(f"TEST: {name}")
+    print(f"TARGET: {target}")
+
+
+def print_block(label: str, content: str) -> None:
+    if not content:
+        return
+    print(f"       {label}:")
+    for line in content.rstrip().splitlines():
+        print(f"         {line}")
+
+
+def print_result(status: str) -> None:
+    upper = status.upper()
+    print()
+    print(f"RESULT: {upper}")
+    print(f"GPIO_TEST_RESULT={status}")
+
+
+def print_command(command: list[str]) -> None:
+    print_detail("command", " ".join(command))
+
+
+def print_command_output(result: CommandResult) -> None:
+    if not result.stdout and not result.stderr:
+        return
+
+    if result.stdout and result.stderr:
+        print_block("stdout", result.stdout)
+        print_block("stderr", result.stderr)
+        return
+
+    if result.stdout:
+        print_block("output", result.stdout)
+    elif result.stderr:
+        print_block("output", result.stderr)
+
+
+def run_command(command: list[str], log: bool = True) -> CommandResult:
+    if log:
+        print_command(command)
+    proc = subprocess.run(command, text=True, capture_output=True, check=False)
+    result = CommandResult(proc.stdout, proc.stderr, proc.returncode)
+    if log:
+        print_command_output(result)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise GpioTestError(
+            detail or f"command failed with exit code {result.returncode}"
+        )
+    return result
+
+
+def filter_gpioinfo_output(output: str, offsets: set[int]) -> str:
+    if not offsets:
+        return output
+
+    filtered: list[str] = []
+    include_current_chip = False
+    for line in output.splitlines():
+        if re.match(r"^gpiochip\d+\s+-\s+\d+\s+lines:", line):
+            filtered.append(line)
+            include_current_chip = True
+            continue
+        if not include_current_chip:
+            continue
+        match = re.match(r"\s*line\s+(\d+):", line)
+        if match and int(match.group(1)) in offsets:
+            filtered.append(line)
+    return "\n".join(filtered)
+
+
+def run_gpioinfo(
+    command: list[str], log: bool, focus_offsets: set[int] | None = None
+) -> CommandResult:
+    if not log:
+        return run_command(command, log=False)
+
+    print_command(command)
+    proc = subprocess.run(command, text=True, capture_output=True, check=False)
+    result = CommandResult(proc.stdout, proc.stderr, proc.returncode)
+    display_stdout = filter_gpioinfo_output(
+        result.stdout, focus_offsets or set()
+    )
+    print_command_output(
+        CommandResult(display_stdout, result.stderr, result.returncode)
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise GpioTestError(
+            detail or f"command failed with exit code {result.returncode}"
+        )
+    return result
+
+
+def detect_major_version(log: bool = True) -> int:
+    global _DETECTED_MAJOR
+    if _DETECTED_MAJOR is not None:
+        return _DETECTED_MAJOR
+
+    if not shutil.which("gpioinfo"):
+        raise GpioTestError("gpioinfo command not found")
+
+    result = run_command(["gpioinfo", "-v"], log=log)
+    match = re.search(r"v(\d+)\.", result.stdout + result.stderr)
+    if not match:
+        raise GpioTestError(
+            "unable to detect libgpiod version from gpioinfo -v"
+        )
+    major = int(match.group(1))
+    if major not in (1, 2):
+        raise GpioTestError(f"unsupported libgpiod major version: {major}")
+    _DETECTED_MAJOR = major
+    return major
+
+
+def require_commands() -> None:
+    missing = [
+        cmd
+        for cmd in ("gpiodetect", "gpioinfo", "gpioget", "gpioset")
+        if not shutil.which(cmd)
+    ]
+    if missing:
+        raise GpioTestError(
+            f"missing required command(s): {', '.join(missing)}"
+        )
+
+
+def parse_line(chip: str, line: str, major: int) -> GpioLine | None:
+    match = re.match(r"\s*line\s+(\d+):\s*(.*)$", line)
+    if not match:
+        return None
+
+    offset = int(match.group(1))
+    details = match.group(2)
+    quoted = re.findall(r'"([^"]*)"', details)
+
+    if major == 1:
+        if quoted:
+            name = quoted[0]
+        elif re.search(r"\bunnamed\b", details):
+            name = ""
+        else:
+            name = ""
+        used = not bool(re.search(r"\bunused\b", details))
+    else:
+        name = quoted[0] if quoted else ""
+        used = 'consumer="' in details
+
+    direction_match = re.search(r"\b(input|output)\b", details)
+    direction = direction_match.group(1) if direction_match else None
+    active_low = "active-low" in details or "active_low" in details
+    return GpioLine(chip, offset, name, used, direction, active_low)
+
+
+def parse_gpioinfo(output: str, major: int) -> dict[str, GpioLine]:
+    lines: dict[str, GpioLine] = {}
+    chip: str | None = None
+    for raw_line in output.splitlines():
+        header = re.match(r"^(gpiochip\d+)\s+-\s+\d+\s+lines:", raw_line)
+        if header:
+            chip = header.group(1)
+            continue
+        if chip is None:
+            continue
+        parsed = parse_line(chip, raw_line, major)
+        if parsed is not None:
+            lines[f"{parsed.chip}-{parsed.offset}"] = parsed
+    return lines
+
+
+def load_lines(
+    chip: str | None = None,
+    log: bool = True,
+    focus_offsets: set[int] | None = None,
+) -> dict[str, GpioLine]:
+    require_commands()
+    major = detect_major_version(log=log)
+    command = ["gpioinfo"]
+    if chip:
+        if major == 2:
+            command.extend(["--chip", chip])
+        else:
+            command.append(chip)
+    result = run_gpioinfo(command, log=log, focus_offsets=focus_offsets)
+    return parse_gpioinfo(result.stdout, major)
+
+
+def initialize_test_state() -> TestState:
+    require_commands()
+    print_step("Get libgpiod version")
+    major = detect_major_version(log=True)
+    print_step("List all GPIO chips and lines")
+    result = run_gpioinfo(["gpioinfo"], log=True)
+    return TestState(major=major, lines=parse_gpioinfo(result.stdout, major))
+
+
+def parse_line_id(identifier: str) -> tuple[str, int]:
+    match = re.fullmatch(r"(gpiochip\d+)-(\d+)", identifier.strip())
+    if not match:
+        raise GpioTestError(f"invalid GPIO line identifier: {identifier}")
+    return match.group(1), int(match.group(2))
+
+
+def parse_ignore(value: str | None, lines: dict[str, GpioLine]) -> set[str]:
+    if not value:
+        return set()
+
+    ignored: set[str] = set()
+    for raw_item in value.split(","):
+        item = raw_item.strip()
+        if not item:
+            continue
+
+        chip_match = re.fullmatch(r"(gpiochip\d+)(?:-\*)?", item)
+        if chip_match:
+            chip = chip_match.group(1)
+            ignored.update(
+                key for key, line in lines.items() if line.chip == chip
+            )
+            continue
+
+        range_match = re.fullmatch(r"(gpiochip\d+)-(\d+)\.\.(\d+)", item)
+        if range_match:
+            chip = range_match.group(1)
+            start = int(range_match.group(2))
+            end = int(range_match.group(3))
+            if start > end:
+                raise GpioTestError(f"invalid ignore range: {item}")
+            ignored.update(
+                f"{chip}-{offset}" for offset in range(start, end + 1)
+            )
+            continue
+
+        chip, offset = parse_line_id(item)
+        ignored.add(f"{chip}-{offset}")
+    return ignored
+
+
+def parse_pairs(value: str) -> list[tuple[str, int, str, int]]:
+    pairs = []
+    for item in value.split(","):
+        if ":" not in item:
+            raise GpioTestError(f"invalid loopback pair: {item}")
+        input_, output = item.split(":", 1)
+        in_chip, in_line = parse_line_id(input_)
+        out_chip, out_line = parse_line_id(output)
+        pairs.append((out_chip, out_line, in_chip, in_line))
+    return pairs
+
+
+def emit_records(records: list[dict[str, object]], fmt: str) -> None:
+    if fmt == "json":
+        print(json.dumps(records, indent=2, sort_keys=True))
+        return
+    for record in records:
+        for key, value in record.items():
+            print(f"{key}={value}")
+        print()
+
+
+def resource_simple(args: argparse.Namespace) -> int:
+    lines = load_lines(log=False)
+    ignored = parse_ignore(args.ignore, lines)
+    candidates = []
+    for key in sorted(
+        lines,
+        key=lambda item: (
+            int(item.split("-")[0].removeprefix("gpiochip")),
+            int(item.split("-")[1]),
+        ),
+    ):
+        line = lines[key]
+        if line.used or key in ignored:
+            continue
+        candidates.append({"GPIO_CHIP": line.chip, "GPIO_LINE": line.offset})
+    emit_records(candidates, args.format)
+    return 0
+
+
+def resource_loopback(args: argparse.Namespace) -> int:
+    lines = load_lines(log=False)
+    records = []
+    for out_chip, out_line, in_chip, in_line in parse_pairs(args.pairs):
+        out_key = f"{out_chip}-{out_line}"
+        in_key = f"{in_chip}-{in_line}"
+        if out_key == in_key:
+            raise GpioTestError(
+                f"loopback output and input are the same line: {out_key}"
+            )
+        if out_key not in lines:
+            raise GpioTestError(f"output line not found: {out_key}")
+        if in_key not in lines:
+            raise GpioTestError(f"input line not found: {in_key}")
+        if lines[out_key].used:
+            raise GpioTestError(f"output line is already used: {out_key}")
+        if lines[in_key].used:
+            raise GpioTestError(f"input line is already used: {in_key}")
+        records.append(
+            {
+                "GPIO_OUTPUT_CHIP": out_chip,
+                "GPIO_OUTPUT_LINE": out_line,
+                "GPIO_INPUT_CHIP": in_chip,
+                "GPIO_INPUT_LINE": in_line,
+            }
+        )
+    emit_records(records, args.format)
+    return 0
+
+
+def get_line_or_raise(chip: str, offset: int, purpose: str = "") -> GpioLine:
+    label = f"{chip}-{offset}"
+    print_step(f"Find {purpose + ' ' if purpose else ''}{label}")
+    lines = load_lines(chip, log=True, focus_offsets={offset})
+    if label not in lines:
+        raise StepError(f"Find {label}", f"GPIO line not found: {label}")
+    return lines[label]
+
+
+def get_line_from_state_or_raise(
+    state: TestState,
+    chip: str,
+    offset: int,
+    purpose: str = "",
+) -> GpioLine:
+    label = f"{chip}-{offset}"
+    print_step(f"Find {purpose + ' ' if purpose else ''}{label}")
+    if label not in state.lines:
+        raise StepError(f"Find {label}", f"GPIO line not found: {label}")
+    return state.lines[label]
+
+
+def get_loopback_lines_or_raise(
+    args: argparse.Namespace, state: TestState
+) -> tuple[GpioLine, GpioLine]:
+    out_label = f"{args.out_chip}-{args.out_line}"
+    in_label = f"{args.in_chip}-{args.in_line}"
+
+    print_step(f"Find input {in_label}")
+    print_step(f"Find output {out_label}")
+
+    if out_label not in state.lines:
+        raise StepError(
+            f"Find output {out_label}", f"GPIO line not found: {out_label}"
+        )
+    if in_label not in state.lines:
+        raise StepError(
+            f"Find input {in_label}", f"GPIO line not found: {in_label}"
+        )
+    return state.lines[out_label], state.lines[in_label]
+
+
+def ensure_unused(line: GpioLine) -> None:
+    step = print_step(f"Check {line.chip}-{line.offset} is unused")
+    if line.used:
+        raise StepError(
+            step, f"GPIO line is already used: {line.chip}-{line.offset}"
+        )
+
+
+def cmd_gpioget(chip: str, offset: int, major: int) -> list[str]:
+    if major == 2:
+        return ["gpioget", "--numeric", "--chip", chip, str(offset)]
+    return ["gpioget", chip, str(offset)]
+
+
+def cmd_gpioset(chip: str, offset: int, value: int, major: int) -> list[str]:
+    if major == 2:
+        return [
+            "gpioset",
+            "--toggle",
+            "0",
+            "--chip",
+            chip,
+            f"{offset}={value}",
+        ]
+    return ["gpioset", chip, f"{offset}={value}"]
+
+
+def read_value(chip: str, offset: int, major: int) -> int:
+    result = run_command(cmd_gpioget(chip, offset, major))
+    output = result.stdout.strip()
+    if output not in ("0", "1"):
+        raise GpioTestError(f"unexpected GPIO value: {output!r}")
+    return int(output)
+
+
+def set_value(chip: str, offset: int, value: int, major: int) -> None:
+    run_command(cmd_gpioset(chip, offset, value, major))
+
+
+def save_line_state(line: GpioLine, major: int) -> SavedLineState:
+    value = (
+        read_value(line.chip, line.offset, major)
+        if line.direction == "output"
+        else None
+    )
+    return SavedLineState(line=line, value=value)
+
+
+def restore_line_state(saved: SavedLineState, major: int) -> None:
+    line = saved.line
+    if line.direction == "input":
+        read_value(line.chip, line.offset, major)
+    elif line.direction == "output":
+        set_value(
+            line.chip,
+            line.offset,
+            saved.value if saved.value is not None else 0,
+            major,
+        )
+
+
+def recover_saved_states(
+    states: list[SavedLineState], major: int | None
+) -> None:
+    if major is None:
+        return
+    for saved in states:
+        try:
+            restore_line_state(saved, major)
+        except Exception as exc:
+            print(
+                f"GPIO_RECOVERY_ERROR={saved.line.chip}-{saved.line.offset}: {exc}",
+                file=sys.stderr,
+            )
+
+
+def cmd_gpioset_hold(
+    chip: str, offset: int, value: int, major: int
+) -> list[str]:
+    if major == 2:
+        return ["gpioset", "--chip", chip, f"{offset}={value}"]
+    return ["gpioset", "--mode=signal", chip, f"{offset}={value}"]
+
+
+def start_held_value(
+    chip: str, offset: int, value: int, major: int
+) -> subprocess.Popen[str]:
+    command = cmd_gpioset_hold(chip, offset, value, major)
+    print_command(command)
+    proc = subprocess.Popen(
+        command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    time.sleep(0.05)
+    if proc.poll() is not None:
+        stdout, stderr = proc.communicate()
+        print_command_output(
+            CommandResult(stdout, stderr, proc.returncode or 1)
+        )
+        detail = (stderr or stdout).strip()
+        raise GpioTestError(
+            detail or f"command failed with exit code {proc.returncode}"
+        )
+    return proc
+
+
+def stop_held_value(proc: subprocess.Popen[str]) -> None:
+    proc.send_signal(signal.SIGTERM)
+    try:
+        stdout, stderr = proc.communicate(timeout=2)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        stdout, stderr = proc.communicate()
+    print_command_output(CommandResult(stdout, stderr, proc.returncode or 0))
+
+
+def release_line(chip: str, offset: int) -> None:
+    print_step(f"Release {chip}-{offset}")
+
+
+def test_simple_input(args: argparse.Namespace) -> int:
+    try:
+        print_test_header("GPIO simple input", f"{args.chip}-{args.line}")
+        state = initialize_test_state()
+        line = get_line_from_state_or_raise(state, args.chip, args.line)
+        ensure_unused(line)
+        print_step(f"Request {args.chip}-{args.line} as input")
+        print_detail(
+            "note",
+            "gpioget requests the line as input when the read command runs",
+        )
+        print_step(f"Read value from {args.chip}-{args.line}")
+        value = read_value(args.chip, args.line, state.major)
+        release_line(args.chip, args.line)
+        print(f"GPIO_VALUE={value}")
+        print_result("pass")
+        return 0
+    except Exception as exc:
+        return fail_current_step(exc)
+
+
+def test_simple_output(args: argparse.Namespace) -> int:
+    saved: SavedLineState | None = None
+    major: int | None = None
+    try:
+        print_test_header("GPIO simple output", f"{args.chip}-{args.line}")
+        state = initialize_test_state()
+        major = state.major
+        line = get_line_from_state_or_raise(state, args.chip, args.line)
+        ensure_unused(line)
+        print_step(f"Save original state for {args.chip}-{args.line}")
+        saved = save_line_state(line, state.major)
+        print_step(f"Request {args.chip}-{args.line} as output")
+        print_detail(
+            "note",
+            "gpioset requests the line as output when the set command runs",
+        )
+        print_step(f"Set {args.chip}-{args.line} low")
+        set_value(args.chip, args.line, 0, state.major)
+        print_step(f"Set {args.chip}-{args.line} high")
+        set_value(args.chip, args.line, 1, state.major)
+        print_step(f"Recover original state for {args.chip}-{args.line}")
+        restore_line_state(saved, state.major)
+        release_line(args.chip, args.line)
+        print_result("pass")
+        return 0
+    except Exception as exc:
+        if saved is not None:
+            print_step(f"Recover original state for {args.chip}-{args.line}")
+            recover_saved_states([saved], major)
+        return fail_current_step(exc)
+
+
+def test_loopback(args: argparse.Namespace) -> int:
+    saved_states: list[SavedLineState] = []
+    major: int | None = None
+    try:
+        print_test_header(
+            "GPIO loopback",
+            f"input={args.in_chip}-{args.in_line} output={args.out_chip}-{args.out_line}",
+        )
+        state = initialize_test_state()
+        major = state.major
+        output, input_ = get_loopback_lines_or_raise(args, state)
+        if (args.out_chip, args.out_line) == (args.in_chip, args.in_line):
+            raise StepError(
+                "Check loopback lines", "output and input line are the same"
+            )
+
+        step = print_step(
+            f"Check {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line} are unused"
+        )
+        if output.used or input_.used:
+            raise StepError(
+                step, "one or both loopback lines are already used"
+            )
+
+        print_step(
+            f"Save original state for {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
+        )
+        saved_states = [
+            save_line_state(output, state.major),
+            save_line_state(input_, state.major),
+        ]
+        print_step(f"Request {args.out_chip}-{args.out_line} as output")
+        print_detail(
+            "note",
+            "gpioset requests and holds the output line while verification runs",
+        )
+        print_step(f"Request {args.in_chip}-{args.in_line} as input")
+        print_detail(
+            "note",
+            "gpioget requests the input line when each read command runs",
+        )
+
+        held: subprocess.Popen[str] | None = None
+        for _ in range(args.repeat):
+            print_step(f"Set {args.out_chip}-{args.out_line} low")
+            held = start_held_value(
+                args.out_chip, args.out_line, 0, state.major
+            )
+            try:
+                time.sleep(args.delay)
+                print_step(f"Verify {args.in_chip}-{args.in_line} reads low")
+                if read_value(args.in_chip, args.in_line, state.major) != 0:
+                    raise StepError(
+                        f"Verify {args.in_chip}-{args.in_line} reads low",
+                        "input did not read low",
+                    )
+            finally:
+                stop_held_value(held)
+                held = None
+
+            print_step(f"Set {args.out_chip}-{args.out_line} high")
+            held = start_held_value(
+                args.out_chip, args.out_line, 1, state.major
+            )
+            try:
+                time.sleep(args.delay)
+                print_step(f"Verify {args.in_chip}-{args.in_line} reads high")
+                if read_value(args.in_chip, args.in_line, state.major) != 1:
+                    raise StepError(
+                        f"Verify {args.in_chip}-{args.in_line} reads high",
+                        "input did not read high",
+                    )
+            finally:
+                stop_held_value(held)
+                held = None
+
+        print_step(
+            f"Recover original state for {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
+        )
+        recover_saved_states(saved_states, state.major)
+        print_step(
+            f"Release {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
+        )
+        print_result("pass")
+        return 0
+    except Exception as exc:
+        if saved_states:
+            print_step(
+                f"Recover original state for {args.out_chip}-{args.out_line} and {args.in_chip}-{args.in_line}"
+            )
+            recover_saved_states(saved_states, major)
+        return fail_current_step(exc)
+
+
+def fail_current_step(exc: Exception) -> int:
+    if isinstance(exc, StepError):
+        print()
+        print(f"[FAIL] {exc.step}")
+        print_detail("error", exc.message)
+        print(f"GPIO_ERROR={exc.message}", file=sys.stderr)
+    else:
+        print()
+        print("[FAIL] GPIO test failed")
+        print_detail("error", exc)
+        print(f"GPIO_ERROR={exc}", file=sys.stderr)
+    print_result("fail")
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    formatter = argparse.RawDescriptionHelpFormatter
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=formatter
+    )
+    subparsers = parser.add_subparsers(dest="category", required=True)
+
+    resource = subparsers.add_parser("resource", formatter_class=formatter)
+    resource_sub = resource.add_subparsers(
+        dest="resource_command", required=True
+    )
+    simple_resource = resource_sub.add_parser(
+        "simple",
+        formatter_class=formatter,
+        epilog=(
+            "Examples:\n"
+            "  gpio_test_subprocess.py resource simple\n"
+            "  gpio_test_subprocess.py resource simple --ignore gpiochip0-2,gpiochip1-14\n"
+            "  gpio_test_subprocess.py resource simple --ignore gpiochip14,gpiochip16-0..4\n"
+            "  gpio_test_subprocess.py resource simple --ignore gpiochip14-*,gpiochip16-0..1,gpiochip16-2..4\n"
+            "  gpio_test_subprocess.py resource simple --allow-named --format json\n"
+        ),
+    )
+    simple_resource.add_argument(
+        "--ignore",
+        metavar="IDS",
+        help=(
+            "Comma-separated GPIO lines, ranges, or chips to exclude. Supports "
+            "gpiochipN-LINE, gpiochipN-START..END, gpiochipN, and gpiochipN-*. "
+            "Examples: gpiochip0-2,gpiochip14,gpiochip16-0..4."
+        ),
+    )
+    simple_resource.add_argument(
+        "--allow-named",
+        action="store_true",
+        help=(
+            "Compatibility option. Named unused GPIO lines are included by "
+            "default; use --ignore to exclude unsafe platform lines."
+        ),
+    )
+    simple_resource.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format. Default: text.",
+    )
+    simple_resource.set_defaults(func=resource_simple)
+
+    loopback_resource = resource_sub.add_parser(
+        "loopback",
+        formatter_class=formatter,
+        epilog=(
+            "Examples:\n"
+            "  gpio_test_subprocess.py resource loopback --pairs gpiochip0-100:gpiochip0-0\n"
+            "  gpio_test_subprocess.py resource loopback --pairs gpiochip0-100:gpiochip0-0,gpiochip1-2:gpiochip1-1\n"
+            "\n"
+            "Pair format is INPUT:OUTPUT.\n"
+        ),
+    )
+    loopback_resource.add_argument(
+        "--pairs",
+        required=True,
+        help="Comma-separated loopback pairs in INPUT:OUTPUT format.",
+    )
+    loopback_resource.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format. Default: text.",
+    )
+    loopback_resource.set_defaults(func=resource_loopback)
+
+    test = subparsers.add_parser("test", formatter_class=formatter)
+    test_sub = test.add_subparsers(dest="test_command", required=True)
+    simple_test = test_sub.add_parser("simple", formatter_class=formatter)
+    simple_test_sub = simple_test.add_subparsers(
+        dest="direction", required=True
+    )
+
+    input_test = simple_test_sub.add_parser("input")
+    input_test.add_argument("chip")
+    input_test.add_argument("line", type=int)
+    input_test.add_argument(
+        "--bias", choices=("pull-up", "pull-down", "disabled")
+    )
+    input_test.set_defaults(func=test_simple_input)
+
+    output_test = simple_test_sub.add_parser("output")
+    output_test.add_argument("chip")
+    output_test.add_argument("line", type=int)
+    output_test.add_argument("--initial", choices=("0", "1"))
+    output_test.set_defaults(func=test_simple_output)
+
+    loopback_test = test_sub.add_parser("loopback")
+    loopback_test.add_argument("in_chip")
+    loopback_test.add_argument("in_line", type=int)
+    loopback_test.add_argument("out_chip")
+    loopback_test.add_argument("out_line", type=int)
+    loopback_test.add_argument("--repeat", type=int, default=3)
+    loopback_test.add_argument("--delay", type=float, default=0.05)
+    loopback_test.set_defaults(func=test_loopback)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return args.func(args)
+    except GpioTestError as exc:
+        print(f"GPIO_ERROR={exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_subprocess.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_subprocess.py
@@ -7,8 +7,6 @@ tests.  It discovers GPIO lines with ``gpioinfo`` and performs requests through
 blocks while keeping ``GPIO_TEST_RESULT=...`` available for Checkbox parsing.
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import re
@@ -17,47 +15,33 @@ import signal
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
+from collections import namedtuple
 
 CONSUMER = "gpio-test"
-_DETECTED_MAJOR: int | None = None
+_DETECTED_MAJOR = None
+
+# Description of one GPIO line discovered from ``gpioinfo``.
+GpioLine = namedtuple(
+    "GpioLine",
+    ["chip", "offset", "name", "used", "direction", "active_low"],
+)
+
+# Captured output and return code from a subprocess command.
+CommandResult = namedtuple("CommandResult", ["stdout", "stderr", "returncode"])
+
+# Cached discovery state shared by all steps in one test command.
+TestState = namedtuple("TestState", ["major", "lines"])
+
+# Original line state used to restore GPIO direction and value.
+SavedLineState = namedtuple("SavedLineState", ["line", "value"])
 
 
-@dataclass(frozen=True)
-class GpioLine:
-    """Description of one GPIO line discovered from ``gpioinfo``."""
+def strip_prefix(text, prefix):
+    """Return ``text`` without ``prefix`` (str.removeprefix for Python 3.5)."""
 
-    chip: str
-    offset: int
-    name: str
-    used: bool
-    direction: str | None
-    active_low: bool
-
-
-@dataclass(frozen=True)
-class CommandResult:
-    """Captured output and return code from a subprocess command."""
-
-    stdout: str
-    stderr: str
-    returncode: int
-
-
-@dataclass(frozen=True)
-class TestState:
-    """Cached discovery state shared by all steps in one test command."""
-
-    major: int
-    lines: dict[str, GpioLine]
-
-
-@dataclass(frozen=True)
-class SavedLineState:
-    """Original line state used to restore GPIO direction and value."""
-
-    line: GpioLine
-    value: int | None
+    if text.startswith(prefix):
+        return text[len(prefix) :]
+    return text
 
 
 class GpioTestError(Exception):
@@ -69,59 +53,59 @@ class GpioTestError(Exception):
 class StepError(GpioTestError):
     """Exception that records the human-readable step that failed."""
 
-    def __init__(self, step: str, message: str) -> None:
+    def __init__(self, step, message):
         super().__init__(message)
         self.step = step
         self.message = message
 
 
-def print_step(message: str) -> str:
+def print_step(message):
     """Print and return a human-readable progress step."""
 
     print()
-    print(f"[INFO] {message}")
+    print("[INFO] {}".format(message))
     return message
 
 
-def print_detail(key: str, value: object) -> None:
+def print_detail(key, value):
     """Print an indented key/value detail line under the current step."""
 
-    print(f"       {key}: {value}")
+    print("       {}: {}".format(key, value))
 
 
-def print_test_header(name: str, target: str) -> None:
+def print_test_header(name, target):
     """Print the test name and target line or line pair."""
 
-    print(f"TEST: {name}")
-    print(f"TARGET: {target}")
+    print("TEST: {}".format(name))
+    print("TARGET: {}".format(target))
 
 
-def print_block(label: str, content: str) -> None:
+def print_block(label, content):
     """Print multi-line command output under an indented label."""
 
     if not content:
         return
-    print(f"       {label}:")
+    print("       {}:".format(label))
     for line in content.rstrip().splitlines():
-        print(f"         {line}")
+        print("         {}".format(line))
 
 
-def print_result(status: str) -> None:
+def print_result(status):
     """Print the human and machine-readable final test result."""
 
     upper = status.upper()
     print()
-    print(f"RESULT: {upper}")
-    print(f"GPIO_TEST_RESULT={status}")
+    print("RESULT: {}".format(upper))
+    print("GPIO_TEST_RESULT={}".format(status))
 
 
-def print_command(command: list[str]) -> None:
+def print_command(command):
     """Print the exact subprocess command before it runs."""
 
     print_detail("command", " ".join(command))
 
 
-def print_command_output(result: CommandResult) -> None:
+def print_command_output(result):
     """Print stdout/stderr from a command result when output exists."""
 
     if not result.stdout and not result.stderr:
@@ -138,30 +122,37 @@ def print_command_output(result: CommandResult) -> None:
         print_block("output", result.stderr)
 
 
-def run_command(command: list[str], log: bool = True) -> CommandResult:
+def run_command(command, log=True):
     """Run a subprocess command and raise ``GpioTestError`` on failure."""
 
     if log:
         print_command(command)
-    proc = subprocess.run(command, text=True, capture_output=True, check=False)
+    proc = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        check=False,
+    )
     result = CommandResult(proc.stdout, proc.stderr, proc.returncode)
     if log:
         print_command_output(result)
     if result.returncode != 0:
         detail = (result.stderr or result.stdout).strip()
         raise GpioTestError(
-            detail or f"command failed with exit code {result.returncode}"
+            detail
+            or "command failed with exit code {}".format(result.returncode)
         )
     return result
 
 
-def filter_gpioinfo_output(output: str, offsets: set[int]) -> str:
+def filter_gpioinfo_output(output, offsets):
     """Limit displayed ``gpioinfo`` output to selected line offsets."""
 
     if not offsets:
         return output
 
-    filtered: list[str] = []
+    filtered = []
     include_current_chip = False
     for line in output.splitlines():
         if re.match(r"^gpiochip\d+\s+-\s+\d+\s+lines:", line):
@@ -176,16 +167,20 @@ def filter_gpioinfo_output(output: str, offsets: set[int]) -> str:
     return "\n".join(filtered)
 
 
-def run_gpioinfo(
-    command: list[str], log: bool, focus_offsets: set[int] | None = None
-) -> CommandResult:
+def run_gpioinfo(command, log, focus_offsets=None):
     """Run ``gpioinfo`` and optionally filter only the logged output."""
 
     if not log:
         return run_command(command, log=False)
 
     print_command(command)
-    proc = subprocess.run(command, text=True, capture_output=True, check=False)
+    proc = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        check=False,
+    )
     result = CommandResult(proc.stdout, proc.stderr, proc.returncode)
     display_stdout = filter_gpioinfo_output(
         result.stdout, focus_offsets or set()
@@ -196,12 +191,13 @@ def run_gpioinfo(
     if result.returncode != 0:
         detail = (result.stderr or result.stdout).strip()
         raise GpioTestError(
-            detail or f"command failed with exit code {result.returncode}"
+            detail
+            or "command failed with exit code {}".format(result.returncode)
         )
     return result
 
 
-def detect_major_version(log: bool = True) -> int:
+def detect_major_version(log=True):
     """Return the detected libgpiod command-line major version."""
 
     global _DETECTED_MAJOR
@@ -219,12 +215,14 @@ def detect_major_version(log: bool = True) -> int:
         )
     major = int(match.group(1))
     if major not in (1, 2):
-        raise GpioTestError(f"unsupported libgpiod major version: {major}")
+        raise GpioTestError(
+            "unsupported libgpiod major version: {}".format(major)
+        )
     _DETECTED_MAJOR = major
     return major
 
 
-def require_commands() -> None:
+def require_commands():
     """Ensure all required libgpiod command-line tools are available."""
 
     missing = [
@@ -234,11 +232,11 @@ def require_commands() -> None:
     ]
     if missing:
         raise GpioTestError(
-            f"missing required command(s): {', '.join(missing)}"
+            "missing required command(s): {}".format(", ".join(missing))
         )
 
 
-def parse_line(chip: str, line: str, major: int) -> GpioLine | None:
+def parse_line(chip, line, major):
     """Parse one ``gpioinfo`` line for libgpiod v1 or v2 output."""
 
     match = re.match(r"\s*line\s+(\d+):\s*(.*)$", line)
@@ -267,11 +265,11 @@ def parse_line(chip: str, line: str, major: int) -> GpioLine | None:
     return GpioLine(chip, offset, name, used, direction, active_low)
 
 
-def parse_gpioinfo(output: str, major: int) -> dict[str, GpioLine]:
+def parse_gpioinfo(output, major):
     """Parse complete ``gpioinfo`` output into GPIO line objects."""
 
-    lines: dict[str, GpioLine] = {}
-    chip: str | None = None
+    lines = {}
+    chip = None
     for raw_line in output.splitlines():
         header = re.match(r"^(gpiochip\d+)\s+-\s+\d+\s+lines:", raw_line)
         if header:
@@ -281,15 +279,15 @@ def parse_gpioinfo(output: str, major: int) -> dict[str, GpioLine]:
             continue
         parsed = parse_line(chip, raw_line, major)
         if parsed is not None:
-            lines[f"{parsed.chip}-{parsed.offset}"] = parsed
+            lines["{}-{}".format(parsed.chip, parsed.offset)] = parsed
     return lines
 
 
 def load_lines(
-    chip: str | None = None,
-    log: bool = True,
-    focus_offsets: set[int] | None = None,
-) -> dict[str, GpioLine]:
+    chip=None,
+    log=True,
+    focus_offsets=None,
+):
     """Discover GPIO lines, optionally limited to one chip."""
 
     require_commands()
@@ -304,7 +302,7 @@ def load_lines(
     return parse_gpioinfo(result.stdout, major)
 
 
-def initialize_test_state() -> TestState:
+def initialize_test_state():
     """Collect and cache version and full GPIO discovery for one test."""
 
     require_commands()
@@ -315,16 +313,18 @@ def initialize_test_state() -> TestState:
     return TestState(major=major, lines=parse_gpioinfo(result.stdout, major))
 
 
-def parse_line_id(identifier: str) -> tuple[str, int]:
+def parse_line_id(identifier):
     """Parse ``gpiochipN-LINE`` into chip name and line offset."""
 
     match = re.fullmatch(r"(gpiochip\d+)-(\d+)", identifier.strip())
     if not match:
-        raise GpioTestError(f"invalid GPIO line identifier: {identifier}")
+        raise GpioTestError(
+            "invalid GPIO line identifier: {}".format(identifier)
+        )
     return match.group(1), int(match.group(2))
 
 
-def parse_ignore(value: str | None, lines: dict[str, GpioLine]) -> set[str]:
+def parse_ignore(value, lines):
     """Expand ignore expressions into concrete ``gpiochipN-LINE`` keys.
 
     Supported input forms are ``gpiochipN-LINE``, ``gpiochipN-START..END``,
@@ -334,7 +334,7 @@ def parse_ignore(value: str | None, lines: dict[str, GpioLine]) -> set[str]:
     if not value:
         return set()
 
-    ignored: set[str] = set()
+    ignored = set()
     for raw_item in value.split(","):
         item = raw_item.strip()
         if not item:
@@ -354,24 +354,25 @@ def parse_ignore(value: str | None, lines: dict[str, GpioLine]) -> set[str]:
             start = int(range_match.group(2))
             end = int(range_match.group(3))
             if start > end:
-                raise GpioTestError(f"invalid ignore range: {item}")
+                raise GpioTestError("invalid ignore range: {}".format(item))
             ignored.update(
-                f"{chip}-{offset}" for offset in range(start, end + 1)
+                "{}-{}".format(chip, offset)
+                for offset in range(start, end + 1)
             )
             continue
 
         chip, offset = parse_line_id(item)
-        ignored.add(f"{chip}-{offset}")
+        ignored.add("{}-{}".format(chip, offset))
     return ignored
 
 
-def parse_pairs(value: str) -> list[tuple[str, int, str, int]]:
+def parse_pairs(value):
     """Parse comma-separated loopback pairs in ``INPUT:OUTPUT`` format."""
 
     pairs = []
     for item in value.split(","):
         if ":" not in item:
-            raise GpioTestError(f"invalid loopback pair: {item}")
+            raise GpioTestError("invalid loopback pair: {}".format(item))
         input_, output = item.split(":", 1)
         in_chip, in_line = parse_line_id(input_)
         out_chip, out_line = parse_line_id(output)
@@ -379,7 +380,7 @@ def parse_pairs(value: str) -> list[tuple[str, int, str, int]]:
     return pairs
 
 
-def emit_records(records: list[dict[str, object]], fmt: str) -> None:
+def emit_records(records, fmt):
     """Emit Checkbox resource records as text or JSON."""
 
     if fmt == "json":
@@ -387,11 +388,11 @@ def emit_records(records: list[dict[str, object]], fmt: str) -> None:
         return
     for record in records:
         for key, value in record.items():
-            print(f"{key}: {value}")
+            print("{}: {}".format(key, value))
         print()
 
 
-def resource_simple(args: argparse.Namespace) -> int:
+def resource_simple(args):
     """Generate unused GPIO line resources for simple input/output jobs."""
 
     lines = load_lines(log=False)
@@ -400,7 +401,7 @@ def resource_simple(args: argparse.Namespace) -> int:
     for key in sorted(
         lines,
         key=lambda item: (
-            int(item.split("-")[0].removeprefix("gpiochip")),
+            int(strip_prefix(item.split("-")[0], "gpiochip")),
             int(item.split("-")[1]),
         ),
     ):
@@ -412,26 +413,32 @@ def resource_simple(args: argparse.Namespace) -> int:
     return 0
 
 
-def resource_loopback(args: argparse.Namespace) -> int:
+def resource_loopback(args):
     """Generate validated GPIO loopback resources from pair definitions."""
 
     lines = load_lines(log=False)
     records = []
     for out_chip, out_line, in_chip, in_line in parse_pairs(args.pairs):
-        out_key = f"{out_chip}-{out_line}"
-        in_key = f"{in_chip}-{in_line}"
+        out_key = "{}-{}".format(out_chip, out_line)
+        in_key = "{}-{}".format(in_chip, in_line)
         if out_key == in_key:
             raise GpioTestError(
-                f"loopback output and input are the same line: {out_key}"
+                "loopback output and input are the same line: {}".format(
+                    out_key
+                )
             )
         if out_key not in lines:
-            raise GpioTestError(f"output line not found: {out_key}")
+            raise GpioTestError("output line not found: {}".format(out_key))
         if in_key not in lines:
-            raise GpioTestError(f"input line not found: {in_key}")
+            raise GpioTestError("input line not found: {}".format(in_key))
         if lines[out_key].used:
-            raise GpioTestError(f"output line is already used: {out_key}")
+            raise GpioTestError(
+                "output line is already used: {}".format(out_key)
+            )
         if lines[in_key].used:
-            raise GpioTestError(f"input line is already used: {in_key}")
+            raise GpioTestError(
+                "input line is already used: {}".format(in_key)
+            )
         records.append(
             {
                 "GPIO_OUTPUT_CHIP": out_chip,
@@ -444,65 +451,70 @@ def resource_loopback(args: argparse.Namespace) -> int:
     return 0
 
 
-def get_line_or_raise(chip: str, offset: int, purpose: str = "") -> GpioLine:
+def get_line_or_raise(chip, offset, purpose=""):
     """Find a line from fresh discovery or raise a step-aware error."""
 
-    label = f"{chip}-{offset}"
-    print_step(f"Find {purpose + ' ' if purpose else ''}{label}")
+    label = "{}-{}".format(chip, offset)
+    print_step("Find {}{}".format(purpose + " " if purpose else "", label))
     lines = load_lines(chip, log=True, focus_offsets={offset})
     if label not in lines:
-        raise StepError(f"Find {label}", f"GPIO line not found: {label}")
+        raise StepError(
+            "Find {}".format(label), "GPIO line not found: {}".format(label)
+        )
     return lines[label]
 
 
 def get_line_from_state_or_raise(
-    state: TestState,
-    chip: str,
-    offset: int,
-    purpose: str = "",
-) -> GpioLine:
+    state,
+    chip,
+    offset,
+    purpose="",
+):
     """Find a line in cached test state or raise a step-aware error."""
 
-    label = f"{chip}-{offset}"
-    print_step(f"Find {purpose + ' ' if purpose else ''}{label}")
+    label = "{}-{}".format(chip, offset)
+    print_step("Find {}{}".format(purpose + " " if purpose else "", label))
     if label not in state.lines:
-        raise StepError(f"Find {label}", f"GPIO line not found: {label}")
+        raise StepError(
+            "Find {}".format(label), "GPIO line not found: {}".format(label)
+        )
     return state.lines[label]
 
 
-def get_loopback_lines_or_raise(
-    args: argparse.Namespace, state: TestState
-) -> tuple[GpioLine, GpioLine]:
+def get_loopback_lines_or_raise(args, state):
     """Return output and input lines for a loopback test."""
 
-    out_label = f"{args.out_chip}-{args.out_line}"
-    in_label = f"{args.in_chip}-{args.in_line}"
+    out_label = "{}-{}".format(args.out_chip, args.out_line)
+    in_label = "{}-{}".format(args.in_chip, args.in_line)
 
-    print_step(f"Find input {in_label}")
-    print_step(f"Find output {out_label}")
+    print_step("Find input {}".format(in_label))
+    print_step("Find output {}".format(out_label))
 
     if out_label not in state.lines:
         raise StepError(
-            f"Find output {out_label}", f"GPIO line not found: {out_label}"
+            "Find output {}".format(out_label),
+            "GPIO line not found: {}".format(out_label),
         )
     if in_label not in state.lines:
         raise StepError(
-            f"Find input {in_label}", f"GPIO line not found: {in_label}"
+            "Find input {}".format(in_label),
+            "GPIO line not found: {}".format(in_label),
         )
     return state.lines[out_label], state.lines[in_label]
 
 
-def ensure_unused(line: GpioLine) -> None:
+def ensure_unused(line):
     """Fail the current step if a line is already requested."""
 
-    step = print_step(f"Check {line.chip}-{line.offset} is unused")
+    step = print_step("Check {}-{} is unused".format(line.chip, line.offset))
     if line.used:
         raise StepError(
-            step, f"GPIO line is already used: {line.chip}-{line.offset}"
+            step,
+            "GPIO line is already used: {}-{}".format(line.chip, line.offset),
         )
 
 
-def cmd_gpioget(chip: str, offset: int, major: int) -> list[str]:
+def cmd_gpioget(chip, offset, major):
     """Build the version-specific ``gpioget`` command."""
 
     if major == 2:
@@ -510,7 +522,7 @@ def cmd_gpioget(chip: str, offset: int, major: int) -> list[str]:
     return ["gpioget", chip, str(offset)]
 
 
-def cmd_gpioset(chip: str, offset: int, value: int, major: int) -> list[str]:
+def cmd_gpioset(chip, offset, value, major):
     """Build the version-specific non-holding ``gpioset`` command."""
 
     if major == 2:
@@ -520,28 +532,28 @@ def cmd_gpioset(chip: str, offset: int, value: int, major: int) -> list[str]:
             "0",
             "--chip",
             chip,
-            f"{offset}={value}",
+            "{}={}".format(offset, value),
         ]
-    return ["gpioset", chip, f"{offset}={value}"]
+    return ["gpioset", chip, "{}={}".format(offset, value)]
 
 
-def read_value(chip: str, offset: int, major: int) -> int:
+def read_value(chip, offset, major):
     """Read a GPIO value through ``gpioget``."""
 
     result = run_command(cmd_gpioget(chip, offset, major))
     output = result.stdout.strip()
     if output not in ("0", "1"):
-        raise GpioTestError(f"unexpected GPIO value: {output!r}")
+        raise GpioTestError("unexpected GPIO value: {!r}".format(output))
     return int(output)
 
 
-def set_value(chip: str, offset: int, value: int, major: int) -> None:
+def set_value(chip, offset, value, major):
     """Set a GPIO value through non-holding ``gpioset``."""
 
     run_command(cmd_gpioset(chip, offset, value, major))
 
 
-def save_line_state(line: GpioLine, major: int) -> SavedLineState:
+def save_line_state(line, major):
     """Save the original direction and readable output value."""
 
     value = (
@@ -552,7 +564,7 @@ def save_line_state(line: GpioLine, major: int) -> SavedLineState:
     return SavedLineState(line=line, value=value)
 
 
-def restore_line_state(saved: SavedLineState, major: int) -> None:
+def restore_line_state(saved, major):
     """Restore one line to its original direction and saved value."""
 
     line = saved.line
@@ -567,9 +579,7 @@ def restore_line_state(saved: SavedLineState, major: int) -> None:
         )
 
 
-def recover_saved_states(
-    states: list[SavedLineState], major: int | None
-) -> None:
+def recover_saved_states(states, major):
     """Best-effort restoration for all saved line states."""
 
     if major is None:
@@ -578,32 +588,31 @@ def recover_saved_states(
         try:
             restore_line_state(saved, major)
         except Exception as exc:
-            line_id = f"{saved.line.chip}-{saved.line.offset}"
+            line_id = "{}-{}".format(saved.line.chip, saved.line.offset)
             print(
-                f"GPIO_RECOVERY_ERROR={line_id}: {exc}",
+                "GPIO_RECOVERY_ERROR={}: {}".format(line_id, exc),
                 file=sys.stderr,
             )
 
 
-def cmd_gpioset_hold(
-    chip: str, offset: int, value: int, major: int
-) -> list[str]:
+def cmd_gpioset_hold(chip, offset, value, major):
     """Build a ``gpioset`` command that holds the requested value."""
 
     if major == 2:
-        return ["gpioset", "--chip", chip, f"{offset}={value}"]
-    return ["gpioset", "--mode=signal", chip, f"{offset}={value}"]
+        return ["gpioset", "--chip", chip, "{}={}".format(offset, value)]
+    return ["gpioset", "--mode=signal", chip, "{}={}".format(offset, value)]
 
 
-def start_held_value(
-    chip: str, offset: int, value: int, major: int
-) -> subprocess.Popen[str]:
+def start_held_value(chip, offset, value, major):
     """Start ``gpioset`` and keep the output value asserted."""
 
     command = cmd_gpioset_hold(chip, offset, value, major)
     print_command(command)
     proc = subprocess.Popen(
-        command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
     )
     time.sleep(0.05)
     if proc.poll() is not None:
@@ -613,12 +622,13 @@ def start_held_value(
         )
         detail = (stderr or stdout).strip()
         raise GpioTestError(
-            detail or f"command failed with exit code {proc.returncode}"
+            detail
+            or "command failed with exit code {}".format(proc.returncode)
         )
     return proc
 
 
-def stop_held_value(proc: subprocess.Popen[str]) -> None:
+def stop_held_value(proc):
     """Terminate a held ``gpioset`` process and print any output."""
 
     proc.send_signal(signal.SIGTERM)
@@ -630,80 +640,90 @@ def stop_held_value(proc: subprocess.Popen[str]) -> None:
     print_command_output(CommandResult(stdout, stderr, proc.returncode or 0))
 
 
-def release_line(chip: str, offset: int) -> None:
+def release_line(chip, offset):
     """Log release of a line after a one-shot command has exited."""
 
-    print_step(f"Release {chip}-{offset}")
+    print_step("Release {}-{}".format(chip, offset))
 
 
-def test_simple_input(args: argparse.Namespace) -> int:
+def test_simple_input(args):
     """Run the simple input test for one GPIO line."""
 
     try:
-        print_test_header("GPIO simple input", f"{args.chip}-{args.line}")
+        print_test_header(
+            "GPIO simple input", "{}-{}".format(args.chip, args.line)
+        )
         state = initialize_test_state()
         line = get_line_from_state_or_raise(state, args.chip, args.line)
         ensure_unused(line)
-        print_step(f"Request {args.chip}-{args.line} as input")
+        print_step("Request {}-{} as input".format(args.chip, args.line))
         print_detail(
             "note",
             "gpioget requests the line as input when the read command runs",
         )
-        print_step(f"Read value from {args.chip}-{args.line}")
+        print_step("Read value from {}-{}".format(args.chip, args.line))
         value = read_value(args.chip, args.line, state.major)
         release_line(args.chip, args.line)
-        print(f"GPIO_VALUE={value}")
+        print("GPIO_VALUE={}".format(value))
         print_result("pass")
         return 0
     except Exception as exc:
         return fail_current_step(exc)
 
 
-def test_simple_output(args: argparse.Namespace) -> int:
+def test_simple_output(args):
     """Run the simple output low/high test for one GPIO line."""
 
-    saved: SavedLineState | None = None
-    major: int | None = None
+    saved = None
+    major = None
     try:
-        print_test_header("GPIO simple output", f"{args.chip}-{args.line}")
+        print_test_header(
+            "GPIO simple output", "{}-{}".format(args.chip, args.line)
+        )
         state = initialize_test_state()
         major = state.major
         line = get_line_from_state_or_raise(state, args.chip, args.line)
         ensure_unused(line)
-        print_step(f"Save original state for {args.chip}-{args.line}")
+        print_step(
+            "Save original state for {}-{}".format(args.chip, args.line)
+        )
         saved = save_line_state(line, state.major)
-        print_step(f"Request {args.chip}-{args.line} as output")
+        print_step("Request {}-{} as output".format(args.chip, args.line))
         print_detail(
             "note",
             "gpioset requests the line as output when the set command runs",
         )
-        print_step(f"Set {args.chip}-{args.line} low")
+        print_step("Set {}-{} low".format(args.chip, args.line))
         set_value(args.chip, args.line, 0, state.major)
-        print_step(f"Set {args.chip}-{args.line} high")
+        print_step("Set {}-{} high".format(args.chip, args.line))
         set_value(args.chip, args.line, 1, state.major)
-        print_step(f"Recover original state for {args.chip}-{args.line}")
+        print_step(
+            "Recover original state for {}-{}".format(args.chip, args.line)
+        )
         restore_line_state(saved, state.major)
         release_line(args.chip, args.line)
         print_result("pass")
         return 0
     except Exception as exc:
         if saved is not None:
-            print_step(f"Recover original state for {args.chip}-{args.line}")
+            print_step(
+                "Recover original state for {}-{}".format(args.chip, args.line)
+            )
             recover_saved_states([saved], major)
         return fail_current_step(exc)
 
 
-def test_loopback(args: argparse.Namespace) -> int:
+def test_loopback(args):
     """Run a physical loopback test using an input/output line pair."""
 
-    saved_states: list[SavedLineState] = []
-    major: int | None = None
+    saved_states = []
+    major = None
     try:
-        in_id = f"{args.in_chip}-{args.in_line}"
-        out_id = f"{args.out_chip}-{args.out_line}"
+        in_id = "{}-{}".format(args.in_chip, args.in_line)
+        out_id = "{}-{}".format(args.out_chip, args.out_line)
         print_test_header(
             "GPIO loopback",
-            f"input={in_id} output={out_id}",
+            "input={} output={}".format(in_id, out_id),
         )
         state = initialize_test_state()
         major = state.major
@@ -713,89 +733,93 @@ def test_loopback(args: argparse.Namespace) -> int:
                 "Check loopback lines", "output and input line are the same"
             )
 
-        step = print_step(f"Check {out_id} and {in_id} are unused")
+        step = print_step("Check {} and {} are unused".format(out_id, in_id))
         if output.used or input_.used:
             raise StepError(
                 step, "one or both loopback lines are already used"
             )
 
-        print_step(f"Save original state for {out_id} and {in_id}")
+        print_step("Save original state for {} and {}".format(out_id, in_id))
         saved_states = [
             save_line_state(output, state.major),
             save_line_state(input_, state.major),
         ]
-        print_step(f"Request {out_id} as output")
+        print_step("Request {} as output".format(out_id))
         print_detail("note", "gpioset requests and holds output during read")
-        print_step(f"Request {in_id} as input")
+        print_step("Request {} as input".format(in_id))
         print_detail(
             "note",
             "gpioget requests the input line when each read command runs",
         )
 
-        held: subprocess.Popen[str] | None = None
+        held = None
         for _ in range(args.repeat):
-            print_step(f"Set {out_id} low")
+            print_step("Set {} low".format(out_id))
             held = start_held_value(
                 args.out_chip, args.out_line, 0, state.major
             )
             try:
                 time.sleep(args.delay)
-                print_step(f"Verify {in_id} reads low")
+                print_step("Verify {} reads low".format(in_id))
                 if read_value(args.in_chip, args.in_line, state.major) != 0:
                     raise StepError(
-                        f"Verify {in_id} reads low",
+                        "Verify {} reads low".format(in_id),
                         "input did not read low",
                     )
             finally:
                 stop_held_value(held)
                 held = None
 
-            print_step(f"Set {out_id} high")
+            print_step("Set {} high".format(out_id))
             held = start_held_value(
                 args.out_chip, args.out_line, 1, state.major
             )
             try:
                 time.sleep(args.delay)
-                print_step(f"Verify {in_id} reads high")
+                print_step("Verify {} reads high".format(in_id))
                 if read_value(args.in_chip, args.in_line, state.major) != 1:
                     raise StepError(
-                        f"Verify {in_id} reads high",
+                        "Verify {} reads high".format(in_id),
                         "input did not read high",
                     )
             finally:
                 stop_held_value(held)
                 held = None
 
-        print_step(f"Recover original state for {out_id} and {in_id}")
+        print_step(
+            "Recover original state for {} and {}".format(out_id, in_id)
+        )
         recover_saved_states(saved_states, state.major)
-        print_step(f"Release {out_id} and {in_id}")
+        print_step("Release {} and {}".format(out_id, in_id))
         print_result("pass")
         return 0
     except Exception as exc:
         if saved_states:
-            print_step(f"Recover original state for {out_id} and {in_id}")
+            print_step(
+                "Recover original state for {} and {}".format(out_id, in_id)
+            )
             recover_saved_states(saved_states, major)
         return fail_current_step(exc)
 
 
-def fail_current_step(exc: Exception) -> int:
+def fail_current_step(exc):
     """Print a failed result and return a Checkbox-compatible exit code."""
 
     if isinstance(exc, StepError):
         print()
-        print(f"[FAIL] {exc.step}")
+        print("[FAIL] {}".format(exc.step))
         print_detail("error", exc.message)
-        print(f"GPIO_ERROR={exc.message}", file=sys.stderr)
+        print("GPIO_ERROR={}".format(exc.message), file=sys.stderr)
     else:
         print()
         print("[FAIL] GPIO test failed")
         print_detail("error", exc)
-        print(f"GPIO_ERROR={exc}", file=sys.stderr)
+        print("GPIO_ERROR={}".format(exc), file=sys.stderr)
     print_result("fail")
     return 1
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser():
     """Create the command-line parser for resources and tests."""
 
     formatter = argparse.RawDescriptionHelpFormatter
@@ -912,7 +936,7 @@ def build_parser() -> argparse.ArgumentParser:
 class SubprocessGpioApplication:
     """Command-line application for subprocess-based GPIO validation."""
 
-    def __init__(self, parser: argparse.ArgumentParser) -> None:
+    def __init__(self, parser):
         """Initialize the application with an argument parser.
 
         Args:
@@ -921,7 +945,7 @@ class SubprocessGpioApplication:
 
         self._parser = parser
 
-    def run(self, argv: list[str] | None = None) -> int:
+    def run(self, argv=None):
         """Parse arguments and run the selected resource or test command.
 
         Args:
@@ -935,11 +959,11 @@ class SubprocessGpioApplication:
         try:
             return args.func(args)
         except GpioTestError as exc:
-            print(f"GPIO_ERROR={exc}", file=sys.stderr)
+            print("GPIO_ERROR={}".format(exc), file=sys.stderr)
             return 1
 
 
-def main() -> int:
+def main():
     """Parse arguments and dispatch to the selected subcommand."""
 
     return SubprocessGpioApplication(build_parser()).run()

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_subprocess.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/gpio_test_subprocess.py
@@ -387,7 +387,7 @@ def emit_records(records: list[dict[str, object]], fmt: str) -> None:
         return
     for record in records:
         for key, value in record.items():
-            print(f"{key}={value}")
+            print(f"{key}: {value}")
         print()
 
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/README.md
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/README.md
@@ -1,0 +1,106 @@
+# GPIO Tests
+
+The GPIO tests validate GPIO lines through `libgpiod`. The resource jobs
+discover lines with the `gpio_test_subprocess.py` helper and generate one test
+job for each eligible GPIO line or loopback pair.
+
+These tests do not use the deprecated `/sys/class/gpio` interface.
+
+## Common setup
+
+Enable the `libgpiod` GPIO tests with the `has_gpiod_gpio` manifest entry:
+
+```ini
+[manifest]
+has_gpiod_gpio = true
+```
+
+The test device needs the `gpiod` command-line tools available in the test
+environment:
+
+```bash
+sudo apt install gpiod
+```
+
+To inspect GPIO chips and line names on the target device, run:
+
+```bash
+sudo gpioinfo
+```
+
+Use the stable chip name and line offset shown by `gpioinfo`, for example
+`gpiochip0-8`. The scripts support both `libgpiod` v1 and v2 command output.
+
+## `ce-oem-gpiod-gpio/simple-input-GPIO_CHIP-GPIO_LINE`
+
+This template job requests one generated GPIO line as input and reads its value.
+Generated jobs come from the `ce-oem-gpiod-gpio/simple-resource` resource job.
+
+## `ce-oem-gpiod-gpio/simple-output-GPIO_CHIP-GPIO_LINE`
+
+This template job requests one generated GPIO line as output, drives it low and
+high, then restores the original direction and value when possible. Generated
+jobs come from the `ce-oem-gpiod-gpio/simple-resource` resource job.
+
+### Optional environment variables
+
+Use these variables in the launcher `[environment]` section when needed:
+
+| Variable                 | Description                                 | Default |
+|--------------------------|---------------------------------------------|---------|
+| `GPIOD_GPIO_IGNORE`      | GPIO lines, ranges, or chips to skip.       | Not set |
+| `GPIOD_GPIO_ALLOW_NAMED` | Compatibility option; named lines are used. | Not set |
+
+`GPIOD_GPIO_IGNORE` accepts multiple values separated by commas. Each value can
+be one of:
+
+- one line, for example `gpiochip0-2`
+- a line range, for example `gpiochip16-0..4`
+- a whole chip, for example `gpiochip14`
+- a whole chip wildcard, for example `gpiochip14-*`
+
+### Example simple-test launcher environment
+
+```ini
+[environment]
+GPIOD_GPIO_IGNORE = gpiochip14-*,gpiochip16-0..4
+GPIOD_GPIO_ALLOW_NAMED = true
+```
+
+Named unused GPIO lines are included by default. Use `GPIOD_GPIO_IGNORE` to skip
+lines that appear unused but should not be driven, such as platform reset,
+power, interrupt, or externally connected I/O lines.
+
+## `ce-oem-gpiod-gpio/loopback-input-GPIO_INPUT_CHIP-GPIO_INPUT_LINE-output-GPIO_OUTPUT_CHIP-GPIO_OUTPUT_LINE`
+
+This template job drives one GPIO output line and verifies that a physically
+connected GPIO input line follows low and high states. Generated jobs come from
+the `ce-oem-gpiod-gpio/loopback-resource` resource job.
+
+### Required environment variables
+
+Use this variable in the launcher `[environment]` section:
+
+| Variable                   | Description                                    | Default  |
+|----------------------------|------------------------------------------------|----------|
+| `GPIOD_GPIO_LOOPBACK_PAIRS` | Comma-separated loopback pairs in `INPUT:OUTPUT` format. | Not set |
+
+Each pair uses `INPUT:OUTPUT` order. For example, if `gpiochip0-100` is wired
+to read the signal driven by `gpiochip0-0`, use:
+
+```ini
+[environment]
+GPIOD_GPIO_LOOPBACK_PAIRS = gpiochip0-100:gpiochip0-0
+```
+
+Multiple pairs are separated by commas:
+
+```ini
+[environment]
+GPIOD_GPIO_LOOPBACK_PAIRS = gpiochip0-100:gpiochip0-0,gpiochip1-2:gpiochip1-1
+```
+
+Before enabling loopback jobs, verify the physical wiring and any board-level
+requirements such as common ground, external power, or isolated digital I/O
+terminal wiring. Some lines shown by `gpioinfo` are control lines for external
+I/O circuitry and may not behave as direct SoC GPIO loopbacks.

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
@@ -118,7 +118,7 @@ command:
             set -- "$@" --allow-named
             ;;
     esac
-    gpio_test_subprocess.py resource simple "$@" --format text | sed 's/=/\: /'
+    gpio_test_subprocess.py resource simple "$@" --format text
 
 
 unit: template
@@ -179,7 +179,7 @@ command:
         echo "GPIOD_GPIO_LOOPBACK_PAIRS is not defined" >&2
         exit 1
     fi
-    gpio_test_subprocess.py resource loopback --pairs "$GPIOD_GPIO_LOOPBACK_PAIRS" --format text | sed 's/=/\: /'
+    gpio_test_subprocess.py resource loopback --pairs "$GPIOD_GPIO_LOOPBACK_PAIRS" --format text
 
 
 unit: template

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
@@ -124,12 +124,13 @@ command:
 unit: template
 template-resource: ce-oem-gpiod-gpio/simple-resource
 template-unit: job
-template-id: ce-oem-gpiod-gpio/simple-input
-_template-summary: Test libgpiod GPIO input on {GPIO_CHIP}-{GPIO_LINE}
-id: ce-oem-gpiod-gpio/simple-input-{GPIO_CHIP}-{GPIO_LINE}
-_summary: Test libgpiod GPIO input on {GPIO_CHIP}-{GPIO_LINE}
+template-engine: jinja2
+template-id: ce-oem-gpiod-gpio/simple-input-GPIO_CHIP-GPIO_LINE
+_template-summary: Test libgpiod GPIO input on {{GPIO_CHIP}}-{{GPIO_LINE}}
+id: ce-oem-gpiod-gpio/simple-input-{{GPIO_CHIP}}-{{GPIO_LINE}}
+_summary: Test libgpiod GPIO input on {{GPIO_CHIP}}-{{GPIO_LINE}}
 _description:
-    Request GPIO line {GPIO_CHIP}-{GPIO_LINE} as input through
+    Request GPIO line {{GPIO_CHIP}}-{{GPIO_LINE}} as input through
     libgpiod and read its value.
 plugin: shell
 user: root
@@ -139,18 +140,19 @@ requires: manifest.has_gpiod_gpio == 'True'
 estimated_duration: 10s
 flags: also-after-suspend
 command:
-    gpio_test_subprocess.py test simple input {GPIO_CHIP} {GPIO_LINE}
+    gpio_test_subprocess.py test simple input {{GPIO_CHIP}} {{GPIO_LINE}}
 
 
 unit: template
 template-resource: ce-oem-gpiod-gpio/simple-resource
 template-unit: job
-template-id: ce-oem-gpiod-gpio/simple-output
-_template-summary: Test libgpiod GPIO output on {GPIO_CHIP}-{GPIO_LINE}
-id: ce-oem-gpiod-gpio/simple-output-{GPIO_CHIP}-{GPIO_LINE}
-_summary: Test libgpiod GPIO output on {GPIO_CHIP}-{GPIO_LINE}
+template-engine: jinja2
+template-id: ce-oem-gpiod-gpio/simple-output-GPIO_CHIP-GPIO_LINE
+_template-summary: Test libgpiod GPIO output on {{GPIO_CHIP}}-{{GPIO_LINE}}
+id: ce-oem-gpiod-gpio/simple-output-{{GPIO_CHIP}}-{{GPIO_LINE}}
+_summary: Test libgpiod GPIO output on {{GPIO_CHIP}}-{{GPIO_LINE}}
 _description:
-    Request GPIO line {GPIO_CHIP}-{GPIO_LINE} as output through
+    Request GPIO line {{GPIO_CHIP}}-{{GPIO_LINE}} as output through
     libgpiod, toggle low/high, and restore its original state.
 plugin: shell
 user: root
@@ -160,7 +162,7 @@ requires: manifest.has_gpiod_gpio == 'True'
 estimated_duration: 10s
 flags: also-after-suspend
 command:
-    gpio_test_subprocess.py test simple output {GPIO_CHIP} {GPIO_LINE}
+    gpio_test_subprocess.py test simple output {{GPIO_CHIP}} {{GPIO_LINE}}
 
 
 id: ce-oem-gpiod-gpio/loopback-resource
@@ -185,13 +187,14 @@ command:
 unit: template
 template-resource: ce-oem-gpiod-gpio/loopback-resource
 template-unit: job
-template-id: ce-oem-gpiod-gpio/loopback
+template-engine: jinja2
+template-id: ce-oem-gpiod-gpio/loopback-input-GPIO_INPUT_CHIP-GPIO_INPUT_LINE-output-GPIO_OUTPUT_CHIP-GPIO_OUTPUT_LINE
 _template-summary: Test libgpiod GPIO loopback
-id: ce-oem-gpiod-gpio/loopback-input-{GPIO_INPUT_CHIP}-{GPIO_INPUT_LINE}-output-{GPIO_OUTPUT_CHIP}-{GPIO_OUTPUT_LINE}
+id: ce-oem-gpiod-gpio/loopback-input-{{GPIO_INPUT_CHIP}}-{{GPIO_INPUT_LINE}}-output-{{GPIO_OUTPUT_CHIP}}-{{GPIO_OUTPUT_LINE}}
 _summary: Test libgpiod GPIO loopback
 _description:
-    Drive GPIO output line {GPIO_OUTPUT_CHIP}-{GPIO_OUTPUT_LINE} and
-    verify GPIO input line {GPIO_INPUT_CHIP}-{GPIO_INPUT_LINE} follows
+    Drive GPIO output line {{GPIO_OUTPUT_CHIP}}-{{GPIO_OUTPUT_LINE}} and
+    verify GPIO input line {{GPIO_INPUT_CHIP}}-{{GPIO_INPUT_LINE}} follows
     low and high states through libgpiod.
 plugin: shell
 user: root
@@ -201,4 +204,4 @@ requires: manifest.has_gpiod_gpio == 'True'
 estimated_duration: 20s
 flags: also-after-suspend
 command:
-    gpio_test_subprocess.py test loopback {GPIO_INPUT_CHIP} {GPIO_INPUT_LINE} {GPIO_OUTPUT_CHIP} {GPIO_OUTPUT_LINE}
+    gpio_test_subprocess.py test loopback {{GPIO_INPUT_CHIP}} {{GPIO_INPUT_LINE}} {{GPIO_OUTPUT_CHIP}} {{GPIO_OUTPUT_LINE}}

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
@@ -92,3 +92,72 @@ command:
     echo "## Perform the GPIO loopback test"
     gpio_loopback_test.py -oc {{OUTPUT_GPIO_CHIP_NUMBER}} -ic {{INPUT_GPIO_CHIP_NUMBER}} -po {{PHYSICAL_OUTPUT_PORT}} -go {{GPIO_OUTPUT_PIN}} -pi {{PHYSICAL_INPUT_PORT}} -gi {{GPIO_INPUT_PIN}}
 
+
+id: ce-oem-gpiod-gpio/simple-resource
+_summary: Generates libgpiod GPIO lines for simple GPIO tests
+_description:
+    Generates GPIO line resources for libgpiod-based GPIO simple tests.
+    Use GPIOD_GPIO_IGNORE to exclude unsafe lines. Supported ignore
+    formats include gpiochip14, gpiochip14-*, gpiochip16-0..4, and
+    comma-separated combinations. GPIOD_GPIO_ALLOW_NAMED is accepted for
+    compatibility; named unused lines are included by default.
+estimated_duration: 0.02
+category_id: com.canonical.certification::gpio
+plugin: resource
+user: root
+environ:
+    GPIOD_GPIO_IGNORE
+    GPIOD_GPIO_ALLOW_NAMED
+command:
+    set --
+    if [ -n "$GPIOD_GPIO_IGNORE" ]; then
+        set -- "$@" --ignore "$GPIOD_GPIO_IGNORE"
+    fi
+    case "$GPIOD_GPIO_ALLOW_NAMED" in
+        1|true|True|yes|Yes)
+            set -- "$@" --allow-named
+            ;;
+    esac
+    gpio_test_subprocess.py resource simple "$@" --format text | sed 's/=/\: /'
+
+
+unit: template
+template-resource: ce-oem-gpiod-gpio/simple-resource
+template-unit: job
+template-id: ce-oem-gpiod-gpio/simple-input
+_template-summary: Test libgpiod GPIO input on {GPIO_CHIP}-{GPIO_LINE}
+id: ce-oem-gpiod-gpio/simple-input-{GPIO_CHIP}-{GPIO_LINE}
+_summary: Test libgpiod GPIO input on {GPIO_CHIP}-{GPIO_LINE}
+_description:
+    Request GPIO line {GPIO_CHIP}-{GPIO_LINE} as input through
+    libgpiod and read its value.
+plugin: shell
+user: root
+category_id: com.canonical.certification::gpio
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_gpiod_gpio == 'True'
+estimated_duration: 10s
+flags: also-after-suspend
+command:
+    gpio_test_subprocess.py test simple input {GPIO_CHIP} {GPIO_LINE}
+
+
+unit: template
+template-resource: ce-oem-gpiod-gpio/simple-resource
+template-unit: job
+template-id: ce-oem-gpiod-gpio/simple-output
+_template-summary: Test libgpiod GPIO output on {GPIO_CHIP}-{GPIO_LINE}
+id: ce-oem-gpiod-gpio/simple-output-{GPIO_CHIP}-{GPIO_LINE}
+_summary: Test libgpiod GPIO output on {GPIO_CHIP}-{GPIO_LINE}
+_description:
+    Request GPIO line {GPIO_CHIP}-{GPIO_LINE} as output through
+    libgpiod, toggle low/high, and restore its original state.
+plugin: shell
+user: root
+category_id: com.canonical.certification::gpio
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_gpiod_gpio == 'True'
+estimated_duration: 10s
+flags: also-after-suspend
+command:
+    gpio_test_subprocess.py test simple output {GPIO_CHIP} {GPIO_LINE}

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
@@ -161,3 +161,44 @@ estimated_duration: 10s
 flags: also-after-suspend
 command:
     gpio_test_subprocess.py test simple output {GPIO_CHIP} {GPIO_LINE}
+
+
+id: ce-oem-gpiod-gpio/loopback-resource
+_summary: Generates libgpiod GPIO loopback pairs
+_description:
+    Generates GPIO loopback resources for libgpiod-based GPIO loopback tests.
+    Define GPIOD_GPIO_LOOPBACK_PAIRS with comma-separated INPUT:OUTPUT pairs.
+    Example: GPIOD_GPIO_LOOPBACK_PAIRS=gpiochip0-100:gpiochip0-0
+estimated_duration: 0.02
+category_id: com.canonical.certification::gpio
+plugin: resource
+user: root
+environ: GPIOD_GPIO_LOOPBACK_PAIRS
+command:
+    if [ -z "$GPIOD_GPIO_LOOPBACK_PAIRS" ]; then
+        echo "GPIOD_GPIO_LOOPBACK_PAIRS is not defined" >&2
+        exit 1
+    fi
+    gpio_test_subprocess.py resource loopback --pairs "$GPIOD_GPIO_LOOPBACK_PAIRS" --format text | sed 's/=/\: /'
+
+
+unit: template
+template-resource: ce-oem-gpiod-gpio/loopback-resource
+template-unit: job
+template-id: ce-oem-gpiod-gpio/loopback
+_template-summary: Test libgpiod GPIO loopback
+id: ce-oem-gpiod-gpio/loopback-input-{GPIO_INPUT_CHIP}-{GPIO_INPUT_LINE}-output-{GPIO_OUTPUT_CHIP}-{GPIO_OUTPUT_LINE}
+_summary: Test libgpiod GPIO loopback
+_description:
+    Drive GPIO output line {GPIO_OUTPUT_CHIP}-{GPIO_OUTPUT_LINE} and
+    verify GPIO input line {GPIO_INPUT_CHIP}-{GPIO_INPUT_LINE} follows
+    low and high states through libgpiod.
+plugin: shell
+user: root
+category_id: com.canonical.certification::gpio
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_gpiod_gpio == 'True'
+estimated_duration: 20s
+flags: also-after-suspend
+command:
+    gpio_test_subprocess.py test loopback {GPIO_INPUT_CHIP} {GPIO_INPUT_LINE} {GPIO_OUTPUT_CHIP} {GPIO_OUTPUT_LINE}

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
@@ -105,6 +105,8 @@ estimated_duration: 0.02
 category_id: com.canonical.certification::gpio
 plugin: resource
 user: root
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_gpiod_gpio == 'True'
 environ:
     GPIOD_GPIO_IGNORE
     GPIOD_GPIO_ALLOW_NAMED
@@ -175,11 +177,12 @@ estimated_duration: 0.02
 category_id: com.canonical.certification::gpio
 plugin: resource
 user: root
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_gpiod_gpio == 'True'
 environ: GPIOD_GPIO_LOOPBACK_PAIRS
 command:
     if [ -z "$GPIOD_GPIO_LOOPBACK_PAIRS" ]; then
-        echo "GPIOD_GPIO_LOOPBACK_PAIRS is not defined" >&2
-        exit 1
+        exit 0
     fi
     gpio_test_subprocess.py resource loopback --pairs "$GPIOD_GPIO_LOOPBACK_PAIRS" --format text
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
@@ -153,7 +153,7 @@ template-id: ce-oem-gpiod-gpio/simple-output-GPIO_CHIP-GPIO_LINE
 _template-summary: Test libgpiod GPIO output on {{GPIO_CHIP}}-{{GPIO_LINE}}
 id: ce-oem-gpiod-gpio/simple-output-{{GPIO_CHIP}}-{{GPIO_LINE}}
 _summary: Test libgpiod GPIO output on {{GPIO_CHIP}}-{{GPIO_LINE}}
-_description:
+_purpose:
     Request GPIO line {{GPIO_CHIP}}-{{GPIO_LINE}} as output through
     libgpiod, toggle low/high, and restore its original state.
 plugin: shell

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
@@ -131,7 +131,7 @@ template-id: ce-oem-gpiod-gpio/simple-input-GPIO_CHIP-GPIO_LINE
 _template-summary: Test libgpiod GPIO input on {{GPIO_CHIP}}-{{GPIO_LINE}}
 id: ce-oem-gpiod-gpio/simple-input-{{GPIO_CHIP}}-{{GPIO_LINE}}
 _summary: Test libgpiod GPIO input on {{GPIO_CHIP}}-{{GPIO_LINE}}
-_description:
+_purpose:
     Request GPIO line {{GPIO_CHIP}}-{{GPIO_LINE}} as input through
     libgpiod and read its value.
 plugin: shell

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
@@ -195,7 +195,7 @@ template-id: ce-oem-gpiod-gpio/loopback-input-GPIO_INPUT_CHIP-GPIO_INPUT_LINE-ou
 _template-summary: Test libgpiod GPIO loopback
 id: ce-oem-gpiod-gpio/loopback-input-{{GPIO_INPUT_CHIP}}-{{GPIO_INPUT_LINE}}-output-{{GPIO_OUTPUT_CHIP}}-{{GPIO_OUTPUT_LINE}}
 _summary: Test libgpiod GPIO loopback
-_description:
+_purpose:
     Drive GPIO output line {{GPIO_OUTPUT_CHIP}}-{{GPIO_OUTPUT_LINE}} and
     verify GPIO input line {{GPIO_INPUT_CHIP}}-{{GPIO_INPUT_LINE}} follows
     low and high states through libgpiod.

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
@@ -95,7 +95,7 @@ command:
 
 id: ce-oem-gpiod-gpio/simple-resource
 _summary: Generates libgpiod GPIO lines for simple GPIO tests
-_description:
+_purpose:
     Generates GPIO line resources for libgpiod-based GPIO simple tests.
     Use GPIOD_GPIO_IGNORE to exclude unsafe lines. Supported ignore
     formats include gpiochip14, gpiochip14-*, gpiochip16-0..4, and

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
@@ -169,7 +169,7 @@ command:
 
 id: ce-oem-gpiod-gpio/loopback-resource
 _summary: Generates libgpiod GPIO loopback pairs
-_description:
+_purpose:
     Generates GPIO loopback resources for libgpiod-based GPIO loopback tests.
     Define GPIOD_GPIO_LOOPBACK_PAIRS with comma-separated INPUT:OUTPUT pairs.
     Example: GPIOD_GPIO_LOOPBACK_PAIRS=gpiochip0-100:gpiochip0-0

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/manifest.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/manifest.pxu
@@ -2,3 +2,8 @@ unit: manifest entry
 id: has_gpio_slot_been_defined
 _name: Does platform has GPIO slots been defined in Gadget snap?
 value-type: bool
+
+unit: manifest entry
+id: has_gpiod_gpio
+_name: Does platform support GPIO testing through libgpiod?
+value-type: bool

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/test-plan.pxu
@@ -26,6 +26,6 @@ include:
     ce-oem-gpio/loopback-on-phycial-output-.*-input-.*
     ce-oem-gpio/check-slots
     ce-oem-gpio/node-export-test
-    ce-oem-gpiod-gpio/simple-input
-    ce-oem-gpiod-gpio/simple-output
-    ce-oem-gpiod-gpio/loopback
+    ce-oem-gpiod-gpio/simple-input-GPIO_CHIP-GPIO_LINE
+    ce-oem-gpiod-gpio/simple-output-GPIO_CHIP-GPIO_LINE
+    ce-oem-gpiod-gpio/loopback-input-GPIO_INPUT_CHIP-GPIO_INPUT_LINE-output-GPIO_OUTPUT_CHIP-GPIO_OUTPUT_LINE

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/test-plan.pxu
@@ -21,9 +21,11 @@ bootstrap_include:
     ce-oem-gpio-gadget-slots
     gpio_loopback_pin_mapping
     ce-oem-gpiod-gpio/simple-resource
+    ce-oem-gpiod-gpio/loopback-resource
 include:
     ce-oem-gpio/loopback-on-phycial-output-.*-input-.*
     ce-oem-gpio/check-slots
     ce-oem-gpio/node-export-test
     ce-oem-gpiod-gpio/simple-input
     ce-oem-gpiod-gpio/simple-output
+    ce-oem-gpiod-gpio/loopback

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/test-plan.pxu
@@ -20,7 +20,10 @@ _description: Automated GPIO tests for devices
 bootstrap_include:
     ce-oem-gpio-gadget-slots
     gpio_loopback_pin_mapping
+    ce-oem-gpiod-gpio/simple-resource
 include:
     ce-oem-gpio/loopback-on-phycial-output-.*-input-.*
     ce-oem-gpio/check-slots
     ce-oem-gpio/node-export-test
+    ce-oem-gpiod-gpio/simple-input
+    ce-oem-gpiod-gpio/simple-output


### PR DESCRIPTION
## Description
 - Adds CE OEM GPIO tests based on libgpiod.
 - Provides two helper scripts: - gpio_test_subprocess.py: uses gpiod command-line tools.
 - gpio_test_python.py: uses Python gpiod bindings.
 - Checkbox units currently use gpio_test_subprocess.py.
 - Adds has_gpiod_gpio manifest entry.
 - Adds simple input/output and loopback resource/template jobs.
 - Supports GPIOD_GPIO_IGNORE and GPIOD_GPIO_LOOPBACK_PAIRS.

## Resolved issues
 - sysfs GPIO is not available for the target kernel path.
 - GPIO validation needs to move to libgpiod.

## Documentation

 - GPIO README added under:
 contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/README.md



## Tests


