### PR TITLE
Migrate to use libnvml to check nvlink status directly (BugFix)

### DIFF
--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -30,6 +30,7 @@ import re
 import os
 import typing as T
 from shlex import split as sh_split
+import ctypes
 
 
 class PrimeOffloader:
@@ -238,6 +239,97 @@ class PrimeOffloader:
         self.logger.info("  Couldn't find process {}".format(cmd))
         self.check_result = True
 
+    def check_nv_link_status(self) -> bool:
+        """
+        Check NVLink status using ctypes binding to libnvml.
+
+        Returns True if NVLink is active/detected, False otherwise.
+        Returns False if nvml library is not available.
+        """
+        try:
+            # Try to load the NVIDIA Management Library
+            try:
+                nvml = ctypes.CDLL("libnvidia-ml.so.1")
+            except OSError:
+                # Library not found, assume no NVLink
+                self.logger.info(
+                    "libnvidia-ml.so.1 not found, assuming no NVLink"
+                )
+                return False
+
+            # Define NVML return codes
+            NVML_SUCCESS = 0
+            NVML_ERROR_NOT_SUPPORTED = 3
+
+            # Initialize NVML
+            nvmlInit = nvml.nvmlInit_v2
+            nvmlInit.restype = ctypes.c_int
+
+            ret = nvmlInit()
+            if ret != NVML_SUCCESS:
+                self.logger.info("NVML initialization failed")
+                return False
+
+            # Get device count
+            nvmlDeviceGetCount = nvml.nvmlDeviceGetCount_v2
+            nvmlDeviceGetCount.argtypes = [ctypes.POINTER(ctypes.c_uint)]
+            nvmlDeviceGetCount.restype = ctypes.c_int
+
+            device_count = ctypes.c_uint()
+            ret = nvmlDeviceGetCount(ctypes.byref(device_count))
+            if ret != NVML_SUCCESS:
+                nvml.nvmlShutdown()
+                return False
+
+            # Check each device for NVLink
+            nvmlDeviceGetHandleByIndex = nvml.nvmlDeviceGetHandleByIndex_v2
+            nvmlDeviceGetHandleByIndex.argtypes = [
+                ctypes.c_uint,
+                ctypes.POINTER(ctypes.c_void_p),
+            ]
+            nvmlDeviceGetHandleByIndex.restype = ctypes.c_int
+
+            nvmlDeviceGetNvLinkState = nvml.nvmlDeviceGetNvLinkState
+            nvmlDeviceGetNvLinkState.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_uint,
+                ctypes.POINTER(ctypes.c_uint),
+            ]
+            nvmlDeviceGetNvLinkState.restype = ctypes.c_int
+
+            nvlink_detected = False
+            for i in range(device_count.value):
+                handle = ctypes.c_void_p()
+                ret = nvmlDeviceGetHandleByIndex(i, ctypes.byref(handle))
+                if ret != NVML_SUCCESS:
+                    continue
+
+                # Check NVLink links (typically 0-5 for modern GPUs)
+                for link in range(6):
+                    state = ctypes.c_uint()
+                    ret = nvmlDeviceGetNvLinkState(
+                        handle, link, ctypes.byref(state)
+                    )
+                    # Skip if not supported
+                    if ret == NVML_ERROR_NOT_SUPPORTED:
+                        continue
+                    # Check if link is active (state == 1)
+                    if ret == NVML_SUCCESS and state.value == 1:
+                        nvlink_detected = True
+                        break
+
+                if nvlink_detected:
+                    break
+
+            # Shutdown NVML
+            nvml.nvmlShutdown()
+
+            return nvlink_detected
+
+        except Exception as e:
+            self.logger.info("Error checking NVLink status: {}".format(e))
+            return False
+
     def check_nv_offload_env(self):
         """
         prime offload of nvidia driver is limited.
@@ -254,13 +346,8 @@ class PrimeOffloader:
                 raise SystemExit("System isn't on-demand mode")
 
             # prime offload couldn't running on nvlink active or inactive
-            # Therefore, only return empty string is supported environment.
-            nvlink = subprocess.check_output(
-                ["nvidia-smi", "nvlink", "-s"], universal_newlines=True
-            )
-            if nvlink:
-                if "error" in nvlink.lower():
-                    raise SystemExit("nvidia driver error")
+            # Use ctypes binding to libnvml to check NVLink status
+            if self.check_nv_link_status():
                 raise SystemExit("NVLINK detected")
         except FileNotFoundError:
             self.logger.info(
@@ -350,6 +437,10 @@ class PrimeOffloader:
             }
         else:
             offload_env = {"DRI_PRIME": "pci-{}".format(dri_pci_bdf_format)}
+            offload_env = {
+                "DRI_PRIME": "pci-{}".format(dri_pci_bdf_format),
+                "__GLX_VENDOR_LIBRARY_NAME": "mesa",
+            }
 
         env.update(offload_env)
         self.logger.info("prime offload env: {}".format(offload_env))

--- a/providers/base/bin/prime_offload_tester.py
+++ b/providers/base/bin/prime_offload_tester.py
@@ -258,6 +258,7 @@ class PrimeOffloader:
                 return False
 
             # Define NVML return codes
+            # https://github.com/NVIDIA/nvidia-settings/blob/5b341a9e54f08ac324e148e1e7e102030e42b1c4/src/nvml.h#L1293
             NVML_SUCCESS = 0
             NVML_ERROR_NOT_SUPPORTED = 3
 
@@ -265,6 +266,7 @@ class PrimeOffloader:
             nvmlInit = nvml.nvmlInit_v2
             nvmlInit.restype = ctypes.c_int
 
+            # https://github.com/NVIDIA/nvidia-settings/blob/5b341a9e54f08ac324e148e1e7e102030e42b1c4/src/nvml.h#L3974-L4000
             ret = nvmlInit()
             if ret != NVML_SUCCESS:
                 self.logger.info("NVML initialization failed")
@@ -282,11 +284,13 @@ class PrimeOffloader:
                 return False
 
             # Check each device for NVLink
+            # https://github.com/NVIDIA/nvidia-settings/blob/5b341a9e54f08ac324e148e1e7e102030e42b1c4/src/nvml.h#L4593-L4639
             nvmlDeviceGetHandleByIndex = nvml.nvmlDeviceGetHandleByIndex_v2
             nvmlDeviceGetHandleByIndex.argtypes = [
                 ctypes.c_uint,
                 ctypes.POINTER(ctypes.c_void_p),
             ]
+            # https://github.com/NVIDIA/nvidia-settings/blob/5b341a9e54f08ac324e148e1e7e102030e42b1c4/src/nvml.h#L9486-L9504
             nvmlDeviceGetHandleByIndex.restype = ctypes.c_int
 
             nvmlDeviceGetNvLinkState = nvml.nvmlDeviceGetNvLinkState

--- a/providers/base/tests/test_prime_offload_tester.py
+++ b/providers/base/tests/test_prime_offload_tester.py
@@ -396,6 +396,139 @@ class FindOffloadTests(unittest.TestCase):
         self.assertEqual(po.check_result, True)
 
 
+class CheckNvLinkStatusTests(unittest.TestCase):
+    """
+    Test the check_nv_link_status method that uses ctypes to check NVLink.
+    """
+
+    @patch("prime_offload_tester.ctypes.CDLL")
+    def test_library_not_found(self, mock_cdll):
+        po = PrimeOffloader()
+        # Library not found
+        mock_cdll.side_effect = OSError("Library not found")
+        self.assertEqual(False, po.check_nv_link_status())
+
+    @patch("prime_offload_tester.ctypes.CDLL")
+    def test_nvml_init_failed(self, mock_cdll):
+        po = PrimeOffloader()
+        mock_nvml = MagicMock()
+        mock_cdll.return_value = mock_nvml
+        # NVML init returns non-zero (failure)
+        mock_nvml.nvmlInit_v2.return_value = 1
+        self.assertEqual(False, po.check_nv_link_status())
+
+    @patch("prime_offload_tester.ctypes.CDLL")
+    def test_device_count_failed(self, mock_cdll):
+        po = PrimeOffloader()
+        mock_nvml = MagicMock()
+        mock_cdll.return_value = mock_nvml
+        # NVML init succeeds
+        mock_nvml.nvmlInit_v2.return_value = 0
+        # Device count fails
+        mock_nvml.nvmlDeviceGetCount_v2.return_value = 1
+        self.assertEqual(False, po.check_nv_link_status())
+
+    @patch("prime_offload_tester.ctypes.byref")
+    @patch("prime_offload_tester.ctypes.POINTER")
+    @patch("prime_offload_tester.ctypes.c_uint")
+    @patch("prime_offload_tester.ctypes.CDLL")
+    def test_no_devices(
+        self, mock_cdll, mock_c_uint, mock_pointer, mock_byref
+    ):
+        po = PrimeOffloader()
+        mock_nvml = MagicMock()
+        mock_cdll.return_value = mock_nvml
+        # Mock POINTER and byref to avoid ctypes errors
+        mock_pointer.return_value = MagicMock()
+        mock_byref.side_effect = lambda x: x
+        # NVML init succeeds
+        mock_nvml.nvmlInit_v2.return_value = 0
+        # Device count succeeds with 0 devices
+        mock_nvml.nvmlDeviceGetCount_v2.return_value = 0
+        device_count_obj = MagicMock()
+        device_count_obj.value = 0
+        mock_c_uint.return_value = device_count_obj
+        self.assertEqual(False, po.check_nv_link_status())
+
+    @patch("prime_offload_tester.ctypes.byref")
+    @patch("prime_offload_tester.ctypes.POINTER")
+    @patch("prime_offload_tester.ctypes.c_void_p")
+    @patch("prime_offload_tester.ctypes.c_uint")
+    @patch("prime_offload_tester.ctypes.CDLL")
+    def test_nvlink_detected(
+        self,
+        mock_cdll,
+        mock_c_uint,
+        mock_c_void_p,
+        mock_pointer,
+        mock_byref,
+    ):
+        po = PrimeOffloader()
+        mock_nvml = MagicMock()
+        mock_cdll.return_value = mock_nvml
+        # Mock POINTER and byref to avoid ctypes errors
+        mock_pointer.return_value = MagicMock()
+        mock_byref.side_effect = lambda x: x
+        # NVML init succeeds
+        mock_nvml.nvmlInit_v2.return_value = 0
+        # Device count succeeds with 1 device
+        mock_nvml.nvmlDeviceGetCount_v2.return_value = 0
+        device_count_obj = MagicMock()
+        device_count_obj.value = 1
+        # Get device handle succeeds
+        mock_nvml.nvmlDeviceGetHandleByIndex_v2.return_value = 0
+        # NVLink state check succeeds and link is active (state=1)
+        mock_nvml.nvmlDeviceGetNvLinkState.return_value = 0
+        # First call returns device_count, subsequent calls return state
+        state_obj = MagicMock()
+        state_obj.value = 1  # Active link
+        # Return device_count first, then state objects for each link check
+        mock_c_uint.side_effect = [device_count_obj] + [state_obj] * 6
+        self.assertEqual(True, po.check_nv_link_status())
+
+    @patch("prime_offload_tester.ctypes.byref")
+    @patch("prime_offload_tester.ctypes.POINTER")
+    @patch("prime_offload_tester.ctypes.c_void_p")
+    @patch("prime_offload_tester.ctypes.c_uint")
+    @patch("prime_offload_tester.ctypes.CDLL")
+    def test_nvlink_not_detected(
+        self,
+        mock_cdll,
+        mock_c_uint,
+        mock_c_void_p,
+        mock_pointer,
+        mock_byref,
+    ):
+        po = PrimeOffloader()
+        mock_nvml = MagicMock()
+        mock_cdll.return_value = mock_nvml
+        # Mock POINTER and byref to avoid ctypes errors
+        mock_pointer.return_value = MagicMock()
+        mock_byref.side_effect = lambda x: x
+        # NVML init succeeds
+        mock_nvml.nvmlInit_v2.return_value = 0
+        # Device count succeeds with 1 device
+        mock_nvml.nvmlDeviceGetCount_v2.return_value = 0
+        device_count_obj = MagicMock()
+        device_count_obj.value = 1
+        # Get device handle succeeds
+        mock_nvml.nvmlDeviceGetHandleByIndex_v2.return_value = 0
+        # NVLink not supported
+        mock_nvml.nvmlDeviceGetNvLinkState.return_value = 3  # NOT_SUPPORTED
+        state_obj = MagicMock()
+        state_obj.value = 0  # Inactive link
+        # Return device_count first, then state objects
+        mock_c_uint.side_effect = [device_count_obj] + [state_obj] * 6
+        self.assertEqual(False, po.check_nv_link_status())
+
+    @patch("prime_offload_tester.ctypes.CDLL")
+    def test_exception_handling(self, mock_cdll):
+        po = PrimeOffloader()
+        # Raise an unexpected exception
+        mock_cdll.side_effect = Exception("Unexpected error")
+        self.assertEqual(False, po.check_nv_link_status())
+
+
 class CheckNvOffloadEnvTests(unittest.TestCase):
     """
     This function will check this system could use prime offload or not.
