### PR TITLE
Skip xtest 1033 when tee-supplicant was started without the x-test plugin path (BugFix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 
@@ -13,6 +14,9 @@ from pathlib import Path
 from xtest_install_ta import find_ta_path, install_ta
 
 TEST_FILE_PREFIX = "optee-test-"
+# Where tee-supplicant loads TAs from when started without --ta-path/--ta-dir
+# (optee_client default: TEEC_LOAD_PATH/optee_armtz).
+DEFAULT_TA_DIR = "lib/optee_armtz"
 # xtest cases only a tee-supplicant started by the x-test snap can pass:
 # 1033 needs its --plugin-path, 1039 loads subkey-signed TAs that the
 # secure-storage bootstrap rejects, so they cannot be installed either.
@@ -41,19 +45,45 @@ def _run_command(cmd, **kwargs):
         raise e
 
 
-def _supplicant_serves_ta_dir():
-    """Whether the running tee-supplicant was given a TA directory
-    (--ta-path / --ta-dir, as the x-test snap service passes). A
-    supplicant started without one, e.g. the one Ubuntu Core's initramfs
-    runs for the fTPM, can only load TAs from secure storage, so the TAs
-    must be installed there first.
-    """
+def _find_supplicant():
+    """Return (pid, command line) of the running tee-supplicant."""
     ret = subprocess.run(
         shlex.split("pgrep -a tee-supplicant"),
         capture_output=True,
         text=True,
     )
-    return "--ta-path" in ret.stdout or "--ta-dir" in ret.stdout
+    pid, _, cmdline = ret.stdout.strip().partition(" ")
+    return pid, cmdline
+
+
+def _supplicant_serves_ta_dir(cmdline):
+    """Whether tee-supplicant was started with a TA directory, as the
+    x-test snap service does (--ta-path, or --ta-dir on 4.0.0)."""
+    return "--ta-path" in cmdline or "--ta-dir" in cmdline
+
+
+def stage_ta_for_supplicant(ta_path, root):
+    """Copy the snap's TAs into the directory a tee-supplicant started
+    without --ta-path/--ta-dir loads TAs from: its compiled-in default,
+    resolved inside that process's own root.
+
+    The supplicant Ubuntu Core's initramfs starts for the fTPM keeps
+    running after switch-root from the (emptied) initramfs rootfs, so that
+    directory is only reachable through /proc/<pid>/root and is gone on
+    reboot - hence the copy is repeated on every job. OP-TEE still checks
+    each TA signature when loading it; the subkey-signed xtest TAs load
+    this way, whereas a secure-storage install rejects them.
+    """
+    dest = os.path.join(root, DEFAULT_TA_DIR)
+    tas = sorted(glob.glob(os.path.join(ta_path, "*.ta")))
+    try:
+        os.makedirs(dest, exist_ok=True)
+        for ta in tas:
+            shutil.copy(ta, dest)
+    except OSError as e:
+        print("Cannot stage TAs into {}: {}".format(dest, e), flush=True)
+        return
+    print("Staged {} TAs into {}".format(len(tas), dest), flush=True)
 
 
 def launch_xtest(test_suite, test_id):
@@ -71,9 +101,15 @@ def launch_xtest(test_suite, test_id):
             flush=True,
         )
         return 2
-    elif optee_fw < "4.0" or not _supplicant_serves_ta_dir():
+    elif optee_fw < "4.0":
         ta_path = find_ta_path()
         install_ta(test_utility, ta_path)
