### PR TITLE
Fix the supported_resolutions loop in camera_test.py (Bugfix)

### DIFF
--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -43,6 +43,7 @@ import sys
 from glob import glob
 from subprocess import check_call, CalledProcessError, STDOUT, check_output
 from tempfile import NamedTemporaryFile
+from itertools import product
 
 _IOC_NRBITS = 8
 _IOC_TYPEBITS = 8
@@ -373,9 +374,49 @@ class CameraTest:
             self.GLib.timeout_add_seconds(10, self._stop_pipeline)
             self._setup_video_gstreamer()
 
-    def _setup_video_gstreamer(self, sink=None):
+    def _get_int_or_int_array(
+        self, gst_struct: "Gst.Structure", fieldname: str
+    ) -> "list[int]":
+        """Attempt to get an int or a int array from gst_struct.fieldname
+
+        :param gst_struct: the struct to get data from
+        :param fieldname: name of the field like "width"
+        :raises RuntimeError: the field isn't an int or a int array
+        :return: a list[int] with 1 or more elements
         """
-        Setup the gstreamer pipeline to create the video stream
+        # NOTE: This assumes gst_struct.fieldname is an int32
+        # it's possible to get int64 here
+        # but the python binding will panic
+        # so there's nothing we can really do about it
+        # unless we move to python3-gst-1.0
+        ok, raw_val = gst_struct.get_int(fieldname)
+        out = []  # type: list[int]
+        if ok:
+            out.append(int(raw_val))
+        else:
+            ok, raw_values = gst_struct.get_list(fieldname)
+            if not ok:
+                # tried both, neither works => panic!
+                raise RuntimeError(
+                    "Failed to get the {} values! Type is: {}".format(
+                        fieldname, gst_struct.get_field_type(fieldname)
+                    )
+                )
+            for i in range(raw_values.n_values):
+                # get_nth is technically deprecated
+                # but GValueArray as a whole seems deprecated
+                # https://api.pygobject.gnome.org/GObject-2.0/
+                # structure-ValueArray.html
+                val = raw_values.get_nth(i)
+                out.append(int(val))
+        return out
+
+    def _setup_video_gstreamer(self, sink: "str | None" = None):
+        """Setup the gstreamer pipeline to create the video stream
+
+        :param sink: name of the sink element. If not specified, camerabin will
+                     automatically choose something
+        :raises SystemExit: _description_
         """
         webcam = self.Gst.ElementFactory.make("v4l2src")
         webcam.set_property("device", self.device)
@@ -390,16 +431,23 @@ class CameraTest:
             pipeline.set_property("viewfinder-sink", vf_sink)
         pipeline.set_state(self.Gst.State.PAUSED)
         caps = pipeline.get_property("viewfinder-supported-caps")
+
         supported_resolutions = {}
         for i in range(caps.get_size()):
-            key = caps.get_structure(i).get_int("width").value
-            if key not in supported_resolutions.keys():
-                supported_resolutions[key] = set()
-            supported_resolutions[key].add(
-                caps.get_structure(i).get_int("height").value
-            )
+            curr_struct = caps.get_structure(i)
+            widths = self._get_int_or_int_array(curr_struct, "width")
+            heights = self._get_int_or_int_array(curr_struct, "height")
+            # now just put all (width, height) pairs into a dict
+            # so we can stop dealing with gst structures
+            for w, h in product(widths, heights):
+                if w in supported_resolutions:
+                    supported_resolutions[w].add(h)
+                else:
+                    supported_resolutions[w] = {h}
+
         if not supported_resolutions:
             raise SystemExit("No supported resolutions found!")
+
         width = min(
             supported_resolutions.keys(), key=lambda x: abs(x - self._width)
         )
@@ -767,8 +815,7 @@ class CameraTest:
             # more formats, so we ignore it
             if e.errno != errno.EINVAL:
                 print(
-                    "Unable to determine Pixel Formats, this may be a "
-                    "driver issue."
+                    "Unable to determine Pixel Formats, this may be a driver issue."
                 )
             return supported_pixel_formats
         return supported_pixel_formats

--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -815,7 +815,8 @@ class CameraTest:
             # more formats, so we ignore it
             if e.errno != errno.EINVAL:
                 print(
-                    "Unable to determine Pixel Formats, this may be a driver issue."
+                    "Unable to determine Pixel Formats,",
+                    "this may be a driver issue.",
                 )
             return supported_pixel_formats
         return supported_pixel_formats

