### PR TITLE
Use before for jobs that have siblings after suspend (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/ctrl.py
+++ b/checkbox-ng/plainbox/impl/ctrl.py
@@ -37,10 +37,8 @@ try:
 except ImportError:
     grp = None
 import itertools
-import json
 import logging
 import os
-from functools import partial
 
 from plainbox.abc import IJobResult, ISessionStateController
 from plainbox.i18n import gettext as _
@@ -57,7 +55,6 @@ from plainbox.impl.session.jobs import InhibitionCause, JobReadinessInhibitor
 from plainbox.impl.unit.template import TemplateUnit
 from plainbox.impl.unit.unit import MissingParam
 from plainbox.impl.validation import Severity
-from plainbox.suspend_consts import Suspend
 from plainbox.impl.unit.job import InvalidJob
 
 __all__ = [
@@ -117,24 +114,11 @@ class CheckBoxSessionStateController(ISessionStateController):
         except ResourceProgramError:
             resource_deps = ()
 
-        # This step is here to add the dependencies to the suspend jobs.
-        suspend_job_id_list = [
-            Suspend.AUTO_JOB_ID,
-            Suspend.MANUAL_JOB_ID,
-        ]
-        if job.id in suspend_job_id_list:
-            suspend_deps = self._get_before_suspend_dependency_set(
-                job.id, job_list
-            )
-        else:
-            suspend_deps = set()
-
         result = set(
             itertools.chain(
                 zip(itertools.repeat(depends), direct_deps),
                 zip(itertools.repeat(resource), resource_deps),
                 zip(itertools.repeat(after), after_deps),
-                zip(itertools.repeat(after), suspend_deps),
                 zip(itertools.repeat(before), before_refs),
             )
         )
@@ -168,50 +152,6 @@ class CheckBoxSessionStateController(ISessionStateController):
                 )
             else:
                 job_map[dep_id].before_references.add(job.id)
-
-    def _get_before_suspend_dependency_set(self, suspend_job_id, job_list):
-        """
-        Get the set of after dependencies of a suspend job.
-
-        Jobs that have a ``also-after-suspend[-manual]`` flag should be run
-        before their associated suspend job. Similarly, jobs that declare a
-        sibling with a dependency on a suspend job should be run before said
-        suspend job. This function finds these jobs and add them as a
-        dependency for their associated suspend job.
-
-        :param suspend_job_id:
-            The id of a suspend job. One of the following is expected:
-            Suspend.AUTO_JOB_ID or Suspend.MANUAL_JOB_ID.
-        :param job_list:
-            List of jobs to search dependencies on.
-        :returns:
-            A set of job ids that need to be run before the suspend job
-        """
-        p_suspend_job_id = partial(
-            self._is_job_impacting_suspend, suspend_job_id
-        )
-        suspend_deps_jobs = filter(p_suspend_job_id, job_list)
-        suspend_deps = set(job.id for job in suspend_deps_jobs)
-        return suspend_deps
-
-    def _is_job_impacting_suspend(self, suspend_job_id, job):
-        """
-        Check if the ``suspend_job_id`` job needs to be run after a given
-        ``job``. This is the case if the ``job`` has a "also after suspend"
-        flag, or if it defines a sibling that has a dependency on the suspend
-        job.
-        """
-        expected_flag = {
-            Suspend.AUTO_JOB_ID: Suspend.AUTO_FLAG,
-            Suspend.MANUAL_JOB_ID: Suspend.MANUAL_FLAG,
-        }.get(suspend_job_id)
-        if job.flags and expected_flag in job.flags:
-            return True
-        if job.siblings:
-            for sibling_data in job.siblings:
-                if suspend_job_id in sibling_data.get("depends", []):
-                    return True
-        return False
 
     def get_requires_manifest_inhibitor_list(self, session_state, job):
         try:
@@ -341,58 +281,7 @@ class CheckBoxSessionStateController(ISessionStateController):
                     related_job=dep_job_state.job,
                 )
                 inhibitors.append(inhibitor)
