### PR TITLE
Add group and order for manual test jobs (BugFix)

### DIFF
--- a/providers/base/units/audio/jobs.pxu
+++ b/providers/base/units/audio/jobs.pxu
@@ -78,6 +78,7 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/{index}_playback_hdmi_{product_slug}
 template-id: audio/index_playback_hdmi_product_slug
+group: monitor_external_output
 estimated_duration: 30.0
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -113,6 +114,7 @@ _verification:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/playback_hdmi
+group: monitor_external_output
 estimated_duration: 30.0
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -152,6 +154,7 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/{index}_playback_displayport_{product_slug}
 template-id: audio/index_playback_displayport_product_slug
+group: monitor_external_output
 estimated_duration: 30.0
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -187,6 +190,7 @@ _verification:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/playback_displayport
+group: monitor_external_output
 estimated_duration: 30.0
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -265,6 +269,7 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/{index}_playback_thunderbolt3_{product_slug}
 template-id: audio/index_playback_thunderbolt3_product_slug
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 estimated_duration: 30.0
 requires:
@@ -300,6 +305,7 @@ _verification:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/playback_thunderbolt3
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 estimated_duration: 30.0
 requires:
@@ -339,6 +345,7 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/{index}_playback_type-c_displayport_{product_slug}
 template-id: audio/index_playback_type-c_displayport_product_slug
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 estimated_duration: 30.0
 requires:
@@ -374,6 +381,7 @@ _verification:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/playback_type-c_displayport
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 estimated_duration: 30.0
 requires:
@@ -413,6 +421,7 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/{index}_playback_type-c_hdmi_{product_slug}
 template-id: audio/index_playback_type-c_hdmi_product_slug
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 estimated_duration: 30.0
 requires:
@@ -450,6 +459,7 @@ _summary:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/playback_type-c_hdmi
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 estimated_duration: 30.0
 requires:
@@ -488,6 +498,8 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 flags: also-after-suspend
 id: audio/playback_headphones
+group: audio_external_jack
+after: audio/speaker-headphone-plug-detection
 estimated_duration: 20.0
 depends: audio/list_devices
 imports: from com.canonical.plainbox import manifest
@@ -566,6 +578,7 @@ _summary: Test internal microphone recording and playback functionality.
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/alsa_record_playback_external
+group: audio_external_jack
 flags: also-after-suspend
 estimated_duration: 20.0
 depends: audio/playback_headphones
@@ -770,6 +783,7 @@ _summary: Verify acceptable volume levels on the system for all sources and sink
 plugin: manual
 category_id: com.canonical.plainbox::audio
 id: audio/external-lineout
+group: audio_external_jack
 flags: also-after-suspend
 estimated_duration: 30.0
 imports: from com.canonical.plainbox import manifest
@@ -791,6 +805,7 @@ _summary: Verify external line out connection functionality by inserting a cable
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::audio
 id: audio/external-linein
+group: audio_external_jack
 flags: also-after-suspend
 estimated_duration: 120.0
 imports: from com.canonical.plainbox import manifest
@@ -830,6 +845,7 @@ _summary: Verify external line-in connection functionality by recording and play
 plugin: user-interact
 category_id: com.canonical.plainbox::audio
 id: audio/speaker-headphone-plug-detection
+group: audio_external_jack
 flags: also-after-suspend
 estimated_duration: 60.0
 imports: from com.canonical.plainbox import manifest
@@ -859,6 +875,8 @@ _summary: Ensure the system automatically detects when speakers or headphones ar
 plugin: user-interact
 category_id: com.canonical.plainbox::audio
 id: audio/microphone-plug-detection
+group: audio_external_jack
+after: audio/playback_headphones
 flags: also-after-suspend
 estimated_duration: 60.0
 imports: from com.canonical.plainbox import manifest

--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -96,6 +96,7 @@ _summary: Verify the capability to transfer files through a Bluetooth connection
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::bluetooth
 id: bluetooth/audio-a2dp
+group: bluetooth_basic
 depends: bluetooth/detect-output
 flags: also-after-suspend
 estimated_duration: 120.0
@@ -210,6 +211,7 @@ _summary: Conduct an automated Bluetooth file transfer stress test ensuring file
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::bluetooth
 id: bluetooth4/HOGP-mouse
+group: bluetooth_basic
 depends: bluetooth/detect-output
 flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
