### PR TITLE
More debuggable UsageExpectation (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/developer.py
+++ b/checkbox-ng/plainbox/impl/developer.py
@@ -74,6 +74,10 @@ class UnexpectedMethodCall(Exception):
             a part of a string that looks like this: ``' - call {fn_name}() to
             {why}.'``. Developers should use explanations that look natural in
             this context. This text is not meant for internationalization.
+        :param history:
+            A sequence of functions that modified the allowed_pairs and how
+            they did so (fn_name, action), where action is "allow", "disallow",
+            "allow_all_clear", "allow_all_no_clear"
         """
         self.cls = cls
         self.fn_name = fn_name
@@ -91,7 +95,8 @@ class UnexpectedMethodCall(Exception):
                 )
                 for allowed_fn_name, why in self.allowed_pairs
             ),
-            modification_history=" - " + "\n - ".join(self.history),
+            modification_history=" - "
+            + "\n - ".join("{} ({})".format(*x) for x in self.history),
             modification_size=str(MODIFICATION_HISTORY),
         )
 
@@ -155,7 +160,7 @@ class UsageExpectation:
             A string that explains why the function is allowed to be called.
         """
         self._allowed_calls[function.__name__] = reason
-        self._modified(current_function)
+        self._modified(current_function, "allow")
 
     def disallow(self, current_function: Callable, function: Callable):
         """
@@ -168,7 +173,7 @@ class UsageExpectation:
             The function that is now disallowed to be called.
         """
         del self._allowed_calls[function.__name__]
-        self._modified(current_function)
+        self._modified(current_function, "disallow")
 
     def allow_all(
         self,
@@ -195,15 +200,20 @@ class UsageExpectation:
         }
         if clear:
             self._allowed_calls = str_function_reason
+            action = "allow_all, clear"
         else:
             self._allowed_calls.update(str_function_reason)
-        self._modified(current_function)
+            action = "allow_all, don't clear"
+        self._modified(current_function, action)
 
-    def _modified(self, current_function):
+    def _modified(self, current_function, action):
         self.history.append(
-            "{}.{}".format(
-                current_function.__self__.__class__.__name__,
-                current_function.__name__,
+            (
+                "{}.{}".format(
+                    current_function.__self__.__class__.__name__,
+                    current_function.__name__,
+                ),
+                action,
             )
         )
 

--- a/checkbox-ng/plainbox/impl/developer.py
+++ b/checkbox-ng/plainbox/impl/developer.py
@@ -20,6 +20,14 @@
 """Support code for enforcing usage expectations on public API."""
 
 from collections import deque
+from collections.abc import Callable
+
+import sys
+
+if sys.version_info < (3, 9):
+    from typing import Dict
+else:
+    Dict = dict
 
 __all__ = ("UsageExpectation",)
 
@@ -129,25 +137,66 @@ class UsageExpectation:
             something goes wrong.
         """
         self.cls = cls
-        self._allowed_calls = {}
+        self._allowed_calls = {}  # type: Dict[str, str]
         self.history = deque([], maxlen=MODIFICATION_HISTORY)
 
-    def allow(self, current_function, function, reason):
+    def allow(
+        self, current_function: Callable, function: Callable, reason: str
+    ):
+        """
+        Allow the current object to call the given function.
+
+        :param current_function:
+            The function that called this method. This is used to record the
+            history of modifications.
+        :param function:
+            The function that is now allowed to be called.
+        :param reason:
+            A string that explains why the function is allowed to be called.
+        """
         self._allowed_calls[function.__name__] = reason
         self._modified(current_function)
 
-    def disallow(self, current_function, function):
+    def disallow(self, current_function: Callable, function: Callable):
+        """
+        Disallow the current object to call the given function.
+
+        :param current_function:
+            The function that called this method. This is used to record the
+            history of modifications.
+        :param function:
+            The function that is now disallowed to be called.
+        """
         del self._allowed_calls[function.__name__]
         self._modified(current_function)
 
-    def allow_all(self, current_function, function_reason, clear=True):
-        function_reason = {
+    def allow_all(
+        self,
+        current_function: Callable,
+        function_reason: Dict[Callable, str],
+        clear=True,
+    ):
+        """
+        Allow the current object to call all given functions.
+
+        :param current_function:
+            The function that called this method. This is used to record the
+            history of modifications.
+        :param function_reason:
+            A dictionary mapping functions to strings that explain why each
+            function is allowed to be called.
+        :param clear:
+            If True (default), replace the current set of allowed calls with
+            the new ones. If False, merge the new allowed calls into the
+            existing set.
+        """
+        str_function_reason = {
             f.__name__: reason for f, reason in function_reason.items()
         }
         if clear:
-            self._allowed_calls = function_reason
+            self._allowed_calls = str_function_reason
         else:
-            self._allowed_calls.update(function_reason)
+            self._allowed_calls.update(str_function_reason)
         self._modified(current_function)
 
     def _modified(self, current_function):
@@ -158,9 +207,12 @@ class UsageExpectation:
             )
         )
 
-    def enforce(self, current_function):
+    def enforce(self, current_function: Callable):
         """
         Enforce that usage expectations of the caller are met.
+
+        This method checks if the `current_function` is allowed to be called at
+        this time or raises an UnexpectedMethodCall
 
         :raises UnexpectedMethodCall:
             If the expectations are not met.

--- a/checkbox-ng/plainbox/impl/developer.py
+++ b/checkbox-ng/plainbox/impl/developer.py
@@ -1,8 +1,9 @@
 # This file is part of Checkbox.
 #
-# Copyright 2015 Canonical Ltd.
+# Copyright 2015-2026 Canonical Ltd.
 # Written by:
 #   Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
@@ -18,54 +19,28 @@
 
 """Support code for enforcing usage expectations on public API."""
 
-import inspect
-import logging
-import warnings
-
 __all__ = ("UsageExpectation",)
 
-_logger = logging.getLogger("plainbox.developer")
+MODIFICATION_HISTORY = 5
 
-
-class OffByOneBackWarning(UserWarning):
-    """Warning on incorrect use of UsageExpectations(self).enforce(back=2)."""
-
-
-class DeveloperError(Exception):
-    """
-    Exception raised when program flow is incorrect.
-
-    This exception is meant to gently educate the developer about a mistake in
-    his or her choices in the flow of calls. Some classes may use it to explain
-    that a precondition was not met. Applications are not intended to catch
-    this exception.
-    """
-
-    pass  # Eh, PEP-257 checkers...
-
-
-# NOTE: This is not meant for internationalization. There is some string
-# manipulation associated with this that would be a bit more cumbersome to do
-# "correctly" for the small benefit.
 _msg_template = """
 Uh, oh...
 
-You are not expected to call {cls_name}.{fn_name}() at this time.
+If you see this message then there is a bug somewhere in Checkbox. We are
+sorry for this. Please report this to us.
 
-If you see this message then there is a bug somewhere in your code. We are
-sorry for this. Perhaps the documentation is flawed, incomplete or confusing.
-Please reach out to us if  this happens more often than you'd like.
-
+You are not expected to call {cls_name}.{fn_name} at this time.
 The set of allowed calls, at this time, is:
 
 {allowed_calls}
 
-Refer to the documentation of {cls_name} for details.
-    TIP: python -m pydoc {cls_module}.{cls_name}
+The last {modification_size} modifications were done by (most recent last):
+
+{modification_history}
 """
 
 
-class UnexpectedMethodCall(DeveloperError):
+class UnexpectedMethodCall(Exception):
     """
     Developer error reported when an unexpected method call is made.
 
@@ -73,7 +48,7 @@ class UnexpectedMethodCall(DeveloperError):
     called in a given way but that expectation was not followed.
     """
 
-    def __init__(self, cls, fn_name, allowed_pairs):
+    def __init__(self, cls, fn_name, allowed_pairs, history):
         """
         Initialize a new exception.
 
@@ -93,11 +68,11 @@ class UnexpectedMethodCall(DeveloperError):
         self.cls = cls
         self.fn_name = fn_name
         self.allowed_pairs = allowed_pairs
+        self.history = history
 
     def __str__(self):
         """Get a developer-friendly message that describes the problem."""
         return _msg_template.format(
-            cls_module=self.cls.__module__,
             cls_name=self.cls.__name__,
             fn_name=self.fn_name,
             allowed_calls="\n".join(
@@ -106,6 +81,8 @@ class UnexpectedMethodCall(DeveloperError):
                 )
                 for allowed_fn_name, why in self.allowed_pairs
             ),
+            modification_history=" - " + "\n - ".join(self.history),
+            modification_size=str(MODIFICATION_HISTORY),
         )
 
 
@@ -114,19 +91,12 @@ class UsageExpectation:
     Class representing API usage expectation at any given time.
 
     Expectations help formalize the way developers are expected to use some set
-    of classes, methods and other instruments. Technically, they also encode
-    the expectations and can raise :class:`DeveloperError`.
-
-    :attr allowed_calls:
-        A dictionary mapping from bound methods / functions to the use case
-        explaining how that method can be used at the given moment. This works
-        best if the usage is mostly linear (call foo.a(), then foo.b(), then
-        foo.c()).
-
-        This attribute can be set directly for simplicity.
+    of classes, methods and other instruments.
 
     :attr cls:
         The class of objects this expectation object applies to.
+    :attr history:
+        The modification history of allowed calls from older to newer
     """
 
     @classmethod
@@ -157,79 +127,60 @@ class UsageExpectation:
             something goes wrong.
         """
         self.cls = cls
-        self.allowed_calls = {}
+        self._allowed_calls = {}
+        self._last_modifications = [None] * MODIFICATION_HISTORY
+        self._last_modifications_i = 0
 
-    def enforce(self, back=1):
+    def allow(self, current_function, function, reason):
+        self._allowed_calls[function.__name__] = reason
+        self._modified(current_function)
+
+    def disallow(self, current_function, function):
+        del self._allowed_calls[function.__name__]
+        self._modified(current_function)
+
+    def allow_all(self, current_function, function_reason, clear=True):
+        function_reason = {
+            f.__name__: reason for f, reason in function_reason.items()
+        }
+        if clear:
+            self._allowed_calls = function_reason
+        else:
+            self._allowed_calls.update(function_reason)
+        self._modified(current_function)
+
+    def _modified(self, current_function):
+        self._last_modifications[self._last_modifications_i] = "{}.{}".format(
+            current_function.__self__.__class__.__name__,
+            current_function.__name__,
+        )
+        self._last_modifications_i += 1
+        self._last_modifications_i %= len(self._last_modifications)
+
+    @property
+    def history(self):
+        history = [
+            self._last_modifications[self._last_modifications_i - i]
+            for i, _ in enumerate(self._last_modifications)
+        ]
+        return [h for h in reversed(history) if h is not None]
+
+    def enforce(self, current_function):
         """
         Enforce that usage expectations of the caller are met.
 
-        :param back:
-            How many function call frames to climb to look for caller.  By
-            default we always go one frame back (the immediate caller) but if
-            this is used in some decorator or other similar construct then you
-            may need to pass a bigger value.
-
-            Depending on this value, the error message displayed to the
-            developer will be either spot-on or downright wrong and confusing.
-            Make sure the value you use it correct!
-
-        :raises DeveloperError:
+        :raises UnexpectedMethodCall:
             If the expectations are not met.
         """
         # XXX: Allowed calls is a dictionary that may be freely changed by the
         # outside caller. We're unable to protect against it. Therefore the
         # optimized values (for computing what is really allowed) must be
         # obtained each time we are about to check, in enforce()
-        allowed_code = frozenset(
-            (
-                func.__wrapped__.__code__
-                if hasattr(func, "__wrapped__")
-                else func.__code__
-            )
-            for func in self.allowed_calls
+        if current_function.__name__ in self._allowed_calls:
+            return
+        raise UnexpectedMethodCall(
+            self.cls,
+            current_function.__name__,
+            self._allowed_calls.items(),
+            self.history,
         )
-        caller_frame = inspect.stack(0)[back][0]
-        if back > 1:
-            alt_caller_frame = inspect.stack(0)[back - 1][0]
-        else:
-            alt_caller_frame = None
-        _logger.debug("Caller code: %r", caller_frame.f_code)
-        _logger.debug(
-            "Alternate code: %r",
-            alt_caller_frame.f_code if alt_caller_frame else None,
-        )
-        _logger.debug("Allowed code: %r", allowed_code)
-        try:
-            if caller_frame.f_code in allowed_code:
-                return
-            # This can be removed later, it allows the caller to make an
-            # off-by-one mistake and go away with it.
-            if (
-                alt_caller_frame is not None
-                and alt_caller_frame.f_code in allowed_code
-            ):
-                warnings.warn(
-                    "Please back={}. Properly constructed decorators are"
-                    " automatically handled and do not require the use of the"
-                    " back argument.".format(back - 1),
-                    OffByOneBackWarning,
-                    back,
-                )
-                return
-            fn_name = caller_frame.f_code.co_name
-            allowed_undecorated_calls = {
-                func.__wrapped__ if hasattr(func, "__wrapped__") else func: msg
-                for func, msg in self.allowed_calls.items()
-            }
-            allowed_pairs = tuple(
-                (fn.__code__.co_name, why)
-                for fn, why in sorted(
-                    allowed_undecorated_calls.items(),
-                    key=lambda fn_why: fn_why[0].__code__.co_name,
-                )
-            )
-            raise UnexpectedMethodCall(self.cls, fn_name, allowed_pairs)
-        finally:
-            del caller_frame
-            if alt_caller_frame is not None:
-                del alt_caller_frame

--- a/checkbox-ng/plainbox/impl/developer.py
+++ b/checkbox-ng/plainbox/impl/developer.py
@@ -19,6 +19,8 @@
 
 """Support code for enforcing usage expectations on public API."""
 
+from collections import deque
+
 __all__ = ("UsageExpectation",)
 
 MODIFICATION_HISTORY = 5
@@ -128,8 +130,7 @@ class UsageExpectation:
         """
         self.cls = cls
         self._allowed_calls = {}
-        self._last_modifications = [None] * MODIFICATION_HISTORY
-        self._last_modifications_i = 0
+        self.history = deque([], maxlen=MODIFICATION_HISTORY)
 
     def allow(self, current_function, function, reason):
         self._allowed_calls[function.__name__] = reason
@@ -150,20 +151,12 @@ class UsageExpectation:
         self._modified(current_function)
 
     def _modified(self, current_function):
-        self._last_modifications[self._last_modifications_i] = "{}.{}".format(
-            current_function.__self__.__class__.__name__,
-            current_function.__name__,
+        self.history.append(
+            "{}.{}".format(
+                current_function.__self__.__class__.__name__,
+                current_function.__name__,
+            )
         )
-        self._last_modifications_i += 1
-        self._last_modifications_i %= len(self._last_modifications)
-
-    @property
-    def history(self):
-        history = [
-            self._last_modifications[self._last_modifications_i - i]
-            for i, _ in enumerate(self._last_modifications)
-        ]
-        return [h for h in reversed(history) if h is not None]
 
     def enforce(self, current_function):
         """

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -198,26 +198,29 @@ class SessionAssistant:
         self._bootstrap_done_list = []
         self._resume_candidates = {}
         self._load_providers()
-        UsageExpectation.of(self).allowed_calls = {
-            self.start_new_session: "create a new session from scratch",
-            self.prepare_resume_session: "resume a resume candidate",
-            self.get_resumable_sessions: "get resume candidates",
-            self.use_alternate_configuration: (
-                "use an alternate configuration system"
-            ),
-            self.use_alternate_execution_controllers: (
-                "use an alternate execution controllers"
-            ),
-            self.get_old_sessions: ("get previously created sessions"),
-            self.delete_sessions: ("delete previously created sessions"),
-            self.finalize_session: "to finalize session",
-            self.configure_application_restart: (
-                "configure automatic restart capability"
-            ),
-            self.use_alternate_restart_strategy: (
-                "configure automatic restart capability"
-            ),
-        }
+        UsageExpectation.of(self).allow_all(
+            self.__init__,
+            {
+                self.start_new_session: "create a new session from scratch",
+                self.prepare_resume_session: "resume a resume candidate",
+                self.get_resumable_sessions: "get resume candidates",
+                self.use_alternate_configuration: (
+                    "use an alternate configuration system"
+                ),
+                self.use_alternate_execution_controllers: (
+                    "use an alternate execution controllers"
+                ),
+                self.get_old_sessions: ("get previously created sessions"),
+                self.delete_sessions: ("delete previously created sessions"),
+                self.finalize_session: "to finalize session",
+                self.configure_application_restart: (
+                    "configure automatic restart capability"
+                ),
+                self.use_alternate_restart_strategy: (
+                    "configure automatic restart capability"
+                ),
+            },
+        )
         # Restart support
         self._restart_cmd_callback = None
         self._restart_strategy = None  # None implies auto-detection
@@ -261,7 +264,7 @@ class SessionAssistant:
         strategies internally. Applications can create additional strategies
         using the :meth:`use_alternate_restart_strategy()` method.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.configure_application_restart)
         if self._restart_strategy is None:
             # TODO: REMOTE API RAPI:
             # this heuristic of guessing session type from the title
@@ -277,10 +280,14 @@ class SessionAssistant:
         self._restart_cmd_callback = cmd_callback
         # Prevent second call to this method and to the
         # use_alternate_restart_strategy() method.
-        allowed_calls = UsageExpectation.of(self).allowed_calls
-        del allowed_calls[self.configure_application_restart]
-        if self.use_alternate_restart_strategy in allowed_calls:
-            del allowed_calls[self.use_alternate_restart_strategy]
+        UsageExpectation.of(self).disallow(
+            self.configure_application_restart,
+            self.configure_application_restart,
+        )
+        UsageExpectation.of(self).disallow(
+            self.configure_application_restart,
+            self.use_alternate_restart_strategy,
+        )
 
     @raises(UnexpectedMethodCall)
     def use_alternate_restart_strategy(
@@ -314,11 +321,12 @@ class SessionAssistant:
         The primary use of this method is to let applications support
         environments that are not automatically handled correctly by plainbox.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.use_alternate_restart_strategy)
         self._restart_strategy = strategy
-        del UsageExpectation.of(self).allowed_calls[
-            self.use_alternate_restart_strategy
-        ]
+        UsageExpectation.of(self).disallow(
+            self.use_alternate_restart_strategy,
+            self.use_alternate_restart_strategy,
+        )
 
     @raises(UnexpectedMethodCall)
     def use_alternate_configuration(self, config):
@@ -336,7 +344,7 @@ class SessionAssistant:
             Please check the source code to understand which values to pass
             here. This method is currently experimental.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.use_alternate_configuration)
         self._config = config
         self._exclude_qualifiers = []
         for pattern in self._config.get_value("test selection", "exclude"):
@@ -351,9 +359,10 @@ class SessionAssistant:
             )
         Unit.config = config
         # NOTE: We expect applications to call this at most once.
-        del UsageExpectation.of(self).allowed_calls[
-            self.use_alternate_configuration
-        ]
+        UsageExpectation.of(self).disallow(
+            self.use_alternate_configuration,
+            self.use_alternate_configuration,
+        )
 
     @raises(UnexpectedMethodCall)
     def use_alternate_execution_controllers(
@@ -382,12 +391,15 @@ class SessionAssistant:
             Please check the source code to understand which values to pass
             here. This method is currently experimental.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(
+            self.use_alternate_execution_controllers
+        )
         self._ctrl_setup_list = ctrl_setup_list
         # NOTE: We expect applications to call this at most once.
-        del UsageExpectation.of(self).allowed_calls[
-            self.use_alternate_execution_controllers
-        ]
+        UsageExpectation.of(self).disallow(
+            self.use_alternate_execution_controllers,
+            self.use_alternate_execution_controllers,
+        )
 
     def _load_providers(self) -> None:
         """Load all Checkbox providers."""
@@ -442,7 +454,7 @@ class SessionAssistant:
             It is a bug in your program. The error message will indicate what
             is the likely cause.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.get_old_sessions)
         for storage in WellKnownDirsHelper.get_storage_list():
             data = storage.load_checkpoint()
             if len(data) == 0:
@@ -504,7 +516,7 @@ class SessionAssistant:
         intends to use session resuming functionality it should use other
         methods to see if session should be resumed instead.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.start_new_session)
         self._manager = SessionManager.create(prefix=title + "-")
         self._context = self._manager.add_local_device_context()
         for provider in self._selected_providers:
@@ -525,21 +537,24 @@ class SessionAssistant:
         self._init_runner(runner_cls, runner_kwargs)
         self.session_available(self._manager.storage.id)
         _logger.info("New session created: %s", title)
-        UsageExpectation.of(self).allowed_calls = {
-            self.get_test_plans: "to get the list of available test plans",
-            self.get_test_plan: "to get particular test plan object",
-            self.select_test_plan: "select the test plan to execute",
-            self.get_session_id: "to get the id of currently running session",
-            self.hand_pick_jobs: "select jobs to run (w/o a test plan)",
-            self.get_resumable_sessions: "get resume candidates",
-            self.finalize_session: "to finalize session",
-            self.configure_application_restart: (
-                "configure automatic restart capability"
-            ),
-            self.use_alternate_restart_strategy: (
-                "configure automatic restart capability"
-            ),
-        }
+        UsageExpectation.of(self).allow_all(
+            self.start_new_session,
+            {
+                self.get_test_plans: "to get the list of available test plans",
+                self.get_test_plan: "to get particular test plan object",
+                self.select_test_plan: "select the test plan to execute",
+                self.get_session_id: "to get the id of currently running session",
+                self.hand_pick_jobs: "select jobs to run (w/o a test plan)",
+                self.get_resumable_sessions: "get resume candidates",
+                self.finalize_session: "to finalize session",
+                self.configure_application_restart: (
+                    "configure automatic restart capability"
+                ),
+                self.use_alternate_restart_strategy: (
+                    "configure automatic restart capability"
+                ),
+            },
+        )
 
     @raises(KeyError, UnexpectedMethodCall, IncompatibleJobError)
     def prepare_resume_session(
@@ -569,7 +584,7 @@ class SessionAssistant:
         resume a session with a test plan, the test plan must be selected and
         the bootstrap process must be re-executed.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.prepare_resume_session)
         all_units = list(
             itertools.chain(*[p.unit_list for p in self._selected_providers])
         )
@@ -595,17 +610,21 @@ class SessionAssistant:
         self.session_available(self._manager.storage.id)
         _logger.info("Session resumed: %s", session_id)
         if SessionMetaData.FLAG_TESTPLANLESS in self._metadata.flags:
-            UsageExpectation.of(self).allowed_calls = (
-                self._get_allowed_calls_in_normal_state()
+            UsageExpectation.of(self).allow_all(
+                self.prepare_resume_session,
+                self._get_allowed_calls_in_normal_state(),
             )
         else:
-            UsageExpectation.of(self).allowed_calls = {
-                self.get_resumable_sessions: "to get resume candidates",
-                self.select_test_plan: "to save test plan selection",
-                self.use_alternate_configuration: (
-                    "use an alternate configuration system"
-                ),
-            }
+            UsageExpectation.of(self).allow_all(
+                self.prepare_resume_session,
+                {
+                    self.get_resumable_sessions: ("to get resume candidates"),
+                    self.select_test_plan: ("to save test plan selection"),
+                    self.use_alternate_configuration: (
+                        "use an alternate configuration system"
+                    ),
+                },
+            )
         return self._metadata
 
     @raises(UnexpectedMethodCall)
@@ -628,7 +647,7 @@ class SessionAssistant:
         Applications can use sessions' metadata (and the app_blob contained
         in them) to decide which session is the best one to propose resuming.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.get_resumable_sessions)
         # let's keep resume_candidates, so we don't have to load data again
         # also, when this function is called invalidate the cache, as it may
         # have been modified by some external source
@@ -657,9 +676,11 @@ class SessionAssistant:
                 self._resume_candidates[storage.id] = InternalResumeCandidate(
                     storage, metadata
                 )
-                UsageExpectation.of(self).allowed_calls[
-                    self.prepare_resume_session
-                ] = "resume session"
+                UsageExpectation.of(self).allow(
+                    self.get_resumable_sessions,
+                    self.prepare_resume_session,
+                    "resume session",
+                )
                 yield ResumeCandidate(storage.id, metadata)
 
     def update_app_blob(self, app_blob: bytes) -> None:
@@ -720,7 +741,7 @@ class SessionAssistant:
         that session without the need to search and analyze all of the sessions
         in the repository.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.get_session_id)
         return self._manager.storage.id
 
     @raises(UnexpectedMethodCall)
@@ -740,7 +761,7 @@ class SessionAssistant:
         This set does not include bootstrap jobs as they must be executed prior
         to actually allowing the user to know what jobs are available.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.get_test_plans)
         return [
             unit.id
             for unit in self._context.unit_list
@@ -768,7 +789,7 @@ class SessionAssistant:
         Upon making the selection the application can inspect the execution
         plan which is expressed as a list of jobs to execute.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.select_test_plan)
         test_plan = self._context.get_unit(test_plan_id, "test plan")
         self.update_app_blob(
             json.dumps(
@@ -779,24 +800,30 @@ class SessionAssistant:
         )
         self._manager.test_plans = (test_plan,)
         self._manager.checkpoint()
-        UsageExpectation.of(self).allowed_calls = {
-            self.bootstrap: "to run the bootstrap process",
-            self.start_bootstrap: "to get bootstrapping jobs",
-            self.start_setup: "to get setup jobs",
-            self.resume_setup: "to re-start setting up",
-        }
+        UsageExpectation.of(self).allow_all(
+            self.select_test_plan,
+            {
+                self.bootstrap: "to run the bootstrap process",
+                self.start_bootstrap: "to get bootstrapping jobs",
+                self.start_setup: "to get setup jobs",
+                self.resume_setup: "to re-start setting up",
+            },
+        )
 
     def resume_setup(self):
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.resume_setup)
         # no need to set the resume flag here as this is used during resume,
         # the flag is already set
-        UsageExpectation.of(self).allowed_calls = {
-            self.get_job: "to decide what result should be assigned",
-            self.get_job_state: "to see if the job result was already decided",
-            self.use_job_result: "to assign the decided result to the job",
-            self.get_dynamic_todo_list: "to see what is yet to be executed",
-            self.start_setup: "to be called after setting the last job result",
-        }
+        UsageExpectation.of(self).allow_all(
+            self.resume_setup,
+            {
+                self.get_job: "to decide what result should be assigned",
+                self.get_job_state: "to see if the job result was already decided",
+                self.use_job_result: "to assign the decided result to the job",
+                self.get_dynamic_todo_list: "to see what is yet to be executed",
+                self.start_setup: "to be called after setting the last job result",
+            },
+        )
 
     @raises(UnexpectedMethodCall)
     def start_setup(self):
@@ -808,7 +835,7 @@ class SessionAssistant:
             It is a bug in your program. The error message will indicate what
             is the likely cause.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.start_setup)
         self._metadata.setting_up = True
         desired_job_list = select_units(
             self._context.state.job_list,
@@ -819,16 +846,19 @@ class SessionAssistant:
             desired_job_list, include_mandatory=False
         )
 
-        UsageExpectation.of(self).allowed_calls = {
-            self.run_job: "to run setup job",
-            self.get_job: "to get the job definition by id",
-            self.get_job_state: "to get the current state of a job",
-            self.get_dynamic_todo_list: "to see what is yet to be executed",
-            self.finish_setup: "to finish setting up after running all jobs",
-            self.get_session_id: "used internally by get_job",
-            self.get_category: "used by UIs to represent a job",
-            self.get_manifest_repr: "to know which manifests should be filled",
-        }
+        UsageExpectation.of(self).allow_all(
+            self.start_setup,
+            {
+                self.run_job: "to run setup job",
+                self.get_job: "to get the job definition by id",
+                self.get_job_state: "to get the current state of a job",
+                self.get_dynamic_todo_list: "to see what is yet to be executed",
+                self.finish_setup: "to finish setting up after running all jobs",
+                self.get_session_id: "used internally by get_job",
+                self.get_category: "used by UIs to represent a job",
+                self.get_manifest_repr: "to know which manifests should be filled",
+            },
+        )
         return [job.id for job in self._context.state.run_list]
 
     def bootstrapping(self) -> bool:
@@ -847,7 +877,7 @@ class SessionAssistant:
             It is a bug in your program. The error message will indicate what
             is the likely cause.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.start_bootstrap)
         self._metadata.bootstrapping = True
         desired_job_list = select_units(
             self._context.state.job_list,
@@ -861,15 +891,18 @@ class SessionAssistant:
             desired_job_list, include_mandatory=False
         )
 
-        UsageExpectation.of(self).allowed_calls = {
-            self.run_job: "to run setup job",
-            self.get_job: "to get the job definition by id",
-            self.get_job_state: "to get the current state of a job",
-            self.finish_bootstrap: "to finish bootstrapping after running all jobs",
-            self.get_session_id: "used internally by get_job",
-            self.get_dynamic_todo_list: "to see what is yet to be executed",
-            self.finalize_session: "to finalize the session",
-        }
+        UsageExpectation.of(self).allow_all(
+            self.start_bootstrap,
+            {
+                self.run_job: "to run setup job",
+                self.get_job: "to get the job definition by id",
+                self.get_job_state: "to get the current state of a job",
+                self.finish_bootstrap: "to finish bootstrapping after running all jobs",
+                self.get_session_id: "used internally by get_job",
+                self.get_dynamic_todo_list: "to see what is yet to be executed",
+                self.finalize_session: "to finalize the session",
+            },
+        )
         return [job.id for job in self._context.state.run_list]
 
     @raises(UnexpectedMethodCall)
@@ -899,7 +932,7 @@ class SessionAssistant:
             This method will not return until the bootstrap process is
             finished. This can take any amount of time (easily over one minute)
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.bootstrap)
         self.start_bootstrap()
         for job in self._context.state.run_list:
             if self._context.state.job_state_map[job.id].result_history:
@@ -927,7 +960,7 @@ class SessionAssistant:
         There is no bootstrapping done, so templates are not intantiated, thus
         selection is done only among explicit jobs.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.hand_pick_jobs)
         qualifiers = []
         for pattern in id_patterns:
             qualifiers.append(
@@ -943,17 +976,21 @@ class SessionAssistant:
             SessionMetaData.FLAG_INCOMPLETE,
             SessionMetaData.FLAG_TESTPLANLESS,
         }
-        UsageExpectation.of(self).allowed_calls = (
-            self._get_allowed_calls_in_normal_state()
+        UsageExpectation.of(self).allow_all(
+            self.hand_pick_jobs,
+            self._get_allowed_calls_in_normal_state(),
         )
 
     def finish_setup(self):
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.finish_setup)
         self._metadata.setting_up = False
-        UsageExpectation.of(self).allowed_calls = {
-            self.bootstrap: "to run the bootstrap process",
-            self.start_bootstrap: "to get bootstrapping jobs",
-        }
+        UsageExpectation.of(self).allow_all(
+            self.finish_setup,
+            {
+                self.bootstrap: "to run the bootstrap process",
+                self.start_bootstrap: "to get bootstrapping jobs",
+            },
+        )
 
     @raises(UnexpectedMethodCall)
     def finish_bootstrap(self):
@@ -971,7 +1008,7 @@ class SessionAssistant:
         SessionAssistant class, but if the app wants fine control, ilet's let
         it have it.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.finish_bootstrap)
         # we may have a list of rejected jobs if this session is a resumed
         # session
         already_rejected = [
@@ -1024,8 +1061,9 @@ class SessionAssistant:
         # No bootstrap is done update the cache of jobs that were run
         # during bootstrap phase
         self._bootstrap_done_list = self.get_dynamic_done_list()
-        UsageExpectation.of(self).allowed_calls = (
-            self._get_allowed_calls_in_normal_state()
+        UsageExpectation.of(self).allow_all(
+            self.finish_bootstrap,
+            self._get_allowed_calls_in_normal_state(),
         )
 
     @raises(KeyError, UnexpectedMethodCall)
@@ -1053,7 +1091,7 @@ class SessionAssistant:
             Calling this method will alter the result of
             :meth:`get_static_todo_list()` and :meth:`get_dynamic_todo_list()`.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.use_alternate_selection)
         self._metadata.custom_joblist = True
         desired_job_list = []
         for job_id in self.get_static_todo_list():
@@ -1083,7 +1121,7 @@ class SessionAssistant:
             Calling this method will alter the result of
             :meth:`get_static_todo_list()` and :meth:`get_dynamic_todo_list()`.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.filter_jobs_by_categories)
         selection = [
             job.id
             for job in [
@@ -1106,7 +1144,7 @@ class SessionAssistant:
         This method can be called to remove all filters applied from currently
         reigning job selection.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.remove_all_filters)
         desired_job_list = select_units(
             self._context.state.job_list,
             [plan.get_qualifier() for plan in self._manager.test_plans],
@@ -1132,7 +1170,7 @@ class SessionAssistant:
             public api stability promise. Refer to the documentation of the
             JobState class for details.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.get_job_state)
         # XXX: job_state_map is a bit low level, can we avoid that?
         return self._context.state.job_state_map[job_id]
 
@@ -1155,11 +1193,14 @@ class SessionAssistant:
             public api stability promise. Refer to the documentation of the
             JobDefinition class for details.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.get_job)
         # we may want to decide early about the result of the job, without
         # running it (e.g. when skipping the job)
-        allowed_calls = UsageExpectation.of(self).allowed_calls
-        allowed_calls[self.use_job_result] = "remember the result of this job"
+        UsageExpectation.of(self).allow(
+            self.get_job,
+            self.use_job_result,
+            "remember the result of this job",
+        )
         return self._context.get_unit(job_id, "job")
 
     @raises(KeyError, UnexpectedMethodCall)
@@ -1181,7 +1222,7 @@ class SessionAssistant:
             public api stability promise. Refer to the documentation of the
             TestPlanUnit class for details.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.get_test_plan)
         return self._context.get_unit(test_plan_id, "test plan")
 
     @raises(KeyError, UnexpectedMethodCall)
@@ -1203,7 +1244,7 @@ class SessionAssistant:
             public api stability promise. Refer to the documentation of the
             CategoryUnit class for details.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.get_category)
         return self._context.get_unit(category_id, "category")
 
     @raises(UnexpectedMethodCall)
@@ -1223,7 +1264,7 @@ class SessionAssistant:
         This set does not include boostrap jobs as they must be executed prior
         to actually allowing the user to know what jobs are available.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.get_participating_categories)
         test_plan = self._manager.test_plans[0]
         return list(
             set(
@@ -1245,7 +1286,7 @@ class SessionAssistant:
             It is a bug in your program. The error message will indicate what
             is the likely cause.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.get_mandatory_jobs)
         test_plan = self._manager.test_plans[0]
         return [
             job.id
@@ -1277,7 +1318,7 @@ class SessionAssistant:
         explicitly requested by the user. Examples of such mechanisms include
         job dependencies, resource dependencies or mandatory jobs.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.get_static_todo_list)
         return [job.id for job in self._context.state.run_list]
 
     @raises(UnexpectedMethodCall)
@@ -1335,7 +1376,7 @@ class SessionAssistant:
             generating jobs is hidden and handled by the :meth:`boostrap()`
             method.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.get_dynamic_todo_list)
         # XXX: job_state_map is a bit low level, can we avoid that?
         jsm = self._context.state.job_state_map
         return [
@@ -1378,7 +1419,7 @@ class SessionAssistant:
             It is a bug in your program. The error message will indicate what
             is the likely cause.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.get_manifest_repr)
         # XXX: job_state_map is a bit low level, can we avoid that?
         job_state_map = self._context.state.job_state_map
         run_list = self._context.state.run_list
@@ -1509,7 +1550,7 @@ class SessionAssistant:
         with interactive jobs and let the application do anything it needs to
         to accomplish that.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.run_job)
         if isinstance(ui, IJobRunnerUI):
             pass
         elif isinstance(ui, str):
@@ -1634,9 +1675,12 @@ class SessionAssistant:
         # Set up expectations so that run_job() and use_job_result() must be
         # called in pairs and applications cannot just forget and call
         # run_job() all the time.
-        allowed_calls = UsageExpectation.of(self).allowed_calls
-        del allowed_calls[self.run_job]
-        allowed_calls[self.use_job_result] = "remember the result of last job"
+        UsageExpectation.of(self).disallow(self.run_job, self.run_job)
+        UsageExpectation.of(self).allow(
+            self.run_job,
+            self.use_job_result,
+            "remember the result of last job",
+        )
         return builder
 
     @raises(UnexpectedMethodCall)
@@ -1668,7 +1712,7 @@ class SessionAssistant:
         depends on another job will not be able to run if any of its
         dependencies did not complete successfully.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.use_job_result)
         job = self._context.get_unit(job_id, "job")
         job_state = self._context.state.job_state_map[job_id]
         if len(job_state.result_history) > 0 and override_last:
@@ -1691,9 +1735,12 @@ class SessionAssistant:
         # Set up expectations so that run_job() and use_job_result() must be
         # called in pairs and applications cannot just forget and call
         # run_job() all the time.
-        allowed_calls = UsageExpectation.of(self).allowed_calls
-        del allowed_calls[self.use_job_result]
-        allowed_calls[self.run_job] = "run another job"
+        UsageExpectation.of(self).disallow(
+            self.use_job_result, self.use_job_result
+        )
+        UsageExpectation.of(self).allow(
+            self.use_job_result, self.run_job, "run another job"
+        )
 
     @raises(UnexpectedMethodCall)
     def get_rerun_candidates(self, session_type="manual"):
@@ -1816,7 +1863,7 @@ class SessionAssistant:
         finalized; this frees applications from keeping state information in
         them.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.finalize_session)
         finalizable_flags = [
             SessionMetaData.FLAG_INCOMPLETE,
             SessionMetaData.FLAG_BOOTSTRAPPING,
@@ -1842,17 +1889,20 @@ class SessionAssistant:
                 if flag in self._metadata.flags:
                     self._metadata.flags.remove(flag)
             self._manager.checkpoint()
-        UsageExpectation.of(self).allowed_calls = {
-            self.finalize_session: "to finalize session",
-            self.export_to_transport: "to export the results and send them",
-            self.export_to_file: "to export the results to a file",
-            self.export_to_stream: "to export the results to a stream",
-            self.get_resumable_sessions: "to get resume candidates",
-            self.start_new_session: "to create a new session",
-            self.prepare_resume_session: "to resume a session",
-            self.get_old_sessions: ("get previously created sessions"),
-            self.delete_sessions: ("delete previously created sessions"),
-        }
+        UsageExpectation.of(self).allow_all(
+            self.finalize_session,
+            {
+                self.finalize_session: "to finalize session",
+                self.export_to_transport: "to export the results and send them",
+                self.export_to_file: "to export the results to a file",
+                self.export_to_stream: "to export the results to a stream",
+                self.get_resumable_sessions: "to get resume candidates",
+                self.start_new_session: "to create a new session",
+                self.prepare_resume_session: "to resume a session",
+                self.get_old_sessions: ("get previously created sessions"),
+                self.delete_sessions: ("delete previously created sessions"),
+            },
+        )
 
     @raises(KeyError, TransportError, UnexpectedMethodCall, ExporterError)
     def export_to_transport(
@@ -1889,7 +1939,7 @@ class SessionAssistant:
         :raises ExporterError:
             If the exporter unit reported an error.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.export_to_transport)
         try:
             exporter = self._manager.create_exporter(exporter_id, options)
             exported_stream = SpooledTemporaryFile(max_size=102400, mode="w+b")
@@ -1938,7 +1988,7 @@ class SessionAssistant:
         :raises OSError:
             When there is a problem when writing the output.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.export_to_file)
         exporter = self._manager.create_exporter(
             exporter_id, option_list, strict=False
         )
@@ -1979,7 +2029,7 @@ class SessionAssistant:
         :raises OSError:
             When there is a problem when writing the output.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.export_to_stream)
         exporter = self._manager.create_exporter(exporter_id, option_list)
         exporter.dump_from_session_manager(self._manager, stream)
         if SessionMetaData.FLAG_SUBMITTED not in self._metadata.flags:
@@ -2002,7 +2052,7 @@ class SessionAssistant:
             It is a bug in your program. The error message will indicate what
             is the likely cause.
         """
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.get_ubuntu_sso_oauth_transport)
         url = transport_details["url"]
         return OAuthTransport(url, "", transport_details)
 

--- a/checkbox-ng/plainbox/impl/session/test_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/test_assistant.py
@@ -69,37 +69,6 @@ class SessionAssistantTests(morris.SignalTestCase):
         """Get some mocked provides for testing."""
         return [self.p1, self.p2, self.p3]
 
-    def test_expected_call_sequence(self, mock_get_providers):
-        """Track the sequence of allowed method calls."""
-        mock_get_providers.return_value = self._get_mock_providers()
-        # SessionAssistant.start_new_session() must now be allowed
-        self.assertIn(
-            self.sa.start_new_session,
-            UsageExpectation.of(self.sa).allowed_calls,
-        )
-
-        # patch system_information to avoid the actual collection of
-        # system_information in tests
-        with mock.patch(
-            "plainbox.impl.session.state.SessionState.system_information"
-        ):
-            # Call SessionAssistant.start_new_session()
-            self.sa.start_new_session("just for testing")
-
-        # SessionAssistant.start_new_session() must no longer allowed
-        self.assertNotIn(
-            self.sa.start_new_session,
-            UsageExpectation.of(self.sa).allowed_calls,
-        )
-        # SessionAssistant.select_test_plan() must now be allowed
-        self.assertIn(
-            self.sa.select_test_plan,
-            UsageExpectation.of(self.sa).allowed_calls,
-        )
-        # Use the manager to tidy up after the tests when normally you wouldnt
-        # be allowed to
-        self.sa._manager.destroy()
-
     @mock.patch(
         "plainbox.impl.session.assistant.UsageExpectation",
         new=mock.MagicMock(),

--- a/checkbox-ng/plainbox/impl/test_developer.py
+++ b/checkbox-ng/plainbox/impl/test_developer.py
@@ -61,7 +61,14 @@ class UsageExpectationTests(unittest.TestCase):
         ue.allow(foo.m2, foo.m2, "some other motivation")
         foo.m2()
         # m1 allowed, then m1 disallowed them m2 allowed
-        self.assertEqual(list(ue.history), ["_Foo.m1", "_Foo.m1", "_Foo.m2"])
+        self.assertEqual(
+            list(ue.history),
+            [
+                ("_Foo.m1", "allow"),
+                ("_Foo.m1", "disallow"),
+                ("_Foo.m2", "allow"),
+            ],
+        )
 
     def test_add_not_clear(self):
         foo = _Foo()
@@ -76,9 +83,9 @@ class UsageExpectationTests(unittest.TestCase):
     def test_enforce(self):
         """Check that .enforce() works and produces useful messages."""
         foo = _Foo()
-        UsageExpectation.of(foo).allow_all(
-            foo.m1, {foo.m1: "call m1 now"}, clear=True
-        )
+        ue = UsageExpectation.of(foo)
+        ue.allow_all(foo.m1, {foo.m1: "call m1 now"}, clear=True)
+        ue.allow(foo.m1, foo.m1, "stack the history")
         # Nothing should happen here
         foo.m1()
         # Exception should be raised here
@@ -95,10 +102,11 @@ sorry for this. Please report this to us.
 You are not expected to call _Foo.m2 at this time.
 The set of allowed calls, at this time, is:
 
- - call _Foo.m1() to call m1 now.
+ - call _Foo.m1() to stack the history.
 
 The last 5 modifications were done by (most recent last):
 
- - _Foo.m1
+ - _Foo.m1 (allow_all, clear)
+ - _Foo.m1 (allow)
 """,
         )

--- a/checkbox-ng/plainbox/impl/test_developer.py
+++ b/checkbox-ng/plainbox/impl/test_developer.py
@@ -1,8 +1,9 @@
 # This file is part of Checkbox.
 #
-# Copyright 2015 Canonical Ltd.
+# Copyright 2015-2026 Canonical Ltd.
 # Written by:
 #   Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
+#   Massimiliano Girardi <massimiliano.girardi@canonical.com>
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,
@@ -20,26 +21,16 @@
 
 import unittest
 
-from plainbox.impl.developer import DeveloperError
-from plainbox.impl.developer import UnexpectedMethodCall
-from plainbox.impl.developer import UsageExpectation
+from plainbox.impl.developer import UnexpectedMethodCall, UsageExpectation
 
 
 class _Foo:
 
     def m1(self):
-        UsageExpectation.of(self).enforce()
+        UsageExpectation.of(self).enforce(self.m1)
 
     def m2(self):
-        UsageExpectation.of(self).enforce()
-
-
-class UnexpectedMethodCallTests(unittest.TestCase):
-    """Tests for the UnexpectedMethodCall class."""
-
-    def test_ancestry(self):
-        """Check that UnexpectedMethodCall is a subclass of DeveloperError."""
-        self.assertTrue(issubclass(UnexpectedMethodCall, DeveloperError))
+        UsageExpectation.of(self).enforce(self.m2)
 
 
 class UsageExpectationTests(unittest.TestCase):
@@ -60,7 +51,9 @@ class UsageExpectationTests(unittest.TestCase):
     def test_enforce(self):
         """Check that .enforce() works and produces useful messages."""
         foo = _Foo()
-        UsageExpectation.of(foo).allowed_calls = {foo.m1: "call m1 now"}
+        UsageExpectation.of(foo).allow_all(
+            foo.m1, {foo.m1: "call m1 now"}, clear=True
+        )
         # Nothing should happen here
         foo.m1()
         # Exception should be raised here
@@ -71,17 +64,16 @@ class UsageExpectationTests(unittest.TestCase):
             """
 Uh, oh...
 
-You are not expected to call _Foo.m2() at this time.
+If you see this message then there is a bug somewhere in Checkbox. We are
+sorry for this. Please report this to us.
 
-If you see this message then there is a bug somewhere in your code. We are
-sorry for this. Perhaps the documentation is flawed, incomplete or confusing.
-Please reach out to us if  this happens more often than you'd like.
-
+You are not expected to call _Foo.m2 at this time.
 The set of allowed calls, at this time, is:
 
  - call _Foo.m1() to call m1 now.
 
-Refer to the documentation of _Foo for details.
-    TIP: python -m pydoc plainbox.impl.test_developer._Foo
+The last 5 modifications were done by (most recent last):
+
+ - _Foo.m1
 """,
         )

--- a/checkbox-ng/plainbox/impl/test_developer.py
+++ b/checkbox-ng/plainbox/impl/test_developer.py
@@ -48,6 +48,31 @@ class UsageExpectationTests(unittest.TestCase):
         self.assertIs(ue2, UsageExpectation.of(foo2))
         self.assertIsNot(ue1, ue2)
 
+    def test_add_remove(self):
+        foo = _Foo()
+        ue = UsageExpectation.of(foo)
+        ue.allow(foo.m1, foo.m1, "some motivation")
+        foo.m1()
+        with self.assertRaises(UnexpectedMethodCall):
+            foo.m2()
+        ue.disallow(foo.m1, foo.m1)
+        with self.assertRaises(UnexpectedMethodCall):
+            foo.m1()
+        ue.allow(foo.m2, foo.m2, "some other motivation")
+        foo.m2()
+        # m1 allowed, then m1 disallowed them m2 allowed
+        self.assertEqual(list(ue.history), ["_Foo.m1", "_Foo.m1", "_Foo.m2"])
+
+    def test_add_not_clear(self):
+        foo = _Foo()
+        ue = UsageExpectation.of(foo)
+        ue.allow(foo.m2, foo.m2, "some")
+        UsageExpectation.of(foo).allow_all(
+            foo.m1, {foo.m1: "call m1 now"}, clear=False
+        )
+        foo.m1()
+        foo.m2()
+
     def test_enforce(self):
         """Check that .enforce() works and produces useful messages."""
         foo = _Foo()


### PR DESCRIPTION
## Description

Currently when we receive a UsageExpectation error in an issue it is really hard to know what went wrong. The reason is that the usage expectations are modified by any function but there is no way to know how we got to a given set. This PR starts tracking the modifications and includes them in the exception. Additionally the error now is clear about it being an error in Checkbox (the old error was weird for our users) and to report it to us.

On the implementation side, the old implementation compared the function code and had to jump through a few hoops to get the actual calling function and its code (given that it could have been decorated). This new implemtation removes all that and just uses the function name. This makes:
- The code way easier to read 
- The code faster (no inspect, no f_code comparison, no frozenset etc. with way less pointless debug logging)
- No difference in my opinion, UA are scoped to the instance, if the function name matches it is the same function (*) 


> (\*) Technically false, it may be a different function if the bound function was changed at runtime, but I don't see a legitimate reason to do that, especially in the SessionAssistant 

## Resolved issues

N/A

## Documentation

N/A

## Tests

To test this remove some UsageExpectation from (for example) `_get_allowed_calls_in_normal_state`. You will see the new error with a history of modifications.

Here is a sample of the new error:
```
Uh, oh...

If you see this message then there is a bug somewhere in Checkbox. We are
sorry for this. Please report this to us.

You are not expected to call SessionAssistant.get_job at this time.
The set of allowed calls, at this time, is:

 - call SessionAssistant.get_job_state() to to access the state of any job.
 - call SessionAssistant.export_to_transport() to to export the results and send them.
 - call SessionAssistant.export_to_file() to to export the results to a file.
 - call SessionAssistant.export_to_stream() to to export the results to a stream.
 - call SessionAssistant.finalize_session() to to mark the session as complete.
 - call SessionAssistant.get_session_id() to to get the id of currently running session.
 - call SessionAssistant.finish_bootstrap() to to finish bootstrapping.

The last 5 modifications were done by (most recent last):

 - SessionAssistant.use_alternate_configuration
 - SessionAssistant.select_test_plan
 - SessionAssistant.start_bootstrap
 - SessionAssistant.finish_bootstrap
 - SessionAssistant.prepare_resume_session
```