@@ -416,28 +549,16 @@ class CheckNvOffloadEnvTests(unittest.TestCase):
     @patch("subprocess.check_output")
     def test_nvlink_check(self, mock_check):
         po = PrimeOffloader()
-        # with nv driver, on-demand mode. This might be NVLINK environment
-        mock_check.return_value = "prime-select on-demand"
+        # with nv driver, on-demand mode, nvlink detected
+        mock_check.return_value = "on-demand"
+        po.check_nv_link_status = MagicMock(return_value=True)
         with self.assertRaises(SystemExit):
             po.check_nv_offload_env()
-        mock_check.assert_called_with(
-            ["nvidia-smi", "nvlink", "-s"], universal_newlines=True
-        )
 
-        # with nv driver, on-demand mode, nv driver error
-        mock_check.side_effect = ["on-demand", "error"]
-        with self.assertRaises(SystemExit):
-            po.check_nv_offload_env()
-        mock_check.assert_called_with(
-            ["nvidia-smi", "nvlink", "-s"], universal_newlines=True
-        )
-
-        # with nv driver, on-demand mode, no nv driver error
-        mock_check.side_effect = ["on-demand", ""]
+        # with nv driver, on-demand mode, no nvlink
+        mock_check.return_value = "on-demand"
+        po.check_nv_link_status = MagicMock(return_value=False)
         self.assertEqual(None, po.check_nv_offload_env())
