### PR TITLE
Revise Thermal Zone Identity And Validation (BugFix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/thermal_sensor_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/thermal_sensor_test.py
@@ -175,7 +175,7 @@ def _reconcile_legacy_id_upgrades(
 ):
     """Best-effort mapping for stable_id algorithm upgrades.
 
-    This is intended for snapshots produced before/after stable_id strategy 
+    This is intended for snapshots produced before/after stable_id strategy
     changes where the thermal zone identity did not actually change.
     """
     after_by_name_type = {}
@@ -281,7 +281,8 @@ def monitor_temperature_change(target_name, thermal_op, duration, cmd):
 
     if result is False:
         logging.error(
-            "# The temperature of the %s (%s) thermal remains consistently at %s",
+            "# The temperature of the %s (%s) thermal remains "
+            "consistently at %s",
             target_name,
             thermal_op.type,
             initial_value,

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/thermal_sensor_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/thermal_sensor_test.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
+import os
 import sys
 import time
 import logging
 import shlex
 import subprocess
 import argparse
+import hashlib
 from pathlib import Path
 
 SYS_THERMAL_PATH = "/sys/class/thermal"
@@ -80,33 +82,177 @@ class ThermalMonitor:
     def mode(self):
         return self._read_node(self.mode_node)
 
+    def _read_optional_node(self, node):
+        if node.exists():
+            return self._read_node(node)
+        return ""
+
+    def _resolve_optional_node_path(self, node):
+        if node.exists():
+            return str(node.resolve(strict=False))
+        return ""
+
+    @property
+    def sysfs_path(self):
+        return str(self.root_node.resolve(strict=False))
+
+    @property
+    def device_path(self):
+        return self._resolve_optional_node_path(
+            self.root_node.joinpath("device")
+        )
+
+    @property
+    def of_node_path(self):
+        return self._resolve_optional_node_path(
+            self.root_node.joinpath("device", "of_node")
+        )
+
+    @property
+    def firmware_node_path(self):
+        return self._read_optional_node(
+            self.root_node.joinpath("device", "firmware_node", "path")
+        )
+
+    @property
+    def cdev_types(self):
+        """Sorted tuple of cooling device types bound to this zone.
+
+        Cooling devices are discovered via cdev* symlinks.
+
+        cdev* entries are part of the official thermal sysfs ABI and
+        are present whenever a cooling device is associated with the
+        zone. They provide a richer identity signal than falling all
+        the way back to just ``type``
+        on zones that have no physical device node.
+
+        Note: cdev bindings can change at runtime if cooling devices
+        are rebound, so this value is less stable than
+        of_node/firmware_node/device.
+        """
+        types = []
+        for entry in sorted(self.root_node.glob("cdev[0-9]*")):
+            # Only match cdevN, not cdevN_trip_point and similar files.
+            if not entry.name[4:].isdigit():
+                continue
+            t = self._read_optional_node(entry.joinpath("type"))
+            if t:
+                types.append(t)
+        return tuple(sorted(types))
+
+    @property
+    def stable_source(self):
+        return (
+            self.of_node_path
+            or self.firmware_node_path
+            or self.device_path
+            or "|".join(self.cdev_types)
+            or self.type
+        )
+
+    @property
+    def stable_id(self):
+        stable_data = "{}|{}".format(self.type, self.stable_source)
+        return hashlib.sha1(stable_data.encode()).hexdigest()[:12]
+
+
+def _load_snapshot(snapshot_path):
+    entries = {}
+    for line in Path(snapshot_path).read_text().splitlines():
+        if not line:
+            continue
+        stable_id, name, zone_type, stable_source = line.split("\t", 3)
+        entries[stable_id] = {
+            "name": name,
+            "type": zone_type,
+            "stable_source": stable_source,
+        }
+    return entries
+
+
+def _reconcile_legacy_id_upgrades(
+    before_entries, after_entries, missing_ids, new_ids
+):
+    """Best-effort mapping for stable_id algorithm upgrades.
+
+    This is intended for snapshots produced before/after stable_id strategy 
+    changes where the thermal zone identity did not actually change.
+    """
+    after_by_name_type = {}
+    for stable_id in new_ids:
+        entry = after_entries[stable_id]
+        key = (entry["name"], entry["type"])
+        after_by_name_type.setdefault(key, []).append(stable_id)
+
+    upgraded = []
+    missing_remaining = []
+    new_remaining = set(new_ids)
+
+    for stable_id in missing_ids:
+        before = before_entries[stable_id]
+        key = (before["name"], before["type"])
+        matches = after_by_name_type.get(key, [])
+        if len(matches) != 1:
+            missing_remaining.append(stable_id)
+            continue
+
+        upgraded_id = matches[0]
+        if upgraded_id not in new_remaining:
+            missing_remaining.append(stable_id)
+            continue
+
+        upgraded.append(
+            (stable_id, upgraded_id, before, after_entries[upgraded_id])
+        )
+        new_remaining.remove(upgraded_id)
+
+    return upgraded, sorted(missing_remaining), sorted(new_remaining)
+
+
+def resolve_thermal_zone_name(stable_id, zone_type=None):
+    for thermal in sorted(Path(SYS_THERMAL_PATH).glob("thermal_zone*")):
+        node = ThermalMonitor(thermal.name)
+        if node.stable_id != stable_id:
+            continue
+        if zone_type is not None and node.type != zone_type:
+            continue
+        return node.name
+
+    return None
+
 
 def check_temperature(current, initial):
     logging.info("Initial value: %s, current value: %s", initial, current)
     return int(current) != 0 and current != initial
 
 
-def thermal_monitor_test(args):
+def ignore_temp_check_enabled(zone_type):
+    value = os.getenv("TZ_IGNORE_TEMP_CHECK", "").strip()
+    if not value:
+        return False
+
+    if value.lower() == "all":
+        return True
+
+    ignored_types = {entry.strip() for entry in value.split("|")}
+    return zone_type in ignored_types
+
+
+def check_temperature_readable(target_name, thermal_op):
+    current_value = thermal_op.temperature
     logging.info(
-        "# Monitor the temperature of %s thermal around %s seconds",
-        args.name,
-        args.duration,
+        "# TZ_IGNORE_TEMP_CHECK matches %s, readable temperature is %s",
+        thermal_op.type,
+        current_value,
+    )
+    logging.info(
+        "# Temperature readability check for %s (%s) thermal passed",
+        target_name,
+        thermal_op.type,
     )
 
-    if args.extra_commands == "stress-ng":
-        cmd = (
-            "stress-ng --cpu 0 --io 4 --vm 2 " "--vm-bytes 128M --timeout {}s"
-        ).format(args.duration)
-    else:
-        cmd = args.extra_commands
 
-    thermal_op = ThermalMonitor(args.name)
-    if thermal_op.mode == "disabled":
-        raise SystemExit(
-            "Error: The {}-{} thermal is disabled".format(
-                thermal_op.name, thermal_op.type
-            )
-        )
+def monitor_temperature_change(target_name, thermal_op, duration, cmd):
     initial_value = thermal_op.temperature
 
     result = False
@@ -118,12 +264,14 @@ def thermal_monitor_test(args):
         # Due to the command here is trying to increase system loading
         pass
 
-    for _ in range(args.duration):
+    for _ in range(duration):
         cur_temp = thermal_op.temperature
         result = check_temperature(cur_temp, initial_value)
         if result:
             logging.info(
-                "# The temperature of %s thermal has been altered", args.name
+                "# The temperature of %s (%s) thermal has been altered",
+                target_name,
+                thermal_op.type,
             )
             break
         time.sleep(1)
@@ -133,22 +281,216 @@ def thermal_monitor_test(args):
 
     if result is False:
         logging.error(
-            "# The temperature of the %s thermal remains consistently at %s",
-            args.name,
+            "# The temperature of the %s (%s) thermal remains consistently at %s",
+            target_name,
+            thermal_op.type,
             initial_value,
         )
         raise SystemExit(1)
 
 
-def dump_thermal_zones(args):
+def thermal_monitor_test(args):
+    target_name = args.name
+    if target_name is None and args.stable_id is not None:
+        target_name = resolve_thermal_zone_name(
+            args.stable_id, zone_type=args.zone_type
+        )
+        if target_name is None:
+            raise SystemExit(
+                "Error: Unable to resolve thermal zone for "
+                "stable_id={}".format(args.stable_id)
+            )
 
-    for thermal in sorted(Path("/sys/class/thermal").glob("thermal_zone*")):
-        node = ThermalMonitor(thermal.name)
-        print(
-            "name: {}\nmode: {}\ntype: {}\n".format(
-                node.name, node.mode, node.type
+    if args.extra_commands == "stress-ng":
+        cmd = (
+            "stress-ng --cpu 0 --io 4 --vm 2 " "--vm-bytes 128M --timeout {}s"
+        ).format(args.duration)
+    else:
+        cmd = args.extra_commands
+
+    thermal_op = ThermalMonitor(target_name)
+    ignore_temp_check = ignore_temp_check_enabled(thermal_op.type)
+    logging.info(
+        "# Monitor the temperature of %s (%s) thermal around %s seconds",
+        target_name,
+        thermal_op.type,
+        args.duration,
+    )
+    if thermal_op.mode == "disabled":
+        raise SystemExit(
+            "Error: The {}-{} thermal is disabled".format(
+                thermal_op.name, thermal_op.type
             )
         )
+
+    if ignore_temp_check:
+        check_temperature_readable(target_name, thermal_op)
+        return
+
+    monitor_temperature_change(
+        target_name,
+        thermal_op,
+        args.duration,
+        cmd,
+    )
+
+
+def dump_thermal_zones(args):
+
+    for thermal in sorted(Path(SYS_THERMAL_PATH).glob("thermal_zone*")):
+        node = ThermalMonitor(thermal.name)
+        print(
+            (
+                "name: {}\nmode: {}\ntype: {}\nstable_id: {}\n"
+                "sysfs_path: {}\ndevice_path: {}\nof_node_path: {}\n"
+                "firmware_node_path: {}\ncdev_types: {}\n"
+            ).format(
+                node.name,
+                node.mode,
+                node.type,
+                node.stable_id,
+                node.sysfs_path,
+                node.device_path,
+                node.of_node_path,
+                node.firmware_node_path,
+                "|".join(node.cdev_types),
+            )
+        )
+
+
+def snapshot_thermal_zones(args):
+    rows = []
+    for thermal in sorted(Path(SYS_THERMAL_PATH).glob("thermal_zone*")):
+        node = ThermalMonitor(thermal.name)
+        rows.append(
+            "{}\t{}\t{}\t{}".format(
+                node.stable_id,
+                node.name,
+                node.type,
+                node.stable_source,
+            )
+        )
+
+    snapshot = "\n".join(rows) + "\n"
+    if args.output is None:
+        print(snapshot, end="")
+    else:
+        Path(args.output).write_text(snapshot)
+
+
+def compare_thermal_snapshots(args):
+    before_entries = _load_snapshot(args.before)
+    after_entries = _load_snapshot(args.after)
+
+    before_ids = set(before_entries)
+    after_ids = set(after_entries)
+    common_ids = sorted(before_ids & after_ids)
+    missing_ids = sorted(before_ids - after_ids)
+    new_ids = sorted(after_ids - before_ids)
+
+    stable_id_upgraded = []
+    if args.allow_legacy_id_upgrade:
+        stable_id_upgraded, missing_ids, new_ids = (
+            _reconcile_legacy_id_upgrades(
+                before_entries,
+                after_entries,
+                missing_ids,
+                new_ids,
+            )
+        )
+
+    renumbered = []
+    identity_changed = []
+    for stable_id in common_ids:
+        before = before_entries[stable_id]
+        after = after_entries[stable_id]
+        if before["name"] != after["name"]:
+            renumbered.append((stable_id, before, after))
+        if (
+            before["type"] != after["type"]
+            or before["stable_source"] != after["stable_source"]
+        ):
+            identity_changed.append((stable_id, before, after))
+
+    print(
+        (
+            "summary: before={} after={} missing={} new={} "
+            "stable_id_upgraded={} identity_changed={} renumbered={}"
+        ).format(
+            len(before_ids),
+            len(after_ids),
+            len(missing_ids),
+            len(new_ids),
+            len(stable_id_upgraded),
+            len(identity_changed),
+            len(renumbered),
+        )
+    )
+
+    for old_id, new_id, before, after in stable_id_upgraded:
+        print(
+            (
+                "stable_id_upgraded: type={} {} -> {} name={} "
+                "stable_source={} -> {}"
+            ).format(
+                before["type"],
+                old_id,
+                new_id,
+                before["name"],
+                before["stable_source"],
+                after["stable_source"],
+            )
+        )
+
+    for stable_id, before, after in renumbered:
+        print(
+            "renumbered: type={} stable_id={} {} -> {}".format(
+                before["type"],
+                stable_id,
+                before["name"],
+                after["name"],
+            )
+        )
+
+    for stable_id, before, after in identity_changed:
+        print(
+            "identity_changed: stable_id={} {}|{} -> {}|{}".format(
+                stable_id,
+                before["type"],
+                before["stable_source"],
+                after["type"],
+                after["stable_source"],
+            )
+        )
+
+    for stable_id in missing_ids:
+        before = before_entries[stable_id]
+        print(
+            "missing_after: type={} stable_id={} name={}".format(
+                before["type"],
+                stable_id,
+                before["name"],
+            )
+        )
+
+    for stable_id in new_ids:
+        after = after_entries[stable_id]
+        print(
+            "new_after: type={} stable_id={} name={}".format(
+                after["type"],
+                stable_id,
+                after["name"],
+            )
+        )
+
+    if args.fail_on_diff and (
+        missing_ids
+        or new_ids
+        or stable_id_upgraded
+        or identity_changed
+        or renumbered
+    ):
+        raise SystemExit(1)
 
 
 def register_arguments():
@@ -167,7 +509,15 @@ def register_arguments():
     )
 
     monitor_parser = sub_parsers.add_parser("monitor")
-    monitor_parser.add_argument("-n", "--name", required=True, type=str)
+    zone_selector = monitor_parser.add_mutually_exclusive_group(required=True)
+    zone_selector.add_argument("-n", "--name", type=str)
+    zone_selector.add_argument("--stable-id", type=str)
+    monitor_parser.add_argument(
+        "--zone-type",
+        type=str,
+        default=None,
+        help="Use with --stable-id to further disambiguate zones",
+    )
     monitor_parser.add_argument(
         "-d",
         "--duration",
@@ -188,6 +538,34 @@ def register_arguments():
 
     dump_parser = sub_parsers.add_parser("dump")
     dump_parser.set_defaults(test_type=dump_thermal_zones)
+
+    snapshot_parser = sub_parsers.add_parser("snapshot")
+    snapshot_parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default=None,
+        help="Write snapshot to a TSV file",
+    )
+    snapshot_parser.set_defaults(test_type=snapshot_thermal_zones)
+
+    compare_parser = sub_parsers.add_parser("compare")
+    compare_parser.add_argument("--before", required=True, type=str)
+    compare_parser.add_argument("--after", required=True, type=str)
+    compare_parser.add_argument(
+        "--allow-legacy-id-upgrade",
+        action="store_true",
+        help=(
+            "Best-effort compatibility mode for snapshot comparison across "
+            "stable_id algorithm upgrades"
+        ),
+    )
+    compare_parser.add_argument(
+        "--fail-on-diff",
+        action="store_true",
+        help="Exit with status 1 when compare detects any differences",
+    )
+    compare_parser.set_defaults(test_type=compare_thermal_snapshots)
 
     args = parser.parse_args()
     return args

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_thermal_sensor_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_thermal_sensor_test.py
@@ -200,7 +200,7 @@ class ThermalMonitorTest(unittest.TestCase):
                 output = stdout.getvalue()
 
         self.assertIn(
-            "summary: before=2 after=2 missing=1 new=1 identity_changed=0 renumbered=1",
+            "summary: before=2 after=2 missing=1 new=1 stable_id_upgraded=0 identity_changed=0 renumbered=1",
             output,
         )
         self.assertIn(

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_thermal_sensor_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_thermal_sensor_test.py
@@ -61,13 +61,23 @@ class ThermalMonitorTest(unittest.TestCase):
                 name="fake-thermal", duration=30, extra_commands="stress-ng"
             )
         )
-        mock_text.side_effect = ["30000", "30000", "31000"]
+        mock_text.side_effect = [
+            "acpitz",
+            "acpitz",
+            "enabled",
+            "30000",
+            "31000",
+            "acpitz",
+        ]
         mock_check_temp.return_value = True
 
         with self.assertLogs() as lc:
             thermal_sensor_test.thermal_monitor_test(mock_args())
             self.assertIn(
-                "# The temperature of fake-thermal thermal has been altered",
+                (
+                    "# The temperature of fake-thermal "
+                    "(acpitz) thermal has been altered"
+                ),
                 lc.output[-1],
             )
 
@@ -83,11 +93,50 @@ class ThermalMonitorTest(unittest.TestCase):
                 name="fake-thermal", duration=2, extra_commands="stress-ng"
             )
         )