-        if job.id in [Suspend.AUTO_JOB_ID, Suspend.MANUAL_JOB_ID]:
-            for inhibitor in self._get_suspend_inhibitor_list(
-                session_state, job
-            ):
-                inhibitors.append(inhibitor)
         return inhibitors
-
-    def _get_suspend_inhibitor_list(self, session_state, suspend_job):
-        """
-        Get a list of readiness inhibitors that inhibit a suspend job.
-
-        Jobs that have a ``also-after-suspend[-manual]`` flag should be run
-        before their associated suspend job. Similary, jobs that declare a
-        sibling with a dependency on a suspend job should be run before said
-        suspend job. This function finds these jobs and add them as a
-        inhibitor for their associated suspend job.
-
-        :param session_state:
-            A SessionState instance that is used to interrogate the
-            state of the session where it matters for a particular
-            job. Currently this is used to access resources and job
-            results.
-        :param suspend_job:
-            A suspend job.
-        :returns:
-            List of JobReadinessInhibitor
-        """
-        suspend_inhibitors = []
-        undesired_inhibitor = JobReadinessInhibitor(
-            cause=InhibitionCause.UNDESIRED
-        )
-        # We are only interested in jobs that are actually going to run
-        run_list = [
-            state.job
-            for state in session_state.job_state_map.values()
-            if undesired_inhibitor not in state.readiness_inhibitor_list
-        ]
-        p_suspend_job_id = partial(
-            self._is_job_impacting_suspend, suspend_job.id
-        )
-        suspend_inhibitors_jobs = filter(p_suspend_job_id, run_list)
-        for job in suspend_inhibitors_jobs:
-            if (
-                session_state.job_state_map[job.id].result.outcome
-                == IJobResult.OUTCOME_NONE
-            ):
-                inhibitor = JobReadinessInhibitor(
-                    cause=InhibitionCause.PENDING_DEP,
-                    related_job=job,
-                )
-                suspend_inhibitors.append(inhibitor)
-        return suspend_inhibitors
 
     def observe_result(self, session_state, job, result, fake_resources=False):
         """

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -1278,7 +1278,28 @@ class SessionState:
             siblings.append(overrides)
         return siblings
 
+    def _get_job_data_directly_required_suspend(self, job_data):
+        to_r = set()
+
+        def pxu_compatible_in(con):
+            if isinstance(con, list):
+                return con
+            # this is not perfect but it is good enough for what we need here
+            return con.split()
+
+        for suspend_id in [Suspend.AUTO_JOB_ID, Suspend.MANUAL_JOB_ID]:
+            if suspend_id in pxu_compatible_in(job_data.get("depends", [])):
+                to_r.add(suspend_id)
+            elif suspend_id in pxu_compatible_in(job_data.get("after", [])):
+                to_r.add(suspend_id)
+        return to_r
+
     def _add_job_siblings_unit(self, job, recompute, via):
+        job_requiring_suspend = set(
+            self._get_job_data_directly_required_suspend(job._data)
+        )
+        siblings_requiring_suspend = set()
+
         siblings = job.siblings or []
         siblings += self._get_flags_siblings(job)
         for overrides in siblings:
@@ -1300,6 +1321,24 @@ class SessionState:
                 recompute,
                 via,
             )
+            siblings_requiring_suspend |= (
+                self._get_job_data_directly_required_suspend(data)
+            )
+        sibling_required_not_job = (
+            siblings_requiring_suspend - job_requiring_suspend
+        )
+        # when a job doesn't require to be after suspend but has a sibling that
+        # wants to be the job is always before suspend
+        if not sibling_required_not_job:
+            return
+        # Note: intentionally avoid accessing before directly as it is a
+        #       cached property
+        before = job._data.get("before", [])
+        if isinstance(before, list):
+            before += list(sibling_required_not_job)
+        else:
+            before += " " + " ".join(sibling_required_not_job)
+        job._data["before"] = before
 
     def remove_unit(self, unit, *, recompute=True):
         """

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -1350,7 +1350,10 @@ class SessionState:
             before += list(sibling_required_not_job)
         else:
             before += " " + " ".join(sibling_required_not_job)
