### PR TITLE
Stage xtest TAs for a tee-supplicant started without a TA dir (BugFix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import shlex
+import shutil
 import subprocess
 
 from look_up_xtest import look_up_app
@@ -12,6 +13,9 @@ from pathlib import Path
 from xtest_install_ta import find_ta_path, install_ta
 
 TEST_FILE_PREFIX = "optee-test-"
+# Where tee-supplicant loads TAs from when started without --ta-path/--ta-dir
+# (optee_client default: TEEC_LOAD_PATH/optee_armtz).
+DEFAULT_TA_DIR = "lib/optee_armtz"
 
 
 def _run_command(cmd, **kwargs):
@@ -33,19 +37,45 @@ def _run_command(cmd, **kwargs):
         raise e
 
 
-def _supplicant_serves_ta_dir():
-    """Whether the running tee-supplicant was given a TA directory
-    (--ta-path / --ta-dir, as the x-test snap service passes). A
-    supplicant started without one, e.g. the one Ubuntu Core's initramfs
-    runs for the fTPM, can only load TAs from secure storage, so the TAs
-    must be installed there first.
-    """
+def _find_supplicant():
+    """Return (pid, command line) of the running tee-supplicant."""
     ret = subprocess.run(
         shlex.split("pgrep -a tee-supplicant"),
         capture_output=True,
         text=True,
     )
-    return "--ta-path" in ret.stdout or "--ta-dir" in ret.stdout
+    pid, _, cmdline = ret.stdout.strip().partition(" ")
+    return pid, cmdline
+
+
+def _supplicant_serves_ta_dir(cmdline):
+    """Whether tee-supplicant was started with a TA directory, as the
+    x-test snap service does (--ta-path, or --ta-dir on 4.0.0)."""
+    return "--ta-path" in cmdline or "--ta-dir" in cmdline
+
+
+def stage_ta_for_supplicant(ta_path, root):
+    """Copy the snap's TAs into the directory a tee-supplicant started
+    without --ta-path/--ta-dir loads TAs from: its compiled-in default,
+    resolved inside that process's own root.
+
+    The supplicant Ubuntu Core's initramfs starts for the fTPM keeps
+    running after switch-root from the (emptied) initramfs rootfs, so that
+    directory is only reachable through /proc/<pid>/root and is gone on
+    reboot - hence the copy is repeated on every job. OP-TEE still checks
+    each TA signature when loading it; the subkey-signed xtest TAs load
+    this way, whereas a secure-storage install rejects them.
+    """
+    dest = os.path.join(root, DEFAULT_TA_DIR)
+    tas = sorted(glob.glob(os.path.join(ta_path, "*.ta")))
+    try:
+        os.makedirs(dest, exist_ok=True)
+        for ta in tas:
+            shutil.copy(ta, dest)
+    except OSError as e:
+        print("Cannot stage TAs into {}: {}".format(dest, e), flush=True)
+        return
+    print("Staged {} TAs into {}".format(len(tas), dest), flush=True)
 
 
 def launch_xtest(test_suite, test_id):
@@ -63,9 +93,15 @@ def launch_xtest(test_suite, test_id):
             flush=True,
         )
         return 2
-    elif optee_fw < "4.0" or not _supplicant_serves_ta_dir():
+    elif optee_fw < "4.0":
         ta_path = find_ta_path()
         install_ta(test_utility, ta_path)
+    else:
+        pid, cmdline = _find_supplicant()
+        if not _supplicant_serves_ta_dir(cmdline):
+            stage_ta_for_supplicant(
+                find_ta_path(), "/proc/{}/root".format(pid)
+            )
 
     ret = _run_command(
         "{} -t {} {}".format(test_utility, test_suite, test_id), check=False

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
@@ -33,6 +33,21 @@ def _run_command(cmd, **kwargs):
         raise e
 
 
+def _supplicant_serves_ta_dir():
+    """Whether the running tee-supplicant was given a TA directory
+    (--ta-path / --ta-dir, as the x-test snap service passes). A
+    supplicant started without one, e.g. the one Ubuntu Core's initramfs
+    runs for the fTPM, can only load TAs from secure storage, so the TAs
+    must be installed there first.
+    """
+    ret = subprocess.run(
+        shlex.split("pgrep -a tee-supplicant"),
+        capture_output=True,
+        text=True,
+    )
+    return "--ta-path" in ret.stdout or "--ta-dir" in ret.stdout
+
+
 def launch_xtest(test_suite, test_id):
     test_utility = look_up_app("xtest", os.environ.get("XTEST"))
 
@@ -48,7 +63,7 @@ def launch_xtest(test_suite, test_id):
             flush=True,
         )
         return 2
