### PR TITLE
Re-implement max resolution test to handle fractional scaling (New)

### DIFF
--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -132,13 +132,13 @@ class PhysicalMonitor(_PhysicalMonitorT):
     def is_builtin(self) -> bool:
         return self.properties.get("is-builtin", False)
 
-    def max_resolution(self) -> "tuple[int, int]":
+    def get_max_resolution(self) -> "tuple[int, int]":
         """Get the maximum physcial resolution of this monitor
 
         :raises ValueError: if there's no supported modes
         :raises RuntimeError: if all modes are 0
         :return: (width, height) pair like (1920, 1080)
-        """        
+        """
         max_w, max_h = 0, 0
         if len(self.modes) == 0:
             raise ValueError(
@@ -154,6 +154,13 @@ class PhysicalMonitor(_PhysicalMonitorT):
             raise RuntimeError("Unexpected max resolution of 0x0")
 
         return max_w, max_h
+
+    def get_current_mode(self) -> "MutterDisplayMode | None":
+        # it' possible to return none
+        # if somehow all monitors are turned off
+        for mode in self.modes:
+            if mode.is_current:
+                return mode
 
 
 _LogicalMonitorT = NamedTuple(

--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -132,6 +132,29 @@ class PhysicalMonitor(_PhysicalMonitorT):
     def is_builtin(self) -> bool:
         return self.properties.get("is-builtin", False)
 
+    def max_resolution(self) -> "tuple[int, int]":
+        """Get the maximum physcial resolution of this monitor
+
+        :raises ValueError: if there's no supported modes
+        :raises RuntimeError: if all modes are 0
+        :return: (width, height) pair like (1920, 1080)
+        """        
+        max_w, max_h = 0, 0
+        if len(self.modes) == 0:
+            raise ValueError(
+                "Monitor {} doesn't have any supported modes!".format(
+                    self.info.connector
+                )
+            )
+        for mode in self.modes:
+            if (mode.width, mode.height) >= (max_w, max_h):
+                max_w, max_h = mode.width, mode.height
+
+        if (max_w, max_h) == (0, 0):
+            raise RuntimeError("Unexpected max resolution of 0x0")
+
+        return max_w, max_h
+
 
 _LogicalMonitorT = NamedTuple(
     "_LogicalMonitorT",
@@ -344,7 +367,7 @@ class MonitorConfigGnome(MonitorConfig):
         cycle_transforms: bool = False,
         resolution_filter: Optional[ResolutionFilter] = None,
         post_cycle_action: Callable[..., Any] = lambda *a, **k: sleep(5),
-        **post_cycle_action_kwargs: Any
+        **post_cycle_action_kwargs: Any,
     ):
         """Automatically cycle through the supported monitor configurations.
 

--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -120,13 +120,13 @@ class PhysicalMonitor(_PhysicalMonitorT):
     def is_builtin(self) -> bool:
         return self.properties.get("is-builtin", False)
 
