### PR TITLE
Add RS485 Modbus peripheral test (New)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic20/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic20/snap/snapcraft.yaml
@@ -44,6 +44,7 @@ parts:
       - device-tree-compiler
       - linuxptp
       - snmp
+      - python3-pymodbus
       - gpsd
     override-prime: |
       snapcraftctl prime

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic22/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic22/snap/snapcraft.yaml
@@ -45,6 +45,7 @@ parts:
       - linuxptp
       - snmp
       - python3-rpyc
+      - python3-pymodbus
       - gpsd
     override-prime: |
       snapcraftctl prime

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic24/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic24/snap/snapcraft.yaml
@@ -45,6 +45,7 @@ parts:
       - linuxptp
       - snmp
       - python3-rpyc
+      - python3-pymodbus
       - gpsd
     override-prime: |
       craftctl default

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic26/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_classic26/snap/snapcraft.yaml
@@ -45,6 +45,7 @@ parts:
       - linuxptp
       - snmp
       - python3-rpyc
+      - python3-pymodbus
       - gpsd
     override-prime: |
       craftctl default

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc20/snap/snapcraft.yaml
@@ -82,6 +82,7 @@ parts:
       - device-tree-compiler
       - linuxptp
       - snmp
+      - python3-pymodbus
       - gpsd
     override-prime: |
       snapcraftctl prime

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc22/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc22/snap/snapcraft.yaml
@@ -83,6 +83,7 @@ parts:
       - linuxptp
       - snmp
       - python3-rpyc
+      - python3-pymodbus
       - gpsd
     override-prime: |
       snapcraftctl prime

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc24/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc24/snap/snapcraft.yaml
@@ -83,6 +83,7 @@ parts:
       - linuxptp
       - snmp
       - python3-rpyc
+      - python3-pymodbus
       - gpsd
     override-prime: |
       craftctl default

--- a/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc26/snap/snapcraft.yaml
+++ b/contrib/checkbox-ce-oem/checkbox-ce-oem-snap/series_uc26/snap/snapcraft.yaml
@@ -83,6 +83,7 @@ parts:
       - linuxptp
       - snmp
       - python3-rpyc
