### PR TITLE
Add finish and exit option (new)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -59,6 +59,7 @@ from checkbox_ng.urwid_ui import (
     interrupt_dialog,
     resume_dialog,
     ResumeInstead,
+    InterruptDialogAnswer,
 )
 from checkbox_ng.utils import (
     generate_resume_candidate_description,
@@ -475,6 +476,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         self.bootstrap_and_continue()
 
     def automatically_start_via_launcher_and_continue(self):
+        SimpleUI.header("Starting new automated session via launcher")
         _ = self.start_session()
         test_plan_unit = self.launcher.get_value("test plan", "unit")
         self.select_test_plan(test_plan_unit)
@@ -482,6 +484,9 @@ class RemoteController(ReportsStage, MainLoopStage):
 
     def resume_last_session_and_continue(self):
         last_abandoned_session = next(self.sa.get_resumable_sessions())
+        SimpleUI.header(
+            "Resuming last session: {}".format(last_abandoned_session.id)
+        )
         return self.resume_by_id(last_abandoned_session.id)
 
     def start_session(self):
@@ -577,6 +582,7 @@ class RemoteController(ReportsStage, MainLoopStage):
         return self.resume_by_id(resume_params.session_id, result_dict)
 
     def interactively_choose_test_plan_and_continue(self):
+        SimpleUI.header("Starting new interactive session")
         tps = self.start_session()
         _logger.info("controller: Interactively choosing TP.")
         while True:
@@ -781,19 +787,24 @@ class RemoteController(ReportsStage, MainLoopStage):
             self._sa.terminate()
             return False
         response = interrupt_dialog(self._target_host)
-        if response == "cancel":
+        if response == InterruptDialogAnswer.CANCEL:
             return True
-        elif response == "kill-controller":
+        elif response == InterruptDialogAnswer.KILL_CONTROLLER:
             return False
-        elif response == "kill-agent":
+        elif response == InterruptDialogAnswer.KILL_AGENT:
             self._sa.terminate()
             return False
-        elif response == "abandon":
+        elif response == InterruptDialogAnswer.FINALIZE:
             self._sa.finalize_session()
             return True
-        elif response == "kill-command":
+        elif response == InterruptDialogAnswer.FINALIZE_EXIT:
+            self._sa.finalize_session()
+            return False
+        elif response == InterruptDialogAnswer.KILL_COMMAND:
             self._sa.send_signal(signal.SIGKILL.value)
             return True
+        elif response is None:
+            return False
 
     def finish_session(self, *args):
         print(self.C.header("Results"))

--- a/checkbox-ng/checkbox_ng/urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/urwid_ui.py
@@ -24,6 +24,7 @@
 
 import os
 import time
+from enum import Enum
 
 from gettext import gettext as _
 
@@ -828,6 +829,15 @@ class TestPlanBrowser:
             return None
 
 
+class InterruptDialogAnswer(Enum):
+    CANCEL = "cancel"
+    KILL_COMMAND = "kill-command"
+    KILL_CONTROLLER = "kill-controller"
+    KILL_AGENT = "kill-agent"
+    FINALIZE = "finalize"
+    FINALIZE_EXIT = "finalize-exit"
+
+
 def interrupt_dialog(host):
     palette = [
         ("body", "light gray", "black", "standout"),
@@ -837,17 +847,24 @@ def interrupt_dialog(host):
         ("foot", "light gray", "black"),
         ("start", "dark green,bold", "black"),
     ]
-    choices = [
-        _("Nothing, continue testing (ESC)"),
-        _("Stop the test case in progress and move on to the next"),
-        _("Pause the test session and disconnect from the agent (CTRL+C)"),
-        _(
-            "Exit and stop the Checkbox agent on the testbed at {}".format(
-                host
-            )
+    choices = {
+        InterruptDialogAnswer.CANCEL: _("Nothing, continue testing (ESC)"),
+        InterruptDialogAnswer.KILL_COMMAND: _(
+            "Stop the test case in progress and move on to the next"
         ),
-        _("End this test session preserving its data and launch a new one"),
-    ]
+        InterruptDialogAnswer.KILL_CONTROLLER: _(
+            "Pause the test session and disconnect from the agent (CTRL+C)"
+        ),
+        InterruptDialogAnswer.KILL_AGENT: _(
+            "Exit and stop the Checkbox agent on the DUT at {}".format(host)
+        ),
+        InterruptDialogAnswer.FINALIZE: _(
+            "End this test session preserving its data and launch a new one"
+        ),
+        InterruptDialogAnswer.FINALIZE_EXIT: _(
+            "End this test session preserving its data and exit (Q)"
+        ),
+    }
     footer_text = [
         ("Press "),
         ("start", "<Enter>"),
@@ -873,7 +890,7 @@ def interrupt_dialog(host):
                         "buttn",
                         "buttnf",
                     )
-                    for txt in choices
+                    for txt in choices.values()
                 ]
             ),
             left=15,
