### PR TITLE
Add USB HID wake-up test (New)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/power-management/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/power-management/jobs.pxu
@@ -42,7 +42,7 @@ estimated_duration: 1.0
 
 id: ce-oem-power-management/usb_wakeup_hid
 category_id: com.canonical.plainbox::power-management
-_summary: Test waking up the system from suspend using a USB HID device.
+_summary: Wake from suspend via USB HID device
 _purpose:
     To check that a USB HID device can wake the system from suspend.
 _description:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/power-management/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/power-management/jobs.pxu
@@ -38,3 +38,30 @@ imports: from com.canonical.plainbox import manifest
 requires: manifest.has_pdu == 'True'
 command: reboot_check_test.sh -s
 estimated_duration: 1.0
+
+
+id: ce-oem-power-management/usb_wakeup_hid
+category_id: com.canonical.plainbox::power-management
+_summary: Test waking up the system from suspend using a USB HID device.
+_purpose:
+    To check that a USB HID device can wake the system from suspend.
+_description:
+    This test suspends the system and asks the operator to wake it with a
+    connected USB HID device, such as a keyboard or mouse.
+_steps:
+    1. Enable USB wake-up support in firmware/BIOS if required.
+    2. Connect a USB HID device, such as a keyboard or mouse.
+    3. Press "Test" to enter suspend mode.
+    4. Wait at least 30 seconds to confirm the system stays suspended and does
+       not automatically resume.
+    5. Press a key or click/move the USB HID device to wake the system.
+_verification:
+    Did the system wake up from suspend when you used the USB HID device?
+unit: job
+plugin: user-interact-verify
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_usb_wakeup_hid == 'True'
+depends: com.canonical.certification::suspend/suspend_advanced_auto
+command: systemctl suspend
+user: root
+estimated_duration: 120.0

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/power-management/manifest.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/power-management/manifest.pxu
@@ -5,5 +5,5 @@ value-type: bool
 
 unit: manifest entry
 id: has_usb_wakeup_hid
-_name: Does the platform support wake from suspend by USB HID?
+_name: Does the platform support waking from suspend via USB HID?
 value-type: bool

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/power-management/manifest.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/power-management/manifest.pxu
@@ -2,3 +2,8 @@ unit: manifest entry
 id: has_pdu
 _name: Does platform not supported RTC wake and intend to power cycle via PDU?
 value-type: bool
+
+unit: manifest entry
+id: has_usb_wakeup_hid
+_name: Does the platform support wake from suspend by USB HID?
+value-type: bool

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/power-management/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/power-management/test-plan.pxu
@@ -5,3 +5,11 @@ _description: Automated power tests for devices
 include:
     ce-oem-power-management/cold-reboot-by-pdu
     ce-oem-power-management/post-cold-reboot-by-pdu
+
+id: ce-oem-power-manual
+unit: test plan
+_name: Manual power tests
+_description:
+    Manual and semi-automatic power-management tests for devices.
+include:
+    ce-oem-power-management/usb_wakeup_hid


### PR DESCRIPTION


## Description

Add a CE OEM manual power-management test that suspends the DUT and verifies wake from a USB HID device. Gate the job with has_usb_wakeup_hid and include it in a narrow ce-oem-power-manual plan.

## Resolved issues



## Documentation



## Tests


