### PR TITLE
Add ptp minor version param (BugFix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
@@ -99,7 +99,7 @@ command:
             echo "ptp4l version $ptp4l_version does not support --ptp_minor_version, skipping this option."
         fi
     fi
-    (set -x; timeout 30s ptp4l $ptp4l_args | tee "$output_file")
+    (set -x; timeout 30s ptp4l "$ptp4l_args" | tee "$output_file")
     rms_data=$(tail -5 $output_file | awk '/rms/{{print $3}}')
     if [[ -z $rms_data ]]; then
         echo "ERROR: unable to get rms value from the output file"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
@@ -90,8 +90,16 @@ command:
     # Add --tx_timstamp_timeout=5 due to the patch of ptp4l increace from 1 to 5ms.
     # https://www.mail-archive.com/linuxptp-devel@lists.sourceforge.net/msg05015.html
     # And this patch has been merged into the versoin later then V2.0
-    [ -z "$PTP4L_PTP_MINOR_VERSION" ] && PTP4L_PTP_MINOR_VERSION="1"
-    (set -x; timeout 30s ptp4l -i {eth-interface} -m -s --network_transport=L2 --tx_timestamp_timeout=5 --ptp_minor_version="$PTP4L_PTP_MINOR_VERSION" | tee $output_file)
+    ptp4l_args="-i {eth-interface} -m -s --network_transport=L2 --tx_timestamp_timeout=5"
+    if [ -n "$PTP4L_PTP_MINOR_VERSION" ]; then
+        ptp4l_version=$(ptp4l -v 2>&1 | grep -oP '\d+' | head -n 1)
+        if [[ "$ptp4l_version" -ge 4 ]]; then
+            ptp4l_args="$ptp4l_args --ptp_minor_version=$PTP4L_PTP_MINOR_VERSION"
+        else
+            echo "ptp4l version $ptp4l_version does not support --ptp_minor_version, skipping this option."
+        fi
+    fi
+    (set -x; timeout 30s ptp4l $ptp4l_args | tee "$output_file")
     rms_data=$(tail -5 $output_file | awk '/rms/{{print $3}}')
     if [[ -z $rms_data ]]; then
         echo "ERROR: unable to get rms value from the output file"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
@@ -83,13 +83,15 @@ estimated_duration: 32s
 imports: from com.canonical.plainbox import manifest
 requires: manifest.has_ptp == 'True'
 depends: ce-oem-ptp/verify-PTP-support-for-{eth-interface}
+environ: PTP4L_PTP_MINOR_VERSION
 command:
     output_file='/var/tmp/ptp4l_output.txt'
     echo "Executing ptp4l for 30s"
     # Add --tx_timstamp_timeout=5 due to the patch of ptp4l increace from 1 to 5ms.
     # https://www.mail-archive.com/linuxptp-devel@lists.sourceforge.net/msg05015.html
     # And this patch has been merged into the versoin later then V2.0
-    (set -x; timeout 30s ptp4l -i {eth-interface} -m -s --network_transport=L2 --tx_timestamp_timeout=5 | tee $output_file)
+    [ -z "$PTP4L_PTP_MINOR_VERSION" ] && PTP4L_PTP_MINOR_VERSION="1"
+    (set -x; timeout 30s ptp4l -i {eth-interface} -m -s --network_transport=L2 --tx_timestamp_timeout=5 --ptp_minor_version="$PTP4L_PTP_MINOR_VERSION" | tee $output_file)
     rms_data=$(tail -5 $output_file | awk '/rms/{{print $3}}')
     if [[ -z $rms_data ]]; then
         echo "ERROR: unable to get rms value from the output file"


### PR DESCRIPTION
## Description

To solve the issue where the BCM54213PE PHY TX-timestamp packet classifier does not recognize minorVersionPTP=1 as a PTP event frame which causes missed TX timestamps, this PR adds the `--ptp_minor_version=0` environment variable option.

## Resolved issues

Resolves [canonical/checkbox#2746](https://github.com/canonical/checkbox/issues/2746)

## Documentation
ptp4l support `ptp_minor_version` reference:
https://github.com/richardcochran/linuxptp/commit/02a13b039d44479ba429c3cc1b75acb8e6da924a

## Tests
- Test image:
   - Server: Desktop 26.04
   - Client: Desktop 26.04
- submission: https://certification.canonical.com/hardware/202605-38788/submission/504284/test-results/pass/?term=ptp

**A DUT as server**
```
sudo ptp4l -i enx2ccf67d8f658 -m -s --network_transport=L2 --tx_timestamp_timeout=5 --ptp_minor_version=0
ptp4l[92985.712]: selected /dev/ptp0 as PTP clock
ptp4l[92985.730]: port 1 (enx2ccf67d8f658): INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[92985.730]: port 0 (/var/run/ptp4l): INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[92985.730]: port 0 (/var/run/ptp4lro): INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[92985.777]: port 1 (enx2ccf67d8f658): new foreign master c85acf.fffe.be5a9d-1
ptp4l[92987.777]: selected best master clock c85acf.fffe.be5a9d
ptp4l[92987.777]: port 1 (enx2ccf67d8f658): LISTENING to UNCALIBRATED on RS_SLAVE
ptp4l[92988.229]: port 1 (enx2ccf67d8f658): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED
ptp4l[92988.855]: rms 2431869 max 4315189 freq -3558946 +/- 2240681 delay -57869 +/- 70251
ptp4l[92989.857]: rms 570207 max 892299 freq -1631919 +/- 774771 delay -25954 +/-   0
ptp4l[92990.859]: rms 971104 max 1011012 freq +138158 +/- 257818 delay -8192 +/-   0
ptp4l[92991.861]: rms 622705 max 826283 freq +495231 +/- 30526 delay  9569 +/-   0
ptp4l[92992.863]: rms 204167 max 331711 freq +311928 +/- 67460 delay 10975 +/-   0
ptp4l[92993.865]: rms 32979 max 50081 freq +108079 +/- 44623 delay 12382 +/-   0
ptp4l[92994.868]: rms 53904 max 56515 freq +10376 +/- 13841
ptp4l[92995.870]: rms 33543 max 44356 freq  -7422 +/- 1389 delay 12118 +/-  88
ptp4l[92996.872]: rms 10777 max 17803 freq  +2997 +/- 3935 delay 12076 +/-   0
ptp4l[92997.874]: rms 1962 max 2704 freq +14585 +/- 2432 delay 12076 +/-   0
ptp4l[92998.876]: rms 3170 max 3604 freq +19953 +/- 793 delay 12167 +/-   0
ptp4l[92999.878]: rms 1810 max 2279 freq +20684 +/- 122
ptp4l[93000.880]: rms  556 max  933 freq +20049 +/- 286 delay 12263 +/-   0
ptp4l[93001.882]: rms  327 max  545 freq +19378 +/- 432 delay 12396 +/-   0
ptp4l[93002.885]: rms  231 max  411 freq +19378 +/- 313 delay 12329 +/-   0
ptp4l[93003.887]: rms  290 max  644 freq +19177 +/- 362 delay 12329 +/-   0
ptp4l[93004.889]: rms  216 max  481 freq +19178 +/- 289 delay 12408 +/-   0
ptp4l[93005.891]: rms  153 max  312 freq +19171 +/- 207 delay 12475 +/-   0
ptp4l[93006.893]: rms  226 max  365 freq +19174 +/- 313 delay 12475 +/-   0
ptp4l[93007.896]: rms  259 max  467 freq +19248 +/- 350 delay 12475 +/-   0
ptp4l[93008.898]: rms  250 max  401 freq +19261 +/- 342
```

**A DUT as client**
```
----------------------------[ Running job 30 / 30 ]-----------------------------
[ Verify Ethernet interface enx2ccf67d8f570 can establish clock sync by ptp4l ]-
ID: com.canonical.contrib::ce-oem-ptp/ptp4l-time-sync-for-enx2ccf67d8f570-auto
Category: PTP Test
--------------------------------------------------------------------------------
Executing ptp4l for 30s
+ timeout 30s ptp4l -i enx2ccf67d8f570 -m -s --network_transport=L2 --tx_timestamp_timeout=5 --ptp_minor_version=0
+ tee /var/tmp/ptp4l_output.txt
ptp4l[100187.194]: selected /dev/ptp0 as PTP clock
ptp4l[100187.209]: port 1 (enx2ccf67d8f570): INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[100187.209]: port 0 (/var/run/ptp4l): INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[100187.209]: port 0 (/var/run/ptp4lro): INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[100187.308]: port 1 (enx2ccf67d8f570): new foreign master c85acf.fffe.be5a9d-1
ptp4l[100189.309]: selected best master clock c85acf.fffe.be5a9d
ptp4l[100189.309]: port 1 (enx2ccf67d8f570): LISTENING to UNCALIBRATED on RS_SLAVE
ptp4l[100191.005]: port 1 (enx2ccf67d8f570): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED
ptp4l[100191.632]: rms 2447611 max 4315408 freq -3532454 +/- 2230458 delay -62418 +/- 74958
ptp4l[100192.634]: rms 583124 max 900037 freq -1544205 +/- 777374
ptp4l[100193.636]: rms 902472 max 1013453 freq +68711 +/- 187011 delay 12539 +/-   0
ptp4l[100194.638]: rms 598976 max 764183 freq +432730 +/- 22464
ptp4l[100195.641]: rms 223191 max 351789 freq +312916 +/- 60612 delay 13478 +/-   0
ptp4l[100196.643]: rms 31855 max 56818 freq +121542 +/- 43946
ptp4l[100197.645]: rms 49492 max 51792 freq +18714 +/- 15440 delay 14418 +/-   0
ptp4l[100198.647]: rms 33941 max 44599 freq  -4247 +/- 1280 delay 13478 +/-   0
ptp4l[100199.649]: rms 11674 max 18529 freq  +4489 +/- 3314
ptp4l[100200.651]: rms 2048 max 2929 freq +15307 +/- 2886 delay 12539 +/-   0
ptp4l[100201.653]: rms 3043 max 3358 freq +21231 +/- 922 delay 12372 +/-  53
ptp4l[100202.656]: rms 1820 max 2797 freq +22091 +/- 274
ptp4l[100203.658]: rms  472 max  843 freq +21184 +/- 377 delay 12364 +/-   0
ptp4l[100204.660]: rms  322 max  510 freq +20477 +/- 367 delay 12315 +/-   0
ptp4l[100205.662]: rms  303 max  537 freq +20270 +/- 328 delay 12315 +/-   0
ptp4l[100206.664]: rms  302 max  434 freq +20402 +/- 418 delay 12310 +/-   5
ptp4l[100207.666]: rms  218 max  391 freq +20305 +/- 279 delay 12296 +/-   0
ptp4l[100208.669]: rms  310 max  614 freq +20269 +/- 419
ptp4l[100209.671]: rms  262 max  447 freq +20633 +/- 293 delay 12305 +/-   0
ptp4l[100210.673]: rms  135 max  227 freq +20446 +/- 181 delay 12300 +/-   6
ptp4l[100211.675]: rms  307 max  437 freq +20215 +/- 378 delay 12290 +/-   4
ptp4l[100212.678]: rms  245 max  411 freq +20471 +/- 322
ptp4l[100213.680]: rms  272 max  676 freq +20581 +/- 355 delay 12262 +/-   0
ptp4l[100214.682]: rms  339 max  483 freq +20460 +/- 466 delay 12262 +/-   0
ptp4l[100215.685]: rms  272 max  478 freq +20512 +/- 372 delay 12223 +/-   0
ptp4l[100216.687]: rms  221 max  415 freq +20554 +/- 301 delay 12223 +/-   0

PASS: rms value is valid. Clock sync succeed.
--------------------------------------------------------------------------------
Outcome: job passed
[ Verify Ethernet interface enx2ccf67d8f570 can establish clock sync by ptp4l ]-
ID: com.canonical.contrib::ce-oem-ptp/ptp4l-time-sync-for-enx2ccf67d8f570-auto
Category: PTP Test
--------------------------------------------------------------------------------
Outcome: job passed
==================================[ Results ]===================================
```