### PR TITLE
Add jetson-core test plans to ce-oem-iot-ubuntucore-22 plans (New)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-core.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-core.pxu
@@ -146,6 +146,7 @@ include:
     com.canonical.certification::disk/encryption/check-fde-tpm                 # keep if FDE with TPM is enabled
     com.canonical.certification::ubuntucore/kernel-failboot-.*                 # keep if kernel snap is not pc-kernel
 nested_part:
+    jetson-core-manual
     ce-oem-manual
     com.canonical.certification::client-cert-iot-ubuntucore-22-manual
     after-suspend-ce-oem-manual
@@ -203,6 +204,7 @@ include:
     com.canonical.certification::miscellanea/secure_boot_mode_.*               # keep if secure boot is enabled
     com.canonical.certification::disk/encryption/detect                        # keep if FDE is enabled
 nested_part:
+    jetson-core-automated
     ce-oem-automated
     com.canonical.certification::client-cert-iot-ubuntucore-22-automated
     after-suspend-ce-oem-automated


### PR DESCRIPTION
## Description

Nest the Jetson project-specific test plans into the Ubuntu Core 22 CE OEM product plans:

- `jetson-core-manual` → `ce-oem-iot-ubuntucore-22-manual`
- `jetson-core-automated` → `ce-oem-iot-ubuntucore-22-automated`

This matches the composition the `ce-oem-iot-ubuntucore-26-*` plans already use (which nest all the per-SoC plans, Jetson included), so Jetson-specific coverage (camera, container, GPU, CUDA, TensorRT, cuDNN, nvpmodel, video codec, tegra, VPI) is picked up when testing Jetson devices on Ubuntu Core 22 images. The combined `ce-oem-iot-ubuntucore-22` plan inherits both through its existing nesting.

## Resolved issues

<!-- none linked -->

## Documentation

No documentation changes needed; test plan composition only.

## Tests

- The edited `test-plan-ce-oem-full-core.pxu` parses cleanly with the plainbox RFC822 loader; both `ce-oem-iot-ubuntucore-22-manual` and `ce-oem-iot-ubuntucore-22-automated` now list the Jetson plans first in `nested_part`, mirroring the 26-series ordering.
- `jetson-core-manual` and `jetson-core-automated` are defined in the same provider (`units/Jetson/Jetson_test_plan.pxu`), so the bare-id references resolve within the namespace exactly as they do in the 26-series plans.