@@ -901,7 +918,14 @@ def interrupt_dialog(host):
         if key == "enter":
             raise urwid.ExitMainLoop()
         if key == "esc":
-            radio_button_group[0].set_state(True)
+            radio_button_group[
+                list(choices).index(InterruptDialogAnswer.CANCEL)
+            ].set_state(True)
+            raise urwid.ExitMainLoop()
+        if key in ["Q", "q"]:
+            radio_button_group[
+                list(choices).index(InterruptDialogAnswer.FINALIZE_EXIT)
+            ].set_state(True)
             raise urwid.ExitMainLoop()
 
     urwid.MainLoop(
@@ -915,13 +939,7 @@ def interrupt_dialog(host):
         index = next(
             radio_button_group.index(i) for i in radio_button_group if i.state
         )
-        return [
-            "cancel",
-            "kill-command",
-            "kill-controller",
-            "kill-agent",
-            "abandon",
-        ][index]
+        return list(choices)[index]
     except StopIteration:
         return None
 

--- a/checkbox-ng/checkbox_ng/urwid_ui.py
+++ b/checkbox-ng/checkbox_ng/urwid_ui.py
@@ -25,6 +25,7 @@
 import os
 import time
 from enum import Enum
+from collections import OrderedDict
 
 from gettext import gettext as _
 
@@ -830,12 +831,12 @@ class TestPlanBrowser:
 
 
 class InterruptDialogAnswer(Enum):
-    CANCEL = "cancel"
-    KILL_COMMAND = "kill-command"
-    KILL_CONTROLLER = "kill-controller"
-    KILL_AGENT = "kill-agent"
-    FINALIZE = "finalize"
-    FINALIZE_EXIT = "finalize-exit"
+    CANCEL = 0  # auto() doesn't exist in python3.5
+    KILL_COMMAND = 1
+    KILL_CONTROLLER = 2
+    KILL_AGENT = 3
+    FINALIZE = 4
+    FINALIZE_EXIT = 5
 
 
 def interrupt_dialog(host):
@@ -847,24 +848,26 @@ def interrupt_dialog(host):
         ("foot", "light gray", "black"),
         ("start", "dark green,bold", "black"),
     ]
