### PR TITLE
Hidden manifest entry for machines running experimental jobs (New)

### DIFF
--- a/providers/base/units/miscellanea/manifest.pxu
+++ b/providers/base/units/miscellanea/manifest.pxu
@@ -7,3 +7,10 @@ unit: manifest entry
 id: has_sriov
 _name: SR-IOV support
 value-type: bool
+
+unit: manifest entry
+id: _has_experimental_testing
+_name: Experimental testing
+value-type: bool
+hidden-reason: Experimental jobs should run only on systems explicitly flagged
+  for that coverage through configuration.


### PR DESCRIPTION
## Description

Introducing a new test job often comes with new false positives due to the lack of hardware coverage, especially with the huge number of variants we need to consider.

A new job should be introduced depending on `_has_experimental_testing`, which reduces the pool of machines where the test is going to run. After a long enough evaluation, the test shall be updated to removed this dependency.

## Resolved issues

N/A

## Documentation

Should I?

## Tests

 N/A
