### PR TITLE
Read WiFi AP info from file if available and group those jobs (Bugfix)

### DIFF
--- a/providers/base/units/wireless/jobs.pxu
+++ b/providers/base/units/wireless/jobs.pxu
@@ -53,6 +53,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  # shellcheck source=/dev/null
   source "$PLAINBOX_SESSION_SHARE/wifi-bg.env" 2> /dev/null || true
   wifi_nmcli_test.py secured {{ interface }} "$WPA_BG_SSID" "$WPA_BG_PSK"
 category_id: com.canonical.plainbox::wireless
@@ -78,6 +79,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  # shellcheck source=/dev/null
   source "$PLAINBOX_SESSION_SHARE/wifi-bg.env" 2> /dev/null || true
   wifi_nmcli_test.py open {{ interface }} "$OPEN_BG_SSID"
 category_id: com.canonical.plainbox::wireless
@@ -103,6 +105,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  # shellcheck source=/dev/null
   source "$PLAINBOX_SESSION_SHARE/wifi-n.env" 2> /dev/null || true
   wifi_nmcli_test.py secured {{ interface }} "$WPA_N_SSID" "$WPA_N_PSK"
 category_id: com.canonical.plainbox::wireless
@@ -128,6 +131,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  # shellcheck source=/dev/null
   source "$PLAINBOX_SESSION_SHARE/wifi-n.env" 2> /dev/null || true
   wifi_nmcli_test.py open {{ interface }} "$OPEN_N_SSID"
 category_id: com.canonical.plainbox::wireless
@@ -153,6 +157,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  # shellcheck source=/dev/null
   source "$PLAINBOX_SESSION_SHARE/wifi-ac.env" 2> /dev/null || true
   wifi_nmcli_test.py secured {{ interface }} "$WPA_AC_SSID" "$WPA_AC_PSK"
 category_id: com.canonical.plainbox::wireless
@@ -179,6 +184,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  # shellcheck source=/dev/null
   source "$PLAINBOX_SESSION_SHARE/wifi-ac.env" 2> /dev/null || true
   wifi_nmcli_test.py open {{ interface }} "$OPEN_AC_SSID"
 category_id: com.canonical.plainbox::wireless
@@ -205,6 +211,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  # shellcheck source=/dev/null
   source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
   wifi_nmcli_test.py secured {{ interface }} "$WPA_AX_SSID" "$WPA_AX_PSK"
 category_id: com.canonical.plainbox::wireless
@@ -231,6 +238,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  # shellcheck source=/dev/null
   source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
   wifi_nmcli_test.py secured {{ interface }} "$WPA3_AX_SSID" "$WPA3_AX_PSK" --exchange sae
 category_id: com.canonical.plainbox::wireless
@@ -257,6 +265,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  # shellcheck source=/dev/null
   source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
   wifi_nmcli_test.py open {{ interface }} "$OPEN_AX_SSID"
 category_id: com.canonical.plainbox::wireless
@@ -283,6 +292,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  # shellcheck source=/dev/null
   source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
   wifi_nmcli_test.py secured {{ interface }} "$WPA_BE_SSID" "$WPA_BE_PSK"
 category_id: com.canonical.plainbox::wireless
@@ -309,6 +319,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  # shellcheck source=/dev/null
   source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
   wifi_nmcli_test.py secured {{ interface }} "$WPA3_BE_SSID" "$WPA3_BE_PSK" --exchange sae
 category_id: com.canonical.plainbox::wireless
@@ -364,6 +375,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  # shellcheck source=/dev/null
   source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
   wifi_nmcli_test.py open {{ interface }} "$OPEN_BE_SSID"
 category_id: com.canonical.plainbox::wireless

--- a/providers/base/units/wireless/jobs.pxu
+++ b/providers/base/units/wireless/jobs.pxu
@@ -53,8 +53,11 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
-  # shellcheck source=/dev/null
-  source "$PLAINBOX_SESSION_SHARE/wifi-bg.env" 2> /dev/null || true
+  if [ -f "$PLAINBOX_SESSION_SHARE/wifi-bg.env" ]; then
+    echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-bg.env"
+    # shellcheck source=/dev/null
+    source "$PLAINBOX_SESSION_SHARE/wifi-bg.env"
+  fi
   wifi_nmcli_test.py secured {{ interface }} "$WPA_BG_SSID" "$WPA_BG_PSK"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -79,8 +82,11 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
