### PR TITLE
Fix randr_test.py cannot work on suspend unsupport devices (Bugfix)

### DIFF
--- a/providers/base/bin/randr_cycle.py
+++ b/providers/base/bin/randr_cycle.py
@@ -23,6 +23,7 @@ from contextlib import suppress
 import shutil
 
 from checkbox_support.dbus.gnome_monitor import MutterDisplayMode as Mode
+from checkbox_support.manifest import get_manifest
 from checkbox_support.helpers import display_info
 from collections import namedtuple
 from fractions import Fraction
@@ -156,6 +157,15 @@ def action(filename, **kwargs):
 
 
 class MonitorTest:
+    def is_suspend_support(self) -> bool:
+        """
+        Using has_suspend_support in the manifest
+        to check whether suspend is supported
+        """
+        key = "com.canonical.certification::has_suspend_support"
+        manifest = get_manifest()
+        return key in manifest.keys() and manifest[key]
+
     def gen_screenshot_path(
         self, prefix: str, postfix: str, screenshot_dir: str
     ) -> str:
@@ -176,7 +186,7 @@ class MonitorTest:
 
         if postfix and postfix != "":
             path = path + "_" + postfix
-        else:
+        elif self.is_suspend_support():
             # check the status is before or after suspend
             with open("/sys/power/suspend_stats/success", "r") as s:
                 suspend_count = s.readline().strip("\n")

--- a/providers/base/bin/randr_cycle.py
+++ b/providers/base/bin/randr_cycle.py
@@ -200,7 +200,7 @@ class MonitorTest:
         """
         Tar up the screenshots for uploading.
 
-        :param path: the dictionary for screenshot
+        :param  path: the dictionary for screenshot
         """
         try:
             with tarfile.open(path + ".tgz", "w:gz") as screen_tar:

--- a/providers/base/bin/randr_cycle.py
+++ b/providers/base/bin/randr_cycle.py
@@ -188,10 +188,13 @@ class MonitorTest:
             path = path + "_" + postfix
         elif self.is_suspend_support():
             # check the status is before or after suspend
-            with open("/sys/power/suspend_stats/success", "r") as s:
-                suspend_count = s.readline().strip("\n")
-                if suspend_count != "0":
-                    path = "{}_after_suspend".format(path)
+            try:
+                with open("/sys/power/suspend_stats/success", "r") as s:
+                    suspend_count = s.readline().strip("\n")
+                    if suspend_count != "0":
+                        path = "{}_after_suspend".format(path)
+            except (IOError, OSError):
+                pass
         os.makedirs(path, exist_ok=True)
 
         return path

--- a/providers/base/tests/test_randr_cycle.py
+++ b/providers/base/tests/test_randr_cycle.py
@@ -335,6 +335,7 @@ class GenScreenshotPath(unittest.TestCase):
             )
         mock_mkdir.assert_called_with("test/xrandr_screens", exist_ok=True)
 
+
 class TestScreenshotTarring(unittest.TestCase):
     @patch("os.listdir")
     @patch("tarfile.open")

--- a/providers/base/tests/test_randr_cycle.py
+++ b/providers/base/tests/test_randr_cycle.py
@@ -206,15 +206,58 @@ class TestActionFunction(unittest.TestCase):
         mock_sleep.assert_called_once_with(5)
 
 
+class TestIsSuspendSupport(unittest.TestCase):
+    @patch("randr_cycle.get_manifest")
+    def test_suspend_supported_when_manifest_has_key_true(
+        self, mock_get_manifest
+    ):
+        mock_get_manifest.return_value = {
+            "com.canonical.certification::has_suspend_support": True
+        }
+        mt = MonitorTest()
+        self.assertTrue(mt.is_suspend_support())
+
+    @patch("randr_cycle.get_manifest")
+    def test_suspend_not_supported_when_manifest_has_key_false(
+        self, mock_get_manifest
+    ):
+        mock_get_manifest.return_value = {
+            "com.canonical.certification::has_suspend_support": False
+        }
+        mt = MonitorTest()
+        self.assertFalse(mt.is_suspend_support())
+
+    @patch("randr_cycle.get_manifest")
+    def test_suspend_not_supported_when_manifest_missing_key(
+        self, mock_get_manifest
+    ):
+        mock_get_manifest.return_value = {}
+        mt = MonitorTest()
+        self.assertFalse(mt.is_suspend_support())
+
+    @patch("randr_cycle.get_manifest")
+    def test_suspend_not_supported_when_manifest_has_other_keys(
+        self, mock_get_manifest
+    ):
+        mock_get_manifest.return_value = {"other_key": True}
+        mt = MonitorTest()
+        self.assertFalse(mt.is_suspend_support())
+
+
 class GenScreenshotPath(unittest.TestCase):
     """
     This function should generate dictionary such as
     [screenshot_dir]_[keyword]
     """
 
