### PR TITLE
Update touchscreen manual test ordering with group (BugFix)

### DIFF
--- a/providers/base/units/touchscreen/jobs.pxu
+++ b/providers/base/units/touchscreen/jobs.pxu
@@ -49,15 +49,14 @@ _summary: Test for touchscreen tap recognition functionality.
 unit: template
 template-resource: device
 template-filter: device.category == 'TOUCHSCREEN'
-template-engine: jinja2
 template-unit: job
 plugin: manual
 category_id: com.canonical.plainbox::touchscreen
-id: touchscreen/drag-n-drop-{{ product_slug }}
+id: touchscreen/drag-n-drop-{product_slug}
 template-id: touchscreen/drag-n-drop-product_slug
 group: touchscreen_basic
-depends: touchscreen/evdev/single-touch-tap-{{ product_slug }}
-after: touchscreen/evdev/4-touch-tap-{{ product_slug }}
+depends: touchscreen/evdev/single-touch-tap-{product_slug}
+after: touchscreen/evdev/4-touch-tap-{product_slug}
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_touchscreen == 'True'
 estimated_duration: 120.0
@@ -78,15 +77,14 @@ _summary: Assess touchscreen functionality for drag & drop tasks.
 unit: template
 template-resource: device
 template-filter: device.category == 'TOUCHSCREEN'
-template-engine: jinja2
 template-unit: job
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::touchscreen
-id: touchscreen/multitouch-zoom-{{ product_slug }}
+id: touchscreen/multitouch-zoom-{product_slug}
 template-id: touchscreen/multitouch-zoom-product_slug
 group: touchscreen_basic
-depends: touchscreen/evdev/2-touch-tap-{{ product_slug }}
-after: touchscreen/drag-n-drop-{{ product_slug }}
+depends: touchscreen/evdev/2-touch-tap-{product_slug}
+after: touchscreen/drag-n-drop-{product_slug}
 _summary: Check touchscreen pinch gesture for zoom
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_touchscreen_multitouch == 'True'
@@ -105,15 +103,14 @@ flags: also-after-suspend
 unit: template
 template-resource: device
 template-filter: device.category == 'TOUCHSCREEN'
-template-engine: jinja2
 template-unit: job
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::touchscreen
-id: touchscreen/multitouch-rotate-{{ product_slug }}
+id: touchscreen/multitouch-rotate-{product_slug}
 template-id: touchscreen/multitouch-rotate-product_slug
 group: touchscreen_basic
-depends: touchscreen/evdev/2-touch-tap-{{ product_slug }}
-after: touchscreen/drag-n-drop-{{ product_slug }}
+depends: touchscreen/evdev/2-touch-tap-{product_slug}
+after: touchscreen/drag-n-drop-{product_slug}
 _summary: Check touchscreen pinch gesture for rotate
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_touchscreen_multitouch == 'True'
@@ -235,11 +232,10 @@ _summary: Validate functionality of 4-touch tap on touchscreen devices.
 unit: template
 template-resource: device
 template-filter: device.category == 'TOUCHSCREEN'
-template-engine: jinja2
 template-unit: job
 plugin: user-interact
 category_id: com.canonical.plainbox::touchscreen
-id: touchscreen/evdev/single-touch-tap-{{ product_slug }}
+id: touchscreen/evdev/single-touch-tap-{product_slug}
 template-id: touchscreen/evdev/single-touch-tap-product_slug
 group: touchscreen_basic
 flags: also-after-suspend
@@ -254,17 +250,16 @@ _steps:
 _verification:
  If the tap is not detected the test will time out after 10 seconds.
 user: root
-command: timeout 10 evdev_touch_test.py '{{ product }}' -x 1
+command: timeout 10 evdev_touch_test.py '{product}' -x 1
 _summary: Validate the detection of a single-touch tap on touchscreen devices.
 
 unit: template
 template-resource: device
 template-filter: device.category == 'TOUCHSCREEN'
-template-engine: jinja2
 template-unit: job
 plugin: user-interact
 category_id: com.canonical.plainbox::touchscreen
-id: touchscreen/evdev/2-touch-tap-{{ product_slug }}
+id: touchscreen/evdev/2-touch-tap-{product_slug}
 template-id: touchscreen/evdev/2-touch-tap-product_slug
 group: touchscreen_basic
 imports: from com.canonical.plainbox import manifest
@@ -279,19 +274,18 @@ _steps:
 _verification:
     If the tap is not detected the test will time out after 10 seconds.
 user: root
