### PR TITLE
Refactor network NTP test to use native SNTP query (BugFix)

### DIFF
--- a/providers/base/bin/network_ntp_test.py
+++ b/providers/base/bin/network_ntp_test.py
@@ -62,7 +62,7 @@ def ManageTimeDaemon(action, stopped_daemon=None):
                     stderr=subprocess.PIPE,
                 )
                 if check.returncode == 0:
-                    logging.info(f"Stopping {daemon}...")
+                    logging.info("Stopping %s..." % daemon)
                     subprocess.run(
                         ["systemctl", "stop", daemon],
                         stdout=subprocess.DEVNULL,
@@ -72,7 +72,7 @@ def ManageTimeDaemon(action, stopped_daemon=None):
             return checked_daemons
         elif action == "start" and stopped_daemon:
             for daemon in stopped_daemon:
-                logging.info(f"Starting {daemon}...")
+                logging.info("Starting %s..." % daemon)
                 subprocess.run(
                     ["systemctl", "start", daemon],
                     stdout=subprocess.DEVNULL,

--- a/providers/base/bin/network_ntp_test.py
+++ b/providers/base/bin/network_ntp_test.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 """
-Program to test that ntpdate will sync the clock with an internet time server.
+Program to test syncing the clock with an internet time server via
+SNTP UDP query.
 
-Copyright (C) 2010 Canonical Ltd.
+Copyright (C) 2010-2026 Canonical Ltd.
 
-Author:
+Authors:
     Jeff Lane <jeffrey.lane@canonical.com>
+    Jason Leonhard <jason.leonhard@canonical.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 2,
@@ -19,11 +21,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-The purpose of this script is to test to see whether the test system can
-connect to an internet time server and sync the local clock.
+The purpose of this script is to test whether the test system can
+connect to an internet time server and sync the local clock via a native
+SNTP UDP query.
 
-It will also check to see if ntpd is running locally, and if so, stop it for
-the duration of the test and restart it after the test is finished.
+It checks for active time daemons and temporarily stops them
+during the test to prevent background interference.
 
 By default, we're hitting ntp.ubuntu.com, however you can use any valid NTP
 server by passing the URL to the program via --server
@@ -33,90 +36,94 @@ server by passing the URL to the program via --server
 import sys
 import os
 import logging
-import signal
 import time
-from datetime import datetime, timedelta
-from subprocess import Popen, PIPE
+import socket
+import struct
+import subprocess
 from argparse import ArgumentParser
 
+NTP_UNIX_OFFSET = 2208988800
 
-def SilentCall(*popenargs):
+
+def ManageTimeDaemon(action, stopped_daemon=None):
     """
-    Modified version of subprocess.call() to supress output from the command
-    that is executed. Wait for command to complete, then return the returncode
-    attribute.
+    Checks to see if any time daemons are running, and stops them if they are.
+    If the action is "start", it will restart any daemons that were stopped.
     """
-    null_fh = open("/dev/null", "wb", 0)
+    daemons_to_check = ["systemd-timesyncd", "ntpd", "chronyd"]
+    checked_daemons = []
+
     try:
-        return Popen(
-            *popenargs, shell=True, stdout=null_fh, stderr=null_fh
-        ).wait()
-    finally:
-        null_fh.close()
+        if action == "stop":
+            for daemon in daemons_to_check:
+                check = subprocess.run(
+                    ["systemctl", "is-active", daemon],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                if check.returncode == 0:
+                    logging.info(f"Stopping {daemon}...")
+                    subprocess.run(
+                        ["systemctl", "stop", daemon],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                    checked_daemons.append(daemon)
+            return checked_daemons
+        elif action == "start" and stopped_daemon:
+            for daemon in stopped_daemon:
+                logging.info(f"Starting {daemon}...")
+                subprocess.run(
+                    ["systemctl", "start", daemon],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            return []
 
+    except Exception as e:
+        logging.error("Failed to manage time daemon: %s" % e)
 
-def CheckNTPD():
-    """
-    This checks to see if nptd is running or not, if so it returns a tuple
-    (status,pid,command) where status is either on or off.
-    """
-    ps_list = (
-        Popen("ps axo pid,comm", shell=True, stdout=PIPE)
-        .communicate()[0]
-        .splitlines()
-    )
-    for item in ps_list:
-        fields = item.split()
-        if fields[1] == "ntpd":
-            logging.debug("Found %s with PID %s" % (fields[1], fields[0]))
-            break
-    if fields[1] == "ntpd":
-        return ("on", fields[0], fields[1])
-    else:
-        return ("off", "0", "0")
-
-
-def StartStopNTPD(state, pid=0):
-    """
-    This is used to either start or stop ntpd if its running.
-    """
-    if state == "off":
-        logging.info("Stopping ntpd process PID: %s" % pid)
-        os.kill(int(pid), signal.SIGHUP)
-    elif state == "on":
-        logging.info("Starting ntp process")
-        SilentCall("/etc/init.d/ntp start")
-        ntpd_status = CheckNTPD()
-
-        if ntpd_status == 0:
-            logging.debug("ntpd restarted with PID: %s" % ntpd_status[1])
-        else:
-            logging.error("ntpd restart failed for some reason")
-    else:
-        logging.error(
-            "%s is an unknown state, unable to start/stop ntpd" % state
-        )
+    return []
 
 
 def SyncTime(server):
     """
-    This is used to sync time to the specified ntp server.  We use -b here as
-    that syncs time faster than the slewed method that ntpdate uses by default,
-    meaning we'll see something meaningful faster.
+    Syncs time via native SNTP query to the specified ntp server.
+    It avoids ntpdate Snap dependency issues.
     """
-    cmd = "ntpdate -b " + server
-    logging.debug("using %s" % server)
-    sync = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)
-    result = sync.communicate()
+    logging.debug("Querying NTP server %s via native UDP socket..." % server)
+    ntp_packet = b"\x1b" + 47 * b"\x00"
 
-    if sync.returncode == 0:
-        logging.info("Successful NTP update from %s" % server)
-        logging.debug(result[0].strip().decode())
-        return True
-    else:
-        logging.error("Failed to sync with %s" % server)
-        logging.error(result[1].strip().decode())
-        return False
+    try:
+        res = socket.getaddrinfo(
+            server, 123, socket.AF_UNSPEC, socket.SOCK_DGRAM
+        )
+        af, socktype, proto, _, sa = res[0]
+        with socket.socket(af, socktype, proto) as s:
+            s.settimeout(10)
+            s.sendto(ntp_packet, sa)
+            data, _ = s.recvfrom(1024)
+
+        if data and len(data) >= 48:
+            # Unpack the transmit timestamp and conver to Unix time
+            seconds, fraction = struct.unpack("!II", data[40:48])
+            unix_time = (seconds - NTP_UNIX_OFFSET) + (fraction / (2**32))
+            # Set the system time
+            time.clock_settime(time.CLOCK_REALTIME, unix_time)
+            logging.info(
+                "NTP server %s responded with time: %s"
+                % (server, time.ctime(unix_time))
+            )
+            return True
+
+        logging.error("Invalid response from NTP server %s" % server)
+
+    except Exception as e:
+        logging.error(
+            "Failed to sync time with NTP server %s: %s" % (server, e)
+        )
+
+    return False
 
 
 def TimeCheck():
@@ -133,15 +140,11 @@ def SkewTime():
     """
     TIME_SKEW = 1
     logging.info("Time Skewing has been selected. Setting clock ahead 1 hour")
-    # Let's get our current time
-    skewed = datetime.now() + timedelta(hours=TIME_SKEW)
     logging.info("Current time is: %s" % time.asctime())
-    # Now create new time string in the form MMDDhhmmYYYY for the date program
-    date_time_string = skewed.strftime("%m%d%H%M%Y")
-    logging.debug("New date string is: %s" % date_time_string)
-    logging.debug("Setting new system time/date")
-    # This call is necessary for testing, otherwise TimeSkew() does nothing.
-    SilentCall("/bin/date %s" % date_time_string)
+
+    skewed = time.time() + TIME_SKEW * 3600
+    time.clock_settime(time.CLOCK_REALTIME, skewed)
+
     logging.info("Pre-sync time is: %s" % time.asctime())
 
 
@@ -188,40 +191,25 @@ def main():
         logger.setLevel(logging.DEBUG)
     logger.addHandler(handler)
 
-    # Make sure NTP is installed
-    if not os.access("/usr/sbin/ntpdate", os.F_OK):
-        logging.error("NTP is not installed!")
-        return 1
+    stopped_daemons = ManageTimeDaemon("stop")
 
-    # Check for and stop the ntp daemon
-    ntpd_status = CheckNTPD()
-    logging.debug(
-        "Pre-sync ntpd status: %s %s %s"
-        % (ntpd_status[0], ntpd_status[1], ntpd_status[2])
-    )
-    if ntpd_status[0] == "on":
-        logging.debug("Since ntpd is currently running, stopping it now")
-        StartStopNTPD("off", ntpd_status[1])
+    try:
+        # Time skew check
+        if args.skew_time:
+            logging.debug("Setting system time ahead one hour")
+            SkewTime()
+        else:
+            logging.info("Pre-sync time is: %s" % time.asctime(TimeCheck()))
 
-    if args.skew_time:
-        logging.debug("Setting system time ahead one hour")
-        SkewTime()
-    else:
-        logging.info("Pre-sync time is: %s" % time.asctime(TimeCheck()))
+        # Perform sync test
+        sync = SyncTime(args.server)
 
-    sync = SyncTime(args.server)
+        logging.info("Current system time is: %s" % time.asctime(TimeCheck()))
 
-    logging.info("Current system time is: %s" % time.asctime(TimeCheck()))
+    finally:
+        ManageTimeDaemon("start", stopped_daemons)
 
-    # Restart ntp daemon
-    if ntpd_status[0] == "on":
-        logging.debug("Since ntpd was previously running, starting it again")
-        StartStopNTPD("on")
-
-    if sync is True:
-        return 0
-    else:
-        return 1
+    return 0 if sync else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This PR refactors the `networking/ntp` test script to perform time synchronization using native UDP sockets rather than external host binaries (`ntpdate` / `ntpdig`)

In Snap environments, the existing test script calls the host `ntpdate` command, which wraps `ntpdig`. The subprocess inherits Snap `PYTHONPATH`, causing `ntpdig` to load modules from the Snap environment and fail with `ModuleNotFoundError`.

Additionally, `ntpdate` is deprecated and no longer pre-installed on modern Ubuntu releases.

## Resolved issues

- Resolve the `ModuleNotFoundError` caused by the Snap `PYTHONPATH` being inherited by the host `ntpdate` / `ntpdig` subprocess:
https://certification.canonical.com/hardware/202605-38796/submission/506176/test/156/result/62333577/
- Remove dependency on the deprecated `ntpdate`
- Removes the external `ntpdate` / `ntpdig` dependency and performs the NTP query directly over UDP using Python's standard library.

## Tests

Tested on both Snap and Debian Checkbox `networking/ntp` test