@@ -232,6 +234,7 @@ _summary:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::bluetooth
 id: bluetooth4/HOGP-keyboard
+group: bluetooth_basic
 depends: bluetooth/detect-output
 flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
@@ -468,6 +471,7 @@ _purpose: This is an automated Bluetooth file transfer test. It sends an image t
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::bluetooth
 id: bluetooth/audio_record_playback
+group: bluetooth_basic
 depends: bluetooth/detect-output
 estimated_duration: 120.0
 flags: also-after-suspend

--- a/providers/base/units/camera/jobs.pxu
+++ b/providers/base/units/camera/jobs.pxu
@@ -47,6 +47,7 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::camera
 id: camera/display_{name}
 template-id: camera/display_name
+group: camera_basic
 flags: also-after-suspend
 _summary: Webcam video display test for {product_slug}
 estimated_duration: 120.0
@@ -68,6 +69,7 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::camera
 id: camera/led_{name}
 template-id: camera/led_name
+group: camera_basic
 _summary: Webcam LED test for {product_slug}
 estimated_duration: 120.0
 imports: from com.canonical.plainbox import manifest
@@ -93,6 +95,7 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::camera
 id: camera/still_{name}
 template-id: camera/still_name
+group: camera_basic
 flags: also-after-suspend
 _summary: Webcam still image capture test for {product_slug}
 estimated_duration: 120.0

--- a/providers/base/units/ethernet/jobs.pxu
+++ b/providers/base/units/ethernet/jobs.pxu
@@ -326,6 +326,7 @@ template-filter: device.category == 'NETWORK' and device.interface != 'UNKNOWN'
 template-engine: jinja2
 id: ethernet/hotplug-{{ interface }}
 template-id: ethernet/hotplug-interface
+depends: ethernet/detect
 _summary: Ensure hotplugging works on port {{ interface }}
 _purpose:
  Check that hotplugging works on port {{ interface }}

--- a/providers/base/units/fingerprint/jobs.pxu
+++ b/providers/base/units/fingerprint/jobs.pxu
@@ -1,6 +1,7 @@
 plugin: shell
 category_id: com.canonical.plainbox::fingerprint
 id: fingerprint/detect
+group: fingerprint_basic
 flags: also-after-suspend
 user: root
 command: fprintd-list "${SUDO_USER:-$NORMAL_USER}"
@@ -12,6 +13,7 @@ requires: manifest.has_fingerprint_reader == 'True'
 plugin: user-interact
 category_id: com.canonical.plainbox::fingerprint
 id: fingerprint/enroll
+group: fingerprint_basic
 flags: also-after-suspend
 depends: fingerprint/detect
 user: root
@@ -38,6 +40,7 @@ requires:
 plugin: user-interact
 category_id: com.canonical.plainbox::fingerprint
 id: fingerprint/verify-no-match
+group: fingerprint_basic
 flags: also-after-suspend
 depends: fingerprint/enroll
 user: root
@@ -61,6 +64,7 @@ requires:
 plugin: user-interact
 category_id: com.canonical.plainbox::fingerprint
 id: fingerprint/verify-match
+group: fingerprint_basic
 flags: also-after-suspend
 depends: fingerprint/verify-no-match
 user: root
@@ -90,6 +94,7 @@ requires:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::fingerprint
 id: fingerprint/unlock
+group: fingerprint_basic
 flags: also-after-suspend
 depends: fingerprint/verify-match
 user: root
@@ -114,6 +119,7 @@ requires:
 plugin: shell
 category_id: com.canonical.plainbox::fingerprint
 id: fingerprint/delete
+group: fingerprint_basic
 flags: also-after-suspend
 after: fingerprint/unlock
 user: root

--- a/providers/base/units/graphics/jobs.pxu
+++ b/providers/base/units/graphics/jobs.pxu
@@ -489,6 +489,7 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_valid_glxgears_{product_slug}
 template-id: graphics/index_valid_glxgears_product_slug
+group: graphic_glxgears
 flags: also-after-suspend
 requires:
     executable.name == 'glxgears'
@@ -541,6 +542,7 @@ plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 id: graphics/{index}_valid_glxgears_fullscreen_{product_slug}
 template-id: graphics/index_valid_glxgears_fullscreen_product_slug
+group: graphic_glxgears
 flags: also-after-suspend
 requires:
     executable.name == 'glxgears'
