### PR TITLE
Apply blocker to fwts critical only tests in 26.04 stress tests (New)

### DIFF
--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -34,7 +34,6 @@ flags:
 summary: Generate an ID for each reboot iteration
 ---
 id: init-boot-loop-data
-certification-status: blocker
 category_id: com.canonical.plainbox::stress
 summary: Generate the baseline data set to test against
 purpose: |
@@ -56,7 +55,6 @@ flags:
   - preserve-locale
 ---
 id: cold-boot-loop-reboot-1
-certification-status: blocker
 category_id: stress-tests/cold-boot
 summary: Perform cold reboot 1
 unit: job
@@ -82,7 +80,6 @@ depends:
   - init-boot-loop-data
 ---
 id: cold-boot-loop-reboot-{reboot_id}
-certification-status: blocker
 template-id: cold-boot-loop-reboot-reboot_id
 category_id: stress-tests/cold-boot
 summary: Perform cold reboot {reboot_id}
@@ -134,10 +131,9 @@ command: >-
   -t oops
   -f critical
   -l "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-1/fwts-critical-only.log
-certification-status: blocker
 siblings:
   - id: cold-boot-loop-1-fwts-all
-    certification-status: non-blocker
+  
     summary: Cold boot 1 FWTS test (all levels)
     # since we are only checking klog and oops
     # it's safe to do duplicate work and run fwts again
@@ -169,7 +165,6 @@ depends:
   - cold-boot-loop-reboot-1
 ---
 id: cold-boot-loop-{reboot_id}-fwts-critical-only
-certification-status: blocker
 template-id: cold-boot-loop-reboot_id-fwts-critical-only
 category_id: stress-tests/cold-boot
 summary: Cold boot {reboot_id} FWTS test (only fail at critical errors)
@@ -195,7 +190,6 @@ depends:
   - cold-boot-loop-reboot-{reboot_id}
 ---
 id: cold-boot-loop-{reboot_id}-fwts-all
-certification-status: non-blocker
 template-id: cold-boot-loop-reboot_id-fwts-all
 category_id: stress-tests/cold-boot
 summary: Cold boot {reboot_id} FWTS test (all levels)
@@ -221,7 +215,6 @@ depends:
   - cold-boot-loop-reboot-{reboot_id}
 ---
 id: cold-boot-loop-{reboot_id}-device-check
-certification-status: blocker
 template-id: cold-boot-loop-reboot_id-device-check
 category_id: stress-tests/cold-boot
 summary: Cold boot {reboot_id} device difference check
@@ -243,7 +236,6 @@ depends:
   - cold-boot-loop-reboot-{reboot_id}
 ---
 id: cold-boot-loop-{reboot_id}-service-check
-certification-status: blocker
 template-id: cold-boot-loop-reboot_id-service-check
 category_id: stress-tests/cold-boot
 summary: Cold boot {reboot_id} failed services check
@@ -263,7 +255,6 @@ depends:
   - cold-boot-loop-reboot-{reboot_id}
 ---
 id: cold-boot-loop-{reboot_id}-hardware-renderer-check
-certification-status: blocker
 template-id: cold-boot-loop-hardware-renderer-check-reboot_id
 category_id: stress-tests/cold-boot
 summary: Cold boot {reboot_id} hardware renderer check
@@ -283,7 +274,6 @@ depends:
   - cold-boot-loop-reboot-{reboot_id}
 ---
 id: warm-boot-loop-reboot-1
-certification-status: blocker
 category_id: stress-tests/warm-boot
 summary: Perform warm reboot 1
 purpose: Perform warm reboot of the system boot. Specifically, this is how the device will request a reboot.
@@ -299,7 +289,6 @@ depends:
   - init-boot-loop-data
 ---
 id: warm-boot-loop-reboot-{reboot_id}
-certification-status: blocker
 template-id: warm-boot-loop-reboot-reboot_id
 category_id: stress-tests/warm-boot
 summary: Perform warm reboot {reboot_id}
@@ -330,7 +319,6 @@ depends:
   - init-boot-loop-data
 ---
 id: warm-boot-loop-1-fwts-critical-only
-certification-status: blocker
 category_id: stress-tests/warm-boot
 summary: Warm boot 1 FWTS test (only fail at critical errors)
 purpose: Compare data after warm boot with baseline data set
@@ -357,7 +345,6 @@ siblings:
       -t oops
       -f aborted 
       -l "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-1/fwts-all.log
-    certification-status: non-blocker
   - id: warm-boot-loop-1-hardware-renderer-check
     summary: Warm boot 1 hardware renderer check
     command: reboot_check_test.py -g
@@ -378,7 +365,6 @@ depends:
   - warm-boot-loop-reboot-1
 ---
 id: warm-boot-loop-{reboot_id}-fwts-critical-only
-certification-status: blocker
 template-id: warm-boot-loop-reboot_id-fwts-critical-only
 category_id: stress-tests/warm-boot
 summary: Warm boot {reboot_id} FWTS test (only fail at critical errors)
@@ -405,7 +391,6 @@ depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
 id: warm-boot-loop-{reboot_id}-fwts-all
-certification-status: non-blocker
 template-id: warm-boot-loop-reboot_id-fwts-all
 category_id: stress-tests/warm-boot
 summary: Warm boot {reboot_id} FWTS test (all levels)
@@ -432,7 +417,6 @@ depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
 id: warm-boot-loop-{reboot_id}-device-check
-certification-status: blocker
 template-id: warm-boot-loop-reboot_id-device-check
 category_id: stress-tests/warm-boot
 summary: Warm boot {reboot_id} device difference check
@@ -454,7 +438,6 @@ depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
 id: warm-boot-loop-{reboot_id}-service-check
-certification-status: blocker
 template-id: warm-boot-loop-reboot_id-service-check
 category_id: stress-tests/warm-boot
 summary: Warm boot {reboot_id} failed services check
@@ -474,7 +457,6 @@ depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
 id: warm-boot-loop-{reboot_id}-hardware-renderer-check
-certification-status: blocker
 template-id: warm-boot-loop-hardware-renderer-check-reboot_id
 category_id: stress-tests/warm-boot
 summary: Warm boot {reboot_id} hardware renderer check

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -107,7 +107,8 @@ flags:
   - noreturn
 estimated_duration: "180.0"
 after:
-  - cold-boot-loop-{reboot_id_previous}-fwts-test
+  - cold-boot-loop-{reboot_id_previous}-fwts-critical-only
+  - cold-boot-loop-{reboot_id_previous}-fwts-all
   - cold-boot-loop-{reboot_id_previous}-device-check
   - cold-boot-loop-{reboot_id_previous}-service-check
   - cold-boot-loop-{reboot_id_previous}-hardware-renderer-check
@@ -307,7 +308,8 @@ flags:
   - noreturn
 estimated_duration: "60.0"
 after:
-  - warm-boot-loop-{reboot_id_previous}-fwts-test
+  - warm-boot-loop-{reboot_id_previous}-fwts-critical-only
+  - warm-boot-loop-{reboot_id_previous}-fwts-all
   - warm-boot-loop-{reboot_id_previous}-device-check
   - warm-boot-loop-{reboot_id_previous}-service-check
   - warm-boot-loop-{reboot_id_previous}-hardware-renderer-check

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -185,7 +185,10 @@ flags:
   - noreturn
 estimated_duration: "60.0"
 after:
-  - warm-boot-loop-test-{reboot_id_previous}
+  - warm-boot-loop-{reboot_id_previous}-fwts-test
+  - warm-boot-loop-{reboot_id_previous}-device-check
+  - warm-boot-loop-{reboot_id_previous}-service-check
+  - warm-boot-loop-{reboot_id_previous}-hardware-renderer-check
 depends:
   - init-boot-loop-data
 ---
@@ -219,8 +222,8 @@ estimated_duration: "1.0"
 depends:
   - warm-boot-loop-reboot-1
 ---
-id: warm-boot-loop-fwts-test-{reboot_id}
-template-id: warm-boot-loop-fwts-test-reboot_id
+id: warm-boot-loop-{reboot_id}-fwts-test
+template-id: warm-boot-loop-reboot_id-fwts-test
 category_id: stress-tests/warm-boot
 summary: Warm boot FWTS test {reboot_id}
 purpose: Compare data after a warm boot with baseline data set
@@ -230,8 +233,6 @@ template-unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-#  reboot_check_test.py -g -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d
-#"$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}" -s -f
 command: reboot_check_test.py -f
 user: root
 flags:
@@ -240,8 +241,8 @@ estimated_duration: "1.0"
 depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
-id: warm-boot-loop-device-check-{reboot_id}
-template-id: warm-boot-loop-device-check-reboot_id
+id: warm-boot-loop-{reboot_id}-device-check
+template-id: warm-boot-loop-reboot_id-device-check
 category_id: stress-tests/warm-boot
 summary: Warm boot device comparison test {reboot_id}
 unit: template
@@ -261,8 +262,8 @@ estimated_duration: "1.0"
 depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
-id: warm-boot-loop-service-check-{reboot_id}
-template-id: warm-boot-loop-service-check-reboot_id
+id: warm-boot-loop-{reboot_id}-service-check
+template-id: warm-boot-loop-reboot_id-service-check
 category_id: stress-tests/warm-boot
 summary: Check failed services after warm reboot {reboot_id}
 unit: template
@@ -280,7 +281,7 @@ estimated_duration: "1.0"
 depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
-id: warm-boot-loop-hardware-renderer-check-{reboot_id}
+id: warm-boot-loop-{reboot_id}-hardware-renderer-check
 template-id: warm-boot-loop-hardware-renderer-check-reboot_id
 category_id: stress-tests/warm-boot
 summary: Check that the desktop is hardware-rendered after warm reboot {reboot_id}

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -203,7 +203,7 @@ command: >-
   checkbox-support-fwts_test
   -t klog
   -t oops
-  -l $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}/fwts-critical-only.log
+  -l $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}/fwts-all.log
 user: root
 flags:
   - preserve-locale
@@ -388,7 +388,7 @@ depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
 id: warm-boot-loop-{reboot_id}-fwts-all
-template-id: warm-boot-loop-reboot_id-fwts-critical-only
+template-id: warm-boot-loop-reboot_id-fwts-all
 category_id: stress-tests/warm-boot
 summary: Warm boot {reboot_id} FWTS test (all levels) 
 purpose: Compare data after a warm boot with baseline data set

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -34,6 +34,7 @@ flags:
 summary: Generate an ID for each reboot iteration
 ---
 id: init-boot-loop-data
+certification-status: blocker
 category_id: com.canonical.plainbox::stress
 summary: Generate the baseline data set to test against
 purpose: |

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -225,7 +225,7 @@ depends:
 id: warm-boot-loop-{reboot_id}-fwts-test
 template-id: warm-boot-loop-reboot_id-fwts-test
 category_id: stress-tests/warm-boot
-summary: Warm boot FWTS test {reboot_id}
+summary: Warm boot {reboot_id} FWTS test
 purpose: Compare data after a warm boot with baseline data set
 unit: template
 template-resource: reboot-run-generator
@@ -244,7 +244,7 @@ depends:
 id: warm-boot-loop-{reboot_id}-device-check
 template-id: warm-boot-loop-reboot_id-device-check
 category_id: stress-tests/warm-boot
-summary: Warm boot device comparison test {reboot_id}
+summary: Warm boot {reboot_id} device difference check
 unit: template
 template-resource: reboot-run-generator
 template-unit: job
@@ -265,7 +265,7 @@ depends:
 id: warm-boot-loop-{reboot_id}-service-check
 template-id: warm-boot-loop-reboot_id-service-check
 category_id: stress-tests/warm-boot
-summary: Check failed services after warm reboot {reboot_id}
+summary: Warm boot {reboot_id} failed services check
 unit: template
 template-resource: reboot-run-generator
 template-unit: job
@@ -284,7 +284,7 @@ depends:
 id: warm-boot-loop-{reboot_id}-hardware-renderer-check
 template-id: warm-boot-loop-hardware-renderer-check-reboot_id
 category_id: stress-tests/warm-boot
-summary: Check that the desktop is hardware-rendered after warm reboot {reboot_id}
+summary: Warm boot {reboot_id} hardware renderer check
 unit: template
 template-resource: reboot-run-generator
 template-unit: job

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -189,7 +189,7 @@ after:
 depends:
   - init-boot-loop-data
 ---
-id: warm-boot-loop-fwts-test-1
+id: warm-boot-loop-1-fwts-test
 category_id: stress-tests/warm-boot
 summary: Warm boot system configuration test 1
 purpose: Compare data after warm boot with baseline data set
@@ -202,9 +202,9 @@ certification-status: blocker
 siblings:
   - id: warm-boot-loop-1-hardware-renderer-check
     command: reboot_check_test.py -g
-  - id: warm-boot-loop-1-hardware-service-check
+  - id: warm-boot-loop-1-service-check
     command: reboot_check_test.py -s
-  - id: warm-boot-loop-1-hardware-device-check
+  - id: warm-boot-loop-1-device-check
     command: >-
       reboot_check_test.py 
       -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
@@ -216,10 +216,10 @@ estimated_duration: "1.0"
 depends:
   - warm-boot-loop-reboot-1
 ---
-id: warm-boot-loop-test-{reboot_id}
-template-id: warm-boot-loop-test-reboot_id
+id: warm-boot-loop-fwts-test-{reboot_id}
+template-id: warm-boot-loop-fwts-test-reboot_id
 category_id: stress-tests/warm-boot
-summary: Warm boot system configuration test {reboot_id}
+summary: Warm boot FWTS test {reboot_id}
 purpose: Compare data after a warm boot with baseline data set
 unit: template
 template-resource: reboot-run-generator
@@ -227,8 +227,68 @@ template-unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -g -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d
-  "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}" -s -f
+#  reboot_check_test.py -g -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d
+#"$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}" -s -f
+command: reboot_check_test.py -f
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - warm-boot-loop-reboot-{reboot_id}
+---
+id: warm-boot-loop-device-check-{reboot_id}
+template-id: warm-boot-loop-device-check-reboot_id
+category_id: stress-tests/warm-boot
+summary: Warm boot device comparison test {reboot_id}
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  reboot_check_test.py 
+  -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
+  -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}"
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - warm-boot-loop-reboot-{reboot_id}
+---
+id: warm-boot-loop-service-check-{reboot_id}
+template-id: warm-boot-loop-service-check-reboot_id
+category_id: stress-tests/warm-boot
+summary: Check failed services after warm reboot {reboot_id}
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  reboot_check_test.py -s
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - warm-boot-loop-reboot-{reboot_id}
+---
+id: warm-boot-loop-hardware-renderer-check-{reboot_id}
+template-id:  warm-boot-loop-hardware-renderer-check-reboot_id
+category_id: stress-tests/warm-boot
+summary: Check that the desktop is hardware-rendered after warm reboot {reboot_id}
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  reboot_check_test.py -g
 user: root
 flags:
   - preserve-locale

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -107,20 +107,36 @@ flags:
   - noreturn
 estimated_duration: "180.0"
 after:
-  - cold-boot-loop-test-{reboot_id_previous}
+  - cold-boot-loop-{reboot_id_previous}-fwts-test
+  - cold-boot-loop-{reboot_id_previous}-device-check
+  - cold-boot-loop-{reboot_id_previous}-service-check
+  - cold-boot-loop-{reboot_id_previous}-hardware-renderer-check
 depends:
   - init-boot-loop-data
 ---
-id: cold-boot-loop-test-1
+id: cold-boot-loop-1-fwts-test
 category_id: stress-tests/cold-boot
-summary: Cold boot system configuration test 1
-purpose: Compare the data after waking up the system with the base data set
+summary: Cold boot 1 FWTS test
+purpose: Compare data after cold boot with baseline data set
 unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -g -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d
-  "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1" -s -f
+command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1"
+certification-status: blocker
+siblings:
+  - id: cold-boot-loop-1-hardware-renderer-check
+    summary: Cold boot 1 hardware renderer check
+    command: reboot_check_test.py -g
+  - id: cold-boot-loop-1-service-check
+    summary: Cold boot 1 failed services check
+    command: reboot_check_test.py -s
+  - id: cold-boot-loop-1-device-check
+    summary: Cold boot 1 device difference check
+    command: >-
+      reboot_check_test.py 
+      -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
+      -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1"
 user: root
 flags:
   - preserve-locale
@@ -128,19 +144,77 @@ estimated_duration: "1.0"
 depends:
   - cold-boot-loop-reboot-1
 ---
-id: cold-boot-loop-test-{reboot_id}
-template-id: cold-boot-loop-test-reboot_id
+id: cold-boot-loop-{reboot_id}-fwts-test
+template-id: cold-boot-loop-reboot_id-fwts-test
 category_id: stress-tests/cold-boot
-summary: Cold boot system configuration test {reboot_id}
-purpose: Compare the data after cold booting up the system with the base data set
+summary: Cold boot {reboot_id} FWTS test
+purpose: Compare data after a cold boot with baseline data set
 unit: template
 template-resource: reboot-run-generator
 template-unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -g -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d
-  "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}" -s -f
+command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}"
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - cold-boot-loop-reboot-{reboot_id}
+---
+id: cold-boot-loop-{reboot_id}-device-check
+template-id: cold-boot-loop-reboot_id-device-check
+category_id: stress-tests/cold-boot
+summary: Cold boot {reboot_id} device difference check
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  reboot_check_test.py 
+  -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
+  -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}"
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - cold-boot-loop-reboot-{reboot_id}
+---
+id: cold-boot-loop-{reboot_id}-service-check
+template-id: cold-boot-loop-reboot_id-service-check
+category_id: stress-tests/cold-boot
+summary: Cold boot {reboot_id} failed services check
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  reboot_check_test.py -s
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - cold-boot-loop-reboot-{reboot_id}
+---
+id: cold-boot-loop-{reboot_id}-hardware-renderer-check
+template-id: cold-boot-loop-hardware-renderer-check-reboot_id
+category_id: stress-tests/cold-boot
+summary: Cold boot {reboot_id} hardware renderer check
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  reboot_check_test.py -g
 user: root
 flags:
   - preserve-locale

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -355,8 +355,8 @@ siblings:
     summary: Warm boot 1 device difference check
     command: >-
       reboot_check_test.py 
-      -c ""$PLAINBOX_SESSION_SHARE"/before_reboot" 
-      -d ""$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-1"
+      -c "$PLAINBOX_SESSION_SHARE"/before_reboot
+      -d "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-1
 user: root
 flags:
   - preserve-locale

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -46,7 +46,7 @@ imports:
   - from com.canonical.plainbox import manifest
 requires:
   - manifest._ignore_reboot_loop_tests == 'False'
-command: reboot_check_test.py -d "$PLAINBOX_SESSION_SHARE/before_reboot"
+command: reboot_check_test.py -d "$PLAINBOX_SESSION_SHARE"/before_reboot
 environ:
   - LD_LIBRARY_PATH
 user: root
@@ -124,13 +124,13 @@ plugin: shell
 environ:
   - LD_LIBRARY_PATH
 command: >-
-  mkdir -p $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1
+  mkdir -p "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-1
 
   checkbox-support-fwts_test
   -t klog
   -t oops
   -f critical
-  -l $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1/fwts-critical-only.log
+  -l "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-1/fwts-critical-only.log
 certification-status: blocker
 siblings:
   - id: cold-boot-loop-1-fwts-all
@@ -139,13 +139,13 @@ siblings:
     # since we are only checking klog and oops
     # it's safe to do duplicate work and run fwts again
     command: >-
-      mkdir -p $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1
+      mkdir -p "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-1
 
       checkbox-support-fwts_test 
       -t klog 
       -t oops
       -f aborted
-      -l $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1/fwts-all.log
+      -l "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-1/fwts-all.log
   - id: cold-boot-loop-1-hardware-renderer-check
     summary: Cold boot 1 hardware renderer check
     command: reboot_check_test.py -g
@@ -156,8 +156,8 @@ siblings:
     summary: Cold boot 1 device difference check
     command: >-
       reboot_check_test.py 
-      -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
-      -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1"
+      -c "$PLAINBOX_SESSION_SHARE"/before_reboot
+      -d "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-1
 user: root
 flags:
   - preserve-locale
@@ -177,13 +177,13 @@ plugin: shell
 environ:
   - LD_LIBRARY_PATH
 command: >-
-  mkdir -p $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}
+  mkdir -p "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-{reboot_id}
 
   checkbox-support-fwts_test
   -t klog
   -t oops
   -f critical
-  -l $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}/fwts-critical-only.log
+  -l "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-{reboot_id}/fwts-critical-only.log
 user: root
 flags:
   - preserve-locale
@@ -203,13 +203,13 @@ plugin: shell
 environ:
   - LD_LIBRARY_PATH
 command: >- # 'aborted' is the lowest non-warning level
-  mkdir -p $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}
+  mkdir -p "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-{reboot_id}
 
   checkbox-support-fwts_test
   -t klog
   -t oops
   -f aborted 
-  -l $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}/fwts-all.log
+  -l "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-{reboot_id}/fwts-all.log
 user: root
 flags:
   - preserve-locale
@@ -230,8 +230,8 @@ environ:
   - LD_LIBRARY_PATH
 command: >-
   reboot_check_test.py 
-  -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
-  -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}"
+  -c "$PLAINBOX_SESSION_SHARE"/before_reboot
+  -d "$PLAINBOX_SESSION_SHARE"/cold_reboot_cycle-{reboot_id}
 user: root
 flags:
   - preserve-locale
@@ -334,13 +334,13 @@ plugin: shell
 environ:
   - LD_LIBRARY_PATH
 command: >-
-  mkdir -p $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1
+  mkdir -p "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-1
 
   checkbox-support-fwts_test
   -t klog
   -t oops
   -f critical
-  -l $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1/fwts-critical-only.log
+  -l "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-1/fwts-critical-only.log
 siblings:
   - id: warm-boot-loop-1-fwts-all
     summary: Warm boot 1 FWTS test (all levels)
@@ -351,7 +351,7 @@ siblings:
       -t klog
       -t oops
       -f aborted 
-      -l $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1/fwts-all.log
+      -l "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-1/fwts-all.log
     certification-status: non-blocker
   - id: warm-boot-loop-1-hardware-renderer-check
     summary: Warm boot 1 hardware renderer check
@@ -363,8 +363,8 @@ siblings:
     summary: Warm boot 1 device difference check
     command: >-
       reboot_check_test.py 
-      -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
-      -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1"
+      -c ""$PLAINBOX_SESSION_SHARE"/before_reboot" 
+      -d ""$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-1"
 user: root
 flags:
   - preserve-locale
@@ -385,13 +385,13 @@ plugin: shell
 environ:
   - LD_LIBRARY_PATH
 command: >-
-  mkdir -p $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}
+  mkdir -p "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-{reboot_id}
 
   checkbox-support-fwts_test
   -t klog
   -t oops
   -f critical
-  -l $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}/fwts-critical-only.log
+  -l "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-{reboot_id}/fwts-critical-only.log
 user: root
 flags:
   - preserve-locale
@@ -412,13 +412,13 @@ plugin: shell
 environ:
   - LD_LIBRARY_PATH
 command: >-
-  mkdir -p $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}
+  mkdir -p "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-{reboot_id}
 
   checkbox-support-fwts_test
   -t klog
   -t oops
   -f aborted 
-  -l $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}/fwts-all.log
+  -l "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-{reboot_id}/fwts-all.log
 user: root
 flags:
   - preserve-locale
@@ -439,8 +439,8 @@ environ:
   - LD_LIBRARY_PATH
 command: >-
   reboot_check_test.py 
-  -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
-  -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}"
+  -c "$PLAINBOX_SESSION_SHARE"/before_reboot
+  -d "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-{reboot_id}
 user: root
 flags:
   - preserve-locale

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -191,7 +191,7 @@ depends:
 ---
 id: warm-boot-loop-1-fwts-test
 category_id: stress-tests/warm-boot
-summary: Warm boot system configuration test 1
+summary: Warm boot 1 FWTS test
 purpose: Compare data after warm boot with baseline data set
 unit: job
 plugin: shell
@@ -201,10 +201,13 @@ command: reboot_check_test.py -f
 certification-status: blocker
 siblings:
   - id: warm-boot-loop-1-hardware-renderer-check
+    summary: Warm boot 1 hardware renderer check
     command: reboot_check_test.py -g
   - id: warm-boot-loop-1-service-check
+    summary: Warm boot 1 failed services check
     command: reboot_check_test.py -s
   - id: warm-boot-loop-1-device-check
+    summary: Warm boot 1 device difference check
     command: >-
       reboot_check_test.py 
       -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
@@ -278,7 +281,7 @@ depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
 id: warm-boot-loop-hardware-renderer-check-{reboot_id}
-template-id:  warm-boot-loop-hardware-renderer-check-reboot_id
+template-id: warm-boot-loop-hardware-renderer-check-reboot_id
 category_id: stress-tests/warm-boot
 summary: Check that the desktop is hardware-rendered after warm reboot {reboot_id}
 unit: template

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -134,6 +134,7 @@ command: >-
 certification-status: blocker
 siblings:
   - id: cold-boot-loop-1-fwts-all
+    certification-status: non-blocker
     summary: Cold boot 1 FWTS test (all levels)
     # since we are only checking klog and oops
     # it's safe to do duplicate work and run fwts again
@@ -189,6 +190,7 @@ depends:
   - cold-boot-loop-reboot-{reboot_id}
 ---
 id: cold-boot-loop-{reboot_id}-fwts-all
+certification-status: non-blocker
 template-id: cold-boot-loop-reboot_id-fwts-all
 category_id: stress-tests/cold-boot
 summary: Cold boot {reboot_id} FWTS test (all levels)
@@ -344,6 +346,7 @@ siblings:
       -t oops
       -f critical
       -l $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1/fwts-all.log
+    certification-status: non-blocker
   - id: warm-boot-loop-1-hardware-renderer-check
     summary: Warm boot 1 hardware renderer check
     command: reboot_check_test.py -g
@@ -390,6 +393,7 @@ depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
 id: warm-boot-loop-{reboot_id}-fwts-all
+certification-status: non-blocker
 template-id: warm-boot-loop-reboot_id-fwts-all
 category_id: stress-tests/warm-boot
 summary: Warm boot {reboot_id} FWTS test (all levels) 

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -144,6 +144,7 @@ siblings:
       checkbox-support-fwts_test 
       -t klog 
       -t oops
+      -f aborted
       -l $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1/fwts-all.log
   - id: cold-boot-loop-1-hardware-renderer-check
     summary: Cold boot 1 hardware renderer check
@@ -200,12 +201,13 @@ template-unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: >-
+command: >- # 'aborted' is the lowest non-warning level
   mkdir -p $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}
 
   checkbox-support-fwts_test
   -t klog
   -t oops
+  -f aborted 
   -l $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}/fwts-all.log
 user: root
 flags:
@@ -340,11 +342,11 @@ siblings:
     summary: Warm boot 1 FWTS test (all levels)
     command: >-
       mkdir -p $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1
-      
+
       checkbox-support-fwts_test
       -t klog
       -t oops
-      -f critical
+      -f aborted 
       -l $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1/fwts-all.log
     certification-status: non-blocker
   - id: warm-boot-loop-1-hardware-renderer-check
@@ -369,7 +371,7 @@ depends:
 id: warm-boot-loop-{reboot_id}-fwts-critical-only
 template-id: warm-boot-loop-reboot_id-fwts-critical-only
 category_id: stress-tests/warm-boot
-summary: Warm boot {reboot_id} FWTS test (only fail at critical errors) 
+summary: Warm boot {reboot_id} FWTS test (only fail at critical errors)
 purpose: Compare data after a warm boot with baseline data set
 unit: template
 template-resource: reboot-run-generator
@@ -396,7 +398,7 @@ id: warm-boot-loop-{reboot_id}-fwts-all
 certification-status: non-blocker
 template-id: warm-boot-loop-reboot_id-fwts-all
 category_id: stress-tests/warm-boot
-summary: Warm boot {reboot_id} FWTS test (all levels) 
+summary: Warm boot {reboot_id} FWTS test (all levels)
 purpose: Compare data after a warm boot with baseline data set
 unit: template
 template-resource: reboot-run-generator
@@ -410,6 +412,7 @@ command: >-
   checkbox-support-fwts_test
   -t klog
   -t oops
+  -f aborted 
   -l $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}/fwts-all.log
 user: root
 flags:

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -31,7 +31,7 @@ command: |
 estimated_duration: 1s
 flags:
   - preserve-locale
-summary: Generates IDs for each iteration of reboot tests based on the specified number of iterations.
+summary: Generate an ID for each reboot iteration
 ---
 id: init-boot-loop-data
 category_id: com.canonical.plainbox::stress

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -338,7 +338,7 @@ siblings:
   - id: warm-boot-loop-1-fwts-all
     summary: Warm boot 1 FWTS test (all levels)
     command: >-
-      mkdir -p $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1
+      mkdir -p "$PLAINBOX_SESSION_SHARE"/warm_reboot_cycle-1
 
       checkbox-support-fwts_test
       -t klog

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -114,16 +114,35 @@ after:
 depends:
   - init-boot-loop-data
 ---
-id: cold-boot-loop-1-fwts-test
+id: cold-boot-loop-1-fwts-critical-only
 category_id: stress-tests/cold-boot
-summary: Cold boot 1 FWTS test
+summary: Cold boot 1 FWTS test (only fail at critical errors)
+purpose: Compare data after cold boot with baseline data set
 unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1"
+command: >-
+  mkdir -p $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1
+
+  checkbox-support-fwts_test
+  -t klog
+  -t oops
+  -f critical
+  -l $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1/fwts-critical-only.log
 certification-status: blocker
 siblings:
+  - id: cold-boot-loop-1-fwts-all
+    summary: Cold boot 1 FWTS test (all levels)
+    # since we are only checking klog and oops
+    # it's safe to do duplicate work and run fwts again
+    command: >-
+      mkdir -p $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1
+
+      checkbox-support-fwts_test 
+      -t klog 
+      -t oops
+      -l $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1/fwts-all.log
   - id: cold-boot-loop-1-hardware-renderer-check
     summary: Cold boot 1 hardware renderer check
     command: reboot_check_test.py -g
@@ -143,17 +162,48 @@ estimated_duration: "1.0"
 depends:
   - cold-boot-loop-reboot-1
 ---
-id: cold-boot-loop-{reboot_id}-fwts-test
-template-id: cold-boot-loop-reboot_id-fwts-test
+id: cold-boot-loop-{reboot_id}-fwts-critical-only
+template-id: cold-boot-loop-reboot_id-fwts-critical-only
 category_id: stress-tests/cold-boot
-summary: Cold boot {reboot_id} FWTS test
+summary: Cold boot {reboot_id} FWTS test (only fail at critical errors)
 unit: template
 template-resource: reboot-run-generator
 template-unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}"
+command: >-
+  mkdir -p $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}
+
+  checkbox-support-fwts_test
+  -t klog
+  -t oops
+  -f critical
+  -l $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}/fwts-critical-only.log
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - cold-boot-loop-reboot-{reboot_id}
+---
+id: cold-boot-loop-{reboot_id}-fwts-all
+template-id: cold-boot-loop-reboot_id-fwts-all
+category_id: stress-tests/cold-boot
+summary: Cold boot {reboot_id} FWTS test (all levels)
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  mkdir -p $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}
+
+  checkbox-support-fwts_test
+  -t klog
+  -t oops
+  -l $PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}/fwts-critical-only.log
 user: root
 flags:
   - preserve-locale
@@ -264,16 +314,34 @@ after:
 depends:
   - init-boot-loop-data
 ---
-id: warm-boot-loop-1-fwts-test
+id: warm-boot-loop-1-fwts-critical-only
 category_id: stress-tests/warm-boot
-summary: Warm boot 1 FWTS test
+summary: Warm boot 1 FWTS test (only fail at critical errors)
+purpose: Compare data after warm boot with baseline data set
 unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1"
+command: >-
+  mkdir -p $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1
+
+  checkbox-support-fwts_test
+  -t klog
+  -t oops
+  -f critical
+  -l $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1/fwts-critical-only.log
 certification-status: blocker
 siblings:
+  - id: warm-boot-loop-1-fwts-all
+    summary: Warm boot 1 FWTS test (all levels)
+    command: >-
+      mkdir -p $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1
+      
+      checkbox-support-fwts_test
+      -t klog
+      -t oops
+      -f critical
+      -l $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1/fwts-all.log
   - id: warm-boot-loop-1-hardware-renderer-check
     summary: Warm boot 1 hardware renderer check
     command: reboot_check_test.py -g
@@ -293,17 +361,50 @@ estimated_duration: "1.0"
 depends:
   - warm-boot-loop-reboot-1
 ---
-id: warm-boot-loop-{reboot_id}-fwts-test
-template-id: warm-boot-loop-reboot_id-fwts-test
+id: warm-boot-loop-{reboot_id}-fwts-critical-only
+template-id: warm-boot-loop-reboot_id-fwts-critical-only
 category_id: stress-tests/warm-boot
-summary: Warm boot {reboot_id} FWTS test
+summary: Warm boot {reboot_id} FWTS test (only fail at critical errors) 
+purpose: Compare data after a warm boot with baseline data set
 unit: template
 template-resource: reboot-run-generator
 template-unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}"
+command: >-
+  mkdir -p $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}
+
+  checkbox-support-fwts_test
+  -t klog
+  -t oops
+  -f critical
+  -l $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}/fwts-critical-only.log
+user: root
+flags:
+  - preserve-locale
+estimated_duration: "1.0"
+depends:
+  - warm-boot-loop-reboot-{reboot_id}
+---
+id: warm-boot-loop-{reboot_id}-fwts-all
+template-id: warm-boot-loop-reboot_id-fwts-critical-only
+category_id: stress-tests/warm-boot
+summary: Warm boot {reboot_id} FWTS test (all levels) 
+purpose: Compare data after a warm boot with baseline data set
+unit: template
+template-resource: reboot-run-generator
+template-unit: job
+plugin: shell
+environ:
+  - LD_LIBRARY_PATH
+command: >-
+  mkdir -p $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}
+
+  checkbox-support-fwts_test
+  -t klog
+  -t oops
+  -l $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}/fwts-all.log
 user: root
 flags:
   - preserve-locale

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -189,7 +189,7 @@ after:
 depends:
   - init-boot-loop-data
 ---
-id: warm-boot-loop-test-1
+id: warm-boot-loop-fwts-test-1
 category_id: stress-tests/warm-boot
 summary: Warm boot system configuration test 1
 purpose: Compare data after warm boot with baseline data set
@@ -197,8 +197,18 @@ unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -g -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d
-  "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1" -s -f
+command: reboot_check_test.py -f
+certification-status: blocker
+siblings:
+  - id: warm-boot-loop-1-hardware-renderer-check
+    command: reboot_check_test.py -g
+  - id: warm-boot-loop-1-hardware-service-check
+    command: reboot_check_test.py -s
+  - id: warm-boot-loop-1-hardware-device-check
+    command: >-
+      reboot_check_test.py 
+      -c "$PLAINBOX_SESSION_SHARE/before_reboot" 
+      -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1"
 user: root
 flags:
   - preserve-locale

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -117,7 +117,6 @@ depends:
 id: cold-boot-loop-1-fwts-test
 category_id: stress-tests/cold-boot
 summary: Cold boot 1 FWTS test
-purpose: Compare data after cold boot with baseline data set
 unit: job
 plugin: shell
 environ:
@@ -148,7 +147,6 @@ id: cold-boot-loop-{reboot_id}-fwts-test
 template-id: cold-boot-loop-reboot_id-fwts-test
 category_id: stress-tests/cold-boot
 summary: Cold boot {reboot_id} FWTS test
-purpose: Compare data after a cold boot with baseline data set
 unit: template
 template-resource: reboot-run-generator
 template-unit: job
@@ -269,7 +267,6 @@ depends:
 id: warm-boot-loop-1-fwts-test
 category_id: stress-tests/warm-boot
 summary: Warm boot 1 FWTS test
-purpose: Compare data after warm boot with baseline data set
 unit: job
 plugin: shell
 environ:
@@ -300,7 +297,6 @@ id: warm-boot-loop-{reboot_id}-fwts-test
 template-id: warm-boot-loop-reboot_id-fwts-test
 category_id: stress-tests/warm-boot
 summary: Warm boot {reboot_id} FWTS test
-purpose: Compare data after a warm boot with baseline data set
 unit: template
 template-resource: reboot-run-generator
 template-unit: job

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -166,6 +166,7 @@ depends:
   - cold-boot-loop-reboot-1
 ---
 id: cold-boot-loop-{reboot_id}-fwts-critical-only
+certification-status: blocker
 template-id: cold-boot-loop-reboot_id-fwts-critical-only
 category_id: stress-tests/cold-boot
 summary: Cold boot {reboot_id} FWTS test (only fail at critical errors)
@@ -217,6 +218,7 @@ depends:
   - cold-boot-loop-reboot-{reboot_id}
 ---
 id: cold-boot-loop-{reboot_id}-device-check
+certification-status: blocker
 template-id: cold-boot-loop-reboot_id-device-check
 category_id: stress-tests/cold-boot
 summary: Cold boot {reboot_id} device difference check
@@ -238,6 +240,7 @@ depends:
   - cold-boot-loop-reboot-{reboot_id}
 ---
 id: cold-boot-loop-{reboot_id}-service-check
+certification-status: blocker
 template-id: cold-boot-loop-reboot_id-service-check
 category_id: stress-tests/cold-boot
 summary: Cold boot {reboot_id} failed services check
@@ -257,6 +260,7 @@ depends:
   - cold-boot-loop-reboot-{reboot_id}
 ---
 id: cold-boot-loop-{reboot_id}-hardware-renderer-check
+certification-status: blocker
 template-id: cold-boot-loop-hardware-renderer-check-reboot_id
 category_id: stress-tests/cold-boot
 summary: Cold boot {reboot_id} hardware renderer check
@@ -321,6 +325,7 @@ depends:
   - init-boot-loop-data
 ---
 id: warm-boot-loop-1-fwts-critical-only
+certification-status: blocker
 category_id: stress-tests/warm-boot
 summary: Warm boot 1 FWTS test (only fail at critical errors)
 purpose: Compare data after warm boot with baseline data set
@@ -336,7 +341,6 @@ command: >-
   -t oops
   -f critical
   -l $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1/fwts-critical-only.log
-certification-status: blocker
 siblings:
   - id: warm-boot-loop-1-fwts-all
     summary: Warm boot 1 FWTS test (all levels)
@@ -369,6 +373,7 @@ depends:
   - warm-boot-loop-reboot-1
 ---
 id: warm-boot-loop-{reboot_id}-fwts-critical-only
+certification-status: blocker
 template-id: warm-boot-loop-reboot_id-fwts-critical-only
 category_id: stress-tests/warm-boot
 summary: Warm boot {reboot_id} FWTS test (only fail at critical errors)
@@ -422,6 +427,7 @@ depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
 id: warm-boot-loop-{reboot_id}-device-check
+certification-status: blocker
 template-id: warm-boot-loop-reboot_id-device-check
 category_id: stress-tests/warm-boot
 summary: Warm boot {reboot_id} device difference check
@@ -443,6 +449,7 @@ depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
 id: warm-boot-loop-{reboot_id}-service-check
+certification-status: blocker
 template-id: warm-boot-loop-reboot_id-service-check
 category_id: stress-tests/warm-boot
 summary: Warm boot {reboot_id} failed services check
@@ -462,6 +469,7 @@ depends:
   - warm-boot-loop-reboot-{reboot_id}
 ---
 id: warm-boot-loop-{reboot_id}-hardware-renderer-check
+certification-status: blocker
 template-id: warm-boot-loop-hardware-renderer-check-reboot_id
 category_id: stress-tests/warm-boot
 summary: Warm boot {reboot_id} hardware renderer check

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -134,7 +134,7 @@ command: >-
 certification-status: blocker
 siblings:
   - id: cold-boot-loop-1-fwts-all
-    certification-status: non-blocker
+    certification_status: non-blocker
     summary: Cold boot 1 FWTS test (all levels)
     # since we are only checking klog and oops
     # it's safe to do duplicate work and run fwts again
@@ -352,7 +352,7 @@ siblings:
       -t oops
       -f aborted 
       -l $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1/fwts-all.log
-    certification-status: non-blocker
+    certification_status: non-blocker
   - id: warm-boot-loop-1-hardware-renderer-check
     summary: Warm boot 1 hardware renderer check
     command: reboot_check_test.py -g

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -55,6 +55,7 @@ flags:
   - preserve-locale
 ---
 id: cold-boot-loop-reboot-1
+certification-status: blocker
 category_id: stress-tests/cold-boot
 summary: Perform cold reboot 1
 unit: job
@@ -80,6 +81,7 @@ depends:
   - init-boot-loop-data
 ---
 id: cold-boot-loop-reboot-{reboot_id}
+certification-status: blocker
 template-id: cold-boot-loop-reboot-reboot_id
 category_id: stress-tests/cold-boot
 summary: Perform cold reboot {reboot_id}
@@ -280,6 +282,7 @@ depends:
   - cold-boot-loop-reboot-{reboot_id}
 ---
 id: warm-boot-loop-reboot-1
+certification-status: blocker
 category_id: stress-tests/warm-boot
 summary: Perform warm reboot 1
 purpose: Perform warm reboot of the system boot. Specifically, this is how the device will request a reboot.
@@ -295,6 +298,7 @@ depends:
   - init-boot-loop-data
 ---
 id: warm-boot-loop-reboot-{reboot_id}
+certification-status: blocker
 template-id: warm-boot-loop-reboot-reboot_id
 category_id: stress-tests/warm-boot
 summary: Perform warm reboot {reboot_id}

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -134,7 +134,7 @@ command: >-
 certification-status: blocker
 siblings:
   - id: cold-boot-loop-1-fwts-all
-    certification_status: non-blocker
+    certification-status: non-blocker
     summary: Cold boot 1 FWTS test (all levels)
     # since we are only checking klog and oops
     # it's safe to do duplicate work and run fwts again
@@ -352,7 +352,7 @@ siblings:
       -t oops
       -f aborted 
       -l $PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1/fwts-all.log
-    certification_status: non-blocker
+    certification-status: non-blocker
   - id: warm-boot-loop-1-hardware-renderer-check
     summary: Warm boot 1 hardware renderer check
     command: reboot_check_test.py -g

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -274,7 +274,7 @@ unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1"
+command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-1"
 certification-status: blocker
 siblings:
   - id: warm-boot-loop-1-hardware-renderer-check
@@ -307,7 +307,7 @@ template-unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}"
+command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/warm_reboot_cycle-{reboot_id}"
 user: root
 flags:
   - preserve-locale

--- a/providers/base/units/stress/boot.yaml
+++ b/providers/base/units/stress/boot.yaml
@@ -200,7 +200,7 @@ unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f
+command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-1"
 certification-status: blocker
 siblings:
   - id: warm-boot-loop-1-hardware-renderer-check
@@ -233,7 +233,7 @@ template-unit: job
 plugin: shell
 environ:
   - LD_LIBRARY_PATH
-command: reboot_check_test.py -f
+command: reboot_check_test.py -f -d "$PLAINBOX_SESSION_SHARE/cold_reboot_cycle-{reboot_id}"
 user: root
 flags:
   - preserve-locale

--- a/providers/base/units/stress/test-plan.pxu
+++ b/providers/base/units/stress/test-plan.pxu
@@ -339,6 +339,8 @@ nested_part:
     stress-warmboot-coldboot-automated
     stress-pm-graph
 certification_status_overrides:
-    apply blocker to com.canonical.certification::warm-boot-loop-.*
-    apply blocker to com.canonical.certification::cold-boot-loop-.*
+    apply blocker to com.canonical.certification::(warm|cold)-boot-loop-.*-fwts-critical-only
+    apply blocker to com.canonical.certification::(warm|cold)-.*-device-check
+    apply blocker to com.canonical.certification::(warm|cold)-.*-service-check
+    apply blocker to com.canonical.certification::(warm|cold)-.*-renderer-check
     apply blocker to com.canonical.certification::ethernet/iperf3_.*


### PR DESCRIPTION
## Description

This is the final change we want to achieve: make fwts critical failures cert blockers, but not the remaining ones (high failures and lower)

## Resolved issues

Prevents a fwts low failure from failing blocker tests.

## Documentation

We will do the migration to yaml after this is merged because this file contains too many other test plans not relevant to the reboot tests.

## Tests

