### PR TITLE
Setup include requires manifest (new)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -578,7 +578,7 @@ class RemoteController(ReportsStage, MainLoopStage):
     def setup(self, resume_payload=None):
         setup_jobs = json.loads(self.sa.start_setup_json())
         self._save_manifest(
-            interactive=self.launcher.get_value("test selection", "forced")
+            interactive=not self.launcher.get_value("test selection", "forced")
         )
         starting_index = 0
         if resume_payload:

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -577,6 +577,9 @@ class RemoteController(ReportsStage, MainLoopStage):
 
     def setup(self, resume_payload=None):
         setup_jobs = json.loads(self.sa.start_setup_json())
+        self._save_manifest(
+            interactive=self.launcher.get_value("test selection", "forced")
+        )
         starting_index = 0
         if resume_payload:
             last_running_job = resume_payload["last_job"]

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -642,7 +642,7 @@ class Launcher(MainLoopStage, ReportsStage):
     def setup(self):
         setup_jobs = self.sa.start_setup()
         self._save_manifest(
-            interactive=self.configuration.get_value(
+            interactive=not self.configuration.get_value(
                 "test selection", "forced"
             )
         )

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -641,6 +641,11 @@ class Launcher(MainLoopStage, ReportsStage):
 
     def setup(self):
         setup_jobs = self.sa.start_setup()
+        self._save_manifest(
+            interactive=self.configuration.get_value(
+                "test selection", "forced"
+            )
+        )
         failed_setups = self._run_setup_jobs(setup_jobs)
         self.sa.finish_setup()
         return failed_setups

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -430,9 +430,7 @@ class TestLauncher(TestCase):
         failed = Launcher.setup(self_mock)
 
         self.assertTrue(self_mock.sa.start_setup.called)
-        self_mock._save_manifest.assert_called_once_with(
-            interactive=self_mock.configuration.get_value.return_value
-        )
+        self_mock._save_manifest.assert_called_once_with(interactive=False)
         self_mock.configuration.get_value.assert_called_once_with(
             "test selection", "forced"
         )

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -430,6 +430,12 @@ class TestLauncher(TestCase):
         failed = Launcher.setup(self_mock)
 
         self.assertTrue(self_mock.sa.start_setup.called)
+        self_mock._save_manifest.assert_called_once_with(
+            interactive=self_mock.configuration.get_value.return_value
+        )
+        self_mock.configuration.get_value.assert_called_once_with(
+            "test selection", "forced"
+        )
         self.assertTrue(self_mock._run_setup_jobs.called)
         self.assertTrue(self_mock.sa.finish_setup.called)
         self.assertEqual(failed, ["failed1"])

--- a/checkbox-ng/plainbox/impl/ctrl.py
+++ b/checkbox-ng/plainbox/impl/ctrl.py
@@ -215,14 +215,14 @@ class CheckBoxSessionStateController(ISessionStateController):
 
     def get_requires_manifests_inhibitor_list(self, session_state, job):
         try:
-            requires_manifests = job.get_required_manifest_ids()
+            requires_manifests = job.get_required_manifests_spec()
         except AttributeError:
             return []
         manifest = session_state.manifest
         failing_manifests = [
-            manifest_id
-            for manifest_id in requires_manifests
-            if not manifest.get(manifest_id)
+            manifest_spec.id
+            for manifest_spec in requires_manifests
+            if manifest.get(manifest_spec.id, False) != manifest_spec.value
         ]
         if not failing_manifests:
             return []

--- a/checkbox-ng/plainbox/impl/ctrl.py
+++ b/checkbox-ng/plainbox/impl/ctrl.py
@@ -213,15 +213,15 @@ class CheckBoxSessionStateController(ISessionStateController):
                     return True
         return False
 
-    def get_requires_manifests_inhibitor_list(self, session_state, job):
+    def get_requires_manifest_inhibitor_list(self, session_state, job):
         try:
-            requires_manifests = job.get_required_manifests_spec()
+            requires_manifest = job.get_required_manifests_spec()
         except AttributeError:
             return []
         manifest = session_state.manifest
         failing_manifests = [
             manifest_spec.id
-            for manifest_spec in requires_manifests
+            for manifest_spec in requires_manifest
             if manifest.get(manifest_spec.id, False) != manifest_spec.value
         ]
         if not failing_manifests:
@@ -249,7 +249,7 @@ class CheckBoxSessionStateController(ISessionStateController):
             List of JobReadinessInhibitor
         """
         inhibitors = []
-        inhibitors += self.get_requires_manifests_inhibitor_list(
+        inhibitors += self.get_requires_manifest_inhibitor_list(
             session_state, job
         )
         # Check if all job resource requirements are met

--- a/checkbox-ng/plainbox/impl/ctrl.py
+++ b/checkbox-ng/plainbox/impl/ctrl.py
@@ -213,6 +213,27 @@ class CheckBoxSessionStateController(ISessionStateController):
                     return True
         return False
 
+    def get_requires_manifests_inhibitor_list(self, session_state, job):
+        try:
+            requires_manifests = job.get_required_manifest_ids()
+        except AttributeError:
+            return []
+        manifest = session_state.manifest
+        failing_manifests = [
+            manifest_id
+            for manifest_id in requires_manifests
+            if not manifest.get(manifest_id)
+        ]
+        if not failing_manifests:
+            return []
+        return [
+            JobReadinessInhibitor(
+                cause=InhibitionCause.REQUIRED_MANIFEST,
+                related_job=job,
+                related_manifests=failing_manifests,
+            )
+        ]
+
     def get_inhibitor_list(self, session_state, job):
         """
         Get a list of readiness inhibitors that inhibit a particular job.
@@ -228,6 +249,9 @@ class CheckBoxSessionStateController(ISessionStateController):
             List of JobReadinessInhibitor
         """
         inhibitors = []
+        inhibitors += self.get_requires_manifests_inhibitor_list(
+            session_state, job
+        )
         # Check if all job resource requirements are met
         prog = job.get_resource_program()
         if prog is not None:

--- a/checkbox-ng/plainbox/impl/result_utils.py
+++ b/checkbox-ng/plainbox/impl/result_utils.py
@@ -79,9 +79,8 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
     for inhibitor in job_state.readiness_inhibitor_list:
         if inhibitor.cause == InhibitionCause.REQUIRED_MANIFEST:
             has_failed_manifest = True
-            skip_reason["related_manifests"].append(
-                inhibitor.related_manifests
-            )
+            skip_reason["related_manifests"] += inhibitor.related_manifests
+
         elif inhibitor.cause == InhibitionCause.FAILED_DEP:
             has_failed_dep = True
             # Check if the dependency was manually skipped

--- a/checkbox-ng/plainbox/impl/result_utils.py
+++ b/checkbox-ng/plainbox/impl/result_utils.py
@@ -103,9 +103,9 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
                 # Check if this is a manifest expression
                 if inhibitor.related_expression.manifest_id_list:
                     has_failed_manifest = True
-                    skip_reason["related_manifests"].append(
-                        inhibitor.related_expression.text
-                    )
+                    skip_reason[
+                        "related_manifests"
+                    ] += inhibitor.related_expression.manifest_id_list
                 else:
                     skip_reason["related_resources"].append(
                         inhibitor.related_expression.text

--- a/checkbox-ng/plainbox/impl/result_utils.py
+++ b/checkbox-ng/plainbox/impl/result_utils.py
@@ -77,7 +77,12 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
     has_failed_manifest = False
 
     for inhibitor in job_state.readiness_inhibitor_list:
-        if inhibitor.cause == InhibitionCause.FAILED_DEP:
+        if inhibitor.cause == InhibitionCause.REQUIRED_MANIFEST:
+            has_failed_manifest = True
+            skip_reason["related_manifests"].append(
+                inhibitor.related_manifests
+            )
+        elif inhibitor.cause == InhibitionCause.FAILED_DEP:
             has_failed_dep = True
             # Check if the dependency was manually skipped
             if inhibitor.related_job:

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -829,6 +829,7 @@ class SessionAssistant:
             self.finish_setup: "to finish setting up after running all jobs",
             self.get_session_id: "used internally by get_job",
             self.get_category: "used by UIs to represent a job",
+            self.get_manifest_repr: "to know which manifests should be filled",
         }
         return [job.id for job in self._context.state.run_list]
 
@@ -1387,10 +1388,22 @@ class SessionAssistant:
         def didnt_run_yet(job):
             return job_state_map[job.id].result.outcome is None
 
-        todo_list = filter(didnt_run_yet, run_list)
+        def get_required_manifests_if_any(job):
+            try:
+                return job.get_required_manifest_ids()
+            except AttributeError:  # only setup_jobs
+                return []
+
+        todo_list = [x for x in run_list if didnt_run_yet(x)]
+        manifest_id_set = {
+            manifest_id
+            for job in todo_list
+            for manifest_id in get_required_manifests_if_any(job)
+        }
+
         resource_programs = (job.get_resource_program() for job in todo_list)
         resource_programs = filter(bool, resource_programs)
-        manifest_id_set = {
+        manifest_id_set |= {
             manifest_id
             for resource_program in resource_programs
             for expression in resource_program.expression_list
@@ -1441,15 +1454,7 @@ class SessionAssistant:
         """
         Record the manifest on disk.
         """
-        manifest_cache = dict()
-        manifest = WellKnownDirsHelper.manifest_file()
-        if os.path.isfile(manifest):
-            with open(manifest, "rt", encoding="UTF-8") as stream:
-                manifest_cache = json.load(stream)
-        manifest_cache.update(manifest_answers)
-        print("Saving manifest to {}".format(manifest))
-        with open(manifest, "wt", encoding="UTF-8") as stream:
-            json.dump(manifest_cache, stream, sort_keys=True, indent=2)
+        self._context.state.save_manifest(manifest_answers)
 
     def note_metadata_starting_job(self, job, job_state):
         """

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -1390,15 +1390,15 @@ class SessionAssistant:
 
         def get_required_manifests_if_any(job):
             try:
-                return job.get_required_manifest_ids()
+                return job.get_required_manifests_spec()
             except AttributeError:  # only setup_jobs
                 return []
 
         todo_list = [x for x in run_list if didnt_run_yet(x)]
         manifest_id_set = {
-            manifest_id
+            manifest_spec.id
             for job in todo_list
-            for manifest_id in get_required_manifests_if_any(job)
+            for manifest_spec in get_required_manifests_if_any(job)
         }
 
         resource_programs = (job.get_resource_program() for job in todo_list)

--- a/checkbox-ng/plainbox/impl/session/jobs.py
+++ b/checkbox-ng/plainbox/impl/session/jobs.py
@@ -61,7 +61,7 @@ class InhibitionCause(IntEnum):
             This job has a resource requirement that evaluated to a false value
 
         REQUIRED_MANIFEST:
-            This job requred a manifest that is either False or None
+            This job required a manifest that is either False or undefined
     """
 
     UNDESIRED = 0
@@ -267,12 +267,10 @@ class JobReadinessInhibitor(pod.POD):
             )
         elif self.cause == InhibitionCause.REQUIRED_MANIFEST:
             if len(self.related_manifests) == 1:
-                return _("manifest: {!r} is false").format(
+                return _("manifest: {!r} unmet").format(
                     self.related_manifests[0]
                 )
-            return _("manifests: {!r} are false").format(
-                self.related_manifests
-            )
+            return _("manifests: {!r} unmet").format(self.related_manifests)
         elif self.cause == InhibitionCause.NOT_FAILED_DEP:
             return _("required dependency {!r} did not fail").format(
                 self.related_job.id

--- a/checkbox-ng/plainbox/impl/session/jobs.py
+++ b/checkbox-ng/plainbox/impl/session/jobs.py
@@ -59,6 +59,9 @@ class InhibitionCause(IntEnum):
 
         FAILED_RESOURCE:
             This job has a resource requirement that evaluated to a false value
+
+        REQUIRED_MANIFEST:
+            This job requred a manifest that is either False or None
     """
 
     UNDESIRED = 0
@@ -67,6 +70,7 @@ class InhibitionCause(IntEnum):
     PENDING_RESOURCE = 3
     FAILED_RESOURCE = 4
     NOT_FAILED_DEP = 5
+    REQUIRED_MANIFEST = 6
 
 
 def cause_convert_assign_filter(
@@ -166,7 +170,19 @@ class JobReadinessInhibitor(pod.POD):
         assign_filter_list=[pod.read_only_assign_filter],
     )
 
-    def __init__(self, cause, related_job=None, related_expression=None):
+    related_manifests = pod.Field(
+        doc="an (optional) list of missing manifest ids",
+        type=list,
+        assign_filter_list=[pod.read_only_assign_filter],
+    )
+
+    def __init__(
+        self,
+        cause,
+        related_job=None,
+        related_expression=None,
+        related_manifests=None,
+    ):
         """
         Initialize a new inhibitor with the specified cause.
 
@@ -174,7 +190,12 @@ class JobReadinessInhibitor(pod.POD):
         is either PENDING_RESOURCE or FAILED_RESOURCE related_expression is
         necessary as well. A ValueError is raised when this is violated.
         """
-        super().__init__(cause, related_job, related_expression)
+        super().__init__(
+            cause,
+            related_job,
+            related_expression,
+            related_manifests,
+        )
         if (
             self.cause != InhibitionCause.UNDESIRED
             and self.related_job is None
@@ -199,6 +220,17 @@ class JobReadinessInhibitor(pod.POD):
                     # TRANSLATORS: please don't translate related_expression, None
                     # and cause.
                     "related_expression must not be None when cause is {}"
+                ).format(self.cause.name)
+            )
+        if (
+            self.cause == InhibitionCause.REQUIRED_MANIFEST
+            and self.related_manifests is None
+        ):
+            raise ValueError(
+                _(
+                    # TRANSLATORS: please don't translate related_manifests, None
+                    # and cause.
+                    "related_manifests must not be None when cause is {}"
                 ).format(self.cause.name)
             )
 