-command: timeout 10 evdev_touch_test.py '{{ product }}' -x 2
+command: timeout 10 evdev_touch_test.py '{product}' -x 2
 flags: also-after-suspend
-after: touchscreen/evdev/single-touch-tap-{{ product_slug }}
+after: touchscreen/evdev/single-touch-tap-{product_slug}
 _summary: Validate proper detection of a 2-touch tap on touchscreen devices.
 
 unit: template
 template-resource: device
 template-filter: device.category == 'TOUCHSCREEN'
-template-engine: jinja2
 template-unit: job
 plugin: user-interact
 category_id: com.canonical.plainbox::touchscreen
-id: touchscreen/evdev/3-touch-tap-{{ product_slug }}
+id: touchscreen/evdev/3-touch-tap-{product_slug}
 template-id: touchscreen/evdev/3-touch-tap-product_slug
 group: touchscreen_basic
 imports: from com.canonical.plainbox import manifest
@@ -306,19 +300,18 @@ _steps:
 _verification:
  If the tap is not detected the test will time out after 10 seconds.
 user: root
-command: timeout 10 evdev_touch_test.py '{{ product }}' -x 3
+command: timeout 10 evdev_touch_test.py '{product}' -x 3
 flags: also-after-suspend
-after: touchscreen/evdev/2-touch-tap-{{ product_slug }}
+after: touchscreen/evdev/2-touch-tap-{product_slug}
 _summary: Validate proper detection of a 3-touch tap on touchscreen devices.
 
 unit: template
 template-resource: device
 template-filter: device.category == 'TOUCHSCREEN'
-template-engine: jinja2
 template-unit: job
 plugin: user-interact
 category_id: com.canonical.plainbox::touchscreen
-id: touchscreen/evdev/4-touch-tap-{{ product_slug }}
+id: touchscreen/evdev/4-touch-tap-{product_slug}
 template-id: touchscreen/evdev/4-touch-tap-product_slug
 group: touchscreen_basic
 imports: from com.canonical.plainbox import manifest
@@ -332,7 +325,7 @@ _steps:
 _verification:
    If the tap is not detected the test will time out after 10 seconds.
 user: root
-command: timeout 10 evdev_touch_test.py '{{ product }}' -x 4
+command: timeout 10 evdev_touch_test.py '{product}' -x 4
 flags: also-after-suspend
-after: touchscreen/evdev/3-touch-tap-{{ product_slug }}
+after: touchscreen/evdev/3-touch-tap-{product_slug}
 _summary: Validate the detection of a 4-touch tap on touchscreen devices.

--- a/providers/base/units/touchscreen/jobs.pxu
+++ b/providers/base/units/touchscreen/jobs.pxu
@@ -46,9 +46,18 @@ _verification:
     Does tap recognition work?
 _summary: Test for touchscreen tap recognition functionality.
 
+unit: template
+template-resource: device
+template-filter: device.category == 'TOUCHSCREEN'
+template-engine: jinja2
+template-unit: job
 plugin: manual
 category_id: com.canonical.plainbox::touchscreen
-id: touchscreen/drag-n-drop
+id: touchscreen/drag-n-drop-{{ product_slug }}
+template-id: touchscreen/drag-n-drop-product_slug
+group: touchscreen_basic
+depends: touchscreen/evdev/single-touch-tap-{{ product_slug }}
+after: touchscreen/evdev/4-touch-tap-{{ product_slug }}
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_touchscreen == 'True'
 estimated_duration: 120.0
@@ -66,9 +75,18 @@ _verification:
 flags: also-after-suspend
 _summary: Assess touchscreen functionality for drag & drop tasks.
 
+unit: template
+template-resource: device
+template-filter: device.category == 'TOUCHSCREEN'
+template-engine: jinja2
+template-unit: job
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::touchscreen
-id: touchscreen/multitouch-zoom
+id: touchscreen/multitouch-zoom-{{ product_slug }}
+template-id: touchscreen/multitouch-zoom-product_slug
+group: touchscreen_basic
+depends: touchscreen/evdev/2-touch-tap-{{ product_slug }}
+after: touchscreen/drag-n-drop-{{ product_slug }}
 _summary: Check touchscreen pinch gesture for zoom
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_touchscreen_multitouch == 'True'
@@ -84,9 +102,18 @@ _verification:
     Did the blue square change size following the gesture?
 flags: also-after-suspend
 