-    def max_resolution(self) -> "tuple[int, int]":
+    def get_max_resolution(self) -> "tuple[int, int]":
         """Get the maximum physcial resolution of this monitor
 
         :raises ValueError: if there's no supported modes
         :raises RuntimeError: if all modes are 0
         :return: (width, height) pair like (1920, 1080)
-        """        
+        """
         max_w, max_h = 0, 0
         if len(self.modes) == 0:
             raise ValueError(
@@ -142,6 +142,13 @@ class PhysicalMonitor(_PhysicalMonitorT):
             raise RuntimeError("Unexpected max resolution of 0x0")
 
         return max_w, max_h
+
+    def get_current_mode(self) -> "MutterDisplayMode | None":
+        # it' possible to return none
+        # if somehow all monitors are turned off
+        for mode in self.modes:
+            if mode.is_current:
+                return mode
 
 
 class _LogicalMonitorT(NamedTuple):

--- a/checkbox-support/checkbox_support/dbus/gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/gnome_monitor.py
@@ -120,6 +120,29 @@ class PhysicalMonitor(_PhysicalMonitorT):
     def is_builtin(self) -> bool:
         return self.properties.get("is-builtin", False)
 
+    def max_resolution(self) -> "tuple[int, int]":
+        """Get the maximum physcial resolution of this monitor
+
+        :raises ValueError: if there's no supported modes
+        :raises RuntimeError: if all modes are 0
+        :return: (width, height) pair like (1920, 1080)
+        """        
+        max_w, max_h = 0, 0
+        if len(self.modes) == 0:
+            raise ValueError(
+                "Monitor {} doesn't have any supported modes!".format(
+                    self.info.connector
+                )
+            )
+        for mode in self.modes:
+            if (mode.width, mode.height) >= (max_w, max_h):
+                max_w, max_h = mode.width, mode.height
+
+        if (max_w, max_h) == (0, 0):
+            raise RuntimeError("Unexpected max resolution of 0x0")
+
+        return max_w, max_h
+
 
 class _LogicalMonitorT(NamedTuple):
     x: int

--- a/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
+++ b/checkbox-support/checkbox_support/dbus/tests/test_gnome_monitor.py
@@ -1,15 +1,49 @@
 import re
 import sys
 import unittest
-from unittest.mock import patch, Mock, MagicMock
+from unittest.mock import MagicMock, Mock, patch
 
 sys.modules["dbus"] = MagicMock()
 sys.modules["dbus.mainloop.glib"] = MagicMock()
 sys.modules["gi"] = MagicMock()
 sys.modules["gi.repository"] = MagicMock()
 
-from gi.repository import GLib, Gio  # type: ignore
-from checkbox_support.dbus.gnome_monitor import MonitorConfigGnome
+from checkbox_support.dbus.gnome_monitor import (
+    MonitorConfigGnome,
+    MonitorInfo,
+    MutterDisplayMode,
+    PhysicalMonitor,
+)
+from gi.repository import Gio, GLib  # type: ignore
+
+
+def make_mode(
+    width: int,
+    height: int,
+    is_current: bool = False,
+    mode_id: "str | None" = None,
+):
+    if mode_id is None:
+        mode_id = f"{width}x{height}"
+    return MutterDisplayMode(
+        mode_id,
+        width,
+        height,
+        60.0,
+        1.0,
+        [1.0],
+        {"is-current": is_current, "is-preferred": False},
+    )
+
+
+def make_physical_monitor(
+    modes: "list[MutterDisplayMode]", connector: str = "eDP-1"
+):
+    return PhysicalMonitor(
+        MonitorInfo(connector, "LGD", "0x06b3", "0x00000000"),
+        modes,
+        {},
+    )
 
 
 class MonitorConfigGnomeTests(unittest.TestCase):
@@ -552,6 +586,42 @@ class MonitorConfigGnomeTests(unittest.TestCase):
         p2 = "eDP-1_1920x1200_normal_"
         pattern = re.compile(f"{p1}{p2}|{p2}{p1}")
         assert pattern.match(argument_string)
+
+
+class PhysicalMonitorTests(unittest.TestCase):
+
+    def test_get_current_mode_returns_current(self):
+        current_mode = make_mode(1920, 1200, is_current=True)
+        monitor = make_physical_monitor([make_mode(1280, 720), current_mode])
+        self.assertEqual(monitor.get_current_mode(), current_mode)
+
+    def test_get_current_mode_returns_none_if_no_mode_is_current(self):
+        monitor = make_physical_monitor(
+            [make_mode(1280, 720), make_mode(1920, 1200)]
+        )
+        self.assertIsNone(monitor.get_current_mode())
+
+    def test_get_current_mode_returns_none_if_no_modes(self):
+        monitor = make_physical_monitor([])
+        self.assertIsNone(monitor.get_current_mode())
+
+    def test_get_max_resolution_picks_largest_mode(self):
+        monitor = make_physical_monitor(
+            [
+                make_mode(1280, 720),
+                make_mode(1920, 1200),
+                make_mode(1024, 768),
+            ]
+        )
+        self.assertEqual(monitor.get_max_resolution(), (1920, 1200))
+
+    def test_get_max_resolution_raises_value_error_if_no_modes(self):
+        monitor = make_physical_monitor([])
+        self.assertRaises(ValueError, monitor.get_max_resolution)
+
+    def test_get_max_resolution_raises_runtime_error_if_all_zero(self):
+        monitor = make_physical_monitor([make_mode(0, 0), make_mode(0, 0)])
+        self.assertRaises(RuntimeError, monitor.get_max_resolution)
 
 
 if __name__ == "__main__":

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -5,6 +5,7 @@
 # Copyright 2022 Canonical Ltd.
 #
 # Authors:
+#   Zhongning Li <zhongning.li@canonical.com>
 #   Pierre Equoy <pierre.equoy@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -54,7 +54,10 @@ class SysfsDrmCardInfo:
         self.dpms_enabled = (Path(path) / "dpms").read_text().strip() == "On"
 
     def __str__(self) -> str:
-        return "{}: max_resolution={}x{} enabled={}, is_connected={}, dpms_enabled={}".format(
+        return (
+            "{}: max_resolution={}x{} "
+            + "enabled={}, is_connected={}, dpms_enabled={}"
+        ).format(
             self.port,
             self.max_width,
             self.max_height,

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -149,7 +149,7 @@ def ubuntu16_main():
         )
 
 
-def check_max_resolution_in_gnome():
+def main():
     mutter_state = MonitorConfigGnome().get_current_state()
 
     failed = False
@@ -217,5 +217,4 @@ def check_max_resolution_in_gnome():
 
 
 if __name__ == "__main__":
-    # print(get_sysfs_info())
-    check_max_resolution_in_gnome()
+    main()

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -159,10 +159,10 @@ def check_max_resolution_in_gnome():
             monitor.info.vendor, monitor.info.product, monitor.info.connector
         )
 
+        # preserve the original logic of ignoring inactive monitors
         if curr is None:
-            raise SystemExit(
-                msg_prefix + " has no active mode. Is it turned off?"
-            )
+            print(msg_prefix, "has no active mode. Skipping.")
+            continue
 
         max_w, max_h = monitor.get_max_resolution()
         if curr.width != max_w or curr.height != max_h:
@@ -189,4 +189,5 @@ def check_max_resolution_in_gnome():
 
 
 if __name__ == "__main__":
+    # print(get_sysfs_info())
     check_max_resolution_in_gnome()

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -20,9 +20,47 @@
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
 from glob import glob
+import os
 import sys
 from pathlib import Path
 from checkbox_support.dbus.gnome_monitor import MonitorConfigGnome
+
+
+class SysfsDrmCardInfo:
+    def __init__(self, path: Path) -> None:
+        if not path.is_dir():
+            raise ValueError(
+                "{} requires a directory path.".format(type(self).__name__)
+                + "Example: /sys/class/drm/card1-eDP-1/"
+            )
+        with open(Path(path) / "modes") as f:
+            # Topmost line in the modes file is the max resolution
+            max_resolution = f.readline().strip()
+            if not max_resolution:
+                raise ValueError(
+                    "No monitor is connected to this port {}".format(path)
+                )
+            str_width, str_height = max_resolution.split("x")
+            self.max_width, self.max_height = int(str_width), int(str_height)
+
+        self.enabled = (
+            Path(path) / "enabled"
+        ).read_text().strip() == "enabled"
+        self.is_connected = (
+            Path(path) / "status"
+        ).read_text().strip() == "connected"
+        self.port = os.path.basename(path)
+        self.dpms_enabled = (Path(path) / "dpms").read_text().strip() == "On"
+
+    def __str__(self) -> str:
+        return "{}: {}x{} enabled={}, is_connected={}, dpms_enabled={}".format(
+            self.port,
+            self.max_width,
+            self.max_height,
+            self.enabled,
+            self.is_connected,
+            self.dpms_enabled,
+        )
 
 
 def get_sysfs_info():
@@ -31,54 +69,13 @@ def get_sysfs_info():
     connected to a monitor.
     Return a list of ports with information about them.
     """
-    ports = glob("/sys/class/drm/card*-*")
-    entries = []
-    for p in ports:
-        with open(Path(p) / "modes") as f:
-            # Topmost line in the modes file is the max resolution
-            max_resolution = f.readline().strip()
-        if max_resolution:
-            # e.g. "/sys/class/drm/card0-HDMI-A-1"
-            port = p.split("/")[-1]
-            width, height = max_resolution.split("x")
-            with open(Path(p) / "enabled") as f:
-                enabled = f.readline().strip()
-            with open(Path(p) / "dpms") as f:
-                dpms = f.readline().strip()
-            with open(Path(p) / "status") as f:
-                status = f.readline().strip()
-            port_info = {
-                "port": port,
-                "width": int(width),
-                "height": int(height),
-                "enabled": enabled,  # "enabled" or "disabled"
-                "status": status,  # "connected" or "disconnected"
-                "dpms": dpms,  # "On" or "Off"
-            }
-            entries.append(port_info)
-    return entries
-
-
-def get_monitors_info():
-    """
-    Get information (model, manufacturer, resolution) from each connected
-    monitors using Gtk.
-    Return a list of monitors with their information.
-    """
-    Gtk.init()
-    display = Gdk.Display.get_default()
-    monitors = []
-    for i in range(display.get_n_monitors()):
-        mon = display.get_monitor(i)
-        monitor = {
-            "model": mon.get_model(),
-            "manufacturer": mon.get_manufacturer(),
-            "width": mon.get_geometry().width,
-            "height": mon.get_geometry().height,
-            "scale_factor": mon.get_scale_factor(),
-        }
-        monitors.append(monitor)
-    return monitors
+    out = []  # type: list[SysfsDrmCardInfo]
+    for str_path in glob("/sys/class/drm/card*-*"):
+        try:
+            out.append(SysfsDrmCardInfo(Path(str_path)))
+        except ValueError:
+            continue
+    return out
 
 
 def main():
