### PR TITLE
Backward compatible resource-results getter (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/merge_reports.py
+++ b/checkbox-ng/checkbox_ng/launcher/merge_reports.py
@@ -84,7 +84,8 @@ class MergeReports:
                     self.job_list.append(JobDefinition(result))
                 elif mode == "dict":
                     self.job_dict[result["id"]] = JobDefinition(result)
-            for result in data["resource-results"]:
+            # backward compatibility, now resrouce-result are in results
+            for result in data.get("resource-results", []):
                 result["plugin"] = "resource"
                 result["summary"] = result["name"]
                 # 'id' field in json file only contains partial id

--- a/checkbox-ng/checkbox_ng/launcher/merge_reports.py
+++ b/checkbox-ng/checkbox_ng/launcher/merge_reports.py
@@ -84,7 +84,7 @@ class MergeReports:
                     self.job_list.append(JobDefinition(result))
                 elif mode == "dict":
                     self.job_dict[result["id"]] = JobDefinition(result)
-            # backward compatibility, now resrouce-result are in results
+            # backward compatibility, now resource-result are in results
             for result in data.get("resource-results", []):
                 result["plugin"] = "resource"
                 result["summary"] = result["name"]

--- a/checkbox-ng/checkbox_ng/launcher/test_merge_reports.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_merge_reports.py
@@ -84,7 +84,7 @@ class MergeReportsTests(TestCase):
         MergeReports._populate_session_state(self_mock, job_mock, state_mock)
         self.assertTrue(job_mock.get_record_value.called)
 
-    def test_parse_submission(self):
+    def test_parse_submission_legacy(self):
         basic_job_info = {
             "name": "test_name",
             "id": "test_id",  # note: no :: to fetch the default ns
@@ -94,6 +94,30 @@ class MergeReportsTests(TestCase):
             "title": "report title",
             "results": [basic_job_info],
             "resource-results": [basic_job_info],
+            "attachment-results": [basic_job_info],
+            "category_map": {"test_category": "test_name"},
+            "system_information": {"version": 0},
+        }
+        mr = MergeReports()
+        mr._parse_submission(sub_to_read)
+        self.assertEqual(len(mr.job_list), 3)
+        self.assertEqual(
+            mr.job_list[0].id, "com.canonical.certification::test_id"
+        )
+        self.assertEqual(
+            mr.job_list[0].template_id,
+            "com.canonical.certification::test_template_id",
+        )
+
+    def test_parse_submission(self):
+        basic_job_info = {
+            "name": "test_name",
+            "id": "test_id",  # note: no :: to fetch the default ns
+            "template_id": "com.canonical.certification::test_template_id",
+        }
+        sub_to_read = {
+            "title": "report title",
+            "results": [basic_job_info, basic_job_info],
             "attachment-results": [basic_job_info],
             "category_map": {"test_category": "test_name"},
             "system_information": {"version": 0},


### PR DESCRIPTION
## Description

Resource results is no more and this merger expects it to exist. For backward compatibility, this preserves the loader but uses `get` as `[]` is now the actual value that field will always have

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/2694

## Documentation

Added a comment explaining why this line is needed still

## Tests

Added a test without resource-results