### PR TITLE
Add I2C test cases to check expected i2cdetect results (New)

### DIFF
--- a/providers/base/bin/i2c_driver_test.py
+++ b/providers/base/bin/i2c_driver_test.py
@@ -102,15 +102,81 @@ class Device:
         print("I2C device detected")
 
 
+class Address:
+    """Check that an expected I2C device address responds on a bus."""
+
+    def invoked(self, args):
+        # Make sure that we have root privileges
+        if os.geteuid() != 0:
+            raise SystemExit("Error: please run this command as root")
+        if args.address is None:
+            raise SystemExit("Error: -a/--address is required")
+        address = int(args.address, 16)
+        result = subprocess.check_output(
+            ["i2cdetect", "-y", "-r", str(args.bus)], universal_newlines=True
+        )
+        print(result)
+        state = None
+        for line in result.splitlines()[1:]:
+            if ":" not in line:
+                continue
+            if int(line.split(":", 1)[0], 16) == address & 0xF0:
+                # i2cdetect rows are fixed-width: 3 chars per cell, the
+                # first cell starting at column 4
+                offset = 4 + 3 * (address & 0x0F)
+                state = line[offset : offset + 2].strip() or None
+        if state is None:
+            raise SystemExit(
+                "Test failed, address 0x{:02x} was not scanned by i2cdetect "
+                "on bus {}".format(address, args.bus)
+            )
+        if state == "--":
+            raise SystemExit(
+                "Test failed, no device detected at address 0x{:02x} on "
+                "bus {}".format(address, args.bus)
+            )
+        print(
+            "Device detected at address 0x{:02x} on bus {} ({})".format(
+                address, args.bus, state
+            )
+        )
+
+
+class ExpectedDeviceResource:
+    """Print expected I2C devices from configuration as resource records."""
+
+    def invoked(self, args):
+        entries = os.environ.get("EXPECTED_I2C_DEVICES", "")
+        for entry in filter(None, map(str.strip, entries.split(","))):
+            try:
+                bus, _, address = entry.partition(":")
+                print("bus: {}".format(int(bus)))
+                print("address: 0x{:02x}".format(int(address, 16)))
+                print()
+            except ValueError:
+                raise SystemExit(
+                    "Invalid EXPECTED_I2C_DEVICES entry: '{}', expected "
+                    "<bus>:<address> e.g. 1:0x2d".format(entry)
+                )
+
+
 class I2cDriverTest:
     """I2C driver test."""
 
     def main(self):
-        subcommands = {"bus": Bus, "device": Device}
+        subcommands = {
+            "bus": Bus,
+            "device": Device,
+            "address": Address,
+            "resource": ExpectedDeviceResource,
+        }
         parser = argparse.ArgumentParser(
             epilog="NOTE: When using 'device', the IGNORED_I2C_BUSES "
             "environment variable is respected and should contain "
-            "a comma-separated list of bus names to ignore."
+            "a comma-separated list of bus names to ignore. "
+            "When using 'resource', the EXPECTED_I2C_DEVICES environment "
+            "variable should contain a comma-separated list of "
+            "<bus>:<address> entries, e.g. '1:0x2d,1:0x68'."
         )
         parser.add_argument("subcommand", type=str, choices=subcommands)
         parser.add_argument(
@@ -118,7 +184,15 @@ class I2cDriverTest:
             "--bus",
             type=int,
             default=0,
-            help="Expected number of I2C bus.",
+            help="Expected number of I2C buses ('bus') or the bus number "
+            "to scan ('address').",
+        )
+        parser.add_argument(
+            "-a",
+            "--address",
+            type=str,
+            help="Expected I2C device address in hex, e.g. 0x2d "
+            "('address' only).",
         )
         args = parser.parse_args()
         subcommands[args.subcommand]().invoked(args)

--- a/providers/base/tests/test_i2c_driver_test.py
+++ b/providers/base/tests/test_i2c_driver_test.py
@@ -235,3 +235,180 @@ class TestI2CDevice(unittest.TestCase):
                 self.device.invoked(self.mock_args)
 
         self.assertIn("No I2C device detected", str(cm.exception))
