### PR TITLE
Clean and bugfix session reset (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -318,7 +318,13 @@ class RemoteController(ReportsStage, MainLoopStage):
                     # clean is used to recover from the sa being in a weird
                     # unrecoverable state
                     if self._clean:
-                        self._sa.reset_session()
+                        try:
+                            self._sa.reset_session()
+                        except AttributeError:
+                            # backward compatibility with older agents
+                            # Note: this method is not as good, it doesn't reload
+                            #       the units
+                            self._sa._reset_sa()
                     # TODO: REMOTE API RAPI: Remove this API on the next RAPI bump
                     # the check and bailout is not needed if the agent as up to
                     # date as this controller, so after bumping RAPI we can assume

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -21,7 +21,6 @@ functionality.
 """
 
 import contextlib
-import getpass
 import gettext
 import ipaddress
 import json
@@ -36,11 +35,9 @@ import itertools
 
 from collections import namedtuple
 from contextlib import suppress
-from functools import partial
 from tempfile import SpooledTemporaryFile
 
 from plainbox.abc import IJobResult
-from plainbox.impl.result import MemoryJobResult
 from plainbox.impl.color import Colorizer
 from plainbox.impl.config import Configuration
 from plainbox.impl.session.state import SessionMetaData
@@ -178,6 +175,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         self._override_exporting(self.local_export)
         self._launcher_text = ""
         self._has_anything_failed = False
+        self._clean = ctx.args.clean
         self._target_host = ctx.args.host
         self._normal_user = ""
         self.launcher = Configuration()
@@ -283,7 +281,6 @@ class RemoteController(ReportsStage, MainLoopStage):
         spinner = itertools.cycle("-\\|/")
         #  this tracks the disconnection time
         disconnection_time = 0
-        connection_strategy = self.connection_strategy()
         while True:
             try:
                 if interrupted:
@@ -318,6 +315,10 @@ class RemoteController(ReportsStage, MainLoopStage):
                         conn.root.register_controller_blaster(quitter)
                     self._sa = conn.root.get_sa()
                     self.sa.conn = conn
+                    # clean is used to recover from the sa being in a weird
+                    # unrecoverable state
+                    if self._clean:
+                        self._sa.reset_session()
                     # TODO: REMOTE API RAPI: Remove this API on the next RAPI bump
                     # the check and bailout is not needed if the agent as up to
                     # date as this controller, so after bumping RAPI we can assume
@@ -416,6 +417,8 @@ class RemoteController(ReportsStage, MainLoopStage):
         - A job was in progress when the session was abandoned
         - The ongoing test was shell job
         """
+        if self._clean:
+            return False
         try:
             last_abandoned_session = next(self.sa.get_resumable_sessions())
         except StopIteration:
@@ -753,6 +756,14 @@ class RemoteController(ReportsStage, MainLoopStage):
         )
         parser.add_argument(
             "-u", "--user", help=_("normal user to run non-root jobs")
+        )
+        parser.add_argument(
+            "--clean",
+            action="store_true",
+            help=(
+                "Start a session from a clean slate (reset the agent and "
+                "don't try to resume)"
+            ),
         )
 
     def _handle_interrupt(self):

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -975,7 +975,7 @@ class ControllerTests(TestCase):
 
     def test_should_start_via_autoresume_true(self):
         last_session_mock = mock.MagicMock()
-        self_mock = mock.MagicMock()
+        self_mock = mock.MagicMock(_clean=False)
         self_mock.sa.get_resumable_sessions.return_value = iter(
             [last_session_mock]
         )
@@ -1011,7 +1011,7 @@ class ControllerTests(TestCase):
         )
 
     def test_should_start_via_autoresume_no_testplan_id_in_app_blob(self):
-        self_mock = mock.MagicMock()
+        self_mock = mock.MagicMock(_clean=False)
         last_session_mock = mock.MagicMock()
         self_mock.sa.get_resumable_sessions.return_value = iter(
             [last_session_mock]

--- a/checkbox-ng/checkbox_ng/launcher/test_controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_controller.py
@@ -326,7 +326,7 @@ class ControllerTests(TestCase):
         self.assertTrue(self_mock.resume_or_start_new_session.called)
 
     def test_resume_or_start_new_session_interactive(self):
-        self_mock = mock.MagicMock()
+        self_mock = mock.MagicMock(_clean=False)
         self_mock.should_start_via_autoresume.return_value = False
         self_mock.should_start_via_launcher.return_value = False
 
@@ -337,7 +337,7 @@ class ControllerTests(TestCase):
         )
 
     def test_resume_or_start_new_session_auto_last_session(self):
