### PR TITLE
Fix DependencyDuplicateError during light_sensor_resource when multiple ALS devices are present (Bugfix)

### DIFF
--- a/providers/base/bin/light_sensor_test.py
+++ b/providers/base/bin/light_sensor_test.py
@@ -18,6 +18,7 @@ import argparse
 import os
 import time
 from typing import Dict, List, Optional
+from checkbox_support.helpers.slugify import slugify
 
 
 def get_all_sensors() -> List[Dict[str, str]]:
@@ -60,6 +61,7 @@ def get_all_sensors() -> List[Dict[str, str]]:
             sensors.append(
                 {
                     "name": sensor_name if sensor_name else device,
+                    "device": slugify(device),
                     "path": dev_path,
                 }
             )
@@ -90,6 +92,7 @@ def main():
     subparsers.add_parser("detect", help="Detect if light sensors exist")
 
     test_parser = subparsers.add_parser("test", help="Test specific sensor")
+    test_parser.add_argument("--device", required=True, help="Device index")
     test_parser.add_argument("--name", required=True, help="Device name")
     test_parser.add_argument(
         "--rounds", type=int, default=5, help="Test rounds"
@@ -116,6 +119,7 @@ def main():
         sensors = get_all_sensors()
         for s in sensors:
             print("name: {}".format(s["name"]))
+            print("device: {}".format(s["device"]))
             print()
 
     elif args.command == "detect":
@@ -126,14 +130,20 @@ def main():
     elif args.command == "test":
         sensors = get_all_sensors()
         sensors_with_matching_name = [
-            s for s in sensors if s["name"] == args.name
+            s
+            for s in sensors
+            if s["name"] == args.name and s["device"] == args.device
         ]
         if len(sensors_with_matching_name) == 0:
-            raise SystemExit("Error: Sensor '{}' not found.".format(args.name))
+            raise SystemExit(
+                "Error: Sensor '{}/{}' not found.".format(
+                    args.device, args.name
+                )
+            )
         elif len(sensors_with_matching_name) > 1:
             raise SystemExit(
-                "Warning: More than 1 sensor has the name '{}'.".format(
-                    args.name
+                "Warning: More than 1 sensor has the name '{}/{}'.".format(
+                    args.device, args.name
                 )
             )
         target_sensor = sensors_with_matching_name[0]

--- a/providers/base/tests/test_light_sensor_test.py
+++ b/providers/base/tests/test_light_sensor_test.py
@@ -65,6 +65,7 @@ class TestGetAllSensors(unittest.TestCase):
             result = lst.get_all_sensors()
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["name"], "apds9960_light")
+        self.assertEqual(result[0]["device"], "iio_device0")
         self.assertEqual(result[0]["path"], dev)
 
     @patch("light_sensor_test.os.listdir", return_value=["iio:device0"])
@@ -110,6 +111,7 @@ class TestGetAllSensors(unittest.TestCase):
         result = lst.get_all_sensors()
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["name"], "iio:device0")
+        self.assertEqual(result[0]["device"], "iio_device0")
 
     @patch("light_sensor_test.os.listdir", return_value=["iio:device0"])
     @patch("light_sensor_test.os.path.exists")
@@ -170,7 +172,9 @@ class TestGetAllSensors(unittest.TestCase):
 
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0]["name"], "tsl2591")
+        self.assertEqual(result[0]["device"], "iio_device0")
         self.assertEqual(result[1]["name"], "ltr559")
+        self.assertEqual(result[1]["device"], "iio_device1")
 
 
 class TestReadIlluminance(unittest.TestCase):
@@ -254,15 +258,25 @@ class TestMainResource(unittest.TestCase):
     @patch("light_sensor_test.get_all_sensors")
     def test_prints_sensor_names(self, mock_sensors):
         mock_sensors.return_value = [
-            {"name": "tsl2591", "path": "/sys/bus/iio/devices/iio:device0"},
-            {"name": "ltr559", "path": "/sys/bus/iio/devices/iio:device1"},
+            {
+                "name": "tsl2591",
+                "device": "iio_device0",
+                "path": "/sys/bus/iio/devices/iio:device0",
+            },
+            {
+                "name": "ltr559",
+                "device": "iio_device1",
+                "path": "/sys/bus/iio/devices/iio:device1",
+            },
         ]
         with patch("sys.argv", ["lst", "resource"]):
             with patch("sys.stdout", new_callable=StringIO) as mock_out:
                 lst.main()
         output = mock_out.getvalue()
         self.assertIn("name: tsl2591", output)
+        self.assertIn("device: iio_device0", output)
         self.assertIn("name: ltr559", output)
+        self.assertIn("device: iio_device1", output)
 
     @patch("light_sensor_test.get_all_sensors", return_value=[])
     def test_no_output_when_no_sensors(self, _sensors):