@@ -598,6 +600,7 @@ purpose:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 id: graphics/valid_glxgears
+group: graphic_glxgears
 flags: also-after-suspend
 user: root
 requires:
@@ -619,6 +622,7 @@ verification:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::graphics
 id: graphics/valid_glxgears_fullscreen
+group: graphic_glxgears
 flags: also-after-suspend
 user: root
 requires:

--- a/providers/base/units/mediacard/jobs.pxu
+++ b/providers/base/units/mediacard/jobs.pxu
@@ -33,6 +33,7 @@ _summary: Test Multimedia Card (MMC) insertion + read/write + removal.
 plugin: user-interact
 category_id: com.canonical.plainbox::mediacard
 id: mediacard/sdhc-storage-manual
+group: peripherals_manual
 flags: also-after-suspend
 estimated_duration: 30.0
 command:

--- a/providers/base/units/miscellanea/jobs.pxu
+++ b/providers/base/units/miscellanea/jobs.pxu
@@ -631,6 +631,7 @@ _verification:
 plugin: manual
 category_id: com.canonical.plainbox::miscellanea
 id: miscellanea/operation-system-installation
+before: suspend/suspend_advanced_auto
 estimated_duration: 30.0
 _purpose:
     Verify that the operating system can be installed successfully.
@@ -644,6 +645,7 @@ _verification:
 plugin: manual
 category_id: com.canonical.plainbox::miscellanea
 id: miscellanea/factory-recovery
+depends: miscellanea/operation-system-installation
 estimated_duration: 30.0
 _purpose:
     Verify that the factory recovery can be restored successfully.

--- a/providers/base/units/monitor/jobs.pxu
+++ b/providers/base/units/monitor/jobs.pxu
@@ -45,6 +45,7 @@ template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'
 id: monitor/{index}_displayport_{product_slug}
 template-id: monitor/index_displayport_product_slug
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_dp == 'True'
 flags: also-after-suspend
@@ -67,6 +68,7 @@ template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'
 id: monitor/{index}_hdmi_{product_slug}
 template-id: monitor/index_hdmi_product_slug
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_hdmi == 'True'
 flags: also-after-suspend
@@ -146,6 +148,7 @@ _summary:
     Verify multi-monitor output functionality on desktop systems.
 
 id: monitor/multi-head
+group: monitor_external_output
 requires: dmi.sane_product == "non-portable"
 flags: also-after-suspend
 plugin: manual
@@ -267,6 +270,7 @@ template-resource: graphics_card
 template-filter: graphics_card.prime_gpu_offload == 'Off'
 id: monitor/{index}_thunderbolt3_{product_slug}
 template-id: monitor/index_thunderbolt3_product_slug
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 flags: also-after-suspend
@@ -286,6 +290,7 @@ _verification:
     screen in every mode?
 
 id: monitor/thunderbolt3
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'
 flags: also-after-suspend
@@ -308,6 +313,7 @@ unit: template
 template-resource: graphics_card
 id: monitor/{index}_type-c_displayport_{product_slug}
 template-id: monitor/index_type-c_displayport_product_slug
+group: monitor_external_output
 template-filter: graphics_card.prime_gpu_offload == 'Off'
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -329,6 +335,7 @@ _verification:
     connected using a "USB Type-C to DisplayPort" adapter in every mode?
 
 id: monitor/type-c_displayport
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 requires:
   manifest.has_usbc_video == 'True'
@@ -352,6 +359,7 @@ unit: template
 template-resource: graphics_card
 id: monitor/{index}_type-c_hdmi_{product_slug}
 template-id: monitor/index_type-c_hdmi_product_slug
+group: monitor_external_output
 template-filter: graphics_card.prime_gpu_offload == 'Off'
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -373,6 +381,7 @@ _verification:
     connected using a "USB Type-C to HDMI" adapter in every mode?
 
 id: monitor/type-c_hdmi
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 requires:
   manifest.has_usbc_video == 'True'
@@ -396,6 +405,7 @@ unit: template
 template-resource: graphics_card
 id: monitor/{index}_type-c_vga_{product_slug}
 template-id: monitor/index_type-c_vga_product_slug
+group: monitor_external_output
 template-filter: graphics_card.prime_gpu_offload == 'Off'
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -417,6 +427,7 @@ _verification:
     connected using a "USB Type-C to VGA" adapter in every mode?
 
 id: monitor/type-c_vga
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 requires:
   manifest.has_usbc_video == 'True'
@@ -477,6 +488,7 @@ _verification:
     "USB Type-C to VGA" adapter in every mode?
 
 id: monitor/dvi
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_dvi == 'True'
 flags: also-after-suspend
@@ -494,6 +506,7 @@ _verification:
 _summary: Check DVI port functionality by connecting a display and verifying different display modes.
 
 id: monitor/hdmi
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_hdmi == 'True'
 flags: also-after-suspend
@@ -511,6 +524,7 @@ _verification:
 _summary: Check HDMI port functionality as a monitor interconnect.
 
 id: monitor/displayport
+group: monitor_external_output
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_dp == 'True'
 flags: also-after-suspend

--- a/providers/base/units/thunderbolt/jobs.pxu
+++ b/providers/base/units/thunderbolt/jobs.pxu
@@ -50,6 +50,7 @@ _verification:
 plugin: user-interact
 category_id: com.canonical.plainbox::disk
 id: thunderbolt3/storage-manual
+group: peripherals_manual
 flags: also-after-suspend
 user: root
 imports: from com.canonical.plainbox import manifest
@@ -77,6 +78,7 @@ _verification:
 plugin: user-interact-verify
 category_id: com.canonical.plainbox::disk
 id: thunderbolt3/daisy-chain
+group: monitor_external_output
 user: root
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_thunderbolt3 == 'True'

--- a/providers/base/units/touchpad/jobs.pxu
+++ b/providers/base/units/touchpad/jobs.pxu
@@ -1,6 +1,7 @@
 plugin: manual
 category_id: com.canonical.plainbox::touchpad
 id: touchpad/basic
+group: touchpad_basic
 flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -78,6 +79,8 @@ _siblings:
 plugin: manual
 category_id: com.canonical.plainbox::touchpad
 id: touchpad/singletouch-selection
+group: touchpad_basic
+depends: touchpad/basic
 flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -94,6 +97,8 @@ _verification:
 plugin: manual
 category_id: com.canonical.plainbox::touchpad
 id: touchpad/multitouch-rightclick
+group: touchpad_basic
+depends: touchpad/basic
 flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -116,6 +121,8 @@ _summary:
 plugin: user-interact
 category_id: com.canonical.plainbox::touchpad
 id: touchpad/multitouch
+group: touchpad_basic
+depends: touchpad/basic
 flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -137,6 +144,8 @@ _summary: Test the touchpad's 2-finger scroll functionality.
 plugin: manual
 category_id: com.canonical.plainbox::touchpad
 id: touchpad/drag-and-drop
+group: touchpad_basic
+depends: touchpad/basic
 flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -212,6 +221,8 @@ _summary: Check if the touchpad is recognized as a mouse by the system.
 plugin: user-interact
 category_id: com.canonical.plainbox::touchpad
 id: touchpad/continuous-move
+group: touchpad_basic
+depends: touchpad/basic
 flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
 requires:
@@ -253,6 +264,8 @@ _purpose:
     make sure that firmware/labeling bit is set in touchpad firmware.
 
 id: touchpad/palm-rejection
+group: touchpad_basic
+depends: touchpad/basic
 flags: also-after-suspend
 plugin: user-interact
 category_id: com.canonical.plainbox::touchpad

--- a/providers/base/units/usb-dwc3/jobs.pxu
+++ b/providers/base/units/usb-dwc3/jobs.pxu
@@ -33,6 +33,7 @@ command:
   echo "dwc3_pci module loaded"
 
 id: usb-dwc3/mass-storage
+group: peripherals_manual
 _summary: Check DUT can be detected as mass storage device
 _purpose:
   Check that after connecting the device under test (DUT) to another device
@@ -61,6 +62,7 @@ estimated_duration: 5m
 flags: preserve-locale
 
 id: usb-dwc3/mass-storage-cleanup
+group: peripherals_manual
 _summary: Cleanup mass storage setup after mass storage device test
 plugin: shell
 after: usb-dwc3/mass-storage

--- a/providers/base/units/usb/usb-c.pxu
+++ b/providers/base/units/usb/usb-c.pxu
@@ -1,4 +1,5 @@
 id: usb-c/c-to-a-adapter/hid
+group: peripherals_manual
 _summary: USB HID work on USB Type-C port using a "USB Type-C to Type-A" adapter
 _purpose:
      This test will check that you can use a USB HID device plugged in a USB
@@ -17,6 +18,7 @@ requires: manifest.has_usbc_data == 'True'
 estimated_duration: 60
 
 id: usb-c/c-to-a-adapter/storage-manual
+group: peripherals_manual
 _summary: 
     Test USB 3 storage device insertion + read/write + removal using a "Type-C to Type-A" adapter.
 _purpose:
@@ -52,6 +54,7 @@ requires:
 estimated_duration: 120
 
 id: usb-c/storage-manual
+group: peripherals_manual
 _summary: USB 3.0 storage device insertion + read/write + removal on USB Type-C port
 _purpose:
     This test will check that the system correctly detects the insertion of
@@ -84,6 +87,7 @@ requires:
 estimated_duration: 120
 
 id: usb-c/c-to-ethernet-adapter-insert
+group: peripherals_manual
 plugin: user-interact
 flags: also-after-suspend
 category_id: com.canonical.plainbox::usb

--- a/providers/base/units/usb/usb.pxu
+++ b/providers/base/units/usb/usb.pxu
@@ -52,6 +52,7 @@ _verification:
 _summary: Verify USB HID devices functionality by performing specified actions.
 
 id: usb/storage-manual
+group: peripherals_manual
 flags: also-after-suspend fail-on-resource
 _summary: Test USB 2.0 storage device insertion + read/write + removal.
 _purpose:
@@ -79,6 +80,7 @@ category_id: com.canonical.plainbox::usb
 estimated_duration: 120
 
 id: usb3/storage-manual
+group: peripherals_manual
 flags: also-after-suspend
 requires:
  usb.usb3 == 'supported'
@@ -257,6 +259,7 @@ _purpose:
 depends: usb/storage-detect
 
 id: usb/hid
+group: peripherals_manual
 _summary: USB keyboard works
 _purpose:
  Check USB input device works


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
This PR fixes the random ordering of manual tests by adding group, depends, and after tags to various jobs.

Previously, the Checkbox scheduler would jump back and forth between unrelated hardware tests. This update forces Checkbox to run related tests together in a logical sequence, making manual testing much faster and smoother for engineers.

**Change Summary**

- Added group fields to manual/provider jobs so related manual tests can be selected and handled more flexibly.
- Grouped external monitor/audio-output jobs under `monitor_external_output`.
- Grouped external audio jack jobs under `audio_external_jack`.
- Grouped Bluetooth manual checks under `bluetooth_basic`.
- Grouped fingerprint jobs under` fingerprint_basic`.
- Grouped touchpad jobs under` touchpad_basic`.
- Grouped USB, USB-C, media card, Thunderbolt storage, and USB DWC3 manual peripheral jobs under `peripherals_manual`.
- Added dependency/order relationships so prerequisite checks run before dependent manual tests:
  -   Touchpad gesture tests now depend on` touchpad/basic`.
  -   Ethernet hotplug template now depends on `ethernet/detect`.
  -   Factory recovery now depends on OS installation.
  -   OS installation is ordered before advanced suspend.
  -   Some audio jack checks now have explicit after ordering.

07/21 added
- Grouped camera jobs under 'camera_basic'.
- Grouped glxgears jobs under 'graphic_glxgears'.

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues
https://warthogs.atlassian.net/browse/OEMQA-6805
<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
**2026/07/17 result**

- 24.04 manual test
[0717_2404_manual_group.txt](https://github.com/user-attachments/files/30112806/0717_2404_manual_group.txt)
https://certification.canonical.com/hardware/202601-38305/submission/500746/

- 26.04 manual test
[0717_2604_manual_group.txt](https://github.com/user-attachments/files/30112814/0717_2604_manual_group.txt)
https://certification.canonical.com/hardware/202601-38305/submission/500730/

**2026/07/21 result**

- 24.04 manual test
[24_0721_add_camera_glxgears.txt](https://github.com/user-attachments/files/30214976/24_0721_add_camera_glxgears.txt)

- 26.04 manual test
[26_0721_add_camera_glxgears.txt](https://github.com/user-attachments/files/30214980/26_0721_add_camera_glxgears.txt)
https://certification.canonical.com/hardware/202601-38305/submission/501054/


<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