+
+
+class TestAddress(unittest.TestCase):
+    def setUp(self):
+        self.address = i2c_driver_test.Address()
+
+    def args(self, bus, address):
+        return types.SimpleNamespace(bus=bus, address=address)
+
+    @patch("i2c_driver_test.os.geteuid", return_value=1000)
+    def test_address_fails_if_not_root(self, mock_geteuid):
+        """Test fails (raises SystemExit) if not run as root."""
+        with self.assertRaises(SystemExit) as cm:
+            self.address.invoked(self.args(0, "0x3a"))
+
+        self.assertIn(
+            "Error: please run this command as root", str(cm.exception)
+        )
+
+    @patch("i2c_driver_test.subprocess.check_output")
+    @patch("i2c_driver_test.os.geteuid", return_value=0)
+    def test_address_fails_without_address(
+        self, mock_geteuid, mock_check_output
+    ):
+        """Test fails (raises SystemExit) if no address is given."""
+        with self.assertRaises(SystemExit) as cm:
+            self.address.invoked(self.args(0, None))
+
+        self.assertIn("-a/--address is required", str(cm.exception))
+
+    @patch("i2c_driver_test.subprocess.check_output")
+    @patch("i2c_driver_test.os.geteuid", return_value=0)
+    def test_address_success_busy_device(
+        self, mock_geteuid, mock_check_output
+    ):
+        """Test succeeds when the address is in use by a driver (UU)."""
+        mock_check_output.side_effect = mock_subprocess_check_output
+
+        with io.StringIO() as buf, redirect_stdout(buf):
+            self.address.invoked(self.args(0, "0x3a"))
+            output = buf.getvalue()
+
+        self.assertIn("Device detected at address 0x3a on bus 0", output)
+
+    @patch("i2c_driver_test.subprocess.check_output")
+    @patch("i2c_driver_test.os.geteuid", return_value=0)
+    def test_address_success_responding_device(
+        self, mock_geteuid, mock_check_output
+    ):
+        """Test succeeds when the address answers the probe (hex value)."""
+        mock_check_output.side_effect = mock_subprocess_check_output
+
+        with io.StringIO() as buf, redirect_stdout(buf):
+            self.address.invoked(self.args(1, "0x5a"))
+            output = buf.getvalue()
+
+        self.assertIn("Device detected at address 0x5a on bus 1", output)
+
+    @patch("i2c_driver_test.subprocess.check_output")
+    @patch("i2c_driver_test.os.geteuid", return_value=0)
+    def test_address_fails_if_device_missing(
+        self, mock_geteuid, mock_check_output
+    ):
+        """Test fails (raises SystemExit) if the address shows '--'."""
+        mock_check_output.side_effect = mock_subprocess_check_output
+
+        with self.assertRaises(SystemExit) as cm:
+            with io.StringIO() as buf, redirect_stdout(buf):
+                self.address.invoked(self.args(2, "0x2d"))
+
+        self.assertIn(
+            "no device detected at address 0x2d on bus 2", str(cm.exception)
+        )
+
+    @patch("i2c_driver_test.subprocess.check_output")
+    @patch("i2c_driver_test.os.geteuid", return_value=0)
+    def test_address_fails_if_address_not_scanned(
+        self, mock_geteuid, mock_check_output
+    ):
+        """Test fails (raises SystemExit) on an address outside the scan
+        range (i2cdetect only scans 0x08-0x77 by default)."""
+        mock_check_output.side_effect = mock_subprocess_check_output
+
+        with self.assertRaises(SystemExit) as cm:
+            with io.StringIO() as buf, redirect_stdout(buf):
+                self.address.invoked(self.args(0, "0x03"))
+
+        self.assertIn("was not scanned", str(cm.exception))
+
+    @patch("i2c_driver_test.subprocess.check_output")
+    @patch("i2c_driver_test.os.geteuid", return_value=0)
+    def test_address_skips_lines_without_colon(
+        self, mock_geteuid, mock_check_output
+    ):
+        """Junk lines without a ':' in the i2cdetect output are ignored."""
+        mock_check_output.return_value = (
+            MOCK_DETECT_BUS_0_SUCCESS + "\njunk trailing line"
+        )
+
+        with io.StringIO() as buf, redirect_stdout(buf):
+            self.address.invoked(self.args(0, "0x3a"))
+            output = buf.getvalue()
+
+        self.assertIn("Device detected at address 0x3a on bus 0", output)
+
+
+class TestMain(unittest.TestCase):
+    @patch.dict(
+        "i2c_driver_test.os.environ", {"EXPECTED_I2C_DEVICES": "1:0x2d"}
+    )
+    @patch("sys.argv", ["i2c_driver_test.py", "resource"])
+    def test_main_resource(self):
+        """main() dispatches the resource subcommand."""
+        with io.StringIO() as buf, redirect_stdout(buf):
+            i2c_driver_test.I2cDriverTest().main()
+            output = buf.getvalue()
+
+        self.assertEqual(output, "bus: 1\naddress: 0x2d\n\n")
+
+    @patch("i2c_driver_test.subprocess.check_output")
+    @patch("i2c_driver_test.os.geteuid", return_value=0)
+    @patch(
+        "sys.argv",
+        ["i2c_driver_test.py", "address", "-b", "1", "-a", "0x5a"],
+    )
+    def test_main_address(self, mock_geteuid, mock_check_output):
+        """main() dispatches the address subcommand with -b and -a."""
+        mock_check_output.side_effect = mock_subprocess_check_output
+
+        with io.StringIO() as buf, redirect_stdout(buf):
+            i2c_driver_test.I2cDriverTest().main()
+            output = buf.getvalue()
+
+        self.assertIn("Device detected at address 0x5a on bus 1", output)
+
+
+class TestExpectedDeviceResource(unittest.TestCase):
+    def setUp(self):
+        self.resource = i2c_driver_test.ExpectedDeviceResource()
+        self.mock_args = types.SimpleNamespace()
+
+    @patch.dict(
+        "i2c_driver_test.os.environ",
+        {"EXPECTED_I2C_DEVICES": "1:0x2d, 1:0x68,2:50"},
+    )
+    def test_resource_prints_records(self):
+        """Entries are parsed and printed as normalized resource records."""
+        with io.StringIO() as buf, redirect_stdout(buf):
+            self.resource.invoked(self.mock_args)
+            output = buf.getvalue()
+
+        self.assertEqual(
+            output,
+            "bus: 1\naddress: 0x2d\n\n"
+            "bus: 1\naddress: 0x68\n\n"
+            "bus: 2\naddress: 0x50\n\n",
+        )
+
+    @patch.dict("i2c_driver_test.os.environ", {}, clear=True)
+    def test_resource_empty_without_config(self):
+        """No configuration produces no resource records."""
+        with io.StringIO() as buf, redirect_stdout(buf):
+            self.resource.invoked(self.mock_args)
+            output = buf.getvalue()
+
+        self.assertEqual(output, "")
+
+    @patch.dict(
+        "i2c_driver_test.os.environ", {"EXPECTED_I2C_DEVICES": "1-0x2d"}
+    )
+    def test_resource_fails_on_malformed_entry(self):
+        """A malformed entry fails (raises SystemExit) loudly."""
+        with self.assertRaises(SystemExit) as cm:
+            with io.StringIO() as buf, redirect_stdout(buf):
+                self.resource.invoked(self.mock_args)
+
+        self.assertIn("Invalid EXPECTED_I2C_DEVICES entry", str(cm.exception))

