### PR TITLE
Fix ptp4l arg interpolation (BugFix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
@@ -90,7 +90,7 @@ command:
     # Add --tx_timstamp_timeout=5 due to the patch of ptp4l increace from 1 to 5ms.
     # https://www.mail-archive.com/linuxptp-devel@lists.sourceforge.net/msg05015.html
     # And this patch has been merged into the versoin later then V2.0
-    ptp4l_args="-i {eth-interface} -m -s --network_transport=L2 --tx_timestamp_timeout=5"
+    ptp4l_args="-i {eth-interface} -m -s --network_transport=L2 --tx_timestamp_timeout=5 --transportSpecific=1"
     if [ -n "$PTP4L_PTP_MINOR_VERSION" ]; then
         ptp4l_version=$(ptp4l -v 2>&1 | grep -oP '\d+' | head -n 1)
         if [[ "$ptp4l_version" -ge 4 ]]; then

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
@@ -137,7 +137,7 @@ _steps:
     1. Connect an Ethernet cable from another device's Ethernet interface which supports ptp
        which supports ptp directly to the {eth-interface} Ethernet interface of our DUT.
     2. On the Host (another device), execute the command:
-       $ sudo ./ptp4l -i <if_name_on_host> -m --step_threshold=1 --logAnnounceInterval=0 --logSyncInterval=-3 --network_transport=L2
+       $ sudo ./ptp4l -i <if_name_on_host> -m --step_threshold=1 --logAnnounceInterval=0 --logSyncInterval=-3 --network_transport=L2 --transportSpecific=1
     3. Wait for the system to announce it is the Grand Master.
     4. On the DUT, run the command:
        $ sudo ./ptp4l -i {eth-interface} -m -s --network_transport=L2 --tx_timestamp_timeout=5 --transportSpecific=1

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
@@ -99,7 +99,8 @@ command:
             echo "ptp4l version $ptp4l_version does not support --ptp_minor_version, skipping this option."
         fi
     fi
-    (set -x; timeout 30s ptp4l $ptp4l_args | tee "$output_file") # shellcheck disable=SC2086
+    # shellcheck disable=SC2086
+    (set -x; timeout 30s ptp4l $ptp4l_args | tee "$output_file")
     rms_data=$(tail -5 $output_file | awk '/rms/{{print $3}}')
     if [[ -z $rms_data ]]; then
         echo "ERROR: unable to get rms value from the output file"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
@@ -140,7 +140,7 @@ _steps:
        $ sudo ./ptp4l -i <if_name_on_host> -m --step_threshold=1 --logAnnounceInterval=0 --logSyncInterval=-3 --network_transport=L2
     3. Wait for the system to announce it is the Grand Master.
     4. On the DUT, run the command:
-       $ sudo ./ptp4l -i {eth-interface} -m -s --network_transport=L2 --tx_timestamp_timeout=5
+       $ sudo ./ptp4l -i {eth-interface} -m -s --network_transport=L2 --tx_timestamp_timeout=5 --transportSpecific=1
     5. The DUT should announce it has selected a foreign master (Host)
     6. Clock readings will appear on the DUT.  When the "rms" value remains below 100ns,
        the DUT has successfully synchronized to the clock on the Host.

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
@@ -99,7 +99,7 @@ command:
             echo "ptp4l version $ptp4l_version does not support --ptp_minor_version, skipping this option."
         fi
     fi
-    (set -x; timeout 30s ptp4l $ptp4l_args | tee "$output_file")
+    (set -x; timeout 30s ptp4l $ptp4l_args | tee "$output_file") # shellcheck disable=SC2086
     rms_data=$(tail -5 $output_file | awk '/rms/{{print $3}}')
     if [[ -z $rms_data ]]; then
         echo "ERROR: unable to get rms value from the output file"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
@@ -99,7 +99,7 @@ command:
             echo "ptp4l version $ptp4l_version does not support --ptp_minor_version, skipping this option."
         fi
     fi
-    (set -x; timeout 30s ptp4l "$ptp4l_args" | tee "$output_file")
+    (set -x; timeout 30s ptp4l $ptp4l_args | tee "$output_file")
     rms_data=$(tail -5 $output_file | awk '/rms/{{print $3}}')
     if [[ -z $rms_data ]]; then
         echo "ERROR: unable to get rms value from the output file"

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/ptp/jobs.pxu
@@ -103,6 +103,7 @@ command:
     rms_data=$(tail -5 $output_file | awk '/rms/{{print $3}}')
     if [[ -z $rms_data ]]; then
         echo "ERROR: unable to get rms value from the output file"
+        echo "HINT: Make sure the ptp4l grandmaster is using a large enough --logSyncInterval"
         exit 1
     fi
     echo


### PR DESCRIPTION
## Description

When expanding the ptp4largs variable, we shouldn't quote it because doing so would glue all the arguments into 1 string, which isn't recognized by ptp4l. 

```
+ timeout 30s ptp4l '-i enp2s0 -m -s --network_transport=L2 --tx_timestamp_timeout=5'
+ tee /var/tmp/ptp4l_output.txt
failed to create a clock
```

Also added --transportSpecific=1 because the default server config from ptp4l expects it. See `/usr/share/doc/linuxptp/configs/automotive-master.cfg`


## Resolved issues


## Tests
Passing result: https://certification.canonical.com/hardware/202601-38351/submission/505713/test/202445/result/62204193/
