### PR TITLE
Adopt checkbox-support interface (New)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -64,9 +64,10 @@ apps:
     plugs: &standard [home, network-bind, hardware-observe, bluez, bluetooth-control,
       gpio, modem-manager, mount-observe, network-manager, pulseaudio, serial-port,
       system-observe, tpm, udisks2, account-control, accounts-service,
-      login-session-control, login-session-observe]
+      login-session-control, login-session-observe, checkbox-support]
     environment:
       PYTHONPATH: $SNAP/lib/python3.5/site-packages/:$SNAP/lib64/python3.5/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      PATH: /snap/bin:$PATH
   agent:
     command: bin/checkbox-cli run-agent
     daemon: simple
@@ -76,6 +77,7 @@ apps:
     install-mode: disable
     environment:
       PYTHONPATH: $SNAP/lib/python3.5/site-packages/:$SNAP/lib64/python3.5/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      PATH: /snap/bin:$PATH
 
 package-repositories:
   - type: apt

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -68,9 +68,10 @@ apps:
     plugs: &standard [home, network-bind, hardware-observe, bluez, bluetooth-control,
       gpio, modem-manager, mount-observe, network-manager, pulseaudio, serial-port,
       system-observe, tpm, udisks2, account-control, accounts-service,
-      login-session-control, login-session-observe]
+      login-session-control, login-session-observe, checkbox-support]
     environment:
       PYTHONPATH: $SNAP/lib/python3.6/site-packages/:$SNAP/lib64/python3.6/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      PATH: /snap/bin:$PATH
   agent:
     command: bin/checkbox-cli run-agent
     daemon: simple
@@ -80,6 +81,7 @@ apps:
     install-mode: disable
     environment:
       PYTHONPATH: $SNAP/lib/python3.6/site-packages/:$SNAP/lib64/python3.6/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      PATH: /snap/bin:$PATH
 
 package-repositories:
   - type: apt

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -68,9 +68,10 @@ apps:
     plugs: &standard [home, network-bind, hardware-observe, bluez, bluetooth-control,
       gpio, modem-manager, mount-observe, network-manager, pulseaudio, serial-port,
       system-observe, tpm, udisks2, account-control, accounts-service,
-      login-session-control, login-session-observe]
+      login-session-control, login-session-observe, checkbox-support]
     environment:
       PYTHONPATH: $SNAP/lib/python3.8/site-packages/:$SNAP/lib64/python3.8/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      PATH: /snap/bin:$PATH
   agent:
     command: bin/checkbox-cli run-agent
     daemon: simple
@@ -80,6 +81,7 @@ apps:
     install-mode: disable
     environment:
       PYTHONPATH: $SNAP/lib/python3.8/site-packages/:$SNAP/lib64/python3.8/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      PATH: /snap/bin:$PATH
 
 package-repositories:
   - type: apt

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -72,9 +72,10 @@ apps:
     plugs: &standard [home, network-bind, hardware-observe, bluez, bluetooth-control,
       gpio, modem-manager, mount-observe, network-manager, pulseaudio, serial-port,
       system-observe, tpm, udisks2, account-control, accounts-service,
-      login-session-control, login-session-observe]
+      login-session-control, login-session-observe, checkbox-support]
     environment:
       PYTHONPATH: $SNAP/lib/python3.10/site-packages/:$SNAP/lib64/python3.10/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      PATH: /snap/bin:$PATH
   agent:
     command: bin/checkbox-cli run-agent
     daemon: simple
@@ -84,6 +85,7 @@ apps:
     install-mode: disable
     environment:
       PYTHONPATH: $SNAP/lib/python3.10/site-packages/:$SNAP/lib64/python3.10/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      PATH: /snap/bin:$PATH
 
 package-repositories:
   - type: apt

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -72,9 +72,10 @@ apps:
     plugs: &standard [home, network-bind, hardware-observe, bluez, bluetooth-control,
       gpio, modem-manager, mount-observe, network-manager, pulseaudio, serial-port,
       system-observe, tpm, udisks2, account-control, accounts-service,
-      login-session-control, login-session-observe]
+      login-session-control, login-session-observe, checkbox-support]
     environment:
       PYTHONPATH: $SNAP/lib/python3.12/site-packages/:$SNAP/lib64/python3.12/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      PATH: /snap/bin:$PATH
   agent:
     command: bin/checkbox-cli run-agent
     daemon: simple
@@ -84,6 +85,7 @@ apps:
     install-mode: disable
     environment:
       PYTHONPATH: $SNAP/lib/python3.12/site-packages/:$SNAP/lib64/python3.12/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      PATH: /snap/bin:$PATH
 
 package-repositories:
   - type: apt

--- a/checkbox-core-snap/series26/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series26/snap/snapcraft.yaml
@@ -72,9 +72,10 @@ apps:
     plugs: &standard [home, network-bind, hardware-observe, bluez, bluetooth-control,
       gpio, modem-manager, mount-observe, network-manager, pulseaudio, serial-port,
       system-observe, tpm, udisks2, account-control, accounts-service,
-      login-session-control, login-session-observe]
+      login-session-control, login-session-observe, checkbox-support]
     environment:
       PYTHONPATH: $SNAP/lib/python3.14/site-packages/:$SNAP/lib64/python3.14/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      PATH: /snap/bin:$PATH
   agent:
     command: bin/checkbox-cli run-agent
     daemon: simple
@@ -84,6 +85,7 @@ apps:
     install-mode: disable
     environment:
       PYTHONPATH: $SNAP/lib/python3.14/site-packages/:$SNAP/lib64/python3.14/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      PATH: /snap/bin:$PATH
 
 package-repositories:
   - type: apt


### PR DESCRIPTION
## Description

This is the last major step to get us to drop dev-mode. After this, a lot of minor things have to be changed but the biggest hurdles are solved. As a side effect this will make apparmor way less angry with us.

Minor: This also lands a small PATH fix to the snap apps.

## Resolved issues

Fixes: CHECKBOX-1846

## Documentation

N/A

## Tests

To test this install the snap (still in devmode) and connect the interface. Run smoke local/remote. Nothing should change. 

Snap built here: 
- https://github.com/canonical/checkbox/actions/runs/32350554365
- https://github.com/canonical/checkbox/actions/runs/32350702746
