### PR TITLE
Don't escape raw value in HTML reports (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/exporter/jinja2.py
+++ b/checkbox-ng/plainbox/impl/exporter/jinja2.py
@@ -86,7 +86,7 @@ def do_nl2br(value):
     """Convert newlines to <br/> tags for HTML display."""
     if value is None:
         return ""
-    result = escape(value).replace("\n", Markup("<br/>"))
+    result = value.replace("\n", Markup("<br/>"))
     return Markup(result)
 
 


### PR DESCRIPTION

## Description

Some engineers use HTML <a href="..."> tags to create links in the report.

A previous PR (#2719) escaped these, making the links not clickable anymore.

Revert the behavior so that HTML reports can be shared with other stakeholders and they can click on the bug links directly.

## Resolved issues


Fix #2754

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->

- Before the patch: [submission.html](https://github.com/user-attachments/files/31414414/submission.html)
- After the patch: [submission2.html](https://github.com/user-attachments/files/31414417/submission2.html)



