### PR TITLE
Pretty skip reason in UI and comments (New)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -41,6 +41,7 @@ from plainbox.abc import IJobResult
 from plainbox.impl.color import Colorizer
 from plainbox.impl.config import Configuration
 from plainbox.impl.session.state import SessionMetaData
+from plainbox.impl.result_utils import pretty_skip_reason
 from plainbox.impl.session.resume import (
     IncompatibleJobError,
     CorruptedSessionError,
@@ -933,16 +934,16 @@ class RemoteController(ReportsStage, MainLoopStage):
 
     def finish_job(self, result=None, job_state=None):
         _logger.info("controller: Finishing job with a result: %s", result)
-        job_result = self.sa.finish_job(result)
-        if (
-            job_state
-            and result
-            and result.outcome == IJobResult.OUTCOME_NOT_SUPPORTED
-        ):
-            print(_("Job cannot be started because:"))
-            for inhibitor in job_state.readiness_inhibitor_list:
-                SimpleUI.yellow_text(" - {}".format(inhibitor))
+        if result and hasattr(result, "skip_reason"):
+            skip_reason = result.skip_reason
+            try:
+                skip_reason_str = pretty_skip_reason(skip_reason)
+                SimpleUI.yellow_text(skip_reason_str)
+            except ValueError:
+                pass  # unable to pretty print skip reason
+
         SimpleUI.horiz_line()
+        job_result = self.sa.finish_job(result)
         print(_("Outcome") + ": " + SimpleUI.C.result(job_result))
 
     def abandon(self):

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -940,7 +940,9 @@ class RemoteController(ReportsStage, MainLoopStage):
                 skip_reason_str = pretty_skip_reason(skip_reason)
                 SimpleUI.yellow_text(skip_reason_str)
             except ValueError:
-                pass  # unable to pretty print skip reason
+                # unable to pretty print skip reason, it may be that the job
+                # wasnt skipped at all!
+                pass
 
         SimpleUI.horiz_line()
         job_result = self.sa.finish_job(result)

--- a/checkbox-ng/checkbox_ng/launcher/run.py
+++ b/checkbox-ng/checkbox_ng/launcher/run.py
@@ -25,6 +25,7 @@ import sys
 from plainbox.abc import IJobRunnerUI
 from plainbox.i18n import gettext as _
 from plainbox.impl.color import Colorizer
+from plainbox.impl.result_utils import pretty_skip_reason
 
 logger = logging.getLogger("checkbox-ng.launcher.run")
 
@@ -212,6 +213,12 @@ class NormalUI(IJobRunnerUI):
             print()
 
     def job_cannot_start(self, job, job_state, result):
+        if hasattr(result, "skip_reason") and result.skip_reason:
+            try:
+                print(self.C.YELLOW(pretty_skip_reason(result.skip_reason)))
+                return
+            except ValueError:
+                pass
         print(_("Job cannot be started because:"))
         for inhibitor in job_state.readiness_inhibitor_list:
             print(" - {}".format(self.C.YELLOW(inhibitor)))

--- a/checkbox-ng/checkbox_ng/launcher/run.py
+++ b/checkbox-ng/checkbox_ng/launcher/run.py
@@ -218,7 +218,7 @@ class NormalUI(IJobRunnerUI):
                 print(self.C.YELLOW(pretty_skip_reason(result.skip_reason)))
                 return
             except ValueError:
-                pass
+                pass  # unable to pretty print skip reason
         print(_("Job cannot be started because:"))
         for inhibitor in job_state.readiness_inhibitor_list:
             print(" - {}".format(self.C.YELLOW(inhibitor)))

--- a/checkbox-ng/plainbox/impl/exporter/jinja2.py
+++ b/checkbox-ng/plainbox/impl/exporter/jinja2.py
@@ -82,6 +82,14 @@ def highlight_keys(text):
     return re.sub(r"(\w+:\s)", r"<b>\1</b>", text)
 
 
+def do_nl2br(value):
+    """Convert newlines to <br/> tags for HTML display."""
+    if value is None:
+        return ""
+    result = escape(value).replace("\n", Markup("<br/>"))
+    return Markup(result)
+
+
 def pretty_json_decode_error(
     error: json.decoder.JSONDecodeError, lines_around=3
 ):
@@ -182,6 +190,7 @@ class Jinja2SessionStateExporter(SessionStateExporterBase):
         env.filters["strip_ns"] = do_strip_ns
         env.filters["json_load_ordered_dict"] = json_load_ordered_dict
         env.filters["highlight_keys"] = highlight_keys
+        env.filters["nl2br"] = do_nl2br
         env.tests["is_name"] = do_is_name
 
     def dump(self, data, stream):

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
@@ -334,7 +334,7 @@
                                     {%- else %}
                                     <td style='width:10%'></td>
                                     {%- endif %}
-                                    <td style='width:35%'>{% autoescape false %}{{ job_state.result.comments if job_state.result.comments != None }}{% endautoescape %}</td>
+                                    <td style='width:35%'>{{ job_state.result.comments|nl2br if job_state.result.comments != None }}</td>
                                 </tr>
                             {%- endfor %}
                             </tbody>
@@ -375,7 +375,7 @@
                                     <td style='width:10%'></td>
                                     {%- endif %}
                                     <td style='width:10%'></td>
-                                    <td style='width:35%'>{% autoescape false %}{{ job_state.result.comments if job_state.result.comments != None }}{% endautoescape %}</td>
+                                    <td style='width:35%'>{{ job_state.result.comments|nl2br if job_state.result.comments != None }}</td>
                                 </tr>
                             {%- endfor %}
                             </tbody>
@@ -410,7 +410,7 @@
                                     {%- else %}
                                     <td style='width:10%'></td>
                                     {%- endif %}
-                                    <td style='width:35%'>{{ job_state.result.comments if job_state.result.comments != None }}</td>
+                                    <td style='width:35%'>{{ job_state.result.comments|nl2br if job_state.result.comments != None }}</td>
                                 </tr>
                                 {%- else %}
                                 <tr>
@@ -426,7 +426,7 @@
                                     {%- else %}
                                     <td style='width:10%'></td>
                                     {%- endif %}
-                                    <td style='width:35%'>{{ job_state.result.comments if job_state.result.comments != None }}</td>
+                                    <td style='width:35%'>{{ job_state.result.comments|nl2br if job_state.result.comments != None }}</td>
                                 </tr>
                                 {%- endif %}
                             {%- endfor %}
@@ -459,7 +459,7 @@
                                     {%- else %}
                                     <td style='width:10%'></td>
                                     {%- endif %}
-                                    <td style='width:35%'>{{ job_state.result.comments if job_state.result.comments != None }}</td>
+                                    <td style='width:35%'>{{ job_state.result.comments|nl2br if job_state.result.comments != None }}</td>
                                 </tr>
                     {%- if loop.last %}
                             </tbody>

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/multi-page.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/multi-page.html
@@ -379,7 +379,7 @@
                     {%- else %}
                     <td style='width:10%'></td>
                     {%- endif %}
-                    <td style='width:35%'>{% autoescape false %}{{ job_state.result.comments if job_state.result.comments != None }}{% endautoescape %}</td>
+                    <td style='width:35%'>{{ job_state.result.comments|nl2br if job_state.result.comments != None }}</td>
                 </tr>
             {%- endfor %}
             </tbody>
@@ -420,7 +420,7 @@
                     <td style='width:10%'></td>
                     {%- endif %}
                     <td style='width:10%'></td>
-                    <td style='width:35%'>{% autoescape false %}{{ job_state.result.comments if job_state.result.comments != None }}{% endautoescape %}</td>
+                    <td style='width:35%'>{{ job_state.result.comments|nl2br if job_state.result.comments != None }}</td>
                 </tr>
             {%- endfor %}
             </tbody>
@@ -455,7 +455,7 @@
                     {%- else %}
                     <td style='width:10%'></td>
                     {%- endif %}
-                    <td style='width:35%'>{{ job_state.result.comments if job_state.result.comments != None }}</td>
+                    <td style='width:35%'>{{ job_state.result.comments|nl2br if job_state.result.comments != None }}</td>
                 </tr>
                 {%- else %}
                 <tr>
@@ -471,7 +471,7 @@
                     {%- else %}
                     <td style='width:10%'></td>
                     {%- endif %}
-                    <td style='width:35%'>{{ job_state.result.comments if job_state.result.comments != None }}</td>
+                    <td style='width:35%'>{{ job_state.result.comments|nl2br if job_state.result.comments != None }}</td>
                 </tr>
                 {%- endif %}
             {%- endfor %}
@@ -503,7 +503,7 @@
                     {%- else %}
                     <td style='width:10%'></td>
                     {%- endif %}
-                    <td style='width:35%'>{{ job_state.result.comments if job_state.result.comments != None }}</td>
+                    <td style='width:35%'>{{ job_state.result.comments|nl2br if job_state.result.comments != None }}</td>
                 </tr>
     {%- if loop.last %}
             </tbody>

--- a/checkbox-ng/plainbox/impl/result_utils.py
+++ b/checkbox-ng/plainbox/impl/result_utils.py
@@ -31,6 +31,30 @@ from plainbox.abc import IJobResult
 from plainbox.impl.session.jobs import InhibitionCause
 
 
+def pretty_skip_reason(skip_reason):
+    """
+    Returns a pretty string to explain why a job was skipped
+
+    This takes into consideration precedence
+    """
+    if skip_reason.get("related_manifests"):
+        return (
+            "Job cannot be started because of unmet manifest:\n- "
+            + "\n- ".join(skip_reason["related_manifests"])
+        )
+    elif skip_reason.get("related_dependencies"):
+        return (
+            "Job cannot be started because of failed dependency:\n- "
+            + "\n- ".join(skip_reason["related_dependencies"])
+        )
+    elif skip_reason.get("related_resources"):
+        return (
+            "Job cannot be started because of unmet resource:\n- "
+            + "\n- ".join(skip_reason["related_resources"])
+        )
+    raise ValueError("Unable to explain skip reason")
+
+
 def determine_outcome_and_skip_reason(job_state, job_state_map):
     """
     Determine the correct outcome and skip_reason for a job that cannot start.

--- a/checkbox-ng/plainbox/impl/result_utils.py
+++ b/checkbox-ng/plainbox/impl/result_utils.py
@@ -37,6 +37,7 @@ def pretty_skip_reason(skip_reason):
 
     This takes into consideration precedence
     """
+    skip_reason = skip_reason or {}
     if skip_reason.get("related_manifests"):
         return (
             "Job cannot be started because of unmet manifest:\n- "

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -1629,9 +1629,7 @@ class SessionAssistant:
                 comments = pretty_skip_reason(skip_reason)
             except (ValueError, TypeError):
                 comments = job_state.get_readiness_description()
-            builder = JobResultBuilder(
-                outcome=outcome, comments=comments
-            )
+            builder = JobResultBuilder(outcome=outcome, comments=comments)
             if skip_reason:
                 builder.skip_reason = skip_reason
             ui.job_cannot_start(job, job_state, builder.get_result())

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -51,6 +51,7 @@ from plainbox.impl.developer import (
 from plainbox.impl.providers import get_providers
 from plainbox.impl.result import JobResultBuilder, MemoryJobResult
 from plainbox.impl.result_utils import determine_outcome_and_skip_reason
+from plainbox.impl.result_utils import pretty_skip_reason
 from plainbox.impl.runner import JobRunnerUIDelegate
 from plainbox.impl.secure.origin import Origin
 from plainbox.impl.secure.qualifiers import (
@@ -1624,8 +1625,12 @@ class SessionAssistant:
             outcome, skip_reason = determine_outcome_and_skip_reason(
                 job_state, self._context.state.job_state_map
             )
+            try:
+                comments = pretty_skip_reason(skip_reason)
+            except (ValueError, TypeError):
+                comments = job_state.get_readiness_description()
             builder = JobResultBuilder(
-                outcome=outcome, comments=job_state.get_readiness_description()
+                outcome=outcome, comments=comments
             )
             if skip_reason:
                 builder.skip_reason = skip_reason

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -43,6 +43,7 @@ from plainbox.impl.providers.v1 import (
 )
 from plainbox.impl.result import JobResultBuilder, MemoryJobResult
 from plainbox.impl.result_utils import determine_outcome_and_skip_reason
+from plainbox.impl.result_utils import pretty_skip_reason
 from plainbox.impl.secure.providers.v1 import (
     reload_all_providers as reload_all_secure_providers,
 )
@@ -567,9 +568,13 @@ class RemoteSessionAssistant:
             )
 
             def cant_start_builder(*args, **kwargs):
+                try:
+                    comments = pretty_skip_reason(skip_reason)
+                except (ValueError, TypeError):
+                    comments = job_state.get_readiness_description()
                 result_builder = JobResultBuilder(
                     outcome=outcome,
-                    comments=job_state.get_readiness_description(),
+                    comments=comments,
                 )
                 if skip_reason:
                     result_builder.skip_reason = skip_reason

--- a/checkbox-ng/plainbox/impl/test_result_utils.py
+++ b/checkbox-ng/plainbox/impl/test_result_utils.py
@@ -20,7 +20,10 @@ import unittest
 from unittest.mock import Mock
 
 from plainbox.abc import IJobResult
-from plainbox.impl.result_utils import determine_outcome_and_skip_reason
+from plainbox.impl.result_utils import (
+    determine_outcome_and_skip_reason,
+    pretty_skip_reason,
+)
 from plainbox.impl.session.jobs import InhibitionCause
 
 
@@ -405,3 +408,77 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
             "com.canonical.certification::has_touchpad",
             skip_reason["related_manifests"],
         )
+
+
+class PrettySkipReasonTests(unittest.TestCase):
+
+    def test_only_related_dependencies(self):
+        skip_reason = {
+            "related_dependencies": ["job1", "job2"],
+            "related_resources": [],
+            "related_manifests": [],
+        }
+        result = pretty_skip_reason(skip_reason)
+        self.assertIn("job1", result)
+        self.assertIn("job2", result)
+
+    def test_only_related_resources(self):
+        skip_reason = {
+            "related_dependencies": [],
+            "related_resources": ["cpuinfo.count > 2"],
+            "related_manifests": [],
+        }
+        result = pretty_skip_reason(skip_reason)
+        self.assertIn("cpuinfo.count > 2", result)
+
+    def test_only_related_manifests(self):
+        skip_reason = {
+            "related_dependencies": [],
+            "related_resources": [],
+            "related_manifests": [
+                "com.canonical.certification::has_thunderbolt3"
+            ],
+        }
+        result = pretty_skip_reason(skip_reason)
+        self.assertIn("com.canonical.certification::has_thunderbolt3", result)
+
+    def test_precedence_manifests_before_dependencies(self):
+        skip_reason = {
+            "related_dependencies": ["job1"],
+            "related_resources": [],
+            "related_manifests": ["com.canonical.certification::has_feature"],
+        }
+        result = pretty_skip_reason(skip_reason)
+        self.assertIn("com.canonical.certification::has_feature", result)
+        self.assertNotIn("job1", result)
+
+    def test_precedence_dependencies_before_resources(self):
+        """Test that dependencies appear before resources in the output."""
+        skip_reason = {
+            "related_dependencies": ["job1"],
+            "related_resources": ["cpuinfo.count > 2"],
+            "related_manifests": [],
+        }
+        result = pretty_skip_reason(skip_reason)
+        self.assertIn("job1", result)
+        self.assertNotIn("cpuinfo.count > 2", result)
+
+    def test_precedence_all_fields(self):
+        skip_reason = {
+            "related_dependencies": ["job1"],
+            "related_resources": ["cpuinfo.count > 2"],
+            "related_manifests": ["com.canonical.certification::has_touchpad"],
+        }
+        result = pretty_skip_reason(skip_reason)
+        self.assertIn("com.canonical.certification::has_touchpad", result)
+        self.assertNotIn("job1", result)
+        self.assertNotIn("cpuinfo.count > 2", result)
+
+    def test_no_valid_fields_raises_value_error(self):
+        skip_reason = {
+            "related_dependencies": [],
+            "related_resources": [],
+            "related_manifests": [],
+        }
+        with self.assertRaises(ValueError):
+            pretty_skip_reason(skip_reason)

--- a/checkbox-ng/plainbox/impl/test_result_utils.py
+++ b/checkbox-ng/plainbox/impl/test_result_utils.py
@@ -482,3 +482,9 @@ class PrettySkipReasonTests(unittest.TestCase):
         }
         with self.assertRaises(ValueError):
             pretty_skip_reason(skip_reason)
+
+    def test_none_raises_value_error(self):
+        # this is convenient because allows us to call the function
+        # unconditionally when a job wasn't skipped (so it has no skip reason)
+        with self.assertRaises(ValueError):
+            pretty_skip_reason(None)

--- a/metabox/metabox/metabox-provider/units/basic-jobs.yaml
+++ b/metabox/metabox/metabox-provider/units/basic-jobs.yaml
@@ -311,3 +311,50 @@ command: |
 summary: Tests that generated units are validated and reported when params are missing
 flags:
   - simple
+---
+id: requires_skip
+summary: Returns nothing to test skipping
+plugin: resource
+command: |
+  true
+---
+id: simple_skipped
+flags:
+  - simple
+summary: This job is skipped
+requires:
+  - requires_skip.missing == "missing value"
+command: |
+  false
+---
+id: failing_job
+flags:
+  - simple
+summary: This job always fails
+command: |
+  false
+---
+id: skipped_by_dependency
+flags:
+  - simple
+summary: This job is skipped due to failed dependency
+depends:
+  - failing_job
+command: |
+  true
+---
+id: skipped_by_manifest
+flags:
+  - simple
+summary: This job is skipped due to unmet manifest
+imports:
+  - from com.canonical.plainbox import manifest
+requires:
+  - manifest.skipping_test_manifest == 'True'
+command: |
+  true
+---
+unit: manifest entry
+id: skipping_test_manifest
+name: Manifest entry for testing skip due to unmet manifest
+value-type: bool

--- a/metabox/metabox/metabox-provider/units/basic-tps.yaml
+++ b/metabox/metabox/metabox-provider/units/basic-tps.yaml
@@ -92,3 +92,14 @@ name: Test plan that sleeps, terminates only
 include:
   - sleep_1000s
   - basic-shell-passing
+---
+unit: test plan
+id: skipping_test_plan
+name: Test plan to test skipping
+bootstrap_include:
+  - requires_skip
+include:
+  - simple_skipped
+  - failing_job
+  - skipped_by_dependency
+  - skipped_by_manifest

--- a/metabox/metabox/scenarios/basic/skip_reason.py
+++ b/metabox/metabox/scenarios/basic/skip_reason.py
@@ -1,0 +1,50 @@
+# This file is part of Checkbox.
+#
+# Copyright 2025 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+
+from metabox.core.scenario import Scenario
+from metabox.core.actions import AssertPrinted, Start
+from metabox.core.utils import tag
+
+
+@tag("skip-reason", "basic")
+class SkipReasonShownUI(Scenario):
+    modes = ["remote"]
+
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::skipping_test_plan
+        forced = yes
+        [test selection]
+        forced = yes
+        [ui]
+        type = silent
+        [manifest]
+        2021.com.canonical.certification::skipping_test_manifest=False
+        """)
+    steps = [
+        Start(),
+        AssertPrinted("Job cannot be started because of unmet resource:"),
+        AssertPrinted(r'requires_skip\.missing == "missing value"'),
+        AssertPrinted("Job cannot be started because of failed dependency:"),
+        AssertPrinted("failing_job"),
+        AssertPrinted("Job cannot be started because of unmet manifest:"),
+        AssertPrinted("skipping_test_manifest"),
+    ]


### PR DESCRIPTION
## Description

Checkbox used to dump the inhibitors in the console and in the comment of skipped tests but this is not really user friendly as they are hard to read and may not be fully relevant when there is more than one. This PR replaces that mechanism with one that writes the actual skip reason for skipped jobs using the new skip reason system introduced recently. 

## Resolved issues

Fixes: https://warthogs.atlassian.net/browse/CHECKBOX-650

## Documentation

N/A

## Tests

Added metabox tests.
New HTML report: [report_remote.html](https://github.com/user-attachments/files/30261234/report_remote.html)
New submission.json: [submission_remote.json](https://github.com/user-attachments/files/30261244/submission_remote.json)

Try this out with this launcher: [example.txt](https://github.com/user-attachments/files/30261284/example.txt) (txt because GH refuses to upload .conf)
Screenshots:
<img width="566" height="397" alt="image" src="https://github.com/user-attachments/assets/ea91effc-3ecf-4e97-b0eb-5c8727d06d59" />

<img width="574" height="134" alt="image" src="https://github.com/user-attachments/assets/df9fbe4c-8c12-42a3-bc3d-19d1c5b686b9" />



