### PR TITLE
Add Realtime test plans in ce-oem provider (New)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-core.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-core.pxu
@@ -75,6 +75,68 @@ exclude:
 certification_status_overrides:
     apply blocker to .*
 
+id: ce-oem-iot-ubuntucore-26-rt
+unit: test plan
+_name: CE-OEM-IOT - Full manual + automated OEMQA tests for realtime Ubuntu Core 26
+_description:
+    Combined manual and automated test plans for realtime IoT devices running Ubuntu Core.
+include:
+nested_part:
+    ce-oem-iot-ubuntucore-26-manual-rt
+    ce-oem-iot-ubuntucore-26-automated-rt
+    ce-oem-iot-ubuntucore-26-stress-rt
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-ubuntucore-26-manual-rt
+unit: test plan
+_name: CE-OEM-IOT - Manual only OEMQA tests for realtime Ubuntu Core 26
+_description:
+    Ubuntu Core OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the tests that require manual control of device hardware
+    or some other user input to complete.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-ubuntucore-26-manual
+    com.canonical.certification::rt-performance-tests-manual
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-ubuntucore-26-automated-rt
+unit: test plan
+_name: CE-OEM-IOT - Automated only OEMQA tests for realtime Ubuntu Core 26
+_description:
+    Ubuntu Core OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the automated tests used to validate the IoT devices.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-ubuntucore-26-automated
+    com.canonical.certification::rt-performance-tests-automated
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-ubuntucore-26-stress-rt
+unit: test plan
+_name: CE-OEM-IOT - Stress only OEMQA tests for realtime Ubuntu Core 26
+_description:
+    Ubuntu Core OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the stress tests used to validate the IoT devices.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-ubuntucore-26-stress
+    com.canonical.certification::rt-performance-tests-stress
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*
+
 id: ce-oem-iot-ubuntucore-24
 unit: test plan
 _name: CE-OEM-IOT - Full manual + automated OEMQA tests for Ubuntu Core 24
@@ -272,3 +334,64 @@ exclude:
 certification_status_overrides:
     apply blocker to .*
 
+id: ce-oem-iot-ubuntucore-24-rt
+unit: test plan
+_name: CE-OEM-IOT - Full manual + automated OEMQA tests for realtime Ubuntu Core 24
+_description:
+    Combined manual and automated test plans for realtime IoT devices running Ubuntu Core.
+include:
+nested_part:
+    ce-oem-iot-ubuntucore-24-manual-rt
+    ce-oem-iot-ubuntucore-24-automated-rt
+    ce-oem-iot-ubuntucore-24-stress-rt
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-ubuntucore-24-manual-rt
+unit: test plan
+_name: CE-OEM-IOT - Manual only OEMQA tests for realtime Ubuntu Core 24
+_description:
+    Ubuntu Core OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the tests that require manual control of device hardware
+    or some other user input to complete.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-ubuntucore-24-manual
+    com.canonical.certification::rt-performance-tests-manual
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-ubuntucore-24-automated-rt
+unit: test plan
+_name: CE-OEM-IOT - Automated only OEMQA tests for realtime Ubuntu Core 24
+_description:
+    Ubuntu Core OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the automated tests used to validate the IoT devices.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-ubuntucore-24-automated
+    com.canonical.certification::rt-performance-tests-automated
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-ubuntucore-24-stress-rt
+unit: test plan
+_name: CE-OEM-IOT - Stress only OEMQA tests for realtime Ubuntu Core 24
+_description:
+    Ubuntu Core OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the stress tests used to validate the IoT devices.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-ubuntucore-24-stress
+    com.canonical.certification::rt-performance-tests-stress
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-desktop.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-desktop.pxu
@@ -77,7 +77,7 @@ certification_status_overrides:
 
 id: ce-oem-iot-desktop-26-04-rt
 unit: test plan
-_name: CE-OEM-IOT - Full manual + automated OEMQA tests for realtime Ubuntu Desktop 26.04
+_name: CE-OEM-IOT - Full manual + automated tests for realtime Ubuntu Desktop 26.04
 _description:
     Combined manual and automated test plans for realtime IoT devices running Ubuntu Desktop.
 include:
@@ -199,7 +199,7 @@ certification_status_overrides:
 
 id: ce-oem-iot-desktop-24-04-rt
 unit: test plan
-_name: CE-OEM-IOT - Full manual + automated OEMQA tests for realtime Ubuntu Desktop 24.04
+_name: CE-OEM-IOT - Full manual + automated tests for realtime Ubuntu Desktop 24.04
 _description:
     Combined manual and automated test plans for realtime IoT devices running Ubuntu Desktop.
 include:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-desktop.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-desktop.pxu