@@ -128,14 +125,10 @@ def main():
     total_sysfs_res = 0
     print("Checking against these max resolutions shown in sysfs:")
     sysfs_info = get_sysfs_info()
-    for p in sysfs_info:
-        print(
-            " - {}: {}x{} ({})".format(
-                p["port"], p["width"], p["height"], p["enabled"]
-            )
-        )
-        if p["enabled"] == "enabled":
-            total_sysfs_res += int(p["width"]) * int(p["height"])
+    for drm_card in sysfs_info:
+        print(" -", drm_card)
+        if drm_card.enabled:
+            total_sysfs_res += drm_card.max_width * drm_card.max_height
 
     # instead of checking each individual display
     # where we have to do edid matching

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -153,6 +153,7 @@ def check_max_resolution_in_gnome():
     mutter_state = MonitorConfigGnome().get_current_state()
 
     failed = False
+    total_gnome_res = 0
     for monitor in mutter_state.physical_monitors:
         curr = monitor.get_current_mode()
         msg_prefix = "Monitor '{} {}', connected at '{}'".format(
@@ -161,7 +162,7 @@ def check_max_resolution_in_gnome():
 
         # preserve the original logic of ignoring inactive monitors
         if curr is None:
-            print(msg_prefix, "has no active mode. Skipping.")
+            print("[ WARN ]", msg_prefix, "has no active mode. Skipping.")
             continue
 
         max_w, max_h = monitor.get_max_resolution()
@@ -183,9 +184,36 @@ def check_max_resolution_in_gnome():
                 ),
                 "{}x{}".format(curr.width, curr.height),
             )
+            total_gnome_res += curr.width * curr.height
 
     if failed:
+        # no need to do the sysfs check if gnome
+        # is already NOT using the max resolution
         raise SystemExit("See the logs above to see which monitors failed")
+
+    # now we know gnome is using the maximum resolution
+    # compare it with sysfs
+    total_sysfs_res = 0
+    print("Checking against these max resolutions shown in sysfs:")
+    sysfs_info = get_sysfs_info()
+    for p in sysfs_info:
+        print(
+            " - {}: {}x{} ({})".format(
+                p["port"], p["width"], p["height"], p["enabled"]
+            )
+        )
+        if p["enabled"] == "enabled":
+            total_sysfs_res += int(p["width"]) * int(p["height"])
+
+    # instead of checking each individual display
+    # where we have to do edid matching
+    # just add them all together and compare the sum
+    if total_gnome_res == total_sysfs_res:
+        print("[ OK ] Maximum resolution reported by GNOME matches sysfs")
+    else:
+        raise SystemExit(
+            "[ ERR ] Maximum resolution reported by GNOME does not match sysfs"
+        )
 
 
 if __name__ == "__main__":

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -33,7 +33,7 @@ class SysfsDrmCardInfo:
                 "{} requires a directory path.".format(type(self).__name__)
                 + "Example: /sys/class/drm/card1-eDP-1/"
             )
-        with open(Path(path) / "modes") as f:
+        with (Path(path) / "modes").open() as f:
             # Topmost line in the modes file is the max resolution
             max_resolution = f.readline().strip()
             if not max_resolution:
@@ -62,20 +62,17 @@ class SysfsDrmCardInfo:
             self.dpms_enabled,
         )
 
-
-def get_sysfs_info():
-    """
-    Go through each graphics cards sysfs entries to find max resolution if
-    connected to a monitor.
-    Return a list of ports with information about them.
-    """
-    out = []  # type: list[SysfsDrmCardInfo]
-    for str_path in glob("/sys/class/drm/card*-*"):
-        try:
-            out.append(SysfsDrmCardInfo(Path(str_path)))
-        except ValueError:
-            continue
-    return out
+    @classmethod
+    def get_all_active_ports(cls):
+        out = []  # type: list[SysfsDrmCardInfo]
+        for str_path in glob("/sys/class/drm/card*-*"):
+            try:
+                # use the constructor behavior of rejecting ports
+                # that have no monitor connected
+                out.append(SysfsDrmCardInfo(Path(str_path)))
+            except ValueError:
+                continue
+        return out
 
 
 def main():
@@ -124,7 +121,7 @@ def main():
     # compare it with sysfs
     total_sysfs_res = 0
     print("Checking against these max resolutions shown in sysfs:")
-    sysfs_info = get_sysfs_info()
+    sysfs_info = SysfsDrmCardInfo.get_all_active_ports()
     for drm_card in sysfs_info:
         print(" -", drm_card)
         if drm_card.enabled:
@@ -133,6 +130,7 @@ def main():
     # instead of checking each individual display
     # where we have to do edid matching
     # just add them all together and compare the sum
+    # this is the original behavior of this test case
     if total_gnome_res == total_sysfs_res:
         print("[ OK ] Maximum resolution reported by GNOME matches sysfs")
     else:

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -24,6 +24,7 @@ from glob import glob
 import os
 import sys
 from pathlib import Path
+from checkbox_support.dbus.gnome_monitor import MonitorConfigGnome
 
 gi.require_versions({"Gtk": "3.0", "Gdk": "3.0"})
 from gi.repository import Gdk, Gtk  # noqa: E402
@@ -85,7 +86,7 @@ def get_monitors_info():
     return monitors
 
 
-if __name__ == "__main__":
+def ubuntu16_main():
     sysfs_entries = get_sysfs_info()
     mons_entries = get_monitors_info()
     total_sysfs_res = 0
@@ -146,3 +147,43 @@ if __name__ == "__main__":
                 "continuing."
             )
         )
+
+
+def main():
+    mutter_state = MonitorConfigGnome().get_current_state()
+
+    failed = False
+    for monitor in mutter_state.physical_monitors:
+        curr = monitor.get_current_mode()
+        msg_prefix = "Monitor '{} {}', connected at '{}'".format(
+            monitor.info.vendor, monitor.info.product, monitor.info.connector
+        )
+
+        if curr is None:
+            raise RuntimeError(
+                msg_prefix + " has no active mode. Is it turned off?"
+            )
+
+        max_w, max_h = monitor.get_max_resolution()
+        if curr.width != max_w or curr.height != max_h:
+            print(
+                "[ ERR ]",
+                msg_prefix,
+                "is not using its maximum resolution.",
+                "Expected {}x{}, but got {}x{}".format(
+                    max_w, max_h, curr.width, curr.height
+                ),
+                file=sys.stderr,
+            )
+            failed = True
+        else:
+            print(
+                "[ OK ] {} is set to its maximum resolution".format(msg_prefix)
+            )
+
+    if failed:
+        raise SystemExit("See the logs above to see which monitors failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -19,15 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
-import gi
 from glob import glob
-import os
 import sys
 from pathlib import Path
 from checkbox_support.dbus.gnome_monitor import MonitorConfigGnome
-
-gi.require_versions({"Gtk": "3.0", "Gdk": "3.0"})
-from gi.repository import Gdk, Gtk  # noqa: E402
 
 
 def get_sysfs_info():
@@ -84,69 +79,6 @@ def get_monitors_info():
         }
         monitors.append(monitor)
     return monitors
