### PR TITLE
Fix false positive while check clock from rtc (BugFix)

### DIFF
--- a/providers/base/units/rtc/jobs.pxu
+++ b/providers/base/units/rtc/jobs.pxu
@@ -87,7 +87,11 @@ category_id: rtc_category
 estimated_duration: 5
 environ:
 command: 
-    rtc_time=$(cat "/sys/class/rtc/{rtc}/since_epoch")
+    rtc_path="/sys/class/rtc/{rtc}/since_epoch"
+    if ! rtc_time=$(cat "$rtc_path" 2>/dev/null); then
+        echo "FAILED to read RTC time from {rtc}" >&2
+        exit 1
+    fi
     sys_time=$(date +"%s")
     result=$(("$sys_time" - "$rtc_time"))
     if [[ "$result" -le "5" ]]; then


### PR DESCRIPTION
## Description
Add error handling when reading from /sys/class/rtc/{rtc}/since_epoch, preventing incorrect test passes.

## Resolved issues
https://github.com/canonical/checkbox/issues/2747

## Documentation

## Tests
Image: uc 24
Submission: https://certification.canonical.com/submissions/status/396384

```
----------------------------[ Running job 36 / 36 ]-----------------------------
----------[ Check that rtc1 clock is synchronized with system clock ]-----------
ID: com.canonical.certification::rtc/rtc_clock_rtc1
Category: Real Time Clock (RTC)
--------------------------------------------------------------------------------
FAILED to read RTC time from rtc1
--------------------------------------------------------------------------------
Outcome: job failed
==================================[ Results ]===================================
```
