### PR TITLE
Collecting the BIOS settings as an attachment (New)

### DIFF
--- a/providers/base/bin/get_firmware_info_fwupd.py
+++ b/providers/base/bin/get_firmware_info_fwupd.py
@@ -20,27 +20,25 @@
 import os
 import sys
 import json
-import shlex
 import logging
+import argparse
 import subprocess
 from checkbox_support.snap_utils.snapd import Snapd
 
 
-def get_fwupdmgr_services_versions():
+def get_fwupdmgr_services_versions() -> list:
     """Show fwupd client and daemon versions
 
     Returns:
         list: fwupd client and daemon versions
     """
-    fwupd_vers = subprocess.run(
-        shlex.split("fwupdmgr --version --json"), capture_output=True
-    )
-    fwupd_vers = json.loads(fwupd_vers.stdout).get("Versions", [])
+    fwupd_vers = subprocess.check_output(["fwupdmgr", "--version", "--json"])
+    fwupd_vers = json.loads(fwupd_vers).get("Versions", [])
 
     return fwupd_vers
 
 
-def get_fwupd_runtime_version():
+def get_fwupd_runtime_version() -> tuple:
     """Get fwupd runtime version
 
     Returns:
@@ -58,29 +56,90 @@ def get_fwupd_runtime_version():
     return runtime_ver
 
 
-def get_firmware_info_fwupd():
+def choose_command() -> str:
+    """
+    Choose which command should be used
+    """
+    if Snapd().list("fwupd"):
+        return "fwupd.fwupdmgr"
+    else:
+        return "fwupdmgr"
+
+
+def get_environment() -> dict:
+    """
+    Get the environment to use for subprocess execution.
+    Apply workaround to unset the SNAP for the fwupd issue.
+    See details from following PR
+    https://github.com/canonical/checkbox/pull/1089
+    """
+    env = os.environ.copy()
+
+    # If using debian fwupd (not snap)
+    if not Snapd().list("fwupd"):
+        runtime_ver = get_fwupd_runtime_version()
+        # SNAP environ is available, so it's running on checkbox snap
+        # Unset the environ variable if debian fwupd lower than 1.9.14
+        if os.environ.get("SNAP") and runtime_ver < (1, 9, 14):
+            env.pop("SNAP", None)
+
+    return env
+
+
+def get_firmware_info_fwupd() -> None:
     """
     Dump firmware information for all devices detected by fwupd
     """
-    if Snapd().list("fwupd"):
-        # Dump firmware info by fwupd snap
-        subprocess.run(shlex.split("fwupd.fwupdmgr get-devices --json"))
-    else:
-        # Dump firmware info by fwupd debian package
-        runtime_ver = get_fwupd_runtime_version()
-        # Apply workaround to unset the SNAP for the fwupd issue
-        # See details from following PR
-        # https://github.com/canonical/checkbox/pull/1089
+    try:
+        output = subprocess.check_output(
+            [choose_command(), "get-devices", "--json"], env=get_environment()
+        )
+        print(output.decode("utf-8"))
+    except subprocess.CalledProcessError as e:
+        raise SystemExit("fwupdmgr get-devices failed with {}".format(repr(e)))
 
-        # SNAP environ is avaialble, so it's running on checkbox snap
-        # Unset the environ variable if debian fwupd lower than 1.9.14
-        if os.environ.get("SNAP") and runtime_ver < (1, 9, 14):
-            del os.environ["SNAP"]
 
-        subprocess.run(shlex.split("fwupdmgr get-devices --json"))
+def get_bios_setting_fwupd() -> None:
+    """
+    Dump bios setting detected by fwupd
+    """
+    try:
+        output = subprocess.check_output(
+            [choose_command(), "get-bios-setting", "--json"],
+            env=get_environment(),
+        )
+        print(output.decode("utf-8"))
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(
+            "fwupdmgr get-bios-setting failed with {}".format(repr(e))
+        )
+
+
+def parse_args(args=sys.argv[1:]) -> argparse.Namespace:
+    """
+    command line arguments parsing
+
+    :param args: arguments from sys
+    :type args: sys.argv
+    """
+    parser = argparse.ArgumentParser(
+        prog="fwupdmgr executor",
+        description="Executing fwupdmger in the right environment",
+    )
+
+    parser.add_argument(
+        "-c",
+        "--command",
+        type=str,
+        default="get-devices",
+        help="Command to execute: get-devices or get-bios-setting "
+        "(default: get-devices)",
+    )
+    return parser.parse_args(args)
 
 
 if __name__ == "__main__":
+    args = parse_args()
 
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.INFO)
@@ -105,6 +164,13 @@ if __name__ == "__main__":
     root_logger.addHandler(stdout_handler)
 
     try:
-        get_firmware_info_fwupd()
+        if args.command == "get-devices":
+            get_firmware_info_fwupd()
+        elif args.command == "get-bios-setting":
+            get_bios_setting_fwupd()
+        else:
+            msg = "Command [{}] is not supported".format(args.command)
+            logging.error(msg)
+            raise SystemExit(msg)
     except Exception as err:
         logging.error(err)

--- a/providers/base/tests/test_get_firmware_info_fwupd.py
+++ b/providers/base/tests/test_get_firmware_info_fwupd.py
@@ -9,8 +9,8 @@ import get_firmware_info_fwupd
 class TestGetFirmwareInfo(unittest.TestCase):
 
     @patch("json.loads")
-    @patch("subprocess.run")
-    def test_get_deb_fwupd_version_success(self, mock_subporcess, mock_json):
+    @patch("subprocess.check_output")
+    def test_get_deb_fwupd_version_success(self, mock_subprocess, mock_json):
 
         dict_resp = {
             "Versions": [
@@ -27,24 +27,19 @@ class TestGetFirmwareInfo(unittest.TestCase):
             ]
         }
         json_resp = json.dumps(dict_resp)
-        mock_subporcess.return_value = subprocess.CompletedProcess(
-            returncode=0,
-            stdout=json_resp,
-            args=["fwupdmgr", "--version", "--json"],
-        )
+        mock_subprocess.return_value = json_resp
+
         mock_json.return_value = dict_resp
 
         fwupd_vers = get_firmware_info_fwupd.get_fwupdmgr_services_versions()
-        mock_subporcess.assert_called_with(
-            ["fwupdmgr", "--version", "--json"], capture_output=True
-        )
+        mock_subprocess.assert_called_with(["fwupdmgr", "--version", "--json"])
         mock_json.assert_called_with(json_resp)
         self.assertListEqual(dict_resp["Versions"], fwupd_vers)
 
     @patch("json.loads")
-    @patch("subprocess.run")
+    @patch("subprocess.check_output")
     def test_get_deb_fwupd_version_key_not_match(
-        self, mock_subporcess, mock_json
+        self, mock_subprocess, mock_json
     ):
 
         dict_resp = {
@@ -62,17 +57,12 @@ class TestGetFirmwareInfo(unittest.TestCase):
             ]
         }
         json_resp = json.dumps(dict_resp)
-        mock_subporcess.return_value = subprocess.CompletedProcess(
-            returncode=0,
-            stdout=json_resp,
-            args=["fwupdmgr", "--version", "--json"],
-        )
+        mock_subprocess.return_value = json_resp
+
         mock_json.return_value = dict_resp
 
         fwupd_vers = get_firmware_info_fwupd.get_fwupdmgr_services_versions()
-        mock_subporcess.assert_called_with(
-            ["fwupdmgr", "--version", "--json"], capture_output=True
-        )
+        mock_subprocess.assert_called_with(["fwupdmgr", "--version", "--json"])
         mock_json.assert_called_with(json_resp)
         self.assertListEqual([], fwupd_vers)
 
@@ -112,10 +102,11 @@ class TestGetFirmwareInfo(unittest.TestCase):
         runtime_ver = get_firmware_info_fwupd.get_fwupd_runtime_version()
         self.assertEqual((), runtime_ver)
 
-    @patch("subprocess.run")
+    @patch("builtins.print")
+    @patch("subprocess.check_output")
     @patch("checkbox_support.snap_utils.snapd.Snapd.list")
     def test_get_firmware_data_by_fwupd_snap(
-        self, mock_snapd, mock_subporcess
+        self, mock_snapd, mock_subprocess, mock_print
     ):
 
         mock_snapd.return_value = {
@@ -123,63 +114,228 @@ class TestGetFirmwareInfo(unittest.TestCase):
             "title": "fwupd",
             "summary": "Firmware updates for Linux",
         }
+        test_output = b'{"Devices": []}'
+        mock_subprocess.return_value = test_output
         get_firmware_info_fwupd.get_firmware_info_fwupd()
         mock_snapd.assert_called_with("fwupd")
-        mock_subporcess.assert_called_with(
-            ["fwupd.fwupdmgr", "get-devices", "--json"]
+        mock_subprocess.assert_called_with(
+            ["fwupd.fwupdmgr", "get-devices", "--json"], env=unittest.mock.ANY
         )
+        mock_print.assert_called_once_with(test_output.decode("utf-8"))
 
     @patch.dict(os.environ, {"SNAP": "checkbox-snap"})
-    @patch("subprocess.run")
+    @patch("builtins.print")
+    @patch("subprocess.check_output")
     @patch("get_firmware_info_fwupd.get_fwupd_runtime_version")
     @patch("checkbox_support.snap_utils.snapd.Snapd.list")
     def test_get_firmware_data_by_fwupd1914_deb_on_checkbox_snap(
-        self, mock_snapd, mock_fwupd_ver, mock_subporcess
+        self, mock_snapd, mock_fwupd_ver, mock_subprocess, mock_print
     ):
 
         mock_snapd.return_value = None
         mock_fwupd_ver.return_value = (1, 9, 14)
+        test_output = b'{"Devices": []}'
+        mock_subprocess.return_value = test_output
 
         get_firmware_info_fwupd.get_firmware_info_fwupd()
         mock_snapd.assert_called_with("fwupd")
         self.assertEqual(os.environ.get("SNAP"), "checkbox-snap")
-        mock_subporcess.assert_called_with(
-            ["fwupdmgr", "get-devices", "--json"]
+        mock_subprocess.assert_called_with(
+            ["fwupdmgr", "get-devices", "--json"], env=unittest.mock.ANY
         )
+        mock_print.assert_called_once_with(test_output.decode("utf-8"))
 
     @patch.dict(os.environ, {"SNAP": "checkbox-snap"})
-    @patch("subprocess.run")
+    @patch("builtins.print")
+    @patch("subprocess.check_output")
     @patch("get_firmware_info_fwupd.get_fwupd_runtime_version")
     @patch("checkbox_support.snap_utils.snapd.Snapd.list")
     def test_get_firmware_data_by_fwupd_deb179_on_checkbox_snap(
-        self, mock_snapd, mock_fwupd_ver, mock_subporcess
+        self, mock_snapd, mock_fwupd_ver, mock_subprocess, mock_print
     ):
 
         mock_snapd.return_value = False
         mock_fwupd_ver.return_value = (1, 7, 9)
+        test_output = b'{"Devices": []}'
+        mock_subprocess.return_value = test_output
 
         # SNAP env is available before get_firmware_info_fwupd been called
         self.assertEqual(os.environ.get("SNAP"), "checkbox-snap")
         get_firmware_info_fwupd.get_firmware_info_fwupd()
         mock_snapd.assert_called_with("fwupd")
-        # SNAP env is empty after get_firmware_info_fwupd been called
-        self.assertIsNone(os.environ.get("SNAP"))
-        mock_subporcess.assert_called_with(
-            ["fwupdmgr", "get-devices", "--json"]
+        # SNAP env should still be present in os.environ (not deleted globally)
+        self.assertEqual(os.environ.get("SNAP"), "checkbox-snap")
+        # But subprocess should be called with env that has SNAP removed
+        call_args = mock_subprocess.call_args
+        self.assertEqual(
+            call_args[0][0], ["fwupdmgr", "get-devices", "--json"]
         )
+        self.assertNotIn("SNAP", call_args[1]["env"])
+        mock_print.assert_called_once_with(test_output.decode("utf-8"))
 
-    @patch("subprocess.run")
+    @patch("builtins.print")
+    @patch("subprocess.check_output")
     @patch("get_firmware_info_fwupd.get_fwupd_runtime_version")
     @patch("checkbox_support.snap_utils.snapd.Snapd.list")
     def test_get_firmware_data_by_fwupd_deb_on_checkbox_deb(
-        self, mock_snapd, mock_fwupd_ver, mock_subporcess
+        self, mock_snapd, mock_fwupd_ver, mock_subprocess, mock_print
     ):
 
         mock_snapd.return_value = False
         mock_fwupd_ver.return_value = (1, 7, 9)
+        test_output = b'{"Devices": []}'
+        mock_subprocess.return_value = test_output
 
         get_firmware_info_fwupd.get_firmware_info_fwupd()
         mock_snapd.assert_called_with("fwupd")
-        mock_subporcess.assert_called_with(
-            ["fwupdmgr", "get-devices", "--json"]
+        mock_subprocess.assert_called_with(
+            ["fwupdmgr", "get-devices", "--json"], env=unittest.mock.ANY
         )
+        mock_print.assert_called_once_with(test_output.decode("utf-8"))
+
+    @patch("builtins.print")
+    @patch("subprocess.check_output")
+    @patch("checkbox_support.snap_utils.snapd.Snapd.list")
+    def test_get_bios_setting_fwupd_snap(
+        self, mock_snapd, mock_subprocess, mock_print
+    ):
+        """Test get_bios_setting_fwupd with fwupd snap"""
+        mock_snapd.return_value = {
+            "id": "HpOj37PuyuaMUZY0NQhtwnp7oS5P8u5R",
+            "title": "fwupd",
+            "summary": "Firmware updates for Linux",
+        }
+        test_output = b'{"BiosSettings": []}'
+        mock_subprocess.return_value = test_output
+
+        get_firmware_info_fwupd.get_bios_setting_fwupd()
+        mock_snapd.assert_called_with("fwupd")
+        mock_subprocess.assert_called_with(
+            ["fwupd.fwupdmgr", "get-bios-setting", "--json"],
+            env=unittest.mock.ANY,
+        )
+        mock_print.assert_called_once_with(test_output.decode("utf-8"))
+
+    @patch("builtins.print")
+    @patch("subprocess.check_output")
+    @patch("get_firmware_info_fwupd.get_fwupd_runtime_version")
+    @patch("checkbox_support.snap_utils.snapd.Snapd.list")
+    def test_get_bios_setting_fwupd_deb(
+        self, mock_snapd, mock_fwupd_ver, mock_subprocess, mock_print
+    ):
+        """Test get_bios_setting_fwupd with fwupd deb"""
+        mock_snapd.return_value = False
+        mock_fwupd_ver.return_value = (1, 9, 14)
+        test_output = b'{"BiosSettings": []}'
+        mock_subprocess.return_value = test_output
+
+        get_firmware_info_fwupd.get_bios_setting_fwupd()
+        mock_snapd.assert_called_with("fwupd")
+        mock_subprocess.assert_called_with(
+            ["fwupdmgr", "get-bios-setting", "--json"], env=unittest.mock.ANY
+        )
+        mock_print.assert_called_once_with(test_output.decode("utf-8"))
+
+    @patch("subprocess.check_output")
+    @patch("get_firmware_info_fwupd.get_fwupd_runtime_version")
+    @patch("checkbox_support.snap_utils.snapd.Snapd.list")
+    def test_get_firmware_info_fwupd_failure(
+        self, mock_snapd, mock_fwupd_ver, mock_subprocess
+    ):
+        """Test get_firmware_info_fwupd handles subprocess failure"""
+        mock_snapd.return_value = False
+        mock_fwupd_ver.return_value = (1, 9, 14)
+        mock_subprocess.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd=["fwupdmgr", "get-devices", "--json"]
+        )
+
+        with self.assertRaises(SystemExit) as context:
+            get_firmware_info_fwupd.get_firmware_info_fwupd()
+
+    @patch("subprocess.check_output")
+    @patch("get_firmware_info_fwupd.get_fwupd_runtime_version")
+    @patch("checkbox_support.snap_utils.snapd.Snapd.list")
+    def test_get_bios_setting_fwupd_failure(
+        self, mock_snapd, mock_fwupd_ver, mock_subprocess
+    ):
+        """Test get_bios_setting_fwupd handles subprocess failure"""
+        mock_snapd.return_value = False
+        mock_fwupd_ver.return_value = (1, 9, 14)
+        mock_subprocess.side_effect = subprocess.CalledProcessError(
+            returncode=2, cmd=["fwupdmgr", "get-bios-setting", "--json"]
+        )
+
+        with self.assertRaises(SystemExit) as context:
+            get_firmware_info_fwupd.get_bios_setting_fwupd()
+
+    def test_parse_args_default(self):
+        """Test parse_args with default arguments"""
+        args = get_firmware_info_fwupd.parse_args([])
+        self.assertEqual(args.command, "get-devices")
+
+    def test_parse_args_get_devices(self):
+        """Test parse_args with get-devices command"""
+        args = get_firmware_info_fwupd.parse_args(["-c", "get-devices"])
+        self.assertEqual(args.command, "get-devices")
+
+    def test_parse_args_get_bios_setting(self):
+        """Test parse_args with get-bios-setting command"""
+        args = get_firmware_info_fwupd.parse_args(
+            ["--command", "get-bios-setting"]
+        )
+        self.assertEqual(args.command, "get-bios-setting")
+
+    @patch("checkbox_support.snap_utils.snapd.Snapd.list")
+    def test_choose_command_snap(self, mock_snapd):
+        """Test choose_command returns fwupd.fwupdmgr when fwupd snap exists"""
+        mock_snapd.return_value = {
+            "id": "HpOj37PuyuaMUZY0NQhtwnp7oS5P8u5R",
+            "title": "fwupd",
+        }
+        cmd = get_firmware_info_fwupd.choose_command()
+        self.assertEqual(cmd, "fwupd.fwupdmgr")
+
+    @patch("get_firmware_info_fwupd.get_fwupd_runtime_version")
+    @patch("checkbox_support.snap_utils.snapd.Snapd.list")
+    def test_choose_command_deb(self, mock_snapd, mock_fwupd_ver):
+        """Test choose_command returns fwupdmgr when fwupd deb is used"""
+        mock_snapd.return_value = None
+        cmd = get_firmware_info_fwupd.choose_command()
+        self.assertEqual(cmd, "fwupdmgr")
+
+    @patch("checkbox_support.snap_utils.snapd.Snapd.list")
+    def test_get_environment_snap(self, mock_snapd):
+        """Test get_environment returns env with SNAP when using snap"""
+        mock_snapd.return_value = {"id": "test"}
+        with patch.dict(os.environ, {"SNAP": "checkbox-snap"}):
+            env = get_firmware_info_fwupd.get_environment()
+            self.assertEqual(env.get("SNAP"), "checkbox-snap")
+
+    @patch.dict(os.environ, {"SNAP": "checkbox-snap"})
+    @patch("get_firmware_info_fwupd.get_fwupd_runtime_version")
+    @patch("checkbox_support.snap_utils.snapd.Snapd.list")
+    def test_get_environment_deb_old_version(self, mock_snapd, mock_fwupd_ver):
+        """Test get_environment removes SNAP for old fwupd deb"""
+        mock_snapd.return_value = None
+        mock_fwupd_ver.return_value = (1, 7, 9)
+        env = get_firmware_info_fwupd.get_environment()
+        self.assertNotIn("SNAP", env)
+
+    @patch.dict(os.environ, {"SNAP": "checkbox-snap"})
+    @patch("get_firmware_info_fwupd.get_fwupd_runtime_version")
+    @patch("checkbox_support.snap_utils.snapd.Snapd.list")
+    def test_get_environment_deb_new_version(self, mock_snapd, mock_fwupd_ver):
+        """Test get_environment keeps SNAP for new fwupd deb"""
+        mock_snapd.return_value = None
+        mock_fwupd_ver.return_value = (1, 9, 14)
+        env = get_firmware_info_fwupd.get_environment()
+        self.assertEqual(env.get("SNAP"), "checkbox-snap")
+
+    @patch("get_firmware_info_fwupd.get_fwupd_runtime_version")
+    @patch("checkbox_support.snap_utils.snapd.Snapd.list")
+    def test_get_environment_deb_no_snap_env(self, mock_snapd, mock_fwupd_ver):
+        """Test get_environment when no SNAP env variable exists"""
+        mock_snapd.return_value = None
+        mock_fwupd_ver.return_value = (1, 7, 9)
+        env = get_firmware_info_fwupd.get_environment()
+        self.assertNotIn("SNAP", env)

--- a/providers/base/units/firmware/jobs.pxu
+++ b/providers/base/units/firmware/jobs.pxu
@@ -117,3 +117,14 @@ requires:
     executable.name in ("fwupdmgr", "fwupd.fwupdmgr")
 command:
     get_firmware_info_fwupd.py
+
+id: firmware/fwupdmgr_get_bios_setting
+plugin: attachment
+user: root
+category_id: com.canonical.plainbox::firmware
+_summary: Collect the BIOS setting information
+_purpose: Attach information about the BIOS, as reported by the fwupdmgr
+requires:
+    executable.name in ("fwupdmgr", "fwupd.fwupdmgr")
+command:
+    get_firmware_info_fwupd.py -c get-bios-setting

--- a/providers/base/units/firmware/test-plan.pxu
+++ b/providers/base/units/firmware/test-plan.pxu
@@ -55,6 +55,7 @@ bootstrap_include:
     environment
 include:
     firmware/fwupdmgr_get_devices
+    firmware/fwupdmgr_get_bios_setting
 
 id: firmware-fwupdmgr-manual
 unit: test plan


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
This simply add one more attachment job to attach the BIOS setting by `fwupdmgr get-bios-setting --json`.
Base on https://github.com/canonical/checkbox/pull/1089 to do the environment check and improve the code:
1. Using list instead of `shlex.split` the string for the command in the subprocess
2. Removing the `SNAP` environment variable only in the subprocess
3. Using `subprocess.check_output` instead of `subprocess.run` 

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->
Let verifier has information to compare the test environment is changed or not.


## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
26.04 debian: https://certification.canonical.com/hardware/202001-27667/submission/504710/ 
26.04 snap: https://certification.canonical.com/hardware/202001-27667/submission/504709/
24.04 debian: https://certification.canonical.com/hardware/202001-27667/submission/504941/
24.04 snap: https://certification.canonical.com/hardware/202001-27667/submission/504943/
22.04 debian: https://certification.canonical.com/hardware/202001-27667/submission/504933/
22.04 snap: https://certification.canonical.com/hardware/202001-27667/submission/504937/
22.04 snap (This system doesn't support firmware settings): https://certification.canonical.com/hardware/202312-33237/submission/504944/