@@ -275,7 +289,9 @@ class TestMainResource(unittest.TestCase):
 class TestMainDetect(unittest.TestCase):
     @patch("light_sensor_test.get_all_sensors")
     def test_exits_cleanly_when_sensors_present(self, mock_sensors):
-        mock_sensors.return_value = [{"name": "tsl2591", "path": "/dev/null"}]
+        mock_sensors.return_value = [
+            {"name": "tsl2591", "device": "iio_device0", "path": "/dev/null"}
+        ]
         with patch("sys.argv", ["lst", "detect"]):
             lst.main()  # must not raise
 
@@ -297,11 +313,15 @@ class TestMainNoCommand(unittest.TestCase):
 
 class TestMainTest(unittest.TestCase):
 
-    SENSOR = {"name": "tsl2591", "path": "/sys/bus/iio/devices/iio:device0"}
+    SENSOR = {
+        "name": "tsl2591",
+        "device": "iio_device0",
+        "path": "/sys/bus/iio/devices/iio:device0",
+    }
 
     def _run_test_cmd(self, read_values, extra_args=None, sensors=None):
         """
-        Helper: run `lst test --name tsl2591 --rounds N ...` with mocked
+        Helper: run `lst test --device iio_device0 --name tsl2591 --rounds N ...` with mocked
         read_illuminance returning successive values from read_values.
         Returns (stdout_str, exception_or_None).
         """
@@ -310,6 +330,8 @@ class TestMainTest(unittest.TestCase):
         args = [
             "lst",
             "test",
+            "--device",
+            "iio_device0",
             "--name",
             "tsl2591",
             "--rounds",
@@ -343,7 +365,17 @@ class TestMainTest(unittest.TestCase):
 
     def test_raises_systemexit_when_sensor_not_found(self):
         with patch(
-            "sys.argv", ["lst", "test", "--name", "unknown", "--rounds", "1"]
+            "sys.argv",
+            [
+                "lst",
+                "test",
+                "--device",
+                "unknown-device",
+                "--name",
+                "unknown",
+                "--rounds",
+                "1",
+            ],
         ), patch(
             "light_sensor_test.get_all_sensors", return_value=[self.SENSOR]
         ):
@@ -354,7 +386,17 @@ class TestMainTest(unittest.TestCase):
     def test_raises_systemexit_when_duplicate_sensor_names(self):
         duplicate_sensors = [self.SENSOR, self.SENSOR]
         with patch(
-            "sys.argv", ["lst", "test", "--name", "tsl2591", "--rounds", "1"]
+            "sys.argv",
+            [
+                "lst",
+                "test",
+                "--device",
+                "iio_device0",
+                "--name",
+                "tsl2591",
+                "--rounds",
+                "1",
+            ],
         ), patch(
             "light_sensor_test.get_all_sensors", return_value=duplicate_sensors
         ):
@@ -403,6 +445,8 @@ class TestMainTest(unittest.TestCase):
             [
                 "lst",
                 "test",
+                "--device",
+                "iio_device0",
                 "--name",
                 "tsl2591",
                 "--rounds",
@@ -437,6 +481,8 @@ class TestMainTest(unittest.TestCase):
             [
                 "lst",
                 "test",
+                "--device",
+                "iio_device0",
                 "--name",
                 "tsl2591",
                 "--rounds",
@@ -470,6 +516,8 @@ class TestMainTest(unittest.TestCase):
             [
                 "lst",
                 "test",
+                "--device",
+                "iio_device0",
                 "--name",
                 "tsl2591",
                 "--rounds",

--- a/providers/base/units/power-management/jobs.pxu
+++ b/providers/base/units/power-management/jobs.pxu
@@ -636,11 +636,11 @@ template-resource: light_sensor_resource
 template-unit: job
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::power-management
-id: power-management/light_sensor_test_{name}
+id: power-management/light_sensor_test_{device}_{name}
 template-id: power-management/light_sensor_test_device
 flags: also-after-suspend
 estimated_duration: 50
 depends: com.canonical.certification::power-management/light_sensor_detect
 command:
-    light_sensor_test.py test --name {name} --rounds 5 --period 5 --delay 5
+    light_sensor_test.py test --device {device} --name {name} --rounds 5 --period 5 --delay 5
 summary: Verify if light sensor {name} can detect the light change or not.


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
There are some devices that include multiple light sensors with the same name. Therefore, we need to add one more argument, `device`, to ensure the job ID is unique.


## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->
#2638

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
Single light sensor: https://certification.canonical.com/hardware/202001-27667/submission/499535/
Multiple light sensors:  https://certification.canonical.com/hardware/202601-38307/submission/499500/
