### PR TITLE
Apply blocker status to fwts critical failures in 26 stress tests (New)

### DIFF
--- a/providers/base/units/stress/test-plan.pxu
+++ b/providers/base/units/stress/test-plan.pxu
@@ -339,6 +339,7 @@ nested_part:
     stress-warmboot-coldboot-automated
     stress-pm-graph
 certification_status_overrides:
+    apply blocker to com.canonical.certification::(warm|cold)-boot-loop-reboot-.*
     apply blocker to com.canonical.certification::(warm|cold)-boot-loop-.*-fwts-critical-only
     apply blocker to com.canonical.certification::(warm|cold)-.*-device-check
     apply blocker to com.canonical.certification::(warm|cold)-.*-service-check

--- a/providers/base/units/stress/test-plan.pxu
+++ b/providers/base/units/stress/test-plan.pxu
@@ -339,6 +339,8 @@ nested_part:
     stress-warmboot-coldboot-automated
     stress-pm-graph
 certification_status_overrides:
-    apply blocker to com.canonical.certification::warm-boot-loop-.*
-    apply blocker to com.canonical.certification::cold-boot-loop-.*
+    apply blocker to com.canonical.certification::(warm|cold)-boot-loop-.*-fwts-critical-only
+    apply blocker to com.canonical.certification::(warm|cold)-.*-device-check
+    apply blocker to com.canonical.certification::(warm|cold)-.*-service-check
+    apply blocker to com.canonical.certification::(warm|cold)-.*-renderer-check
     apply blocker to com.canonical.certification::ethernet/iperf3_.*


### PR DESCRIPTION
## Description

This is the final change we want to achieve: make fwts critical failures cert blockers, but not the remaining ones (high failures and lower)

## Resolved issues

Prevents a fwts low failure from failing blocker tests.

## Documentation

We will do the migration to yaml after this is merged because this file contains too many other test plans not relevant to the reboot tests.

## Tests

~~Successful run: https://certification.canonical.com/hardware/202601-38351/submission/506200/~~

Successful run after fixing copilot suggestion: https://certification.canonical.com/hardware/202601-38351/submission/508318/