-        job._data["before"] = before
+        # here change the property, not the _data. Changing the data may lead
+        # (on resume) that the same unit is re-adopted, but given we've mutated
+        # the data, it is different and it crashes Checkbox
+        job.before = before
 
     def remove_unit(self, unit, *, recompute=True):
         """

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -1279,12 +1279,24 @@ class SessionState:
         return siblings
 
     def _get_job_data_directly_required_suspend(self, job_data):
+        """
+        Get which suspend ids the current job data follows
+
+        :param job_data:
+            job data to inspect
+        :returns:
+            set of suspend job ids that the job data either depends on or comes
+            after
+        """
         to_r = set()
 
         def pxu_compatible_in(con):
             if isinstance(con, list):
+                # yaml path, in works fine here as it "full matches"
                 return con
-            # this is not perfect but it is good enough for what we need here
+            # string in doesn't work well for string because the manual id is
+            # contained in the auto id.
+            # This is not perfect but it is good enough for what we need.
             return con.split()
 
         for suspend_id in [Suspend.AUTO_JOB_ID, Suspend.MANUAL_JOB_ID]:

--- a/checkbox-ng/plainbox/impl/session/test_state.py
+++ b/checkbox-ng/plainbox/impl/session/test_state.py
@@ -22,6 +22,7 @@ plainbox.impl.test_session
 Test definitions for plainbox.impl.session module
 """
 
+import json
 from doctest import REPORT_NDIFF, DocTestSuite
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
@@ -422,6 +423,63 @@ class SessionStateAPITests(TestCase):
             [UndesiredJobReadinessInhibitor],
         )
 
+    def test_also_after_suspend_flag_adds_before_constraint(self):
+        job = make_job("A", summary="foo", flags=[Suspend.AUTO_FLAG])
+
+        session = SessionState([])
+        session.add_unit(job)
+
+        self.assertEqual(job.before, [Suspend.AUTO_JOB_ID])
+
+    def test_also_after_suspend_flag_preserves_before_constraint(self):
+        job = make_job(
+            "A",
+            summary="foo",
+            flags=[Suspend.AUTO_FLAG],
+            before="later_job",
+        )
+
+        session = SessionState([])
+        session.add_unit(job)
+
+        self.assertEqual(job.before, "later_job " + Suspend.AUTO_JOB_ID)
+
+    def test_also_after_suspend_manual_flag_adds_before_constraint(self):
+        job = make_job("A", summary="foo", flags=[Suspend.MANUAL_FLAG])
+
+        session = SessionState([])
+        session.add_unit(job)
+
+        self.assertEqual(job.before, [Suspend.MANUAL_JOB_ID])
+
+    def test_also_after_suspend_flags_add_before_constraints(self):
+        job = make_job(
+            "A",
+            summary="foo",
+            flags=[Suspend.AUTO_FLAG, Suspend.MANUAL_FLAG],
+        )
+
+        session = SessionState([])
+        session.add_unit(job)
+
+        self.assertEqual(
+            set(job.before),
+            {Suspend.AUTO_JOB_ID, Suspend.MANUAL_JOB_ID},
+        )
+
+    def test_also_after_suspend_flag_with_suspend_dep_no_before(self):
+        job = make_job(
+            "A",
+            summary="foo",
+            flags=[Suspend.AUTO_FLAG],
+            depends=[Suspend.AUTO_JOB_ID],
+        )
+
+        session = SessionState([])
+        session.add_unit(job)
+
+        self.assertEqual(job.before, None)
+
     def test_also_after_suspend_flag_extra_fields(self):
         # Define a job
         job = make_job(
@@ -509,6 +567,65 @@ class SessionStateAPITests(TestCase):
             session.job_state_map[sibling.id].readiness_inhibitor_list,
             [UndesiredJobReadinessInhibitor],
         )
