### PR TITLE
Whitelist sosreport in snap confinement test (bugfix)

### DIFF
--- a/providers/base/bin/snap_confinement_test.py
+++ b/providers/base/bin/snap_confinement_test.py
@@ -142,7 +142,7 @@ class SnapsConfinementVerifier:
             r"checkbox.*",
             r"^mir-test-tools$",
             r"^graphics-test-tools$",
-            r"^sosreport$"
+            r"^sosreport$",
         ]
         self._allowlist_from_config_var = [
             element.strip()

--- a/providers/base/bin/snap_confinement_test.py
+++ b/providers/base/bin/snap_confinement_test.py
@@ -142,6 +142,7 @@ class SnapsConfinementVerifier:
             r"checkbox.*",
             r"^mir-test-tools$",
             r"^graphics-test-tools$",
+            r"^sosreport$"
         ]
         self._allowlist_from_config_var = [
             element.strip()


### PR DESCRIPTION
## Description

This PR adds sosreport to the official allow list in snap confinement test.

## Resolved issues

sosreport is used pretty heavily when running everyday tests to collect logs, but the current snap confinement test will complain that it's using classic confinement. Officially allowing sosreport would make things more convenient (so we don't have to install -> grab logs -> uninstall -> run tests -> install again... etc.)

## Documentation


## Tests

Run `snap_confinement_test.py` on a device with sosreport installed and it correctly reports that sosreport was skipped.