### PR TITLE
Always set PYTHONUNBUFFERED for jobs and snap apps (bugfix)

### DIFF
--- a/checkbox-core-snap/common_files/config/wrapper_common
+++ b/checkbox-core-snap/common_files/config/wrapper_common
@@ -6,6 +6,8 @@ function append_path() {
   fi
 }
 
+export PYTHONUNBUFFERED=1
+
 if [ -z "$RUNTIME" ]; then
   RUNTIME=$SNAP
 else

--- a/checkbox-core-snap/common_files/config/wrapper_common_classic
+++ b/checkbox-core-snap/common_files/config/wrapper_common_classic
@@ -14,6 +14,8 @@ function prepend_dir() {
   fi
 }
 
+export PYTHONUNBUFFERED=1
+
 if [ -z "$RUNTIME" ]; then
   RUNTIME=$SNAP
 else

--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -68,6 +68,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/lib/python3.5/site-packages/:$SNAP/lib64/python3.5/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH
+      PYTHONUNBUFFERED: "1"
   agent:
     command: bin/checkbox-cli run-agent
     daemon: simple
@@ -78,6 +79,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/lib/python3.5/site-packages/:$SNAP/lib64/python3.5/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH
+      PYTHONUNBUFFERED: "1"
 
 package-repositories:
   - type: apt

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -72,6 +72,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/lib/python3.6/site-packages/:$SNAP/lib64/python3.6/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH
+      PYTHONUNBUFFERED: "1"
   agent:
     command: bin/checkbox-cli run-agent
     daemon: simple
@@ -82,6 +83,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/lib/python3.6/site-packages/:$SNAP/lib64/python3.6/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH
+      PYTHONUNBUFFERED: "1"
 
 package-repositories:
   - type: apt

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -72,6 +72,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/lib/python3.8/site-packages/:$SNAP/lib64/python3.8/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH
+      PYTHONUNBUFFERED: "1"
   agent:
     command: bin/checkbox-cli run-agent
     daemon: simple
@@ -82,6 +83,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/lib/python3.8/site-packages/:$SNAP/lib64/python3.8/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH
+      PYTHONUNBUFFERED: "1"
 
 package-repositories:
   - type: apt

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -76,6 +76,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/lib/python3.10/site-packages/:$SNAP/lib64/python3.10/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH
+      PYTHONUNBUFFERED: "1"
   agent:
     command: bin/checkbox-cli run-agent
     daemon: simple
@@ -86,6 +87,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/lib/python3.10/site-packages/:$SNAP/lib64/python3.10/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH
+      PYTHONUNBUFFERED: "1"
 
 package-repositories:
   - type: apt

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -76,6 +76,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/lib/python3.12/site-packages/:$SNAP/lib64/python3.12/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH
+      PYTHONUNBUFFERED: "1"
   agent:
     command: bin/checkbox-cli run-agent
     daemon: simple
@@ -86,6 +87,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/lib/python3.12/site-packages/:$SNAP/lib64/python3.12/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH
+      PYTHONUNBUFFERED: "1"
 
 package-repositories:
   - type: apt

--- a/checkbox-core-snap/series26/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series26/snap/snapcraft.yaml
@@ -76,6 +76,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/lib/python3.14/site-packages/:$SNAP/lib64/python3.14/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH
+      PYTHONUNBUFFERED: "1"
   agent:
     command: bin/checkbox-cli run-agent
     daemon: simple
@@ -86,6 +87,7 @@ apps:
     environment:
       PYTHONPATH: $SNAP/lib/python3.14/site-packages/:$SNAP/lib64/python3.14/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH
+      PYTHONUNBUFFERED: "1"
 
 package-repositories:
   - type: apt

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -642,6 +642,7 @@ def get_execution_environment(job, environ, session_id, nest_dir):
     set_if_not_none("PLAINBOX_PROVIDER_DATA", job.provider.data_dir)
     set_if_not_none("PLAINBOX_PROVIDER_UNITS", job.provider.units_dir)
     set_if_not_none("CHECKBOX_SHARE", job.provider.CHECKBOX_SHARE)
+    set_if_not_none("PYTHONUNBUFFERED", "1")
     if os.getenv("SNAP"):
         set_if_not_none("CHECKBOX_RUNTIME", str(get_checkbox_runtime_path()))
 


### PR DESCRIPTION
## Description

Given the nature of what we are doing in Checkbox, and the fact that any test may brick the machine leaving us with nothing but the log remote was able to salvage, output buffering is antithetical to what we want. This both applies to Checkbox itself but especially our jobs that are mostly written in python. 

Additionally, this is a source of confusion, recurrently pushing people to ask why the job output isn't live printed in remote while in local (given that the session that prints is the session that runs) it was. This partially solves the issue by disabling python output buffering in all jobs and all snaps.

## Resolved issues

Relevant to: https://github.com/canonical/checkbox/issues/1391 (the complaints about missing output)

## Documentation

N/A

## Tests

N/A
