### PR TITLE
Force use lxd for all native builds (infra)

### DIFF
--- a/.github/workflows/checkbox-daily-native-builds.yaml
+++ b/.github/workflows/checkbox-daily-native-builds.yaml
@@ -34,9 +34,9 @@ jobs:
           - arch: arm64
             tag: ARM64
           - release: 18
-            snapcraft_version: 7.x/stable
+            snapcraft_version: 6.x/stable
           - release: 20
-            snapcraft_version: 8.x/stable
+            snapcraft_version: 7.x/stable
           - release: 22
             snapcraft_version: 8.x/stable
           - release: 24
@@ -45,7 +45,7 @@ jobs:
             snapcraft_version: 9.x/stable
     runs-on:
       group: "Canonical self-hosted runners"
-      labels: ["self-hosted", "linux", "large", "${{ matrix.tag }}"]
+      labels: ["self-hosted", "linux", "large", "${{ matrix.tag }}", "noble"]
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     name: Runtime ${{ matrix.release }}  (${{matrix.arch}})
     steps:
@@ -60,11 +60,16 @@ jobs:
           sudo apt update && sudo apt install -qq -y python3-setuptools-scm
           ./prepare.sh series${{ matrix.release }}
 
-      - name: Refresh LXD to latest/beta
+      - name: Refresh snapd to latest/stable
+        run: |
+          # Note: snapd bug, snap install always returns 0
+          sudo snap refresh snapd --channel=latest/stable || sudo snap install snapd --channel=latest/stable
+
+      - name: Refresh LXD to latest/stable
         if: matrix.release >= 26 # temporary workaround snapcraft 9 doesn't work on 5.x
         run: |
           # Note: snapd bug, snap install always returns 0
-          sudo snap refresh lxd --channel=latest/beta || sudo snap install lxd --channel=latest/beta
+          sudo snap refresh lxd --channel=latest/stable || sudo snap install lxd --channel=latest/stable
 
       - id: snap_build
         uses: Wandalen/wretry.action@df981d2bb22b26b5b23754bb516d0de8c1bfbbec
@@ -118,9 +123,9 @@ jobs:
           - arch: arm64
             tag: ARM64
           - release: 18
-            snapcraft_version: 7.x/stable
+            snapcraft_version: 6.x/stable
           - release: 20
-            snapcraft_version: 8.x/stable
+            snapcraft_version: 7.x/stable
           - release: 22
             snapcraft_version: 8.x/stable
           - release: 24
@@ -129,7 +134,7 @@ jobs:
             snapcraft_version: 9.x/stable
     runs-on:
       group: "Canonical self-hosted runners"
-      labels: ["self-hosted", "linux", "large", "${{ matrix.tag }}"]
+      labels: ["self-hosted", "linux", "large", "${{ matrix.tag }}", "noble"]
     timeout-minutes: 1200 #20h, this will timeout sooner due to inner timeouts
     name: Frontend ${{ matrix.type }}${{ matrix.release }} (${{matrix.arch}})
     steps:
@@ -144,11 +149,16 @@ jobs:
           sudo apt update && sudo apt install -qq -y python3-setuptools-scm
           ./prepare_${{ matrix.type }}.sh series_${{ matrix.type }}${{ matrix.release }}
 
-      - name: Refresh LXD to latest/beta
+      - name: Refresh snapd to latest/stable
+        run: |
+          # Note: snapd bug, snap install always returns 0
+          sudo snap refresh snapd --channel=latest/stable || sudo snap install snapd --channel=latest/stable
+
+      - name: Refresh LXD to latest/stable
         if: matrix.release >= 26 # temporary workaround snapcraft 9 doesn't work on 5.x
         run: |
           # Note: snapd bug, snap install always returns 0
-          sudo snap refresh lxd --channel=latest/beta || sudo snap install lxd --channel=latest/beta
+          sudo snap refresh lxd --channel=latest/stable || sudo snap install lxd --channel=latest/stable
 
       - id: snap_build
         uses: Wandalen/wretry.action@df981d2bb22b26b5b23754bb516d0de8c1bfbbec

--- a/.github/workflows/checkbox-daily-native-builds.yaml
+++ b/.github/workflows/checkbox-daily-native-builds.yaml
@@ -34,7 +34,7 @@ jobs:
           - arch: arm64
             tag: ARM64
           - release: 18
-            snapcraft_version: 6.x/stable
+            snapcraft_version: 7.x/stable
           - release: 20
             snapcraft_version: 7.x/stable
           - release: 22

--- a/.github/workflows/checkbox-daily-native-builds.yaml
+++ b/.github/workflows/checkbox-daily-native-builds.yaml
@@ -77,6 +77,7 @@ jobs:
           with: |
             path: checkbox-core-snap/series${{ matrix.release }}
             snapcraft-channel: ${{ matrix.snapcraft_version }}
+            snapcraft-args: --use-lxd
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         name: Upload logs on failure
@@ -160,6 +161,7 @@ jobs:
           with: |
             path: checkbox-snap/series_${{ matrix.type }}${{ matrix.release }}
             snapcraft-channel: ${{ matrix.snapcraft_version }}
+            snapcraft-args: --use-lxd
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         name: Upload logs on failure


### PR DESCRIPTION

## Description

core20 builds are currently failing because snapcraft is trying to use multipass. This forces all builds to just use lxd because that is what we setup to build the snaps

## Resolved issues

Fixes: CER-4235

## Documentation

N/A

## Tests

N/A
