### PR TITLE
Unit tests and minor fixes for network.py (New)

### DIFF
--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -87,7 +87,8 @@ class IPerfPerformanceTest:
         self.scan_timeout = scan_timeout
         self.iface_timeout = iface_timeout
         self.reverse = reverse
-        self.results = []  # type: list[str]
+
+        self._results = []  # type: list[str]
         self._results_lock = threading.Lock()
 
     def run_one_thread(self, cmd: str, port_num: int):
@@ -137,14 +138,14 @@ class IPerfPerformanceTest:
                 logging.warning("iperf timed out - this should be OK")
                 iperf_return = iperf_exception.output
         with self._results_lock:
-            self.results.append(iperf_return)
+            self._results.append(iperf_return)
 
     def summarize_speeds(self):
         """Search self.results[], computing the throughput for each thread
         and returning the total throughput for all threads."""
         total_throughput = 0
         n = 0
-        for run in self.results:
+        for run in self._results:
             logging.debug(run)
             # iperf3 provides "sender" and "receiver" summaries; remove them
             run = re.sub(r".*(sender|receiver)", "", run)
@@ -176,7 +177,7 @@ class IPerfPerformanceTest:
         sum_cpu = 0.0
         avg_cpu = 0.0
         n = 0
-        for thread_results in self.results:
+        for thread_results in self._results:
             # "CPU Utilization" line present only in iperf3 output
             new_cpu = re.findall(
                 r"CPU Utilization.*local/sender\s([\w\.]+)", thread_results
@@ -339,7 +340,7 @@ class IPerfPerformanceTest:
         # Handle threading -- start Python threads (even if just one is
         # used), then use join() to wait for them all to complete....
         t = []
-        self.results.clear()
+        self._results.clear()
         for thread_num in range(0, python_threads):
             if self.iperf3 and len(core_list) > 0:
                 core = core_list[thread_num % len(core_list)]

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -69,7 +69,9 @@ class IPerfPerformanceTest:
         iperf3: str,
         num_threads: int,
         reverse: bool,
-        protocol: "t.Literal['tcp', 'udp']" = "tcp",
+        # the following are never used anywhere
+        # so their types are basically guesswork
+        protocol: "t.Literal['tcp', 'udp']" = "tcp", 
         data_size: int = 1,
         run_time: "int | None" = None,
         scan_timeout: int = 3600,
@@ -199,10 +201,9 @@ class IPerfPerformanceTest:
         :return: node int, from /sys/class/net/<device>/device/numa_node
                  returns -1 if unsupported
         """
-        filename = (Path("/sys/class/net/") / device) / "device" / "numa_node"
+        filename = Path("/sys/class/net/") / device / "device" / "numa_node"
         try:
-            with open(filename, "r") as file:
-                node_num = int(file.read())
+            node_num = int(filename.read_text().strip())
         except FileNotFoundError:
             node_num = -1
         # Some systems (that don't support NUMA?) produce a node_num of -1.
@@ -672,7 +673,7 @@ def can_ping(the_interface, test_target):
     return working_interface
 
 
-def run_test(args, test_target):
+def run_test(args: Namespace, test_target: str):
     # Ensure that interface is fully up by waiting until it can
     # ping the test server
     logging.info("Testing {} against {}".format(args.interface, test_target))
@@ -732,7 +733,7 @@ def run_test(args, test_target):
     return error_number
 
 
-def make_target_list(iface, test_targets, log_warnings):
+def make_target_list(iface: str, test_targets: str, log_warnings: bool):
     """Convert comma-separated string of test targets into a list form.
 
     Converts test target list in string form into Python list form, omitting
@@ -1007,7 +1008,7 @@ def interface_test(args: Namespace):
             args.interface, test_targets, True
         )
     else:
-        test_targets = None
+        test_targets = ''
         test_targets_list = []
 
     # Validate that we got reasonable values

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -54,7 +54,7 @@ SIOCGIFNETMASK = 0x891B
 
 class IPerfPerformanceTest:
     """Measures performance of interface using iperf client
-    and target. Calculated speed is measured against theorectical
+    and target. Calculated speed is measured against theoretical
     throughput of selected interface"""
 
     def __init__(

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -48,12 +48,9 @@ import sys
 import time
 import typing as t
 
-# Global results[] variable to pass results from multiple threads....
-results = []
-
-
 ETH_P_IBOE = 0x8915
 SIOCGIFNETMASK = 0x891B
+
 
 class IPerfPerformanceTest:
     """Measures performance of interface using iperf client
@@ -71,7 +68,7 @@ class IPerfPerformanceTest:
         reverse: bool,
         # the following are never used anywhere
         # so their types are basically guesswork
-        protocol: "t.Literal['tcp', 'udp']" = "tcp", 
+        protocol: "t.Literal['tcp', 'udp']" = "tcp",
         data_size: int = 1,
         run_time: "int | None" = None,
         scan_timeout: int = 3600,
@@ -90,10 +87,11 @@ class IPerfPerformanceTest:
         self.scan_timeout = scan_timeout
         self.iface_timeout = iface_timeout
         self.reverse = reverse
+        self.results = []  # type: list[str]
+        self._results_lock = threading.Lock()
 
     def run_one_thread(self, cmd: str, port_num: int):
-        """Run a single test thread, storing the output in the global results[]
-        variable."""
+        """Run a single test thread, storing the output in self.results[]."""
         cmd = cmd + " -p {}".format(port_num)
         logging.debug("Executing command {}".format(cmd))
         logging.info("Connecting to port {} on server....".format(port_num))
@@ -138,14 +136,15 @@ class IPerfPerformanceTest:
                 # a partial (but usable) result.
                 logging.warning("iperf timed out - this should be OK")
                 iperf_return = iperf_exception.output
-        results.append(iperf_return)
+        with self._results_lock:
+            self.results.append(iperf_return)
 
     def summarize_speeds(self):
-        """Search the global results[] variable, computing the throughput for
-        each thread and returning the total throughput for all threads."""
+        """Search self.results[], computing the throughput for each thread
+        and returning the total throughput for all threads."""
         total_throughput = 0
         n = 0
-        for run in results:
+        for run in self.results:
             logging.debug(run)
             # iperf3 provides "sender" and "receiver" summaries; remove them
             run = re.sub(r".*(sender|receiver)", "", run)
@@ -177,7 +176,7 @@ class IPerfPerformanceTest:
         sum_cpu = 0.0
         avg_cpu = 0.0
         n = 0
-        for thread_results in results:
+        for thread_results in self.results:
             # "CPU Utilization" line present only in iperf3 output
             new_cpu = re.findall(
                 r"CPU Utilization.*local/sender\s([\w\.]+)", thread_results
@@ -340,7 +339,7 @@ class IPerfPerformanceTest:
         # Handle threading -- start Python threads (even if just one is
         # used), then use join() to wait for them all to complete....
         t = []
-        results.clear()
+        self.results.clear()
         for thread_num in range(0, python_threads):
             if self.iperf3 and len(core_list) > 0:
                 core = core_list[thread_num % len(core_list)]
@@ -1008,7 +1007,7 @@ def interface_test(args: Namespace):
             args.interface, test_targets, True
         )
     else:
-        test_targets = ''
+        test_targets = ""
         test_targets_list = []
 
     # Validate that we got reasonable values

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -46,30 +46,31 @@ from contextlib import contextmanager, suppress
 from pathlib import Path
 import sys
 import time
+import typing as t
 
 # Global results[] variable to pass results from multiple threads....
 results = []
 
 
-class IPerfPerformanceTest(object):
+class IPerfPerformanceTest:
     """Measures performance of interface using iperf client
     and target. Calculated speed is measured against theorectical
     throughput of selected interface"""
 
     def __init__(
         self,
-        interface,
-        target,
-        fail_threshold,
-        cpu_load_fail_threshold,
-        iperf3,
-        num_threads,
-        reverse,
-        protocol="tcp",
-        data_size="1",
-        run_time=None,
-        scan_timeout=3600,
-        iface_timeout=120,
+        interface: str,
+        target: str,
+        fail_threshold: float,
+        cpu_load_fail_threshold: float,
+        iperf3: str,
+        num_threads: int,
+        reverse: bool,
+        protocol: "t.Literal['tcp', 'udp']" = "tcp",
+        data_size: int = 1,
+        run_time: "int | None" = None,
+        scan_timeout: int = 3600,
+        iface_timeout: int = 120,
     ):
 
         self.iface = Interface(interface)
@@ -86,7 +87,7 @@ class IPerfPerformanceTest(object):
         self.iface_timeout = iface_timeout
         self.reverse = reverse
 
-    def run_one_thread(self, cmd, port_num):
+    def run_one_thread(self, cmd: str, port_num: int):
         """Run a single test thread, storing the output in the global results[]
         variable."""
         cmd = cmd + " -p {}".format(port_num)
@@ -199,8 +200,9 @@ class IPerfPerformanceTest(object):
         # to iperf3, thus disabling NUMA features.
         if node_num == -1:
             logging.warning(
-                "WARNING: Could not find the NUMA node "
-                "associated with {}!".format(device)
+                "WARNING: Could not find the NUMA node associated with {}!".format(
+                    device
+                )
             )
         else:
             logging.info("NUMA node of {} is {}....".format(device, node_num))
@@ -445,7 +447,6 @@ class IPerfPerformanceTest(object):
 
 
 class StressPerformanceTest:
-
     def __init__(self, interface, target, iperf3):
         self.interface = interface
         self.target = target
@@ -495,7 +496,7 @@ class Interface(socket.socket):
     Simple class that provides network interface information.
     """
 
-    def __init__(self, interface):
+    def __init__(self, interface: str):
 
         super(Interface, self).__init__(socket.AF_INET, socket.IPPROTO_ICMP)
 
@@ -847,13 +848,13 @@ def check_underspeed(iface):
         and network_if.max_speed != 0
     ):
         logging.error(
-            "Detected link speed ({}) is lower than detected max "
-            "speed ({})".format(network_if.link_speed, network_if.max_speed)
+            "Detected link speed ({}) is lower than detected max speed ({})".format(
+                network_if.link_speed, network_if.max_speed
+            )
         )
         logging.error("Check your device configuration and try again.")
         logging.error(
-            "If you want to override and test despite this "
-            "under-speed link, use"
+            "If you want to override and test despite this under-speed link, use"
         )
         logging.error("the --underspeed-ok option.")
         return True
