### PR TITLE
Split reboot checks into individual sibling jobs, then split blocker and non-blocker fwts tests (New)

### DIFF
--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -185,7 +185,10 @@ flags:
   - noreturn
 estimated_duration: "60.0"
 after:
-  - warm-boot-loop-test-{reboot_id_previous}
+  - warm-boot-loop-{reboot_id_previous}-fwts-test
+  - warm-boot-loop-{reboot_id_previous}-device-check
+  - warm-boot-loop-{reboot_id_previous}-service-check
+  - warm-boot-loop-{reboot_id_previous}-hardware-renderer-check
 depends:
   - init-boot-loop-data
 ---
@@ -219,8 +222,8 @@ estimated_duration: "1.0"
 depends:
   - warm-boot-loop-reboot-1
 ---
-id: warm-boot-loop-fwts-test-{reboot_id}
-template-id: warm-boot-loop-fwts-test-reboot_id
+id: warm-boot-loop-{reboot_id}-fwts-test
+template-id: warm-boot-loop-reboot_id-fwts-test
 category_id: stress-tests/warm-boot
 summary: Warm boot FWTS test {reboot_id}
 purpose: Compare data after a warm boot with baseline data set
@@ -230,8 +233,6 @@ template-unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-#  reboot_check_test.py -g -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d
-#"$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}" -s -f
 command: reboot_check_test.py -f
 user: root
 flags:
@@ -240,8 +241,8 @@ estimated_duration: "1.0"
 depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
-id: warm-boot-loop-device-check-{reboot_id}
-template-id: warm-boot-loop-device-check-reboot_id
+id: warm-boot-loop-{reboot_id}-device-check
+template-id: warm-boot-loop-reboot_id-device-check
 category_id: stress-tests/warm-boot
 summary: Warm boot device comparison test {reboot_id}
 unit: template
@@ -261,8 +262,8 @@ estimated_duration: "1.0"
 depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
-id: warm-boot-loop-service-check-{reboot_id}
-template-id: warm-boot-loop-service-check-reboot_id
+id: warm-boot-loop-{reboot_id}-service-check
+template-id: warm-boot-loop-reboot_id-service-check
 category_id: stress-tests/warm-boot
 summary: Check failed services after warm reboot {reboot_id}
 unit: template
@@ -280,7 +281,7 @@ estimated_duration: "1.0"
 depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
-id: warm-boot-loop-hardware-renderer-check-{reboot_id}
+id: warm-boot-loop-{reboot_id}-hardware-renderer-check
 template-id: warm-boot-loop-hardware-renderer-check-reboot_id
 category_id: stress-tests/warm-boot
 summary: Check that the desktop is hardware-rendered after warm reboot {reboot_id}

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -225,7 +225,7 @@ depends:
 id: warm-boot-loop-{reboot_id}-fwts-test
 template-id: warm-boot-loop-reboot_id-fwts-test
 category_id: stress-tests/warm-boot
-summary: Warm boot FWTS test {reboot_id}
+summary: Warm boot {reboot_id} FWTS test
 purpose: Compare data after a warm boot with baseline data set
 unit: template
 template-resource: reboot-run-generator
@@ -244,7 +244,7 @@ depends:
 id: warm-boot-loop-{reboot_id}-device-check
 template-id: warm-boot-loop-reboot_id-device-check
 category_id: stress-tests/warm-boot
-summary: Warm boot device comparison test {reboot_id}
+summary: Warm boot {reboot_id} device difference check
 unit: template
 template-resource: reboot-run-generator
 template-unit: job
@@ -265,7 +265,7 @@ depends:
 id: warm-boot-loop-{reboot_id}-service-check
 template-id: warm-boot-loop-reboot_id-service-check
 category_id: stress-tests/warm-boot
-summary: Check failed services after warm reboot {reboot_id}
+summary: Warm boot {reboot_id} failed services check
 unit: template
 template-resource: reboot-run-generator
 template-unit: job
@@ -284,7 +284,7 @@ depends:
 id: warm-boot-loop-{reboot_id}-hardware-renderer-check
 template-id: warm-boot-loop-hardware-renderer-check-reboot_id
 category_id: stress-tests/warm-boot