-        self_mock = mock.MagicMock()
+        self_mock = mock.MagicMock(_clean=False)
         self_mock.should_start_via_autoresume.return_value = True
         self_mock.should_start_via_launcher.return_value = False
 
@@ -346,7 +346,7 @@ class ControllerTests(TestCase):
         self.assertTrue(self_mock.resume_last_session_and_continue.called)
 
     def test_resume_or_start_new_session_auto_launcher(self):
-        self_mock = mock.MagicMock()
+        self_mock = mock.MagicMock(_clean=False)
         self_mock.should_start_via_autoresume.return_value = False
         self_mock.should_start_via_launcher.return_value = True
 
@@ -885,8 +885,15 @@ class ControllerTests(TestCase):
             },
         )
 
+    def test_should_start_via_autoresume_clean(self):
+        self_mock = mock.MagicMock(_clean=True)
+
+        self.assertFalse(
+            RemoteController.should_start_via_autoresume(self_mock)
+        )
+
     def test_should_start_via_launcher_true(self):
-        self_mock = mock.MagicMock()
+        self_mock = mock.MagicMock(_clean=False)
 
         def get_value_mock(top_level, attribute):
             if top_level == "test plan":
@@ -901,7 +908,7 @@ class ControllerTests(TestCase):
         self.assertTrue(RemoteController.should_start_via_launcher(self_mock))
 
     def test_should_start_via_launcher_false(self):
-        self_mock = mock.MagicMock()
+        self_mock = mock.MagicMock(_clean=False)
 
         def get_value_mock(top_level, attribute):
             if top_level == "test plan":
@@ -916,7 +923,7 @@ class ControllerTests(TestCase):
         self.assertFalse(RemoteController.should_start_via_launcher(self_mock))
 
     def test_should_start_via_launcher_exit(self):
-        self_mock = mock.MagicMock()
+        self_mock = mock.MagicMock(_clean=False)
 
         def get_value_mock(top_level, attribute):
             if top_level == "test plan":
@@ -974,7 +981,7 @@ class ControllerTests(TestCase):
         self.assertTrue(self_mock.sa.abandon_session.called)
 
     def test_should_start_via_autoresume_true(self):