-    elif optee_fw < "4.0":
+    elif optee_fw < "4.0" or not _supplicant_serves_ta_dir():
         ta_path = find_ta_path()
         install_ta(test_utility, ta_path)
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
@@ -1,9 +1,19 @@
 #!/usr/bin/env python3
 
 from look_up_xtest import look_up_app
-from subprocess import run
+from subprocess import run, CalledProcessError
 import glob
 import os
+
+
+def run_command(cmd, capture_output=True, text=True, check=True):
+    try:
+        result = run(
+            cmd, capture_output=capture_output, text=text, check=check
+        )
+        return result.stdout.strip() if capture_output else None
+    except CalledProcessError as e:
+        raise SystemExit("Error: {}".format(e))
 
 
 def find_ta_path():
@@ -21,35 +31,10 @@ def find_ta_path():
 
 
 def install_ta(xtest, path):
-    """Install every TA under path into OP-TEE secure storage, one file at
-    a time: xtest stops at the first TA the TEE rejects (subkey-signed
-    TAs fail the secure-storage bootstrap with TEEC_ERROR_SECURITY), so a
-    whole-directory install would leave the remaining TAs uninstalled.
-    Returns the rejected TA file names.
-    """
+    cmd = ["timeout", "30", xtest, "--install-ta", path]
     print("Attempting to install TA...", flush=True)