@@ -75,6 +75,68 @@ exclude:
 certification_status_overrides:
     apply blocker to .*
 
+id: ce-oem-iot-desktop-26-04-rt
+unit: test plan
+_name: CE-OEM-IOT - Full manual + automated OEMQA tests for realtime Ubuntu Desktop 26.04
+_description:
+    Combined manual and automated test plans for realtime IoT devices running Ubuntu Desktop.
+include:
+nested_part:
+    ce-oem-iot-desktop-26-04-manual-rt
+    ce-oem-iot-desktop-26-04-automated-rt
+    ce-oem-iot-desktop-26-04-stress-rt
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-desktop-26-04-manual-rt
+unit: test plan
+_name: CE-OEM-IOT - Manual only OEMQA tests for realtime Ubuntu Desktop 26.04
+_description:
+    Ubuntu Desktop OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the tests that require manual control of device hardware
+    or some other user input to complete.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-desktop-26-04-manual
+    com.canonical.certification::rt-performance-tests-manual
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-desktop-26-04-automated-rt
+unit: test plan
+_name: CE-OEM-IOT - Automated only OEMQA tests for realtime Ubuntu Desktop 26.04
+_description:
+    Ubuntu Desktop OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the automated tests used to validate the IoT devices.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-desktop-26-04-automated
+    com.canonical.certification::rt-performance-tests-automated
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-desktop-26-04-stress-rt
+unit: test plan
+_name: CE-OEM-IOT - Stress only OEMQA tests for realtime Ubuntu Desktop 26.04
+_description:
+    Ubuntu Desktop OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the stress tests used to validate the IoT devices.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-desktop-26-04-stress
+    com.canonical.certification::rt-performance-tests-stress
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*
+
 id: ce-oem-iot-desktop-24-04
 unit: test plan
 _name: CE-OEM-IOT - Full manual + automated OEMQA tests for Ubuntu Desktop 24.04
@@ -132,5 +194,67 @@ nested_part:
     ce-oem-stress
 exclude:
     com.canonical.certification::stress-tests/hibernate.*
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-desktop-24-04-rt
+unit: test plan
+_name: CE-OEM-IOT - Full manual + automated OEMQA tests for realtime Ubuntu Desktop 24.04
+_description:
+    Combined manual and automated test plans for realtime IoT devices running Ubuntu Desktop.
+include:
+nested_part:
+    ce-oem-iot-desktop-24-04-manual-rt
+    ce-oem-iot-desktop-24-04-automated-rt
+    ce-oem-iot-desktop-24-04-stress-rt
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-desktop-24-04-manual-rt
+unit: test plan
+_name: CE-OEM-IOT - Manual only OEMQA tests for realtime Ubuntu Desktop 24.04
+_description:
+    Ubuntu Desktop OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the tests that require manual control of device hardware
+    or some other user input to complete.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-desktop-24-04-manual
+    com.canonical.certification::rt-performance-tests-manual
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-desktop-24-04-automated-rt
+unit: test plan
+_name: CE-OEM-IOT - Automated only OEMQA tests for realtime Ubuntu Desktop 24.04
+_description:
+    Ubuntu Desktop OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the automated tests used to validate the IoT devices.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-desktop-24-04-automated
+    com.canonical.certification::rt-performance-tests-automated
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-desktop-24-04-stress-rt
+unit: test plan
+_name: CE-OEM-IOT - Stress only OEMQA tests for realtime Ubuntu Desktop 24.04
+_description:
+    Ubuntu Desktop OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the stress tests used to validate the IoT devices.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-desktop-24-04-stress
+    com.canonical.certification::rt-performance-tests-stress
+exclude:
+    .*::.*suspend.*
 certification_status_overrides:
     apply blocker to .*

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-server.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-server.pxu
@@ -256,3 +256,126 @@ exclude:
 certification_status_overrides:
     apply blocker to .*
 