-        mock_text.return_value = "30000"
+        mock_text.side_effect = [
+            "acpitz",
+            "acpitz",
+            "enabled",
+            "30000",
+            "30000",
+            "30000",
+            "acpitz",
+        ]
         mock_check_temp.return_value = False
 
         with self.assertRaises(SystemExit):
             thermal_sensor_test.thermal_monitor_test(mock_args())
+
+    @mock.patch("pathlib.Path.read_text")
+    @mock.patch("pathlib.Path.exists")
+    def test_thermal_monitor_ignore_temp_check_reads_once(
+        self, mock_exists, mock_text
+    ):
+        mock_args = mock.Mock(
+            return_value=argparse.Namespace(
+                name="fake-thermal",
+                duration=30,
+                extra_commands="stress-ng",
+                stable_id=None,
+                zone_type=None,
+            )
+        )
+        mock_exists.return_value = True
+        mock_text.side_effect = [
+            "acpitz",
+            "acpitz",
+            "enabled",
+            "30000",
+            "acpitz",
+            "acpitz",
+        ]
+
+        with mock.patch.dict(
+            "os.environ", {"TZ_IGNORE_TEMP_CHECK": "acpitz"}, clear=False
+        ):
+            thermal_sensor_test.thermal_monitor_test(mock_args())
+
+        self.assertEqual(mock_text.call_count, 6)
 
     @mock.patch("thermal_sensor_test.ThermalMonitor")
     @mock.patch("pathlib.Path.glob")