-    choices = {
-        InterruptDialogAnswer.CANCEL: _("Nothing, continue testing (ESC)"),
-        InterruptDialogAnswer.KILL_COMMAND: _(
-            "Stop the test case in progress and move on to the next"
-        ),
-        InterruptDialogAnswer.KILL_CONTROLLER: _(
-            "Pause the test session and disconnect from the agent (CTRL+C)"
-        ),
-        InterruptDialogAnswer.KILL_AGENT: _(
-            "Exit and stop the Checkbox agent on the DUT at {}".format(host)
-        ),
-        InterruptDialogAnswer.FINALIZE: _(
-            "End this test session preserving its data and launch a new one"
-        ),
-        InterruptDialogAnswer.FINALIZE_EXIT: _(
-            "End this test session preserving its data and exit (Q)"
-        ),
-    }
+    choices = OrderedDict()
+    choices[InterruptDialogAnswer.CANCEL] = _(
+        "Nothing, continue testing (ESC)"
+    )
+    choices[InterruptDialogAnswer.KILL_COMMAND] = _(
+        "Stop the test case in progress and move on to the next"
+    )
+    choices[InterruptDialogAnswer.KILL_CONTROLLER] = _(
+        "Pause the test session and disconnect from the agent (CTRL+C)"
+    )
+    choices[InterruptDialogAnswer.KILL_AGENT] = _(
+        "Exit and stop the Checkbox agent on the DUT at {}".format(host)
+    )
+    choices[InterruptDialogAnswer.FINALIZE] = _(
+        "End this test session preserving its data and launch a new one"
+    )
+    choices[InterruptDialogAnswer.FINALIZE_EXIT] = _(
+        "End this test session preserving its data and exit (Q)"
+    )
+
     footer_text = [
         ("Press "),
         ("start", "<Enter>"),

--- a/metabox/metabox/scenarios/ui/interrupt_menu.py
+++ b/metabox/metabox/scenarios/ui/interrupt_menu.py
@@ -18,7 +18,7 @@
 import textwrap
 
 import metabox.core.keys as keys
-from metabox.core.actions import Expect, Send, Start, Signal, RunCmd
+from metabox.core.actions import Expect, Send, Start, Signal, ExpectNot
 from metabox.core.scenario import Scenario
 from metabox.core.utils import tag
 
@@ -136,4 +136,34 @@ class CtrlCMenuEndSession(Scenario):
         Send(keys.KEY_ENTER),
         Expect("ID: 2021.com.canonical.certification::sleep_1000s"),
         Expect("starting to sleep"),
+    ]
+
+
+@tag("ui", "interact", "interrupt")
+class CtrlCMenuEndSessionExit(Scenario):
+    modes = ["remote"]
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::tired_test_plan
+        forced = yes
+        [test selection]
+        forced = yes
+        """)
+
+    steps = [
+        Start(),
+        Expect("ID: 2021.com.canonical.certification::sleep_1000s"),
+        Expect("starting to sleep"),
+        Signal(keys.SIGINT),
+        Expect("Interruption!"),
+        Send(keys.KEY_DOWN * 5 + keys.KEY_SPACE),
+        Expect("(X) End this test session"),
+        # Note: this is the session re-starting as we have an automated
+        #       launcher
+        Send(keys.KEY_ENTER),
+        ExpectNot("ID: 2021.com.canonical.certification::sleep_1000s"),
+        ExpectNot("starting to sleep"),
     ]


### PR DESCRIPTION
## Description

When running an automated launcher run (so with forced test selection and test plan selection), the user is unable to exit the test run (finalizing it) back to the cli via the Ctrl+c menu. The reason is that the option doesn't exist, the closest option is to select the `"End this test session preserving its data and launch a new one"` and then rapidly cltr+c twice. The reason is that `"End this test session preserving its data and launch a new one"` finalizes the session and starts a new one, that give that the launcher is provided and automated, immediatly starts testing.

This also looks like a bug because when starting checkbox doesn't signal to the user what it is doing, so there is no way to separate resumes from new sessions from new interactive sessions.

This PR fixes both issues:
1. Introduces a new option to finalize and close the controller (fast key: Q)
2. Introduces a new banner when starting a session that explains how that session was started (handy in general but especially in these situations)

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/2720

## Documentation

N/A

## Tests

This was manually tested. The banner looks like this:
```
----------------[ Starting new automated session via launcher ]-----------------
```
This is the launcher used to play around with it
```
#!/usr/bin/env checkbox-cli
#[ui]
#type=silent
[launcher]
launcher_version = 1
stock_reports = text
[test plan]
unit=2021.com.canonical.certification::tired_test_plan
forced = yes
[test selection]
forced = yes
```

Note: a metabox test for this is WIP but it is pretty tricky to develop so lets see if I manage