### PR TITLE
Hidden manifest entry for ignoring efi testing on the devices that does not have UEFI (New)

### DIFF
--- a/providers/base/units/miscellanea/jobs.pxu
+++ b/providers/base/units/miscellanea/jobs.pxu
@@ -121,8 +121,10 @@ plugin: shell
 category_id: com.canonical.plainbox::miscellanea
 estimated_duration: 0.5
 id: miscellanea/efi_boot_mode
+imports: from com.canonical.plainbox import manifest
 requires:
  cpuinfo.platform in ("i386", "x86_64", "aarch64")
+ manifest._ignore_efi_boot_mode == 'False'
 _summary: Test that system booted in EFI mode
 _purpose:
  Test to verify that the system booted in EFI mode.

--- a/providers/base/units/miscellanea/manifest.pxu
+++ b/providers/base/units/miscellanea/manifest.pxu
@@ -14,3 +14,11 @@ _name: Experimental testing
 value-type: bool
 hidden-reason: Experimental jobs should run only on systems explicitly flagged
   for that coverage through configuration.
+
+unit: manifest entry
+id: _ignore_efi_boot_mode
+_name: Ignore EFI boot mode requirement
+value-type: bool
+hidden-reason: Some ARM boards (e.g. Raspberry Pi) boot via native firmware
+  rather than UEFI and should not run efi_boot_mode test when running in
+  the lab.


### PR DESCRIPTION
## Description

RPIs boot using custom firmware rather then UEFI. This results that `miscellanea/efi_boot_mode` is constantly failing on that devices. 
Hidden manifest `_ignore_efi_boot_mode` provides explicit leverage to ignore the test on a specific devices.

## Resolved issues

[CER-4095](https://warthogs.atlassian.net/browse/CER-4095)

## Documentation

N/A

## Tests

N/A


[CER-4095]: https://warthogs.atlassian.net/browse/CER-4095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