-  # shellcheck source=/dev/null
-  source "$PLAINBOX_SESSION_SHARE/wifi-bg.env" 2> /dev/null || true
+  if [ -f "$PLAINBOX_SESSION_SHARE/wifi-bg.env" ]; then
+    echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-bg.env"
+    # shellcheck source=/dev/null
+    source "$PLAINBOX_SESSION_SHARE/wifi-bg.env"
+  fi
   wifi_nmcli_test.py open {{ interface }} "$OPEN_BG_SSID"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -105,8 +111,11 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
-  # shellcheck source=/dev/null
-  source "$PLAINBOX_SESSION_SHARE/wifi-n.env" 2> /dev/null || true
+  if [ -f "$PLAINBOX_SESSION_SHARE/wifi-n.env" ]; then
+    echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-n.env"
+    # shellcheck source=/dev/null
+    source "$PLAINBOX_SESSION_SHARE/wifi-n.env"
+  fi
   wifi_nmcli_test.py secured {{ interface }} "$WPA_N_SSID" "$WPA_N_PSK"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -131,8 +140,11 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
-  # shellcheck source=/dev/null
-  source "$PLAINBOX_SESSION_SHARE/wifi-n.env" 2> /dev/null || true
+  if [ -f "$PLAINBOX_SESSION_SHARE/wifi-n.env" ]; then
+    echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-n.env"
+    # shellcheck source=/dev/null
+    source "$PLAINBOX_SESSION_SHARE/wifi-n.env"
+  fi
   wifi_nmcli_test.py open {{ interface }} "$OPEN_N_SSID"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -157,8 +169,11 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
-  # shellcheck source=/dev/null
-  source "$PLAINBOX_SESSION_SHARE/wifi-ac.env" 2> /dev/null || true
+  if [ -f "$PLAINBOX_SESSION_SHARE/wifi-ac.env" ]; then
+    echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-ac.env"
+    # shellcheck source=/dev/null
+    source "$PLAINBOX_SESSION_SHARE/wifi-ac.env"
+  fi
   wifi_nmcli_test.py secured {{ interface }} "$WPA_AC_SSID" "$WPA_AC_PSK"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -184,8 +199,11 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
-  # shellcheck source=/dev/null
-  source "$PLAINBOX_SESSION_SHARE/wifi-ac.env" 2> /dev/null || true
+  if [ -f "$PLAINBOX_SESSION_SHARE/wifi-ac.env" ]; then
+    echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-ac.env"
+    # shellcheck source=/dev/null
+    source "$PLAINBOX_SESSION_SHARE/wifi-ac.env"
+  fi
   wifi_nmcli_test.py open {{ interface }} "$OPEN_AC_SSID"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -211,8 +229,11 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
-  # shellcheck source=/dev/null
-  source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
+  if [ -f "$PLAINBOX_SESSION_SHARE/wifi-ax.env" ]; then
+    echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-ax.env"
+    # shellcheck source=/dev/null
+    source "$PLAINBOX_SESSION_SHARE/wifi-ax.env"
+  fi
   wifi_nmcli_test.py secured {{ interface }} "$WPA_AX_SSID" "$WPA_AX_PSK"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -238,8 +259,11 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
-  # shellcheck source=/dev/null
-  source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
+  if [ -f "$PLAINBOX_SESSION_SHARE/wifi-ax.env" ]; then
+    echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-ax.env"
+    # shellcheck source=/dev/null
+    source "$PLAINBOX_SESSION_SHARE/wifi-ax.env"
+  fi
   wifi_nmcli_test.py secured {{ interface }} "$WPA3_AX_SSID" "$WPA3_AX_PSK" --exchange sae
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -265,8 +289,11 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
-  # shellcheck source=/dev/null
-  source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
+  if [ -f "$PLAINBOX_SESSION_SHARE/wifi-ax.env" ]; then
+    echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-ax.env"
+    # shellcheck source=/dev/null
+    source "$PLAINBOX_SESSION_SHARE/wifi-ax.env"
+  fi
   wifi_nmcli_test.py open {{ interface }} "$OPEN_AX_SSID"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -292,8 +319,11 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
-  # shellcheck source=/dev/null
-  source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
+  if [ -f "$PLAINBOX_SESSION_SHARE/wifi-be.env" ]; then
+    echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-be.env"
+    # shellcheck source=/dev/null
+    source "$PLAINBOX_SESSION_SHARE/wifi-be.env"
+  fi
   wifi_nmcli_test.py secured {{ interface }} "$WPA_BE_SSID" "$WPA_BE_PSK"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -319,8 +349,11 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