@@ -232,6 +264,14 @@ class JobReadinessInhibitor(pod.POD):
         elif self.cause == InhibitionCause.FAILED_RESOURCE:
             return _("resource expression {!r} evaluates to false").format(
                 self.related_expression.text
+            )
+        elif self.cause == InhibitionCause.REQUIRED_MANIFEST:
+            if len(self.related_manifests) == 1:
+                return _("manifest: {!r} is false").format(
+                    self.related_manifests[0]
+                )
+            return _("manifests: {!r} are false").format(
+                self.related_manifests
             )
         elif self.cause == InhibitionCause.NOT_FAILED_DEP:
             return _("required dependency {!r} did not fail").format(

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -880,7 +880,7 @@ class SessionState:
             with open(manifest, "rt", encoding="UTF-8") as stream:
                 manifest_cache = json.load(stream)
         manifest_cache.update(manifest_answers)
-        print("Saving manifest to {}".format(manifest))
+        logger.info("Saving manifest to {}".format(manifest))
         with open(manifest, "wt", encoding="UTF-8") as stream:
             json.dump(manifest_cache, stream, sort_keys=True, indent=2)
 

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -29,6 +29,7 @@ import os
 import re
 import shutil
 from contextlib import suppress
+from pathlib import Path
 from copy import copy
 
 from plainbox.abc import IJobResult
@@ -860,6 +861,9 @@ class SessionState:
         self._metadata = SessionMetaData()
         # If unset, this is loaded via system_information
         self._system_information = None
+        # manifest cache, refreshed on file writes
+        self._manifest = {}
+        self._manifest_last_mod_time = 0
 
         super(SessionState, self).__init__()
 
@@ -867,22 +871,26 @@ class SessionState:
     def manifest(self):
         # do not cache this, as it may change during the test run due to both
         # pre-setup and post boostrap manifest saving
-        manifest_path = WellKnownDirsHelper.manifest_file()
-        if not os.path.isfile(manifest_path):
+        manifest_path = Path(WellKnownDirsHelper.manifest_file())
+        if not manifest_path.is_file():
             return {}
-        with open(manifest_path, "r") as stream:
-            return json.load(stream)
+        last_mod_time = manifest_path.stat().st_mtime
+        if last_mod_time != self._manifest_last_mod_time:
+            with manifest_path.open("r") as f:
+                self._manifest_last_mod_time = last_mod_time
+                self._manifest = json.load(f)
+        return self._manifest
 
     def save_manifest(self, manifest_answers):
-        manifest_cache = dict()
-        manifest = WellKnownDirsHelper.manifest_file()
-        if os.path.isfile(manifest):
-            with open(manifest, "rt", encoding="UTF-8") as stream:
-                manifest_cache = json.load(stream)
-        manifest_cache.update(manifest_answers)
-        logger.info("Saving manifest to {}".format(manifest))
-        with open(manifest, "wt", encoding="UTF-8") as stream:
-            json.dump(manifest_cache, stream, sort_keys=True, indent=2)
+        manifest = dict()
+        manifest_path = Path(WellKnownDirsHelper.manifest_file())
+        if manifest_path.is_file():
+            with manifest_path.open("r") as f:
+                manifest = json.load(f)
+        manifest.update(manifest_answers)
+        logger.info("Saving manifest to {}".format(manifest_path))
+        with manifest_path.open("w") as f:
+            json.dump(manifest, f, sort_keys=True, indent=2)
 
         # manifest requiring jobs may now be runnable
         self._recompute_job_readiness()

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -865,11 +865,27 @@ class SessionState:
 
     @property
     def manifest(self):
+        # do not cache this, as it may change during the test run due to both
+        # pre-setup and post boostrap manifest saving
         manifest_path = WellKnownDirsHelper.manifest_file()
         if not os.path.isfile(manifest_path):
             return {}
         with open(manifest_path, "r") as stream:
             return json.load(stream)
+
+    def save_manifest(self, manifest_answers):
+        manifest_cache = dict()
+        manifest = WellKnownDirsHelper.manifest_file()
+        if os.path.isfile(manifest):
+            with open(manifest, "rt", encoding="UTF-8") as stream:
+                manifest_cache = json.load(stream)
+        manifest_cache.update(manifest_answers)
+        print("Saving manifest to {}".format(manifest))
+        with open(manifest, "wt", encoding="UTF-8") as stream:
+            json.dump(manifest_cache, stream, sort_keys=True, indent=2)
+
+        # manifest requiring jobs may now be runnable
+        self._recompute_job_readiness()
 
     def trim_job_list(self, qualifier):
         """

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -25,6 +25,7 @@ Session State Handling.
 import collections
 import json
 import logging
+import os
 import re
 import shutil
 from contextlib import suppress
@@ -40,6 +41,7 @@ from plainbox.impl.depmgr import (
 )
 from plainbox.impl.secure.qualifiers import select_units
 from plainbox.impl.session.jobs import JobState, UndesiredJobReadinessInhibitor
+from plainbox.impl.session.storage import WellKnownDirsHelper
 from plainbox.impl.session.system_information import (
     collect as collect_system_information,
 )
@@ -860,6 +862,14 @@ class SessionState:
         self._system_information = None
 
         super(SessionState, self).__init__()
+
+    @property
+    def manifest(self):
+        manifest_path = WellKnownDirsHelper.manifest_file()
+        if not os.path.isfile(manifest_path):
+            return {}
+        with open(manifest_path, "r") as stream:
+            return json.load(stream)
 
     def trim_job_list(self, qualifier):
         """

--- a/checkbox-ng/plainbox/impl/session/test_jobs.py
+++ b/checkbox-ng/plainbox/impl/session/test_jobs.py
@@ -183,7 +183,7 @@ class JobReadinessInhibitorTests(TestCase):
             related_job=job,
             related_manifests=["manifest-id"],
         )
