### PR TITLE
LXD Image Check now mirrors behaviour of KVM Image Check (New)

### DIFF
--- a/providers/certification-server/tools/canonical-certification-precheck
+++ b/providers/certification-server/tools/canonical-certification-precheck
@@ -478,6 +478,35 @@ fi
 LXD_Image_Check(){
 echoname "LXD Image Check"
 
+local template_needs_fallback=0
+local rootfs_needs_fallback=0
+
+# Validate that default upstream LXD image assets are reachable.
+validate_upstream_lxd_images() {
+    local upstream_template_url="http://cloud-images.ubuntu.com/$codename/current/$codename-server-cloudimg-$arch-lxd.tar.xz"
+    local upstream_rootfs_url="http://cloud-images.ubuntu.com/$codename/current/$codename-server-cloudimg-$arch.squashfs"
+    local failed=0
+
+    if curl --output /dev/null --silent --head -fail "$upstream_template_url"; then
+        echo -e " We can get the LXD template image from $upstream_template_url."
+    else
+        echo -e " We cannot get the LXD template image from $upstream_template_url."
+        failed=1
+    fi
+
+    if curl --output /dev/null --silent --head -fail "$upstream_rootfs_url"; then
+        echo -e " We can get the LXD rootfs image from $upstream_rootfs_url."
+    else
+        echo -e " We cannot get the LXD rootfs image from $upstream_rootfs_url."
+        failed=1
+    fi
+
+    if [ "$failed" -eq 0 ]; then
+        return 0
+    fi
+    return 1
+}
+
 #Check template image
 if grep "^LXD_TEMPLATE =" $configfile >/dev/null; then
     templateurl=$(grep ^LXD_TEMPLATE $configfile|awk '{print $3}')
@@ -540,7 +569,7 @@ else
         fi
     else
         echo -e " Leaving LXD_TEMPLATE unconfigured"
-        fail
+        template_needs_fallback=1
     fi
 fi
 # Check RootFS
@@ -607,6 +636,16 @@ else
         fi
     else
         echo -e " Leaving LXD_ROOTFS unconfigured"
+        rootfs_needs_fallback=1
+    fi
+fi
+
+if [ "$template_needs_fallback" -eq 1 ] || [ "$rootfs_needs_fallback" -eq 1 ]; then
+    if validate_upstream_lxd_images; then
+        echo -e " Continuing to use upstream LXD images"
+        pass
+    else
+        echo -e " Marking as failed"
         fail
     fi
 fi


### PR DESCRIPTION


<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
When precheck runs now, if the user chooses 'n' when prompted to enter a local file path for the LXD filesystem and template files, the script will mirror the KVM Image Check section and attempt to verify connectivity to upstream images . If the upstream check passes, the LXD section will pass. If the user selects 'n' here AND the upstream test fails, then the section will fail indicating the upstream images are not accessible and the test will have now way to launch LXD containers for the tests.


<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
resolves CHECKBOX-2302
resolves #2645
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

## Documentation
NA, minor behavioral update
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
Tested manually on a SUT...

Original output from Checks:
```
============ KVM Image Check ============
KVM_IMAGE is not configured.
Note: If left unconfigured, we will pull our image from
cloud-images.ubuntu.com.
Would you like to configure it now? (Y/n)? n
We can get our image from http://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img.
Continuing to use this image

============ LXD Image Check ============
LXD_TEMPLATE is not configured.
Note: If left unconfigured, we will attempt to get the LXD image from the
ubuntu LXD image stream.
Would you like to configure it now? (Y/n)? ^[[Bn
Please enter 'Y' or 'N'!
Would you like to configure it now? (Y/n)? n
Leaving LXD_TEMPLATE unconfigured
LXD_ROOTFS is not configured.
Note: If left unconfigured, we will attempt to get the ROOTFS image from the
ubuntu LXD image stream.
Would you like to configure it now? (Y/n)? n
Leaving LXD_ROOTFS unconfigured
```

Original summary output:
```
============ Report ============

              Fix_APT_Issues  --------------------  Passed
          Verify_Config_File  --------------------  Passed
              Ubuntu_Version  --------------------  Ubuntu 24.04.4 LTS
                        Arch  --------------------  amd64
                    EFI_Mode  --------------------  This is an EFI Mode installation
                 CCS_Version  --------------------  7.4.0~dev48~ubuntu24.04.1
                   SID_Check  --------------------  j7LBo8hhx7hWA3yV5sWME7
               Installed_Ram  --------------------  Passed
      Virtualization_Support  --------------------  Passed
                NICs_enabled  --------------------  Failed
                Jumbo_Frames  --------------------  Passed
                       IPERF  --------------------  Passed
             Network_Subnets  --------------------  Passed
                   LVM_Check  --------------------  Passed
                  Hard_Disks  --------------------  Passed
                   USB_Disks  --------------------  Passed
            Disk_Speed_Check  --------------------  Passed
             KVM_Image_Check  --------------------  Passed
             LXD_Image_Check  --------------------  Failed
                   XDG_Check  --------------------  Failed
               CPUFreq_Check  --------------------  Passed
                 GPGPU_Check  --------------------  No GPGPU detected
```

Now updated checks output:
```
============ KVM Image Check ============
 KVM_IMAGE is not configured.
 Note: If left unconfigured, we will pull our image from
 cloud-images.ubuntu.com.
 Would you like to configure it now? (Y/n)? n
 We can get our image from http://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img.
 Continuing to use this image

============ LXD Image Check ============
 LXD_TEMPLATE is not configured.
 Note: If left unconfigured, we will attempt to get the LXD image from the
 ubuntu LXD image stream.
 Would you like to configure it now? (Y/n)? n
 Leaving LXD_TEMPLATE unconfigured
 LXD_ROOTFS is not configured.
 Note: If left unconfigured, we will attempt to get the ROOTFS image from the
 ubuntu LXD image stream.
 Would you like to configure it now? (Y/n)? n
 Leaving LXD_ROOTFS unconfigured
 We can get the LXD template image from http://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64-lxd.tar.xz.
 We can get the LXD rootfs image from http://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.squashfs.
 Continuing to use upstream LXD images
```

and updated summary output:
```
============ Report ============

              Fix_APT_Issues  --------------------  Passed
          Verify_Config_File  --------------------  Passed
              Ubuntu_Version  --------------------  Ubuntu 24.04.4 LTS
                        Arch  --------------------  amd64
                    EFI_Mode  --------------------  This is an EFI Mode installation
                 CCS_Version  --------------------  7.4.0~dev48~ubuntu24.04.1
                   SID_Check  --------------------  j7LBo8hhx7hWA3yV5sWME7
               Installed_Ram  --------------------  Passed
      Virtualization_Support  --------------------  Passed
                NICs_enabled  --------------------  Passed
                Jumbo_Frames  --------------------  Passed
                       IPERF  --------------------  Passed
             Network_Subnets  --------------------  Multiple subnets detected
                   LVM_Check  --------------------  Passed
                  Hard_Disks  --------------------  Passed
                   USB_Disks  --------------------  Passed
            Disk_Speed_Check  --------------------  Passed
             KVM_Image_Check  --------------------  Passed
             LXD_Image_Check  --------------------  Passed
                   XDG_Check  --------------------  Failed
               CPUFreq_Check  --------------------  Passed
                 GPGPU_Check  --------------------  No GPGPU detected
```
<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