+unit: template
+template-resource: device
+template-filter: device.category == 'TOUCHSCREEN'
+template-engine: jinja2
+template-unit: job
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::touchscreen
-id: touchscreen/multitouch-rotate
+id: touchscreen/multitouch-rotate-{{ product_slug }}
+template-id: touchscreen/multitouch-rotate-product_slug
+group: touchscreen_basic
+depends: touchscreen/evdev/2-touch-tap-{{ product_slug }}
+after: touchscreen/drag-n-drop-{{ product_slug }}
 _summary: Check touchscreen pinch gesture for rotate
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_touchscreen_multitouch == 'True'
@@ -214,6 +241,7 @@ plugin: user-interact
 category_id: com.canonical.plainbox::touchscreen
 id: touchscreen/evdev/single-touch-tap-{{ product_slug }}
 template-id: touchscreen/evdev/single-touch-tap-product_slug
+group: touchscreen_basic
 flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_touchscreen == 'True'
@@ -238,6 +266,7 @@ plugin: user-interact
 category_id: com.canonical.plainbox::touchscreen
 id: touchscreen/evdev/2-touch-tap-{{ product_slug }}
 template-id: touchscreen/evdev/2-touch-tap-product_slug
+group: touchscreen_basic
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_touchscreen_multitouch == 'True'
 estimated_duration: 10.0
@@ -264,6 +293,7 @@ plugin: user-interact
 category_id: com.canonical.plainbox::touchscreen
 id: touchscreen/evdev/3-touch-tap-{{ product_slug }}
 template-id: touchscreen/evdev/3-touch-tap-product_slug
+group: touchscreen_basic
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_touchscreen_multitouch == 'True'
 estimated_duration: 10.0
@@ -290,6 +320,7 @@ plugin: user-interact
 category_id: com.canonical.plainbox::touchscreen
 id: touchscreen/evdev/4-touch-tap-{{ product_slug }}
 template-id: touchscreen/evdev/4-touch-tap-product_slug
+group: touchscreen_basic
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_touchscreen_multitouch == 'True'
 estimated_duration: 10.0

--- a/providers/base/units/touchscreen/test-plan.pxu
+++ b/providers/base/units/touchscreen/test-plan.pxu
@@ -14,13 +14,13 @@ _name: Touchscreen tests (Manual)
 _description:
  Touchscreen tests (Manual)
 include:
- touchscreen/drag-n-drop                    certification-status=blocker
- touchscreen/multitouch-zoom                certification-status=blocker
- touchscreen/multitouch-rotate
- touchscreen/evdev/single-touch-tap-.*      certification-status=blocker
- touchscreen/evdev/2-touch-tap-.*           certification-status=blocker
- touchscreen/evdev/3-touch-tap-.*           certification-status=blocker
- touchscreen/evdev/4-touch-tap-.*           certification-status=blocker
+ touchscreen/evdev/single-touch-tap-product_slug      certification-status=blocker
+ touchscreen/evdev/2-touch-tap-product_slug           certification-status=blocker
+ touchscreen/evdev/3-touch-tap-product_slug           certification-status=blocker
+ touchscreen/evdev/4-touch-tap-product_slug           certification-status=blocker
+ touchscreen/drag-n-drop-product_slug                 certification-status=blocker
+ touchscreen/multitouch-zoom-product_slug             certification-status=blocker
+ touchscreen/multitouch-rotate-product_slug
 bootstrap_include:
  device
 
@@ -47,13 +47,13 @@ _name: Touchscreen tests (Manual after suspend)
 _description:
  Touchscreen tests (Manual after suspend)
 include:
- after-suspend-touchscreen/drag-n-drop                certification-status=blocker
- after-suspend-touchscreen/multitouch-zoom            certification-status=blocker
- after-suspend-touchscreen/multitouch-rotate
- after-suspend-touchscreen/evdev/single-touch-tap-.*  certification-status=blocker
- after-suspend-touchscreen/evdev/2-touch-tap-.*       certification-status=blocker
- after-suspend-touchscreen/evdev/3-touch-tap-.*       certification-status=blocker
- after-suspend-touchscreen/evdev/4-touch-tap-.*       certification-status=blocker
+ after-suspend-touchscreen/evdev/single-touch-tap-product_slug     certification-status=blocker
+ after-suspend-touchscreen/evdev/2-touch-tap-product_slug          certification-status=blocker
+ after-suspend-touchscreen/evdev/3-touch-tap-product_slug          certification-status=blocker
+ after-suspend-touchscreen/evdev/4-touch-tap-product_slug          certification-status=blocker
+ after-suspend-touchscreen/drag-n-drop-product_slug                certification-status=blocker
+ after-suspend-touchscreen/multitouch-zoom-product_slug            certification-status=blocker
+ after-suspend-touchscreen/multitouch-rotate-product_slug
 bootstrap_include:
  device
 