-
-
-def ubuntu16_main():
-    sysfs_entries = get_sysfs_info()
-    mons_entries = get_monitors_info()
-    total_sysfs_res = 0
-    total_mons_res = 0
-    compositor = os.environ.get("XDG_SESSION_TYPE")
-    print("Current compositor: {}".format(compositor))
-    print()
-    print("Maximum resolution found for each connected monitors:")
-    for p in sysfs_entries:
-        port = p["port"]
-        width = p["width"]
-        height = p["height"]
-        enabled = p["enabled"]
-        status = p["status"]
-        dpms = p["dpms"].lower()
-        print(
-            "\t{}: {}x{} ({}, {}, {})".format(
-                port, width, height, dpms, status, enabled
-            )
-        )
-        # If the monitor is disabled (e.g. "Single Display" mode), don't take
-        # its surface into account.
-        if enabled == "enabled":
-            total_sysfs_res += width * height
-    print()
-    print("Current resolution found for each connected monitors:")
-    for m in mons_entries:
-        model = m["model"]
-        manufacturer = m["manufacturer"]
-        scale = m["scale_factor"]
-        # Under X11, the returned width and height are in "application pixels",
-        # not "device pixels", so it has to be multiplied by the scale factor.
-        # However, Wayland always returns the "device pixels" width and height.
-        #
-        # Example: a 3840x2160 screen set to 200% scale will have
-        # width = 1920, height = 1080, scale_factor = 2 on X11
-        # width = 3840, height = 2160, scale_factor = 2 on Wayland
-        if compositor == "x11":
-            width = m["width"] * m["scale_factor"]
-            height = m["height"] * m["scale_factor"]
-        else:
-            width = m["width"]
-            height = m["height"]
-        print(
-            "\t{} ({}): {}x{} @{}%".format(
-                model, manufacturer, width, height, scale * 100
-            )
-        )
-        total_mons_res += width * height
-    print()
-    if total_sysfs_res == total_mons_res:
-        print("The displays are configured at their maximum resolution.")
-    else:
-        sys.exit(
-            (
-                "The displays do not seem to be configured at their maximum "
-                "resolution.\nPlease switch to the maximum resolution before "
-                "continuing."
-            )
-        )
 
 
 def main():

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -54,7 +54,7 @@ class SysfsDrmCardInfo:
         self.dpms_enabled = (Path(path) / "dpms").read_text().strip() == "On"
 
     def __str__(self) -> str:
-        return "{}: {}x{} enabled={}, is_connected={}, dpms_enabled={}".format(
+        return "{}: max_resolution={}x{} enabled={}, is_connected={}, dpms_enabled={}".format(
             self.port,
             self.max_width,
             self.max_height,

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -149,7 +149,7 @@ def ubuntu16_main():
         )
 
 
-def main():
+def check_max_resolution_in_gnome():
     mutter_state = MonitorConfigGnome().get_current_state()
 
     failed = False
@@ -160,7 +160,7 @@ def main():
         )
 
         if curr is None:
-            raise RuntimeError(
+            raise SystemExit(
                 msg_prefix + " has no active mode. Is it turned off?"
             )
 
@@ -178,7 +178,10 @@ def main():
             failed = True
         else:
             print(
-                "[ OK ] {} is set to its maximum resolution".format(msg_prefix)
+                "[ OK ] {} is set to its maximum resolution".format(
+                    msg_prefix
+                ),
+                "{}x{}".format(curr.width, curr.height),
             )
 
     if failed:
@@ -186,4 +189,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    check_max_resolution_in_gnome()

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -151,6 +151,7 @@ def check_max_resolution_in_gnome():
     mutter_state = MonitorConfigGnome().get_current_state()
 
     failed = False
+    total_gnome_res = 0
     for monitor in mutter_state.physical_monitors:
         curr = monitor.get_current_mode()
         msg_prefix = "Monitor '{} {}', connected at '{}'".format(
@@ -159,7 +160,7 @@ def check_max_resolution_in_gnome():
 
         # preserve the original logic of ignoring inactive monitors
         if curr is None:
-            print(msg_prefix, "has no active mode. Skipping.")
+            print("[ WARN ]", msg_prefix, "has no active mode. Skipping.")
             continue
 
         max_w, max_h = monitor.get_max_resolution()
@@ -181,9 +182,36 @@ def check_max_resolution_in_gnome():
                 ),
                 "{}x{}".format(curr.width, curr.height),
             )
+            total_gnome_res += curr.width * curr.height
 
     if failed:
+        # no need to do the sysfs check if gnome
+        # is already NOT using the max resolution
         raise SystemExit("See the logs above to see which monitors failed")
+
+    # now we know gnome is using the maximum resolution
+    # compare it with sysfs
+    total_sysfs_res = 0
+    print("Checking against these max resolutions shown in sysfs:")
+    sysfs_info = get_sysfs_info()
+    for p in sysfs_info:
+        print(
+            " - {}: {}x{} ({})".format(
+                p["port"], p["width"], p["height"], p["enabled"]
+            )
+        )
+        if p["enabled"] == "enabled":
+            total_sysfs_res += int(p["width"]) * int(p["height"])
+
+    # instead of checking each individual display
+    # where we have to do edid matching
+    # just add them all together and compare the sum
+    if total_gnome_res == total_sysfs_res:
+        print("[ OK ] Maximum resolution reported by GNOME matches sysfs")
+    else:
+        raise SystemExit(
+            "[ ERR ] Maximum resolution reported by GNOME does not match sysfs"
+        )
 
 
 if __name__ == "__main__":

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -107,7 +107,8 @@ def main():
                 "[ ERR ]",
                 msg_prefix,
                 "is not using its maximum resolution.",
-                f"Expected {max_w}x{max_h}, got {curr.width}x{curr.height}",
+                f"Expected {max_w}x{max_h},"
+                f"but got {curr.width}x{curr.height}",
                 file=sys.stderr,
             )
             failed = True

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -147,7 +147,7 @@ def ubuntu16_main():
         )
 
 
-def check_max_resolution_in_gnome():
+def main():
     mutter_state = MonitorConfigGnome().get_current_state()
 
     failed = False
@@ -215,5 +215,4 @@ def check_max_resolution_in_gnome():
 
 
 if __name__ == "__main__":