-    rejected = []
-    for ta in sorted(glob.glob(os.path.join(path, "*.ta"))):
-        result = run(
-            ["timeout", "30", xtest, "--install-ta", ta],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
-            rejected.append(os.path.basename(ta))
-            print(
-                "Rejected {}: {}".format(
-                    os.path.basename(ta), result.stderr.strip()
-                ),
-                flush=True,
-            )
-    print(
-        "TA install done, {} rejected: {}".format(
-            len(rejected), " ".join(rejected) or "-"
-        ),
-        flush=True,
-    )
-    return rejected
+    run_command(cmd)
+    print("TA install succeeded!", flush=True)
 
 
 def main():

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
@@ -1,19 +1,9 @@
 #!/usr/bin/env python3
 
 from look_up_xtest import look_up_app
-from subprocess import run, CalledProcessError
+from subprocess import run
 import glob
 import os
-
-
-def run_command(cmd, capture_output=True, text=True, check=True):
-    try:
-        result = run(
-            cmd, capture_output=capture_output, text=text, check=check
-        )
-        return result.stdout.strip() if capture_output else None
-    except CalledProcessError as e:
-        raise SystemExit("Error: {}".format(e))
 
 
 def find_ta_path():
@@ -31,10 +21,35 @@ def find_ta_path():
 
 
 def install_ta(xtest, path):
-    cmd = ["timeout", "30", xtest, "--install-ta", path]
+    """Install every TA under path into OP-TEE secure storage, one file at
+    a time: xtest stops at the first TA the TEE rejects (subkey-signed
+    TAs fail the secure-storage bootstrap with TEEC_ERROR_SECURITY), so a
+    whole-directory install would leave the remaining TAs uninstalled.
+    Returns the rejected TA file names.
+    """
     print("Attempting to install TA...", flush=True)
-    run_command(cmd)
-    print("TA install succeeded!", flush=True)
+    rejected = []
+    for ta in sorted(glob.glob(os.path.join(path, "*.ta"))):
+        result = run(
+            ["timeout", "30", xtest, "--install-ta", ta],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            rejected.append(os.path.basename(ta))
+            print(
+                "Rejected {}: {}".format(
+                    os.path.basename(ta), result.stderr.strip()
+                ),
+                flush=True,
+            )
+    print(
+        "TA install done, {} rejected: {}".format(
+            len(rejected), " ".join(rejected) or "-"
+        ),
+        flush=True,
+    )
+    return rejected
 
 
 def main():

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_optee_helper.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_optee_helper.py
@@ -1,90 +1,127 @@
 import io
+import os
+import tempfile
 import unittest
 from contextlib import redirect_stdout
 from subprocess import CompletedProcess
 from unittest.mock import patch
 
 import optee_helper
-import xtest_install_ta
+
+INITRAMFS_SUPPLICANT = "352 @tee-supplicant --fs-parent-path /run/mnt/tee-data"
+SNAP_SUPPLICANT = (
+    "1234 tee-supplicant --fs-parent-path /var/snap/x-test/common/lib/"
+    "optee-fs --ta-path /var/snap/x-test/common/lib/optee_armtz "
+    "--plugin-path /var/snap/x-test/common/usr/lib/tee-supplicant/plugins"
+)
 
 
 def _proc(returncode=0, stdout="", stderr=""):
     return CompletedProcess([], returncode, stdout=stdout, stderr=stderr)
 
 
+class TestFindSupplicant(unittest.TestCase):
+    @patch("optee_helper.subprocess.run")
+    def test_splits_pid_and_cmdline(self, mock_run):
+        mock_run.return_value = _proc(stdout=INITRAMFS_SUPPLICANT + "\n")
+        self.assertEqual(
+            optee_helper._find_supplicant(),
+            ("352", "@tee-supplicant --fs-parent-path /run/mnt/tee-data"),
+        )
+
+
 class TestSupplicantServesTaDir(unittest.TestCase):
-    @patch("optee_helper.subprocess.run")
-    def test_snap_supplicant_with_ta_path(self, mock_run):
-        mock_run.return_value = _proc(
-            stdout="1234 tee-supplicant --fs-parent-path /var/snap/x-test/"
-            "common/lib/optee-fs --ta-path /var/snap/x-test/common/lib/"
-            "optee_armtz\n"
+    def test_snap_supplicant_with_ta_path(self):
+        self.assertTrue(
+            optee_helper._supplicant_serves_ta_dir(SNAP_SUPPLICANT)
         )
-        self.assertTrue(optee_helper._supplicant_serves_ta_dir())
 
-    @patch("optee_helper.subprocess.run")
-    def test_snap_supplicant_with_ta_dir(self, mock_run):
-        mock_run.return_value = _proc(
-            stdout="1234 tee-supplicant --ta-dir /var/snap/x-test/common/"
-            "lib/optee_armtz\n"
+    def test_snap_supplicant_400_with_ta_dir(self):
+        self.assertTrue(
+            optee_helper._supplicant_serves_ta_dir(
+                "tee-supplicant --ta-dir /var/snap/x-test/common/lib/"
+                "optee_armtz"
+            )
         )
-        self.assertTrue(optee_helper._supplicant_serves_ta_dir())
 
-    @patch("optee_helper.subprocess.run")
-    def test_initramfs_supplicant_without_ta_dir(self, mock_run):
-        mock_run.return_value = _proc(
-            stdout="352 @tee-supplicant --fs-parent-path /run/mnt/tee-data\n"
+    def test_initramfs_supplicant_without_ta_dir(self):
+        self.assertFalse(
+            optee_helper._supplicant_serves_ta_dir(INITRAMFS_SUPPLICANT)
         )
-        self.assertFalse(optee_helper._supplicant_serves_ta_dir())
 
 
+@patch("optee_helper.stage_ta_for_supplicant")
 @patch("optee_helper.install_ta")
 @patch("optee_helper.find_ta_path", return_value="/var/snap/x/optee_armtz")
 @patch("optee_helper._run_command", return_value=_proc())
 @patch("optee_helper.look_up_app", return_value="x-test.xtest")
-class TestLaunchXtestInstallsTa(unittest.TestCase):
-    @patch("optee_helper._supplicant_serves_ta_dir", return_value=False)
+class TestLaunchXtestTaDelivery(unittest.TestCase):
+    @patch(
+        "optee_helper._find_supplicant",
+        return_value=("352", INITRAMFS_SUPPLICANT),
+    )
     @patch("optee_helper._lookup_optee_version", return_value="4.2")
-    def test_4x_system_supplicant_installs(self, *_):
+    def test_4x_supplicant_without_ta_dir_stages(self, *_):
+        optee_helper.launch_xtest("regression", "4101")
+        optee_helper.stage_ta_for_supplicant.assert_called_once_with(
+            "/var/snap/x/optee_armtz", "/proc/352/root"
+        )
+        optee_helper.install_ta.assert_not_called()
+
+    @patch(
+        "optee_helper._find_supplicant", return_value=("1234", SNAP_SUPPLICANT)
+    )
+    @patch("optee_helper._lookup_optee_version", return_value="4.2")
+    def test_4x_snap_supplicant_does_nothing(self, *_):
+        optee_helper.launch_xtest("regression", "4101")
+        optee_helper.stage_ta_for_supplicant.assert_not_called()
+        optee_helper.install_ta.assert_not_called()
+
+    @patch(
+        "optee_helper._find_supplicant", return_value=("1234", SNAP_SUPPLICANT)
+    )
+    @patch("optee_helper._lookup_optee_version", return_value="3.19")
+    def test_pre_4x_still_installs(self, *_):
         optee_helper.launch_xtest("regression", "4101")
         optee_helper.install_ta.assert_called_once_with(
             "x-test.xtest", "/var/snap/x/optee_armtz"
         )
-
-    @patch("optee_helper._supplicant_serves_ta_dir", return_value=True)
-    @patch("optee_helper._lookup_optee_version", return_value="4.2")
-    def test_4x_snap_supplicant_skips_install(self, *_):
-        optee_helper.launch_xtest("regression", "4101")
-        optee_helper.install_ta.assert_not_called()
-
-    @patch("optee_helper._supplicant_serves_ta_dir", return_value=True)
-    @patch("optee_helper._lookup_optee_version", return_value="3.19")
-    def test_pre_4x_always_installs(self, *_):
-        optee_helper.launch_xtest("regression", "4101")
-        optee_helper.install_ta.assert_called_once()
+        optee_helper.stage_ta_for_supplicant.assert_not_called()
 
 
-class TestInstallTa(unittest.TestCase):
-    @patch("xtest_install_ta.run")
-    @patch(
-        "xtest_install_ta.glob.glob",
-        return_value=["/ta/b.ta", "/ta/a.ta", "/ta/c.ta"],
-    )
-    def test_rejected_ta_does_not_block_the_rest(self, _, mock_run):
-        mock_run.side_effect = [
-            _proc(),
-            _proc(1, stderr="TEEC_InvokeCommand: 0xffff000f"),
-            _proc(),
-        ]
+class TestStageTaForSupplicant(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.ta_path = os.path.join(self.tmp.name, "optee_armtz")
+        os.mkdir(self.ta_path)
+        for name in ("b.ta", "a.ta", "version"):
+            with open(os.path.join(self.ta_path, name), "w") as fp:
+                fp.write(name)
+        self.root = os.path.join(self.tmp.name, "root")
+        os.mkdir(self.root)
+
+    def test_copies_only_ta_files_into_default_dir_under_root(self):
         with redirect_stdout(io.StringIO()) as out:
-            rejected = xtest_install_ta.install_ta("x-test.xtest", "/ta")
-        self.assertEqual(rejected, ["b.ta"])
-        self.assertEqual(mock_run.call_count, 3)
-        self.assertEqual(
-            [c.args[0][-1] for c in mock_run.call_args_list],
-            ["/ta/a.ta", "/ta/b.ta", "/ta/c.ta"],
-        )
-        self.assertIn("Rejected b.ta: TEEC_InvokeCommand", out.getvalue())
+            optee_helper.stage_ta_for_supplicant(self.ta_path, self.root)
+        dest = os.path.join(self.root, "lib", "optee_armtz")
+        self.assertEqual(sorted(os.listdir(dest)), ["a.ta", "b.ta"])
+        self.assertIn("Staged 2 TAs into {}".format(dest), out.getvalue())
+
+    def test_repeat_overwrites_without_error(self):
+        with redirect_stdout(io.StringIO()):
+            optee_helper.stage_ta_for_supplicant(self.ta_path, self.root)
+            optee_helper.stage_ta_for_supplicant(self.ta_path, self.root)
+        dest = os.path.join(self.root, "lib", "optee_armtz")
+        self.assertEqual(sorted(os.listdir(dest)), ["a.ta", "b.ta"])
+
+    def test_unwritable_root_is_reported_not_raised(self):
+        not_a_dir = os.path.join(self.tmp.name, "file")
+        with open(not_a_dir, "w") as fp:
+            fp.write("x")
+        with redirect_stdout(io.StringIO()) as out:
+            optee_helper.stage_ta_for_supplicant(self.ta_path, not_a_dir)
+        self.assertIn("Cannot stage TAs into", out.getvalue())
 
 
 if __name__ == "__main__":

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_optee_helper.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_optee_helper.py
@@ -1,0 +1,91 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import optee_helper
+import xtest_install_ta
+
+
+def _proc(returncode=0, stdout="", stderr=""):
+    return CompletedProcess([], returncode, stdout=stdout, stderr=stderr)
+
+
+class TestSupplicantServesTaDir(unittest.TestCase):
+    @patch("optee_helper.subprocess.run")
+    def test_snap_supplicant_with_ta_path(self, mock_run):
+        mock_run.return_value = _proc(
+            stdout="1234 tee-supplicant --fs-parent-path /var/snap/x-test/"
+            "common/lib/optee-fs --ta-path /var/snap/x-test/common/lib/"
+            "optee_armtz\n"
+        )
+        self.assertTrue(optee_helper._supplicant_serves_ta_dir())
+
+    @patch("optee_helper.subprocess.run")
+    def test_snap_supplicant_with_ta_dir(self, mock_run):
+        mock_run.return_value = _proc(
+            stdout="1234 tee-supplicant --ta-dir /var/snap/x-test/common/"
+            "lib/optee_armtz\n"
+        )
+        self.assertTrue(optee_helper._supplicant_serves_ta_dir())
+
+    @patch("optee_helper.subprocess.run")
+    def test_initramfs_supplicant_without_ta_dir(self, mock_run):
+        mock_run.return_value = _proc(
+            stdout="352 @tee-supplicant --fs-parent-path /run/mnt/tee-data\n"
+        )
+        self.assertFalse(optee_helper._supplicant_serves_ta_dir())
+
+
+@patch("optee_helper.install_ta")
+@patch("optee_helper.find_ta_path", return_value="/var/snap/x/optee_armtz")
+@patch("optee_helper._run_command", return_value=_proc())
+@patch("optee_helper.look_up_app", return_value="x-test.xtest")
+class TestLaunchXtestInstallsTa(unittest.TestCase):
+    @patch("optee_helper._supplicant_serves_ta_dir", return_value=False)
+    @patch("optee_helper._lookup_optee_version", return_value="4.2")
+    def test_4x_system_supplicant_installs(self, *_):
+        optee_helper.launch_xtest("regression", "4101")
+        optee_helper.install_ta.assert_called_once_with(
+            "x-test.xtest", "/var/snap/x/optee_armtz"
+        )
+
+    @patch("optee_helper._supplicant_serves_ta_dir", return_value=True)
+    @patch("optee_helper._lookup_optee_version", return_value="4.2")
+    def test_4x_snap_supplicant_skips_install(self, *_):
+        optee_helper.launch_xtest("regression", "4101")
+        optee_helper.install_ta.assert_not_called()
+
+    @patch("optee_helper._supplicant_serves_ta_dir", return_value=True)
+    @patch("optee_helper._lookup_optee_version", return_value="3.19")
+    def test_pre_4x_always_installs(self, *_):
+        optee_helper.launch_xtest("regression", "4101")
+        optee_helper.install_ta.assert_called_once()
+
+
+class TestInstallTa(unittest.TestCase):
+    @patch("xtest_install_ta.run")
+    @patch(
+        "xtest_install_ta.glob.glob",
+        return_value=["/ta/b.ta", "/ta/a.ta", "/ta/c.ta"],
+    )
+    def test_rejected_ta_does_not_block_the_rest(self, _, mock_run):
+        mock_run.side_effect = [
+            _proc(),
+            _proc(1, stderr="TEEC_InvokeCommand: 0xffff000f"),
+            _proc(),
+        ]
+        with redirect_stdout(io.StringIO()) as out:
+            rejected = xtest_install_ta.install_ta("x-test.xtest", "/ta")
+        self.assertEqual(rejected, ["b.ta"])
+        self.assertEqual(mock_run.call_count, 3)
+        self.assertEqual(
+            [c.args[0][-1] for c in mock_run.call_args_list],
+            ["/ta/a.ta", "/ta/b.ta", "/ta/c.ta"],
+        )
+        self.assertIn("Rejected b.ta: TEEC_InvokeCommand", out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

On Ubuntu Core images the kernel snap's initramfs starts `tee-supplicant` for the fTPM (transient unit, `RefuseManualStop=yes`, `SurviveFinalKillSignal`) and it is the only supplicant the TEE accepts. After switch-root it keeps running from the emptied initramfs rootfs (`/proc/<pid>/exe -> (deleted)`, empty `/proc/<pid>/root`), so its TA directory does not exist; the x-test snap's own supplicant (`--ta-path $SNAP_COMMON/lib/optee_armtz`) can never take over. Every xtest case that needs a user TA then fails with `0xffff0008 = TEEC_ERROR_ITEM_NOT_FOUND` — 116 `ce-oem-optee/xtest-*` jobs on the UC22 Jetson Orin NX DUTs (C3 submission [202606-38923/504198](https://certification.canonical.com/hardware/202606-38923/submission/504198/)).

`launch_xtest()` only installed TAs for OP-TEE < 4.0 (#1814): on 4.x `xtest --install-ta <dir>` exits 1 at the first rejected TA (the subkey-signed ones fail the secure-storage bootstrap), and the boards #1814 was validated on ran the snap's supplicant, where nothing is needed.

OP-TEE does not care *which* supplicant answers its RPCs, only what that supplicant can reach. A supplicant started without `--ta-path`/`--ta-dir` loads TAs from its compiled-in default `/lib/optee_armtz`, resolved inside its own root — reachable through `/proc/<pid>/root`. This PR:

- reads `pgrep -a tee-supplicant`; when the command line has no `--ta-path`/`--ta-dir`, copies the snap's `*.ta` into `/proc/<pid>/root/lib/optee_armtz` before running xtest (every job — the ramfs is gone at reboot; the copy is idempotent, 21 small files). OP-TEE still verifies each TA signature on load; the subkey-signed TAs of `regression_1039` load this way, which a secure-storage install rejects. Nothing is written to the `tee-data` partition.
- keeps the `< 4.0` path (`install_ta()`) unchanged; on boards where `x-test.tee-supplicant` is active nothing happens.
- adds 10 unit tests (pgrep parsing, decision, staging: only `*.ta`, idempotent, unwritable root reported not raised).

History: the first commit tried a per-file secure-storage install; the second replaces it with the staging above (`xtest_install_ta.py` is back to upstream). Squash on merge.

`regression_1033` (supplicant plugin framework) still fails on such images because `optee_client` loads plugins once at supplicant startup; that is #2776 (OEMQA-6839 / OEMQA-6841).

## Resolved issues

- Bug: [OEMQA-6838](https://warthogs.atlassian.net/browse/OEMQA-6838)
- Task: [OEMQA-6840](https://warthogs.atlassian.net/browse/OEMQA-6840)
- Epic: [OEMQA-6837](https://warthogs.atlassian.net/browse/OEMQA-6837)

## Documentation

N/A

## Tests

- Unit tests: `contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_optee_helper.py` (10 tests, pass); black/flake8 clean.
- UC22 Jetson Orin NX 202606-38921 (OP-TEE 4.2, x-test 4.x rev 23, initramfs supplicant), modified scripts run inside the `checkbox-riverside` snap environment:
  - `optee_helper.py xtest regression 1039` → `Staged 21 TAs into /proc/352/root/lib/optee_armtz`, `regression_1039 OK` — its TAs exist nowhere else on that DUT, so this exercises the staged path alone;
  - `regression 4101` → OK; `regression 1033` → FAILED (expected, #2776).
  - Earlier in the investigation, with the TAs reachable, 113 of the 116 jobs that failed in submission 504198 passed when re-run one by one; 1039 now makes it 114.
- 202606-38923 (pristine secure storage) was not reachable (host key changed after re-provision, key login denied); a full side-loaded `ce-oem-optee-automated` run there is still to be done — hence draft.


[OEMQA-6838]: https://warthogs.atlassian.net/browse/OEMQA-6838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