@@ -995,19 +996,18 @@ def interface_test(args):
         # Default values found in config file
         logging.error("Valid target server has not been supplied.")
         logging.error(
-            "Configuration settings can be configured 3 different " "ways:"
+            "Configuration settings can be configured 3 different ways:"
         )
         logging.error(
-            "1- If calling the script directly, pass the --target " "option"
+            "1- If calling the script directly, pass the --target option"
         )
         logging.error("2- Define the TEST_TARGET_IPERF environment variable")
         logging.error(
-            "3- If running the test via checkbox/plainbox, define " "the "
+            "3- If running the test via checkbox/plainbox, define the "
         )
         logging.error("target in /etc/xdg/canonical-certification.conf")
         logging.error(
-            "Please run this script with -h to see more details on "
-            "how to configure"
+            "Please run this script with -h to see more details on how to configure"
         )
         sys.exit(1)
 
@@ -1304,7 +1304,7 @@ TEST_TARGET_IPERF = iperf-server.example.com
         and not args.iperf3
     ):
         parser.error(
-            "--cpu-load-fail-threshold can only be set with " "--iperf3."
+            "--cpu-load-fail-threshold can only be set with --iperf3."
         )
 
     if args.debug:

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -212,9 +212,8 @@ class IPerfPerformanceTest:
         # to iperf3, thus disabling NUMA features.
         if node_num == -1:
             logging.warning(
-                "WARNING: Could not find the NUMA node associated with {}!".format(
-                    device
-                )
+                "WARNING: Could not find the NUMA node "
+                + "associated with {}!".format(device)
             )
         else:
             logging.info("NUMA node of {} is {}....".format(device, node_num))
@@ -867,14 +866,11 @@ def check_underspeed(iface):
         and network_if.max_speed != 0
     ):
         logging.error(
-            "Detected link speed ({}) is lower than detected max speed ({})".format(
-                network_if.link_speed, network_if.max_speed
-            )
+            "Detected link speed ({}) is lower ".format(network_if.link_speed)
+            + "than detected max speed ({})".format(network_if.max_speed)
         )
         logging.error("Check your device configuration and try again.")
-        logging.error(
-            "If you want to override and test despite this under-speed link, use"
-        )
+        logging.error("If you want to test despite this under-speed link, use")
         logging.error("the --underspeed-ok option.")
         return True
     return False
@@ -1028,7 +1024,7 @@ def interface_test(args: Namespace):
         )
         logging.error("target in /etc/xdg/canonical-certification.conf")
         logging.error(
-            "Please run this script with -h to see more details on how to configure"
+            "Please run with -h to see more details on how to configure"
         )
         sys.exit(1)
 

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -52,6 +52,9 @@ import typing as t
 results = []
 
 