-    # print(get_sysfs_info())
-    check_max_resolution_in_gnome()
+    main()

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -56,7 +56,7 @@ class SysfsDrmCardInfo:
 
     def __str__(self) -> str:
         return (
-            "{}: max_resolution={}x{} "
+            "{}: max_resolution={}x{}, "
             + "enabled={}, is_connected={}, dpms_enabled={}"
         ).format(
             self.port,
@@ -69,7 +69,7 @@ class SysfsDrmCardInfo:
 
     @classmethod
     def get_all_active_ports(cls):
-        out = []  # type: list[SysfsDrmCardInfo]
+        out: "list[SysfsDrmCardInfo]" = []
         for str_path in glob("/sys/class/drm/card*-*"):
             try:
                 # use the constructor behavior of rejecting ports
@@ -87,11 +87,18 @@ def main():
     total_gnome_res = 0
     for monitor in mutter_state.physical_monitors:
         curr = monitor.get_current_mode()
-        msg_prefix = f"Monitor '{monitor.info.vendor} {monitor.info.product}', connected at '{monitor.info.connector}'"
+        msg_prefix = (
+            f"Monitor '{monitor.info.vendor} {monitor.info.product}', "
+            + f"connected at '{monitor.info.connector}'"
+        )
 
         # preserve the original logic of ignoring inactive monitors
         if curr is None:
-            print("[ WARN ]", msg_prefix, "has no active mode. Skipping.")
+            print(
+                "[ WARN ]",
+                msg_prefix,
+                "has no active mode (likely turned off). Skipping.",
+            )
             continue
 
         max_w, max_h = monitor.get_max_resolution()
@@ -118,8 +125,9 @@ def main():
 
     # now we know gnome is using the maximum resolution
     # compare it with sysfs
-    total_sysfs_res = 0
+
     print("Checking against these max resolutions shown in sysfs:")
+    total_sysfs_res = 0
     sysfs_info = SysfsDrmCardInfo.get_all_active_ports()
     for drm_card in sysfs_info:
         print(" -", drm_card)

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -19,15 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
-import gi
 from glob import glob
-import os
 import sys
 from pathlib import Path
 from checkbox_support.dbus.gnome_monitor import MonitorConfigGnome
-
-gi.require_versions({"Gtk": "3.0", "Gdk": "3.0"})
-from gi.repository import Gdk, Gtk  # noqa: E402
 
 
 def get_sysfs_info():
@@ -84,67 +79,6 @@ def get_monitors_info():
         }
         monitors.append(monitor)
     return monitors
-
-
-def ubuntu16_main():
-    sysfs_entries = get_sysfs_info()
-    mons_entries = get_monitors_info()
-    total_sysfs_res = 0
-    total_mons_res = 0
-    compositor = os.environ.get("XDG_SESSION_TYPE")
-    print(f"Current compositor: {compositor}")
-    print()
-    print("Maximum resolution found for each connected monitors:")
-    for p in sysfs_entries:
-        port = p["port"]
-        width = p["width"]
-        height = p["height"]
-        enabled = p["enabled"]
-        status = p["status"]
-        dpms = p["dpms"].lower()
-        print(
-            "\t{}: {}x{} ({}, {}, {})".format(
-                port, width, height, dpms, status, enabled
-            )
-        )
-        # If the monitor is disabled (e.g. "Single Display" mode), don't take
-        # its surface into account.
-        if enabled == "enabled":
-            total_sysfs_res += width * height
-    print()
-    print("Current resolution found for each connected monitors:")
-    for m in mons_entries:
-        model = m["model"]
-        manufacturer = m["manufacturer"]
-        scale = m["scale_factor"]
-        # Under X11, the returned width and height are in "application pixels",
-        # not "device pixels", so it has to be multiplied by the scale factor.
-        # However, Wayland always returns the "device pixels" width and height.
-        #
-        # Example: a 3840x2160 screen set to 200% scale will have
-        # width = 1920, height = 1080, scale_factor = 2 on X11
-        # width = 3840, height = 2160, scale_factor = 2 on Wayland
-        if compositor == "x11":
-            width = m["width"] * m["scale_factor"]
-            height = m["height"] * m["scale_factor"]
-        else:
-            width = m["width"]
-            height = m["height"]
-        print(
-            "\t{} ({}): {}x{} @{}%".format(
-                model, manufacturer, width, height, scale * 100
-            )
-        )
-        total_mons_res += width * height
-    print()
-    if total_sysfs_res == total_mons_res:
-        print("The displays are configured at their maximum resolution.")
-    else:
-        sys.exit(
-            "The displays do not seem to be configured at their maximum "
-            "resolution.\nPlease switch to the maximum resolution before "
-            "continuing."
-        )
 
 
 def main():

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -147,7 +147,7 @@ def ubuntu16_main():
         )
 
 
-def main():
+def check_max_resolution_in_gnome():
     mutter_state = MonitorConfigGnome().get_current_state()
 
     failed = False
@@ -158,7 +158,7 @@ def main():
         )
 
         if curr is None:
-            raise RuntimeError(
+            raise SystemExit(
                 msg_prefix + " has no active mode. Is it turned off?"
             )
 
@@ -176,7 +176,10 @@ def main():
             failed = True
         else:
             print(
-                "[ OK ] {} is set to its maximum resolution".format(msg_prefix)
+                "[ OK ] {} is set to its maximum resolution".format(
+                    msg_prefix
+                ),
+                "{}x{}".format(curr.width, curr.height),
             )
 
     if failed:
@@ -184,4 +187,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    check_max_resolution_in_gnome()

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -20,10 +20,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
-from glob import glob
 import os
 import sys
+from glob import glob
 from pathlib import Path
+
 from checkbox_support.dbus.gnome_monitor import MonitorConfigGnome
 
 
@@ -31,7 +32,7 @@ class SysfsDrmCardInfo:
     def __init__(self, path: Path) -> None:
         if not path.is_dir():
             raise ValueError(
-                "{} requires a directory path.".format(type(self).__name__)
+                f"{type(self).__name__} requires a directory path."
                 + "Example: /sys/class/drm/card1-eDP-1/"
             )
         with (Path(path) / "modes").open() as f:
@@ -39,7 +40,7 @@ class SysfsDrmCardInfo:
             max_resolution = f.readline().strip()
             if not max_resolution:
                 raise ValueError(
-                    "No monitor is connected to this port {}".format(path)
+                    f"No monitor is connected to this port {path}"
                 )
             str_width, str_height = max_resolution.split("x")
             self.max_width, self.max_height = int(str_width), int(str_height)
@@ -86,9 +87,7 @@ def main():
     total_gnome_res = 0
     for monitor in mutter_state.physical_monitors:
         curr = monitor.get_current_mode()
-        msg_prefix = "Monitor '{} {}', connected at '{}'".format(
-            monitor.info.vendor, monitor.info.product, monitor.info.connector
-        )
+        msg_prefix = f"Monitor '{monitor.info.vendor} {monitor.info.product}', connected at '{monitor.info.connector}'"
 
         # preserve the original logic of ignoring inactive monitors
         if curr is None:
@@ -101,18 +100,14 @@ def main():
                 "[ ERR ]",
                 msg_prefix,
                 "is not using its maximum resolution.",
-                "Expected {}x{}, but got {}x{}".format(
-                    max_w, max_h, curr.width, curr.height
-                ),
+                f"Expected {max_w}x{max_h}, but got {curr.width}x{curr.height}",
                 file=sys.stderr,
             )
             failed = True
         else:
             print(
-                "[ OK ] {} is set to its maximum resolution".format(
-                    msg_prefix
-                ),
-                "{}x{}".format(curr.width, curr.height),
+                f"[ OK ] {msg_prefix} is set to its maximum resolution",
+                f"{curr.width}x{curr.height}",
             )
             total_gnome_res += curr.width * curr.height
 

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -24,6 +24,7 @@ from glob import glob
 import os
 import sys
 from pathlib import Path
