### PR TITLE
Add usb_wakeup_hid to after-suspend manual plan (BugFix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/power-management/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/power-management/test-plan.pxu
@@ -6,10 +6,11 @@ include:
     ce-oem-power-management/cold-reboot-by-pdu
     ce-oem-power-management/post-cold-reboot-by-pdu
 
-id: ce-oem-power-manual
+id: after-suspend-ce-oem-power-manual
 unit: test plan
-_name: Manual power tests
+_name: After suspend manual power tests
 _description:
-    Manual and semi-automatic power-management tests for devices.
+    Manual and semi-automatic power-management tests for devices that must
+    run after suspend.
 include:
     ce-oem-power-management/usb_wakeup_hid

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/power-management/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/power-management/test-plan.pxu
@@ -6,11 +6,10 @@ include:
     ce-oem-power-management/cold-reboot-by-pdu
     ce-oem-power-management/post-cold-reboot-by-pdu
 
-id: after-suspend-ce-oem-power-manual
+id: ce-oem-power-manual
 unit: test plan
-_name: After suspend manual power tests
+_name: Manual power tests
 _description:
-    Manual and semi-automatic power-management tests for devices that must
-    run after suspend.
+    Manual and semi-automatic power-management tests for devices.
 include:
     ce-oem-power-management/usb_wakeup_hid

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
@@ -143,6 +143,7 @@ nested_part:
     after-suspend-ce-oem-barcode-scanner-manual
     after-suspend-ce-oem-printer-manual
     after-suspend-ce-oem-cash-drawer-manual
+    after-suspend-ce-oem-power-manual
 certification_status_overrides:
     apply blocker to .*
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
@@ -54,6 +54,7 @@ nested_part:
     ce-oem-barcode-scanner-manual
     ce-oem-printer-manual
     ce-oem-cash-drawer-manual
+    ce-oem-power-manual
 certification_status_overrides:
     apply blocker to .*
 
@@ -143,7 +144,6 @@ nested_part:
     after-suspend-ce-oem-barcode-scanner-manual
     after-suspend-ce-oem-printer-manual
     after-suspend-ce-oem-cash-drawer-manual
-    after-suspend-ce-oem-power-manual
 certification_status_overrides:
     apply blocker to .*
 


### PR DESCRIPTION
## Description

Follow-up to #2660, which added the `ce-oem-power-management/usb_wakeup_hid`
manual test under a new `ce-oem-power-manual` plan but did not wire that
plan into any top-level plan, so the test never ran in the standard OEMQA
after-suspend manual pass.

The job depends on `com.canonical.certification::suspend/suspend_advanced_auto`
and suspends the DUT itself, so it is inherently an after-suspend test.
This PR therefore:

- Renames `ce-oem-power-manual` to `after-suspend-ce-oem-power-manual`
  (with matching `_name`/`_description`). The old id merged less than two
  days ago and is referenced nowhere else (repo grep is clean; no DUT
  config/launcher adoption expected in that window).
- Nests `after-suspend-ce-oem-power-manual` into `after-suspend-ce-oem-manual`
  (`units/test-plan-ce-oem.pxu`), following the existing per-category
  `nested_part` convention.

Deliberately NOT using `flags: also-after-suspend`: the generated sibling
would depend on the original job plus the suspend job, pulling in the
original and making the operator repeat the whole suspend/HID-wake
sequence (three suspends in total). Including the original job id in an
after-suspend category plan runs it exactly once, after
`suspend_advanced_auto`, which its `depends` already enforces.

No job, manifest, or data-format changes.

## Resolved issues

Follow-up to #2660.
<!-- Add the Jira card link here if one tracks this. -->

## Documentation

No documentation impact: provider test-plan wiring only; the job,
manifest entry, and their descriptions are unchanged.

## Tests

- `manage.py validate` on `checkbox-provider-ce-oem` (venv,
  checkbox-ng from this repo): "The provider seems to be valid", zero
  `error:` lines; remaining `advice:` lines are pre-existing
  `template-summary` notices on unrelated templates.
- Repo grep confirms no remaining reference to the bare
  `ce-oem-power-manual` id.
- Runtime spot-check on suspend-capable hardware still pending (manual
  USB HID wake test): `checkbox-cli list-bootstrapped` for
  `after-suspend-ce-oem-manual` should now list
  `com.canonical.qa.ceoem::ce-oem-power-management/usb_wakeup_hid`.
  <!-- Update this bullet once you run it on a DUT. -->