-  # shellcheck source=/dev/null
-  source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
+  if [ -f "$PLAINBOX_SESSION_SHARE/wifi-be.env" ]; then
+    echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-be.env"
+    # shellcheck source=/dev/null
+    source "$PLAINBOX_SESSION_SHARE/wifi-be.env"
+  fi
   wifi_nmcli_test.py secured {{ interface }} "$WPA3_BE_SSID" "$WPA3_BE_PSK" --exchange sae
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -375,8 +408,11 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
-  # shellcheck source=/dev/null
-  source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
+  if [ -f "$PLAINBOX_SESSION_SHARE/wifi-be.env" ]; then
+    echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-be.env"
+    # shellcheck source=/dev/null
+    source "$PLAINBOX_SESSION_SHARE/wifi-be.env"
+  fi
   wifi_nmcli_test.py open {{ interface }} "$OPEN_BE_SSID"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0

--- a/providers/base/units/wireless/jobs.pxu
+++ b/providers/base/units/wireless/jobs.pxu
@@ -40,6 +40,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa_bg_nm_{{ interface }}
 template-id: wireless/wireless_connection_wpa_bg_nm_interface
+group: wireless-client-{{ interface }}-bg
 depends: wireless/detect
 _summary: Connect to WPA-encrypted 802.11b/g Wi-Fi network on {{ interface }}
 _purpose:
@@ -63,6 +64,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_open_bg_nm_{{ interface }}
 template-id: wireless/wireless_connection_open_bg_nm_interface
+group: wireless-client-{{ interface }}-bg
 depends: wireless/detect
 _summary: Connect to an unencrypted 802.11b/g Wi-Fi network on {{ interface }}
 _purpose:
@@ -86,6 +88,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa_n_nm_{{ interface }}
 template-id: wireless/wireless_connection_wpa_n_nm_interface
+group: wireless-client-{{ interface }}-n
 depends: wireless/detect
 _summary: Connect to a WPA-encrypted 802.11n Wi-Fi network on {{ interface }}
 _purpose:
@@ -109,6 +112,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_open_n_nm_{{ interface }}
 template-id: wireless/wireless_connection_open_n_nm_interface
+group: wireless-client-{{ interface }}-n
 depends: wireless/detect
 _summary: Connect to an unencrypted 802.11n Wi-Fi network on {{ interface }}
 _purpose:
@@ -132,6 +136,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa_ac_nm_{{ interface }}
 template-id: wireless/wireless_connection_wpa_ac_nm_interface
+group: wireless-client-{{ interface }}-ac
 depends: wireless/detect
 _summary: Connect to WPA-encrypted 802.11ac Wi-Fi network on {{ interface }}
 _purpose:
@@ -156,6 +161,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_open_ac_nm_{{ interface }}
 template-id: wireless/wireless_connection_open_ac_nm_interface
+group: wireless-client-{{ interface }}-ac
 depends: wireless/detect
 _summary: Connect to unencrypted 802.11ac Wi-Fi network on {{ interface }}
 _purpose:
@@ -180,6 +186,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa_ax_nm_{{ interface }}
 template-id: wireless/wireless_connection_wpa_ax_nm_interface
+group: wireless-client-{{ interface }}-ax
 depends: wireless/detect
 _summary: Connect to WPA-encrypted 802.11ax Wi-Fi network on {{ interface }}
 _purpose:
@@ -204,6 +211,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa3_ax_nm_{{ interface }}
 template-id: wireless/wireless_connection_wpa3_ax_nm_interface
+group: wireless-client-{{ interface }}-ax
 depends: wireless/detect
 _summary: Connect to WPA3-encrypted 802.11ax Wi-Fi network on {{ interface }}
 _purpose:
@@ -229,6 +237,7 @@ template-unit: job
 id: wireless/wireless_connection_open_ax_nm_{{ interface }}
 depends: wireless/detect
 template-id: wireless/wireless_connection_open_ax_nm_interface
+group: wireless-client-{{ interface }}-ax
 _summary: Connect to unencrypted 802.11ax Wi-Fi network on {{ interface }}
 _purpose:
   Check system can connect to insecure 802.11ax AP
@@ -252,6 +261,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa_be_nm_{{ interface }}
 template-id: wireless/wireless_connection_wpa_be_nm_interface
+group: wireless-client-{{ interface }}-be
 depends: wireless/detect
 _summary: Connect to WPA-encrypted 802.11be Wi-Fi network on {{ interface }}
 _purpose:
@@ -276,6 +286,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa3_be_nm_{{ interface }}
 template-id: wireless/wireless_connection_wpa3_be_nm_interface
