### PR TITLE
Allow setting agent log level (infra)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/agent.py
+++ b/checkbox-ng/checkbox_ng/launcher/agent.py
@@ -20,21 +20,14 @@ functionality.
 """
 
 import gettext
-import json
 import logging
 import os
 import socket
-import sys
 
-from checkbox_ng import app_context
 from checkbox_ng.utils import set_all_loggers_level
 
-from plainbox.impl.config import Configuration
 from plainbox.impl.secure.sudo_broker import is_passwordless_sudo
-from plainbox.impl.session.assistant import ResumeCandidate
 from plainbox.impl.session.remote_assistant import RemoteSessionAssistant
-from plainbox.impl.session.restart import RemoteDebRestartStrategy
-from plainbox.impl.session.restart import RemoteSnappyRestartStrategy
 from plainbox.vendor import rpyc
 from plainbox.vendor.rpyc.utils.server import ThreadedServer
 
@@ -124,8 +117,9 @@ class RemoteAgent:
         # present if not specified
         if not hasattr(ctx.args, "debug") or not ctx.args.debug:
             # default log level of the agent is INFO
-            logging.basicConfig(level=logging.INFO)
-            set_all_loggers_level(logging.INFO)
+            level = getattr(logging, ctx.args.log_level)
+            logging.basicConfig(level=level)
+            set_all_loggers_level(level)
         self.ensure_sudo()
         if ctx.args.resume:
             msg = (
@@ -169,6 +163,12 @@ class RemoteAgent:
         )
         parser.add_argument(
             "--port", type=int, default=18871, help=_("port to listen on")
+        )
+        parser.add_argument(
+            "--log-level",
+            choices=["DEBUG", "INFO", "WARNING"],
+            default="INFO",
+            help=_("sets the global logging level if `--debug` is not used"),
         )
 
 

--- a/checkbox-ng/checkbox_ng/launcher/test_agent.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_agent.py
@@ -26,7 +26,6 @@ from checkbox_ng.launcher.agent import RemoteAgent
 @mock.patch("checkbox_ng.launcher.agent._logger")
 @mock.patch("checkbox_ng.launcher.agent.is_passwordless_sudo")
 @mock.patch("checkbox_ng.launcher.agent.SessionAssistantAgent")
-@mock.patch("checkbox_ng.launcher.agent.RemoteDebRestartStrategy")
 @mock.patch("checkbox_ng.launcher.agent.RemoteSessionAssistant")
 @mock.patch("checkbox_ng.launcher.agent.ThreadedServer")
 @mock.patch("os.geteuid")
@@ -39,7 +38,6 @@ class AgentTests(TestCase):
         geteuid_mock,
         threaded_server_mock,
         remote_assistant_mock,
-        remote_strategy_mock,
         session_assistant_mock,
         pwdless_sudo_mock,
         logger_mock,
@@ -70,7 +68,6 @@ class AgentTests(TestCase):
         geteuid_mock,
         threaded_server_mock,
         remote_assistant_mock,
-        remote_strategy_mock,
         session_assistant_mock,
         pwdless_sudo_mock,
         logger_mock,
@@ -101,7 +98,6 @@ class AgentTests(TestCase):
         geteuid_mock,
         threaded_server_mock,
         remote_assistant_mock,
-        remote_strategy_mock,
         sa_mock,
         pwdless_sudo_mock,
         logger_mock,

--- a/checkbox-ng/checkbox_ng/launcher/test_agent.py
+++ b/checkbox-ng/checkbox_ng/launcher/test_agent.py
@@ -28,6 +28,7 @@ from checkbox_ng.launcher.agent import RemoteAgent
 @mock.patch("checkbox_ng.launcher.agent.SessionAssistantAgent")
 @mock.patch("checkbox_ng.launcher.agent.RemoteSessionAssistant")
 @mock.patch("checkbox_ng.launcher.agent.ThreadedServer")
+@mock.patch("checkbox_ng.launcher.agent.set_all_loggers_level")
 @mock.patch("os.geteuid")
 @mock.patch("os.getenv")
 class AgentTests(TestCase):
@@ -36,6 +37,7 @@ class AgentTests(TestCase):
         self,
         getenv_mock,
         geteuid_mock,
+        set_all_loggers_level_mock,
         threaded_server_mock,
         remote_assistant_mock,
         session_assistant_mock,
@@ -44,7 +46,9 @@ class AgentTests(TestCase):
         gettext_mock,
     ):
         ctx_mock = mock.MagicMock()
+        ctx_mock.args.debug = False
         ctx_mock.args.resume = False
+        ctx_mock.args.log_level = "INFO"
 
         self_mock = mock.MagicMock()
 
@@ -60,12 +64,47 @@ class AgentTests(TestCase):
         server = threaded_server_mock.return_value
         # the server was started
         self.assertTrue(server.start.called)
+        self.assertTrue(set_all_loggers_level_mock.called)
+
+    def test_invoked_ok_noset_log(
+        self,
+        getenv_mock,
+        geteuid_mock,
+        set_all_loggers_level_mock,
+        threaded_server_mock,
+        remote_assistant_mock,
+        session_assistant_mock,
+        pwdless_sudo_mock,
+        logger_mock,
+        gettext_mock,
+    ):
+        ctx_mock = mock.MagicMock()
+        ctx_mock.args.debug = True
+        ctx_mock.args.resume = False
+        ctx_mock.args.log_level = "INFO"
+
+        self_mock = mock.MagicMock()
+
+        geteuid_mock.return_value = 0  # agent will not run as non-root
+        pwdless_sudo_mock.return_value = True  # agent needs pwd-less sudo
+        getenv_mock.return_value = None
+
+        with mock.patch("builtins.open"):
+            RemoteAgent.invoked(self_mock, ctx_mock)
+
+        # agent server was created
+        self.assertTrue(threaded_server_mock.called)
+        server = threaded_server_mock.return_value
+        # the server was started
+        self.assertTrue(server.start.called)
+        self.assertFalse(set_all_loggers_level_mock.called)
 
     # used to load an empty launcher with no error
     def test_invoked_with_resume_warns(
         self,
         getenv_mock,
         geteuid_mock,
+        set_all_loggers_level_mock,
         threaded_server_mock,
         remote_assistant_mock,
         session_assistant_mock,
@@ -96,6 +135,7 @@ class AgentTests(TestCase):
         self,
         getenv_mock,
         geteuid_mock,
+        set_all_loggers_level_mock,
         threaded_server_mock,
         remote_assistant_mock,
         sa_mock,


### PR DESCRIPTION
## Description

While debugging issues (especially with both agent and controller in the same tty), info level logging is a bit too verbose. Give that it is now the default, we have to add a mechanism to tune it down when necessary. This doesn't change the behaviour, just adds the possibility to:
- set debug in the `--log-level` (for uniformity)
- set warning to tune the logging down

## Resolved issues

N/A

## Documentation

Adde Help to explain

## Tests

This prints a lot more (just a bit if you don't start a session):
```
export ALLOW_CHECKBOX_AGENT_NONROOT=1; checkbox-cli run-agent --log-level DEBUG
```
This prints a bit less (a lot less if you start a session):
```
export ALLOW_CHECKBOX_AGENT_NONROOT=1; checkbox-cli run-agent --log-level INFO
```
This prints very little
```
export ALLOW_CHECKBOX_AGENT_NONROOT=1; checkbox-cli run-agent --log-level WARNING
```