-        mock_check.assert_called_with(
-            ["nvidia-smi", "nvlink", "-s"], universal_newlines=True
-        )
 
         # No prime-select
         mock_check.side_effect = FileNotFoundError


### PR DESCRIPTION


<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
With nvidia-driver-580, the output of nvidia-smi nvlink --status was empty. However, with nvidia-driver-595, nvidia-smi nvlink --status now returns something, which broke the `prime_offload_test.py` and we don't want to depend on the output from `nvidia-smi nvlink -s` anymore. Therefore, migrating to use `ctype` would be a easier way to skip to add more dependencies into checkbox. 
At the same time, add `__GLX_VENDOR_LIBRARY_NAME=mesa` for all non-nvidia to make sure the default is set to the right one.
 

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->
https://github.com/canonical/checkbox/issues/2560

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
26.04 (I+N): https://certification.canonical.com/hardware/202001-27667/submission/498212/
24.04 (I+N): https://certification.canonical.com/hardware/202001-27667/submission/498219/
22.04 run 24.04 test plan (I+N) : https://certification.canonical.com/hardware/202001-27667/submission/498211/
22.04 with NVLINK: https://certification.canonical.com/hardware/202303-31329/submission/498220/
24.04 (A+N): https://certification.canonical.com/hardware/202603-38521/submission/498366/