-summary: Check that the desktop is hardware-rendered after warm reboot {reboot_id}
+summary: Warm boot {reboot_id} hardware renderer check
 unit: template
 template-resource: reboot-run-generator
 template-unit: job

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -189,7 +189,7 @@ after:
 depends:
   - init-boot-loop-data
 ---
-id: warm-boot-loop-fwts-test-1
+id: warm-boot-loop-1-fwts-test
 category_id: stress-tests/warm-boot
 summary: Warm boot system configuration test 1
 purpose: Compare data after warm boot with baseline data set
@@ -202,9 +202,9 @@ certification-status: blocker
 siblings:
   - id: warm-boot-loop-1-hardware-renderer-check
     command: reboot_check_test.py -g
-  - id: warm-boot-loop-1-hardware-service-check
+  - id: warm-boot-loop-1-service-check
     command: reboot_check_test.py -s
-  - id: warm-boot-loop-1-hardware-device-check
+  - id: warm-boot-loop-1-device-check
     command: >-
       reboot_check_test.py 
       -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
@@ -216,10 +216,10 @@ estimated_duration: "1.0"
 depends:
   - warm-boot-loop-reboot-1
 ---
-id: warm-boot-loop-test-{reboot_id}
-template-id: warm-boot-loop-test-reboot_id
+id: warm-boot-loop-fwts-test-{reboot_id}
+template-id: warm-boot-loop-fwts-test-reboot_id
 category_id: stress-tests/warm-boot
-summary: Warm boot system configuration test {reboot_id}
+summary: Warm boot FWTS test {reboot_id}
 purpose: Compare data after a warm boot with baseline data set
 unit: template
 template-resource: reboot-run-generator
@@ -227,8 +227,68 @@ template-unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -g -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d
-  "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}" -s -f
+#  reboot_check_test.py -g -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d
+#"$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}" -s -f
+command: reboot_check_test.py -f
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - warm-boot-loop-reboot-{reboot_id}
+---
+id: warm-boot-loop-device-check-{reboot_id}
+template-id: warm-boot-loop-device-check-reboot_id
+category_id: stress-tests/warm-boot
+summary: Warm boot device comparison test {reboot_id}
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  reboot_check_test.py 
+  -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
+  -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}"
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - warm-boot-loop-reboot-{reboot_id}
+---
+id: warm-boot-loop-service-check-{reboot_id}
+template-id: warm-boot-loop-service-check-reboot_id
+category_id: stress-tests/warm-boot
+summary: Check failed services after warm reboot {reboot_id}
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  reboot_check_test.py -s
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - warm-boot-loop-reboot-{reboot_id}
+---
+id: warm-boot-loop-hardware-renderer-check-{reboot_id}
+template-id:  warm-boot-loop-hardware-renderer-check-reboot_id
+category_id: stress-tests/warm-boot
+summary: Check that the desktop is hardware-rendered after warm reboot {reboot_id}
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  reboot_check_test.py -g
 user: root
 flags:
   - preserve-locale

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -107,20 +107,36 @@ flags:
   - noreturn
 estimated_duration: "180.0"
 after:
-  - cold-boot-loop-test-{reboot_id_previous}
+  - cold-boot-loop-{reboot_id_previous}-fwts-test
+  - cold-boot-loop-{reboot_id_previous}-device-check
+  - cold-boot-loop-{reboot_id_previous}-service-check
+  - cold-boot-loop-{reboot_id_previous}-hardware-renderer-check
 depends:
   - init-boot-loop-data
 ---
-id: cold-boot-loop-test-1
+id: cold-boot-loop-1-fwts-test
 category_id: stress-tests/cold-boot
-summary: Cold boot system configuration test 1
-purpose: Compare the data after waking up the system with the base data set
+summary: Cold boot 1 FWTS test
+purpose: Compare data after cold boot with baseline data set
 unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -g -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d
