### PR TITLE
Add SocketCAN interface presence check (New)

### DIFF
--- a/providers/base/bin/socketcan_test.py
+++ b/providers/base/bin/socketcan_test.py
@@ -21,6 +21,7 @@ import argparse
 import ctypes
 import os
 import socket
+import subprocess
 import struct
 import sys
 import textwrap
@@ -173,20 +174,53 @@ def echo_test(args):
     print("\nPASSED")
 
 
+def get_can_interface_count():
+    result = subprocess.run(
+        ["ip", "-o", "link", "show", "type", "can"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return len([line for line in result.stdout.splitlines() if line.strip()])
+
+
+def check_interfaces(args):
+    try:
+        detected_can_num = get_can_interface_count()
+    except (OSError, subprocess.CalledProcessError):
+        raise SystemExit("ERROR: Failed to detect CAN interfaces")
+
+    if detected_can_num == 0:
+        raise SystemExit("No CAN interfaces found on this platform")
+
+    if args.expected_count is not None:
+        if detected_can_num != args.expected_count:
+            raise SystemExit(
+                "Expected {} CAN interfaces, found {}".format(
+                    args.expected_count, detected_can_num
+                )
+            )
+
+
 def main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="SocketCAN Tests",
         epilog=textwrap.dedent("""
         Examples:
+            socketcan_test.py --check-interfaces
+            socketcan_test.py --check-interfaces --expected-count 2
             socketcan_test.py can0 123
             socketcan_test.py can0 212 --remote
             socketcan_test.py can0 FA123 --effid
             socketcan_test.py can0 E407DB --effid --fdmode""").lstrip(),
     )
-    parser.add_argument("interface", type=str, help="Interface name e.g. can0")
+    parser.add_argument(
+        "interface", nargs="?", type=str, help="Interface name e.g. can0"
+    )
     parser.add_argument(
         "can_id",
+        nargs="?",
         type=str,
         help=textwrap.dedent("""
         CAN ID of source in Hex, max of 11 bits using Standard Frame
@@ -206,10 +240,26 @@ def main():
         action="store_true",
         help="Attempt to send 64 bytes of data i.e. FD mode",
     )
-    parser.set_defaults(func=echo_test)
+    parser.add_argument(
+        "--check-interfaces",
+        action="store_true",
+        help="Check whether CAN interfaces exist on the platform",
+    )
+    parser.add_argument(
+        "--expected-count",
+        type=int,
+        help="Expected number of CAN interfaces",
+    )
 
     args = parser.parse_args()
-    args.func(args)
+    if args.check_interfaces:
+        check_interfaces(args)
+        return
+
+    if args.interface is None or args.can_id is None:
+        parser.error("the following arguments are required: interface, can_id")
+
+    echo_test(args)
 
 
 if __name__ == "__main__":

--- a/providers/base/tests/test_socketcan_test.py
+++ b/providers/base/tests/test_socketcan_test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from argparse import Namespace
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import socketcan_test
+
+
+class TestCheckInterfaces(unittest.TestCase):
+    @patch("socketcan_test.subprocess.run")
+    def test_fails_when_no_can_interfaces(self, mock_run):
+        mock_run.return_value = CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+
+        with self.assertRaises(SystemExit) as context:
+            socketcan_test.check_interfaces(Namespace(expected_count=None))
+
+        self.assertEqual(
+            str(context.exception), "No CAN interfaces found on this platform"
+        )
+
+    @patch("socketcan_test.subprocess.run")
+    def test_passes_when_interfaces_exist_without_expected(self, mock_run):
+        mock_run.return_value = CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="2: can0: <NOARP> mtu 16\n3: can1: <NOARP> mtu 16\n",
+            stderr="",
+        )
+
+        socketcan_test.check_interfaces(Namespace(expected_count=None))
+
+    @patch("socketcan_test.subprocess.run")
+    def test_passes_when_expected_matches_detected(self, mock_run):
+        mock_run.return_value = CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="2: can0: <NOARP> mtu 16\n3: can1: <NOARP> mtu 16\n",
+            stderr="",
+        )
+
+        socketcan_test.check_interfaces(Namespace(expected_count=2))
+
+    @patch("socketcan_test.subprocess.run")
+    def test_fails_when_expected_does_not_match_detected(self, mock_run):
+        mock_run.return_value = CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="2: can0: <NOARP> mtu 16\n3: can1: <NOARP> mtu 16\n",
+            stderr="",
+        )
+
+        with self.assertRaises(SystemExit) as context:
+            socketcan_test.check_interfaces(Namespace(expected_count=3))
+
+        self.assertEqual(
+            str(context.exception),
+            "Expected 3 CAN interfaces, found 2",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/providers/base/units/socketcan/jobs.pxu
+++ b/providers/base/units/socketcan/jobs.pxu
@@ -26,7 +26,7 @@ plugin: shell
 user: root
 flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
-requires: manifest.socket_can == 'True'
+requires: manifest.has_socket_can == 'True'
 estimated_duration: 1
 command:
   expected_can_num="${EXPECTED_CAN_INTERFACES:-}"

--- a/providers/base/units/socketcan/jobs.pxu
+++ b/providers/base/units/socketcan/jobs.pxu
@@ -16,6 +16,30 @@ command:
     ip link add vcan0 type vcan
   fi
 
+id: socketcan/check_interfaces
+category_id: socketcan
+_summary: Check CAN interfaces on the platform
+_description:
+  Check whether CAN interfaces exist on the platform.
+  If EXPECTED_CAN_INTERFACES is set, the detected count must match it.
+plugin: shell
+user: root
+flags: also-after-suspend
+imports: from com.canonical.plainbox import manifest
+requires: manifest.socket_can == 'True'
+estimated_duration: 1
+command:
+  expected_can_num="${EXPECTED_CAN_INTERFACES:-}"
+  detected_can_num="$(ip -o link show type can | wc -l | tr -d '[:space:]')"
+  if [ "${detected_can_num}" -eq 0 ]; then
+      echo "No CAN interfaces found on this platform"
+      exit 1
+  fi
+  if [ -n "${expected_can_num}" ] && [ "${detected_can_num}" -ne "${expected_can_num}" ]; then
+      echo "Expected ${expected_can_num} CAN interfaces, found ${detected_can_num}"
+      exit 1
+  fi
+
 id: socketcan/send_packet_local_sff_virtual
 depends: socketcan/modprobe_vcan
 _summary: Virtual CAN device support test (Raw, Local)

--- a/providers/base/units/socketcan/jobs.pxu
+++ b/providers/base/units/socketcan/jobs.pxu
@@ -16,28 +16,24 @@ command:
     ip link add vcan0 type vcan
   fi
 
-id: socketcan/check_interfaces
+id: socketcan/detect_can
 category_id: socketcan
-_summary: Check CAN interfaces on the platform
-_description:
-  Check whether CAN interfaces exist on the platform.
-  If EXPECTED_CAN_INTERFACES is set, the detected count must match it.
+_summary: Ensure socketcan are available for detection.
+_purpose:
+  Test to detect if there are available socketcan interfaces
+  If EXPECTED_COUNT_OF_CAN_INTERFACES is set, the detected count must match
+  it.
+  e.g. EXPECTED_COUNT_OF_CAN_INTERFACES=2
 plugin: shell
 user: root
 flags: also-after-suspend
-imports: from com.canonical.plainbox import manifest
-requires: manifest.has_socket_can == 'True'
 estimated_duration: 1
+environ: EXPECTED_COUNT_OF_CAN_INTERFACES
 command:
-  expected_can_num="${EXPECTED_CAN_INTERFACES:-}"
-  detected_can_num="$(ip -o link show type can | wc -l | tr -d '[:space:]')"
-  if [ "${detected_can_num}" -eq 0 ]; then
-      echo "No CAN interfaces found on this platform"
-      exit 1
-  fi
-  if [ -n "${expected_can_num}" ] && [ "${detected_can_num}" -ne "${expected_can_num}" ]; then
-      echo "Expected ${expected_can_num} CAN interfaces, found ${detected_can_num}"
-      exit 1
+  if [ -n "${EXPECTED_COUNT_OF_CAN_INTERFACES:-}" ]; then
+    socketcan_test.py --check-interfaces --expected-count "${EXPECTED_COUNT_OF_CAN_INTERFACES}"
+  else
+    socketcan_test.py --check-interfaces
   fi
 
 id: socketcan/send_packet_local_sff_virtual

--- a/providers/base/units/socketcan/manifest.pxu
+++ b/providers/base/units/socketcan/manifest.pxu
@@ -6,6 +6,11 @@ _name: A SocketCAN Echo Server
 value-type: bool
 
 unit: manifest entry
+id: has_socket_can
+_name: SocketCAN capable devices
+value-type: bool
+
+unit: manifest entry
 id: has_socket_can_fd
 _name: CAN FD capable devices
 value-type: bool

--- a/providers/base/units/socketcan/test-plan.pxu
+++ b/providers/base/units/socketcan/test-plan.pxu
@@ -5,7 +5,7 @@ _name: SocketCAN Tests (Automated, Remote)
 _description:
   SocketCAN Tests (Automated, Remote)
 include:
-  socketcan/check_interfaces
+  socketcan/detect_can
   socketcan/send_packet_remote_.*
 
 
@@ -23,7 +23,7 @@ _name: SocketCAN Tests (Automated, Remote, After Suspend)
 _description:
   SocketCAN Tests (Automated, Remote, After Suspend)
 include:
-  after-suspend-socketcan/check_interfaces
+  after-suspend-socketcan/detect_can
   after-suspend-socketcan/send_packet_remote_.*
 
 
@@ -41,7 +41,7 @@ _name: SocketCAN Tests (Automated, Local)
 _description:
   SocketCAN Tests (Automated, Local)
 include:
-  socketcan/check_interfaces
+  socketcan/detect_can
   socketcan/send_packet_local_.*
 
 
@@ -59,7 +59,7 @@ _name: SocketCAN Tests (Automated, Local, After Suspend)
 _description:
   SocketCAN Tests (Automated, Local, After Suspend)
 include:
-  after-suspend-socketcan/check_interfaces
+  after-suspend-socketcan/detect_can
   after-suspend-socketcan/send_packet_local_.*
 
 

--- a/providers/base/units/socketcan/test-plan.pxu
+++ b/providers/base/units/socketcan/test-plan.pxu
@@ -5,6 +5,7 @@ _name: SocketCAN Tests (Automated, Remote)
 _description:
   SocketCAN Tests (Automated, Remote)
 include:
+  socketcan/check_interfaces
   socketcan/send_packet_remote_.*
 
 
@@ -22,6 +23,7 @@ _name: SocketCAN Tests (Automated, Remote, After Suspend)
 _description:
   SocketCAN Tests (Automated, Remote, After Suspend)
 include:
+  after-suspend-socketcan/check_interfaces
   after-suspend-socketcan/send_packet_remote_.*
 
 
@@ -39,6 +41,7 @@ _name: SocketCAN Tests (Automated, Local)
 _description:
   SocketCAN Tests (Automated, Local)
 include:
+  socketcan/check_interfaces
   socketcan/send_packet_local_.*
 
 
@@ -56,6 +59,7 @@ _name: SocketCAN Tests (Automated, Local, After Suspend)
 _description:
   SocketCAN Tests (Automated, Local, After Suspend)
 include:
+  after-suspend-socketcan/check_interfaces
   after-suspend-socketcan/send_packet_local_.*
 
 


### PR DESCRIPTION
## Description

- Add a new SocketCAN precheck job that fails when no CAN interface is detected on the system.

- Add a new manifest entry, has_socket_can, and gate the precheck job with that manifest flag.

- Include the precheck in SocketCAN automated local/remote plans and their after-suspend variants so interface availability is validated before packet tests run.

## Resolved issues

Because jobs like socketcan/send_packet_local_eff_{interface} and socketcan/send_packet_remote_sff_{interface} are all generated through resource templates, when a system should support it but no CAN interface exists, it will lead to a false Pass because the corresponding test cases are not created, making it impossible to detect the issue. 

For example: https://certification.canonical.com/hardware/202605-38787/submission/495127/test-results/?term=socketcan
 - Two socketcan interfaces should exist in system
 - Real issue causes no can interface exists in system
 - Checkbox didn't reflect this problem
 
## Documentation

N/A

## Tests

Sideload Submission - https://certification.canonical.com/hardware/202605-38787/submission/500777/test-results/