+    @patch("randr_cycle.get_manifest")
     @patch("os.makedirs")
-    def test_before_suspend_without_keyword(self, mock_mkdir):
-
+    def test_before_suspend_without_keyword(
+        self, mock_mkdir, mock_get_manifest
+    ):
+        mock_get_manifest.return_value = {
+            "com.canonical.certification::has_suspend_support": True
+        }
         mt = MonitorTest()
         with patch("builtins.open", mock_open(read_data="0")) as mock_file:
             self.assertEqual(
@@ -223,9 +266,14 @@ class GenScreenshotPath(unittest.TestCase):
         mock_file.assert_called_with("/sys/power/suspend_stats/success", "r")
         mock_mkdir.assert_called_with("test/xrandr_screens", exist_ok=True)
 
+    @patch("randr_cycle.get_manifest")
     @patch("os.makedirs")
-    def test_after_suspend_without_keyword(self, mock_mkdir):
-
+    def test_after_suspend_without_keyword(
+        self, mock_mkdir, mock_get_manifest
+    ):
+        mock_get_manifest.return_value = {
+            "com.canonical.certification::has_suspend_support": True
+        }
         mt = MonitorTest()
         with patch("builtins.open", mock_open(read_data="1")) as mock_file:
             self.assertEqual(
@@ -237,9 +285,10 @@ class GenScreenshotPath(unittest.TestCase):
             "test/xrandr_screens_after_suspend", exist_ok=True
         )
 
+    @patch("randr_cycle.get_manifest")
     @patch("os.makedirs")
-    def test_with_keyword(self, mock_mkdir):
-
+    def test_with_keyword(self, mock_mkdir, mock_get_manifest):
+        mock_get_manifest.return_value = {}
         mt = MonitorTest()
         self.assertEqual(
             mt.gen_screenshot_path("", "key", "test"),
@@ -254,6 +303,23 @@ class GenScreenshotPath(unittest.TestCase):
         mock_mkdir.assert_called_with(
             "test/1_xrandr_screens_key", exist_ok=True
         )
+
+    @patch("randr_cycle.get_manifest")
+    @patch("os.makedirs")
+    def test_without_suspend_support_and_no_postfix(
+        self, mock_mkdir, mock_get_manifest
+    ):
+        """
+        When suspend is not supported and no postfix is provided,
+        suspend stats should not be checked
+        """
+        mock_get_manifest.return_value = {}
+        mt = MonitorTest()
+        # No open() call should be made since suspend is not supported
+        self.assertEqual(
+            mt.gen_screenshot_path("", "", "test"), "test/xrandr_screens"
+        )
+        mock_mkdir.assert_called_with("test/xrandr_screens", exist_ok=True)
 
 
 class TestScreenshotTarring(unittest.TestCase):

--- a/providers/base/tests/test_randr_cycle.py
+++ b/providers/base/tests/test_randr_cycle.py
@@ -309,18 +309,31 @@ class GenScreenshotPath(unittest.TestCase):
     def test_without_suspend_support_and_no_postfix(
         self, mock_mkdir, mock_get_manifest
     ):
-        """
-        When suspend is not supported and no postfix is provided,
-        suspend stats should not be checked
-        """
         mock_get_manifest.return_value = {}
         mt = MonitorTest()
-        # No open() call should be made since suspend is not supported
-        self.assertEqual(
-            mt.gen_screenshot_path("", "", "test"), "test/xrandr_screens"
-        )
+        with patch("builtins.open", mock_open()) as mock_file:
+            self.assertEqual(
+                mt.gen_screenshot_path("", "", "test"),
+                "test/xrandr_screens",
+            )
+        mock_file.assert_not_called()
         mock_mkdir.assert_called_with("test/xrandr_screens", exist_ok=True)
 
+    @patch("randr_cycle.get_manifest")
+    @patch("os.makedirs")
+    def test_suspend_supported_but_suspend_stats_missing(
+        self, mock_mkdir, mock_get_manifest
+    ):
+        mock_get_manifest.return_value = {
+            "com.canonical.certification::has_suspend_support": True
+        }
+        mt = MonitorTest()
+        with patch("builtins.open", side_effect=FileNotFoundError):
+            self.assertEqual(
+                mt.gen_screenshot_path("", "", "test"),
+                "test/xrandr_screens",
+            )
+        mock_mkdir.assert_called_with("test/xrandr_screens", exist_ok=True)
 
 class TestScreenshotTarring(unittest.TestCase):
     @patch("os.listdir")


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
The `/sys/power/suspend_stats/success` might not exist in some devices that don't support suspend feature. Therefore, we should ignore the suspend status check in this condition.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->
#2619

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
Suspend supported: https://certification.canonical.com/hardware/202001-27667/submission/499431/
Suspend not supported: https://certification.canonical.com/hardware/202605-38787/submission/499595/