--- a/providers/base/bin/camera_test.py
+++ b/providers/base/bin/camera_test.py
@@ -374,12 +374,10 @@ class CameraTest:
             self.GLib.timeout_add_seconds(10, self._stop_pipeline)
             self._setup_video_gstreamer()
 
-    def _get_int_or_int_array(
-        self, gst_struct: "Gst.Structure", fieldname: str
-    ) -> "list[int]":
+    def _get_int_or_int_array(self, gst_struct, fieldname: str) -> "list[int]":
         """Attempt to get an int or a int array from gst_struct.fieldname
 
-        :param gst_struct: the struct to get data from
+        :param gst_struct: the Gst.Structure to get data from
         :param fieldname: name of the field like "width"
         :raises RuntimeError: the field isn't an int or a int array
         :return: a list[int] with 1 or more elements

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -1011,9 +1011,7 @@ class GetIntOrIntArrayTests(unittest.TestCase):
         mock_struct.get_field_type.return_value = "GstValueRange"
 
         with self.assertRaises(RuntimeError) as ctx:
-            CameraTest._get_int_or_int_array(
-                mock_camera, mock_struct, "width"
-            )
+            CameraTest._get_int_or_int_array(mock_camera, mock_struct, "width")
 
         self.assertIn("width", str(ctx.exception))
         self.assertIn("GstValueRange", str(ctx.exception))

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -286,6 +286,9 @@ class CameraTestTests(unittest.TestCase):
         mock_make = mock_camera.Gst.ElementFactory.make
         mock_camera.Gst.State.PAUSED = "paused"
         mock_camera.Gst.State.PLAYING = "playing"
+        mock_camera._get_int_or_int_array.side_effect = [[640], [480, 320]]
+        mock_camera._width = 640
+        mock_camera._height = 480
 
         CameraTest._setup_video_gstreamer(mock_camera)
         make_calls = mock_make.call_args_list
@@ -307,6 +310,9 @@ class CameraTestTests(unittest.TestCase):
         mock_make = mock_camera.Gst.ElementFactory.make
         mock_camera.Gst.State.PAUSED = "paused"
         mock_camera.Gst.State.PLAYING = "playing"
+        mock_camera._get_int_or_int_array.side_effect = [[640], [480, 320]]
+        mock_camera._width = 640
+        mock_camera._height = 480
 
         CameraTest._setup_video_gstreamer(mock_camera, "sink")
         make_calls = mock_make.call_args_list
@@ -340,6 +346,9 @@ class CameraTestTests(unittest.TestCase):
         mock_camera.GLib.Error = Exception
         mock_camera.GLib.MainLoop.return_value.run.side_effect = Exception()
         mock_camera.Gst.State.NULL = "null"
+        mock_camera._get_int_or_int_array.side_effect = [[640], [480, 320]]
+        mock_camera._width = 640
+        mock_camera._height = 480
         CameraTest._setup_video_gstreamer(mock_camera)
 
         self.assertEqual(mock_camera.main_loop.run.call_count, 1)
@@ -856,9 +865,10 @@ class CameraTestTests(unittest.TestCase):
         mock_camera = MagicMock()
         mock_exists.return_value = True
         with patch("builtins.open", mock_open(read_data=b"")):
-            with patch("builtins.print") as mocked_print, patch(
-                "camera_test.check_output"
-            ) as mock_check_output:
+            with (
+                patch("builtins.print") as mocked_print,
+                patch("camera_test.check_output") as mock_check_output,
+            ):
                 mock_check_output.return_value = "inode/empty"
                 result = CameraTest._validate_image(
                     mock_camera, "/tmp/test.jpg", 480, 320

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -967,5 +967,57 @@ class CameraTestTests(unittest.TestCase):
         sys.stdout = sys.__stdout__
 
 
+class GetIntOrIntArrayTests(unittest.TestCase):
+    """tests CameraTest._get_int_or_int_array."""
+
+    def _make_camera(self):
+        return MagicMock(spec=CameraTest)
+
+    def test_int_only_happy_path(self):
+        mock_camera = self._make_camera()
+        mock_struct = MagicMock()
+        mock_struct.get_int.return_value = (True, 1920)
+
+        result = CameraTest._get_int_or_int_array(
+            mock_camera, mock_struct, "width"
+        )
+
+        mock_struct.get_int.assert_called_once_with("width")
+        self.assertEqual(result, [1920])
+
+    def test_int_array_happy_path(self):
+        mock_camera = self._make_camera()
+        mock_struct = MagicMock()
+        mock_struct.get_int.return_value = (False, 0)
+
+        mock_value_array = MagicMock()
+        mock_value_array.n_values = 3
+        mock_value_array.get_nth.side_effect = [640, 1280, 1920]
+        mock_struct.get_list.return_value = (True, mock_value_array)
+
+        result = CameraTest._get_int_or_int_array(
+            mock_camera, mock_struct, "width"
+        )
+
+        mock_struct.get_int.assert_called_once_with("width")
+        mock_struct.get_list.assert_called_once_with("width")
+        self.assertEqual(result, [640, 1280, 1920])
+
+    def test_both_fail(self):
+        mock_camera = self._make_camera()
+        mock_struct = MagicMock()
+        mock_struct.get_int.return_value = (False, 0)
+        mock_struct.get_list.return_value = (False, None)
+        mock_struct.get_field_type.return_value = "GstValueRange"
+
+        with self.assertRaises(RuntimeError) as ctx:
+            CameraTest._get_int_or_int_array(
+                mock_camera, mock_struct, "width"
+            )
+
+        self.assertIn("width", str(ctx.exception))
+        self.assertIn("GstValueRange", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/providers/base/tests/test_camera_test.py
+++ b/providers/base/tests/test_camera_test.py
@@ -864,21 +864,19 @@ class CameraTestTests(unittest.TestCase):
     def test_validate_image_wrong_format(self, mock_exists):
         mock_camera = MagicMock()
         mock_exists.return_value = True
-        with patch("builtins.open", mock_open(read_data=b"")):
-            with (
-                patch("builtins.print") as mocked_print,
-                patch("camera_test.check_output") as mock_check_output,
-            ):
-                mock_check_output.return_value = "inode/empty"
-                result = CameraTest._validate_image(
-                    mock_camera, "/tmp/test.jpg", 480, 320
-                )
-                # should not even start reading the file if the `file` command
-                # check didn't pass
-                mocked_print.assert_any_call(
-                    "Image is not a standard JPEG file"
-                )
-                self.assertEqual(result, False)
+        with patch("builtins.open", mock_open(read_data=b"")), patch(
+            "builtins.print"
+        ) as mocked_print, patch(
+            "camera_test.check_output"
+        ) as mock_check_output:
+            mock_check_output.return_value = "inode/empty"
+            result = CameraTest._validate_image(
+                mock_camera, "/tmp/test.jpg", 480, 320
+            )
+            # should not even start reading the file if the `file` command
+            # check didn't pass
+            mocked_print.assert_any_call("Image is not a standard JPEG file")
+            self.assertEqual(result, False)
 
     @patch("builtins.open")
     @patch("os.path.exists")


### PR DESCRIPTION
## Description

Inside camera_test.py's `_setup_video_gstreamer` method, the loop gathering the supported resolutions of the viewfinder sink is broken because it does not check if `get_int` has succeeded before collecting the value and doesn't handle int arrays. This PR fixes it and raises an exception if we can't handle the value types.

## Resolved issues

#2605 

## Documentation

Every `<Gst.Structure>.get_*` method like `get_int` returns a tuple of the type `(bool, ValueType)`. For example `get_int` returns `(bool, int)`. If we don't check if [0] is true, then we get junk values in [1]. The exception being `<Gst.Structure>.get_value` which just returns `Any` and expects the caller to test for the type.


There also the easy way out where we just don't set anything for the viewfinder caps and let GStreamer figure it out.

## Tests

C3: 
- Original DUT https://certification.canonical.com/hardware/202606-38926/submission/497757/
- 24.04 https://certification.canonical.com/hardware/202503-36476/submission/497805/
- 22.04 https://certification.canonical.com/hardware/202001-27667/submission/498085/
- 16.04 https://certification.canonical.com/hardware/201812-26713/submission/498046/

(I manually closed the window so there's the "Error: Output window was closed" line)