### PR TITLE
Also export resource results in junit (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/providers/exporters/data/junit.xml
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/junit.xml
@@ -2,12 +2,12 @@
 {%- set job_state_map = state.job_state_map -%}
 {%- set passes = manager.state.get_test_outcome_stats()["pass"] -%}
 {%- set fails = manager.state.get_test_outcome_stats()["fail"] -%}
-{%- set skips = manager.state.get_test_outcome_stats()["skip"] + 
-                manager.state.get_test_outcome_stats()["not-supported"] -%} 
+{%- set skips = manager.state.get_test_outcome_stats()["skip"] +
+                manager.state.get_test_outcome_stats()["not-supported"] -%}
 {%- set errors = manager.state.get_test_outcome_stats()["crash"] -%}
 <?xml version="1.0" encoding="UTF-8"?>
   <testsuites failures="{{ fails }}" name="" tests="{{ passes+fails+skips+errors }}" skipped="{{ skips }}" errors="{{ errors }}">
-    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.job.plugin not in ("resource", "attachment") %}
+    {%- for job_id, job_state in job_state_map|dictsort if job_state.result.outcome != None and job_state.job.plugin != "attachment" %}
     <testcase classname="{{ job_state.job.id }}" name="{{ job_state.job.id }}" time="{{ job_state.result.execution_duration }}">
     {%- if job_state.result.outcome == 'skip' or job_state.result.outcome == 'not-supported' -%}
       <skipped />


### PR DESCRIPTION

<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

This is necessary because we modified the submission but forgot to change it here, so our jenkins, that uses junit, shows different results than C3/TO


## Resolved issues

N/A

## Documentation

N/A

## Tests

Tested locally, it is the same change we did to the checkbox.json template
