### PR TITLE
Add Rack Mount Chassis as non-portable server type (BugFix)

### DIFF
--- a/providers/resource/bin/dmi_resource.py
+++ b/providers/resource/bin/dmi_resource.py
@@ -45,6 +45,7 @@ def sane_product(og_product: str) -> str:
         "aio",
         "mini-pc",
         "main-server-chassis",
+        "rack-mount-chassis",
     ]:
         return "non-portable"
     elif cleaned in [

--- a/providers/resource/tests/test_dmi_resource.py
+++ b/providers/resource/tests/test_dmi_resource.py
@@ -45,6 +45,7 @@ class TestDmiResource(TestCase):
             "Mini-Tower",
             "Space Saving",
             "Mini PC",
+            "Rack Mount Chassis",
         ]
         category = set(map(dmi_resource.sane_product, products))
         self.assertEqual(category, {"non-portable"})


### PR DESCRIPTION
## Description

**Problem**:
New chassis type rack-mount-chassis has not been added into sane_product. So these cases below skipped during test
-[graphics/valid_glxgears]
-[graphics/valid_glxgears_fullscreen]
-[monitor/multi-head]

**Solve**
Add "rack-mount-chassis" to the non-portable branch of sane_product() in dmi_resource.py and cover it in the corresponding unit test.

## Resolved issues

Resolved:
https://warthogs.atlassian.net/browse/OEMQA-6636?atlOrigin=eyJpIjoiNWI0ODAwMjFkNmM4NDgyOTlmNmIxMWVhMzQ5MGJkYzkiLCJwIjoiaiJ9

## Documentation

## Tests

**Fail result:**
Manual:
https://certification.canonical.com/hardware/202208-30518/submission/496484/test-results/?term=monitor/multi-head
https://certification.canonical.com/hardware/202208-30518/submission/496484/test-results/?term=glxgears

**After modified - Pass result:**
Manual:
https://certification.canonical.com/hardware/202208-30518/submission/497792/test-results/?term=glxgear
https://certification.canonical.com/hardware/202208-30518/submission/497792/test-results/?term=monitor