+group: wireless-client-{{ interface }}-be
 depends: wireless/detect
 _summary: Connect to WPA3-encrypted 802.11be Wi-Fi network on {{ interface }}
 _purpose:
@@ -300,6 +311,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wifi7_mlo_{{ interface }}
 template-id: wireless/wifi7_mlo_interface
+group: wireless-client-{{ interface }}-be
 depends: wireless/detect
 _summary: Test Wi-Fi 7 Multi-Link-Operation (MLO) on {{ interface }}
 _purpose:
@@ -329,6 +341,7 @@ template-unit: job
 id: wireless/wireless_connection_open_be_nm_{{ interface }}
 depends: wireless/detect
 template-id: wireless/wireless_connection_open_be_nm_interface
+group: wireless-client-{{ interface }}-be
 _summary: Connect to unencrypted 802.11be Wi-Fi network on {{ interface }}
 _purpose:
   Check system can connect to insecure 802.11be AP

--- a/providers/base/units/wireless/jobs.pxu
+++ b/providers/base/units/wireless/jobs.pxu
@@ -33,6 +33,10 @@ requires:
  net_if_management.device == '{{ interface }}' and net_if_management.managed_by == 'NetworkManager'
  manifest.has_wlan_adapter == 'True'
 
+# Wi-Fi client jobs optionally read per-band shell credentials from
+# $PLAINBOX_SESSION_SHARE/wifi-<band>.env. The file should define the
+# same variable names used by the job command, for example WPA_BG_SSID
+# and WPA_BG_PSK. Missing files fall back to the environment.
 unit: template
 template-resource: device
 template-filter: device.category == 'WIRELESS' and device.interface != 'UNKNOWN'
@@ -49,6 +53,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  source "$PLAINBOX_SESSION_SHARE/wifi-bg.env" 2> /dev/null || true
   wifi_nmcli_test.py secured {{ interface }} "$WPA_BG_SSID" "$WPA_BG_PSK"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -73,6 +78,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  source "$PLAINBOX_SESSION_SHARE/wifi-bg.env" 2> /dev/null || true
   wifi_nmcli_test.py open {{ interface }} "$OPEN_BG_SSID"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -97,6 +103,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  source "$PLAINBOX_SESSION_SHARE/wifi-n.env" 2> /dev/null || true
   wifi_nmcli_test.py secured {{ interface }} "$WPA_N_SSID" "$WPA_N_PSK"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -121,6 +128,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  source "$PLAINBOX_SESSION_SHARE/wifi-n.env" 2> /dev/null || true
   wifi_nmcli_test.py open {{ interface }} "$OPEN_N_SSID"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -145,6 +153,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  source "$PLAINBOX_SESSION_SHARE/wifi-ac.env" 2> /dev/null || true
   wifi_nmcli_test.py secured {{ interface }} "$WPA_AC_SSID" "$WPA_AC_PSK"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -170,6 +179,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  source "$PLAINBOX_SESSION_SHARE/wifi-ac.env" 2> /dev/null || true
   wifi_nmcli_test.py open {{ interface }} "$OPEN_AC_SSID"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -195,6 +205,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
   wifi_nmcli_test.py secured {{ interface }} "$WPA_AX_SSID" "$WPA_AX_PSK"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -220,6 +231,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
   wifi_nmcli_test.py secured {{ interface }} "$WPA3_AX_SSID" "$WPA3_AX_PSK" --exchange sae
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -245,6 +257,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
   wifi_nmcli_test.py open {{ interface }} "$OPEN_AX_SSID"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -270,6 +283,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
   wifi_nmcli_test.py secured {{ interface }} "$WPA_BE_SSID" "$WPA_BE_PSK"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -295,6 +309,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
   wifi_nmcli_test.py secured {{ interface }} "$WPA3_BE_SSID" "$WPA3_BE_PSK" --exchange sae
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
@@ -349,6 +364,7 @@ plugin: shell
 user: root
 command:
   net_driver_info.py "$NET_DRIVER_INFO"
+  source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
   wifi_nmcli_test.py open {{ interface }} "$OPEN_BE_SSID"
 category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0

--- a/providers/base/units/wireless/wireless-connection-netplan.pxu
+++ b/providers/base/units/wireless/wireless-connection-netplan.pxu
@@ -17,8 +17,11 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
-    # shellcheck source=/dev/null
-    source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
+    if [ -f "$PLAINBOX_SESSION_SHARE/wifi-be.env" ]; then
+      echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-be.env"
+      # shellcheck source=/dev/null
+      source "$PLAINBOX_SESSION_SHARE/wifi-be.env"
+    fi
     wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_BE_SSID" -d
 user: root
 environ: LD_LIBRARY_PATH OPEN_BE_SSID NET_DRIVER_INFO
