### PR TITLE
Fixed unused manifest (BugFix)

### DIFF
--- a/providers/base/units/socketcan/jobs.pxu
+++ b/providers/base/units/socketcan/jobs.pxu
@@ -29,6 +29,9 @@ user: root
 flags: also-after-suspend
 estimated_duration: 1
 environ: EXPECTED_COUNT_OF_CAN_INTERFACES
+imports: from com.canonical.plainbox import manifest
+requires:
+  manifest.has_socket_can == 'True'
 command:
   if [ -n "${EXPECTED_COUNT_OF_CAN_INTERFACES:-}" ]; then
     socketcan_test.py --check-interfaces --expected-count "${EXPECTED_COUNT_OF_CAN_INTERFACES}"


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

The manifest for introduced for socketcan/detect_can here was not being used:
https://github.com/canonical/checkbox/pull/2622/changes#diff-4913cefe50262fe14cd66242928562cb68f107043687271d5c5f82e1c131233b

This PR fixes it.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->

Before, with `com.canonical.certification::has_socket_can = false`
```
-----------------------------[ Running job 1 / 1 ]------------------------------
---------------[ Ensure socketcan are available for detection. ]----------------
ID: com.canonical.certification::socketcan/detect_can
Category: SocketCAN interface tests
--------------------------------------------------------------------------------
No CAN interfaces found on this platform
--------------------------------------------------------------------------------
Outcome: job failed
==================================[ Results ]===================================
 ☒ : Ensure socketcan are available for detection.
```

Now with `com.canonical.certification::has_socket_can = false`
```
----------------------------[ Running job 1 / 2 ]------------------------------
-----------------------------[ Hardware Manifest ]------------------------------
ID: com.canonical.plainbox::manifest
Category: Informational tests
--------------------------------------------------------------------------------
Outcome: job passed
-----------------------------[ Running job 2 / 2 ]------------------------------
---------------[ Ensure socketcan are available for detection. ]----------------
ID: com.canonical.certification::socketcan/detect_can
Category: SocketCAN interface tests
--------------------------------------------------------------------------------
Outcome: job cannot be started (unmet manifest)
==================================[ Results ]===================================
 ☑ : Hardware Manifest
 ☐ : Ensure socketcan are available for detection.

```
And with `com.canonical.certification::has_socket_can = true`

```
-----------------------------[ Running job 1 / 2 ]------------------------------
-----------------------------[ Hardware Manifest ]------------------------------
ID: com.canonical.plainbox::manifest
Category: Informational tests
--------------------------------------------------------------------------------
Outcome: job passed
-----------------------------[ Running job 2 / 2 ]------------------------------
---------------[ Ensure socketcan are available for detection. ]----------------
ID: com.canonical.certification::socketcan/detect_can
Category: SocketCAN interface tests
--------------------------------------------------------------------------------
Outcome: job failed
==================================[ Results ]===================================
 ☑ : Hardware Manifest
 ☒ : Ensure socketcan are available for detection.
```