-  "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1" -s -f
+command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1"
+certification-status: blocker
+siblings:
+  - id: cold-boot-loop-1-hardware-renderer-check
+    summary: Cold boot 1 hardware renderer check
+    command: reboot_check_test.py -g
+  - id: cold-boot-loop-1-service-check
+    summary: Cold boot 1 failed services check
+    command: reboot_check_test.py -s
+  - id: cold-boot-loop-1-device-check
+    summary: Cold boot 1 device difference check
+    command: >-
+      reboot_check_test.py 
+      -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
+      -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1"
 user: root
 flags:
   - preserve-locale
@@ -128,19 +144,77 @@ estimated_duration: "1.0"
 depends:
   - cold-boot-loop-reboot-1
 ---
-id: cold-boot-loop-test-{reboot_id}
-template-id: cold-boot-loop-test-reboot_id
+id: cold-boot-loop-{reboot_id}-fwts-test
+template-id: cold-boot-loop-reboot_id-fwts-test
 category_id: stress-tests/cold-boot
-summary: Cold boot system configuration test {reboot_id}
-purpose: Compare the data after cold booting up the system with the base data set
+summary: Cold boot {reboot_id} FWTS test
+purpose: Compare data after a cold boot with baseline data set
 unit: template
 template-resource: reboot-run-generator
 template-unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -g -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d
-  "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}" -s -f
+command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}"
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - cold-boot-loop-reboot-{reboot_id}
+---
+id: cold-boot-loop-{reboot_id}-device-check
+template-id: cold-boot-loop-reboot_id-device-check
+category_id: stress-tests/cold-boot
+summary: Cold boot {reboot_id} device difference check
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  reboot_check_test.py 
+  -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
+  -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}"
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - cold-boot-loop-reboot-{reboot_id}
+---
+id: cold-boot-loop-{reboot_id}-service-check
+template-id: cold-boot-loop-reboot_id-service-check
+category_id: stress-tests/cold-boot
+summary: Cold boot {reboot_id} failed services check
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  reboot_check_test.py -s
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - cold-boot-loop-reboot-{reboot_id}
+---
+id: cold-boot-loop-{reboot_id}-hardware-renderer-check
+template-id: cold-boot-loop-hardware-renderer-check-reboot_id
+category_id: stress-tests/cold-boot
+summary: Cold boot {reboot_id} hardware renderer check
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  reboot_check_test.py -g
 user: root
 flags:
   - preserve-locale

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -31,7 +31,7 @@ command: |
 estimated_duration: 1s
 flags:
   - preserve-locale
-summary: Generates IDs for each iteration of reboot tests based on the specified number of iterations.
+summary: Generate an ID for each reboot iteration
 ---
 id: init-boot-loop-data
 category_id: com.canonical.plainbox::stress
@@ -46,7 +46,7 @@ imports:
   - from com.canonical.plainbox import manifest
 requires:
   - manifest._ignore_reboot_loop_tests == 'False'
-command: reboot_check_test.py -d "$PLAINBOX_SESSION_SHARE/before_reboot"
+command: reboot_check_test.py -d "$PLAINBOX_SESSION_SHARE"/before_reboot
 environ:
   - LD_LIBRARY_PATH
 user: root
@@ -107,23 +107,42 @@ flags:
   - noreturn
 estimated_duration: "180.0"
 after:
-  - cold-boot-loop-{reboot_id_previous}-fwts-test
+  - cold-boot-loop-{reboot_id_previous}-fwts-critical-only
+  - cold-boot-loop-{reboot_id_previous}-fwts-all
   - cold-boot-loop-{reboot_id_previous}-device-check
   - cold-boot-loop-{reboot_id_previous}-service-check
   - cold-boot-loop-{reboot_id_previous}-hardware-renderer-check
 depends:
   - init-boot-loop-data
 ---
-id: cold-boot-loop-1-fwts-test
+id: cold-boot-loop-1-fwts-critical-only
 category_id: stress-tests/cold-boot
-summary: Cold boot 1 FWTS test
+summary: Cold boot 1 FWTS test (only fail at critical errors)
 unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1"
-certification-status: blocker
+command: >-
+  mkdir -p "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-1
+
+  checkbox-support-fwts_test
+  -t klog
+  -t oops
+  -f critical
+  -l "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-1/fwts-critical-only.log
 siblings:
+  - id: cold-boot-loop-1-fwts-all
+    summary: Cold boot 1 FWTS test (all levels)
+    # since we are only checking klog and oops
+    # it's safe to do duplicate work and run fwts again
+    command: >-
+      mkdir -p "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-1
+
+      checkbox-support-fwts_test 
+      -t klog 
+      -t oops
+      -f low
+      -l "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-1/fwts-all.log
   - id: cold-boot-loop-1-hardware-renderer-check
     summary: Cold boot 1 hardware renderer check
     command: reboot_check_test.py -g
@@ -134,8 +153,8 @@ siblings:
     summary: Cold boot 1 device difference check
     command: >-
       reboot_check_test.py 
-      -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
-      -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1"
+      -c "$PLAINBOX_SESSION_SHARE"/before_reboot
+      -d "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-1
 user: root
 flags:
   - preserve-locale
@@ -143,17 +162,49 @@ estimated_duration: "1.0"
 depends:
   - cold-boot-loop-reboot-1
 ---
-id: cold-boot-loop-{reboot_id}-fwts-test
-template-id: cold-boot-loop-reboot_id-fwts-test
+id: cold-boot-loop-{reboot_id}-fwts-critical-only
+template-id: cold-boot-loop-reboot_id-fwts-critical-only
 category_id: stress-tests/cold-boot
-summary: Cold boot {reboot_id} FWTS test
+summary: Cold boot {reboot_id} FWTS test (only fail at critical errors)
 unit: template
 template-resource: reboot-run-generator
 template-unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}"
+command: >-
+  mkdir -p "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-{reboot_id}
+
+  checkbox-support-fwts_test
+  -t klog
+  -t oops
+  -f critical
+  -l "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-{reboot_id}/fwts-critical-only.log
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - cold-boot-loop-reboot-{reboot_id}
+---
+id: cold-boot-loop-{reboot_id}-fwts-all
+template-id: cold-boot-loop-reboot_id-fwts-all
+category_id: stress-tests/cold-boot
+summary: Cold boot {reboot_id} FWTS test (all levels)
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  mkdir -p "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-{reboot_id}
+
+  checkbox-support-fwts_test
+  -t klog
+  -t oops
+  -f low 
+  -l "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-{reboot_id}/fwts-all.log
 user: root
 flags:
   - preserve-locale
@@ -173,8 +224,8 @@ environ:
   - LD_LIBRARY_PATH
 command: >-
   reboot_check_test.py 
-  -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
-  -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}"
+  -c "$PLAINBOX_SESSION_SHARE"/before_reboot
+  -d "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-{reboot_id}
 user: root
 flags:
   - preserve-locale
@@ -257,23 +308,41 @@ flags:
   - noreturn
 estimated_duration: "60.0"
 after:
-  - warm-boot-loop-{reboot_id_previous}-fwts-test
+  - warm-boot-loop-{reboot_id_previous}-fwts-critical-only
+  - warm-boot-loop-{reboot_id_previous}-fwts-all
   - warm-boot-loop-{reboot_id_previous}-device-check
   - warm-boot-loop-{reboot_id_previous}-service-check
   - warm-boot-loop-{reboot_id_previous}-hardware-renderer-check
 depends:
   - init-boot-loop-data
 ---
-id: warm-boot-loop-1-fwts-test
+id: warm-boot-loop-1-fwts-critical-only
 category_id: stress-tests/warm-boot
-summary: Warm boot 1 FWTS test
+summary: Warm boot 1 FWTS test (only fail at critical errors)
+purpose: Compare data after warm boot with baseline data set
 unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1"
-certification-status: blocker
+command: >-
+  mkdir -p "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-1
+
+  checkbox-support-fwts_test
+  -t klog
+  -t oops
+  -f critical
+  -l "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-1/fwts-critical-only.log
 siblings:
+  - id: warm-boot-loop-1-fwts-all
+    summary: Warm boot 1 FWTS test (all levels)
+    command: >-
+      mkdir -p "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-1
+
+      checkbox-support-fwts_test
+      -t klog
+      -t oops
+      -f low 
+      -l "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-1/fwts-all.log
   - id: warm-boot-loop-1-hardware-renderer-check
     summary: Warm boot 1 hardware renderer check
     command: reboot_check_test.py -g
@@ -284,8 +353,8 @@ siblings:
     summary: Warm boot 1 device difference check
     command: >-
       reboot_check_test.py 
-      -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
-      -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1"
+      -c "$PLAINBOX_SESSION_SHARE"/before_reboot
+      -d "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-1
 user: root
 flags:
   - preserve-locale
@@ -293,17 +362,51 @@ estimated_duration: "1.0"
 depends:
   - warm-boot-loop-reboot-1
 ---
-id: warm-boot-loop-{reboot_id}-fwts-test
-template-id: warm-boot-loop-reboot_id-fwts-test
+id: warm-boot-loop-{reboot_id}-fwts-critical-only
+template-id: warm-boot-loop-reboot_id-fwts-critical-only
 category_id: stress-tests/warm-boot
-summary: Warm boot {reboot_id} FWTS test
+summary: Warm boot {reboot_id} FWTS test (only fail at critical errors)
+purpose: Compare data after a warm boot with baseline data set
 unit: template
 template-resource: reboot-run-generator
 template-unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}"
+command: >-
+  mkdir -p "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-{reboot_id}
+
+  checkbox-support-fwts_test
+  -t klog
+  -t oops
+  -f critical
+  -l "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-{reboot_id}/fwts-critical-only.log
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - warm-boot-loop-reboot-{reboot_id}
+---
+id: warm-boot-loop-{reboot_id}-fwts-all
+template-id: warm-boot-loop-reboot_id-fwts-all
+category_id: stress-tests/warm-boot
+summary: Warm boot {reboot_id} FWTS test (all levels)
+purpose: Compare data after a warm boot with baseline data set
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  mkdir -p "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-{reboot_id}
+
+  checkbox-support-fwts_test
+  -t klog
+  -t oops
+  -f low 
+  -l "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-{reboot_id}/fwts-all.log
 user: root
 flags:
   - preserve-locale
@@ -323,8 +426,8 @@ environ:
   - LD_LIBRARY_PATH
 command: >-
   reboot_check_test.py 
-  -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
-  -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}"
+  -c "$PLAINBOX_SESSION_SHARE"/before_reboot
+  -d "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-{reboot_id}
 user: root
 flags:
   - preserve-locale

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -191,7 +191,7 @@ depends:
 ---
 id: warm-boot-loop-1-fwts-test
 category_id: stress-tests/warm-boot
-summary: Warm boot system configuration test 1
+summary: Warm boot 1 FWTS test
 purpose: Compare data after warm boot with baseline data set
 unit: job
 plugin: shell
@@ -201,10 +201,13 @@ command: reboot_check_test.py -f
 certification-status: blocker
 siblings:
   - id: warm-boot-loop-1-hardware-renderer-check
+    summary: Warm boot 1 hardware renderer check
     command: reboot_check_test.py -g
   - id: warm-boot-loop-1-service-check
+    summary: Warm boot 1 failed services check
     command: reboot_check_test.py -s
   - id: warm-boot-loop-1-device-check
+    summary: Warm boot 1 device difference check
     command: >-
       reboot_check_test.py 
       -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
@@ -278,7 +281,7 @@ depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
 id: warm-boot-loop-hardware-renderer-check-{reboot_id}
-template-id:  warm-boot-loop-hardware-renderer-check-reboot_id
+template-id: warm-boot-loop-hardware-renderer-check-reboot_id
 category_id: stress-tests/warm-boot
 summary: Check that the desktop is hardware-rendered after warm reboot {reboot_id}
 unit: template

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -189,7 +189,7 @@ after:
 depends:
   - init-boot-loop-data
 ---
-id: warm-boot-loop-test-1
+id: warm-boot-loop-fwts-test-1
 category_id: stress-tests/warm-boot
 summary: Warm boot system configuration test 1
 purpose: Compare data after warm boot with baseline data set