+
+    def test_sibling_with_suspend_dep_adds_before_constraint(self):
+        job = make_job(
+            "A",
+            summary="foo",
+            siblings=json.dumps(
+                [
+                    {
+                        "id": "after-suspend-A",
+                        "depends": "A " + Suspend.AUTO_JOB_ID,
+                    }
+                ]
+            ),
+        )
+
+        session = SessionState([])
+        session.add_unit(job)
+
+        self.assertEqual(job.before, [Suspend.AUTO_JOB_ID])
+
+    def test_sibling_with_suspend_dep_preserves_before_constraint(self):
+        job = make_job(
+            "A",
+            summary="foo",
+            siblings=json.dumps(
+                [
+                    {
+                        "id": "after-suspend-A",
+                        "depends": "A " + Suspend.AUTO_JOB_ID,
+                    }
+                ]
+            ),
+            before="later_job",
+        )
+
+        session = SessionState([])
+        session.add_unit(job)
+
+        self.assertEqual(job.before, "later_job " + Suspend.AUTO_JOB_ID)
+
+    def test_sibling_with_suspend_dep_and_suspend_dep_no_before(self):
+        job = make_job(
+            "A",
+            summary="foo",
+            siblings=json.dumps(
+                [
+                    {
+                        "id": "after-suspend-A",
+                        "depends": "A " + Suspend.AUTO_JOB_ID,
+                    }
+                ]
+            ),
+            depends=[Suspend.AUTO_JOB_ID],
+        )
+
+        session = SessionState([])
+        session.add_unit(job)
+
+        self.assertIsNone(job.before)
 
     def test_also_after_suspend_manual_flag_extra_fields(self):
         # Define a job
@@ -1209,9 +1326,7 @@ class SessionDeviceContextTests(SignalTestCase):
         self.unit.provider = self.provider
         self.provider.unit_list = [self.unit]
         self.provider.problem_list = []
-        self.job = Mock(name="job", spec_set=JobDefinition, siblings=None)
-        self.job.get_flag_set = Mock(return_value=())
-        self.job.Meta.name = "job"
+        self.job = make_job("job")
 
     def test_smoke(self):
         """

--- a/checkbox-ng/plainbox/impl/test_ctrl.py
+++ b/checkbox-ng/plainbox/impl/test_ctrl.py
@@ -24,10 +24,8 @@ Test definitions for plainbox.impl.ctrl module
 """
 
 from unittest import TestCase
-import json
 
 from plainbox.abc import IJobResult