-        self.assertEqual(str(obj), "manifest: 'manifest-id' is false")
+        self.assertEqual(str(obj), "manifest: 'manifest-id' unmet")
 
     def test_unknown_global(self):
         self.assertEqual(

--- a/checkbox-ng/plainbox/impl/session/test_jobs.py
+++ b/checkbox-ng/plainbox/impl/session/test_jobs.py
@@ -64,6 +64,9 @@ class JobReadinessInhibitorTests(TestCase):
         self.assertRaises(
             ValueError, JobReadinessInhibitor, InhibitionCause.FAILED_RESOURCE
         )
+        self.assertRaises(
+            ValueError, JobReadinessInhibitor, InhibitionCause.REQUIRED_MANIFEST
+        )
         job = make_job("A")
         self.assertRaises(
             ValueError,
@@ -169,6 +172,17 @@ class JobReadinessInhibitorTests(TestCase):
                 "resource expression \"resource.attr == 'value'\""
                 " evaluates to false"
             ),
+        )
+
+    def test_required_manifest(self):
+        job = make_job("A")
+        obj = JobReadinessInhibitor(
+            InhibitionCause.REQUIRED_MANIFEST,
+            related_job=job,
+            related_manifests=["manifest-id"],
+        )
+        self.assertEqual(
+            str(obj), "manifest: ['manifest-id'] is false"
         )
 
     def test_unknown_global(self):