+from checkbox_support.dbus.gnome_monitor import MonitorConfigGnome
 
 gi.require_versions({"Gtk": "3.0", "Gdk": "3.0"})
 from gi.repository import Gdk, Gtk  # noqa: E402
@@ -85,7 +86,7 @@ def get_monitors_info():
     return monitors
 
 
-if __name__ == "__main__":
+def ubuntu16_main():
     sysfs_entries = get_sysfs_info()
     mons_entries = get_monitors_info()
     total_sysfs_res = 0
@@ -144,3 +145,43 @@ if __name__ == "__main__":
             "resolution.\nPlease switch to the maximum resolution before "
             "continuing."
         )
+
+
+def main():
+    mutter_state = MonitorConfigGnome().get_current_state()
+
+    failed = False
+    for monitor in mutter_state.physical_monitors:
+        curr = monitor.get_current_mode()
+        msg_prefix = "Monitor '{} {}', connected at '{}'".format(
+            monitor.info.vendor, monitor.info.product, monitor.info.connector
+        )
+
+        if curr is None:
+            raise RuntimeError(
+                msg_prefix + " has no active mode. Is it turned off?"
+            )
+
+        max_w, max_h = monitor.get_max_resolution()
+        if curr.width != max_w or curr.height != max_h:
+            print(
+                "[ ERR ]",
+                msg_prefix,
+                "is not using its maximum resolution.",
+                "Expected {}x{}, but got {}x{}".format(
+                    max_w, max_h, curr.width, curr.height
+                ),
+                file=sys.stderr,
+            )
+            failed = True
+        else:
+            print(
+                "[ OK ] {} is set to its maximum resolution".format(msg_prefix)
+            )
+
+    if failed:
+        raise SystemExit("See the logs above to see which monitors failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -107,7 +107,7 @@ def main():
                 "[ ERR ]",
                 msg_prefix,
                 "is not using its maximum resolution.",
-                f"Expected {max_w}x{max_h},"
+                f"Expected {max_w}x{max_h},",
                 f"but got {curr.width}x{curr.height}",
                 file=sys.stderr,
             )

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -107,7 +107,7 @@ def main():
                 "[ ERR ]",
                 msg_prefix,
                 "is not using its maximum resolution.",
-                f"Expected {max_w}x{max_h}, but got {curr.width}x{curr.height}",
+                f"Expected {max_w}x{max_h}, got {curr.width}x{curr.height}",
                 file=sys.stderr,
             )
             failed = True

--- a/providers/base/bin/graphics_max_resolution.py
+++ b/providers/base/bin/graphics_max_resolution.py
@@ -157,10 +157,10 @@ def check_max_resolution_in_gnome():
             monitor.info.vendor, monitor.info.product, monitor.info.connector
         )
 
+        # preserve the original logic of ignoring inactive monitors
         if curr is None:
-            raise SystemExit(
-                msg_prefix + " has no active mode. Is it turned off?"
-            )
+            print(msg_prefix, "has no active mode. Skipping.")
+            continue
 
         max_w, max_h = monitor.get_max_resolution()
         if curr.width != max_w or curr.height != max_h:
@@ -187,4 +187,5 @@ def check_max_resolution_in_gnome():
 
 
 if __name__ == "__main__":
+    # print(get_sysfs_info())
     check_max_resolution_in_gnome()

--- a/providers/base/tests/test_graphics_max_resolution.py
+++ b/providers/base/tests/test_graphics_max_resolution.py
@@ -26,15 +26,19 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 
-# gnome_monitor imports gi.repository at module level, which requires a
-# running GNOME session. Stub out the entire gi stack before any import
-# that transitively pulls it in, so we can test graphics_max_resolution
-# in isolation.
 _mock_gi = MagicMock()
 sys.modules.setdefault("gi", _mock_gi)
 sys.modules.setdefault("gi.repository", _mock_gi.repository)
 sys.modules.setdefault("gi.repository.Gio", _mock_gi.repository.Gio)
 sys.modules.setdefault("gi.repository.GLib", _mock_gi.repository.GLib)
+
+_mock_gnome_monitor = MagicMock()
+sys.modules.setdefault("checkbox_support", _mock_gnome_monitor)
+sys.modules.setdefault("checkbox_support.dbus", _mock_gnome_monitor.dbus)
+sys.modules.setdefault(
+    "checkbox_support.dbus.gnome_monitor",
+    _mock_gnome_monitor.dbus.gnome_monitor,
+)
 
 from graphics_max_resolution import SysfsDrmCardInfo, main  # noqa: E402
 

--- a/providers/base/tests/test_graphics_max_resolution.py
+++ b/providers/base/tests/test_graphics_max_resolution.py
@@ -33,8 +33,6 @@ sys.modules.setdefault("gi.repository.Gio", _mock_gi.repository.Gio)
 sys.modules.setdefault("gi.repository.GLib", _mock_gi.repository.GLib)
 
 _mock_gnome_monitor = MagicMock()
