### PR TITLE
No longer crash if setup jobs fail in local (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -711,9 +711,7 @@ class Launcher(MainLoopStage, ReportsStage):
             except FileNotFoundError:
                 pass
         self.sa.update_app_blob(json.dumps(app_blob).encode("UTF-8"))
-        failed_setups = self.setup()
-        if failed_setups:
-            raise SystemExit("Failed to prepare the machine")
+        self.setup()
         self.bootstrap()
 
     def _delete_old_sessions(self, ids):


### PR DESCRIPTION

## Description

Although this was the intended design, we have decided that this is not the way Checkbox should work. Checkbox should always conclude the test session regardless of what is going on because else we don't get the report.

Note that this internally also makes the setup job results available in the report due to a previous patch, and this is desirable

Note2 this was actually never done for remote, so no need to remove it from there.

## Resolved issues

Fixes: CHECKBOX-2298

## Documentation

N/A

## Tests

N/A