--- a/checkbox-ng/plainbox/impl/session/test_jobs.py
+++ b/checkbox-ng/plainbox/impl/session/test_jobs.py
@@ -65,7 +65,9 @@ class JobReadinessInhibitorTests(TestCase):
             ValueError, JobReadinessInhibitor, InhibitionCause.FAILED_RESOURCE
         )
         self.assertRaises(
-            ValueError, JobReadinessInhibitor, InhibitionCause.REQUIRED_MANIFEST
+            ValueError,
+            JobReadinessInhibitor,
+            InhibitionCause.REQUIRED_MANIFEST,
         )
         job = make_job("A")
         self.assertRaises(
@@ -181,9 +183,7 @@ class JobReadinessInhibitorTests(TestCase):
             related_job=job,
             related_manifests=["manifest-id"],
         )
-        self.assertEqual(
-            str(obj), "manifest: ['manifest-id'] is false"
-        )
+        self.assertEqual(str(obj), "manifest: 'manifest-id' is false")
 
     def test_unknown_global(self):
         self.assertEqual(

--- a/checkbox-ng/plainbox/impl/session/test_state.py
+++ b/checkbox-ng/plainbox/impl/session/test_state.py
@@ -95,6 +95,72 @@ class SessionStateSmokeTests(TestCase):
         self.assertEqual(expected, observed)
 
 
+class SessionStateManifestTests(TestCase):
+
+    @patch("plainbox.impl.session.state.json.load")
+    @patch("plainbox.impl.session.state.Path")
+    def test_manifest_loads_manifest_from_file(self, mock_path_cls, mock_load):
+        self_mock = MagicMock()
+        self_mock._manifest = {}
+        self_mock._manifest_last_mod_time = 0
+        manifest_path = mock_path_cls.return_value
+        manifest_path.is_file.return_value = True
+        manifest_path.stat.return_value.st_mtime = 1
+        manifest_file = manifest_path.open.return_value.__enter__.return_value
+        mock_load.return_value = {"manifest-id": True}
+
+        observed = SessionState.manifest.fget(self_mock)
+
+        self.assertEqual(observed, {"manifest-id": True})
+        self.assertEqual(self_mock._manifest, {"manifest-id": True})
+        self.assertEqual(self_mock._manifest_last_mod_time, 1)
+        manifest_path.open.assert_called_once_with("r")
+        mock_load.assert_called_once_with(manifest_file)
+
+    @patch("plainbox.impl.session.state.json.load")
+    @patch("plainbox.impl.session.state.Path")
+    def test_manifest_uses_cache_when_file_is_unchanged(
+        self, mock_path_cls, mock_load
+    ):
+        self_mock = MagicMock()
+        self_mock._manifest = {"manifest-id": True}
+        self_mock._manifest_last_mod_time = 1
+        manifest_path = mock_path_cls.return_value
+        manifest_path.is_file.return_value = True
+        manifest_path.stat.return_value.st_mtime = 1
+
+        observed = SessionState.manifest.fget(self_mock)
+
+        self.assertEqual(observed, {"manifest-id": True})
+        manifest_path.open.assert_not_called()
+        mock_load.assert_not_called()
+
+    @patch("plainbox.impl.session.state.json.dump")
+    @patch("plainbox.impl.session.state.json.load")
+    @patch("plainbox.impl.session.state.Path")
+    def test_save_manifest_updates_manifest_file(
+        self, mock_path_cls, mock_load, mock_dump
+    ):
+        self_mock = MagicMock()
+        manifest_path = mock_path_cls.return_value
+        manifest_path.is_file.return_value = True
+        manifest_file = manifest_path.open.return_value.__enter__.return_value
+        mock_load.return_value = {"old-id": True}
+
+        SessionState.save_manifest(self_mock, {"new-id": "value"})
+
+        manifest_path.open.assert_any_call("r")
+        manifest_path.open.assert_any_call("w")
+        mock_load.assert_called_once_with(manifest_file)
+        mock_dump.assert_called_once_with(
+            {"old-id": True, "new-id": "value"},
+            manifest_file,
+            sort_keys=True,
+            indent=2,
+        )
+        self_mock._recompute_job_readiness.assert_called_once_with()
+
+
 class RegressionTests(TestCase):
     # Tests for bugfixes
 

--- a/checkbox-ng/plainbox/impl/test_ctrl.py
+++ b/checkbox-ng/plainbox/impl/test_ctrl.py
@@ -193,6 +193,69 @@ class CheckBoxSessionStateControllerTests(TestCase):
         session_state.job_state_map["j2"].job = j2
         self.assertEqual(self.ctrl.get_inhibitor_list(session_state, j1), [])
 
+    def test_get_requires_manifest_inhibitor_list__no_manifest_specs(self):
+        job = object()
+        session_state = mock.MagicMock(spec=SessionState)
+        self_mock = mock.MagicMock()
+
+        self.assertEqual(
+            CheckBoxSessionStateController.get_requires_manifest_inhibitor_list(
+                self_mock, session_state, job
+            ),
+            [],
+        )
+
+    def test_get_requires_manifest_inhibitor_list__undefined_false(self):
+        job = mock.MagicMock()
+        manifest_spec = mock.MagicMock(id="manifest-id", value=False)
+        job.get_required_manifests_spec.return_value = [manifest_spec]
+        session_state = mock.MagicMock(spec=SessionState)
+        session_state.manifest = {}
+        self_mock = mock.MagicMock()
+
+        self.assertEqual(
+            CheckBoxSessionStateController.get_requires_manifest_inhibitor_list(
+                self_mock, session_state, job
+            ),
+            [],
+        )
+
+    def test_get_requires_manifest_inhibitor_list__defined_true(self):
+        job = mock.MagicMock()
+        manifest_spec = mock.MagicMock(id="manifest-id", value=True)
+        job.get_required_manifests_spec.return_value = [manifest_spec]
+        session_state = mock.MagicMock(spec=SessionState)
+        session_state.manifest = {"manifest-id": True}
+        self_mock = mock.MagicMock()
+
+        self.assertEqual(
+            CheckBoxSessionStateController.get_requires_manifest_inhibitor_list(
+                self_mock, session_state, job
+            ),
+            [],
+        )
+
+    def test_get_requires_manifest_inhibitor_list__defined_false(self):
+        job = mock.MagicMock()
+        manifest_spec = mock.MagicMock(id="manifest-id", value=True)
+        job.get_required_manifests_spec.return_value = [manifest_spec]
+        session_state = mock.MagicMock(spec=SessionState)
+        session_state.manifest = {"manifest-id": False}
+        self_mock = mock.MagicMock()
+
+        self.assertEqual(
+            CheckBoxSessionStateController.get_requires_manifest_inhibitor_list(
+                self_mock, session_state, job
+            ),
+            [
+                JobReadinessInhibitor(
+                    cause=InhibitionCause.REQUIRED_MANIFEST,
+                    related_job=job,
+                    related_manifests=["manifest-id"],
+                )
+            ],
+        )
+
     def test_get_inhibitor_list_PENDING_DEP(self):
         # verify that jobs that depend on another job or wait (via after) for
         # another  that hasn't been invoked yet produce the PENDING_DEP

--- a/checkbox-ng/plainbox/impl/test_result_utils.py
+++ b/checkbox-ng/plainbox/impl/test_result_utils.py
@@ -130,7 +130,9 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
         """Test with a FAILED_RESOURCE inhibitor for a manifest."""
         expr = Mock()
         expr.text = "manifest.has_thunderbolt3 == 'True'"
-        expr.manifest_id_list = ["com.canonical.plainbox::manifest-id"]
+        expr.manifest_id_list = [
+            "com.canonical.certification::has_thunderbolt3"
+        ]
 
         inhibitor = Mock()
         inhibitor.cause = InhibitionCause.FAILED_RESOURCE
@@ -145,11 +147,45 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
         self.assertEqual(outcome, IJobResult.OUTCOME_SKIPPED_MANIFEST)
         self.assertIsNotNone(skip_reason)
         self.assertIn(
-            "manifest.has_thunderbolt3 == 'True'",
+            "com.canonical.certification::has_thunderbolt3",
             skip_reason["related_manifests"],
         )
         self.assertEqual(skip_reason["related_dependencies"], [])
         self.assertEqual(skip_reason["related_resources"], [])
+
+    def test_required_manifest_inhibitor_matches_failed_manifest(self):
+        """Test REQUIRED_MANIFEST matches failed manifest expressions."""
+        expr = Mock()
+        expr.text = "manifest.has_thunderbolt3 == 'True'"
+        expr.manifest_id_list = [
+            "com.canonical.certification::has_thunderbolt3"
+        ]
+
+        failed_manifest_inhibitor = Mock()
+        failed_manifest_inhibitor.cause = InhibitionCause.FAILED_RESOURCE
+        failed_manifest_inhibitor.related_expression = expr
+
+        required_manifest_inhibitor = Mock()
+        required_manifest_inhibitor.cause = InhibitionCause.REQUIRED_MANIFEST
+        required_manifest_inhibitor.related_manifests = [
+            "com.canonical.certification::has_thunderbolt3"
+        ]
+
+        failed_manifest_job_state = Mock()
+        failed_manifest_job_state.readiness_inhibitor_list = [
+            failed_manifest_inhibitor
+        ]
+        failed_manifest_job_state.job.get_flag_set.return_value = set()
+
+        required_manifest_job_state = Mock()
+        required_manifest_job_state.readiness_inhibitor_list = [
+            required_manifest_inhibitor
+        ]
+
+        self.assertEqual(
+            determine_outcome_and_skip_reason(required_manifest_job_state, {}),
+            determine_outcome_and_skip_reason(failed_manifest_job_state, {}),
+        )
 
     def test_multiple_failed_resources(self):
         """Test with multiple FAILED_RESOURCE inhibitors."""
@@ -221,7 +257,7 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
         manifest_expr = Mock()
         manifest_expr.text = "manifest.has_feature == 'True'"
         manifest_expr.manifest_id_list = [
-            "com.canonical.plainbox::manifest-id"
+            "com.canonical.certification::has_feature"
         ]
 
         manifest_inhibitor = Mock()
@@ -249,7 +285,8 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
         self.assertEqual(outcome, IJobResult.OUTCOME_SKIPPED_MANIFEST)
         # But skip_reason should include both
         self.assertIn(
-            "manifest.has_feature == 'True'", skip_reason["related_manifests"]
+            "com.canonical.certification::has_feature",
+            skip_reason["related_manifests"],
         )
         self.assertIn("cpuinfo.count > 2", skip_reason["related_resources"])
 
@@ -332,7 +369,9 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
 
         manifest_expr = Mock()
         manifest_expr.text = "manifest.has_touchpad == 'True'"
-        manifest_expr.manifest_id_list = ["has_touchpad"]
+        manifest_expr.manifest_id_list = [
+            "com.canonical.certification::has_touchpad"
+        ]
 
         manifest_inhibitor = Mock()
         manifest_inhibitor.cause = InhibitionCause.FAILED_RESOURCE
@@ -363,5 +402,6 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
         self.assertIn("job2", skip_reason["related_dependencies"])
         self.assertIn("cpuinfo.count > 4", skip_reason["related_resources"])
         self.assertIn(
-            "manifest.has_touchpad == 'True'", skip_reason["related_manifests"]
+            "com.canonical.certification::has_touchpad",
+            skip_reason["related_manifests"],
         )

--- a/checkbox-ng/plainbox/impl/unit/setup_job.py
+++ b/checkbox-ng/plainbox/impl/unit/setup_job.py
@@ -22,12 +22,16 @@
 """
 
 import logging
+import re
 
-from plainbox.i18n import gettext as _, gettext_noop as N_
+from plainbox.i18n import gettext as _
+from plainbox.i18n import gettext_noop as N_
+from plainbox.impl.decorators import cached_property
 from plainbox.impl.symbol import SymbolDef
 from plainbox.impl.unit import concrete_validators
 from plainbox.impl.unit.job import JobDefinition, propertywithsymbols
 from plainbox.impl.unit.validators import (
+    CorrectFieldValueValidator,
     MemberOfFieldValidator,
 )
 
@@ -74,6 +78,18 @@ class SetupJobUnit(JobDefinition):
             plugin = "shell"
         return plugin
 
+    @cached_property
+    def requires_manifest(self):
+        return self.get_record_value("requires_manifest")
+
+    def get_required_manifest_ids(self):
+        manifest_ids = self.requires_manifest
+        if manifest_ids is None:
+            return []
+        if not isinstance(manifest_ids, list):
+            raise ValueError(_("requires_manifest must be a list"))
+        return [self.qualify_id(manifest_id) for manifest_id in manifest_ids]
+
     class Meta:
 
         # this Meta name is job because we are restricting a job but not
@@ -102,6 +118,7 @@ class SetupJobUnit(JobDefinition):
             certification_status = "certification_status"
             siblings = "siblings"
             auto_retry = "auto_retry"
+            requires_manifest = "requires_manifest"
 
         field_validators = {
             fields.name: JobDefinition.Meta.field_validators[fields.name],
@@ -144,5 +161,13 @@ class SetupJobUnit(JobDefinition):
             ],
             fields.auto_retry: JobDefinition.Meta.field_validators[
                 fields.auto_retry
+            ],
+            fields.requires_manifest: [
+                concrete_validators.templateInvariant,
+                CorrectFieldValueValidator(
+                    lambda value, unit: (
+                        unit.get_required_manifest_ids() is not None
+                    )
+                ),
             ],
         }

--- a/checkbox-ng/plainbox/impl/unit/setup_job.py
+++ b/checkbox-ng/plainbox/impl/unit/setup_job.py
@@ -49,7 +49,7 @@ class _PluginValues(SymbolDef):
     shell = "shell"
 
 
-def valid_requires_manifests(values, _):
+def valid_requires_manifest(values, _):
     if values is None:
         return True
     if not isinstance(values, list):
@@ -190,6 +190,6 @@ class SetupJobUnit(JobDefinition):
             ],
             fields.requires_manifest: [
                 concrete_validators.templateInvariant,
-                CorrectFieldValueValidator(valid_requires_manifests),
+                CorrectFieldValueValidator(valid_requires_manifest),
             ],
         }

--- a/checkbox-ng/plainbox/impl/unit/setup_job.py
+++ b/checkbox-ng/plainbox/impl/unit/setup_job.py
@@ -22,7 +22,7 @@
 """
 
 import logging
-import re
+from collections import namedtuple
 
 from plainbox.i18n import gettext as _
 from plainbox.i18n import gettext_noop as N_
@@ -47,6 +47,24 @@ class _PluginValues(SymbolDef):
     """
 
     shell = "shell"
+
+
+def valid_requires_manifests(values, _):
+    if values is None:
+        return True
+    if not isinstance(values, list):
+        return False
+    # strings are a valid requires manifests, they are the manifest id == True
+    values = [value for value in values if not isinstance(value, str)]
+    return all(
+        isinstance(value, dict)
+        and len(value) == 1
+        and isinstance(list(value)[0], str)
+        for value in values
+    )
+
+
+RequiredManifest = namedtuple("RequiredManifest", ["id", "value"])
 
 
 class SetupJobUnit(JobDefinition):
@@ -82,13 +100,21 @@ class SetupJobUnit(JobDefinition):
     def requires_manifest(self):
         return self.get_record_value("requires_manifest")
 
-    def get_required_manifest_ids(self):
-        manifest_ids = self.requires_manifest
-        if manifest_ids is None:
+    def _get_required_manifests_spec(self, manifest_spec):
+        if isinstance(manifest_spec, str):
+            id, value = manifest_spec, True
+        else:
+            id, value = list(manifest_spec.items())[0]
+        return RequiredManifest(self.qualify_id(id), value)
+
+    def get_required_manifests_spec(self):
+        manifest_specs = self.requires_manifest
+        if manifest_specs is None:
             return []
-        if not isinstance(manifest_ids, list):
-            raise ValueError(_("requires_manifest must be a list"))
-        return [self.qualify_id(manifest_id) for manifest_id in manifest_ids]
+        return [
+            self._get_required_manifests_spec(manifest_id)
+            for manifest_id in manifest_specs
+        ]
 
     class Meta:
 
@@ -164,10 +190,6 @@ class SetupJobUnit(JobDefinition):
             ],
             fields.requires_manifest: [
                 concrete_validators.templateInvariant,
-                CorrectFieldValueValidator(
-                    lambda value, unit: (
-                        unit.get_required_manifest_ids() is not None
-                    )
-                ),
+                CorrectFieldValueValidator(valid_requires_manifests),
             ],
         }

--- a/checkbox-ng/plainbox/impl/unit/test_setup_job.py
+++ b/checkbox-ng/plainbox/impl/unit/test_setup_job.py
@@ -1,0 +1,82 @@
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+plainbox.impl.unit.test_setup_job
+=================================
+
+Test definitions for plainbox.impl.unit.setup_job module
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from plainbox.impl.unit.setup_job import RequiredManifest
+from plainbox.impl.unit.setup_job import SetupJobUnit
+from plainbox.impl.unit.setup_job import valid_requires_manifest
+
+
+class ValidRequiresManifestTests(TestCase):
+
+    def test_none_is_valid(self):
+        self.assertTrue(valid_requires_manifest(None, None))
+
+    def test_string_is_invalid(self):
+        self.assertFalse(valid_requires_manifest("manifest-id", None))
+
+    def test_list_of_strings_is_valid(self):
+        self.assertTrue(
+            valid_requires_manifest(["manifest-id", "other-manifest-id"], None)
+        )
+
+    def test_list_of_single_item_dicts_is_valid(self):
+        self.assertTrue(
+            valid_requires_manifest(
+                [
+                    {"manifest-id": True},
+                    {"other-manifest-id": "value"},
+                ],
+                None,
+            )
+        )
+
+
+class SetupJobUnitTests(TestCase):
+
+    def setUp(self):
+        self.self_mock = MagicMock()
+        self.self_mock._get_required_manifests_spec = (
+            lambda manifest_spec: SetupJobUnit._get_required_manifests_spec(
+                self.self_mock, manifest_spec
+            )
+        )
+        self.self_mock.qualify_id = lambda manifest_id: manifest_id
+
+    def test_get_required_manifests_spec_string_without_value(self):
+        self.self_mock.requires_manifest = ["manifest-id"]
+
+        self.assertEqual(
+            SetupJobUnit.get_required_manifests_spec(self.self_mock),
+            [RequiredManifest("manifest-id", True)],
+        )
+
+    def test_get_required_manifests_spec_dict_with_one_item(self):
+        self.self_mock.requires_manifest = [{"manifest-id": "value"}]
+
+        self.assertEqual(
+            SetupJobUnit.get_required_manifests_spec(self.self_mock),
+            [RequiredManifest("manifest-id", "value")],
+        )

--- a/docs/how-to/using-setup-include.rst
+++ b/docs/how-to/using-setup-include.rst
@@ -53,6 +53,38 @@ With this structure, Checkbox installs ``example-tool`` first. It then runs the
 bootstrap job that discovers devices or generates tests, and finally runs the
 main test selection.
 
+Using manifest values
+---------------------
+
+Use ``requires_manifest`` when a setup job should only run for specific manifest
+values. List a manifest entry directly when the required value is ``true``:
+
+.. code-block:: yaml
+
+    unit: setup job
+    id: setup/install_touchscreen_tool
+    summary: Install touchscreen test dependencies
+    plugin: shell
+    user: root
+    requires_manifest:
+      - has_touchscreen
+      - has_touchscreen_special_pen
+    command: snap install touchscreen-tool-pen
+
+Use an explicit key/value mapping when the setup job requires a manifest value to
+be ``false``:
+
+.. code-block:: yaml
+
+    unit: setup job
+    id: setup/install_non_touchscreen_tool
+    summary: Install non-touchscreen test dependencies
+    plugin: shell
+    user: root
+    requires_manifest:
+      - has_touchscreen: false
+    command: snap install non-touchscreen-tool
+
 When to use a setup job
 -----------------------
 

--- a/docs/reference/units/setup_job.rst
+++ b/docs/reference/units/setup_job.rst
@@ -78,6 +78,22 @@ The following fields may be used by the setup job unit:
     should be listed, not the *values*, which will be taken from the existing
     environment.
 
+.. option:: requires_manifest
+
+    (optional, YAML only) - A list of manifest entries that must match before
+    the setup job can run. This field is only supported in YAML unit
+    definitions.
+
+    List a manifest entry directly when the required value is ``true``::
+
+        requires_manifest:
+            - has_touchscreen
+
+    Use a mapping when the required value is ``false``::
+
+        requires_manifest:
+            - has_touchscreen: false
+
 .. option:: estimated_duration
 
     (optional) - This field contains metadata about how long the setup job is

--- a/metabox/metabox/metabox-provider/manage.py
+++ b/metabox/metabox/metabox-provider/manage.py
@@ -6,4 +6,5 @@ setup(
     version="1.0",
     description=N_("The 2021.com.canonical.certification:metabox provider"),
     gettext_domain="2021_com_canonical_certification_metabox",
+    strict=False,
 )

--- a/metabox/metabox/metabox-provider/units/setup_include.yaml
+++ b/metabox/metabox/metabox-provider/units/setup_include.yaml
@@ -81,12 +81,26 @@ unit: setup job
 flags: [simple]
 requires_manifest:
   - setup_manifest_true
+  - setup_manifest_false: false
 command: |
-  echo abc
+  echo Setup job
+---
+id: manifest_include_followup
+flags: [simple]
+imports: from com.canonical.plainbox import manifest
+requires:
+  - manifest.setup_manifest_true == "True"
+command: |
+  echo Setup job
 ---
 unit: manifest entry
 id: setup_manifest_true
-name: Setup manifest to be shown before running manifest
+name: Setup manifest to be shown before running manifest that has to be true
+value-type: bool
+---
+unit: manifest entry
+id: setup_manifest_false
+name: Setup manifest to be shown before running manifest that has to be false
 value-type: bool
 ---
 id: manifest_setup_include_tp
@@ -94,4 +108,5 @@ unit: test plan
 name: Test manifest in setup include
 setup_include:
   - manifest_setup_include
-include: []
+include:
+  - manifest_include_followup

--- a/metabox/metabox/metabox-provider/units/setup_include.yaml
+++ b/metabox/metabox/metabox-provider/units/setup_include.yaml
@@ -76,37 +76,46 @@ include:
   - verify_simple_guards
   - verify_resume_guards
 ---
-id: manifest_setup_include
-unit: setup job
-flags: [simple]
-requires_manifest:
-  - setup_manifest_true
-  - setup_manifest_false: false
-command: |
-  echo Setup job
----
-id: manifest_include_followup
-flags: [simple]
-imports: from com.canonical.plainbox import manifest
-requires:
-  - manifest.setup_manifest_true == "True"
-command: |
-  echo Setup job
----
-unit: manifest entry
-id: setup_manifest_true
-name: Setup manifest to be shown before running manifest that has to be true
-value-type: bool
----
 unit: manifest entry
 id: setup_manifest_false
 name: Setup manifest to be shown before running manifest that has to be false
 value-type: bool
 ---
-id: manifest_setup_include_tp
+unit: manifest entry
+id: _setup_manifest_hidden
+name: Setup manifest hidden from the UI
+value-type: bool
+---
+unit: manifest entry
+id: setup_job_manifest
+name: Setup job manifest question shown
+value-type: bool
+---
+unit: setup job
+id: setup_job_requiring_manifest
+flags: [simple]
+requires_manifest:
+  - setup_job_manifest
+  - setup_manifest_false: false
+  - _setup_manifest_hidden
+command: |
+  echo "setup_ran" > $PLAINBOX_SESSION_SHARE/setup_manifest_guard
+---
+id: verify_setup_manifest_ran
+flags: [simple]
+imports: from com.canonical.plainbox import manifest
+command: |
+  if test -f $PLAINBOX_SESSION_SHARE/setup_manifest_guard; then
+    echo "setup job ran correctly"
+  else
+    echo "setup job did not run"
+    exit 1
+  fi
+---
+id: manifest_menu_setup_job_tp
 unit: test plan
-name: Test manifest in setup include
+name: Test manifest menu shown for setup job
 setup_include:
-  - manifest_setup_include
+  - setup_job_requiring_manifest
 include:
-  - manifest_include_followup
+  - verify_setup_manifest_ran

--- a/metabox/metabox/metabox-provider/units/setup_include.yaml
+++ b/metabox/metabox/metabox-provider/units/setup_include.yaml
@@ -103,7 +103,8 @@ command: |
 ---
 id: verify_setup_manifest_ran
 flags: [simple]
-imports: from com.canonical.plainbox import manifest
+imports:
+  - from com.canonical.plainbox import manifest
 command: |
   if test -f $PLAINBOX_SESSION_SHARE/setup_manifest_guard; then
     echo "setup job ran correctly"

--- a/metabox/metabox/metabox-provider/units/setup_include.yaml
+++ b/metabox/metabox/metabox-provider/units/setup_include.yaml
@@ -84,6 +84,7 @@ value-type: bool
 unit: manifest entry
 id: _setup_manifest_hidden
 name: Setup manifest hidden from the UI
+hidden-reason: Intentionally hidden to validate that it is not shown in the UI
 value-type: bool
 ---
 unit: manifest entry
@@ -120,3 +121,21 @@ setup_include:
   - setup_job_requiring_manifest
 include:
   - verify_setup_manifest_ran
+---
+id: verify_setup_manifest_not_ran
+flags: [simple]
+command: |
+  if test -f $PLAINBOX_SESSION_SHARE/setup_manifest_guard; then
+    echo "setup job ran, when it should have been skipped"
+    exit 1
+  else
+    echo "setup job did not run, as expected"
+  fi
+---
+id: manifest_menu_setup_job_tp_not_ran
+unit: test plan
+name: Test that skipping actually works for setup jobs
+setup_include:
+  - setup_job_requiring_manifest
+include:
+  - verify_setup_manifest_not_ran

--- a/metabox/metabox/metabox-provider/units/setup_include.yaml
+++ b/metabox/metabox/metabox-provider/units/setup_include.yaml
@@ -75,3 +75,23 @@ bootstrap_include:
 include:
   - verify_simple_guards
   - verify_resume_guards
+---
+id: manifest_setup_include
+unit: setup job
+flags: [simple]
+requires_manifest:
+  - setup_manifest_true
+command: |
+  echo abc
+---
+unit: manifest entry
+id: setup_manifest_true
+name: Setup manifest to be shown before running manifest
+value-type: bool
+---
+id: manifest_setup_include_tp
+unit: test plan
+name: Test manifest in setup include
+setup_include:
+  - manifest_setup_include
+include: []

--- a/metabox/metabox/scenarios/ui/manifest_menu.py
+++ b/metabox/metabox/scenarios/ui/manifest_menu.py
@@ -184,3 +184,28 @@ class ManifestSelectionUsesLauncherManifestForSetupJob(Scenario):
         Expect("2021.com.canonical.certification::verify_setup_manifest_ran"),
         Expect("job passed"),
     ]
+
+
+@tag("manual", "interact", "manifest")
+class ManifestSelectionUsesLauncherManifestForSetupJobNotRan(Scenario):
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit=2021.com.canonical.certification::manifest_menu_setup_job_tp_not_ran
+        forced = yes
+        [test selection]
+        forced = yes
+        [manifest]
+        2021.com.canonical.certification::setup_job_manifest=False
+        """)
+
+    steps = [
+        Start(),
+        ExpectNot("System Manifest", timeout=0.5),
+        Expect(
+            "2021.com.canonical.certification::verify_setup_manifest_not_ran"
+        ),
+        Expect("job passed"),
+    ]

