### PR TITLE
Use builtin sorted_keys insted of sort by hand (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/unit/unit.py
+++ b/checkbox-ng/plainbox/impl/unit/unit.py
@@ -953,11 +953,8 @@ class Unit(metaclass=UnitType):
         """
         Compute the value for :attr:`checksum`.
         """
-        # Ideally we'd use simplejson.dumps() with sorted keys to get
-        # predictable serialization but that's another dependency. To get
-        # something simple that is equally reliable, just sort all the keys
-        # manually and ask standard json to serialize that..
-        sorted_data = collections.OrderedDict(sorted(self._data.items()))
+        data = self._data.copy()
+
         # Define a helper function to convert symbols to strings for the
         # purpose of computing the checksum's canonical representation.
 
@@ -969,24 +966,27 @@ class Unit(metaclass=UnitType):
         # add a namespace iformation to the data, so same units located
         # in different providers won't clash
         if self._provider and self._provider.namespace:
-            sorted_data["namespace"] = self._provider.namespace
+            data["namespace"] = self._provider.namespace
         # Compute the canonical form which is arbitrarily defined as sorted
         # json text with default indent and separator settings.
         canonical_form = json.dumps(
-            sorted_data, indent=None, separators=(",", ":"), default=default_fn
+            data,
+            indent=None,
+            separators=(",", ":"),
+            default=default_fn,
+            sort_keys=True,
         )
         text = canonical_form.encode("UTF-8")
         # Parametric units also get a copy of their parameters stored as an
         # additional piece of data
         if self.is_parametric:
-            sorted_parameters = collections.OrderedDict(
-                sorted(self.parameters.items())
-            )
+            parameters = self.parameters.copy()
             canonical_parameters = json.dumps(
-                sorted_parameters,
+                parameters,
                 indent=None,
                 separators=(",", ":"),
                 default=default_fn,
+                sort_keys=True,
             )
             text += canonical_parameters.encode("UTF-8")
         # Compute the sha256 hash of the UTF-8 encoding of the canonical form


### PR DESCRIPTION


<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

OrderedDict doesn't work when there are nested collections (like in yaml siblings) so the checksum can mismatch on older python versions

## Resolved issues

Fixes: CHECKBOX-2314

## Documentation

N/A

## Tests

N/A
