### PR TITLE
Added more logging for usb tests (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/run_watcher.py
+++ b/checkbox-support/checkbox_support/scripts/run_watcher.py
@@ -84,7 +84,7 @@ class StorageInterface(ABC):
         :param line_str: str of the scanned log lines.
         """
 
-        print(line_str)
+        print(line_str, flush=True)
 
     @abstractmethod
     def _validate_insertion(self):
@@ -474,14 +474,44 @@ def main():
         watcher = USBStorage(args.storage_type)
 
     if args.testcase == "insertion":
-        mounted_partition = watcher.run_insertion()
-        watcher.run_removal(mounted_partition)
+        try:
+            mounted_partition = watcher.run_insertion()
+        except TimeoutError:
+            raise SystemExit(
+                "The {} insertion could not be detected in time.".format(
+                    args.storage_type
+                )
+            )
+
+        try:
+            watcher.run_removal(mounted_partition)
+        except TimeoutError:
+            raise SystemExit(
+                "The {} removal could not be detected in time.".format(
+                    args.storage_type
+                )
+            )
+
     elif args.testcase == "storage":
-        mounted_partition = watcher.run_insertion()
+        try:
+            mounted_partition = watcher.run_insertion()
+        except TimeoutError:
+            raise SystemExit(
+                "The {} insertion could not be detected in time.".format(
+                    args.storage_type
+                )
+            )
         watcher.run_storage(mounted_partition)
         print("Press Enter to start removal", flush=True)
         input()
-        watcher.run_removal(mounted_partition)
+        try:
+            watcher.run_removal(mounted_partition)
+        except TimeoutError:
+            raise SystemExit(
+                "The {} removal could not be detected in time.".format(
+                    args.storage_type
+                )
+            )
     else:
         raise SystemExit("Invalid test case")
 

--- a/checkbox-support/checkbox_support/tests/test_run_watcher.py
+++ b/checkbox-support/checkbox_support/tests/test_run_watcher.py
@@ -229,7 +229,7 @@ class TestRunWatcher(unittest.TestCase):
     def test_parse_journal_line(self, mock_print):
         mock_storage = MagicMock()
         StorageWatcher._parse_journal_line(mock_storage, "hello")
-        mock_print.assert_called_once_with("hello")
+        mock_print.assert_called_once_with("hello", flush=True)
 
     @patch("checkbox_support.scripts.run_watcher.super")
     def test_usb_storage_parse_journal_line(self, mock_super):

--- a/checkbox-support/checkbox_support/tests/test_run_watcher.py
+++ b/checkbox-support/checkbox_support/tests/test_run_watcher.py
@@ -632,3 +632,63 @@ class TestRunWatcher(unittest.TestCase):
         watcher = mock_thunderbolt.return_value
         # check that the watcher is an ThunderboltStorage object
         self.assertIsInstance(watcher, ThunderboltStorage)
+
+    @patch("checkbox_support.scripts.run_watcher.USBStorage", spec=USBStorage)
+    @patch("checkbox_support.scripts.run_watcher.parse_args")
+    def test_main_insertion_timeout(self, mock_parse_args, mock_usb):
+        mock_parse_args.return_value = argparse.Namespace(
+            testcase="insertion", storage_type="usb2"
+        )
+        mock_usb.return_value.run_insertion.side_effect = TimeoutError
+        with self.assertRaises(SystemExit) as cm:
+            main()
+        self.assertEqual(
+            cm.exception.args[0],
+            "The usb2 insertion could not be detected in time.",
+        )
+        self.assertEqual(mock_usb.return_value.run_removal.call_count, 0)
+
+    @patch("checkbox_support.scripts.run_watcher.USBStorage", spec=USBStorage)
+    @patch("checkbox_support.scripts.run_watcher.parse_args")
+    def test_main_removal_timeout(self, mock_parse_args, mock_usb):
+        mock_parse_args.return_value = argparse.Namespace(
+            testcase="insertion", storage_type="usb2"
+        )
+        mock_usb.return_value.run_removal.side_effect = TimeoutError
+        with self.assertRaises(SystemExit) as cm:
+            main()
+        self.assertEqual(
+            cm.exception.args[0],
+            "The usb2 removal could not be detected in time.",
+        )
+
+    @patch("checkbox_support.scripts.run_watcher.input", MagicMock())
+    @patch("checkbox_support.scripts.run_watcher.USBStorage", spec=USBStorage)
+    @patch("checkbox_support.scripts.run_watcher.parse_args")
+    def test_main_storage_insertion_timeout(self, mock_parse_args, mock_usb):
+        mock_parse_args.return_value = argparse.Namespace(
+            testcase="storage", storage_type="usb3"
+        )
+        mock_usb.return_value.run_insertion.side_effect = TimeoutError
+        with self.assertRaises(SystemExit) as cm:
+            main()
+        self.assertEqual(
+            cm.exception.args[0],
+            "The usb3 insertion could not be detected in time.",
+        )
+        self.assertEqual(mock_usb.return_value.run_storage.call_count, 0)
+
+    @patch("checkbox_support.scripts.run_watcher.input", MagicMock())
+    @patch("checkbox_support.scripts.run_watcher.USBStorage", spec=USBStorage)
+    @patch("checkbox_support.scripts.run_watcher.parse_args")
+    def test_main_storage_removal_timeout(self, mock_parse_args, mock_usb):
+        mock_parse_args.return_value = argparse.Namespace(
+            testcase="storage", storage_type="usb3"
+        )
+        mock_usb.return_value.run_removal.side_effect = TimeoutError
+        with self.assertRaises(SystemExit) as cm:
+            main()
+        self.assertEqual(
+            cm.exception.args[0],
+            "The usb3 removal could not be detected in time.",
+        )


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

This PR adds the journalctl logs for the usb tests when the test fails.

Also, the test does not crash directly with the timeout. The error is catched and a more friendly message is shown:
 "The usb3 insertion could not be detected in time."

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
Tested locally. The actual functionality has not been changed.

```
--------- Testing insertion ---------


INSERT NOW


Timeout: 30 seconds
pam_unix(sudo:session): session opened for user root(uid=0) by fernando(uid=1000)
pam_unix(sudo:session): session closed for user root
...
**USB NOT REMOVED**
...
The usb3 insertion could not be detected in time.
```

```
--------- Testing insertion ---------


INSERT NOW


Timeout: 30 seconds
...
usb 2-2: new SuperSpeed USB device number 20 using xhci_hcd
...
INFO:super_speed_usb was inserted. Controller: xhci_hcd, Number: 20
INFO:usable partition: sda1
INFO:USB3 insertion test passed.

------- Insertion test passed -------
```