--- a/metabox/metabox/scenarios/ui/manifest_menu.py
+++ b/metabox/metabox/scenarios/ui/manifest_menu.py
@@ -95,3 +95,92 @@ class ManifestSelectionCanSetHiddenLauncher(Scenario):
         Expect("2021.com.canonical.certification::job_requires_not_hidden"),
         Expect("job cannot be started"),
     ]
+
+
+@tag("manual", "interact", "manifest")
+class ManifestSelectionShownForSetupJobManifest(Scenario):
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit=2021.com.canonical.certification::manifest_menu_setup_job_tp
+        forced = yes
+        [manifest]
+        2021.com.canonical.certification::_setup_manifest_hidden=True
+        """)
+
+    steps = [
+        Start(),
+        Expect("System Manifest"),
+        Expect("Setup job manifest question shown"),
+        Expect("manifest that has to be"),
+        ExpectNot("hidden from the UI", timeout=0.1),
+        Expect("Press (T) to start Testing"),
+        Send("ynt"),
+        Expect("Choose tests to run on your system"),
+        Send("t"),
+        Expect("2021.com.canonical.certification::verify_setup_manifest_ran"),
+        Expect("job passed"),
+    ]
+
+
+@tag("manual", "interact", "manifest")
+class ManifestSelectionUsesOnDiskManifestForSetupJob(Scenario):
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit=2021.com.canonical.certification::manifest_menu_setup_job_tp
+        forced = yes
+        [manifest]
+        2021.com.canonical.certification::_setup_manifest_hidden=True
+        """)
+    machine_manifest = textwrap.dedent("""
+        {
+            "2021.com.canonical.certification::setup_job_manifest" : true,
+            "2021.com.canonical.certification::setup_manifest_false" : false
+        }
+        """)
+
+    steps = [
+        MkTree("/var/tmp/checkbox-ng"),
+        Put("/var/tmp/checkbox-ng/machine-manifest.json", machine_manifest),
+        Start(),
+        Expect("System Manifest"),
+        Expect("Setup job manifest question shown"),
+        Expect("manifest that has to be"),
+        ExpectNot("hidden from the UI", timeout=0.1),
+        Expect("Press (T) to start Testing"),
+        Send("t"),
+        Expect("Choose tests to run on your system"),
+        Send("t"),
+        Expect("2021.com.canonical.certification::verify_setup_manifest_ran"),
+        Expect("job passed"),
+    ]
+
+
+@tag("manual", "interact", "manifest")
+class ManifestSelectionUsesLauncherManifestForSetupJob(Scenario):
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit=2021.com.canonical.certification::manifest_menu_setup_job_tp
+        forced = yes
+        [test selection]
+        forced = yes
+        [manifest]
+        2021.com.canonical.certification::setup_job_manifest=True
+        2021.com.canonical.certification::setup_manifest_false=False
+        2021.com.canonical.certification::_setup_manifest_hidden=True
+        """)
+
+    steps = [
+        Start(),
+        ExpectNot("System Manifest", timeout=0.5),
+        Expect("2021.com.canonical.certification::verify_setup_manifest_ran"),
+        Expect("job passed"),
+    ]

--- a/unit_json_schema/setup-job.schema.json
+++ b/unit_json_schema/setup-job.schema.json
@@ -91,6 +91,21 @@
           "items": {
             "type": "string"
           }
+        },
+        "requires_manifest": {
+          "title": "Requires Manifest (Setup Job Unit)",
+          "description": "List of manifest entries the job requires. Each item is either a manifest id (string) or a single-key mapping of a manifest id to its required value.",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "type": "string" },
+              {
+                "type": "object",
+                "minProperties": 1,
+                "maxProperties": 1
+              }
+            ]
+          }
         }
       }
     }


### PR DESCRIPTION
## Description

Manifests are very important during setup but up until now there was no way to actually use them properly. The reason is that, although a checkbox-support API offers the capability of reading the machine manifest, editing it or saving it did not work and had to be done manually. 

This introduces:
- requires_manifest: new field to require a manifest (optionally with a specific value) to run a job
- second manifest selection screen before setup include phase that shows all relevant manifests (added via requires_manifest)
- manifest saving also before setup include

#### About the implementation

This adds a new field instead of using resource for two reasons:
1. we've been wanting a separate field for a while for this thing, manifests should be handled separately because it makes it easier to parse them out of metadata/read the test requirements etc.
2. requires (and resources) don't exist/make sense before bootstrap, as bootstrap is the phase where resources are built. To actually allow someone to use requires in setup we would either need a new bootstrap before setup (hard no) or a restricted requires syntax that only allows manifests. In my opinion it is better this way

This adds a new inhibitor to clearly separate the old resource inhibitor from this case, this is just to have code that is a bit easier to read and a better error text in the output. The result is the same as the manifest skip result was added in a previous PR.

This uses the same behaviour that we normally use to decide if the manifest selection screen is shown (that is, do show it if test selection is not forced). This will be changed with a new config in a follow up (`manifest selection`).

This moves the manifest saving code to the session state (because handling the manifest is a state issue, not quite clear to me why it was an assistant thing)

## Resolved issues

Fixes: CHECKBOX-1895

## Documentation

This also adds to the how to and reference all relevant behaviours and fields.

## Tests

Metabox tests + Unit tests (WIP)
