### PR TITLE
Support buzzer via GPIOD (New)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/buzzer_test.sh
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/buzzer_test.sh
@@ -261,7 +261,7 @@ help_function() {
     echo "Usage: button_test.sh -t type -n button_name -p gpio_port -e [0|1]"
     echo -e "\t-e    the state to make a sound from buzzer. [0|1]"
     echo -e "\t-n    button name."
-    echo -e "\t-p    gpio or pwm port. GPIO accepts a line name when gpiod tools are available, otherwise a global GPIO number.""
+    echo -e "\t-p    gpio or pwm port. GPIO accepts a line name when gpiod tools are available, otherwise a global GPIO number."
     echo -e "\t-c    pwm chip number"
     echo -e "\t-t    type of test target in gpio or pwm"
 }

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/buzzer_test.sh
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/buzzer_test.sh
@@ -32,6 +32,132 @@ export_gpio() {
     fi
 }
 
+has_gpiod() {
+    which gpioset > /dev/null 2>&1 && \
+    which gpioinfo > /dev/null 2>&1 && \
+    which gpiodetect > /dev/null 2>&1 && \
+    which gpioget > /dev/null 2>&1
+}
+
+resolve_gpio_by_name() {
+    # Resolve a GPIO line name to gpio_chip and gpio_offset using gpioinfo output.
+    # Avoids relying on chip numbers which can change
+    # between power cycles depending on driver probe order.
+    local gpio_name="$1"
+    local gpioinfo_dump found
+
+    # Prefer the no-argument form (libgpiod >= 1.5 lists all chips at once).
+    # Fall back to gpiodetect + per-chip gpioinfo for older libgpiod.
+    if ! gpioinfo_dump="$(gpioinfo 2>/dev/null)" || [ -z "$gpioinfo_dump" ]; then
+        gpioinfo_dump="$(
+            gpiodetect | awk '{print $1}' | while read -r c; do
+                gpioinfo "$c"
+            done
+        )"
+    fi
+
+    found="$(
+        printf '%s\n' "$gpioinfo_dump" | awk -v target="$gpio_name" '
+            BEGIN { found=0 }
+            /^gpiochip[0-9]/ {
+                chip = $1
+                next
+            }
+            index($0, "\"" target "\"") {
+                offset = $2
+                sub(/:$/, "", offset)
+                printf "%s %s\n", chip, offset
+                found = 1
+                exit
+            }
+            END { exit (found ? 0 : 1) }
+        '
+    )" || {
+        echo "Error: cannot resolve GPIO name '${gpio_name}'" >&2
+        echo "----- gpioinfo dump begin -----" >&2
+        printf '%s\n' "$gpioinfo_dump" >&2
+        echo "----- gpioinfo dump end -----" >&2
+        return 1
+    }
+
+    # shellcheck disable=SC2086
+    set -- $found
+    gpio_chip="$1"
+    gpio_offset="$2"
+    return 0
+}
+
+run_gpioset() {
+    value="$1"
+
+    # gpioset keeps the line requested while the process is alive.
+    # Stop any previous gpioset process first so we can safely set a new value.
+    if [ -n "$gpioset_pid" ] && kill -0 "$gpioset_pid" 2>/dev/null; then
+        kill "$gpioset_pid" 2>/dev/null || true
+        # wait reaps the old process and releases its line request cleanly.
+        wait "$gpioset_pid" 2>/dev/null || true
+    fi
+
+    # Run gpioset in background so this script can continue to interactive steps
+    # while gpioset keeps driving the GPIO value.
+    if gpioset --help 2>&1 | grep -q -- '--chip'; then
+        gpioset -c "$gpio_chip" "${gpio_offset}=${value}" &
+    else
+        gpioset "$gpio_chip" "${gpio_offset}=${value}" &
+    fi
+
+    gpioset_pid=$!
+    sleep 0.1
+
+    if kill -0 "$gpioset_pid" 2>/dev/null; then
+        return 0
+    fi
+
+    wait "$gpioset_pid" 2>/dev/null
+    return 1
+}
+
+cleanup_gpioset() {
+    # Ensure no gpioset process is left behind after the script exits.
+    if [ -n "$gpioset_pid" ] && kill -0 "$gpioset_pid" 2>/dev/null; then
+        kill "$gpioset_pid" 2>/dev/null || true
+        wait "$gpioset_pid" 2>/dev/null || true
+    fi
+}
+
+setup_gpio_backend() {
+    use_gpiod=0
+
+    # Prefer GPIO line names through gpiod when those tools are available.
+    if has_gpiod; then
+        if ! resolve_gpio_by_name "$port"; then
+            exit 1
+        fi
+
+        use_gpiod=1
+        echo "## Use gpiod backend on ${gpio_chip} line ${gpio_offset} (resolved from name '${port}')"
+        return
+    fi
+
+    echo "gpiod tools not available, falling back to legacy sysfs GPIO export"
+    # if the port is a number, then use sysfs GPIO export.
+    if [[ ! "$port" =~ ^[0-9]+$ ]]; then
+        echo "Error: GPIO name format '${port}' requires gpioset/gpioinfo/gpioget"
+        exit 1
+    fi
+
+    if [ ! -d /sys/class/gpio ]; then
+        echo "Error: /sys/class/gpio is not available on this system"
+        exit 1
+    fi
+
+    node="/sys/class/gpio/gpio$port"
+    direct="out"
+    echo "## Use sysfs GPIO backend on gpio$port"
+    export_gpio
+}
+
+
 test_pwm_buzzer() {
     # Make sounds with different musical scale by pwm
     echo "Configure $type chip$chipnum pwm$port"
@@ -55,8 +181,15 @@ test_buzzer() {
     echo "## Start $type Buzzer $name test"
     echo "## Set $type $port to $enable"
     if [ "$type" == 'gpio' ]; then
-        enable_node="$node"/value
-        echo "$enable" > "$enable_node"
+        if [ "$use_gpiod" == '1' ]; then
+            if ! run_gpioset "$enable"; then
+                echo "Error: failed to set GPIO ${gpio_chip}:${gpio_offset} to ${enable}"
+                exit 1
+            fi
+        else
+            enable_node="$node"/value
+            echo "$enable" > "$enable_node"
+        fi
     else
         enable_node="$node"/enable
         echo "$enable" > "$enable_node"
@@ -76,7 +209,14 @@ test_buzzer() {
     done
 
     echo "## Set $type $port to $disable"
-    echo "$disable" > "$enable_node"
+    if [ "$type" == 'gpio' ] && [ "$use_gpiod" == '1' ]; then
+        if ! run_gpioset "$disable"; then
+            echo "Error: failed to set GPIO ${gpio_chip}:${gpio_offset} to ${disable}"
+            exit 1
+        fi
+    else
+        echo "$disable" > "$enable_node"
+    fi
     while true
     do
         echo "Is the buzzer $name stop? (y/n)"
@@ -98,10 +238,8 @@ main() {
         disable=1
     fi
     if [ "$type" == "gpio" ]; then
-        node="/sys/class/gpio/gpio$port"
-        direct="out"
-        # Configure GPIO interface if needed
-        export_gpio
+        # Prefer gpiod when available, fallback to legacy sysfs export.
+        setup_gpio_backend
     elif [ "$type" == "pwm" ]; then
         node="/sys/class/pwm/pwmchip$chipnum/pwm$port"
         direct="out"
@@ -114,6 +252,8 @@ main() {
     test_buzzer
 }
 
+trap cleanup_gpioset EXIT
+
 help_function() {
     echo "This script is uses for test GPIO/PWM buzzer"
     echo "Will change GPIO/PWM value to make a sound from buzzer"
@@ -121,7 +261,7 @@ help_function() {
     echo "Usage: button_test.sh -t type -n button_name -p gpio_port -e [0|1]"
     echo -e "\t-e    the state to make a sound from buzzer. [0|1]"
     echo -e "\t-n    button name."
-    echo -e "\t-p    gpio or pwm port."
+    echo -e "\t-p    gpio or pwm port. GPIO accepts a line name when gpiod tools are available, otherwise a global GPIO number.""
     echo -e "\t-c    pwm chip number"
     echo -e "\t-t    type of test target in gpio or pwm"
 }

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/buzzer/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/buzzer/jobs.pxu
@@ -23,19 +23,34 @@ requires: manifest.has_buzzer == 'True'
 id: ce-oem-gpio-buzzer-mapping
 _summary: Generates a GPIO and buzzer mappings for further buzzer test
 _description:
-    A buzzer-gpio mapping resource that relies on the user specifying in config varirable.
-    Usage of parameter: GPIO_BUZZER=name1:port1:enable_value1 name2:port2:enable_value2 ...
-    e.g. GPIO_BUZZER=buzzer1:498:0
+    This resource maps buzzer names to GPIO settings from the GPIO_BUZZER configuration variable.
+    Supported formats:
+    GPIO_BUZZER=name1:port1:enable_value1 name2:port2:enable_value2 ...
+    or GPIO_BUZZER=GPIO_line_name1:enable_value1 ...
+    The port can be either a legacy global GPIO number or a GPIO line name.
+    If a GPIO line name is missing or shown as "-" (unnamed), please file an issue and ask the customer to define a proper GPIO line name.
+    Example: GPIO_BUZZER=buzzer1:498:0 BUZZER_EN:1
 estimated_duration: 0.02
 category_id: buzzer
 plugin: resource
 environ: GPIO_BUZZER
 command:
     awk '{
-        split($0, record, " ")
-        for (i in record) {
+        count = split($0, record, " ")
+        for (i = 1; i <= count; i++) {
             split(record[i], data, ":")
-            printf "name: %s\nport: %s\nenable_value: %s\n", data[1], data[2], data[3]
+            if (length(data) == 2) {
+                # Example: BUZZER_EN:1
+                #   BUZZER_EN is the GPIO line name
+                #   You can find the name via /sys/kernel/debug/gpio or the gpioinfo command
+                port = data[1]
+                enable_value = data[2]
+            } else if (length(data) == 3) {
+                # Example: buzzer1:498:0
+                port = data[2]
+                enable_value = data[3]
+            }
+            printf "name: %s\nport: %s\nenable_value: %s\n\n", data[1], port, enable_value
         }
     }' <<< "$GPIO_BUZZER"
 


### PR DESCRIPTION
## Description

Support GPIO buzzer testing with gpiod line-name resolution while
keeping compatibility with legacy numeric sysfs environments.

- Prefer gpiod when required tools are available, and resolve the GPIO
target by line name.
- Fall back to sysfs only when gpiod tools are unavailable, and require
a numeric port for that fallback path.
- Keep gpioset process lifecycle cleanup to avoid leaving stale line
requests after exit.
- Keep GPIO_BUZZER parsing compatible with 2-field and 3-field inputs,
preserve input order, and emit blank-line-separated records for
template job expansion.

## Resolved issues

sysfs GPIO is not available for the target kernel path.

## Documentation

No gpiofind command in 2.2.1-3 gpiod deb package

```bash
ubuntu@ubuntu:/var/tmp/checkbox-providers$ gpioinfo --version
gpioinfo (libgpiod) v2.2.1
Copyright (C) 2017-2023 Bartosz Golaszewski
License: GPL-2.0-or-later
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

gpiod/resolute,now 2.2.1-3build1 arm64 [installed]
  Tools for interacting with Linux GPIO character device - binary

libgpiod3/resolute,now 2.2.1-3build1 arm64 [installed,automatic]
  C library for interacting with Linux GPIO device - shared libraries

ubuntu@ubuntu:/var/tmp/checkbox-providers$ gpio
gpiodetect  gpioget     gpioinfo    gpiomon     gpionotify  gpioset
```

```mermaid
flowchart TD
    A["Start buzzer_test.sh (GPIO mode)"] --> B["main -> setup_gpio_backend"]

    B --> C{"gpiod tools available?"}
    C -->|Yes| D{"resolve_gpio_by_name(port) success?"}
    D -->|No| D1["Fail: cannot resolve GPIO name"]
    D -->|Yes| E["Use gpiod backend (gpio_chip + gpio_offset)"]

    C -->|No| F["Fallback to sysfs GPIO export"]
    F --> G{"Port is numeric only?"}
    G -->|No| G1["Fail: GPIO name requires gpiod tools"]
    G -->|Yes| H{"sysfs /sys/class/gpio exists?"}
    H -->|No| H1["Fail: sysfs GPIO not available"]
    H -->|Yes| I["Use sysfs backend, export_gpio, set direction"]

    E --> J["Enable buzzer"]
    I --> J

    J --> K{"Backend is gpiod?"}
    K -->|Yes| L{"run_gpioset(enable) success?"}
    L -->|No| L1["Fail: unable to set GPIO"]
    L -->|Yes| M["Ask user: buzzer audible? (y/n)"]
    K -->|No| N["Write enable to sysfs value"]
    N --> M

    M --> O{"User answered y?"}
    O -->|No| O1["Result: FAILED"]
    O -->|Yes| P["Disable buzzer"]

    P --> Q{"Backend is gpiod?"}
    Q -->|Yes| R{"run_gpioset(disable) success?"}
    R -->|No| R1["Fail: unable to clear GPIO"]
    R -->|Yes| S["Ask user: buzzer stopped? (y/n)"]
    Q -->|No| T["Write disable to sysfs value"]
    T --> S

    S --> U{"User answered y?"}
    U -->|No| U1["Result: FAILED"]
    U -->|Yes| V["Result: PASSED"]

    D1 --> W["EXIT trap: cleanup_gpioset"]
    G1 --> W
    H1 --> W
    L1 --> W
    R1 --> W
    O1 --> W
    U1 --> W
    V --> W
    W --> END["End"]
```

## Tests

Submission: https://certification.canonical.com/hardware/202605-38787/submission/498126/test-results/?term=gpio-buzzer

env: GPIO_BUZZER=BUZZER_EN:1 FAKE_TEST:1
BUZZER_EN is real gpio buzzer to prove the pass scenraio
FAKE_TEST is dummy buzzer to prove the failed scenraio
```bash
ubuntu@ubuntu:/sys/devices$ sudo gpioinfo -c gpiochip15
gpiochip15 - 16 lines:
	line   0:	"5V_GOOD"       	input
	line   1:	"LVD"           	input
	line   2:	"BUZZER_EN"     	output
	line   3:	"4G_RST"        	input
	line   4:	"4G_LED"        	input
	line   5:	"USER_LED"      	input
	line   6:	unnamed         	input
	line   7:	unnamed         	input
	line   8:	unnamed         	input
	line   9:	unnamed         	input
	line  10:	unnamed         	input
	line  11:	unnamed         	input
	line  12:	unnamed         	input
	line  13:	unnamed         	input
	line  14:	unnamed         	input
	line  15:	unnamed         	input
```
