### PR TITLE
Fix Pipewire source/sink change detection (BugFix)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/pipewire_utils.py
+++ b/checkbox-support/checkbox_support/scripts/pipewire_utils.py
@@ -249,7 +249,7 @@ class PipewireTest:
         Checks whether the sink is available for the given device.
         This function parse output of pw-dump to find the device type
         equals PipeWire:Interface:Device and media.class equals Audio/Device.
-        For pipewire, the active port will be listed under 
+        For pipewire, the active port will be listed under
             info.params.EnumRoute.
         Therefore, you could check this object to know the state of it.
 
@@ -328,7 +328,7 @@ class PipewireTest:
         Get simple audio configuration
         This function parse output of pw-dump to find the device type
         equals PipeWire:Interface:Device and media.class equals Audio/Device.
-        For pipewire, the active port will be listed under 
+        For pipewire, the active port will be listed under
             info.params.EnumRoute.
         Therefore, you could check this object to know the state of it.
 

--- a/checkbox-support/checkbox_support/scripts/pipewire_utils.py
+++ b/checkbox-support/checkbox_support/scripts/pipewire_utils.py
@@ -33,9 +33,9 @@ import gi
 
 gi.require_version("Gst", "1.0")
 gi.require_version("GLib", "2.0")
-from gi.repository import (
-    GLib,  # noqa: E402
-    Gst,  # noqa: E402
+from gi.repository import (  # noqa: E402
+    GLib,  # pyright: ignore[reportMissingModuleSource]
+    Gst,  # pyright: ignore[reportMissingModuleSource]
 )
 
 
@@ -322,7 +322,7 @@ class PipewireTest:
 
         return PipewireTestError.NO_ERROR
 
-    def _get_audio_config(self, mode):
+    def _get_audio_config(self, mode: "t.Literal['sink', 'source']"):
         """
         Get simple audio configuration
         This function parse output of pw-dump to find the device type
@@ -336,20 +336,20 @@ class PipewireTest:
         clients = self._get_pw_dump("Device")
         cfg = set()  # type: set[tuple[str, str, str]]
         for client in clients:
-            active_ports = None
+            active_ports = []
             mclass = client["info"]["props"].get("media.class")
             if mclass == "Audio/Device":
-                active_ports = client["info"]["params"]["Route"]
-            if active_ports:
-                for p in active_ports:
-                    if p["direction"] == self._get_pw_type(mode):
-                        cfg.add(
-                            (
-                                "{} #{}".format(mode, client["id"]),
-                                p["name"],
-                                p["available"],
-                            )
+                active_ports = client["info"]["params"]["EnumRoute"]
+
+            for p in active_ports:
+                if p["direction"] == self._get_pw_type(mode):
+                    cfg.add(
+                        (
+                            "{} #{}".format(mode, client["id"]),
+                            p["name"],
+                            p["available"],
                         )
+                    )
         return cfg
 
     def monitor_active_port_change(self, timeout, mode) -> int:

--- a/checkbox-support/checkbox_support/scripts/pipewire_utils.py
+++ b/checkbox-support/checkbox_support/scripts/pipewire_utils.py
@@ -322,7 +322,7 @@ class PipewireTest:
 
         return PipewireTestError.NO_ERROR
 
-    def _get_audio_config(self, mode: "t.Literal['sink', 'source']"):
+    def _get_audio_config(self, mode: "t.Literal['sinks', 'sources']"):
         """
         Get simple audio configuration
         This function parse output of pw-dump to find the device type
@@ -352,7 +352,9 @@ class PipewireTest:
                     )
         return cfg
 
-    def monitor_active_port_change(self, timeout, mode) -> int:
+    def monitor_active_port_change(
+        self, timeout: int, mode: "t.Literal['sinks', 'sources']"
+    ) -> int:
         """
         Monitoring Audio active port changing
         This script checks if the active port on either sinks
@@ -383,7 +385,9 @@ class PipewireTest:
         self.logger.info("Couldn't detect active port change!")
         return PipewireTestError.NO_CHANGE_DETECTED
 
-    def go_through_ports(self, cmd: str, mode: 't.Literal["source", "sink"]'):
+    def go_through_ports(
+        self, cmd: str, mode: 't.Literal["sinks", "sources"]'
+    ):
         """
         Go through available ports for testing
         This script checks if the ports on either sinks