@@ -118,8 +118,8 @@ nested_part:
     after-suspend-touchscreen-cert-manual
     info-attachment-cert-full
 certification_status_overrides:
-    apply blocker to com.canonical.certification::touchscreen/multitouch-rotate
-    apply blocker to com.canonical.certification::after-suspend-touchscreen/multitouch-rotate
+    apply blocker to com.canonical.certification::touchscreen/multitouch-rotate-product_slug
+    apply blocker to com.canonical.certification::after-suspend-touchscreen/multitouch-rotate-product_slug
 
 id: touchscreen-base-26-04-automated
 unit: test plan

--- a/providers/base/units/touchscreen/test-plan.pxu
+++ b/providers/base/units/touchscreen/test-plan.pxu
@@ -118,8 +118,8 @@ nested_part:
     after-suspend-touchscreen-cert-manual
     info-attachment-cert-full
 certification_status_overrides:
-    apply blocker to com.canonical.certification::touchscreen/multitouch-rotate-product_slug
-    apply blocker to com.canonical.certification::after-suspend-touchscreen/multitouch-rotate-product_slug
+    apply blocker to com.canonical.certification::touchscreen/multitouch-rotate-.*
+    apply blocker to com.canonical.certification::after-suspend-touchscreen/multitouch-rotate-.*
 
 id: touchscreen-base-26-04-automated
 unit: test plan


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
Updates the touchscreen manual test plan so generated touchscreen jobs run in the expected order. Also clarifies the dependency chain for gesture tests so rotate and zoom follow the required 2-finger tap flow, including the after-suspend touchscreen sequence.

The touchscreen manual test ordering will be

1. single-touch-tap
2. 2-touch-tap
3. 3-touch-tap
4. 4-touch-tap
5. drag-n-drop
6. multitouch-rotate
7. multitouch-zoom

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
https://warthogs.atlassian.net/browse/OEMQA-6802?atlOrigin=eyJpIjoiMjBkYzEyNGEzMWVlNGVkZmFmYzRiZDliOGNmZDMwOWUiLCJwIjoiaiJ9
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

## Documentation
https://documentation.ubuntu.com/checkbox/stable/how-to/using-groups/
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
https://certification.canonical.com/hardware/202601-38305/submission/500652/
https://certification.canonical.com/hardware/202601-38305/submission/500651/
remove jinja2 
https://certification.canonical.com/hardware/202601-38305/submission/500783/

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
$checkbox-cli list-bootstrapped com.canonical.certification::client-cert-desktop-26-04-manual
```
...
com.canonical.certification::touchscreen/evdev/single-touch-tap-GTCH7503_00_2A94_A84F
com.canonical.certification::touchscreen/evdev/2-touch-tap-GTCH7503_00_2A94_A84F
com.canonical.certification::touchscreen/evdev/3-touch-tap-GTCH7503_00_2A94_A84F
com.canonical.certification::touchscreen/evdev/4-touch-tap-GTCH7503_00_2A94_A84F
com.canonical.certification::touchscreen/drag-n-drop-GTCH7503_00_2A94_A84F
com.canonical.certification::touchscreen/multitouch-rotate-GTCH7503_00_2A94_A84F
com.canonical.certification::touchscreen/multitouch-zoom-GTCH7503_00_2A94_A84F
...
com.canonical.certification::after-suspend-touchscreen/evdev/single-touch-tap-GTCH7503_00_2A94_A84F
com.canonical.certification::after-suspend-touchscreen/evdev/2-touch-tap-GTCH7503_00_2A94_A84F
com.canonical.certification::after-suspend-touchscreen/evdev/3-touch-tap-GTCH7503_00_2A94_A84F
com.canonical.certification::after-suspend-touchscreen/evdev/4-touch-tap-GTCH7503_00_2A94_A84F
com.canonical.certification::after-suspend-touchscreen/drag-n-drop-GTCH7503_00_2A94_A84F
com.canonical.certification::after-suspend-touchscreen/multitouch-zoom-GTCH7503_00_2A94_A84F
com.canonical.certification::after-suspend-touchscreen/multitouch-rotate-GTCH7503_00_2A94_A84F

...