+    else:
+        pid, cmdline = _find_supplicant()
+        if not _supplicant_serves_ta_dir(cmdline):
+            stage_ta_for_supplicant(
+                find_ta_path(), "/proc/{}/root".format(pid)
+            )
 
     ret = _run_command(
         "{} -t {} {}".format(test_utility, test_suite, test_id), check=False
@@ -163,9 +199,10 @@ def parse_json_file(filepath, filter_pkcs11=False):
     if not fp.exists():
         print("error: {} is not available".format(filepath))
     else:
+        _, cmdline = _find_supplicant()
         skipped = (
             set()
-            if _supplicant_serves_ta_dir()
+            if _supplicant_serves_ta_dir(cmdline)
             else SNAP_SUPPLICANT_ONLY_CASES
         )
         for test in json.loads(fp.read_text()):

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
@@ -17,13 +17,9 @@ TEST_FILE_PREFIX = "optee-test-"
 # Where tee-supplicant loads TAs from when started without --ta-path/--ta-dir
 # (optee_client default: TEEC_LOAD_PATH/optee_armtz).
 DEFAULT_TA_DIR = "lib/optee_armtz"
-# xtest cases only a tee-supplicant started by the x-test snap can pass:
-# 1033 needs its --plugin-path, 1039 loads subkey-signed TAs that the
-# secure-storage bootstrap rejects, so they cannot be installed either.
-SNAP_SUPPLICANT_ONLY_CASES = {
-    ("regression", "1033"),
-    ("regression", "1039"),
-}
+# xtest cases that need tee-supplicant to have been *started* with the
+# x-test plugin path: the supplicant loads plugins once, at startup.
+SUPPLICANT_PLUGIN_CASES = {("regression", "1033")}
 
 
 def _run_command(cmd, **kwargs):
@@ -201,15 +197,15 @@ def parse_json_file(filepath, filter_pkcs11=False):
     else:
         _, cmdline = _find_supplicant()
         skipped = (
-            set()
-            if _supplicant_serves_ta_dir(cmdline)
-            else SNAP_SUPPLICANT_ONLY_CASES
+            set() if "--plugin-path" in cmdline else SUPPLICANT_PLUGIN_CASES
         )
         for test in json.loads(fp.read_text()):
             if (test["suite"], test["test_id"]) in skipped:
                 print(
-                    "skipping {} {}: needs the x-test snap "
-                    "tee-supplicant".format(test["suite"], test["test_id"]),
+                    "skipping {} {}: tee-supplicant was started without "
+                    "the x-test plugin path".format(
+                        test["suite"], test["test_id"]
+                    ),
                     file=sys.stderr,
                 )
                 continue

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
@@ -33,6 +33,21 @@ def _run_command(cmd, **kwargs):
         raise e
 
 
+def _supplicant_serves_ta_dir():
+    """Whether the running tee-supplicant was given a TA directory
+    (--ta-path / --ta-dir, as the x-test snap service passes). A
+    supplicant started without one, e.g. the one Ubuntu Core's initramfs
+    runs for the fTPM, can only load TAs from secure storage, so the TAs
+    must be installed there first.
+    """
+    ret = subprocess.run(
+        shlex.split("pgrep -a tee-supplicant"),
+        capture_output=True,
+        text=True,
+    )
+    return "--ta-path" in ret.stdout or "--ta-dir" in ret.stdout
+
+
 def launch_xtest(test_suite, test_id):
     test_utility = look_up_app("xtest", os.environ.get("XTEST"))
 
@@ -48,7 +63,7 @@ def launch_xtest(test_suite, test_id):
             flush=True,
         )
         return 2
-    elif optee_fw < "4.0":
+    elif optee_fw < "4.0" or not _supplicant_serves_ta_dir():
         ta_path = find_ta_path()
         install_ta(test_utility, ta_path)
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
@@ -6,12 +6,20 @@ import os
 import re
 import shlex
 import subprocess
+import sys
 
 from look_up_xtest import look_up_app
 from pathlib import Path
 from xtest_install_ta import find_ta_path, install_ta
 
 TEST_FILE_PREFIX = "optee-test-"
+# xtest cases only a tee-supplicant started by the x-test snap can pass:
+# 1033 needs its --plugin-path, 1039 loads subkey-signed TAs that the
+# secure-storage bootstrap rejects, so they cannot be installed either.
+SNAP_SUPPLICANT_ONLY_CASES = {
+    ("regression", "1033"),
+    ("regression", "1039"),
+}
 
 
 def _run_command(cmd, **kwargs):
@@ -155,7 +163,19 @@ def parse_json_file(filepath, filter_pkcs11=False):
     if not fp.exists():
         print("error: {} is not available".format(filepath))
     else:
+        skipped = (
+            set()
+            if _supplicant_serves_ta_dir()
+            else SNAP_SUPPLICANT_ONLY_CASES
+        )
         for test in json.loads(fp.read_text()):
+            if (test["suite"], test["test_id"]) in skipped:
+                print(
+                    "skipping {} {}: needs the x-test snap "
+                    "tee-supplicant".format(test["suite"], test["test_id"]),
+                    file=sys.stderr,
+                )
+                continue
             if (filter_pkcs11 and test["suite"] == "pkcs11") or (
                 not filter_pkcs11 and test["suite"] != "pkcs11"
             ):

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
@@ -1,9 +1,19 @@
 #!/usr/bin/env python3
 
 from look_up_xtest import look_up_app
-from subprocess import run
+from subprocess import run, CalledProcessError
 import glob
 import os
+
+
+def run_command(cmd, capture_output=True, text=True, check=True):
+    try:
+        result = run(
+            cmd, capture_output=capture_output, text=text, check=check
+        )
+        return result.stdout.strip() if capture_output else None
+    except CalledProcessError as e:
+        raise SystemExit("Error: {}".format(e))
 
 
 def find_ta_path():
@@ -21,35 +31,10 @@ def find_ta_path():
 
 
 def install_ta(xtest, path):
-    """Install every TA under path into OP-TEE secure storage, one file at
-    a time: xtest stops at the first TA the TEE rejects (subkey-signed
-    TAs fail the secure-storage bootstrap with TEEC_ERROR_SECURITY), so a
-    whole-directory install would leave the remaining TAs uninstalled.
-    Returns the rejected TA file names.
-    """
+    cmd = ["timeout", "30", xtest, "--install-ta", path]
     print("Attempting to install TA...", flush=True)