+id: ce-oem-iot-server-26-04-rt
+unit: test plan
+_name: CE-OEM-IOT - Full manual + automated OEMQA tests for realtime Ubuntu Server 26.04
+_description:
+    Combined manual and automated test plans for realtime IoT devices running Ubuntu Server.
+include:
+nested_part:
+    ce-oem-iot-server-26-04-manual-rt
+    ce-oem-iot-server-26-04-automated-rt
+    ce-oem-iot-server-26-04-stress-rt
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-server-26-04-manual-rt
+unit: test plan
+_name: CE-OEM-IOT - Manual only OEMQA tests for realtime Ubuntu Server 26.04
+_description:
+    Ubuntu Server OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the tests that require manual control of device hardware
+    or some other user input to complete.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-server-26-04-manual
+    com.canonical.certification::rt-performance-tests-manual
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-server-26-04-automated-rt
+unit: test plan
+_name: CE-OEM-IOT - Automated only OEMQA tests for realtime Ubuntu Server 26.04
+_description:
+    Ubuntu Server OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the automated tests used to validate the IoT devices.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-server-26-04-automated
+    com.canonical.certification::rt-performance-tests-automated
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-server-26-04-stress-rt
+unit: test plan
+_name: CE-OEM-IOT - Stress only OEMQA tests for realtime Ubuntu Server 26.04
+_description:
+    Ubuntu Server OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the stress tests used to validate the IoT devices.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-server-26-04-stress
+    com.canonical.certification::rt-performance-tests-stress
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-server-24-04-rt
+unit: test plan
+_name: CE-OEM-IOT - Full manual + automated OEMQA tests for realtime Ubuntu Server 24.04
+_description:
+    Combined manual and automated test plans for realtime IoT devices running Ubuntu Server.
+include:
+nested_part:
+    ce-oem-iot-server-24-04-manual-rt
+    ce-oem-iot-server-24-04-automated-rt
+    ce-oem-iot-server-24-04-stress-rt
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-server-24-04-manual-rt
+unit: test plan
+_name: CE-OEM-IOT - Manual only OEMQA tests for realtime Ubuntu Server 24.04
+_description:
+    Ubuntu Server OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the tests that require manual control of device hardware
+    or some other user input to complete.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-server-24-04-manual
+    com.canonical.certification::rt-performance-tests-manual
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-server-24-04-automated-rt
+unit: test plan
+_name: CE-OEM-IOT - Automated only OEMQA tests for realtime Ubuntu Server 24.04
+_description:
+    Ubuntu Server OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the automated tests used to validate the IoT devices.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-server-24-04-automated
+    com.canonical.certification::rt-performance-tests-automated
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*
+
+id: ce-oem-iot-server-24-04-stress-rt
+unit: test plan
+_name: CE-OEM-IOT - Stress only OEMQA tests for realtime Ubuntu Server 24.04
+_description:
+    Ubuntu Server OEMQA test plan for the realtime IoT devices. This test plan contains
+    all of the stress tests used to validate the IoT devices.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-iot-server-24-04-stress
+    com.canonical.certification::rt-performance-tests-stress
+exclude:
+    .*::.*suspend.*
+certification_status_overrides:
+    apply blocker to .*

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-server.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-server.pxu
@@ -258,7 +258,7 @@ certification_status_overrides:
 
 id: ce-oem-iot-server-26-04-rt
 unit: test plan
-_name: CE-OEM-IOT - Full manual + automated OEMQA tests for realtime Ubuntu Server 26.04
+_name: CE-OEM-IOT - Full manual + automated tests for realtime Ubuntu Server 26.04
 _description:
     Combined manual and automated test plans for realtime IoT devices running Ubuntu Server.
 include:
@@ -320,7 +320,7 @@ certification_status_overrides:
 
 id: ce-oem-iot-server-24-04-rt
 unit: test plan
-_name: CE-OEM-IOT - Full manual + automated OEMQA tests for realtime Ubuntu Server 24.04
+_name: CE-OEM-IOT - Full manual + automated tests for realtime Ubuntu Server 24.04
 _description:
     Combined manual and automated test plans for realtime IoT devices running Ubuntu Server.
 include:


### PR DESCRIPTION
## Description

Land the ubuntu 26.04 & 24.04 and Ubuntu Core 26 & 24 test plans into checkbox ce-oem providers.

## Resolved issues

Add realtime kernel test plans 24 & 26 in checkbox-provider-ce-oem

## Documentation

N/A

## Tests

Sideload and list-bootstrapped test plans to make suure tgpio, tsn and cyclic-test cases are listed

- test plan: com.canonical.contrib::ce-oem-iot-desktop-26-04-rt
  - https://pastebin.canonical.com/p/gdc2HBMdMD/
- test plan: com.canonical.contrib::ce-oem-iot-server-26-04-rt
  - https://pastebin.canonical.com/p/jbycPbC3pM/
- test plan: com.canonical.contrib::ce-oem-iot-ubuntucore-26-rt
  - https://pastebin.canonical.com/p/zj6C9jJtQJ/