-from plainbox.suspend_consts import Suspend
 from plainbox.impl.ctrl import (
     CheckBoxSessionStateController,
     SymLinkNest,
@@ -94,14 +92,6 @@ class CheckBoxSessionStateControllerTests(TestCase):
         self.assertEqual(
             self.ctrl.get_dependency_set(job_f),
             {(DependencyType.DEPENDS, "j6"), (DependencyType.RESOURCE, "j6")},
-        )
-        # Job with an "also-after-suspend" flag, meaning this job should be
-        # set to run before the suspend job
-        job_g = JobDefinition({"id": "j7", "flags": Suspend.AUTO_FLAG})
-        suspend_job = JobDefinition({"id": Suspend.AUTO_JOB_ID})
-        self.assertEqual(
-            self.ctrl.get_dependency_set(suspend_job, [job_g]),
-            {(DependencyType.AFTER, "j7")},
         )
 
     def test_add_before_deps(self):
@@ -362,91 +352,6 @@ class CheckBoxSessionStateControllerTests(TestCase):
         jsm_j3.job = j3
         jsm_j3.result.outcome = IJobResult.OUTCOME_PASS
         self.assertEqual(self.ctrl.get_inhibitor_list(session_state, j1), [])
-
-    def test_get_inhibitor_list__suspend_job(self):
-        j1 = JobDefinition(
-            {
-                "id": "j1",
-                "flags": Suspend.AUTO_FLAG,
-            }
-        )
-        j2 = JobDefinition(
-            {
-                "id": "j2",
-            }
-        )
-        suspend_job = JobDefinition({"id": Suspend.AUTO_JOB_ID})
-        session_state = mock.MagicMock(spec=SessionState)
-        session_state.job_state_map = {
-            "j1": mock.Mock(spec_set=JobState),
-            "j2": mock.Mock(spec_set=JobState),
-            Suspend.AUTO_JOB_ID: mock.Mock(spec_set=JobState),
-        }
-        jsm_j1 = session_state.job_state_map["j1"]
-        jsm_j1.job = j1
-        jsm_j1.result.outcome = IJobResult.OUTCOME_NONE
-        jsm_j1.readiness_inhibitor_list = []
-        jsm_j2 = session_state.job_state_map["j2"]
-        jsm_j2.job = j2
-        jsm_j2.result.outcome = IJobResult.OUTCOME_NONE
-        jsm_j2.readiness_inhibitor_list = []
-        jsm_suspend = session_state.job_state_map[Suspend.AUTO_JOB_ID]
-        jsm_suspend.job = suspend_job
-        jsm_suspend.result.outcome = IJobResult.OUTCOME_NONE
-        jsm_suspend.readiness_inhibitor_list = []
-        self.assertEqual(
-            self.ctrl.get_inhibitor_list(session_state, suspend_job),
-            [JobReadinessInhibitor(InhibitionCause.PENDING_DEP, j1, None)],
-        )
-
-    def test_is_job_impacting_suspend__wrong_suspend_job(self):
-        job = JobDefinition(
-            {
-                "id": "job",
-            }
-        )
-        self.assertEqual(
-            self.ctrl._is_job_impacting_suspend("wrong-suspend-job-id", job),
-            False,
-        )
-
-    def test_is_job_impacting_suspend__flag(self):
-        job = JobDefinition(
-            {
-                "id": "job",
-                "flags": "also-after-suspend",
-            }
-        )
-        self.assertEqual(
-            self.ctrl._is_job_impacting_suspend(Suspend.AUTO_JOB_ID, job), True
-        )
-        self.assertEqual(
-            self.ctrl._is_job_impacting_suspend(Suspend.MANUAL_JOB_ID, job),
-            False,
-        )
-
-    def test_is_job_impacting_suspend__siblings(self):
-        job = JobDefinition(
-            {
-                "id": "job",
-                "siblings": json.dumps(
-                    [
-                        {
-                            "id": "sibling-j1",
-                            "depends": Suspend.MANUAL_JOB_ID,
-                        }
-                    ]
-                ),
-            }
-        )
-        self.assertEqual(
-            self.ctrl._is_job_impacting_suspend(Suspend.AUTO_JOB_ID, job),
-            False,
-        )
-        self.assertEqual(
-            self.ctrl._is_job_impacting_suspend(Suspend.MANUAL_JOB_ID, job),
-            True,
-        )
 
     def test_observe_result__normal(self):
         job = mock.Mock(spec=JobDefinition)


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

In Checkbox when a job has a sibling that depends on suspend (including auto generated siblings) it (the job) is implicitly treated as a job that runs before suspend. This relied on a mechanism that pre-dates the `before:` field by a few years introduced here: #1037

In this PR we align this ad-hoc behaviour to how we enforce before ordering now, with the before field, so this effectively reverts (most) of the old change in favour of just using `before`

## Resolved issues

Fixes: CHECKBOX-1928

## Documentation

N/A

## Tests

Added tests to cover all scenarios, namely:
- If a sibling is after suspend (via depends or after) and the job is not after suspend, we set the before
- If a sibling is after suspend and the job is after suspend, we leave it as is
- Same should work for the flag

> Note: For backward compatibility this also supports the manual suspend flag, to a fault, given that if both siblings are present or if both flags are used, both before are defined, but I think that is what a user would expect either way 