-    rejected = []
-    for ta in sorted(glob.glob(os.path.join(path, "*.ta"))):
-        result = run(
-            ["timeout", "30", xtest, "--install-ta", ta],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
-            rejected.append(os.path.basename(ta))
-            print(
-                "Rejected {}: {}".format(
-                    os.path.basename(ta), result.stderr.strip()
-                ),
-                flush=True,
-            )
-    print(
-        "TA install done, {} rejected: {}".format(
-            len(rejected), " ".join(rejected) or "-"
-        ),
-        flush=True,
-    )
-    return rejected
+    run_command(cmd)
+    print("TA install succeeded!", flush=True)
 
 
 def main():

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
@@ -1,19 +1,9 @@
 #!/usr/bin/env python3
 
 from look_up_xtest import look_up_app
-from subprocess import run, CalledProcessError
+from subprocess import run
 import glob
 import os
-
-
-def run_command(cmd, capture_output=True, text=True, check=True):
-    try:
-        result = run(
-            cmd, capture_output=capture_output, text=text, check=check
-        )
-        return result.stdout.strip() if capture_output else None
-    except CalledProcessError as e:
-        raise SystemExit("Error: {}".format(e))
 
 
 def find_ta_path():
@@ -31,10 +21,35 @@ def find_ta_path():
 
 
 def install_ta(xtest, path):
-    cmd = ["timeout", "30", xtest, "--install-ta", path]
+    """Install every TA under path into OP-TEE secure storage, one file at
+    a time: xtest stops at the first TA the TEE rejects (subkey-signed
+    TAs fail the secure-storage bootstrap with TEEC_ERROR_SECURITY), so a
+    whole-directory install would leave the remaining TAs uninstalled.
+    Returns the rejected TA file names.
+    """
     print("Attempting to install TA...", flush=True)
-    run_command(cmd)
-    print("TA install succeeded!", flush=True)
+    rejected = []
+    for ta in sorted(glob.glob(os.path.join(path, "*.ta"))):
+        result = run(
+            ["timeout", "30", xtest, "--install-ta", ta],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            rejected.append(os.path.basename(ta))
+            print(
+                "Rejected {}: {}".format(
+                    os.path.basename(ta), result.stderr.strip()
+                ),
+                flush=True,
+            )
+    print(
+        "TA install done, {} rejected: {}".format(
+            len(rejected), " ".join(rejected) or "-"
+        ),
+        flush=True,
+    )
+    return rejected
 
 
 def main():

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_optee_helper.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_optee_helper.py
@@ -1,5 +1,6 @@
 import io
 import json
+import os
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -7,86 +8,121 @@ from subprocess import CompletedProcess
 from unittest.mock import patch
 
 import optee_helper
-import xtest_install_ta
+
+INITRAMFS_SUPPLICANT = "352 @tee-supplicant --fs-parent-path /run/mnt/tee-data"
+SNAP_SUPPLICANT = (
+    "1234 tee-supplicant --fs-parent-path /var/snap/x-test/common/lib/"
+    "optee-fs --ta-path /var/snap/x-test/common/lib/optee_armtz "
+    "--plugin-path /var/snap/x-test/common/usr/lib/tee-supplicant/plugins"
+)
 
 
 def _proc(returncode=0, stdout="", stderr=""):
     return CompletedProcess([], returncode, stdout=stdout, stderr=stderr)
 
 
+class TestFindSupplicant(unittest.TestCase):
+    @patch("optee_helper.subprocess.run")
+    def test_splits_pid_and_cmdline(self, mock_run):
+        mock_run.return_value = _proc(stdout=INITRAMFS_SUPPLICANT + "\n")
+        self.assertEqual(
+            optee_helper._find_supplicant(),
+            ("352", "@tee-supplicant --fs-parent-path /run/mnt/tee-data"),
+        )
+
+
 class TestSupplicantServesTaDir(unittest.TestCase):
-    @patch("optee_helper.subprocess.run")
-    def test_snap_supplicant_with_ta_path(self, mock_run):
-        mock_run.return_value = _proc(
-            stdout="1234 tee-supplicant --fs-parent-path /var/snap/x-test/"
-            "common/lib/optee-fs --ta-path /var/snap/x-test/common/lib/"
-            "optee_armtz\n"
+    def test_snap_supplicant_with_ta_path(self):
+        self.assertTrue(
+            optee_helper._supplicant_serves_ta_dir(SNAP_SUPPLICANT)
         )
-        self.assertTrue(optee_helper._supplicant_serves_ta_dir())
 
-    @patch("optee_helper.subprocess.run")
-    def test_snap_supplicant_with_ta_dir(self, mock_run):
-        mock_run.return_value = _proc(
-            stdout="1234 tee-supplicant --ta-dir /var/snap/x-test/common/"
-            "lib/optee_armtz\n"
+    def test_snap_supplicant_400_with_ta_dir(self):
+        self.assertTrue(
+            optee_helper._supplicant_serves_ta_dir(
+                "tee-supplicant --ta-dir /var/snap/x-test/common/lib/"
+                "optee_armtz"
+            )
         )
-        self.assertTrue(optee_helper._supplicant_serves_ta_dir())
 
-    @patch("optee_helper.subprocess.run")
-    def test_initramfs_supplicant_without_ta_dir(self, mock_run):
-        mock_run.return_value = _proc(
-            stdout="352 @tee-supplicant --fs-parent-path /run/mnt/tee-data\n"
+    def test_initramfs_supplicant_without_ta_dir(self):
+        self.assertFalse(
+            optee_helper._supplicant_serves_ta_dir(INITRAMFS_SUPPLICANT)
         )
-        self.assertFalse(optee_helper._supplicant_serves_ta_dir())
 
 
+@patch("optee_helper.stage_ta_for_supplicant")
 @patch("optee_helper.install_ta")
 @patch("optee_helper.find_ta_path", return_value="/var/snap/x/optee_armtz")
 @patch("optee_helper._run_command", return_value=_proc())
 @patch("optee_helper.look_up_app", return_value="x-test.xtest")
-class TestLaunchXtestInstallsTa(unittest.TestCase):
-    @patch("optee_helper._supplicant_serves_ta_dir", return_value=False)
+class TestLaunchXtestTaDelivery(unittest.TestCase):
+    @patch(
+        "optee_helper._find_supplicant",
+        return_value=("352", INITRAMFS_SUPPLICANT),
+    )
     @patch("optee_helper._lookup_optee_version", return_value="4.2")
-    def test_4x_system_supplicant_installs(self, *_):
+    def test_4x_supplicant_without_ta_dir_stages(self, *_):
+        optee_helper.launch_xtest("regression", "4101")
+        optee_helper.stage_ta_for_supplicant.assert_called_once_with(
+            "/var/snap/x/optee_armtz", "/proc/352/root"
+        )
+        optee_helper.install_ta.assert_not_called()
+
+    @patch(
+        "optee_helper._find_supplicant", return_value=("1234", SNAP_SUPPLICANT)
+    )
+    @patch("optee_helper._lookup_optee_version", return_value="4.2")
+    def test_4x_snap_supplicant_does_nothing(self, *_):
+        optee_helper.launch_xtest("regression", "4101")
+        optee_helper.stage_ta_for_supplicant.assert_not_called()
+        optee_helper.install_ta.assert_not_called()
+
+    @patch(
+        "optee_helper._find_supplicant", return_value=("1234", SNAP_SUPPLICANT)
+    )
+    @patch("optee_helper._lookup_optee_version", return_value="3.19")
+    def test_pre_4x_still_installs(self, *_):
         optee_helper.launch_xtest("regression", "4101")
         optee_helper.install_ta.assert_called_once_with(
             "x-test.xtest", "/var/snap/x/optee_armtz"
         )
-
-    @patch("optee_helper._supplicant_serves_ta_dir", return_value=True)
-    @patch("optee_helper._lookup_optee_version", return_value="4.2")
-    def test_4x_snap_supplicant_skips_install(self, *_):
-        optee_helper.launch_xtest("regression", "4101")
-        optee_helper.install_ta.assert_not_called()
-
-    @patch("optee_helper._supplicant_serves_ta_dir", return_value=True)
-    @patch("optee_helper._lookup_optee_version", return_value="3.19")
-    def test_pre_4x_always_installs(self, *_):
-        optee_helper.launch_xtest("regression", "4101")
-        optee_helper.install_ta.assert_called_once()
+        optee_helper.stage_ta_for_supplicant.assert_not_called()
 
 
-class TestInstallTa(unittest.TestCase):
-    @patch("xtest_install_ta.run")
-    @patch(
-        "xtest_install_ta.glob.glob",
-        return_value=["/ta/b.ta", "/ta/a.ta", "/ta/c.ta"],
-    )
-    def test_rejected_ta_does_not_block_the_rest(self, _, mock_run):
-        mock_run.side_effect = [
-            _proc(),
-            _proc(1, stderr="TEEC_InvokeCommand: 0xffff000f"),
-            _proc(),
-        ]
+class TestStageTaForSupplicant(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.ta_path = os.path.join(self.tmp.name, "optee_armtz")
+        os.mkdir(self.ta_path)
+        for name in ("b.ta", "a.ta", "version"):
+            with open(os.path.join(self.ta_path, name), "w") as fp:
+                fp.write(name)
+        self.root = os.path.join(self.tmp.name, "root")
+        os.mkdir(self.root)
+
+    def test_copies_only_ta_files_into_default_dir_under_root(self):
         with redirect_stdout(io.StringIO()) as out:
-            rejected = xtest_install_ta.install_ta("x-test.xtest", "/ta")
-        self.assertEqual(rejected, ["b.ta"])
-        self.assertEqual(mock_run.call_count, 3)
-        self.assertEqual(
-            [c.args[0][-1] for c in mock_run.call_args_list],
-            ["/ta/a.ta", "/ta/b.ta", "/ta/c.ta"],
-        )
-        self.assertIn("Rejected b.ta: TEEC_InvokeCommand", out.getvalue())
+            optee_helper.stage_ta_for_supplicant(self.ta_path, self.root)
+        dest = os.path.join(self.root, "lib", "optee_armtz")
+        self.assertEqual(sorted(os.listdir(dest)), ["a.ta", "b.ta"])
+        self.assertIn("Staged 2 TAs into {}".format(dest), out.getvalue())
+
+    def test_repeat_overwrites_without_error(self):
+        with redirect_stdout(io.StringIO()):
+            optee_helper.stage_ta_for_supplicant(self.ta_path, self.root)
+            optee_helper.stage_ta_for_supplicant(self.ta_path, self.root)
+        dest = os.path.join(self.root, "lib", "optee_armtz")
+        self.assertEqual(sorted(os.listdir(dest)), ["a.ta", "b.ta"])
+
+    def test_unwritable_root_is_reported_not_raised(self):
+        not_a_dir = os.path.join(self.tmp.name, "file")
+        with open(not_a_dir, "w") as fp:
+            fp.write("x")
+        with redirect_stdout(io.StringIO()) as out:
+            optee_helper.stage_ta_for_supplicant(self.ta_path, not_a_dir)
+        self.assertIn("Cannot stage TAs into", out.getvalue())
 
 
 class TestGenerateSkipsSnapSupplicantOnlyCases(unittest.TestCase):
@@ -109,7 +145,10 @@ class TestGenerateSkipsSnapSupplicantOnlyCases(unittest.TestCase):
                 optee_helper.parse_json_file(fp.name)
         return out.getvalue(), err.getvalue()
 
-    @patch("optee_helper._supplicant_serves_ta_dir", return_value=False)
+    @patch(
+        "optee_helper._find_supplicant",
+        return_value=("352", INITRAMFS_SUPPLICANT),
+    )
     def test_system_supplicant_drops_1033_and_1039(self, _):
         out, err = self._generate()
         self.assertNotIn("test_id: 1033", out)
@@ -118,7 +157,9 @@ class TestGenerateSkipsSnapSupplicantOnlyCases(unittest.TestCase):
         self.assertIn("skipping regression 1033", err)
         self.assertIn("skipping regression 1039", err)
 
-    @patch("optee_helper._supplicant_serves_ta_dir", return_value=True)
+    @patch(
+        "optee_helper._find_supplicant", return_value=("1234", SNAP_SUPPLICANT)
+    )
     def test_snap_supplicant_keeps_every_case(self, _):
         out, err = self._generate()
         self.assertIn("test_id: 1033", out)

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_optee_helper.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_optee_helper.py
@@ -1,6 +1,8 @@
 import io
+import json
+import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from subprocess import CompletedProcess
 from unittest.mock import patch
 
@@ -85,6 +87,43 @@ class TestInstallTa(unittest.TestCase):
             ["/ta/a.ta", "/ta/b.ta", "/ta/c.ta"],
         )
         self.assertIn("Rejected b.ta: TEEC_InvokeCommand", out.getvalue())
+
+
+class TestGenerateSkipsSnapSupplicantOnlyCases(unittest.TestCase):
+    CASES = [
+        {"suite": s, "test_id": i, "test_name": "t" + i, "test_description": d}
+        for s, i, d in [
+            ("regression", "1033", "Test the supplicant plugin framework"),
+            ("regression", "1039", "Test subkey verification"),
+            ("regression", "4101", "Bigint init"),
+            ("pkcs11", "1000", "Initialize and close Cryptoki library"),
+        ]
+    ]
+
+    def _generate(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json") as fp:
+            json.dump(self.CASES, fp)
+            fp.flush()
+            out, err = io.StringIO(), io.StringIO()
+            with redirect_stdout(out), redirect_stderr(err):
+                optee_helper.parse_json_file(fp.name)
+        return out.getvalue(), err.getvalue()
+
+    @patch("optee_helper._supplicant_serves_ta_dir", return_value=False)
+    def test_system_supplicant_drops_1033_and_1039(self, _):
+        out, err = self._generate()
+        self.assertNotIn("test_id: 1033", out)
+        self.assertNotIn("test_id: 1039", out)
+        self.assertIn("test_id: 4101", out)
+        self.assertIn("skipping regression 1033", err)
+        self.assertIn("skipping regression 1039", err)
+
+    @patch("optee_helper._supplicant_serves_ta_dir", return_value=True)
+    def test_snap_supplicant_keeps_every_case(self, _):
+        out, err = self._generate()
+        self.assertIn("test_id: 1033", out)
+        self.assertIn("test_id: 1039", out)
+        self.assertEqual(err, "")
 
 
 if __name__ == "__main__":

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_optee_helper.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_optee_helper.py
@@ -125,7 +125,7 @@ class TestStageTaForSupplicant(unittest.TestCase):
         self.assertIn("Cannot stage TAs into", out.getvalue())
 
 
-class TestGenerateSkipsSnapSupplicantOnlyCases(unittest.TestCase):
+class TestGenerateSkipsSupplicantPluginCases(unittest.TestCase):
     CASES = [
         {"suite": s, "test_id": i, "test_name": "t" + i, "test_description": d}
         for s, i, d in [
@@ -149,13 +149,13 @@ class TestGenerateSkipsSnapSupplicantOnlyCases(unittest.TestCase):
         "optee_helper._find_supplicant",
         return_value=("352", INITRAMFS_SUPPLICANT),
     )
-    def test_system_supplicant_drops_1033_and_1039(self, _):
+    def test_supplicant_without_plugin_path_drops_1033_only(self, _):
         out, err = self._generate()
         self.assertNotIn("test_id: 1033", out)
-        self.assertNotIn("test_id: 1039", out)
+        self.assertIn("test_id: 1039", out)
         self.assertIn("test_id: 4101", out)
         self.assertIn("skipping regression 1033", err)
-        self.assertIn("skipping regression 1039", err)
+        self.assertNotIn("1039", err)
 
     @patch(
         "optee_helper._find_supplicant", return_value=("1234", SNAP_SUPPLICANT)

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_optee_helper.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_optee_helper.py
@@ -1,0 +1,91 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import optee_helper
+import xtest_install_ta
+
+
+def _proc(returncode=0, stdout="", stderr=""):
+    return CompletedProcess([], returncode, stdout=stdout, stderr=stderr)
+
+
+class TestSupplicantServesTaDir(unittest.TestCase):
+    @patch("optee_helper.subprocess.run")
+    def test_snap_supplicant_with_ta_path(self, mock_run):
+        mock_run.return_value = _proc(
+            stdout="1234 tee-supplicant --fs-parent-path /var/snap/x-test/"
+            "common/lib/optee-fs --ta-path /var/snap/x-test/common/lib/"
+            "optee_armtz\n"
+        )
+        self.assertTrue(optee_helper._supplicant_serves_ta_dir())
+
+    @patch("optee_helper.subprocess.run")
+    def test_snap_supplicant_with_ta_dir(self, mock_run):
+        mock_run.return_value = _proc(
+            stdout="1234 tee-supplicant --ta-dir /var/snap/x-test/common/"
+            "lib/optee_armtz\n"
+        )
+        self.assertTrue(optee_helper._supplicant_serves_ta_dir())
+
+    @patch("optee_helper.subprocess.run")
+    def test_initramfs_supplicant_without_ta_dir(self, mock_run):
+        mock_run.return_value = _proc(
+            stdout="352 @tee-supplicant --fs-parent-path /run/mnt/tee-data\n"
+        )
+        self.assertFalse(optee_helper._supplicant_serves_ta_dir())
+
+
+@patch("optee_helper.install_ta")
+@patch("optee_helper.find_ta_path", return_value="/var/snap/x/optee_armtz")
+@patch("optee_helper._run_command", return_value=_proc())
+@patch("optee_helper.look_up_app", return_value="x-test.xtest")
+class TestLaunchXtestInstallsTa(unittest.TestCase):
+    @patch("optee_helper._supplicant_serves_ta_dir", return_value=False)
+    @patch("optee_helper._lookup_optee_version", return_value="4.2")
+    def test_4x_system_supplicant_installs(self, *_):
+        optee_helper.launch_xtest("regression", "4101")
+        optee_helper.install_ta.assert_called_once_with(
+            "x-test.xtest", "/var/snap/x/optee_armtz"
+        )
+
+    @patch("optee_helper._supplicant_serves_ta_dir", return_value=True)
+    @patch("optee_helper._lookup_optee_version", return_value="4.2")
+    def test_4x_snap_supplicant_skips_install(self, *_):
+        optee_helper.launch_xtest("regression", "4101")
+        optee_helper.install_ta.assert_not_called()
+
+    @patch("optee_helper._supplicant_serves_ta_dir", return_value=True)
+    @patch("optee_helper._lookup_optee_version", return_value="3.19")
+    def test_pre_4x_always_installs(self, *_):
+        optee_helper.launch_xtest("regression", "4101")
+        optee_helper.install_ta.assert_called_once()
+
+
+class TestInstallTa(unittest.TestCase):
+    @patch("xtest_install_ta.run")
+    @patch(
+        "xtest_install_ta.glob.glob",
+        return_value=["/ta/b.ta", "/ta/a.ta", "/ta/c.ta"],
+    )
+    def test_rejected_ta_does_not_block_the_rest(self, _, mock_run):
+        mock_run.side_effect = [
+            _proc(),
+            _proc(1, stderr="TEEC_InvokeCommand: 0xffff000f"),
+            _proc(),
+        ]
+        with redirect_stdout(io.StringIO()) as out:
+            rejected = xtest_install_ta.install_ta("x-test.xtest", "/ta")
+        self.assertEqual(rejected, ["b.ta"])
+        self.assertEqual(mock_run.call_count, 3)
+        self.assertEqual(
+            [c.args[0][-1] for c in mock_run.call_args_list],
+            ["/ta/a.ta", "/ta/b.ta", "/ta/c.ta"],
+        )
+        self.assertIn("Rejected b.ta: TEEC_InvokeCommand", out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Stacked on #2775 (this branch contains its commits; only the last commit(s) are new here — merge #2775 first).

`regression_1033` "Test the supplicant plugin framework" needs the x-test test plugin inside `tee-supplicant`. `optee_client` loads plugins exactly once, in `main()` via `plugin_load_all()` (tee-supplicant/src/tee_supplicant.c:895 in 4.2.0), before serving any request. On images whose only supplicant is the one the kernel snap's initramfs starts for the fTPM (UC22 Jetson Orin NX) it was started without `--plugin-path`, cannot be restarted (`RefuseManualStop=yes`, one supplicant per TEE), and staging the plugin into its root changes nothing (no `.plugin` ever appears in `/proc/<pid>/maps`). The case therefore fails in every certification run on such images although nothing is wrong with the DUT.

This PR drops `regression 1033` from the `ce-oem-optee-test-list` resource (`optee_helper.py generate`) when the running supplicant's command line has no `--plugin-path`, and prints `skipping regression 1033: tee-supplicant was started without the x-test plugin path` on stderr so the omission is visible in the submission. Boards running `x-test.tee-supplicant` (which passes `--plugin-path`) keep generating it.

`regression_1039` is deliberately **not** filtered: with the TAs staged by #2775, OP-TEE verifies its subkey-signed TAs itself and the case passes (the first commit of this branch filtered it too; the last commit reverts that).

## Resolved issues

- Bug: [OEMQA-6839](https://warthogs.atlassian.net/browse/OEMQA-6839)
- Task: [OEMQA-6841](https://warthogs.atlassian.net/browse/OEMQA-6841)
- Epic: [OEMQA-6837](https://warthogs.atlassian.net/browse/OEMQA-6837)

## Documentation

N/A

## Tests

- Unit tests in `tests/test_optee_helper.py` (2 for the generator, 12 total with #2775's, pass); black/flake8 clean.
- UC22 Jetson Orin NX 202606-38921, `optee_helper.py generate` run inside the `checkbox-riverside` snap environment: 116 records emitted, none with `test_id: 1033`, `test_id: 1039` present, stderr shows the single `skipping regression 1033 …` line; `generate -p` still emits the 31 pkcs11 cases.
- Draft until a full side-loaded `ce-oem-optee-automated` run on the Jetson DUTs confirms the job id is no longer instantiated.


[OEMQA-6839]: https://warthogs.atlassian.net/browse/OEMQA-6839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