@@ -946,7 +950,11 @@ class PipewireTest:
             help="Timeout after which the script fails",
         )
         parser_monitor.add_argument(
-            "-m", "--mode", type=str, help="Monitor either sinks or sources"
+            "-m",
+            "--mode",
+            type=str,
+            help="Monitor either sinks or sources",
+            choices=("sinks", "sources"),
         )
 
         # Add parser for go through function
@@ -961,7 +969,11 @@ class PipewireTest:
             help="command for testing",
         )
         parser_through.add_argument(
-            "-m", "--mode", type=str, help="Either sinks or sources"
+            "-m",
+            "--mode",
+            type=str,
+            help="Either sinks or sources",
+            choices=("sinks", "sources"),
         )
 
         parser_iter_sink = subparsers.add_parser(

--- a/checkbox-support/checkbox_support/scripts/pipewire_utils.py
+++ b/checkbox-support/checkbox_support/scripts/pipewire_utils.py
@@ -249,7 +249,8 @@ class PipewireTest:
         Checks whether the sink is available for the given device.
         This function parse output of pw-dump to find the device type
         equals PipeWire:Interface:Device and media.class equals Audio/Device.
-        For pipewire, the active port will be listed under info.params.Route.
+        For pipewire, the active port will be listed under 
+            info.params.EnumRoute.
         Therefore, you could check this object to know the state of it.
 
         :param device: device you would like to check
@@ -327,7 +328,8 @@ class PipewireTest:
         Get simple audio configuration
         This function parse output of pw-dump to find the device type
         equals PipeWire:Interface:Device and media.class equals Audio/Device.
-        For pipewire, the active port will be listed under info.params.Route.
+        For pipewire, the active port will be listed under 
+            info.params.EnumRoute.
         Therefore, you could check this object to know the state of it.
 
         :param mode: sink or source

--- a/checkbox-support/checkbox_support/scripts/pipewire_utils.py
+++ b/checkbox-support/checkbox_support/scripts/pipewire_utils.py
@@ -260,7 +260,7 @@ class PipewireTest:
             for client in clients:
                 mclass = client["info"]["props"].get("media.class")
                 if mclass == "Audio/Device":
-                    for route in client["info"]["params"]["Route"]:
+                    for route in client["info"]["params"]["EnumRoute"]:
                         name = route["name"]
                         available = route["available"]
                         if (

--- a/checkbox-support/checkbox_support/scripts/pipewire_utils.py
+++ b/checkbox-support/checkbox_support/scripts/pipewire_utils.py
@@ -953,6 +953,7 @@ class PipewireTest:
             "-m",
             "--mode",
             type=str,
+            required=True,
             help="Monitor either sinks or sources",
             choices=("sinks", "sources"),
         )
@@ -971,6 +972,7 @@ class PipewireTest:
         parser_through.add_argument(
             "-m",
             "--mode",
+            required=True,
             type=str,
             help="Either sinks or sources",
             choices=("sinks", "sources"),

--- a/checkbox-support/checkbox_support/scripts/tests/test_pipewire_utils.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_pipewire_utils.py
@@ -406,7 +406,7 @@ class GstPipeLineTests(unittest.TestCase):
                    "object.serial": 29
                  },
                  "params": {
-                     "Route": [{
+                     "EnumRoute": [{
                          "name": "hdmi_demo_output",
                          "available": "yes",
                          "description": "hdmi demo output",
@@ -478,7 +478,7 @@ class MonitorActivePortTests(unittest.TestCase):
                            "object.serial": 29
                          },
                          "params": {
-                             "Route": [{
+                             "EnumRoute": [{
                                  "name": "hdmi_demo_output",
                                  "available": "yes",
                                  "direction": "Output",
@@ -521,7 +521,7 @@ class MonitorActivePortTests(unittest.TestCase):
                           "object.serial": 29
                         },
                         "params": {
-                            "Route": [{
+                            "EnumRoute": [{
                                 "name": "hdmi_after_output",
                                 "available": "yes",
                                 "direction": "Output",
@@ -539,7 +539,7 @@ class MonitorActivePortTests(unittest.TestCase):
         mock_checkout.return_value = self.before_device
         self.assertEqual(
             PipewireTestError.NO_CHANGE_DETECTED,
-            pt.monitor_active_port_change(2, "sink"),
+            pt.monitor_active_port_change(2, "sinks"),
         )
 
     @patch("subprocess.check_output")
@@ -549,7 +549,7 @@ class MonitorActivePortTests(unittest.TestCase):
         mock_checkout.side_effect = [self.before_device, self.after_device]
         self.assertEqual(
             PipewireTestError.NO_ERROR,
-            pt.monitor_active_port_change(2, "sink"),
+            pt.monitor_active_port_change(2, "sinks"),
         )
 
 
@@ -603,7 +603,7 @@ class GoThroughPortTests(unittest.TestCase):
 
         mock_checkout.return_value = self.device
         mock_input.side_effect = ["yes", "yes"]
-        self.assertEqual(None, pt.go_through_ports("echo test", "sink"))
+        self.assertEqual(None, pt.go_through_ports("echo test", "sinks"))
 
 
 class IterAudioSinksTests(unittest.TestCase):
@@ -1397,15 +1397,15 @@ class ArgsParsingTests(unittest.TestCase):
         self.assertEqual(rv.PIPELINE, "PIPELINE")
         self.assertEqual(rv.device, "device")
 
-        args = ["monitor", "-t", "30", "-m", "mode"]
+        args = ["monitor", "-t", "30", "-m", "sinks"]
         rv = pt._args_parsing(args)
         self.assertEqual(rv.timeout, 30)
-        self.assertEqual(rv.mode, "mode")
+        self.assertEqual(rv.mode, "sinks")
 
-        args = ["through", "-c", "echo", "-m", "mode"]
+        args = ["through", "-c", "echo", "-m", "sources"]
         rv = pt._args_parsing(args)
         self.assertEqual(rv.command, "echo")
-        self.assertEqual(rv.mode, "mode")
+        self.assertEqual(rv.mode, "sources")
 
         args = ["show", "-t", "AUDIO"]
         rv = pt._args_parsing(args)
@@ -1458,7 +1458,7 @@ class FunctionSelectTests(unittest.TestCase):
     )
     def test_monitor(self, mock_monitor):
         pt = PipewireTest()
-        args = ["monitor", "-t", "30", "-m", "mode"]
+        args = ["monitor", "-t", "30", "-m", "sinks"]
         rv = pt.function_select(pt._args_parsing(args))
         self.assertEqual(rv, 66)
 
@@ -1468,7 +1468,7 @@ class FunctionSelectTests(unittest.TestCase):
     )
     def test_through(self, mock_through):
         pt = PipewireTest()
-        args = ["through", "-c", "echo", "-m", "mode"]
+        args = ["through", "-c", "echo", "-m", "sinks"]
         rv = pt.function_select(pt._args_parsing(args))
         self.assertEqual(rv, 55)
 


### PR DESCRIPTION
## Description

The program used to check `["info"]["params"]["Route"]` for each pipewire client but the more accurate way is to check `["info"]["params"]["EnumRoute"]` because sometimes the `Route` list isn't updated upon device removal, but EnumRoute is.

Also added some type annotations and restrict `monitor` and `through` subcommands to only accept `sinks`/`sources` for the `--mode` param.

## Resolved issues

On some desktops, GNOME will correctly report sink/source changes, but `checkbox-support-pipewire-utils` (and notably `wpctl status`) don't.

## Documentation

This would align with how wireplumber detects insertion events.
https://github.com/PipeWire/wireplumber/blob/cb92ef9846e2b2f827e1831515bc3a31e7d2ed1a/src/scripts/device/select-routes.lua#L11

Why the test data was directly modified: EnumRoute and Route seem to share the exact same schema, just updated based on different events. 

## Tests

Unit tests

Regular laptop: https://certification.canonical.com/hardware/202503-36476/submission/500627/

The desktop in question: https://certification.canonical.com/hardware/202607-39073/submission/500626/