--- a/providers/base/units/i2c/jobs.pxu
+++ b/providers/base/units/i2c/jobs.pxu
@@ -38,3 +38,34 @@ category_id: i2c
 environ: IGNORED_I2C_BUSES
 estimated_duration: 3m
 depends: i2c/i2c-bus-detect
+
+unit: job
+id: i2c/expected-device-resource
+_summary: Gather the list of expected I²C devices from the configuration
+_description:
+  Parses the EXPECTED_I2C_DEVICES configuration variable, a comma-separated
+  list of <bus>:<address> entries (e.g. "1:0x2d,1:0x68"), into resource
+  records used to generate one detection job per expected device.
+plugin: resource
+category_id: i2c
+environ: EXPECTED_I2C_DEVICES
+command: i2c_driver_test.py resource
+estimated_duration: 1s
+
+unit: template
+template-resource: i2c/expected-device-resource
+template-unit: job
+template-id: i2c/i2c-expected-device-check
+id: i2c/i2c-expected-device-check-{bus}-{address}
+_summary: Check the I²C device at address {address} on bus {bus} is detected
+_purpose:
+  The test will pass only if the expected I²C device at address {address}
+  appears in the i2cdetect scan results of bus {bus}, not merely if some
+  I²C device is detected.
+command:
+  i2c_driver_test.py address -b {bus} -a {address}
+user: root
+plugin: shell
+category_id: i2c
+estimated_duration: 5s
+depends: i2c/i2c-bus-detect

