### PR TITLE
Run nxp_ele_list_tv_files when has_nxp_secure_element_ele is set (BugFix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/crypto/nxp-secure-element.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/crypto/nxp-secure-element.pxu
@@ -1,4 +1,6 @@
 id: nxp_ele_list_tv_files
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_nxp_secure_element_ele == 'True'
 plugin: resource
 _summary: Enumerate available NXP ELE test vector files
 _description:


### PR DESCRIPTION
## Description

 * Not all the hardware devices have a NXP EdgeLock Secure Enclave (ELE) which is intended for i.MX processors, it is better for this test case only to be executed when `has_nxp_secure_element_ele == 'True'`.

## Resolved issues

https://warthogs.atlassian.net/browse/PERI-1566

## Documentation

## Tests

The `nxp_ele_list_tv_files` Resource was called in a Jetson Orin NX DUT (which does not have a NXP Secure Element) having the manifest property enabled and disabled, as can be seen the test is skipped when it is set as "false".

* [Jetson_Orin_NX_has_nxp_secure_element_ele_false.txt](https://github.com/user-attachments/files/31281609/Jetson_Orin_NX_has_nxp_secure_element_ele_false.txt)
* [Jetson_Orin_NX_has_nxp_secure_element_ele_true.txt](https://github.com/user-attachments/files/31281612/Jetson_Orin_NX_has_nxp_secure_element_ele_true.txt)