+      - python3-pymodbus
       - gpsd
     override-build: |
       export PYTHONPATH=/snap/checkbox26/current/lib/python3.14/site-packages/:/usr/lib/python3/dist-packages

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rs485_modbus_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/rs485_modbus_test.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""List and test RS485 Modbus RTU peripherals."""
+
+import argparse
+import re
+from typing import Callable, List
+
+EXPECTED_FORMAT = (
+    "NAME:NODE:BAUDRATE:UNIT_ID:REGISTER_TYPE:REGISTER_ADDRESS:"
+    "REGISTER_COUNT:PARITY"
+)
+REGISTER_TYPES = ("holding", "input")
+
+
+def sanitize_id(value):
+    """Return a short identifier safe for generated Checkbox job IDs."""
+
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("_")
+
+
+class RS485ModbusPeripheral:
+    """A configured RS485 Modbus peripheral."""
+
+    def __init__(
+        self,
+        name,
+        node,
+        baudrate,
+        unit_id,
+        register_type,
+        register_address,
+        register_count,
+        parity,
+    ):
+        self.name = name
+        self.node = node
+        self.baudrate = baudrate
+        self.unit_id = unit_id
+        self.register_type = register_type
+        self.register_address = register_address
+        self.register_count = register_count
+        self.parity = parity
+
+    @property
+    def name_id(self) -> str:
+        """Return the configured name normalized for generated job IDs."""
+
+        return sanitize_id(self.name)
+
+    @property
+    def node_id(self) -> str:
+        """Return a short node identifier safe for generated job IDs."""
+
+        return sanitize_id(self.node)
+
+
+class ModbusReadConfig:
+    """Configuration for one Modbus RTU register read."""
+
+    def __init__(
+        self,
+        port,
+        baudrate,
+        unit_id,
+        register_type,
+        address,
+        count,
+        parity,
+    ):
+        self.port = port
+        self.baudrate = baudrate
+        self.unit_id = unit_id
+        self.register_type = register_type
+        self.address = address
+        self.count = count
+        self.parity = parity
+
+
+def _parse_positive_int(raw_value, field_name):
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise ValueError("{} must be an integer".format(field_name)) from exc
+    if value < 1:
+        raise ValueError("{} must be greater than 0".format(field_name))
+    return value
+
+
+def _parse_non_negative_int(raw_value, field_name):
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise ValueError("{} must be an integer".format(field_name)) from exc
+    if value < 0:
+        raise ValueError("{} must be 0 or greater".format(field_name))
+    return value
+
+
+def positive_int(raw_value):
+    """Parse a positive integer for argparse."""
+
+    try:
+        return _parse_positive_int(raw_value, "value")
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc))
+
+
+def non_negative_int(raw_value):
+    """Parse a non-negative integer for argparse."""
+
+    try:
+        return _parse_non_negative_int(raw_value, "value")
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc))
+
+
+def parse_peripheral(entry: str) -> RS485ModbusPeripheral:
+    """Parse one RS485 Modbus peripheral configuration entry."""
+
+    parts = entry.split(":")
+    if len(parts) != 8:
+        raise ValueError("invalid format, expected {}".format(EXPECTED_FORMAT))
+
+    (
+        name,
+        node,
+        baudrate,
+        unit_id,
+        register_type,
+        register_address,
+        register_count,
+        parity,
+    ) = parts
+
+    if not name:
+        raise ValueError("NAME must not be empty")
+    if not sanitize_id(name):
+        raise ValueError("NAME must contain an ID-safe character")
+    if not node:
+        raise ValueError("NODE must not be empty")
+    if not sanitize_id(node):
+        raise ValueError("NODE must contain an ID-safe character")
+
+    normalized_register_type = register_type.lower()
+    if normalized_register_type not in REGISTER_TYPES:
+        raise ValueError(
+            "REGISTER_TYPE must be one of: {}".format(
+                ", ".join(REGISTER_TYPES)
+            )
+        )
+
+    normalized_parity = parity.upper()
+    if normalized_parity not in ("N", "E", "O"):
+        raise ValueError("PARITY must be one of: N, E, O")
+
+    return RS485ModbusPeripheral(
+        name=name,
+        node=node,
+        baudrate=_parse_positive_int(baudrate, "BAUDRATE"),
+        unit_id=_parse_positive_int(unit_id, "UNIT_ID"),
+        register_type=normalized_register_type,
+        register_address=_parse_non_negative_int(
+            register_address, "REGISTER_ADDRESS"
+        ),
+        register_count=_parse_positive_int(register_count, "REGISTER_COUNT"),
+        parity=normalized_parity,
+    )
+
+
+def parse_peripherals(config: str) -> List[RS485ModbusPeripheral]:
+    """Parse a space-separated RS485 Modbus peripheral configuration."""
+
+    return [parse_peripheral(entry) for entry in config.split()]
+
+
+def print_peripherals_config(config: str) -> None:
+    """Print Checkbox resource records for configured peripherals."""
+
+    for peripheral in parse_peripherals(config):
+        print("name: {}".format(peripheral.name))
+        print("name_id: {}".format(peripheral.name_id))
+        print("node: {}".format(peripheral.node))
+        print("node_id: {}".format(peripheral.node_id))
+        print("baudrate: {}".format(peripheral.baudrate))
+        print("unit_id: {}".format(peripheral.unit_id))
+        print("register_type: {}".format(peripheral.register_type))
+        print("register_address: {}".format(peripheral.register_address))
+        print("register_count: {}".format(peripheral.register_count))
+        print("parity: {}".format(peripheral.parity))
+        print()
+
+
+def create_modbus_client(config: ModbusReadConfig):
+    """Create a pymodbus RTU serial client.
+
+    The import supports both pymodbus 2.x and 3.x module layouts.
+    """
+
+    try:
+        from pymodbus.client import ModbusSerialClient
+    except ImportError:
+        from pymodbus.client.sync import ModbusSerialClient
+
+    client_args = {
+        "port": config.port,
+        "baudrate": config.baudrate,
+        "parity": config.parity,
+        "stopbits": 1,
+        "bytesize": 8,
+        "timeout": 3,
+    }
+    try:
+        return ModbusSerialClient(method="rtu", **client_args)
+    except TypeError:
+        return ModbusSerialClient(framer="rtu", **client_args)
+
+
+def read_registers(config, client):
+    """Read registers from an open Modbus client."""
+
+    if config.register_type == "holding":
+        read_method = client.read_holding_registers
+    elif config.register_type == "input":
+        read_method = client.read_input_registers
+    else:
+        raise ValueError(
+            "unsupported register type: {}".format(config.register_type)
+        )
+
+    for unit_id_keyword in ("slave", "unit", "device_id"):
+        try:
+            result = read_method(
+                config.address,
+                count=config.count,
+                **{unit_id_keyword: config.unit_id}
+            )
+            break
+        except TypeError:
+            if unit_id_keyword == "device_id":
+                raise
+
+    if result.isError():
+        raise RuntimeError("Modbus error response: {}".format(result))
+
+    registers = getattr(result, "registers", None)
+    if registers is None:
+        raise RuntimeError("Modbus response does not contain registers")
+
+    return list(registers)
+
+
+def run_modbus_read(
+    config: ModbusReadConfig,
+    client_factory: Callable[
+        [ModbusReadConfig], object
+    ] = create_modbus_client,
+):
+    """Connect to a Modbus peripheral and read configured registers."""
+
+    client = client_factory(config)
+    try:
+        if not client.connect():
+            raise RuntimeError("Failed to connect to {}".format(config.port))
+        return read_registers(config, client)
+    finally:
+        client.close()
+
+
+def build_read_config(args):
+    """Build a Modbus read config from parsed CLI arguments."""
+
+    return ModbusReadConfig(
+        port=args.port,
+        baudrate=args.baudrate,
+        unit_id=args.unit_id,
+        register_type=args.register_type,
+        address=args.address,
+        count=args.count,
+        parity=args.parity,
+    )
+
+
+def list_command(args):
+    """Run the list subcommand."""
+
+    try:
+        print_peripherals_config(args.config)
+    except ValueError as exc:
+        print("Error: {}".format(exc))
+        raise SystemExit(1)
+
+
+def read_command(args):
+    """Run the read subcommand."""
+
+    config = build_read_config(args)
+    try:
+        registers = run_modbus_read(config)
+    except (RuntimeError, ValueError) as exc:
+        print("Error: {}".format(exc))
+        raise SystemExit(1)
+
+    print("registers: {}".format(" ".join(str(value) for value in registers)))
+
+
+def write_command(args):
+    """Run the write subcommand."""
+
+    print("Error: Modbus write is not implemented")
+    raise SystemExit(1)
+
+
+def build_parser():
+    """Build the rs485_modbus_test command-line parser."""
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+
+    list_parser = subparsers.add_parser(
+        "list",
+        help="Print Checkbox resources from RS485_MODBUS_PERIPHERALS",
+    )
+    list_parser.add_argument(
+        "config",
+        help=(
+            "Space-separated entries using the format "
+            "{}".format(EXPECTED_FORMAT)
+        ),
+    )
+    list_parser.set_defaults(entry_func=list_command)
+
+    read_parser = subparsers.add_parser(
+        "read",
+        help="Read raw registers from an RS485 Modbus peripheral",
+    )
+    read_parser.add_argument("--port", required=True)
+    read_parser.add_argument("--baudrate", required=True, type=positive_int)
+    read_parser.add_argument("--unit-id", required=True, type=positive_int)
+    read_parser.add_argument(
+        "--register-type",
+        required=True,
+        choices=REGISTER_TYPES,
+    )
+    read_parser.add_argument("--address", required=True, type=non_negative_int)
+    read_parser.add_argument("--count", required=True, type=positive_int)
+    read_parser.add_argument(
+        "--parity",
+        required=True,
+        choices=("N", "E", "O"),
+        type=str.upper,
+    )
+    read_parser.set_defaults(entry_func=read_command)
+
+    write_parser = subparsers.add_parser(
+        "write",
+        help="Reserved for future RS485 Modbus write tests",
+    )
+    write_parser.set_defaults(entry_func=write_command)
+
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not hasattr(args, "entry_func"):
+        parser.print_usage()
+        raise SystemExit(1)
+    args.entry_func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_rs485_modbus_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_rs485_modbus_test.py
@@ -1,0 +1,287 @@
+import unittest
+from io import StringIO
+from unittest import mock
+
+import rs485_modbus_test
+
+
+class FakeResponse:
+    def __init__(self, registers=None, is_error=False):
+        self.registers = registers
+        self._is_error = is_error
+
+    def isError(self):
+        return self._is_error
+
+
+class FakeClient:
+    def __init__(self, connect_result=True, response=None):
+        self.connect_result = connect_result
+        self.response = response or FakeResponse([11, 22])
+        self.closed = False
+        self.holding_calls = []
+        self.input_calls = []
+
+    def connect(self):
+        return self.connect_result
+
+    def close(self):
+        self.closed = True
+
+    def read_holding_registers(self, *args, **kwargs):
+        self.holding_calls.append((args, kwargs))
+        return self.response
+
+    def read_input_registers(self, *args, **kwargs):
+        self.input_calls.append((args, kwargs))
+        return self.response
+
+
+class LegacyFakeClient(FakeClient):
+    def read_holding_registers(self, *args, **kwargs):
+        if "slave" in kwargs:
+            raise TypeError("unexpected keyword argument 'slave'")
+        self.holding_calls.append((args, kwargs))
+        return self.response
+
+
+class NewFakeClient(FakeClient):
+    def read_holding_registers(self, *args, **kwargs):
+        if "slave" in kwargs or "unit" in kwargs:
+            raise TypeError("unexpected unit ID keyword")
+        self.holding_calls.append((args, kwargs))
+        return self.response
+
+
+class RS485ModbusTest(unittest.TestCase):
+    """Unit tests for RS485 Modbus test helper commands."""
+
+    def test_parse_multiple_peripherals(self):
+        peripherals = rs485_modbus_test.parse_peripherals(
+            "device0:/dev/ttyS0:9600:1:holding:0:2:N "
+            "meter0:/dev/ttyS1:19200:2:input:10:4:E"
+        )
+
+        self.assertEqual(len(peripherals), 2)
+        self.assertEqual(peripherals[0].name, "device0")
+        self.assertEqual(peripherals[0].name_id, "device0")
+        self.assertEqual(peripherals[0].node, "/dev/ttyS0")
+        self.assertEqual(peripherals[0].node_id, "dev_ttyS0")
+        self.assertEqual(peripherals[0].baudrate, 9600)
+        self.assertEqual(peripherals[0].unit_id, 1)
+        self.assertEqual(peripherals[0].register_type, "holding")
+        self.assertEqual(peripherals[0].register_address, 0)
+        self.assertEqual(peripherals[0].register_count, 2)
+        self.assertEqual(peripherals[0].parity, "N")
+        self.assertEqual(peripherals[1].register_type, "input")
+        self.assertEqual(peripherals[1].parity, "E")
+
+    def test_rejects_malformed_entry(self):
+        with self.assertRaisesRegex(ValueError, "invalid format"):
+            rs485_modbus_test.parse_peripheral("device0:/dev/ttyS0:9600")
+
+    def test_rejects_unsupported_register_type(self):
+        with self.assertRaisesRegex(ValueError, "REGISTER_TYPE"):
+            rs485_modbus_test.parse_peripheral(
+                "device0:/dev/ttyS0:9600:1:coil:0:2:N"
+            )
+
+    def test_list_command_prints_checkbox_resource_records(self):
+        output = StringIO()
+        with mock.patch("sys.stdout", output):
+            rs485_modbus_test.main(
+                [
+                    "list",
+                    "device0:/dev/ttyS0:9600:1:holding:0:2:N",
+                ]
+            )
+
+        self.assertEqual(
+            output.getvalue(),
+            "name: device0\n"
+            "name_id: device0\n"
+            "node: /dev/ttyS0\n"
+            "node_id: dev_ttyS0\n"
+            "baudrate: 9600\n"
+            "unit_id: 1\n"
+            "register_type: holding\n"
+            "register_address: 0\n"
+            "register_count: 2\n"
+            "parity: N\n\n",
+        )
+
+    def test_build_read_config(self):
+        parser = rs485_modbus_test.build_parser()
+        args = parser.parse_args(
+            [
+                "read",
+                "--port",
+                "/dev/ttyS0",
+                "--baudrate",
+                "9600",
+                "--unit-id",
+                "1",
+                "--register-type",
+                "holding",
+                "--address",
+                "0",
+                "--count",
+                "2",
+                "--parity",
+                "n",
+            ]
+        )
+
+        config = rs485_modbus_test.build_read_config(args)
+
+        self.assertEqual(config.port, "/dev/ttyS0")
+        self.assertEqual(config.baudrate, 9600)
+        self.assertEqual(config.unit_id, 1)
+        self.assertEqual(config.register_type, "holding")
+        self.assertEqual(config.address, 0)
+        self.assertEqual(config.count, 2)
+        self.assertEqual(config.parity, "N")
+
+    def test_holding_register_read_success(self):
+        config = rs485_modbus_test.ModbusReadConfig(
+            "/dev/ttyS0", 9600, 1, "holding", 0, 2, "N"
+        )
+        client = FakeClient(response=FakeResponse([100, 200]))
+
+        registers = rs485_modbus_test.run_modbus_read(
+            config, client_factory=lambda config: client
+        )
+
+        self.assertEqual(registers, [100, 200])
+        self.assertEqual(
+            client.holding_calls,
+            [((0,), {"count": 2, "slave": 1})],
+        )
+        self.assertTrue(client.closed)
+
+    def test_input_register_read_success(self):
+        config = rs485_modbus_test.ModbusReadConfig(
+            "/dev/ttyS0", 9600, 1, "input", 10, 4, "E"
+        )
+        client = FakeClient(response=FakeResponse([1, 2, 3, 4]))
+
+        registers = rs485_modbus_test.run_modbus_read(
+            config, client_factory=lambda config: client
+        )
+
+        self.assertEqual(registers, [1, 2, 3, 4])
+        self.assertEqual(
+            client.input_calls,
+            [((10,), {"count": 4, "slave": 1})],
+        )
+        self.assertTrue(client.closed)
+
+    def test_legacy_pymodbus_unit_keyword_fallback(self):
+        config = rs485_modbus_test.ModbusReadConfig(
+            "/dev/ttyS0", 9600, 1, "holding", 0, 2, "N"
+        )
+        client = LegacyFakeClient(response=FakeResponse([10, 20]))
+
+        registers = rs485_modbus_test.run_modbus_read(
+            config, client_factory=lambda config: client
+        )
+
+        self.assertEqual(registers, [10, 20])
+        self.assertEqual(
+            client.holding_calls,
+            [((0,), {"count": 2, "unit": 1})],
+        )
+
+    def test_new_pymodbus_device_id_keyword_fallback(self):
+        config = rs485_modbus_test.ModbusReadConfig(
+            "/dev/ttyS0", 9600, 1, "holding", 0, 2, "N"
+        )
+        client = NewFakeClient(response=FakeResponse([10, 20]))
+
+        registers = rs485_modbus_test.run_modbus_read(
+            config, client_factory=lambda config: client
+        )
+
+        self.assertEqual(registers, [10, 20])
+        self.assertEqual(
+            client.holding_calls,
+            [((0,), {"count": 2, "device_id": 1})],
+        )
+
+    def test_modbus_error_response_fails(self):
+        config = rs485_modbus_test.ModbusReadConfig(
+            "/dev/ttyS0", 9600, 1, "holding", 0, 2, "N"
+        )
+        client = FakeClient(response=FakeResponse(is_error=True))
+
+        with self.assertRaisesRegex(RuntimeError, "Modbus error response"):
+            rs485_modbus_test.run_modbus_read(
+                config, client_factory=lambda config: client
+            )
+
+        self.assertTrue(client.closed)
+
+    def test_connection_failure_fails(self):
+        config = rs485_modbus_test.ModbusReadConfig(
+            "/dev/ttyS0", 9600, 1, "holding", 0, 2, "N"
+        )
+        client = FakeClient(connect_result=False)
+
+        with self.assertRaisesRegex(RuntimeError, "Failed to connect"):
+            rs485_modbus_test.run_modbus_read(
+                config, client_factory=lambda config: client
+            )
+
+        self.assertTrue(client.closed)
+
+    def test_unsupported_register_type_fails(self):
+        config = rs485_modbus_test.ModbusReadConfig(
+            "/dev/ttyS0", 9600, 1, "coil", 0, 2, "N"
+        )
+        client = FakeClient()
+
+        with self.assertRaisesRegex(ValueError, "unsupported register type"):
+            rs485_modbus_test.run_modbus_read(
+                config, client_factory=lambda config: client
+            )
+
+        self.assertTrue(client.closed)
+
+    @mock.patch("rs485_modbus_test.run_modbus_read")
+    def test_read_command_exits_non_zero_on_read_failure(self, mock_run):
+        mock_run.side_effect = RuntimeError("Failed to connect to /dev/ttyS0")
+
+        with mock.patch("sys.stdout", StringIO()):
+            with self.assertRaises(SystemExit) as cm:
+                rs485_modbus_test.main(
+                    [
+                        "read",
+                        "--port",
+                        "/dev/ttyS0",
+                        "--baudrate",
+                        "9600",
+                        "--unit-id",
+                        "1",
+                        "--register-type",
+                        "holding",
+                        "--address",
+                        "0",
+                        "--count",
+                        "2",
+                        "--parity",
+                        "N",
+                    ]
+                )
+
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_write_command_is_reserved(self):
+        with mock.patch("sys.stdout", StringIO()):
+            with self.assertRaises(SystemExit) as cm:
+                rs485_modbus_test.main(["write"])
+
+        self.assertEqual(cm.exception.code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/serial/README.md
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/serial/README.md
@@ -1,0 +1,74 @@
+# RS485 Modbus peripheral tests
+
+The RS485 Modbus peripheral test checks that the DUT can read raw registers
+from one or more RS485 Modbus RTU devices. It is a general CE OEM serial test.
+
+## Test plan
+
+The generated jobs are included by `ce-oem-serial-automated` through the
+`ce-oem-serial/rs485-modbus-read-tests` template ID. They also use
+`flags: also-after-suspend`, so Checkbox can generate before-suspend and
+after-suspend variants for suspend flows.
+
+## Manifest
+
+Enable the manifest gate before running the generated jobs:
+
+```text
+has_rs485_modbus_peripheral: True
+```
+
+If this manifest value is not `True`, the generated Modbus read jobs are not
+selected even when `RS485_MODBUS_PERIPHERALS` is configured.
+
+## Environment
+
+Set `RS485_MODBUS_PERIPHERALS` in the Checkbox configuration. The value is a
+space-separated list of entries with this format:
+
+```text
+NAME:NODE:BAUDRATE:UNIT_ID:REGISTER_TYPE:REGISTER_ADDRESS:REGISTER_COUNT:PARITY
+```
+
+Fields:
+
+| Field | Description |
+| --- | --- |
+| `NAME` | Short unique name for the peripheral. It is normalized for the generated job ID. |
+| `NODE` | Serial device node, such as `/dev/ttyS0`. |
+| `BAUDRATE` | Serial baudrate, such as `9600`. |
+| `UNIT_ID` | Modbus slave/unit ID. |
+| `REGISTER_TYPE` | `holding` for holding registers or `input` for input registers. |
+| `REGISTER_ADDRESS` | Starting register address. Use `0` when the first register is required. |
+| `REGISTER_COUNT` | Number of registers to read. |
+| `PARITY` | Serial parity: `N`, `E`, or `O`. |
+
+Example with one peripheral:
+
+```text
+RS485_MODBUS_PERIPHERALS=device0:/dev/ttyS0:9600:1:holding:0:2:N
+```
+
+Example with two peripherals:
+
+```text
+RS485_MODBUS_PERIPHERALS="device0:/dev/ttyS0:9600:1:holding:0:2:N meter0:/dev/ttyS1:19200:2:input:10:4:E"
+```
+
+## Running the job
+
+After setting the manifest and environment, run the automated serial plan:
+
+```bash
+checkbox-ce-oem.checkbox-cli run com.canonical.contrib::ce-oem-serial-automated
+```
+
+The resource job uses `rs485_modbus_test.py list` to generate resources from
+`RS485_MODBUS_PERIPHERALS`. The generated test job uses
+`rs485_modbus_test.py read` to read the configured registers with `pymodbus`
+and print the raw register values. The command also reserves
+`rs485_modbus_test.py write` for future Modbus write tests.
+
+The job fails if the configuration is malformed, the serial device cannot be
+opened, the Modbus read fails, or the peripheral returns a Modbus error
+response.

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/serial/manifest.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/serial/manifest.pxu
@@ -7,3 +7,8 @@ unit: manifest entry
 id: has_serial_console_loopback
 _name: Does serial console port loopback to itself?
 value-type: bool
+
+unit: manifest entry
+id: has_rs485_modbus_peripheral
+_name: Has RS485 Modbus peripheral connected?
+value-type: bool

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/serial/rs485_modbus_peripheral.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/serial/rs485_modbus_peripheral.pxu
@@ -1,0 +1,51 @@
+id: ce-oem-serial/rs485-modbus-peripheral-list
+_summary:
+    Generates RS485 Modbus peripheral resources from user configuration
+_description:
+    Generates one resource for each RS485 Modbus peripheral listed in
+    RS485_MODBUS_PERIPHERALS.
+    NAME:NODE:BAUDRATE:UNIT_ID:REGISTER_TYPE:REGISTER_ADDRESS:REGISTER_COUNT:PARITY
+plugin: resource
+estimated_duration: 1.0
+environ:
+    RS485_MODBUS_PERIPHERALS
+command:
+    if [ -z "$RS485_MODBUS_PERIPHERALS" ]; then
+        exit 0
+    fi
+    rs485_modbus_test.py list "$RS485_MODBUS_PERIPHERALS"
+
+unit: template
+template-resource: ce-oem-serial/rs485-modbus-peripheral-list
+template-unit: job
+template-engine: jinja2
+template-id: ce-oem-serial/rs485-modbus-read-tests
+id: ce-oem-serial/rs485-modbus-read-{{ name_id }}-{{ node_id }}
+imports: from com.canonical.plainbox import manifest
+requires:
+    manifest.has_rs485_modbus_peripheral == 'True'
+_template-summary:
+    Read registers from configured RS485 Modbus peripherals
+_summary: Read RS485 Modbus registers from {{ name }}
+_purpose:
+    To check that the DUT can read raw registers from RS485 Modbus
+    peripheral {{ name }} on {{ node }}.
+_description:
+    This test opens {{ node }} as an RS485 Modbus RTU client with baudrate
+    {{ baudrate }}, parity {{ parity }}, unit ID {{ unit_id }}, and reads
+    {{ register_count }} {{ register_type }} register(s) starting at address
+    {{ register_address }}.
+plugin: shell
+user: root
+category_id: com.canonical.certification::serial
+estimated_duration: 5
+flags: also-after-suspend
+command:
+    rs485_modbus_test.py read \
+        --port "{{ node }}" \
+        --baudrate "{{ baudrate }}" \
+        --unit-id "{{ unit_id }}" \
+        --register-type "{{ register_type }}" \
+        --address "{{ register_address }}" \
+        --count "{{ register_count }}" \
+        --parity "{{ parity }}"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/serial/rs485_modbus_peripheral.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/serial/rs485_modbus_peripheral.pxu
@@ -5,6 +5,10 @@ _description:
     Generates one resource for each RS485 Modbus peripheral listed in
     RS485_MODBUS_PERIPHERALS.
     NAME:NODE:BAUDRATE:UNIT_ID:REGISTER_TYPE:REGISTER_ADDRESS:REGISTER_COUNT:PARITY
+    For single device:
+    RS485_MODBUS_PERIPHERALS=device0:/dev/ttyS0:9600:1:holding:0:2:N
+    For multiple devices (seperate with the white space):
+    RS485_MODBUS_PERIPHERALS="device0:/dev/ttyS0:9600:1:holding:0:2:N meter0:/dev/ttyS1:19200:2:input:10:4:E"
 plugin: resource
 estimated_duration: 1.0
 environ:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/serial/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/serial/test-plan.pxu
@@ -19,9 +19,11 @@ _description:
 bootstrap_include:
     ce-oem-serial/serial-list
     ce-oem-serial/serial-console-list
+    ce-oem-serial/rs485-modbus-peripheral-list
 include:
     ce-oem-serial/serial-transmit-data-tests
     ce-oem-serial/serial-console-tests
+    ce-oem-serial/rs485-modbus-read-tests
 
 id: before-suspend-ce-oem-serial-automated
 unit: test plan
@@ -31,9 +33,11 @@ _description:
 bootstrap_include:
     ce-oem-serial/serial-list
     ce-oem-serial/serial-console-list
+    ce-oem-serial/rs485-modbus-peripheral-list
 include:
     ce-oem-serial/serial-transmit-data-.*
     ce-oem-serial/serial-console-(?!list\b).*$
+    ce-oem-serial/rs485-modbus-read-tests
 
 id: after-suspend-ce-oem-serial-automated
 unit: test plan
@@ -43,9 +47,11 @@ _description:
 bootstrap_include:
     ce-oem-serial/serial-list
     ce-oem-serial/serial-console-list
+    ce-oem-serial/rs485-modbus-peripheral-list
 include:
     after-suspend-ce-oem-serial/serial-transmit-data-.*
     after-suspend-ce-oem-serial/serial-console-.*
+    after-suspend-ce-oem-serial/rs485-modbus-read-tests
 
 id: ce-oem-serial-stress
 unit: test plan


### PR DESCRIPTION



## Description

Migrate the Limerick RS485 thermal-sensor smoke test into a generic CE OEM serial Modbus peripheral read test. Add configurable resource generation, pymodbus-based register reads, documentation, tests, and snap runtime dependencies.
## Resolved issues



## Documentation



## Tests


