### PR TITLE
Usb dwc3 cleanup add requires (BugFix)

### DIFF
--- a/providers/base/units/usb-dwc3/jobs.pxu
+++ b/providers/base/units/usb-dwc3/jobs.pxu
@@ -64,6 +64,9 @@ flags: preserve-locale
 id: usb-dwc3/mass-storage-cleanup
 group: peripherals_manual
 _summary: Cleanup mass storage setup after mass storage device test
+imports: from com.canonical.plainbox import manifest
+requires:
+  manifest.has_usb_dwc3_controller == 'True'
 plugin: shell
 after: usb-dwc3/mass-storage
 command:
@@ -76,4 +79,3 @@ command:
 user: root
 category_id: usb-dwc3
 estimated_duration: 1s
-

--- a/providers/base/units/usb-dwc3/jobs.pxu
+++ b/providers/base/units/usb-dwc3/jobs.pxu
@@ -79,3 +79,4 @@ command:
 user: root
 category_id: usb-dwc3
 estimated_duration: 1s
+


### PR DESCRIPTION
## Description
Issue: usb-dwc3/mass-storage-cleanup is executed even when depended jobs are skipped.
Implementation: Add same manifest requirement as depended jobs.


<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

## Documentation

## Tests
submission: https://certification.canonical.com/submissions/status/397472

```
-----------------[ Detect if the USB DWC3 module is loaded ]-------------------                                                                                     
ID: com.canonical.certification::usb-dwc3/module-detect                                                                                                              
Category: DesignWare Core SuperSpeed USB 3.0 Controller                                                                                                              
--------------------------------------------------------------------------------                                                                                     
Job cannot be started because of unmet manifest:                                                                                                                     
- com.canonical.certification::has_usb_dwc3_controller                                                                                                               
--------------------------------------------------------------------------------                                                                                     
Outcome: job cannot be started (unmet manifest)                                                                                                                      
-----------------------------[ Running job 3 / 5 ]------------------------------
-----------------[ Detect if the USB DWC3 drivers are loaded ]------------------
ID: com.canonical.certification::usb-dwc3/driver-detect
Category: DesignWare Core SuperSpeed USB 3.0 Controller
--------------------------------------------------------------------------------
Job cannot be started because of unmet manifest:
- com.canonical.certification::has_usb_dwc3_controller
--------------------------------------------------------------------------------
Outcome: job cannot be started (unmet manifest)
-----------------------------[ Running job 4 / 5 ]------------------------------
--------------[ Check DUT can be detected as mass storage device ]--------------
ID: com.canonical.certification::usb-dwc3/mass-storage
Category: DesignWare Core SuperSpeed USB 3.0 Controller
--------------------------------------------------------------------------------
Job cannot be started because of failed dependency:
- com.canonical.certification::usb-dwc3/driver-detect
- com.canonical.certification::usb-dwc3/module-detect
--------------------------------------------------------------------------------
Outcome: job cannot be started (failed dependency)
-----------------------------[ Running job 5 / 5 ]------------------------------
---------[ Cleanup mass storage setup after mass storage device test ]----------
ID: com.canonical.certification::usb-dwc3/mass-storage-cleanup
Category: DesignWare Core SuperSpeed USB 3.0 Controller
--------------------------------------------------------------------------------
Job cannot be started because of unmet manifest:
- com.canonical.certification::has_usb_dwc3_controller
--------------------------------------------------------------------------------
Outcome: job cannot be started (unmet manifest)
```