### PR TITLE
Comment out algif_aead test from test-plan-crypto (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/crypto/test-plan-crypto.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/crypto/test-plan-crypto.pxu
@@ -23,7 +23,7 @@ include:
     ce-oem-crypto/cryptsetup_benchmark
     ce-oem-crypto/af_alg_hash_crc64_test
     ce-oem-crypto/af_alg_hash_sha256_test
-    ce-oem-crypto/af_alg_aead_gcm_aes_test
+    # ce-oem-crypto/af_alg_aead_gcm_aes_test - CVE-2026-31431
     ce-oem-crypto/af_alg_skcipher_cbc_aes_test
     ce-oem-crypto/af_alg_rng_stdrng_test
 
@@ -52,6 +52,6 @@ include:
     after-suspend-ce-oem-crypto/cryptsetup_benchmark
     after-suspend-ce-oem-crypto/af_alg_hash_crc64_test
     after-suspend-ce-oem-crypto/af_alg_hash_sha256_test
-    after-suspend-ce-oem-crypto/af_alg_aead_gcm_aes_test
+    # after-suspend-ce-oem-crypto/af_alg_aead_gcm_aes_test - CVE-2026-31431
     after-suspend-ce-oem-crypto/af_alg_skcipher_cbc_aes_test
     after-suspend-ce-oem-crypto/af_alg_rng_stdrng_test


### PR DESCRIPTION
## Description
 
* Currently, when trying to run the `af_alg_aead_gcm_aes_test` Checkbox test case, the following error is displayed.
  ```
  Traceback (most recent call last):
    File "/tmp/nest-cvrw56sd.33bd35500f1701f6e719f7f391c8f609fb6fe71c8729b9164c609ead8d8a2f9b/af_alg_test.py", line 15, in create_alg
      sock.bind((crypto_type, name))
  FileNotFoundError: [Errno 2] No such file or directory
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/tmp/nest-cvrw56sd.33bd35500f1701f6e719f7f391c8f609fb6fe71c8729b9164c609ead8d8a2f9b/af_alg_test.py", line 219, in <module>
      main()
  Starting AF_ALG type aead_gcm_aes...
  Error: [Errno 2] No such file or directory
    File "/tmp/nest-cvrw56sd.33bd35500f1701f6e719f7f391c8f609fb6fe71c8729b9164c609ead8d8a2f9b/af_alg_test.py", line 215, in main
      getattr(crypto_test, "test_{}".format(args.type))()
    File "/tmp/nest-cvrw56sd.33bd35500f1701f6e719f7f391c8f609fb6fe71c8729b9164c609ead8d8a2f9b/af_alg_test.py", line 106, in test_aead_gcm_aes
      with self.create_alg("aead", "gcm(aes)") as algo:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/tmp/nest-cvrw56sd.33bd35500f1701f6e719f7f391c8f609fb6fe71c8729b9164c609ead8d8a2f9b/af_alg_test.py", line 20, in create_alg
      raise Exception(
  Exception: Error: Not able to use algorithm
  Please check kernel config!
  ```
* This is because `af_alg_aead_gcm_aes_test` runs the `af_alg_test.py` script which creates `AF_ALG` sockets, implicitly loading the `algif_aead` module, and at the moment this fails when trying to test `aead_gcm_aes` since the `/etc/modprobe.d/disable-algif_aead.conf` prevents the `algif_aead` module installation due to: https://ubuntu.com/security/CVE-2026-31431
  ```
  ubuntu@ubuntu:~$ cat /etc/modprobe.d/disable-algif_aead.conf
  # Disable algif_aead module due to CVE-2026-31431 (AKA copy.fail)
  # This will likely be re-enabled in a subsequent update once an updated
  # kernel has been deployed.
  # Blacklisting the module isn't sufficient, we need to do as below:
  install algif_aead /bin/false
  ```
  
* Additionally, as of now, not all kernels have the CVE-2026-3143 kmod fix implemented, so to prevent vulnerabilities, it is better to skip this test.

* This PR proposes commenting out `af_alg_aead_gcm_aes_test` from the crypto test plans, so it is not executed, preventing the `af_alg_test.py script` to try to load the `algif_aead` module. 

## Resolved issues

https://warthogs.atlassian.net/browse/PERI-1483

## Documentation

https://ubuntu.com/security/CVE-2026-31431

## Tests

The `ce-oem-crypto-automated` test plan was executed on a DUT which has the modified `checkbox-provider-ce-oem` side-loaded, and as can be seen the `af_alg_aead_gcm_aes_test` has not been called.

[nvidia-jetson-agx-thor-ce-oem-crypto-automated.txt](https://github.com/user-attachments/files/31322258/nvidia-jetson-agx-thor-ce-oem-crypto-automated.txt)