@@ -44,8 +47,11 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
-    # shellcheck source=/dev/null
-    source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
+    if [ -f "$PLAINBOX_SESSION_SHARE/wifi-ax.env" ]; then
+      echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-ax.env"
+      # shellcheck source=/dev/null
+      source "$PLAINBOX_SESSION_SHARE/wifi-ax.env"
+    fi
     wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_AX_SSID" -d
 user: root
 environ: LD_LIBRARY_PATH OPEN_AX_SSID NET_DRIVER_INFO
@@ -71,8 +77,11 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
-    # shellcheck source=/dev/null
-    source "$PLAINBOX_SESSION_SHARE/wifi-ac.env" 2> /dev/null || true
+    if [ -f "$PLAINBOX_SESSION_SHARE/wifi-ac.env" ]; then
+      echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-ac.env"
+      # shellcheck source=/dev/null
+      source "$PLAINBOX_SESSION_SHARE/wifi-ac.env"
+    fi
     wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_AC_SSID" -d
 user: root
 environ: LD_LIBRARY_PATH OPEN_AC_SSID NET_DRIVER_INFO
@@ -98,8 +107,11 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
-    # shellcheck source=/dev/null
-    source "$PLAINBOX_SESSION_SHARE/wifi-bg.env" 2> /dev/null || true
+    if [ -f "$PLAINBOX_SESSION_SHARE/wifi-bg.env" ]; then
+      echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-bg.env"
+      # shellcheck source=/dev/null
+      source "$PLAINBOX_SESSION_SHARE/wifi-bg.env"
+    fi
     wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_BG_SSID" -d
 user: root
 environ: LD_LIBRARY_PATH OPEN_BG_SSID NET_DRIVER_INFO
@@ -124,8 +136,11 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
-    # shellcheck source=/dev/null
-    source "$PLAINBOX_SESSION_SHARE/wifi-n.env" 2> /dev/null || true
+    if [ -f "$PLAINBOX_SESSION_SHARE/wifi-n.env" ]; then
+      echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-n.env"
+      # shellcheck source=/dev/null
+      source "$PLAINBOX_SESSION_SHARE/wifi-n.env"
+    fi
     wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_N_SSID" -d
 user: root
 environ: LD_LIBRARY_PATH OPEN_N_SSID NET_DRIVER_INFO
@@ -150,8 +165,11 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
-    # shellcheck source=/dev/null
-    source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
+    if [ -f "$PLAINBOX_SESSION_SHARE/wifi-be.env" ]; then
+      echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-be.env"
+      # shellcheck source=/dev/null
+      source "$PLAINBOX_SESSION_SHARE/wifi-be.env"
+    fi
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_BE_SSID" -k "$WPA_BE_PSK" -d
 user: root
 environ: LD_LIBRARY_PATH WPA_BE_SSID WPA_BE_PSK NET_DRIVER_INFO
@@ -177,8 +195,11 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
-    # shellcheck source=/dev/null
-    source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
+    if [ -f "$PLAINBOX_SESSION_SHARE/wifi-ax.env" ]; then
+      echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-ax.env"
+      # shellcheck source=/dev/null
+      source "$PLAINBOX_SESSION_SHARE/wifi-ax.env"
+    fi
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_AX_SSID" -k "$WPA_AX_PSK" -d
 user: root
 environ: LD_LIBRARY_PATH WPA_AX_SSID WPA_AX_PSK NET_DRIVER_INFO
@@ -204,8 +225,11 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
-    # shellcheck source=/dev/null
-    source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
+    if [ -f "$PLAINBOX_SESSION_SHARE/wifi-be.env" ]; then
+      echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-be.env"
+      # shellcheck source=/dev/null
+      source "$PLAINBOX_SESSION_SHARE/wifi-be.env"
+    fi
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA3_BE_SSID" -k "$WPA3_BE_PSK" -d --wpa3
 user: root
 environ: LD_LIBRARY_PATH WPA3_BE_SSID WPA3_BE_PSK NET_DRIVER_INFO
@@ -231,8 +255,11 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
-    # shellcheck source=/dev/null
-    source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
+    if [ -f "$PLAINBOX_SESSION_SHARE/wifi-ax.env" ]; then
+      echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-ax.env"
+      # shellcheck source=/dev/null
+      source "$PLAINBOX_SESSION_SHARE/wifi-ax.env"
+    fi
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA3_AX_SSID" -k "$WPA3_AX_PSK" -d --wpa3
 user: root
 environ: LD_LIBRARY_PATH WPA3_AX_SSID WPA3_AX_PSK NET_DRIVER_INFO