@@ -197,8 +197,18 @@ unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -g -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d
-  "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1" -s -f
+command: reboot_check_test.py -f
+certification-status: blocker
+siblings:
+  - id: warm-boot-loop-1-hardware-renderer-check
+    command: reboot_check_test.py -g
+  - id: warm-boot-loop-1-hardware-service-check
+    command: reboot_check_test.py -s
+  - id: warm-boot-loop-1-hardware-device-check
+    command: >-
+      reboot_check_test.py 
+      -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
+      -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1"
 user: root
 flags:
   - preserve-locale

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -117,7 +117,6 @@ depends:
 id: cold-boot-loop-1-fwts-test
 category_id: stress-tests/cold-boot
 summary: Cold boot 1 FWTS test
-purpose: Compare data after cold boot with baseline data set
 unit: job
 plugin: shell
 environ:
@@ -148,7 +147,6 @@ id: cold-boot-loop-{reboot_id}-fwts-test
 template-id: cold-boot-loop-reboot_id-fwts-test
 category_id: stress-tests/cold-boot
 summary: Cold boot {reboot_id} FWTS test
-purpose: Compare data after a cold boot with baseline data set
 unit: template
 template-resource: reboot-run-generator
 template-unit: job
@@ -269,7 +267,6 @@ depends:
 id: warm-boot-loop-1-fwts-test
 category_id: stress-tests/warm-boot
 summary: Warm boot 1 FWTS test
-purpose: Compare data after warm boot with baseline data set
 unit: job
 plugin: shell
 environ:
@@ -300,7 +297,6 @@ id: warm-boot-loop-{reboot_id}-fwts-test
 template-id: warm-boot-loop-reboot_id-fwts-test
 category_id: stress-tests/warm-boot
 summary: Warm boot {reboot_id} FWTS test
-purpose: Compare data after a warm boot with baseline data set
 unit: template
 template-resource: reboot-run-generator
 template-unit: job

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -274,7 +274,7 @@ unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1"
+command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1"
 certification-status: blocker
 siblings:
   - id: warm-boot-loop-1-hardware-renderer-check
@@ -307,7 +307,7 @@ template-unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}"
+command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}"
 user: root
 flags:
   - preserve-locale

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -200,7 +200,7 @@ unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f
+command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1"
 certification-status: blocker
 siblings:
   - id: warm-boot-loop-1-hardware-renderer-check
@@ -233,7 +233,7 @@ template-unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f
+command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}"
 user: root
 flags:
   - preserve-locale

--- a/providers/base/units/stress/test-plan.pxu
+++ b/providers/base/units/stress/test-plan.pxu
@@ -339,6 +339,9 @@ nested_part:
     stress-warmboot-coldboot-automated
     stress-pm-graph
 certification_status_overrides:
-    apply blocker to com.canonical.certification::warm-boot-loop-.*
-    apply blocker to com.canonical.certification::cold-boot-loop-.*
+    apply blocker to com.canonical.certification::(warm|cold)-boot-loop-reboot-.*
+    apply blocker to com.canonical.certification::(warm|cold)-boot-loop-.*-fwts-critical-only
+    apply blocker to com.canonical.certification::(warm|cold)-.*-device-check
+    apply blocker to com.canonical.certification::(warm|cold)-.*-service-check
+    apply blocker to com.canonical.certification::(warm|cold)-.*-renderer-check
     apply blocker to com.canonical.certification::ethernet/iperf3_.*


### PR DESCRIPTION
## Description

Originally the `warm-boot-loop-test*` and `cold-boot-loop-test*` jobs were 4 little tests combined into one job. This structure allows any sub-test fail the entire job which can be hard to track down which exact test failed without looking through all 60 jobs. This PR splits the checks into individual sibling jobs.

## Resolved issues

It's kinda difficult to review results when any of the 4 sub-tests can fail the entire job. This also allows checks like the desktop package detection from the renderer test to be moved to the yaml definition instead of trying to figure it out inside the job.

## Documentation

## Tests

Successful run https://certification.canonical.com/hardware/202601-38351/submission/505955/