+ETH_P_IBOE = 0x8915
+SIOCGIFNETMASK = 0x891B
+
 class IPerfPerformanceTest:
     """Measures performance of interface using iperf client
     and target. Calculated speed is measured against theorectical
@@ -509,21 +512,24 @@ class Interface(socket.socket):
         super(Interface, self).__init__(socket.AF_INET, socket.IPPROTO_ICMP)
 
         self.interface = interface
+        self.dev_path = Path("/sys/class/net") / interface
 
-        self.dev_path = os.path.join("/sys/class/net", self.interface)
+        if not self.dev_path.exists():
+            raise FileNotFoundError("Not such interface: " + interface)
 
-    def _read_data(self, type):
+    def _read_data(self, attribute: str):
         try:
-            return open(os.path.join(self.dev_path, type)).read().strip()
+            # use .read_text to have file automatically close itself
+            return (self.dev_path / attribute).read_text().strip()
         except OSError:
-            logging.warning("%s: Attribute not found", type)
+            logging.warning("%s: Attribute not found", attribute)
 
     @property
     def ipaddress(self):
         freq = struct.pack("256s", self.interface[:15].encode())
 
         try:
-            nic_data = fcntl.ioctl(self.fileno(), 0x8915, freq)
+            nic_data = fcntl.ioctl(self.fileno(), ETH_P_IBOE, freq)
         except IOError:
             logging.error("No IP address for %s", self.interface)
             return None
@@ -534,7 +540,7 @@ class Interface(socket.socket):
         freq = struct.pack("256s", self.interface.encode())
 
         try:
-            mask_data = fcntl.ioctl(self.fileno(), 0x891B, freq)
+            mask_data = fcntl.ioctl(self.fileno(), SIOCGIFNETMASK, freq)
         except IOError:
             logging.error("No netmask for %s", self.interface)
             return None

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -6,6 +6,7 @@ Authors
   Jeff Marcom <jeff.marcom@canonical.com>
   Daniel Manrique <roadmr@ubuntu.com>
   Jeff Lane <jeff@ubuntu.com>
+  Zhongning Li <zhongning.li@canonical.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3,

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -995,7 +995,7 @@ def interface_test_initialize(
 
 
 def interface_test(args: Namespace):
-    if hasattr(args, "test_type"):
+    if not hasattr(args, "test_type"):
         return
 
     # Get the actual test data from one of two possible sources

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from argparse import ArgumentParser, RawTextHelpFormatter
+from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 import datetime
 import fcntl
 import ipaddress
@@ -72,7 +72,6 @@ class IPerfPerformanceTest:
         scan_timeout: int = 3600,
         iface_timeout: int = 120,
     ):
-
         self.iface = Interface(interface)
         self.interface = interface
         self.target = target
@@ -103,7 +102,9 @@ class IPerfPerformanceTest:
             if iperf_exception.returncode != 124:
                 # timeout command will return 124 if iperf timed out, so any
                 # other return value means something did fail
-                if "unable to connect to server" in iperf_exception.output:
+                if "unable to connect to server" in str(
+                    iperf_exception.output
+                ):
                     logging.error(
                         "Unable to connect to server on port {}".format(
                             port_num
@@ -187,9 +188,15 @@ class IPerfPerformanceTest:
                 avg_cpu = sum_cpu / n
         return avg_cpu
 
-    def find_numa(self, device):
-        """Return the NUMA node of the specified network device."""
-        filename = "/sys/class/net/" + device + "/device/numa_node"
+    def find_numa(self, device: str):
+        """
+        Return the NUMA node of the specified network device.
+
+        :param device: device name like eno1
+        :return: node int, from /sys/class/net/<device>/device/numa_node
+                 returns -1 if unsupported
+        """
+        filename = (Path("/sys/class/net/") / device) / "device" / "numa_node"
         try:
             with open(filename, "r") as file:
                 node_num = int(file.read())
@@ -208,12 +215,14 @@ class IPerfPerformanceTest:
             logging.info("NUMA node of {} is {}....".format(device, node_num))
         return node_num
 
-    def extract_core_list(self, line):
-        """Extract a list of CPU cores from a line of the form:
-        NUMA node# CPU(s):    a-b[,c-d[,...]]"""
+    def extract_core_list(self, line: str):
+        """
+        Extract a list of CPU cores from a line of the form:
+        NUMA node# CPU(s):    a-b[,c-d[,...]]
+        """
         colon = line.find(":")
         cpu_list = line[colon + 1 :]
-        core_list = []
+        core_list = []  # type: list[int]
         for core_range in cpu_list.split(","):
             # Skip it if the CPU list for the NUMA node is empty....
             core_range = core_range.strip()
@@ -237,7 +246,7 @@ class IPerfPerformanceTest:
         logging.debug("Will use CPU cores: {}....".format(core_list))
         return core_list
 