@@ -258,8 +285,11 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
-    # shellcheck source=/dev/null
-    source "$PLAINBOX_SESSION_SHARE/wifi-ac.env" 2> /dev/null || true
+    if [ -f "$PLAINBOX_SESSION_SHARE/wifi-ac.env" ]; then
+      echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-ac.env"
+      # shellcheck source=/dev/null
+      source "$PLAINBOX_SESSION_SHARE/wifi-ac.env"
+    fi
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_AC_SSID" -k "$WPA_AC_PSK" -d
 user: root
 environ: LD_LIBRARY_PATH WPA_AC_SSID WPA_AC_PSK NET_DRIVER_INFO
@@ -285,8 +315,11 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
-    # shellcheck source=/dev/null
-    source "$PLAINBOX_SESSION_SHARE/wifi-bg.env" 2> /dev/null || true
+    if [ -f "$PLAINBOX_SESSION_SHARE/wifi-bg.env" ]; then
+      echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-bg.env"
+      # shellcheck source=/dev/null
+      source "$PLAINBOX_SESSION_SHARE/wifi-bg.env"
+    fi
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_BG_SSID" -k "$WPA_BG_PSK" -d
 user: root
 environ: LD_LIBRARY_PATH WPA_BG_SSID WPA_BG_PSK NET_DRIVER_INFO
@@ -311,8 +344,11 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
-    # shellcheck source=/dev/null
-    source "$PLAINBOX_SESSION_SHARE/wifi-n.env" 2> /dev/null || true
+    if [ -f "$PLAINBOX_SESSION_SHARE/wifi-n.env" ]; then
+      echo "Loading Wi-Fi credentials from $PLAINBOX_SESSION_SHARE/wifi-n.env"
+      # shellcheck source=/dev/null
+      source "$PLAINBOX_SESSION_SHARE/wifi-n.env"
+    fi
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_N_SSID" -k "$WPA_N_PSK" -d
 user: root
 environ: LD_LIBRARY_PATH WPA_N_SSID WPA_N_PSK NET_DRIVER_INFO

--- a/providers/base/units/wireless/wireless-connection-netplan.pxu
+++ b/providers/base/units/wireless/wireless-connection-netplan.pxu
@@ -17,6 +17,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    # shellcheck source=/dev/null
     source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_BE_SSID" -d
 user: root
@@ -43,6 +44,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    # shellcheck source=/dev/null
     source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_AX_SSID" -d
 user: root
@@ -69,6 +71,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    # shellcheck source=/dev/null
     source "$PLAINBOX_SESSION_SHARE/wifi-ac.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_AC_SSID" -d
 user: root
@@ -95,6 +98,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    # shellcheck source=/dev/null
     source "$PLAINBOX_SESSION_SHARE/wifi-bg.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_BG_SSID" -d
 user: root
@@ -120,6 +124,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    # shellcheck source=/dev/null
     source "$PLAINBOX_SESSION_SHARE/wifi-n.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_N_SSID" -d
 user: root
@@ -145,6 +150,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    # shellcheck source=/dev/null
     source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_BE_SSID" -k "$WPA_BE_PSK" -d
 user: root
@@ -171,6 +177,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    # shellcheck source=/dev/null
     source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_AX_SSID" -k "$WPA_AX_PSK" -d
 user: root
@@ -197,6 +204,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    # shellcheck source=/dev/null
     source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA3_BE_SSID" -k "$WPA3_BE_PSK" -d --wpa3
 user: root
@@ -223,6 +231,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    # shellcheck source=/dev/null
     source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA3_AX_SSID" -k "$WPA3_AX_PSK" -d --wpa3
 user: root
@@ -249,6 +258,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    # shellcheck source=/dev/null
     source "$PLAINBOX_SESSION_SHARE/wifi-ac.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_AC_SSID" -k "$WPA_AC_PSK" -d
 user: root
@@ -275,6 +285,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    # shellcheck source=/dev/null
     source "$PLAINBOX_SESSION_SHARE/wifi-bg.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_BG_SSID" -k "$WPA_BG_PSK" -d
 user: root
@@ -300,6 +311,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    # shellcheck source=/dev/null
     source "$PLAINBOX_SESSION_SHARE/wifi-n.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_N_SSID" -k "$WPA_N_PSK" -d
 user: root

--- a/providers/base/units/wireless/wireless-connection-netplan.pxu
+++ b/providers/base/units/wireless/wireless-connection-netplan.pxu
@@ -1,3 +1,7 @@
+# Wi-Fi client jobs optionally read per-band shell credentials from
+# $PLAINBOX_SESSION_SHARE/wifi-<band>.env. The file should define the
+# same variable names used by the job command, for example WPA_BG_SSID
+# and WPA_BG_PSK. Missing files fall back to the environment.
 unit: template
 template-resource: device
 template-filter: device.category == 'WIRELESS' and device.interface != 'UNKNOWN'
@@ -13,6 +17,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_BE_SSID" -d
 user: root
 environ: LD_LIBRARY_PATH OPEN_BE_SSID NET_DRIVER_INFO
@@ -38,6 +43,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_AX_SSID" -d
 user: root
 environ: LD_LIBRARY_PATH OPEN_AX_SSID NET_DRIVER_INFO
@@ -63,6 +69,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    source "$PLAINBOX_SESSION_SHARE/wifi-ac.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_AC_SSID" -d
 user: root
 environ: LD_LIBRARY_PATH OPEN_AC_SSID NET_DRIVER_INFO
@@ -88,6 +95,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    source "$PLAINBOX_SESSION_SHARE/wifi-bg.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_BG_SSID" -d
 user: root
 environ: LD_LIBRARY_PATH OPEN_BG_SSID NET_DRIVER_INFO
@@ -112,6 +120,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    source "$PLAINBOX_SESSION_SHARE/wifi-n.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$OPEN_N_SSID" -d
 user: root
 environ: LD_LIBRARY_PATH OPEN_N_SSID NET_DRIVER_INFO
@@ -136,6 +145,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_BE_SSID" -k "$WPA_BE_PSK" -d
 user: root
 environ: LD_LIBRARY_PATH WPA_BE_SSID WPA_BE_PSK NET_DRIVER_INFO
@@ -161,6 +171,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_AX_SSID" -k "$WPA_AX_PSK" -d
 user: root
 environ: LD_LIBRARY_PATH WPA_AX_SSID WPA_AX_PSK NET_DRIVER_INFO
@@ -186,6 +197,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    source "$PLAINBOX_SESSION_SHARE/wifi-be.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA3_BE_SSID" -k "$WPA3_BE_PSK" -d --wpa3
 user: root
 environ: LD_LIBRARY_PATH WPA3_BE_SSID WPA3_BE_PSK NET_DRIVER_INFO
@@ -211,6 +223,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    source "$PLAINBOX_SESSION_SHARE/wifi-ax.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA3_AX_SSID" -k "$WPA3_AX_PSK" -d --wpa3
 user: root
 environ: LD_LIBRARY_PATH WPA3_AX_SSID WPA3_AX_PSK NET_DRIVER_INFO
@@ -236,6 +249,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    source "$PLAINBOX_SESSION_SHARE/wifi-ac.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_AC_SSID" -k "$WPA_AC_PSK" -d
 user: root
 environ: LD_LIBRARY_PATH WPA_AC_SSID WPA_AC_PSK NET_DRIVER_INFO
@@ -261,6 +275,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    source "$PLAINBOX_SESSION_SHARE/wifi-bg.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_BG_SSID" -k "$WPA_BG_PSK" -d
 user: root
 environ: LD_LIBRARY_PATH WPA_BG_SSID WPA_BG_PSK NET_DRIVER_INFO
@@ -285,6 +300,7 @@ _purpose:
 plugin: shell
 command:
     net_driver_info.py "$NET_DRIVER_INFO"
+    source "$PLAINBOX_SESSION_SHARE/wifi-n.env" 2> /dev/null || true
     wifi_client_test_netplan.py -i {{ interface }} -s "$WPA_N_SSID" -k "$WPA_N_PSK" -d
 user: root
 environ: LD_LIBRARY_PATH WPA_N_SSID WPA_N_PSK NET_DRIVER_INFO

--- a/providers/base/units/wireless/wireless-connection-netplan.pxu
+++ b/providers/base/units/wireless/wireless-connection-netplan.pxu
@@ -5,6 +5,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_open_be_np_{{ interface }}
 template-id: wireless/wireless_connection_open_be_np_interface
+group: wireless-client-{{ interface }}-be
 _summary:
  Connect to unencrypted 802.11be Wi-Fi network on {{ interface }} - netplan
 _purpose:
@@ -29,6 +30,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_open_ax_np_{{ interface }}
 template-id: wireless/wireless_connection_open_ax_np_interface