@@ -200,11 +249,17 @@ class ThermalMonitorTest(unittest.TestCase):
                 output = stdout.getvalue()
 
         self.assertIn(
-            "summary: before=2 after=2 missing=1 new=1 stable_id_upgraded=0 identity_changed=0 renumbered=1",
+            (
+                "summary: before=2 after=2 missing=1 new=1 "
+                "stable_id_upgraded=0 identity_changed=0 renumbered=1"
+            ),
             output,
         )
         self.assertIn(
-            "renumbered: type=cpu stable_id=sid-a thermal_zone1 -> thermal_zone5",
+            (
+                "renumbered: type=cpu stable_id=sid-a "
+                "thermal_zone1 -> thermal_zone5"
+            ),
             output,
         )
         self.assertIn(

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_thermal_sensor_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_thermal_sensor_test.py
@@ -189,7 +189,12 @@ class ThermalMonitorTest(unittest.TestCase):
             before.write_text(before_data)
             after.write_text(after_data)
 
-            args = argparse.Namespace(before=str(before), after=str(after))
+            args = argparse.Namespace(
+                before=str(before),
+                after=str(after),
+                allow_legacy_id_upgrade=False,
+                fail_on_diff=False,
+            )
             with mock.patch("sys.stdout", new_callable=io.StringIO) as stdout:
                 thermal_sensor_test.compare_thermal_snapshots(args)
                 output = stdout.getvalue()

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_thermal_sensor_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_thermal_sensor_test.py
@@ -219,18 +219,24 @@ class ThermalMonitorTest(unittest.TestCase):
         self.assertEqual(thermal_node.stable_source, "/soc/thermal/node")
 
     def test_compare_thermal_snapshots_human_readable_output(self):
-        before_data = "\n".join(
-            [
-                "sid-a\tthermal_zone1\tcpu\t/source/cpu",
-                "sid-b\tthermal_zone2\tgpu\t/source/gpu",
-            ]
-        ) + "\n"
-        after_data = "\n".join(
-            [
-                "sid-a\tthermal_zone5\tcpu\t/source/cpu",
-                "sid-c\tthermal_zone3\tddr\t/source/ddr",
-            ]
-        ) + "\n"
+        before_data = (
+            "\n".join(
+                [
+                    "sid-a\tthermal_zone1\tcpu\t/source/cpu",
+                    "sid-b\tthermal_zone2\tgpu\t/source/gpu",
+                ]
+            )
+            + "\n"
+        )
+        after_data = (
+            "\n".join(
+                [
+                    "sid-a\tthermal_zone5\tcpu\t/source/cpu",
+                    "sid-c\tthermal_zone3\tddr\t/source/ddr",
+                ]
+            )
+            + "\n"
+        )
 
         with tempfile.TemporaryDirectory() as tmpdir:
             before = Path(tmpdir).joinpath("before.tsv")

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_thermal_sensor_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_thermal_sensor_test.py
@@ -1,6 +1,10 @@
 import unittest
 import argparse
+import tempfile
+import io
 from unittest import mock
+from unittest.mock import PropertyMock
+from pathlib import Path
 import thermal_sensor_test
 
 
@@ -84,3 +88,125 @@ class ThermalMonitorTest(unittest.TestCase):
 
         with self.assertRaises(SystemExit):
             thermal_sensor_test.thermal_monitor_test(mock_args())
+
+    @mock.patch("thermal_sensor_test.ThermalMonitor")
+    @mock.patch("pathlib.Path.glob")
+    def test_resolve_thermal_zone_name_by_stable_id(
+        self, mock_glob, mock_thermal_monitor
+    ):
+        mock_glob.return_value = [Path("thermal_zone9"), Path("thermal_zone1")]
+
+        def monitor_factory(name):
+            monitor = mock.Mock()
+            monitor.name = name
+            if name == "thermal_zone1":
+                monitor.stable_id = "match-id"
+                monitor.type = "x86_pkg_temp"
+            else:
+                monitor.stable_id = "other-id"
+                monitor.type = "acpitz"
+            return monitor
+
+        mock_thermal_monitor.side_effect = monitor_factory
+
+        self.assertEqual(
+            thermal_sensor_test.resolve_thermal_zone_name(
+                "match-id", zone_type="x86_pkg_temp"
+            ),
+            "thermal_zone1",
+        )
+
+    @mock.patch("thermal_sensor_test.resolve_thermal_zone_name")
+    def test_monitor_fails_when_stable_id_cannot_be_resolved(
+        self, mock_resolve
+    ):
+        mock_resolve.return_value = None
+        mock_args = mock.Mock(
+            return_value=argparse.Namespace(
+                name=None,
+                stable_id="missing-id",
+                zone_type="acpitz",
+                duration=10,
+                extra_commands="stress-ng",
+            )
+        )
+
+        with self.assertRaises(SystemExit):
+            thermal_sensor_test.thermal_monitor_test(mock_args())
+
+    @mock.patch.object(
+        thermal_sensor_test.ThermalMonitor,
+        "type",
+        new_callable=PropertyMock,
+    )
+    @mock.patch.object(
+        thermal_sensor_test.ThermalMonitor,
+        "device_path",
+        new_callable=PropertyMock,
+    )
+    @mock.patch.object(
+        thermal_sensor_test.ThermalMonitor,
+        "firmware_node_path",
+        new_callable=PropertyMock,
+    )
+    @mock.patch.object(
+        thermal_sensor_test.ThermalMonitor,
+        "of_node_path",
+        new_callable=PropertyMock,
+    )
+    def test_stable_source_prefers_of_node(
+        self,
+        mock_of_node_path,
+        mock_firmware_node_path,
+        mock_device_path,
+        mock_type,
+    ):
+        mock_of_node_path.return_value = "/soc/thermal/node"
+        mock_firmware_node_path.return_value = ""
+        mock_device_path.return_value = "/sys/devices/virtual/thermal/fallback"
+        mock_type.return_value = "acpitz"
+
+        thermal_node = thermal_sensor_test.ThermalMonitor("fake-thermal")
+        self.assertEqual(thermal_node.stable_source, "/soc/thermal/node")
+
+    def test_compare_thermal_snapshots_human_readable_output(self):
+        before_data = "\n".join(
+            [
+                "sid-a\tthermal_zone1\tcpu\t/source/cpu",
+                "sid-b\tthermal_zone2\tgpu\t/source/gpu",
+            ]
+        ) + "\n"
+        after_data = "\n".join(
+            [
+                "sid-a\tthermal_zone5\tcpu\t/source/cpu",
+                "sid-c\tthermal_zone3\tddr\t/source/ddr",
+            ]
+        ) + "\n"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            before = Path(tmpdir).joinpath("before.tsv")
+            after = Path(tmpdir).joinpath("after.tsv")
+            before.write_text(before_data)
+            after.write_text(after_data)
+
+            args = argparse.Namespace(before=str(before), after=str(after))
+            with mock.patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                thermal_sensor_test.compare_thermal_snapshots(args)
+                output = stdout.getvalue()
+
+        self.assertIn(
+            "summary: before=2 after=2 missing=1 new=1 identity_changed=0 renumbered=1",
+            output,
+        )
+        self.assertIn(
+            "renumbered: type=cpu stable_id=sid-a thermal_zone1 -> thermal_zone5",
+            output,
+        )
+        self.assertIn(
+            "missing_after: type=gpu stable_id=sid-b name=thermal_zone2",
+            output,
+        )
+        self.assertIn(
+            "new_after: type=ddr stable_id=sid-c name=thermal_zone3",
+            output,
+        )

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/sensor/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/strict-confinement/sensor/jobs.pxu
@@ -2,10 +2,10 @@ unit: template
 template-engine: jinja2
 template-resource: thermal_zones
 template-id: strict-confinement/temperature-test
-id: strict-confinement/temperature_{{ name }}_{{ type }}
-_summary: Check Thermal temperature of {{ name }} - {{ type }}
+id: strict-confinement/temperature_{{ stable_id }}_{{ type }}
+_summary: Check Thermal temperature of {{ type }} - {{ stable_id }}
 _description:
-    Test a thermal temperature for {{ name }} - {{ type }}.
+  Test a thermal temperature for {{ type }} ({{ stable_id }}).
 category_id: strict-confinement-mode
 plugin: shell
 estimated_duration: 5m
@@ -19,4 +19,4 @@ requires:
   snap.name == 'test-strict-confinement'
   connections.slot == "snapd:hardware-observe" and connections.plug == "test-strict-confinement:hardware-observe"
 command:
-  test-strict-confinement.thermal-test monitor -n {{ name }} --extra-commands "dd if=/dev/zero of=/dev/null"
+  test-strict-confinement.thermal-test monitor --stable-id {{ stable_id }} --zone-type "{{ type }}" --extra-commands "dd if=/dev/zero of=/dev/null"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
@@ -31,7 +31,6 @@ nested_part:
     ce-oem-installation-info-manual
     ce-oem-cpu-manual
     ce-oem-button-manual
-    ce-oem-thermal-manual
     ce-oem-gps-manual
     ce-oem-mtd-manual
     ce-oem-buzzer-manual
@@ -123,7 +122,6 @@ include:
 nested_part:
     after-suspend-ce-oem-cpu-manual
     after-suspend-ce-oem-button-manual
-    after-suspend-ce-oem-thermal-manual
     after-suspend-ce-oem-gps-manual
     after-suspend-ce-oem-mtd-manual
     after-suspend-ce-oem-buzzer-manual
@@ -159,7 +157,6 @@ nested_part:
     after-suspend-ce-oem-cpu-automated
     after-suspend-ce-oem-button-automated
     after-suspend-ce-oem-ptp-automated
-    after-suspend-ce-oem-thermal-automated
     after-suspend-ce-oem-gps-automated
     after-suspend-ce-oem-mtd-automated
     after-suspend-ce-oem-buzzer-automated

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/README.md
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/README.md
@@ -1,0 +1,230 @@
+# Thermal Sensor Tests
+
+This directory contains the Checkbox CE OEM thermal test units and test
+plans.
+
+## Files in this directory
+
+- `category.pxu`: defines the `thermal` category.
+- `jobs.pxu`: defines the thermal resource job, the per-zone temperature
+  test template, and the suspend/resume identity checks.
+- `test-plan.pxu`: groups the thermal jobs into automated and
+  after-suspend plans.
+
+## What the tests do
+
+The thermal test flow has two main goals:
+
+1. Verify that each discovered thermal zone is usable during normal test
+   execution.
+2. Verify that thermal zone identity remains stable across suspend and
+   resume.
+
+### Zone discovery
+
+The `thermal_zones` resource job runs:
+
+```bash
+thermal_sensor_test.py dump
+```
+
+This enumerates all `thermal_zone*` nodes under `/sys/class/thermal` and
+collects metadata including:
+
+- zone name
+- zone type
+- stable ID
+- sysfs path
+- device / firmware / DT identity hints
+- bound cooling-device types
+
+### Per-zone temperature test
+
+The template job `ce-oem-thermal/temperature_{stable_id}_{type}` runs:
+
+```bash
+thermal_sensor_test.py monitor --stable-id {stable_id} --zone-type "{type}"
+```
+
+The helper resolves the current `thermal_zoneN` by using both:
+
+- `stable_id`
+- thermal `type`
+
+This is intentional. The test does not rely on `thermal_zone42` staying a
+specific zone forever. Instead, it resolves the zone from a more stable
+identity derived from sysfs properties.
+
+During execution the script logs both:
+
+- the current zone name, for example `thermal_zone42`
+- the thermal type, for example `camera0-thermal`
+
+### Suspend and resume identity check
+
+Two additional jobs protect the suspend/resume path:
+
+- `ce-oem-thermal/snapshot_before_suspend`
+- `after-suspend-ce-oem-thermal/compare_snapshot_after_suspend`
+
+The strategy is:
+
+1. Take a pre-suspend snapshot of all thermal zones.
+2. Suspend and resume the system.
+3. Take a post-resume snapshot.
+4. Compare both snapshots and fail if zone identity changed.
+
+The compare step uses:
+
+```bash
+thermal_sensor_test.py compare --before ... --after ... --fail-on-diff
+```
+
+This is meant to catch platform regressions where thermal zones are
+unexpectedly renumbered, disappear, or come back with changed identity
+information after resume.
+
+## How stable identity is derived
+
+The helper computes a `stable_source` using the best available sysfs
+identity in this order:
+
+1. `device/of_node`
+2. `device/firmware_node/path`
+3. `device`
+4. bound cooling-device types (`cdev*`)
+5. thermal `type`
+
+The final `stable_id` is a hash of:
+
+- thermal type
+- stable source
+
+This allows the test to survive `thermal_zoneN` renumbering better than a
+plain zone-index lookup.
+
+## Configuring `TZ_IGNORE_TEMP_CHECK`
+
+Some platforms expose readable thermal nodes whose values do not change in
+practice during the stress window. In those cases, you can configure the
+job to skip the "temperature must change" validation.
+
+The job already exposes this environment variable:
+
+```text
+TZ_IGNORE_TEMP_CHECK
+```
+
+### Supported values
+
+`TZ_IGNORE_TEMP_CHECK` supports two modes.
+
+Global override:
+
+```text
+TZ_IGNORE_TEMP_CHECK=all
+```
+
+Type-specific override:
+
+```text
+TZ_IGNORE_TEMP_CHECK=cpu-thermal|cpu2-thermal|camera0-thermal
+```
+
+Matching is done against the thermal zone `type` string.
+
+### Behavior when enabled
+
+If `TZ_IGNORE_TEMP_CHECK` matches the current thermal type, the monitor job
+switches to a readability-only check.
+
+That means the test will:
+
+1. resolve the target thermal zone
+2. read the temperature value once
+3. pass if the temperature node is readable
+
+It will not:
+
+- require the value to change
+- run the stress-based temperature-change loop
+
+This is useful for hardware where the thermal path is valid but the sensor
+value is static or too coarse during the test duration.
+
+## How to choose `TZ_IGNORE_TEMP_CHECK`
+
+Use the override only for zones that are known to be readable but not
+suitable for change-detection.
+
+Recommended approach:
+
+1. Run the thermal tests normally first.
+2. Check the logs for zones that repeatedly stay constant while still
+   reading valid temperatures.
+3. Add only those thermal types to `TZ_IGNORE_TEMP_CHECK`.
+4. Prefer a type-specific list over `all` whenever possible.
+
+Using `all` is broader and should usually be reserved for bring-up or
+special debugging scenarios.
+
+## Manual helper commands
+
+When debugging outside Checkbox, these helper commands are useful.
+
+Dump zones:
+
+```bash
+thermal_sensor_test.py dump
+```
+
+Take a snapshot:
+
+```bash
+thermal_sensor_test.py snapshot -o /tmp/thermal.tsv
+```
+
+Compare two snapshots:
+
+```bash
+thermal_sensor_test.py compare --before /tmp/before.tsv --after /tmp/after.tsv
+```
+
+Monitor a specific stable ID:
+
+```bash
+thermal_sensor_test.py monitor --stable-id <stable_id> --zone-type "<type>"
+```
+
+Readability-only behavior for selected types:
+
+```bash
+TZ_IGNORE_TEMP_CHECK="cpu-thermal|cpu2-thermal" \
+thermal_sensor_test.py monitor --stable-id <stable_id> --zone-type "<type>"
+```
+
+## Test-plan structure
+
+The thermal test plans are split into:
+
+- `ce-oem-thermal-automated`
+- `after-suspend-ce-oem-thermal-automated`
+
+The automated plan includes:
+
+- the pre-suspend snapshot job
+- one generated temperature job per discovered zone
+
+The after-suspend automated plan includes:
+
+- the post-resume snapshot compare job
+- the same per-zone temperature jobs re-run after suspend
+
+## Practical notes
+
+- The zone name in logs may change across boots or platform revisions.
+  The type and stable ID are the more meaningful identifiers.
+- `TZ_IGNORE_TEMP_CHECK` is a test-policy override, not a fix for broken
+  thermal hardware.
+- If a zone is both unreadable and static, the readability-only path will
+  still fail because it must be able to read the temperature node.

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/jobs.pxu
@@ -6,16 +6,43 @@ _description:
 estimated_duration: 1s
 command: thermal_sensor_test.py dump
 
+id: ce-oem-thermal/snapshot_before_suspend
+plugin: shell
+user: root
+before: suspend/suspend_advanced_auto
+estimated_duration: 1s
+_summary: Record thermal zone snapshot before suspend
+_description:
+ Record thermal zone identities before suspend for post-resume comparison.
+command:
+    thermal_sensor_test.py snapshot -o "$PLAINBOX_SESSION_SHARE"/thermal_before_suspend.tsv
+
+id: after-suspend-ce-oem-thermal/compare_snapshot_after_suspend
+plugin: shell
+user: root
+depends: 
+  com.canonical.certification::suspend/suspend_advanced_auto 
+  ce-oem-thermal/snapshot_before_suspend
+estimated_duration: 2s
+_summary: Verify thermal zone identities after suspend
+_description:
+ Compare thermal zone identities after resume against the pre-suspend snapshot.
+command:
+    thermal_sensor_test.py snapshot -o "$PLAINBOX_SESSION_SHARE"/thermal_after_suspend.tsv && \
+    thermal_sensor_test.py compare --before "$PLAINBOX_SESSION_SHARE"/thermal_before_suspend.tsv --after "$PLAINBOX_SESSION_SHARE"/thermal_after_suspend.tsv --fail-on-diff
+
 unit: template
 template-resource: thermal_zones
-id: ce-oem-thermal/temperature_{name}_{type}
-_summary: Check Thermal temperature of {name} - {type}
+id: ce-oem-thermal/temperature_{stable_id}_{type}
+_summary: Check Thermal temperature of {type} - {stable_id}
 _description:
-    Test a thermal temperature for {name} - {type}.
+    Test a thermal temperature for {type} ({stable_id}).
 category_id: thermal
 plugin: shell
 user: root
 estimated_duration: 5m
+environ:
+    TZ_IGNORE_TEMP_CHECK
 flags: also-after-suspend
 command:
-    thermal_sensor_test.py monitor -n {name}
+    thermal_sensor_test.py monitor --stable-id {stable_id} --zone-type "{type}"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/jobs.pxu
@@ -33,10 +33,13 @@ command:
 
 unit: template
 template-resource: thermal_zones
-id: ce-oem-thermal/temperature_{stable_id}_{type}
-_summary: Check Thermal temperature of {type} - {stable_id}
+template-unit: job
+template-engine: jinja2
+template-id: ce-oem-thermal/temperature-test
+id: ce-oem-thermal/temperature_{{ stable_id }}_{{ type }}
+_summary: Check Thermal temperature of {{ type }} - {{ stable_id }}
 _description:
-    Test a thermal temperature for {type} ({stable_id}).
+    Test a thermal temperature for {{ type }} ({{ stable_id }}).
 category_id: thermal
 plugin: shell
 user: root
@@ -45,4 +48,4 @@ environ:
     TZ_IGNORE_TEMP_CHECK
 flags: also-after-suspend
 command:
-    thermal_sensor_test.py monitor --stable-id {stable_id} --zone-type "{type}"
+    thermal_sensor_test.py monitor --stable-id {{ stable_id }} --zone-type "{{ type }}"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/jobs.pxu
@@ -20,9 +20,9 @@ command:
 id: after-suspend-ce-oem-thermal/compare_snapshot_after_suspend
 plugin: shell
 user: root
-depends: 
-  com.canonical.certification::suspend/suspend_advanced_auto 
-  ce-oem-thermal/snapshot_before_suspend
+depends:
+    com.canonical.certification::suspend/suspend_advanced_auto
+    ce-oem-thermal/snapshot_before_suspend
 estimated_duration: 2s
 _summary: Verify thermal zone identities after suspend
 _description:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/jobs.pxu
@@ -9,7 +9,7 @@ command: thermal_sensor_test.py dump
 id: ce-oem-thermal/snapshot_before_suspend
 plugin: shell
 user: root
-before: suspend/suspend_advanced_auto
+before: com.canonical.certification::suspend/suspend_advanced_auto
 estimated_duration: 1s
 _summary: Record thermal zone snapshot before suspend
 _description:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/test-plan.pxu
@@ -16,12 +16,4 @@ bootstrap_include:
 include:
     ce-oem-thermal/snapshot_before_suspend
     ce-oem-thermal/temperature-test
-
-id: after-suspend-ce-oem-thermal-automated
-unit: test plan
-_name: After suspend thermal auto tests
-_description: Automated after suspend thermal tests for devices
-bootstrap_include:
-    thermal_zones
-include:
     after-suspend-ce-oem-thermal/compare_snapshot_after_suspend

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/test-plan.pxu
@@ -5,7 +5,6 @@ _description: Full thermal thermal tests for devices
 include:
 nested_part:
     ce-oem-thermal-automated
-    after-suspend-ce-oem-thermal-automated
 
 id: ce-oem-thermal-automated
 unit: test plan

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/test-plan.pxu
@@ -22,6 +22,7 @@ _description: Automated thermal tests for devices
 bootstrap_include:
     thermal_zones
 include:
+    ce-oem-thermal/snapshot_before_suspend
     ce-oem-thermal/temperature_.*
 
 id: after-suspend-ce-oem-thermal-manual
@@ -37,4 +38,5 @@ _description: Automated after suspend thermal tests for devices
 bootstrap_include:
     thermal_zones
 include:
+    after-suspend-ce-oem-thermal/compare_snapshot_after_suspend
     after-suspend-ce-oem-thermal/temperature_.*

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/thermal-sensor/test-plan.pxu
@@ -4,16 +4,8 @@ _name: Thermal thermal tests
 _description: Full thermal thermal tests for devices
 include:
 nested_part:
-    ce-oem-thermal-manual
     ce-oem-thermal-automated
-    after-suspend-ce-oem-thermal-manual
     after-suspend-ce-oem-thermal-automated
-
-id: ce-oem-thermal-manual
-unit: test plan
-_name: Thermal manual tests
-_description: Manual thermal tests for devices
-include:
 
 id: ce-oem-thermal-automated
 unit: test plan
@@ -23,13 +15,7 @@ bootstrap_include:
     thermal_zones
 include:
     ce-oem-thermal/snapshot_before_suspend
-    ce-oem-thermal/temperature_.*
-
-id: after-suspend-ce-oem-thermal-manual
-unit: test plan
-_name: After suspend thermal manual tests
-_description: Manual after suspend thermal tests for devices
-include:
+    ce-oem-thermal/temperature-test
 
 id: after-suspend-ce-oem-thermal-automated
 unit: test plan
@@ -39,4 +25,3 @@ bootstrap_include:
     thermal_zones
 include:
     after-suspend-ce-oem-thermal/compare_snapshot_after_suspend
-    after-suspend-ce-oem-thermal/temperature_.*


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
- Thermal zone selection no longer depends on the thermal_zoneN index remaining stable.
- The monitor path resolves a zone using [stable_id] plus thermal [type], which is safer when zone numbering changes.
- Stable identity support was added to the helper script, including: [stable_source], [stable_id]
- snapshot export
- snapshot comparison
- better cross-boot and cross-resume mapping

For temperature validation behavior:

added `TZ_IGNORE_TEMP_CHECK`, it supports either all or a |-separated list of exact thermal types
when matched, the test switches from “temperature must change” to “temperature must be readable”


<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
[Test results: https://certification.canonical.com/hardware/202510-38024/submission/498453/](https://certification.canonical.com/hardware/202510-38024/submission/499871/)
#### list bootstrapped
```
ubuntu@ubuntu:~$ checkbox-carmel-classic.checkbox-cli list-bootstrapped com.canonical.contrib::ce-oem-thermal-automated
We are deprecating the classic frontend Checkbox snaps
Consider switching to the strict frontend

$PROVIDERPATH is defined, so following provider sources are ignored ['/snap/checkbox-carmel-classic/149/providers/checkbox-provider-carmel', '/home/ubuntu/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Using sideloaded provider: checkbox-provider-ce-oem, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-ce-oem
Using `ubuntu` user
com.canonical.contrib::ce-oem-thermal/snapshot_before_suspend
com.canonical.contrib::ce-oem-thermal/temperature_6bcbf45eea5b_vbat
com.canonical.contrib::ce-oem-thermal/temperature_e329c0b45b53_pm7250b-bcl-lvl1
com.canonical.contrib::ce-oem-thermal/temperature_ffb21bac3850_mdmss1-thermal
com.canonical.certification::rtc
com.canonical.contrib::ce-oem-thermal/temperature_8635e63910b9_xo-thermal
com.canonical.contrib::ce-oem-thermal/temperature_e8acadee2fa3_pm7250b-thermal
com.canonical.contrib::ce-oem-thermal/temperature_5f0fe9e2c1ae_cpu5-thermal
com.canonical.contrib::ce-oem-thermal/temperature_0f1195f6d557_cpu1-thermal
com.canonical.contrib::ce-oem-thermal/temperature_c3f3022ccb31_nspss0-thermal
com.canonical.contrib::ce-oem-thermal/temperature_6be8a5542f7b_cpu0-thermal
com.canonical.contrib::ce-oem-thermal/temperature_520aa20cb756_ddr-thermal
com.canonical.certification::sleep
com.canonical.contrib::ce-oem-thermal/temperature_e80c8d93f44e_cpu9-thermal
com.canonical.contrib::ce-oem-thermal/temperature_321f92b04822_cpu10-thermal
com.canonical.contrib::ce-oem-thermal/temperature_41140525ea11_camera0-thermal
com.canonical.contrib::ce-oem-thermal/temperature_eb3e9d9c1353_cpu2-thermal
com.canonical.contrib::ce-oem-thermal/temperature_6ae70f62fcdd_cpuss1-thermal
com.canonical.contrib::ce-oem-thermal/temperature_7573c23e6e04_pm8350c-bcl-lvl2
com.canonical.contrib::ce-oem-thermal/temperature_40fdb04583fa_gpuss0-thermal
com.canonical.plainbox::manifest
com.canonical.contrib::ce-oem-thermal/temperature_f30488ddbcd8_cpu11-thermal
com.canonical.contrib::ce-oem-thermal/temperature_bddfabc48dbc_pm7325-thermal
com.canonical.contrib::ce-oem-thermal/temperature_cfa31130c01a_pm7250b-ibat-lvl0
com.canonical.contrib::ce-oem-thermal/temperature_55baad714f98_cpu4-thermal
com.canonical.contrib::ce-oem-thermal/temperature_ab76ea2622fa_aoss1-thermal
com.canonical.contrib::ce-oem-thermal/temperature_15bb586a09a6_mdmss3-thermal
com.canonical.contrib::ce-oem-thermal/temperature_ccec86acf683_cpu6-thermal
com.canonical.contrib::ce-oem-thermal/temperature_5d0cd535bf8b_mdmss2-thermal
com.canonical.contrib::ce-oem-thermal/temperature_ff9dbdc27338_cpu8-thermal
com.canonical.contrib::ce-oem-thermal/temperature_e09931f90485_cpu7-thermal
com.canonical.contrib::ce-oem-thermal/temperature_7d0bc71c8b44_pm7250b-bcl-lvl2
com.canonical.contrib::ce-oem-thermal/temperature_03b73b807cd4_cpu3-thermal
com.canonical.contrib::ce-oem-thermal/temperature_5d75d3114e09_pm7250b-ibat-lvl1
com.canonical.contrib::ce-oem-thermal/temperature_2b6594720054_pm8350c-thermal
com.canonical.contrib::ce-oem-thermal/temperature_90b3fd39aa0e_nspss1-thermal
com.canonical.contrib::ce-oem-thermal/temperature_36e19699aa84_gpuss1-thermal
com.canonical.contrib::ce-oem-thermal/temperature_07e5346f6d5a_pm8350c-bcl-lvl0
com.canonical.contrib::ce-oem-thermal/temperature_083c72553b48_quiet-thermal
com.canonical.contrib::ce-oem-thermal/temperature_6fac1301ab14_sdm-skin-thermal
com.canonical.contrib::ce-oem-thermal/temperature_1fd0d0aaf3ab_qcom-battmgr-bat
com.canonical.contrib::ce-oem-thermal/temperature_245738816e90_cpuss0-thermal
com.canonical.contrib::ce-oem-thermal/temperature_d6b59d40de9a_pm8350c-bcl-lvl1
com.canonical.contrib::ce-oem-thermal/temperature_1d92f2618326_video-thermal
com.canonical.contrib::ce-oem-thermal/temperature_9f0b44104c5c_aoss0-thermal
com.canonical.contrib::ce-oem-thermal/temperature_a6754a92725f_pm7250b-bcl-lvl0
com.canonical.contrib::ce-oem-thermal/temperature_793cd19122a5_mdmss0-thermal
com.canonical.certification::suspend/suspend_advanced_auto
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_6bcbf45eea5b_vbat
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_cfa31130c01a_pm7250b-ibat-lvl0
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_9f0b44104c5c_aoss0-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_6be8a5542f7b_cpu0-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_0f1195f6d557_cpu1-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_eb3e9d9c1353_cpu2-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_03b73b807cd4_cpu3-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_245738816e90_cpuss0-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_6ae70f62fcdd_cpuss1-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_55baad714f98_cpu4-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_5f0fe9e2c1ae_cpu5-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_ccec86acf683_cpu6-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_5d75d3114e09_pm7250b-ibat-lvl1
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_e09931f90485_cpu7-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_ff9dbdc27338_cpu8-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_e80c8d93f44e_cpu9-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_2b6594720054_pm8350c-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_321f92b04822_cpu10-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_f30488ddbcd8_cpu11-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_e8acadee2fa3_pm7250b-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_bddfabc48dbc_pm7325-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_ab76ea2622fa_aoss1-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_8635e63910b9_xo-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_a6754a92725f_pm7250b-bcl-lvl0
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_40fdb04583fa_gpuss0-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_36e19699aa84_gpuss1-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_083c72553b48_quiet-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_6fac1301ab14_sdm-skin-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_c3f3022ccb31_nspss0-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_90b3fd39aa0e_nspss1-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_1d92f2618326_video-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_520aa20cb756_ddr-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_793cd19122a5_mdmss0-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_ffb21bac3850_mdmss1-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_e329c0b45b53_pm7250b-bcl-lvl1
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_5d0cd535bf8b_mdmss2-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_15bb586a09a6_mdmss3-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_41140525ea11_camera0-thermal
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_7d0bc71c8b44_pm7250b-bcl-lvl2
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_07e5346f6d5a_pm8350c-bcl-lvl0
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_d6b59d40de9a_pm8350c-bcl-lvl1
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_7573c23e6e04_pm8350c-bcl-lvl2
com.canonical.contrib::after-suspend-ce-oem-thermal/temperature_1fd0d0aaf3ab_qcom-battmgr-bat
com.canonical.contrib::after-suspend-ce-oem-thermal/compare_snapshot_after_suspend
```
<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