--- a/providers/base/units/i2c/test-plan.pxu
+++ b/providers/base/units/i2c/test-plan.pxu
@@ -17,6 +17,9 @@ id: i2c-automated
 unit: test plan
 _name: Automated I²C tests
 _description: Automated I²C tests for Ubuntu Core devices
+bootstrap_include:
+    i2c/expected-device-resource
 include:
     i2c/i2c-bus-detect       certification-status=blocker
     i2c/i2c-device-detect    certification-status=blocker
+    i2c/i2c-expected-device-check


### PR DESCRIPTION
## Description

Our current I2C coverage (`i2c/i2c-device-detect`) only checks that *at least one* I2C device is detected on *any* bus. It does not check that the i2cdetect results are the expected ones, so a specific device silently disappearing from a bus goes unnoticed. This happened on KV260 Rev2 boards with the Ubuntu 24.04 image: the USB hub at bus 1 address `0x2d` was missing from `i2cdetect -y -r 1` output, yet the existing test kept passing (LP: #2105941).

This PR adds configuration-driven test cases that check the i2cdetect results against an expected device list:

- New `EXPECTED_I2C_DEVICES` configuration variable: a comma-separated list of `<bus>:<address>` entries, e.g. `EXPECTED_I2C_DEVICES=1:0x2d,1:0x68`.
- New resource job `i2c/expected-device-resource` parses it into resource records (new `resource` subcommand of `i2c_driver_test.py`).
- New template job `i2c/i2c-expected-device-check` generates one job per expected device (e.g. `i2c/i2c-expected-device-check-1-0x2d`), which runs the new `address` subcommand: it scans the bus with `i2cdetect -y -r <bus>` and fails unless the expected address is present in the results (either responding with its hex value or busy `UU`).
- The `i2c-automated` test plan bootstraps the resource and includes the template. When `EXPECTED_I2C_DEVICES` is not set, no jobs are generated, so existing projects are unaffected.

## Resolved issues

- https://warthogs.atlassian.net/browse/PEL-1494
- https://bugs.launchpad.net/limerick/+bug/2105941

## Documentation

The `EXPECTED_I2C_DEVICES` format is documented in the resource job description and in the script's argparse help/epilog.

## Tests
- Full `checkbox-cli launcher` runs of the `i2c-automated` test plan (this provider side-loaded, checkbox-ng 7.3.0~dev42, `EXPECTED_I2C_DEVICES=1:0x2d`, manifest `has_i2c=true`) on two KV260 boards reproducing LP: #2105941, results submitted to C3:
  - CID 202405-34052 (Ubuntu 22.04, kernel 5.15.0-9003-xilinx-zynqmp): all i2c jobs passed, including the new `i2c/i2c-expected-device-check-1-0x2d` — [C3 submission 396821](https://certification.canonical.com/submissions/status/396821).
  - CID 202311-32317 (Ubuntu 24.04, kernel 6.8.0-1015-xilinx, affected): the pre-existing `i2c/i2c-device-detect` still passes while the new job fails with `Test failed, no device detected at address 0x2d on bus 1` — exactly the gap this PR closes — [C3 submission 396822](https://certification.canonical.com/submissions/status/396822).