+group: wireless-client-{{ interface }}-ax
 _summary:
  Connect to unencrypted 802.11ax Wi-Fi network on {{ interface }} - netplan
 _purpose:
@@ -53,6 +55,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_open_ac_np_{{ interface }}
 template-id: wireless/wireless_connection_open_ac_np_interface
+group: wireless-client-{{ interface }}-ac
 _summary:
  Connect to unencrypted 802.11ac Wi-Fi network on {{ interface }} - netplan
 _purpose:
@@ -77,6 +80,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_open_bg_np_{{ interface }}
 template-id: wireless/wireless_connection_open_bg_np_interface
+group: wireless-client-{{ interface }}-bg
 _summary:
  Connect to unencrypted 802.11b/g Wi-Fi network on {{ interface }} using netplan
 _purpose:
@@ -100,6 +104,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_open_n_np_{{ interface }}
 template-id: wireless/wireless_connection_open_n_np_interface
+group: wireless-client-{{ interface }}-n
 _summary:
  Connect to unencrypted 802.11n Wi-Fi network on {{ interface }} - netplan
 _purpose:
@@ -123,6 +128,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa_be_np_{{ interface }}
 template-id: wireless/wireless_connection_wpa_be_np_interface
+group: wireless-client-{{ interface }}-be
 _summary:
  Connect to WPA-encrypted 802.11be Wi-Fi network on {{ interface }} - netplan
 _purpose:
@@ -147,6 +153,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa_ax_np_{{ interface }}
 template-id: wireless/wireless_connection_wpa_ax_np_interface
+group: wireless-client-{{ interface }}-ax
 _summary:
  Connect to WPA-encrypted 802.11ax Wi-Fi network on {{ interface }} - netplan
 _purpose:
@@ -171,6 +178,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa3_be_np_{{ interface }}
 template-id: wireless/wireless_connection_wpa3_be_np_interface
+group: wireless-client-{{ interface }}-be
 _summary:
  Connect to WPA3-encrypted 802.11be Wi-Fi network on {{ interface }} - netplan
 _purpose:
@@ -195,6 +203,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa3_ax_np_{{ interface }}
 template-id: wireless/wireless_connection_wpa3_ax_np_interface
+group: wireless-client-{{ interface }}-ax
 _summary:
  Connect to WPA3-encrypted 802.11ax Wi-Fi network on {{ interface }} - netplan
 _purpose:
@@ -219,6 +228,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa_ac_np_{{ interface }}
 template-id: wireless/wireless_connection_wpa_ac_np_interface
+group: wireless-client-{{ interface }}-ac
 _summary:
  Connect to WPA-encrypted 802.11ac Wi-Fi network on {{ interface }} - netplan
 _purpose:
@@ -243,6 +253,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa_bg_np_{{ interface }}
 template-id: wireless/wireless_connection_wpa_bg_np_interface
+group: wireless-client-{{ interface }}-bg
 _summary:
  Connect to WPA-encrypted 802.11b/g Wi-Fi network on {{ interface }} - netplan
 _purpose:
@@ -266,6 +277,7 @@ template-engine: jinja2
 template-unit: job
 id: wireless/wireless_connection_wpa_n_np_{{ interface }}
 template-id: wireless/wireless_connection_wpa_n_np_interface
+group: wireless-client-{{ interface }}-n
 _summary:
  Connect to a WPA-encrypted 802.11n Wi-Fi network on {{ interface }} using netplan
 _purpose:


### PR DESCRIPTION
## WARNING: This modifies com.canonical.certification::sru-server

## Description

The goal is to provide setup/teardown jobs for an external WiFi access point later on.

1. Include WiFi jobs in templated groups
2. Make them read SSID/Password from file, fallback to regular envars

Notes:
The proposed solution to load envar is marked by shellcheck but it's also the most straightforward I've found.
1. The test case doesn't have a clue of the band we're testing
2. ... and it doesn't have a clue of the envars we're using to store SSID and password

Other file parsers just look more complex to add inline.

## Resolved issues

Part of https://warthogs.atlassian.net/browse/ZAP-1502

## Documentation

N/A

## Tests

Current behavior is not impacted:
```
[launcher]
launcher_version = 1
stock_reports = text

[test plan]
unit = com.canonical.certification::wireless-automated
forced = yes

[test selection]
forced = true
match = ".*_ac_.*"

[ui]
type = silent

[environment]
OPEN_AC_SSID = <test-open-ssid>
WPA_AC_SSID = <test-wpa-ssid>
WPA_AC_PSK = <test-pwd>

[manifest]
com.canonical.certification::has_wlan_adapter = true
```