-        last_session_mock = mock.MagicMock()
+        last_session_mock = mock.MagicMock(_clean=False)
         self_mock = mock.MagicMock(_clean=False)
         self_mock.sa.get_resumable_sessions.return_value = iter(
             [last_session_mock]
@@ -1001,7 +1008,7 @@ class ControllerTests(TestCase):
         self.assertTrue(self_mock.sa.bootstrap.called)
 
     def test_should_start_via_autoresume_no_resumable_sessions(self):
-        self_mock = mock.MagicMock()
+        self_mock = mock.MagicMock(_clean=False)
         self_mock.sa.get_resumable_sessions.return_value = iter(
             []
         )  # No resumable sessions
@@ -1029,7 +1036,7 @@ class ControllerTests(TestCase):
         self.assertTrue(self_mock.sa.abandon_session.called)
 
     def test_should_start_via_autoresume_no_running_job_name(self):
-        self_mock = mock.MagicMock()
+        self_mock = mock.MagicMock(_clean=False)
         last_session_mock = mock.MagicMock()
         self_mock.sa.get_resumable_sessions.return_value = iter(
             [last_session_mock]
@@ -1047,7 +1054,7 @@ class ControllerTests(TestCase):
         )
 
     def test_should_start_via_autoresume_job_plugin_not_shell(self):
-        self_mock = mock.MagicMock()
+        self_mock = mock.MagicMock(_clean=False)
         last_session_mock = mock.MagicMock()
         self_mock.sa.get_resumable_sessions.return_value = iter(
             [last_session_mock]

--- a/checkbox-ng/plainbox/impl/providers/v1.py
+++ b/checkbox-ng/plainbox/impl/providers/v1.py
@@ -127,3 +127,9 @@ class InsecureProvider1PlugInCollection(FsPlugInCollection):
 
 # Collection of all providers
 all_providers = InsecureProvider1PlugInCollection()
+
+
+def reload_all_providers():
+    global all_providers
+
+    all_providers = InsecureProvider1PlugInCollection()

--- a/checkbox-ng/plainbox/impl/secure/providers/v1.py
+++ b/checkbox-ng/plainbox/impl/secure/providers/v1.py
@@ -1995,3 +1995,9 @@ class SecureProvider1PlugInCollection(FsPlugInCollection):
 
 # Collection of all providers
 all_providers = SecureProvider1PlugInCollection()
+
+
+def reload_all_providers():
+    global all_providers
+
+    all_providers = SecureProvider1PlugInCollection()

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -16,42 +16,40 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 import fnmatch
+import gettext
 import io
 import json
-import gettext
 import logging
 import os
 import pwd
 import time
-import itertools
-from functools import wraps
 from collections import namedtuple
 from contextlib import suppress
 from enum import Enum
+from functools import wraps
 from tempfile import SpooledTemporaryFile
-from threading import Thread, Lock
-from enum import Enum
+from threading import Lock, Thread
 
-from plainbox.impl.config import Configuration
-from plainbox.impl.execution import UnifiedRunner
-from plainbox.impl.session.state import SessionMetaData
-from plainbox.impl.session.assistant import SessionAssistant
-from plainbox.impl.session.assistant import SA_RESTARTABLE
-from plainbox.impl.session.jobs import InhibitionCause
-from plainbox.impl.session.storage import WellKnownDirsHelper
-from plainbox.impl.secure.sudo_broker import is_passwordless_sudo
-from plainbox.impl.result import JobResultBuilder
-from plainbox.impl.result import MemoryJobResult
-from plainbox.impl.result_utils import determine_outcome_and_skip_reason
-from plainbox.abc import IJobResult
+import psutil
 
 from checkbox_ng.config import load_configs
 from checkbox_ng.launcher.run import SilentUI
-from checkbox_ng.user_utils import check_user_exists
-from checkbox_ng.user_utils import guess_normal_user
-
-
-import psutil
+from checkbox_ng.user_utils import check_user_exists, guess_normal_user
+from plainbox.abc import IJobResult
+from plainbox.impl.config import Configuration
+from plainbox.impl.execution import UnifiedRunner
+from plainbox.impl.providers.v1 import (
+    reload_all_providers as reload_all_insecure_providers,
+)
+from plainbox.impl.result import JobResultBuilder, MemoryJobResult
+from plainbox.impl.result_utils import determine_outcome_and_skip_reason
+from plainbox.impl.secure.providers.v1 import (
+    reload_all_providers as reload_all_secure_providers,
+)
+from plainbox.impl.secure.sudo_broker import is_passwordless_sudo
+from plainbox.impl.session.assistant import SessionAssistant
+from plainbox.impl.session.state import SessionMetaData
+from plainbox.impl.session.storage import WellKnownDirsHelper
 
 _ = gettext.gettext
 
@@ -211,12 +209,18 @@ class RemoteSessionAssistant:
         self._pipe_to_subproc = open(self._input_piping[0])
         self._sa = None  # type: SessionAssistant
         self._state = RemoteSessionStates.Idle
-        self._reset_sa()
+        self.reset_session()
         self._currently_running_job = None
 
-    def _reset_sa(self):
+    def reset_session(self):
         _logger.info("Resetting RSA")
         self._state = RemoteSessionStates.Idle
+
+        if self._sa:
+            reload_all_secure_providers()
+            reload_all_insecure_providers()
+            del self._sa
+
         self._sa = SessionAssistant()
         self._be = None
         self._session_id = ""
@@ -378,7 +382,7 @@ class RemoteSessionAssistant:
 
     @allowed_when(RemoteSessionStates.Idle)
     def start_session(self, configuration):
-        self._reset_sa()
+        self.reset_session()
         _logger.info("start_session: %r", configuration)
         session_title = "remote"
         session_desc = "remote session"
@@ -1002,10 +1006,10 @@ class RemoteSessionAssistant:
 
     def finalize_session(self):
         self._sa.finalize_session()
-        self._reset_sa()
+        self.reset_session()
 
     def abandon_session(self):
-        self._reset_sa()
+        self.reset_session()
 
     def transmit_input(self, text):
         if not text:

--- a/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_remote_assistant.py
@@ -517,7 +517,7 @@ class RemoteAssistantTests(TestCase):
     def test_abandon_session(self):
         self_mock = mock.MagicMock()
         RemoteSessionAssistant.abandon_session(self_mock)
-        self.assertTrue(self_mock._reset_sa.called)
+        self.assertTrue(self_mock.reset_session.called)
 
     def test_delete_sessions(self):
         self_mock = mock.MagicMock()


### PR DESCRIPTION
## Description

This adds a new `--clean` option to the `checkbox-cli control` command to force cleanup and reset of an agent. When this option is used:
- No session is resumed
- The agent is brought back to a (semi-)clean state so even if it was stuck in a weird state, reconnection is now possible

This also fixes a very long standing bug we thought was a feature: when a unit is changed and the agent is not restarted before starting a new session with the controller, the unit is not reloaded. We thought this was intended but actually this is entirely incidental (and a bad behaviour) that stems from the fact that the units are loaded at import time (yuck) and "cached" globally in the module. I've decided to add a reset function instead of removing this abomination because I'm scared of what could happen if I do.

## Resolved issues

Fixes: CHECKBOX-2309

## Documentation

Added help command

## Tests

Adjusted tests