-sys.modules.setdefault("checkbox_support", _mock_gnome_monitor)
-sys.modules.setdefault("checkbox_support.dbus", _mock_gnome_monitor.dbus)
 sys.modules.setdefault(
     "checkbox_support.dbus.gnome_monitor",
     _mock_gnome_monitor.dbus.gnome_monitor,

--- a/providers/base/tests/test_graphics_max_resolution.py
+++ b/providers/base/tests/test_graphics_max_resolution.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+#
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+#
+# Authors:
+#   Zhongning Li <zhongning.li@canonical.com>
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+
+from graphics_max_resolution import SysfsDrmCardInfo, main
+
+
+def _make_drm_port(
+    base_dir: str,
+    port_name: str,
+    mode: str,
+    enabled: str,
+    status: str,
+    dpms: str,
+):
+    port_dir = Path(base_dir) / port_name
+    port_dir.mkdir()
+    (port_dir / "modes").write_text(mode)
+    (port_dir / "enabled").write_text(enabled)
+    (port_dir / "status").write_text(status)
+    (port_dir / "dpms").write_text(dpms)
+    return port_dir
+
+
+class TestSysfsDrmCardInfoInit(unittest.TestCase):
+    def test_raises_when_path_is_not_a_directory(self):
+        with TemporaryDirectory() as tmp:
+            file_path = Path(tmp) / "not_a_dir"
+            file_path.touch()
+            with self.assertRaises(ValueError):
+                SysfsDrmCardInfo(file_path)
+
+    def test_raises_when_modes_file_is_empty(self):
+        with TemporaryDirectory() as tmp:
+            port_dir = _make_drm_port(
+                tmp, "card1-eDP-1", "", "enabled", "connected", "On"
+            )
+            with self.assertRaises(ValueError):
+                SysfsDrmCardInfo(port_dir)
+
+    def test_parses_max_resolution_from_first_line(self):
+        with TemporaryDirectory() as tmp:
+            # modes file has multiple resolutions; only the first matters
+            port_dir = _make_drm_port(
+                tmp,
+                "card1-eDP-1",
+                "1920x1080\n1280x720\n",
+                "enabled",
+                "connected",
+                "On",
+            )
+            info = SysfsDrmCardInfo(port_dir)
+            self.assertEqual(info.max_width, 1920)
+            self.assertEqual(info.max_height, 1080)
+
+    def test_enabled_true(self):
+        with TemporaryDirectory() as tmp:
+            port_dir = _make_drm_port(
+                tmp, "card1-eDP-1", "1920x1080\n", "enabled", "connected", "On"
+            )
+            info = SysfsDrmCardInfo(port_dir)
+            self.assertTrue(info.enabled)
+
+    def test_enabled_false(self):
+        with TemporaryDirectory() as tmp:
+            port_dir = _make_drm_port(
+                tmp,
+                "card1-eDP-1",
+                "1920x1080\n",
+                "disabled",
+                "connected",
+                "On",
+            )
+            info = SysfsDrmCardInfo(port_dir)
+            self.assertFalse(info.enabled)
+
+    def test_is_connected_true(self):
+        with TemporaryDirectory() as tmp:
+            port_dir = _make_drm_port(
+                tmp, "card1-eDP-1", "1920x1080\n", "enabled", "connected", "On"
+            )
+            info = SysfsDrmCardInfo(port_dir)
+            self.assertTrue(info.is_connected)
+
+    def test_is_connected_false(self):
+        with TemporaryDirectory() as tmp:
+            port_dir = _make_drm_port(
+                tmp,
+                "card1-eDP-1",
+                "1920x1080\n",
+                "enabled",
+                "disconnected",
+                "On",
+            )
+            info = SysfsDrmCardInfo(port_dir)
+            self.assertFalse(info.is_connected)
+
+    def test_dpms_enabled_true(self):
+        with TemporaryDirectory() as tmp:
+            port_dir = _make_drm_port(
+                tmp, "card1-eDP-1", "1920x1080\n", "enabled", "connected", "On"
+            )
+            info = SysfsDrmCardInfo(port_dir)
+            self.assertTrue(info.dpms_enabled)
+
+    def test_dpms_enabled_false(self):
+        with TemporaryDirectory() as tmp:
+            port_dir = _make_drm_port(
+                tmp,
+                "card1-eDP-1",
+                "1920x1080\n",
+                "enabled",
+                "connected",
+                "Off",
+            )
+            info = SysfsDrmCardInfo(port_dir)
+            self.assertFalse(info.dpms_enabled)
+
+    def test_port_name_is_set(self):
+        with TemporaryDirectory() as tmp:
+            port_dir = _make_drm_port(
+                tmp,
+                "card1-HDMI-A-1",
+                "2560x1440\n",
+                "enabled",
+                "connected",
+                "On",
+            )
+            info = SysfsDrmCardInfo(port_dir)
+            self.assertEqual(info.port, "card1-HDMI-A-1")
+
+
+class TestSysfsDrmCardInfoStr(unittest.TestCase):
+    def test_str_contains_all_fields(self):
+        with TemporaryDirectory() as tmp:
+            port_dir = _make_drm_port(
+                tmp,
+                "card1-eDP-1",
+                "1920x1080\n",
+                "enabled",
+                "connected",
+                "On",
+            )
+            info = SysfsDrmCardInfo(port_dir)
+            result = str(info)
+            self.assertIn("card1-eDP-1", result)
+            self.assertIn("1920", result)
+            self.assertIn("1080", result)
+            self.assertIn("True", result)
+
+
+class TestGetAllActivePorts(unittest.TestCase):
+    def test_returns_only_valid_ports(self):
+        with TemporaryDirectory() as tmp:
+            # One valid port, one port with no monitor (empty modes → ValueError)
+            valid_port = _make_drm_port(
+                tmp,
+                "card1-eDP-1",
+                "1920x1080\n",
+                "enabled",
+                "connected",
+                "On",
+            )
+            empty_port = _make_drm_port(
+                tmp, "card1-DP-1", "", "enabled", "disconnected", "Off"
+            )
+            fake_paths = [str(valid_port), str(empty_port)]
+            with patch(
+                "graphics_max_resolution.glob", return_value=fake_paths
+            ):
+                ports = SysfsDrmCardInfo.get_all_active_ports()
+            self.assertEqual(len(ports), 1)
+            self.assertEqual(ports[0].port, "card1-eDP-1")
+
+    def test_returns_empty_list_when_no_ports(self):
+        with patch("graphics_max_resolution.glob", return_value=[]):
+            ports = SysfsDrmCardInfo.get_all_active_ports()
+        self.assertEqual(ports, [])
+
+
+def _make_monitor(vendor, product, connector, curr_w, curr_h, max_w, max_h):
+    """Build a mock PhysicalMonitor for use in main() tests."""
+    monitor = MagicMock()
+    monitor.info.vendor = vendor
+    monitor.info.product = product
+    monitor.info.connector = connector
+
+    if curr_w is None:
+        monitor.get_current_mode.return_value = None
+    else:
+        curr_mode = MagicMock()
+        curr_mode.width = curr_w
+        curr_mode.height = curr_h
+        monitor.get_current_mode.return_value = curr_mode
+
+    monitor.get_max_resolution.return_value = (max_w, max_h)
+    return monitor
+
+
+def _make_drm_card(max_w, max_h, enabled=True):
+    """Build a mock SysfsDrmCardInfo."""
+    card = MagicMock(spec=SysfsDrmCardInfo)
+    card.max_width = max_w
+    card.max_height = max_h
+    card.enabled = enabled
+    return card
+
+
+class TestMain(unittest.TestCase):
+    def _run_main(self, monitors, drm_cards):
+        """Patch dependencies and call main(), returning captured stdout."""
+        mutter_state = MagicMock()
+        mutter_state.physical_monitors = monitors
+
+        with (
+            patch("graphics_max_resolution.MonitorConfigGnome") as MockGnome,
+            patch(
+                "graphics_max_resolution.SysfsDrmCardInfo.get_all_active_ports",
+                return_value=drm_cards,
+            ),
+            patch("sys.stdout", new_callable=StringIO) as mock_stdout,
+        ):
+            MockGnome.return_value.get_current_state.return_value = (
+                mutter_state
+            )
+            main()
+            return mock_stdout.getvalue()
+
+    def test_single_monitor_at_max_resolution_passes(self):
+        monitors = [
+            _make_monitor(
+                "BOE", "NE135A1M-NY1", "eDP-1", 1920, 1080, 1920, 1080
+            )
+        ]
+        drm_cards = [_make_drm_card(1920, 1080, enabled=True)]
+        output = self._run_main(monitors, drm_cards)
+        self.assertIn("[ OK ]", output)
+        self.assertIn("1920x1080", output)
+
+    def test_monitor_below_max_resolution_raises_system_exit(self):
+        monitors = [
+            _make_monitor(
+                "BOE", "NE135A1M-NY1", "eDP-1", 1280, 720, 1920, 1080
+            )
+        ]
+        with self.assertRaises(SystemExit):
+            self._run_main(monitors, [])
+
+    def test_monitor_below_max_resolution_prints_error(self):
+        monitors = [
+            _make_monitor(
+                "BOE", "NE135A1M-NY1", "eDP-1", 1280, 720, 1920, 1080
+            )
+        ]
+        mutter_state = MagicMock()
+        mutter_state.physical_monitors = monitors
+
+        with (
+            patch("graphics_max_resolution.MonitorConfigGnome") as MockGnome,
+            patch("sys.stderr", new_callable=StringIO) as mock_err,
+        ):
+            MockGnome.return_value.get_current_state.return_value = (
+                mutter_state
+            )
+            with self.assertRaises(SystemExit):
+                main()
+            self.assertIn("[ ERR ]", mock_err.getvalue())
+            self.assertIn("1920x1080", mock_err.getvalue())
+
+    def test_inactive_monitor_is_skipped(self):
+        # curr mode is None → should print WARN and continue
+        monitors = [
+            _make_monitor(
+                "BOE", "NE135A1M-NY1", "eDP-1", None, None, 1920, 1080
+            )
+        ]
+        drm_cards = []
+        output = self._run_main(monitors, drm_cards)
+        self.assertIn("WARN", output)
+
+    def test_gnome_sysfs_resolution_mismatch_raises_system_exit(self):
+        # GNOME sees 1920x1080 but sysfs reports 2560x1440
+        monitors = [
+            _make_monitor(
+                "BOE", "NE135A1M-NY1", "eDP-1", 1920, 1080, 1920, 1080
+            )
+        ]
+        drm_cards = [_make_drm_card(2560, 1440, enabled=True)]
+        with self.assertRaises(SystemExit):
+            self._run_main(monitors, drm_cards)
+
+    def test_disabled_drm_cards_excluded_from_sysfs_total(self):
+        # Monitor at 1920x1080 in GNOME; sysfs has a matching enabled card
+        # plus a disabled card that must NOT be counted
+        monitors = [
+            _make_monitor(
+                "BOE", "NE135A1M-NY1", "eDP-1", 1920, 1080, 1920, 1080
+            )
+        ]
+        drm_cards = [
+            _make_drm_card(1920, 1080, enabled=True),
+            _make_drm_card(3840, 2160, enabled=False),
+        ]
+        # Should pass because the disabled card is excluded
+        output = self._run_main(monitors, drm_cards)
+        self.assertIn("matches sysfs", output)
+
+    def test_multiple_monitors_all_at_max_passes(self):
+        monitors = [
+            _make_monitor(
+                "BOE", "NE135A1M-NY1", "eDP-1", 1920, 1080, 1920, 1080
+            ),
+            _make_monitor("DEL", "U2722D", "HDMI-1", 2560, 1440, 2560, 1440),
+        ]
+        drm_cards = [
+            _make_drm_card(1920, 1080, enabled=True),
+            _make_drm_card(2560, 1440, enabled=True),
+        ]
+        output = self._run_main(monitors, drm_cards)
+        self.assertIn("matches sysfs", output)
+
+    def test_no_monitors_passes(self):
+        # No monitors → nothing to fail, sysfs total also 0 → OK
+        output = self._run_main([], [])
+        self.assertIn("matches sysfs", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/providers/base/tests/test_graphics_max_resolution.py
+++ b/providers/base/tests/test_graphics_max_resolution.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Checkbox.
 #
-# Copyright 2026 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #
 # Authors:
 #   Zhongning Li <zhongning.li@canonical.com>
@@ -19,13 +19,24 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys
 import unittest
 from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 
-from graphics_max_resolution import SysfsDrmCardInfo, main
+# gnome_monitor imports gi.repository at module level, which requires a
+# running GNOME session. Stub out the entire gi stack before any import
+# that transitively pulls it in, so we can test graphics_max_resolution
+# in isolation.
+_mock_gi = MagicMock()
+sys.modules.setdefault("gi", _mock_gi)
+sys.modules.setdefault("gi.repository", _mock_gi.repository)
+sys.modules.setdefault("gi.repository.Gio", _mock_gi.repository.Gio)
+sys.modules.setdefault("gi.repository.GLib", _mock_gi.repository.GLib)
+
+from graphics_max_resolution import SysfsDrmCardInfo, main  # noqa: E402
 
 
 def _make_drm_port(

--- a/providers/base/tests/test_graphics_max_resolution.py
+++ b/providers/base/tests/test_graphics_max_resolution.py
@@ -31,12 +31,8 @@ sys.modules.setdefault("gi", _mock_gi)
 sys.modules.setdefault("gi.repository", _mock_gi.repository)
 sys.modules.setdefault("gi.repository.Gio", _mock_gi.repository.Gio)
 sys.modules.setdefault("gi.repository.GLib", _mock_gi.repository.GLib)
-
-_mock_gnome_monitor = MagicMock()
-sys.modules.setdefault(
-    "checkbox_support.dbus.gnome_monitor",
-    _mock_gnome_monitor.dbus.gnome_monitor,
-)
+sys.modules.setdefault("dbus", MagicMock())
+sys.modules.setdefault("dbus.mainloop.glib", MagicMock())
 
 from graphics_max_resolution import SysfsDrmCardInfo, main  # noqa: E402
 


### PR DESCRIPTION
## Description

This PR re-implements the `graphics_max_resolution` test to handle fractional scaling that's now officially supported on 26.04.

## Resolved issues

Originally the test case uses the display object returned by `Gdk.Display.get_default()` to get the current application-level resolution and scaling. The scaling value returned by Gdk is [always an integer](https://docs.gtk.org/gdk4/method.Monitor.get_scale_factor.html) which makes the test case unable to handle fractional scaling. The new implementation directly queries GNOME about the physical monitor dimensions instead so we can ignore scaling and wayland/x11 differences altogether. Since we have dropped 16.04, we don't even need to include a unity path.

## Documentation

**This test does not work on 16.04, just like the original version.** The new one doesn't work on 16.04 because the dbus call used by MonitorConfigGnome is not present in unity. The old one doesn't work is because of this line
```py
gi.require_versions({"Gtk": "3.0", "Gdk": "3.0"})
```
the `require_versions` method does not exist in 16.04's python3-gi binding.

## Tests

C3: https://certification.canonical.com/hardware/202503-36476/submission/511274/ pass correctly when both monitors are set to 150% scaling. If I manually lower the resolution it will fail https://certification.canonical.com/hardware/202503-36476/submission/511276/