### PR TITLE
Also run setup jobs via Run (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/startprovider.py
+++ b/checkbox-ng/checkbox_ng/launcher/startprovider.py
@@ -25,7 +25,6 @@
 import inspect
 import logging
 import os
-import re
 
 from plainbox.i18n import gettext as _
 from plainbox.impl.secure.providers.v1 import IQNValidator

--- a/checkbox-ng/checkbox_ng/launcher/subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/subcommands.py
@@ -1214,8 +1214,14 @@ class Run(MainLoopStage):
         except KeyboardInterrupt:
             return 1
 
+    def setup(self):
+        setup_jobs = self.sa.start_setup()
+        self._run_jobs(setup_jobs)
+        self.sa.finish_setup()
+
     def just_run_test_plan(self, tp_id):
         self.sa.select_test_plan(tp_id)
+        self.setup()
         self.sa.bootstrap()
         print(self.C.header(_("Running Selected Test Plan")))
         self._run_jobs(self.sa.get_dynamic_todo_list())

--- a/checkbox-ng/checkbox_ng/launcher/test_agent.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_agent.py
@@ -16,13 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
-import json
 from unittest import TestCase, mock
 
 from checkbox_ng.launcher.agent import exit_if_port_unavailable
 from checkbox_ng.launcher.agent import RemoteAgent
-from plainbox.impl.session.assistant import ResumeCandidate
-from plainbox.impl.session.state import SessionMetaData
 
 
 @mock.patch("checkbox_ng.launcher.agent._")

--- a/checkbox-ng/checkbox_ng/launcher/test_merge_submissions.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_merge_submissions.py
@@ -17,7 +17,6 @@
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
 from unittest import TestCase, mock
-from functools import partial
 
 from checkbox_ng.launcher.merge_submissions import MergeSubmissions
 

--- a/checkbox-ng/checkbox_ng/launcher/test_stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_stages.py
@@ -17,7 +17,6 @@
 # along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from pathlib import Path
 from functools import partial
 from unittest import TestCase, mock
 

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -1392,22 +1392,26 @@ class TestUtilsFunctions(TestCase):
 
 
 class TestRun(TestCase):
+    def called_once(self, mock):
+        self.assertTrue(mock.called)
+        self.assertEqual(mock.call_count, 1)
+
     def test_just_run_test_plan_calls_setup(self):
         self_mock = MagicMock()
         tp_id = "com.canonical.certification::some-tp"
         Run.just_run_test_plan(self_mock, tp_id)
-        self_mock.sa.select_test_plan.assert_called_once()
-        self_mock.setup.assert_called_once()
-        self_mock.sa.bootstrap.assert_called_once()
+        self.called_once(self_mock.sa.select_test_plan)
+        self.called_once(self_mock.setup)
+        self.called_once(self_mock.sa.bootstrap)
 
     def test_setup_starts_and_ends_setup_and_runs_jobs(self):
         self_mock = MagicMock()
         setup_jobs = ["job1", "job2"]
         self_mock.sa.start_setup.return_value = setup_jobs
         Run.setup(self_mock)
-        self_mock.sa.start_setup.assert_called_once()
-        self_mock._run_jobs.assert_called_once_with(setup_jobs)
-        self_mock.sa.finish_setup.assert_called_once()
+        self.called_once(self_mock.sa.start_setup)
+        self.called_once(self_mock._run_jobs)
+        self.called_once(self_mock.sa.finish_setup)
 
     @patch("checkbox_ng.launcher.subcommands.Explorer")
     def test__get_relevant_units(self, explorer_mock):

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -43,6 +43,7 @@ from checkbox_ng.launcher.subcommands import (
     get_testplan_id_by_id,
     print_objs,
 )
+from checkbox_ng.launcher.stages import MainLoopStage
 from checkbox_ng.urwid_ui import ManifestBrowser
 
 
@@ -1394,6 +1395,23 @@ class TestUtilsFunctions(TestCase):
 
 
 class TestRun(TestCase):
+    def test_just_run_test_plan_calls_setup(self):
+        self_mock = MagicMock()
+        tp_id = "com.canonical.certification::some-tp"
+        Run.just_run_test_plan(self_mock, tp_id)
+        self_mock.sa.select_test_plan.assert_called_once()
+        self_mock.setup.assert_called_once()
+        self_mock.sa.bootstrap.assert_called_once()
+
+    def test_setup_starts_and_ends_setup_and_runs_jobs(self):
+        self_mock = MagicMock()
+        setup_jobs = ["job1", "job2"]
+        self_mock.sa.start_setup.return_value = setup_jobs
+        Run.setup(self_mock)
+        self_mock.sa.start_setup.assert_called_once()
+        self_mock._run_jobs.assert_called_once_with(setup_jobs)
+        self_mock.sa.finish_setup.assert_called_once()
+
     @patch("checkbox_ng.launcher.subcommands.Explorer")
     def test__get_relevant_units(self, explorer_mock):
         self_mock = MagicMock()

--- a/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_subcommands.py
@@ -32,7 +32,6 @@ from plainbox.impl.unit.template import TemplateUnit
 from checkbox_ng.launcher.subcommands import (
     Run,
     Expand,
-    List,
     Launcher,
     ListBootstrapped,
     IncompatibleJobError,
@@ -43,8 +42,6 @@ from checkbox_ng.launcher.subcommands import (
     get_testplan_id_by_id,
     print_objs,
 )
-from checkbox_ng.launcher.stages import MainLoopStage
-from checkbox_ng.urwid_ui import ManifestBrowser
 
 
 class TestSharedFunctions(TestCase):

--- a/checkbox-ng/checkbox_ng/support/parsers/udevadm.py
+++ b/checkbox-ng/checkbox_ng/support/parsers/udevadm.py
@@ -23,7 +23,7 @@ from __future__ import unicode_literals
 
 from collections import OrderedDict
 import json
-from subprocess import check_output, CalledProcessError
+from subprocess import check_output
 import os
 import re
 import string

--- a/checkbox-ng/checkbox_ng/support/parsers/xrandr.py
+++ b/checkbox-ng/checkbox_ng/support/parsers/xrandr.py
@@ -40,7 +40,7 @@ DP-3 AOC 2770M GDBFBHA000236
 import re
 import subprocess
 from collections import defaultdict, namedtuple
-from typing import Dict, List, Set
+from typing import Dict, Set
 from checkbox_ng.support.monitor_config import MonitorConfig
 
 Mode = namedtuple(

--- a/checkbox-ng/plainbox/impl/applogic.py
+++ b/checkbox-ng/plainbox/impl/applogic.py
@@ -26,15 +26,10 @@
     THIS MODULE DOES NOT HAVE STABLE PUBLIC API
 """
 
-import os
-
-from plainbox.abc import IJobResult
-from plainbox.i18n import gettext as _
 from plainbox.impl.result import MemoryJobResult
 from plainbox.impl.result_utils import determine_outcome_and_skip_reason
 from plainbox.impl.secure.qualifiers import select_units
 from plainbox.impl.session import SessionManager
-from plainbox.impl.session.jobs import InhibitionCause
 
 
 # Deprecated, use plainbox.impl.secure.qualifiers.select_units() instead

--- a/checkbox-ng/plainbox/impl/commands/cmd_session.py
+++ b/checkbox-ng/plainbox/impl/commands/cmd_session.py
@@ -25,7 +25,6 @@ from argparse import FileType
 from plainbox.i18n import docstring
 from plainbox.i18n import gettext as _
 from plainbox.i18n import gettext_noop as N_
-from plainbox.impl.applogic import get_all_exporter_names
 from plainbox.impl.commands import PlainBoxCommand
 
 

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -39,7 +39,7 @@ import tempfile
 import threading
 import time
 from contextlib import suppress
-from subprocess import check_call, check_output, run
+from subprocess import check_call, run
 
 from plainbox.abc import IJobResult, IJobRunner
 from plainbox.i18n import gettext as _

--- a/checkbox-ng/plainbox/impl/providers/manifest/manage.py
+++ b/checkbox-ng/plainbox/impl/providers/manifest/manage.py
@@ -25,7 +25,6 @@ from gettext import dgettext
 from plainbox.impl.providers.special import get_manifest_def
 from plainbox.provider_manager import DevelopCommand
 from plainbox.provider_manager import InstallCommand
-from plainbox.provider_manager import ManageCommand
 from plainbox.provider_manager import N_
 from plainbox.provider_manager import manage_py_extension
 from plainbox.provider_manager import setup

--- a/checkbox-ng/plainbox/impl/secure/sudo_broker.py
+++ b/checkbox-ng/plainbox/impl/secure/sudo_broker.py
@@ -23,14 +23,11 @@ transmitted over network in plaintext, so it's up to the operator to use
 secure connection.
 """
 
-import gc
 import getpass
-import hashlib
 import logging
 import os
 import sys
 
-from plainbox.i18n import gettext as _
 from subprocess import (
     check_output,
     check_call,

--- a/checkbox-ng/plainbox/impl/secure/test_qualifiers.py
+++ b/checkbox-ng/plainbox/impl/secure/test_qualifiers.py
@@ -24,17 +24,13 @@ plainbox.impl.secure.test_qualifiers
 Test definitions for plainbox.impl.secure.qualifiers module
 """
 
-from contextlib import contextmanager
-from io import TextIOWrapper
 from itertools import permutations
 from unittest import TestCase
 import operator
 
 from plainbox.abc import IUnitQualifier
 from plainbox.impl.job import JobDefinition
-from plainbox.impl.secure.origin import FileTextSource
 from plainbox.impl.secure.origin import Origin
-from plainbox.impl.secure.origin import UnknownTextSource
 from plainbox.impl.secure.qualifiers import CompositeQualifier
 from plainbox.impl.secure.qualifiers import FieldQualifier
 from plainbox.impl.secure.qualifiers import IMatcher

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -33,7 +33,6 @@ import logging
 import os
 import shlex
 import time
-from contextlib import suppress
 from collections import defaultdict
 from tempfile import SpooledTemporaryFile
 
@@ -75,7 +74,6 @@ from plainbox.impl.session.restart import (
 )
 from plainbox.impl.session.resume import IncompatibleJobError
 from plainbox.impl.session.storage import WellKnownDirsHelper
-from plainbox.impl.session.state import SessionDeviceContext
 from plainbox.impl.transport import OAuthTransport, TransportError
 from plainbox.impl.unit.exporter import ExporterError
 from plainbox.impl.unit.unit import Unit

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -25,12 +25,10 @@ Session State Handling.
 import collections
 import json
 import logging
-import os
 import re
 import shutil
 from contextlib import suppress
 from pathlib import Path
-from copy import copy
 
 from plainbox.abc import IJobResult
 from plainbox.i18n import gettext as _

--- a/checkbox-ng/plainbox/impl/session/test_resume.py
+++ b/checkbox-ng/plainbox/impl/session/test_resume.py
@@ -29,7 +29,6 @@ import base64
 import binascii
 import copy
 import gzip
-import json
 
 from plainbox.abc import IUnitQualifier
 from plainbox.abc import IJobResult

--- a/checkbox-ng/plainbox/impl/session/test_suspend.py
+++ b/checkbox-ng/plainbox/impl/session/test_suspend.py
@@ -24,7 +24,6 @@
 Test definitions for :mod:`plainbox.impl.session.suspend` module
 """
 
-from functools import partial
 from unittest import TestCase
 import gzip
 

--- a/checkbox-ng/plainbox/impl/test_execution.py
+++ b/checkbox-ng/plainbox/impl/test_execution.py
@@ -366,12 +366,11 @@ class TestDangerousNsenter(TestCase):
     def call_args_to_string(self, call_arg):
         return " ".join(str(x) for x in call_arg[0][0])
 
-    @mock.patch("plainbox.impl.execution.check_output")
     @mock.patch("plainbox.impl.execution.check_call")
     @mock.patch("plainbox.impl.execution.run")
     @mock.patch("shutil.which")
     def test_dangerous_nsenter_cleanup(
-        self, which_mock, run_mock, check_call_mock, check_output_mock
+        self, which_mock, run_mock, check_call_mock
     ):
         which_mock.return_value = "/bin/plz-run"
         with self.assertRaises(ValueError):
@@ -379,9 +378,7 @@ class TestDangerousNsenter(TestCase):
                 # prepared dangerous nsenter is copied somewhere, made extable
                 # and given caps
                 subprocess_calls = (
-                    run_mock.call_args_list
-                    + check_call_mock.call_args_list
-                    + check_output_mock.call_args_list
+                    run_mock.call_args_list + check_call_mock.call_args_list
                 )
                 subprocess_calls = [
                     self.call_args_to_string(arg) for arg in subprocess_calls
@@ -404,13 +401,10 @@ class TestDangerousNsenter(TestCase):
                 self.assertIn("cap_sys_admin", subprocess_calls_str)
                 run_mock.reset_mock()
                 check_call_mock.reset_mock()
-                check_output_mock.reset_mock()
                 raise ValueError("Ensure decorator always deletes the binary")
 
         subprocess_calls = (
-            run_mock.call_args_list
-            + check_call_mock.call_args_list
-            + check_output_mock.call_args_list
+            run_mock.call_args_list + check_call_mock.call_args_list
         )
         subprocess_calls_str = "\n".join(str(arg) for arg in subprocess_calls)
         self.assertIn("rm", subprocess_calls_str)

--- a/checkbox-ng/plainbox/impl/test_runner.py
+++ b/checkbox-ng/plainbox/impl/test_runner.py
@@ -29,13 +29,11 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 import os
 
-from plainbox.abc import IJobDefinition
 from plainbox.impl.runner import CommandOutputWriter
 from plainbox.impl.runner import FallbackCommandOutputPrinter
 from plainbox.impl.runner import IOLogRecordGenerator
 from plainbox.impl.runner import slugify
 from plainbox.testing_utils.io import TestIO
-from plainbox.vendor.mock import Mock
 
 
 class SlugifyTests(TestCase):

--- a/checkbox-ng/plainbox/impl/unit/file.py
+++ b/checkbox-ng/plainbox/impl/unit/file.py
@@ -22,17 +22,12 @@
 """
 
 import logging
-import os
 
-from plainbox.i18n import gettext as _
 from plainbox.i18n import gettext_noop as N_
 from plainbox.impl.symbol import SymbolDef
 from plainbox.impl.unit.job import propertywithsymbols
 from plainbox.impl.unit.unit import Unit, UnitValidator
-from plainbox.impl.unit.validators import CorrectFieldValueValidator
 from plainbox.impl.unit.validators import MemberOfFieldValidator
-from plainbox.impl.validation import Problem
-from plainbox.impl.validation import Severity
 
 __all__ = ["FileRole", "FileUnit"]
 

--- a/checkbox-ng/plainbox/impl/unit/job.py
+++ b/checkbox-ng/plainbox/impl/unit/job.py
@@ -50,7 +50,6 @@ from plainbox.impl.unit.validators import (
 )
 
 from plainbox.impl.validation import Problem, Severity
-from plainbox.impl.xparsers import Error, Text, Visitor, WordList
 
 __all__ = ["JobDefinition", "propertywithsymbols"]
 

--- a/checkbox-ng/plainbox/impl/unit/setup_job.py
+++ b/checkbox-ng/plainbox/impl/unit/setup_job.py
@@ -24,7 +24,6 @@
 import logging
 from collections import namedtuple
 
-from plainbox.i18n import gettext as _
 from plainbox.i18n import gettext_noop as N_
 from plainbox.impl.decorators import cached_property
 from plainbox.impl.symbol import SymbolDef

--- a/checkbox-ng/plainbox/impl/unit/test_file.py
+++ b/checkbox-ng/plainbox/impl/unit/test_file.py
@@ -25,7 +25,6 @@ Test definitions for plainbox.impl.unit.file module
 """
 
 from plainbox.impl.unit.file import FileUnit
-from plainbox.impl.unit.file import FileRole
 from plainbox.impl.unit.test_unit import UnitFieldValidationTests
 from plainbox.impl.validation import Problem
 from plainbox.impl.validation import Severity


### PR DESCRIPTION
## Description

Run was ignoring the setup jobs because of an oversight when implementing them. This fixes it so that run also runs them

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-2297

## Documentation

N/A

## Tests

Adds test to test that the function is indeed called