-    def find_cores(self, numa_node):
+    def find_cores(self, numa_node: int) -> "list[int]":
         """Return a list of CPU cores tied to the specified NUMA node."""
         numa_return = check_output(
             "lscpu", universal_newlines=True, stderr=STDOUT
@@ -245,9 +254,7 @@ class IPerfPerformanceTest:
         # Note: If numa_node = -1, the below will never find a match, so
         # core_list will remain empty, and later in the script, the -A option
         # to iperf3 will be dropped.
-        expression = "NUMA node.*" + str(numa_node) + ".*CPU"
-
-        regex = re.compile(expression)
+        regex = re.compile("NUMA node.*{}.*CPU".format(numa_node))
         core_list = []
         if numa_return:
             for i in numa_return:
@@ -261,7 +268,7 @@ class IPerfPerformanceTest:
         if self.iface.max_speed == 0:
             logging.warning(
                 "No max speed detected, assuming Wireless device "
-                "and continuing with test."
+                + "and continuing with test."
             )
 
         threads = self.num_threads
@@ -276,17 +283,18 @@ class IPerfPerformanceTest:
         # for running iperf -- but only one; within that thread, iperf 2's
         # own multi-threading handles that detail.)
         if self.iperf3:
-            self.executable = "iperf3 -V"
+            executable = "iperf3 -V"
             start_port = 5201
             iperf_threads = 1
             python_threads = threads
             node = self.find_numa(self.interface)
             core_list = self.find_cores(node)
         else:
-            self.executable = "iperf"
+            executable = "iperf"
             start_port = 5001
             iperf_threads = threads
             python_threads = 1
+            core_list = []
 
         # IN THEORY, limiting the per-thread bit rate should help spread the
         # load across all the threads and prevent huge discrepancies in CPU
@@ -300,7 +308,7 @@ class IPerfPerformanceTest:
         # If we set run_time, use that instead to build the command.
         if self.run_time is not None:
             cmd = "{} -b {}M -c {} -t {} -i 1 -f m -P {}".format(
-                self.executable,
+                executable,
                 thread_bit_rate,
                 self.target,
                 self.run_time,
@@ -315,10 +323,10 @@ class IPerfPerformanceTest:
             # or 1080 seconds per Gigabit. This will allow for a long period of
             # time without timeout to catch devices that slow down, and also
             # not prematurely end iperf on low-bandwidth devices.
-            self.timeout = 1080 * int(self.data_size)
+            timeout = 1080 * int(self.data_size)
             cmd = "timeout -k 1 {} {} -b {}M -c {} -n {}G -i 1 -f m -P {}".format(  # noqa: E501
-                self.timeout,
-                self.executable,
+                timeout,
+                executable,
                 thread_bit_rate,
                 self.target,
                 self.data_size,
@@ -534,7 +542,10 @@ class Interface(socket.socket):
 
     @property
     def link_speed(self):
-        return int(self._read_data("speed"))
+        raw = self._read_data("speed")
+        if raw is None:
+            raise ValueError("Speed value not found for " + self.interface)
+        return int(raw)
 
     @property
     def max_speed(self):
@@ -619,7 +630,7 @@ def get_test_parameters(args, environ):
     # - If command-line args were given, they take precedence
     # - Next come environment variables, if set.
 
-    params = {"test_target_iperf": None}
+    params = {"test_target_iperf": ""}
 
     # See if we have environment variables
     for key in params.keys():
@@ -805,7 +816,7 @@ def get_network_ifaces():
         ):
             continue
         logging.debug("Retrieve the network attribute for %s interface", iface)
-        network_if = Interface(iface)
+        network_if = Interface(iface.name)
         network_info[iface.name] = {
             "status": network_if.status,
             "phys_switch_id": network_if.phys_switch_id,
@@ -936,8 +947,8 @@ def interface_test_initialize(
     target_dev, underspeed_ok, dont_toggle_ifaces, recover_timeout
 ):
     tempfile_route = tempfile.TemporaryFile()
+    network_info = get_network_ifaces()
     try:
-        network_info = get_network_ifaces()
         # Back up routing table, since network down/up process
         # tends to trash it....
         logging.debug("Backup routing table")
@@ -951,7 +962,6 @@ def interface_test_initialize(
             not dont_toggle_ifaces,
             recover_timeout,
         )
-
         yield
 
     finally:
@@ -978,8 +988,8 @@ def interface_test_initialize(
             raise CalledProcessError(3, "restore network failed")
 
 
-def interface_test(args):
-    if not ("test_type" in vars(args)):
+def interface_test(args: Namespace):
+    if hasattr(args, "test_type"):
         return
 
     # Get the actual test data from one of two possible sources
@@ -990,9 +1000,12 @@ def interface_test(args):
         test_targets_list = make_target_list(
             args.interface, test_targets, True
         )
+    else:
+        test_targets = None
+        test_targets_list = []
 
     # Validate that we got reasonable values
-    if not test_targets_list or "example.com" in test_targets:
+    if not test_targets_list:
         # Default values found in config file
         logging.error("Valid target server has not been supplied.")
         logging.error(
@@ -1056,10 +1069,10 @@ def interface_test(args):
         return 3
 
 
-def interface_info(args):
+def interface_info(args: Namespace):
 
     info_set = ""
-    if "all" in vars(args):
+    if hasattr(args, "all"):
         info_set = args.all
 
     for key, value in vars(args).items():

--- a/providers/base/bin/network.py
+++ b/providers/base/bin/network.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Copyright (C) 2012-2015 Canonical Ltd.
+Copyright (C) 2012-2026 Canonical Ltd.
 
 Authors
   Jeff Marcom <jeff.marcom@canonical.com>

--- a/providers/base/tests/test_network.py
+++ b/providers/base/tests/test_network.py
@@ -98,7 +98,7 @@ class NetworkTests(unittest.TestCase):
 
         self.assertDictEqual(result, expected_result)
         mock_glob.assert_called_with("*")
-        mock_intf.assert_called_with(path_list[-1])
+        mock_intf.assert_called_with(str(path_list[-1]))
         self.assertEqual(mock_intf.call_count, 3)
 
     @patch("network.check_call")
@@ -621,23 +621,6 @@ class NetworkTests(unittest.TestCase):
         self.assertEqual(context.exception.code, 1)
         self.assertEqual(mock_logging.call_count, 7)
 
-    @patch("logging.error")
-    @patch("network.make_target_list")
-    @patch("network.get_test_parameters")
-    def test_interface_test_with_example_target_list(
-        self, mock_get_test_params, mock_mk_targets, mock_logging
-    ):
-        mock_mk_targets.return_value = ["192.168.1.1"]
-        mock_get_test_params.return_value = {
-            "test_target_iperf": "example.com"
-        }
-        args = Namespace(test_type="iperf", interface="eth0")
-
-        with self.assertRaises(SystemExit) as context:
-            network.interface_test(args)
-        self.assertEqual(context.exception.code, 1)
-        self.assertEqual(mock_logging.call_count, 7)
-
 
 class InterfaceClassTest(unittest.TestCase):
 
@@ -662,3 +645,6 @@ class InterfaceClassTest(unittest.TestCase):
         mock_read.return_value = "test"
 
         self.assertEqual(self.obj_intf.phys_switch_id, "test")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/providers/base/tests/test_network.py
+++ b/providers/base/tests/test_network.py
@@ -44,17 +44,17 @@ class IPerfPerfomanceTestTests(unittest.TestCase):
         self.assertListEqual(core_list, [])
 
     def test_find_numa_reports_node(self):
-        with patch("builtins.open", mock_open(read_data="1")) as mo:
+        with patch("pathlib.Path.open", mock_open(read_data="1")):
             returned = network.IPerfPerformanceTest.find_numa(None, "device")
             self.assertEqual(returned, 1)
 
     def test_find_numa_minus_one_from_sysfs(self):
-        with patch("builtins.open", mock_open(read_data="-1")) as mo:
+        with patch("pathlib.Path.open", mock_open(read_data="-1")) as mo:
             returned = network.IPerfPerformanceTest.find_numa(None, "device")
             self.assertEqual(returned, -1)
 
     def test_find_numa_numa_node_not_found(self):
-        with patch("builtins.open", mock_open()) as mo:
+        with patch("pathlib.Path.open", mock_open()) as mo:
             mo.side_effect = FileNotFoundError
             returned = network.IPerfPerformanceTest.find_numa(None, "device")
             self.assertEqual(returned, -1)

--- a/providers/base/tests/test_network.py
+++ b/providers/base/tests/test_network.py
@@ -13,7 +13,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+import socket
 import subprocess
+import threading
 from unittest.mock import patch, mock_open, Mock, call
 from contextlib import redirect_stdout, redirect_stderr
 from io import StringIO
@@ -58,6 +60,289 @@ class IPerfPerfomanceTestTests(unittest.TestCase):
             mo.side_effect = FileNotFoundError
             returned = network.IPerfPerformanceTest.find_numa(None, "device")
             self.assertEqual(returned, -1)
+
+    def make_iperf_test(self, **overrides):
+        """Build a real IPerfPerformanceTest with Interface() mocked out
+        (Interface opens a raw socket, which we don't want in unit tests)."""
+        kwargs = dict(
+            interface="eth0",
+            target="192.168.1.1",
+            fail_threshold=40,
+            cpu_load_fail_threshold=100,
+            iperf3=True,
+            num_threads=2,
+            reverse=False,
+        )
+        kwargs.update(overrides)
+        with patch("network.Interface"):
+            return network.IPerfPerformanceTest(**kwargs)
+
+    def test_init_sets_attributes(self):
+        test = self.make_iperf_test(num_threads=5, target="10.0.0.1")
+        self.assertEqual(test.target, "10.0.0.1")
+        self.assertEqual(test.num_threads, 5)
+        self.assertListEqual(test._results, [])
+
+    def test_run_one_thread_success(self):
+        test = self.make_iperf_test()
+        with patch("network.check_output", return_value="100 Mbits/sec"):
+            test.run_one_thread("iperf3 -c host", 5201)
+        self.assertEqual(test._results, ["100 Mbits/sec"])
+
+    def test_run_one_thread_timeout_keeps_partial_output(self):
+        test = self.make_iperf_test()
+        exc = CalledProcessError(124, "cmd")
+        exc.output = "partial output"
+        with patch("network.check_output", side_effect=exc):
+            test.run_one_thread("iperf3 -c host", 5201)
+        self.assertEqual(test._results, ["partial output"])
+
+    def test_run_one_thread_unable_to_connect(self):
+        test = self.make_iperf_test()
+        exc = CalledProcessError(1, "cmd")
+        exc.output = "unable to connect to server"
+        with patch("network.check_output", side_effect=exc):
+            result = test.run_one_thread("iperf3 -c host", 5201)
+        self.assertEqual(result, 1)
+        self.assertListEqual(test._results, [])
+
+    @patch("logging.warning")
+    def test_run_one_thread_unable_to_connect_high_speed_port(self, mock_warn):
+        test = self.make_iperf_test()
+        exc = CalledProcessError(1, "cmd")
+        exc.output = "unable to connect to server"
+        with patch("network.check_output", side_effect=exc):
+            result = test.run_one_thread("iperf3 -c host", 5202)
+        self.assertEqual(result, 1)
+        self.assertTrue(mock_warn.called)
+
+    def test_run_one_thread_unknown_error(self):
+        test = self.make_iperf_test()
+        exc = CalledProcessError(1, "cmd")
+        exc.output = "some other failure"
+        with patch("network.check_output", side_effect=exc):
+            result = test.run_one_thread("iperf3 -c host", 5201)
+        self.assertEqual(result, 1)
+
+    def test_run_one_thread_is_thread_safe(self):
+        """Runs many threads concurrently and checks that no results are
+        lost due to a race condition on self._results."""
+        test = self.make_iperf_test()
+        num_threads = 25
+        with patch("network.check_output", return_value="10 Mbits/sec"):
+            threads = [
+                threading.Thread(
+                    target=test.run_one_thread,
+                    args=("iperf3 -c host", 5200 + i),
+                )
+                for i in range(num_threads)
+            ]
+            for th in threads:
+                th.start()
+            for th in threads:
+                th.join()
+        self.assertEqual(len(test._results), num_threads)
+
+    def test_summarize_speeds_with_data(self):
+        test = self.make_iperf_test()
+        test._results = [
+            "[ 1] 0.0-1.0 sec  10 MBytes  80 Mbits/sec\n"
+            "[SUM] 0.0-1.0 sec 10 MBytes 80 Mbits/sec sender"
+        ]
+        throughput = test.summarize_speeds()
+        self.assertEqual(throughput, 80.0)
+
+    def test_summarize_speeds_no_matches(self):
+        test = self.make_iperf_test()
+        test._results = ["no useful data here"]
+        self.assertEqual(test.summarize_speeds(), 0)
+
+    def test_summarize_cpu_with_data(self):
+        test = self.make_iperf_test()
+        test._results = [
+            "CPU Utilization: local/sender 45.3% (1.2%u/44.1%s), "
+            "remote/receiver 12.0% (...)"
+        ]
+        self.assertEqual(test.summarize_cpu(), 45.3)
+
+    def test_summarize_cpu_no_data(self):
+        test = self.make_iperf_test()
+        test._results = ["no cpu info here"]
+        self.assertEqual(test.summarize_cpu(), 0.0)
+
+    def test_find_cores_found(self):
+        test = self.make_iperf_test()
+        lscpu_output = "NUMA node0 CPU(s):    0-3\nNUMA node1 CPU(s):    4-7\n"
+        with patch("network.check_output", return_value=lscpu_output):
+            cores = test.find_cores(1)
+        self.assertEqual(cores, [4, 5, 6, 7])
+
+    def test_find_cores_not_found(self):
+        test = self.make_iperf_test()
+        with patch("network.check_output", return_value=""):
+            cores = test.find_cores(5)
+        self.assertEqual(cores, [])
+
+    def test_run_wireless_zero_max_speed_passes(self):
+        """When max_speed is 0 (e.g. WiFi), a ZeroDivisionError while
+        computing percent is caught and the test is considered passed."""
+        test = self.make_iperf_test(num_threads=1, iperf3=False)
+        test.iface.max_speed = 0
+        with patch("network.check_output", return_value="1000 Mbits/sec"):
+            result = test.run()
+        self.assertEqual(result, 0)
+
+    def test_run_iperf3_multithread_passes(self):
+        test = self.make_iperf_test(
+            num_threads=3, iperf3=True, fail_threshold=1
+        )
+        test.iface.max_speed = 1000
+        # Per-interval lines (used by summarize_speeds) plus a "sender"
+        # summary line, which is stripped out before parsing speeds.
+        output = (
+            "[ 5]   0.00-1.00 sec  118 MBytes   990 Mbits/sec\n"
+            "[ 5]   1.00-2.00 sec  117 MBytes   983 Mbits/sec\n"
+            "[ 5]   0.00-10.00 sec 1.15 GBytes  987 Mbits/sec  sender\n"
+            "CPU Utilization: local/sender 10.0% (1.2%u/8.8%s)"
+        )
+        with patch.object(test, "find_numa", return_value=0), patch.object(
+            test, "find_cores", return_value=[0, 1]
+        ), patch("network.check_output", return_value=output):
+            result = test.run()
+        self.assertIsNone(result)
+
+    def test_run_below_fail_threshold_returns_30(self):
+        test = self.make_iperf_test(
+            num_threads=1, iperf3=False, fail_threshold=90
+        )
+        test.iface.max_speed = 1000
+        with patch("network.check_output", return_value="1 Mbits/sec"):
+            result = test.run()
+        self.assertEqual(result, 30)
+
+    def test_run_cpu_over_threshold_returns_30(self):
+        test = self.make_iperf_test(
+            num_threads=1,
+            iperf3=True,
+            cpu_load_fail_threshold=10,
+            fail_threshold=0,
+        )
+        test.iface.max_speed = 1000
+        output = (
+            "1000 Mbits/sec sender\n"
+            "CPU Utilization: local/sender 99.0% (...)"
+        )
+        with patch.object(test, "find_numa", return_value=-1), patch(
+            "network.check_output", return_value=output
+        ):
+            result = test.run()
+        self.assertEqual(result, 30)
+
+    def test_run_with_run_time_uses_reverse_flag(self):
+        test = self.make_iperf_test(
+            num_threads=1, iperf3=False, fail_threshold=0
+        )
+        test.iface.max_speed = 1000
+        test.run_time = 10
+        test.reverse = True
+        with patch(
+            "network.check_output", return_value="1000 Mbits/sec"
+        ) as mock_run:
+            result = test.run()
+        self.assertIsNone(result)
+        called_cmd = mock_run.call_args[0][0]
+        self.assertIn("-R", called_cmd)
+
+    def test_optimize_num_threads(self):
+        test = self.make_iperf_test(num_threads=4)
+        orig_run_time = test.run_time
+        orig_scan_timeout = test.scan_timeout
+        with patch.object(
+            test, "run", return_value=None
+        ) as mock_run, patch.object(
+            test, "summarize_speeds", side_effect=[10, 20, 15, 5]
+        ):
+            test.optimize_num_threads()
+        self.assertEqual(mock_run.call_count, 4)
+        # Multiple 1 (index 1) had the highest reported throughput (20)
+        self.assertEqual(test.num_threads, 4)
+        self.assertEqual(test.run_time, orig_run_time)
+        self.assertEqual(test.scan_timeout, orig_scan_timeout)
+
+
+class StressPerformanceTestTests(unittest.TestCase):
+    @patch("subprocess.Popen")
+    def test_run_success_no_issues(self, mock_popen):
+        iperf_mock = Mock(returncode=0)
+        iperf_mock.communicate.return_value = (None, None)
+        ping_mock = Mock()
+        ping_mock.communicate.return_value = (
+            b"64 bytes: icmp_seq=1 ttl=64 time=10 ms\n",
+            b"",
+        )
+        mock_popen.side_effect = [iperf_mock, ping_mock]
+
+        test = network.StressPerformanceTest("eth0", "192.168.1.1", False)
+        with redirect_stdout(StringIO()):
+            result = test.run()
+        self.assertEqual(result, 0)
+        ping_mock.terminate.assert_called_once()
+
+    @patch("subprocess.Popen")
+    def test_run_iperf3_command_used(self, mock_popen):
+        iperf_mock = Mock(returncode=0)
+        iperf_mock.communicate.return_value = (None, None)
+        ping_mock = Mock()
+        ping_mock.communicate.return_value = (b"", b"")
+        mock_popen.side_effect = [iperf_mock, ping_mock]
+
+        test = network.StressPerformanceTest("eth0", "192.168.1.1", True)
+        with redirect_stdout(StringIO()):
+            test.run()
+        iperf_cmd = mock_popen.call_args_list[0][0][0]
+        self.assertIn("iperf3", iperf_cmd)
+
+    @patch("subprocess.Popen")
+    def test_run_iperf_fail_returns_nonzero(self, mock_popen):
+        iperf_mock = Mock(returncode=5)
+        iperf_mock.communicate.return_value = (None, None)
+        ping_mock = Mock()
+        ping_mock.communicate.return_value = (b"", b"")
+        mock_popen.side_effect = [iperf_mock, ping_mock]
+
+        test = network.StressPerformanceTest("eth0", "192.168.1.1", False)
+        with redirect_stdout(StringIO()):
+            result = test.run()
+        self.assertEqual(result, 5)
+
+    @patch("subprocess.Popen")
+    def test_run_ping_delay_detected(self, mock_popen):
+        iperf_mock = Mock(returncode=0)
+        iperf_mock.communicate.return_value = (None, None)
+        ping_mock = Mock()
+        ping_mock.communicate.return_value = (b"time=5000\n", b"")
+        mock_popen.side_effect = [iperf_mock, ping_mock]
+
+        test = network.StressPerformanceTest("eth0", "192.168.1.1", False)
+        with redirect_stdout(StringIO()):
+            result = test.run()
+        self.assertEqual(result, 1)
+
+    @patch("subprocess.Popen")
+    def test_run_ping_unreachable(self, mock_popen):
+        iperf_mock = Mock(returncode=0)
+        iperf_mock.communicate.return_value = (None, None)
+        ping_mock = Mock()
+        ping_mock.communicate.return_value = (
+            b"Destination Host Unreachable\n",
+            b"",
+        )
+        mock_popen.side_effect = [iperf_mock, ping_mock]
+
+        test = network.StressPerformanceTest("eth0", "192.168.1.1", False)
+        with redirect_stdout(StringIO()):
+            result = test.run()
+        self.assertEqual(result, 1)
 
 
 class NetworkTests(unittest.TestCase):
@@ -621,12 +906,255 @@ class NetworkTests(unittest.TestCase):
         self.assertEqual(context.exception.code, 1)
         self.assertEqual(mock_logging.call_count, 7)
 
+    @patch("network.get_test_parameters")
+    def test_interface_test_type_neither_iperf_nor_stress(
+        self, mock_get_test_params
+    ):
+        mock_get_test_params.return_value = {"test_target_iperf": ""}
+        args = Namespace(test_type="bogus", interface="eth0")
+
+        with self.assertRaises(SystemExit):
+            network.interface_test(args)
+
+    def test_get_test_parameters_from_args(self):
+        args = Namespace(target="10.0.0.5")
+        params = network.get_test_parameters(args, {})
+        self.assertEqual(params["test_target_iperf"], "10.0.0.5")
+
+    def test_get_test_parameters_from_environ(self):
+        args = Namespace(target=None)
+        with patch.dict(
+            "os.environ", {"TEST_TARGET_IPERF": "10.0.0.9"}, clear=True
+        ):
+            params = network.get_test_parameters(args, {})
+        self.assertEqual(params["test_target_iperf"], "10.0.0.9")
+
+    def test_get_test_parameters_args_take_precedence(self):
+        args = Namespace(target="10.0.0.5")
+        environ = {"TEST_TARGET_IPERF": "10.0.0.9"}
+        params = network.get_test_parameters(args, environ)
+        self.assertEqual(params["test_target_iperf"], "10.0.0.5")
+
+    @patch("network.sp_run")
+    def test_can_ping_success_on_first_try(self, mock_sp_run):
+        mock_sp_run.return_value = 0
+        self.assertTrue(network.can_ping("eth0", "192.168.1.1"))
+        self.assertEqual(mock_sp_run.call_count, 1)
+
+    @patch("time.sleep")
+    @patch("network.sp_run")
+    def test_can_ping_succeeds_after_retry(self, mock_sp_run, mock_sleep):
+        mock_sp_run.side_effect = [
+            CalledProcessError(1, "ping"),
+            0,
+        ]
+        self.assertTrue(network.can_ping("eth0", "192.168.1.1"))
+        self.assertEqual(mock_sp_run.call_count, 2)
+        mock_sleep.assert_called_with(5)
+
+    @patch("time.sleep")
+    @patch("network.sp_run")
+    def test_can_ping_exhausts_retries(self, mock_sp_run, mock_sleep):
+        mock_sp_run.side_effect = CalledProcessError(1, "ping")
+        self.assertFalse(network.can_ping("eth0", "192.168.1.1"))
+        self.assertEqual(mock_sp_run.call_count, 48)
+
+    @patch("network.IPerfPerformanceTest")
+    @patch("network.can_ping")
+    def test_run_test_iperf(self, mock_can_ping, mock_iperf_cls):
+        mock_can_ping.return_value = True
+        mock_benchmark = Mock(num_threads=1)
+        mock_benchmark.run.return_value = 0
+        mock_iperf_cls.return_value = mock_benchmark
+        args = Namespace(
+            interface="eth0",
+            test_type="iperf",
+            fail_threshold=40,
+            cpu_load_fail_threshold=100,
+            iperf3=False,
+            num_threads=1,
+            reverse=False,
+            datasize=None,
+            runtime=None,
+            num_runs=1,
+        )
+
+        result = network.run_test(args, "192.168.1.1")
+
+        self.assertEqual(result, 0)
+        mock_benchmark.run.assert_called_once()
+
+    @patch("network.StressPerformanceTest")
+    @patch("network.can_ping")
+    def test_run_test_stress(self, mock_can_ping, mock_stress_cls):
+        mock_can_ping.return_value = True
+        mock_benchmark = Mock()
+        mock_benchmark.run.return_value = 0
+        mock_stress_cls.return_value = mock_benchmark
+        args = Namespace(interface="eth0", test_type="stress", iperf3=False)
+
+        result = network.run_test(args, "192.168.1.1")
+
+        self.assertEqual(result, 0)
+        mock_benchmark.run.assert_called_once()
+
+    @patch("network.can_ping")
+    def test_run_test_unknown_type(self, mock_can_ping):
+        mock_can_ping.return_value = True
+        args = Namespace(interface="eth0", test_type="bogus")
+
+        result = network.run_test(args, "192.168.1.1")
+
+        self.assertEqual(result, 10)
+
+    @patch("network.can_ping")
+    def test_run_test_cannot_ping_returns_1(self, mock_can_ping):
+        mock_can_ping.return_value = False
+        args = Namespace(interface="eth0", test_type="iperf")
+
+        result = network.run_test(args, "192.168.1.1")
+
+        self.assertEqual(result, 1)
+
+    @patch("network.Interface")
+    def test_make_target_list_filters_out_of_subnet(self, mock_intf):
+        mock_intf.return_value = Mock(
+            ipaddress="192.168.1.10", netmask="255.255.255.0"
+        )
+        with redirect_stderr(StringIO()):
+            result = network.make_target_list(
+                "eth0", "10.0.0.5,192.168.1.20", True
+            )
+        self.assertEqual(result, ["192.168.1.20"])
+
+    @patch("network.Interface")
+    def test_make_target_list_invalid_address_removed(self, mock_intf):
+        mock_intf.return_value = Mock(
+            ipaddress="192.168.1.10", netmask="255.255.255.0"
+        )
+        with patch(
+            "socket.gethostbyname", side_effect=OSError
+        ), redirect_stderr(StringIO()):
+            result = network.make_target_list("eth0", "not-an-ip", True)
+        self.assertEqual(result, [])
+
+    @patch("network.Interface")
+    def test_make_target_list_address_value_error_exits(self, mock_intf):
+        mock_intf.return_value = Mock(ipaddress=None, netmask=None)
+        with self.assertRaises(SystemExit):
+            network.make_target_list("eth0", "192.168.1.20", True)
+
+    @patch("network.Interface")
+    def test_make_target_list_empty_string_removed(self, mock_intf):
+        mock_intf.return_value = Mock(
+            ipaddress="192.168.1.10", netmask="255.255.255.0"
+        )
+        with patch("socket.gethostbyname", return_value="0.0.0.0"):
+            result = network.make_target_list("eth0", "", True)
+        self.assertEqual(result, [])
+
+    @patch("network.Interface")
+    def test_get_network_ifaces_skips_virtual_interfaces(self, mock_intf):
+        path_list = [
+            Path("lo"),
+            Path("virbr0"),
+            Path("lxdbr0"),
+            Path("eth0"),
+        ]
+        mock_intf.return_value = Mock(
+            status="up", phys_switch_id=None, iflink="2", ifindex="2"
+        )
+        with patch("pathlib.Path.glob", return_value=path_list):
+            result = network.get_network_ifaces()
+        self.assertEqual(list(result.keys()), ["eth0"])
+
+    def test_interface_info_prints_requested_attributes(self):
+        args = Namespace(interface="eth0", max_speed=True, netmask=False)
+        with patch("network.Interface") as mock_intf:
+            mock_intf.return_value = Mock(max_speed=1000)
+            with redirect_stderr(StringIO()) as captured:
+                network.interface_info(args)
+        self.assertIn("max_speed: 1000", captured.getvalue())
+
+    def test_interface_info_all_flag(self):
+        args = Namespace(interface="eth0", all=True)
+        with patch("network.Interface") as mock_intf:
+            mock_intf.return_value = Mock(interface="eth0")
+            with redirect_stderr(StringIO()) as captured:
+                network.interface_info(args)
+        self.assertIn("interface: eth0", captured.getvalue())
+
+    @patch("network.Interface")
+    @patch("network.can_ping")
+    def test_run_test_iperf_computes_num_threads(
+        self, mock_can_ping, mock_intf
+    ):
+        mock_can_ping.return_value = True
+        mock_intf.return_value = Mock(link_speed=50000, max_speed=100000)
+        args = Namespace(
+            interface="eth0",
+            test_type="iperf",
+            fail_threshold=40,
+            cpu_load_fail_threshold=100,
+            iperf3=False,
+            num_threads=-1,
+            reverse=False,
+            datasize="2",
+            runtime=30,
+            num_runs=1,
+        )
+
+        with patch("network.IPerfPerformanceTest.run", return_value=0), patch(
+            "network.IPerfPerformanceTest.optimize_num_threads"
+        ) as mock_opt:
+            result = network.run_test(args, "192.168.1.1")
+
+        self.assertEqual(result, 0)
+        mock_opt.assert_called_once()
+
+    @patch("network.can_ping")
+    @patch("network.interface_test_initialize")
+    @patch("network.make_target_list")
+    @patch("network.get_test_parameters")
+    def test_interface_test_calledprocesserror_returns_3(
+        self,
+        mock_get_test_params,
+        mock_mk_targets,
+        mock_net_init,
+        mock_can_ping,
+    ):
+        mock_mk_targets.return_value = ["192.168.1.1"]
+        mock_get_test_params.return_value = {"test_target_iperf": "x"}
+        mock_net_init.side_effect = CalledProcessError(1, "cmd")
+        args = Namespace(
+            test_type="iperf",
+            interface="eth0",
+            scan_timeout=4,
+            underspeed_ok=True,
+            dont_toggle_ifaces=True,
+            iface_timeout=1,
+        )
+
+        result = network.interface_test(args)
+
+        self.assertEqual(result, 3)
+
+    def test_interface_info_attribute_error_ignored(self):
+        args = Namespace(interface="eth0", nonexistent_attr=True)
+        with patch("network.Interface") as mock_intf:
+            mock_intf.return_value = Mock(spec=[])
+            with redirect_stderr(StringIO()):
+                # Should not raise, AttributeError is caught internally.
+                network.interface_info(args)
+
 
 class InterfaceClassTest(unittest.TestCase):
 
     @patch("network.Interface.__init__", Mock(return_value=None))
     def setUp(self):
         self.obj_intf = network.Interface("eth0")
+        self.obj_intf.interface = "eth0"
+        self.obj_intf.dev_path = Path("/sys/class/net/eth0")
 
     @patch("network.Interface._read_data")
     def test_ifindex(self, mock_read):
@@ -646,5 +1174,163 @@ class InterfaceClassTest(unittest.TestCase):
 
         self.assertEqual(self.obj_intf.phys_switch_id, "test")
 
-if __name__ == '__main__':
+    @patch("network.Interface._read_data")
+    def test_macaddress(self, mock_read):
+        mock_read.return_value = "aa:bb:cc:dd:ee:ff"
+
+        self.assertEqual(self.obj_intf.macaddress, "aa:bb:cc:dd:ee:ff")
+
+    @patch("network.Interface._read_data")
+    def test_duplex_mode(self, mock_read):
+        mock_read.return_value = "full"
+
+        self.assertEqual(self.obj_intf.duplex_mode, "full")
+
+    @patch("network.Interface._read_data")
+    def test_status(self, mock_read):
+        mock_read.return_value = "up"
+
+        self.assertEqual(self.obj_intf.status, "up")
+
+    @patch("network.Interface._read_data")
+    def test_device_name(self, mock_read):
+        mock_read.return_value = "eth0-label"
+
+        self.assertEqual(self.obj_intf.device_name, "eth0-label")
+
+    @patch("pathlib.Path.exists")
+    @patch("socket.socket.__init__")
+    def test_init_success(self, mock_socket_init, mock_exists):
+        mock_socket_init.return_value = None
+        mock_exists.return_value = True
+
+        intf = network.Interface("eth0")
+
+        self.assertEqual(intf.interface, "eth0")
+
+    @patch("pathlib.Path.exists")
+    @patch("socket.socket.__init__")
+    def test_init_missing_interface_raises(
+        self, mock_socket_init, mock_exists
+    ):
+        mock_socket_init.return_value = None
+        mock_exists.return_value = False
+
+        with self.assertRaises(FileNotFoundError):
+            network.Interface("eth0")
+
+    @patch("pathlib.Path.read_text")
+    def test_read_data_success(self, mock_read_text):
+        mock_read_text.return_value = "up\n"
+
+        self.assertEqual(self.obj_intf._read_data("operstate"), "up")
+
+    @patch("logging.warning")
+    @patch("pathlib.Path.read_text")
+    def test_read_data_oserror_returns_none(self, mock_read_text, mock_warn):
+        mock_read_text.side_effect = OSError
+
+        self.assertIsNone(self.obj_intf._read_data("operstate"))
+        mock_warn.assert_called_once()
+
+    @patch("network.fcntl.ioctl")
+    def test_ipaddress_success(self, mock_ioctl):
+        mock_ioctl.return_value = (
+            b"\x00" * 20 + socket.inet_aton("192.168.1.5") + b"\x00" * 4
+        )
+
+        self.assertEqual(self.obj_intf.ipaddress, "192.168.1.5")
+
+    @patch("logging.error")
+    @patch("network.fcntl.ioctl")
+    def test_ipaddress_ioerror_returns_none(self, mock_ioctl, mock_error):
+        mock_ioctl.side_effect = IOError
+
+        self.assertIsNone(self.obj_intf.ipaddress)
+
+    @patch("network.fcntl.ioctl")
+    def test_netmask_success(self, mock_ioctl):
+        mock_ioctl.return_value = (
+            b"\x00" * 20 + socket.inet_aton("255.255.255.0") + b"\x00" * 4
+        )
+
+        self.assertEqual(self.obj_intf.netmask, "255.255.255.0")
+
+    @patch("logging.error")
+    @patch("network.fcntl.ioctl")
+    def test_netmask_ioerror_returns_none(self, mock_ioctl, mock_error):
+        mock_ioctl.side_effect = IOError
+
+        self.assertIsNone(self.obj_intf.netmask)
+
+    @patch("network.Interface._read_data")
+    def test_link_speed_valid(self, mock_read):
+        mock_read.return_value = "1000"
+
+        self.assertEqual(self.obj_intf.link_speed, 1000)
+
+    @patch("network.Interface._read_data")
+    def test_link_speed_none_raises_value_error(self, mock_read):
+        mock_read.return_value = None
+
+        with self.assertRaises(ValueError):
+            self.obj_intf.link_speed
+
+    @patch("network.check_output")
+    def test_max_speed_from_ethtool(self, mock_check_output):
+        mock_check_output.return_value = (
+            "Settings for eth0: Supported link modes: "
+            "100baseT/Full 1000baseT/Full Speed: 1000Mb/s"
+        )
+
+        self.assertEqual(self.obj_intf.max_speed, 1000)
+
+    @patch("logging.error")
+    @patch("network.check_output")
+    def test_max_speed_ethtool_calledprocesserror(
+        self, mock_check_output, mock_error
+    ):
+        mock_check_output.side_effect = CalledProcessError(
+            1, "ethtool", output="boom"
+        )
+
+        self.assertEqual(self.obj_intf.max_speed, 0)
+
+    @patch("logging.warning")
+    @patch("network.check_output")
+    def test_max_speed_falls_back_to_miitool(
+        self, mock_check_output, mock_warn
+    ):
+        mock_check_output.side_effect = [
+            FileNotFoundError,
+            "eth0: negotiated 100baseTx-FD flow-control\n"
+            "  capabilities: 100baseTx-FD 10baseT-HD\n",
+        ]
+
+        self.assertEqual(self.obj_intf.max_speed, 100)
+
+    @patch("logging.warning")
+    @patch("network.check_output")
+    def test_max_speed_miitool_also_not_found(
+        self, mock_check_output, mock_warn
+    ):
+        mock_check_output.side_effect = [FileNotFoundError, FileNotFoundError]
+
+        self.assertEqual(self.obj_intf.max_speed, 0)
+
+    @patch("logging.error")
+    @patch("logging.warning")
+    @patch("network.check_output")
+    def test_max_speed_miitool_calledprocesserror(
+        self, mock_check_output, mock_warn, mock_error
+    ):
+        mock_check_output.side_effect = [
+            FileNotFoundError,
+            CalledProcessError(1, "mii-tool", output="boom"),
+        ]
+
+        self.assertEqual(self.obj_intf.max_speed, 0)
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/providers/base/tests/test_network.py
+++ b/providers/base/tests/test_network.py
@@ -286,7 +286,7 @@ class StressPerformanceTestTests(unittest.TestCase):
         with redirect_stdout(StringIO()):
             result = test.run()
         self.assertEqual(result, 0)
-        ping_mock.terminate.assert_called_once()
+        self.assertEqual(ping_mock.terminate.call_count, 1)
 
     @patch("subprocess.Popen")
     def test_run_iperf3_command_used(self, mock_popen):
@@ -982,7 +982,7 @@ class NetworkTests(unittest.TestCase):
         result = network.run_test(args, "192.168.1.1")
 
         self.assertEqual(result, 0)
-        mock_benchmark.run.assert_called_once()
+        self.assertEqual(mock_benchmark.run.call_count, 1)
 
     @patch("network.StressPerformanceTest")
     @patch("network.can_ping")
@@ -996,7 +996,7 @@ class NetworkTests(unittest.TestCase):
         result = network.run_test(args, "192.168.1.1")
 
         self.assertEqual(result, 0)
-        mock_benchmark.run.assert_called_once()
+        self.assertEqual(mock_benchmark.run.call_count, 1)
 
     @patch("network.can_ping")
     def test_run_test_unknown_type(self, mock_can_ping):
@@ -1110,7 +1110,7 @@ class NetworkTests(unittest.TestCase):
             result = network.run_test(args, "192.168.1.1")
 
         self.assertEqual(result, 0)
-        mock_opt.assert_called_once()
+        self.assertEqual(mock_opt.call_count, 1)
 
     @patch("network.can_ping")
     @patch("network.interface_test_initialize")
@@ -1231,7 +1231,7 @@ class InterfaceClassTest(unittest.TestCase):
         mock_read_text.side_effect = OSError
 
         self.assertIsNone(self.obj_intf._read_data("operstate"))
-        mock_warn.assert_called_once()
+        self.assertEqual(mock_warn.call_count, 1)
 
     @patch("network.fcntl.ioctl")
     def test_ipaddress_success(self, mock_ioctl):


### PR DESCRIPTION
## Description

This PR increases unit test coverage to 90% for network.py and fixed these issues:
1. removed all uses of unbound variables
2. moved the global `results` variable inside the iperf class and added a thread lock to safely collect results when running iperf tests
3. converted all string paths to `Path` objects
4. replaced magic numbers with named constants
5. added more types to help LSPs

## Resolved issues

Low unit test coverage makes it overly difficult to add new features to network.py because any minor change will cause the CI to complain that there's only 30% patch coverage. 

## Documentation

Tbh the lock is added because I couldn't find a definitive answer as to whether `<list>.append()` is thread safe on all the supported versions. If anyone can prove or disprove it please lmk :smiley_cat: .

## Tests

Single-threaded iperf:

Multi-threaded iperf: