### PR TITLE
Replace hyphen with underscore before checking if a sibling job's override field is valid (BugFix)

### DIFF
--- a/checkbox-ng/plainbox/impl/unit/job.py
+++ b/checkbox-ng/plainbox/impl/unit/job.py
@@ -1086,15 +1086,13 @@ class JobDefinition(UnitWithId, IJobDefinition):
                 ),
                 CorrectFieldValueValidator(
                     lambda value, unit: all(
-                        [
-                            all(
-                                [
-                                    hasattr(JobDefinition, k.lstrip("_"))
-                                    for k in s.keys()
-                                ]
+                        all(
+                            hasattr(
+                                JobDefinition, k.lstrip("_").replace("-", "_")
                             )
-                            for s in value
-                        ]
+                            for k in s
+                        )
+                        for s in value
                     ),
                     Problem.bad_reference,
                     Severity.error,

--- a/checkbox-ng/plainbox/impl/unit/test_job.py
+++ b/checkbox-ng/plainbox/impl/unit/test_job.py
@@ -733,6 +733,21 @@ class JobDefinitionFieldValidationTests(UnitWithIdFieldValidationTests):
             Severity.error,
         )
 
+    def test_siblings__override_field_with_hyphen(self):
+        issue_list = self.unit_cls(
+            {
+                "_siblings": (
+                    '[{"id": "bar", "certification-status": "blocker"}]'
+                )
+            },
+            provider=self.provider,
+        ).check()
+        self.assertIssueNotFound(
+            issue_list,
+            self.unit_cls.Meta.fields.siblings,
+            Problem.bad_reference,
+        )
+
 
 class TestJobDefinition(TestCase):
 


### PR DESCRIPTION
## Description

Fixes #2787 and removed 2 unnecessary list comprehensions.

## Resolved issues

This technically only fixes the main issue of 2787 where `certification-status` is not accepted by `manage.py validate`. `certification_status`, although considered invalid by the yaml schema, is not rejected by the validator.

## Documentation


## Tests

Running `manage.py validate` to check the example from #2787 will no longer produce an error.