### PR TITLE
Add an RTC read job to make sure the RTC function is tested properly (New)

### DIFF
--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -403,6 +403,7 @@ parts:
       - xz-utils
       - rt-tests # For realtime performance test
       - mdadm
+      - util-linux-extra
       - on armhf:
           - python3-rpi.gpio # only in focal
       - on arm64:

--- a/checkbox-core-snap/series26/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series26/snap/snapcraft.yaml
@@ -384,6 +384,7 @@ parts:
       - xz-utils
       - rt-tests # For realtime performance test
       - mdadm
+      - util-linux-extra
       - on armhf:
           - python3-rpi.gpio # only in focal
       - on arm64:

--- a/providers/base/bin/rtc_test.py
+++ b/providers/base/bin/rtc_test.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# RTC (Real Time Clock) test utility for Checkbox.
+#
+# Consolidates the shell logic previously embedded in the
+# rtc/battery, rtc/rtc_number, rtc_list, rtc/rtc_read_{rtc},
+# rtc/rtc_alarm_{rtc} and rtc/rtc_clock_{rtc} jobs into a single
+# script with subcommands, following the argparse + dispatch-table
+# pattern used by other checkbox-support scripts.
+
+import argparse
+import glob
+import os
+import subprocess
+import sys
+import time
+
+
+def find_rtc_devices():
+    """Return a sorted list of rtc device names under /dev, e.g. ['rtc0']."""
+    return sorted(os.path.basename(p) for p in glob.glob("/dev/rtc[0-9]*"))
+
+
+def _can_read(path):
+    try:
+        with open(path) as f:
+            f.read()
+        return True
+    except OSError:
+        return False
+
+
+def cmd_list(args):
+    """Resource job: emit one record per RTC device found."""
+    for rtc in find_rtc_devices():
+        print("rtc: {}".format(rtc))
+        print()
+    return 0
+
+
+def cmd_number(args):
+    """Check that the number of RTC devices matches the expected count."""
+    expected = args.total
+    if expected is None:
+        env_val = os.environ.get("TOTAL_RTC_NUM")
+        if env_val:
+            expected = int(env_val)
+        else:
+            print("TOTAL_RTC_NUM not defined, defaulting to 1")
+            expected = 1
+
+    found = find_rtc_devices()
+    print("TOTAL_RTC_NUM: {}".format(expected))
+    print("Number of RTC devices found in sysfs: {}".format(len(found)))
+
+    if len(found) != expected:
+        print("RTC number mismatch")
+        return 1
+    print("RTC number matched")
+    return 0
+
+
+def cmd_read(args):
+    """Check /sys/class/rtc/<rtc>/since_epoch is readable; sync via hwclock if not."""
+    rtc = args.rtc
+    since_epoch_path = "/sys/class/rtc/{}/since_epoch".format(rtc)
+
+    if _can_read(since_epoch_path):
+        return 0
+
+    print("Warning: Unable to read {}.".format(since_epoch_path))
+
+    hwclock_cmd = ["hwclock", "--systohc", "--utc", "--rtc=/dev/{}".format(rtc)]
+    result = subprocess.run(hwclock_cmd)
+    if result.returncode != 0:
+        print("Error: hwclock sync failed.")
+        return 1
+
+    if not _can_read(since_epoch_path):
+        print("Error: RTC is still not readable after hwclock sync.")
+        return 1
+
+    return 0
+
+
+def cmd_alarm(args):
+    """Check that the RTC's wakealarm works via rtcwake, with a timeout guard."""
+    rtc = args.rtc
+    wakealarm_path = "/sys/class/rtc/{}/wakealarm".format(rtc)
+
+    if not os.path.isfile(wakealarm_path):
+        print("{} does not support wakealarm".format(rtc))
+        return 1
+
+    cmd = ["rtcwake", "-d", rtc, "-v", "-m", "on", "-s", str(args.seconds)]
+    try:
+        subprocess.run(cmd, timeout=args.timeout, check=True)
+    except subprocess.TimeoutExpired:
+        print("Error: rtcwake timed out!")
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print("Error: rtcwake failed with exit code {}".format(exc.returncode))
+        return 1
+
+    return 0
+
+
+def cmd_clock(args):
+    """Check that the RTC clock is synchronized with the system clock."""
+    rtc = args.rtc
+    since_epoch_path = "/sys/class/rtc/{}/since_epoch".format(rtc)
+
+    with open(since_epoch_path) as f:
+        rtc_time = int(f.read().strip())
+    sys_time = int(time.time())
+    diff = sys_time - rtc_time
+
+    if diff <= args.tolerance:
+        print("{} Clock synchronized with System Clock".format(rtc))
+        print("RTC clock= {}".format(rtc_time))
+        return 0
+
+    print("{} Clock not synchronized with System Clock".format(rtc))
+    print("System clock= {}".format(sys_time))
+    print("RTC clock= {}".format(rtc_time))
+    return 1
+
+
+def cmd_battery(args):
+    """Disable any pending wakealarm, then power off with a wake scheduled
+    in N seconds. On success this powers the machine off, so the process
+    will not return control to the caller (mirrors the job's `noreturn`
+    flag)."""
+    rtc = args.rtc
+    subprocess.run(["rtcwake", "-v", "-d", rtc, "-m", "disable"], check=False)
+    result = subprocess.run(
+        ["rtcwake", "-v", "-d", rtc, "-m", "off", "-s", str(args.seconds)]
+    )
+    return result.returncode
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="RTC test utility")
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    default_rtc = os.environ.get("RTC_DEVICE_FILE", "rtc0")
+
+    p_list = sub.add_parser("list", help="List RTC devices (resource job)")
+    p_list.set_defaults(func=cmd_list)
+
+    p_number = sub.add_parser("number", help="Check RTC device count")
+    p_number.add_argument(
+        "--total", type=int, default=None,
+        help="Expected RTC count (falls back to $TOTAL_RTC_NUM, then 1)",
+    )
+    p_number.set_defaults(func=cmd_number)
+
+    p_read = sub.add_parser("read", help="Check RTC is readable")
+    p_read.add_argument("--rtc", default=default_rtc)
+    p_read.set_defaults(func=cmd_read)
+
+    p_alarm = sub.add_parser("alarm", help="Check RTC wakealarm")
+    p_alarm.add_argument("--rtc", default=default_rtc)
+    p_alarm.add_argument("--seconds", type=int, default=30)
+    p_alarm.add_argument("--timeout", type=int, default=60)
+    p_alarm.set_defaults(func=cmd_alarm)
+
+    p_clock = sub.add_parser("clock", help="Check RTC clock is in sync")
+    p_clock.add_argument("--rtc", default=default_rtc)
+    p_clock.add_argument("--tolerance", type=int, default=5)
+    p_clock.set_defaults(func=cmd_clock)
+
+    p_battery = sub.add_parser("battery", help="RTC battery wake-from-poweroff test")
+    p_battery.add_argument("--rtc", default=default_rtc)
+    p_battery.add_argument("--seconds", type=int, default=30)
+    p_battery.set_defaults(func=cmd_battery)
+
+    return parser
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/providers/base/bin/rtc_test.py
+++ b/providers/base/bin/rtc_test.py
@@ -32,9 +32,19 @@ def _can_read(path):
 def cmd_list(args):
     """Resource job: emit one record per RTC device found."""
     for rtc in find_rtc_devices():
-        print("rtc: {}".format(rtc))
+        print(f"rtc: {rtc}")
         print()
     return 0
+
+
+def cmd_battery(args):
+    """Disable any pending wakealarm, then power off with a wake scheduled in N seconds."""
+    rtc = args.rtc
+    subprocess.run(["rtcwake", "-v", "-d", rtc, "-m", "disable"], check=False)
+    result = subprocess.run(
+        ["rtcwake", "-v", "-d", rtc, "-m", "off", "-s", str(args.seconds)]
+    )
+    return result.returncode
 
 
 def cmd_number(args):
@@ -49,8 +59,8 @@ def cmd_number(args):
             expected = 1
 
     found = find_rtc_devices()
-    print("TOTAL_RTC_NUM: {}".format(expected))
-    print("Number of RTC devices found in sysfs: {}".format(len(found)))
+    print(f"TOTAL_RTC_NUM: {expected}")
+    print(f"Number of RTC devices found in sysfs: {len(found)}")
 
     if len(found) != expected:
         print("RTC number mismatch")
@@ -62,14 +72,14 @@ def cmd_number(args):
 def cmd_read(args):
     """Check /sys/class/rtc/<rtc>/since_epoch is readable; sync via hwclock if not."""
     rtc = args.rtc
-    since_epoch_path = "/sys/class/rtc/{}/since_epoch".format(rtc)
+    since_epoch_path = f"/sys/class/rtc/{rtc}/since_epoch"
 
     if _can_read(since_epoch_path):
         return 0
 
-    print("Warning: Unable to read {}.".format(since_epoch_path))
+    print(f"Warning: Unable to read {since_epoch_path}.")
 
-    hwclock_cmd = ["hwclock", "--systohc", "--utc", "--rtc=/dev/{}".format(rtc)]
+    hwclock_cmd = ["hwclock", "--systohc", "--utc", f"--rtc=/dev/{rtc}"]
     result = subprocess.run(hwclock_cmd)
     if result.returncode != 0:
         print("Error: hwclock sync failed.")
@@ -85,20 +95,20 @@ def cmd_read(args):
 def cmd_alarm(args):
     """Check that the RTC's wakealarm works via rtcwake, with a timeout guard."""
     rtc = args.rtc
-    wakealarm_path = "/sys/class/rtc/{}/wakealarm".format(rtc)
+    wakealarm_path = f"/sys/class/rtc/{rtc}/wakealarm"
 
     if not os.path.isfile(wakealarm_path):
-        print("{} does not support wakealarm".format(rtc))
+        print(f"{rtc} does not support wakealarm")
         return 1
 
-    cmd = ["rtcwake", "-d", rtc, "-v", "-m", "on", "-s", str(args.seconds)]
+    cmd = ["rtcwake", "-v", "-d", rtc, "-m", "on", "-s", str(args.seconds)]
     try:
         subprocess.run(cmd, timeout=args.timeout, check=True)
     except subprocess.TimeoutExpired:
         print("Error: rtcwake timed out!")
         return 1
     except subprocess.CalledProcessError as exc:
-        print("Error: rtcwake failed with exit code {}".format(exc.returncode))
+        print(f"Error: rtcwake failed with exit code {exc.returncode}")
         return 1
 
     return 0
@@ -107,7 +117,7 @@ def cmd_alarm(args):
 def cmd_clock(args):
     """Check that the RTC clock is synchronized with the system clock."""
     rtc = args.rtc
-    since_epoch_path = "/sys/class/rtc/{}/since_epoch".format(rtc)
+    since_epoch_path = f"/sys/class/rtc/{rtc}/since_epoch"
 
     with open(since_epoch_path) as f:
         rtc_time = int(f.read().strip())
@@ -115,27 +125,14 @@ def cmd_clock(args):
     diff = sys_time - rtc_time
 
     if diff <= args.tolerance:
-        print("{} Clock synchronized with System Clock".format(rtc))
-        print("RTC clock= {}".format(rtc_time))
+        print(f"{rtc} Clock synchronized with System Clock")
+        print(f"RTC clock= {rtc_time}")
         return 0
 
-    print("{} Clock not synchronized with System Clock".format(rtc))
-    print("System clock= {}".format(sys_time))
-    print("RTC clock= {}".format(rtc_time))
+    print(f"{rtc} Clock not synchronized with System Clock")
+    print(f"System clock= {sys_time}")
+    print(f"RTC clock= {rtc_time}")
     return 1
-
-
-def cmd_battery(args):
-    """Disable any pending wakealarm, then power off with a wake scheduled
-    in N seconds. On success this powers the machine off, so the process
-    will not return control to the caller (mirrors the job's `noreturn`
-    flag)."""
-    rtc = args.rtc
-    subprocess.run(["rtcwake", "-v", "-d", rtc, "-m", "disable"], check=False)
-    result = subprocess.run(
-        ["rtcwake", "-v", "-d", rtc, "-m", "off", "-s", str(args.seconds)]
-    )
-    return result.returncode
 
 
 def build_parser():

--- a/providers/base/bin/rtc_test.py
+++ b/providers/base/bin/rtc_test.py
@@ -46,7 +46,9 @@ def cmd_list(args):
 
 
 def cmd_battery(args):
-    """Disable any pending wakealarm, then power off with a wake scheduled in N seconds."""
+    """Disable any pending wakealarm, then power off with a
+    wake scheduled in N seconds.
+    """
     rtc = args.rtc
     subprocess.run(["rtcwake", "-v", "-d", rtc, "-m", "disable"], check=False)
     result = subprocess.run(
@@ -78,7 +80,9 @@ def cmd_number(args):
 
 
 def cmd_read(args):
-    """Check /sys/class/rtc/<rtc>/since_epoch is readable; sync via hwclock if not."""
+    """Check /sys/class/rtc/<rtc>/since_epoch is readable;
+    sync via hwclock if not.
+    """
     rtc = args.rtc
     since_epoch_path = f"/sys/class/rtc/{rtc}/since_epoch"
 
@@ -101,7 +105,9 @@ def cmd_read(args):
 
 
 def cmd_alarm(args):
-    """Check that the RTC's wakealarm works via rtcwake, with a timeout guard."""
+    """Check that the RTC's wakealarm works via rtcwake,
+    with a timeout guard.
+    """
     rtc = args.rtc
     wakealarm_path = f"/sys/class/rtc/{rtc}/wakealarm"
 
@@ -152,9 +158,18 @@ def build_parser():
     p_list = sub.add_parser("list", help="List RTC devices (resource job)")
     p_list.set_defaults(func=cmd_list)
 
+    p_battery = sub.add_parser(
+        "battery", help="RTC battery wake-from-poweroff test"
+    )
+    p_battery.add_argument("--rtc", default=default_rtc)
+    p_battery.add_argument("--seconds", type=int, default=30)
+    p_battery.set_defaults(func=cmd_battery)
+
     p_number = sub.add_parser("number", help="Check RTC device count")
     p_number.add_argument(
-        "--total", type=int, default=None,
+        "--total",
+        type=int,
+        default=None,
         help="Expected RTC count (falls back to $TOTAL_RTC_NUM, then 1)",
     )
     p_number.set_defaults(func=cmd_number)
@@ -173,11 +188,6 @@ def build_parser():
     p_clock.add_argument("--rtc", default=default_rtc)
     p_clock.add_argument("--tolerance", type=int, default=5)
     p_clock.set_defaults(func=cmd_clock)
-
-    p_battery = sub.add_parser("battery", help="RTC battery wake-from-poweroff test")
-    p_battery.add_argument("--rtc", default=default_rtc)
-    p_battery.add_argument("--seconds", type=int, default=30)
-    p_battery.set_defaults(func=cmd_battery)
 
     return parser
 

--- a/providers/base/bin/rtc_test.py
+++ b/providers/base/bin/rtc_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # This file is part of Checkbox.
 #
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Checkbox is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3,

--- a/providers/base/bin/rtc_test.py
+++ b/providers/base/bin/rtc_test.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python3
-# RTC (Real Time Clock) test utility for Checkbox.
+# This file is part of Checkbox.
 #
-# Consolidates the shell logic previously embedded in the
-# rtc/battery, rtc/rtc_number, rtc_list, rtc/rtc_read_{rtc},
-# rtc/rtc_alarm_{rtc} and rtc/rtc_clock_{rtc} jobs into a single
-# script with subcommands, following the argparse + dispatch-table
-# pattern used by other checkbox-support scripts.
+# Copyright 2025 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox. If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
 import glob

--- a/providers/base/bin/rtc_test.py
+++ b/providers/base/bin/rtc_test.py
@@ -151,7 +151,7 @@ def cmd_clock(args):
 
 def build_parser():
     parser = argparse.ArgumentParser(description="RTC test utility")
-    sub = parser.add_subparsers(dest="action", required=True)
+    sub = parser.add_subparsers(dest="action")
 
     default_rtc = os.environ.get("RTC_DEVICE_FILE", "rtc0")
 

--- a/providers/base/tests/test_rtc_tests.py
+++ b/providers/base/tests/test_rtc_tests.py
@@ -66,7 +66,7 @@ class CmdBatteryTests(unittest.TestCase):
             [
                 call(
                     ["rtcwake", "-v", "-d", "rtc0", "-m", "disable"],
-                    check=False
+                    check=False,
                 ),
                 call(["rtcwake", "-v", "-d", "rtc0", "-m", "off", "-s", "30"]),
             ]

--- a/providers/base/tests/test_rtc_tests.py
+++ b/providers/base/tests/test_rtc_tests.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox. If not, see <http://www.gnu.org/licenses/>.
+
+
+import io
+import os
+import subprocess
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, mock_open, patch, call
+
+import rtc_test
+
+
+class FindRtcDevicesTests(unittest.TestCase):
+    @patch("rtc_test.glob.glob")
+    def test_sorts_and_strips_basenames(self, mock_glob):
+        mock_glob.return_value = ["/dev/rtc1", "/dev/rtc0"]
+        self.assertEqual(rtc_test.find_rtc_devices(), ["rtc0", "rtc1"])
+
+
+class CanReadTests(unittest.TestCase):
+    @patch("builtins.open", new_callable=mock_open, read_data="123456\n")
+    def test_readable_file_returns_true(self, mock_file):
+        self.assertTrue(rtc_test._can_read("/fake/rtc/since_epoch"))
+
+    @patch("builtins.open", side_effect=OSError)
+    def test_unreadable_file_returns_false(self, mock_file):
+        self.assertFalse(rtc_test._can_read("/fake/rtc/since_epoch"))
+
+
+class CmdListTests(unittest.TestCase):
+    @patch("rtc_test.find_rtc_devices", return_value=["rtc0", "rtc1"])
+    def test_emits_one_record_per_device(self, mock_find):
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            ret = rtc_test.cmd_list(SimpleNamespace())
+        self.assertEqual(ret, 0)
+        self.assertEqual(mock_stdout.getvalue(), "rtc: rtc0\n\nrtc: rtc1\n\n")
+
+
+class CmdBatteryTests(unittest.TestCase):
+    @patch("rtc_test.subprocess.run")
+    def test_commands_has_called(self, mock_run: MagicMock):
+        mock_run.side_effect = [MagicMock(returncode=0), MagicMock(returncode=0)]
+        args = SimpleNamespace(rtc="rtc0", seconds=30)
+        self.assertEqual(rtc_test.cmd_battery(args), 0)
+        self.assertEqual(mock_run.call_count, 2)
+        mock_run.assert_has_calls([
+            call(["rtcwake", "-v", "-d", "rtc0", "-m", "disable"], check=False),
+            call(["rtcwake", "-v", "-d", "rtc0", "-m", "off", "-s", "30"]),
+        ])
+
+
+class CmdNumberTests(unittest.TestCase):
+    @patch("rtc_test.find_rtc_devices", return_value=["rtc0"])
+    def test_number_match(self, mock_find):
+        self.assertEqual(rtc_test.cmd_number(SimpleNamespace(total=1)), 0)
+
+    @patch("rtc_test.find_rtc_devices", return_value=["rtc0"])
+    def test_number_mismatch(self, mock_find):
+        self.assertEqual(rtc_test.cmd_number(SimpleNamespace(total=2)), 1)
+
+    @patch.dict(os.environ, {"TOTAL_RTC_NUM": "3"}, clear=True)
+    @patch("rtc_test.find_rtc_devices", return_value=["rtc0", "rtc1", "rtc2"])
+    def test_number_match_when_env_val_set(self, mock_find):
+        self.assertEqual(rtc_test.cmd_number(SimpleNamespace(total=None)), 0)
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("rtc_test.find_rtc_devices", return_value=["rtc0"])
+    def test_default_when_env_val_unset(self, mock_find):
+        self.assertEqual(rtc_test.cmd_number(SimpleNamespace(total=None)), 0)
+
+
+class CmdReadTests(unittest.TestCase):
+    @patch("rtc_test._can_read", return_value=True)
+    def test_can_read(self, mock_can_read):
+        self.assertEqual(rtc_test.cmd_read(SimpleNamespace(rtc="rtc0")), 0)
+        mock_can_read.assert_called_once_with("/sys/class/rtc/rtc0/since_epoch")
+
+    @patch("rtc_test.subprocess.run")
+    @patch("rtc_test._can_read", side_effect=[False, True])
+    def test_calls_hwclock_sync_when_unreadable(self, mock_can_read, mock_run: MagicMock):
+        mock_run.return_value = MagicMock(returncode=0)
+        self.assertEqual(rtc_test.cmd_read(SimpleNamespace(rtc="rtc0")), 0)
+        mock_run.assert_called_once_with(
+            ["hwclock", "--systohc", "--utc", "--rtc=/dev/rtc0"]
+        )
+
+    @patch("rtc_test.subprocess.run")
+    @patch("rtc_test._can_read", return_value=False)
+    def test_hwclock_command_itself_fails(self, mock_can_read, mock_run: MagicMock):
+        mock_run.return_value = MagicMock(returncode=1)
+        self.assertEqual(rtc_test.cmd_read(SimpleNamespace(rtc="rtc0")), 1)
+
+    @patch("rtc_test.subprocess.run")
+    @patch("rtc_test._can_read", side_effect=[False, False])
+    def test_still_unreadable_after_successful_sync(self, mock_can_read, mock_run: MagicMock):
+        mock_run.return_value = MagicMock(returncode=0)
+        self.assertEqual(rtc_test.cmd_read(SimpleNamespace(rtc="rtc0")), 1)
+
+
+class CmdAlarmTests(unittest.TestCase):
+    @patch("rtc_test.os.path.isfile", return_value=False)
+    def test_no_wakealarm_support(self, mock_isfile):
+        args = SimpleNamespace(rtc="rtc0", seconds=30, timeout=60)
+        self.assertEqual(rtc_test.cmd_alarm(args), 1)
+
+    @patch("rtc_test.subprocess.run")
+    @patch("rtc_test.os.path.isfile", return_value=True)
+    def test_success_calls_rtcwake_with_expected_args(self, mock_isfile, mock_run):
+        args = SimpleNamespace(rtc="rtc0", seconds=30, timeout=60)
+        self.assertEqual(rtc_test.cmd_alarm(args), 0)
+        mock_run.assert_called_once_with(
+            ["rtcwake", "-v", "-d", "rtc0", "-m", "on", "-s", "30"],
+            timeout=60,
+            check=True,
+        )
+
+    @patch(
+        "rtc_test.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="rtcwake", timeout=60),
+    )
+    @patch("rtc_test.os.path.isfile", return_value=True)
+    def test_timeout_is_reported_as_failure(self, mock_isfile, mock_run):
+        args = SimpleNamespace(rtc="rtc0", seconds=30, timeout=60)
+        self.assertEqual(rtc_test.cmd_alarm(args), 1)
+
+    @patch(
+        "rtc_test.subprocess.run",
+        side_effect=subprocess.CalledProcessError(returncode=2, cmd="rtcwake"),
+    )
+    @patch("rtc_test.os.path.isfile", return_value=True)
+    def test_nonzero_exit_is_reported_as_failure(self, mock_isfile, mock_run):
+        args = SimpleNamespace(rtc="rtc0", seconds=30, timeout=60)
+        self.assertEqual(rtc_test.cmd_alarm(args), 1)
+
+
+class CmdClockTests(unittest.TestCase):
+    @patch("rtc_test.time.time", return_value=1788854686.989309)
+    @patch("builtins.open", new_callable=mock_open, read_data="1788854690\n")
+    def test_within_tolerance_passes(self, mock_file, mock_time):
+        args = SimpleNamespace(rtc="rtc0", tolerance=5)
+        self.assertEqual(rtc_test.cmd_clock(args), 0)
+
+    @patch("rtc_test.time.time", return_value=1788854686.989309)
+    @patch("builtins.open", new_callable=mock_open, read_data="1788854688\n")
+    def test_exactly_at_tolerance_passes(self, mock_file, mock_time):
+        args = SimpleNamespace(rtc="rtc0", tolerance=2)
+        self.assertEqual(rtc_test.cmd_clock(args), 0)
+
+    @patch("rtc_test.time.time", return_value=1788854686.989309)
+    @patch("builtins.open", new_callable=mock_open, read_data="1788854680\n")
+    def test_beyond_tolerance_fails(self, mock_file, mock_time):
+        args = SimpleNamespace(rtc="rtc0", tolerance=5)
+        self.assertEqual(rtc_test.cmd_clock(args), 1)
+
+
+class BuildParserTests(unittest.TestCase):
+    def test_list_dispatches_to_cmd_list(self):
+        parser = rtc_test.build_parser()
+        args = parser.parse_args(["list"])
+        self.assertIs(args.func, rtc_test.cmd_list)
+
+    @patch.dict(os.environ, {"RTC_DEVICE_FILE": "rtc1"}, clear=True)
+    def test_default_rtc_comes_from_env_var(self):
+        parser = rtc_test.build_parser()
+        args = parser.parse_args(["read"])
+        self.assertEqual(args.rtc, "rtc1")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_default_rtc_falls_back_to_rtc0(self):
+        parser = rtc_test.build_parser()
+        args = parser.parse_args(["clock"])
+        self.assertEqual(args.rtc, "rtc0")
+
+    def test_alarm_arguments_have_expected_defaults(self):
+        parser = rtc_test.build_parser()
+        args = parser.parse_args(["alarm"])
+        self.assertEqual(args.seconds, 30)
+        self.assertEqual(args.timeout, 60)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/providers/base/tests/test_rtc_tests.py
+++ b/providers/base/tests/test_rtc_tests.py
@@ -62,13 +62,15 @@ class CmdBatteryTests(unittest.TestCase):
         args = SimpleNamespace(rtc="rtc0", seconds=30)
         self.assertEqual(rtc_test.cmd_battery(args), 0)
         self.assertEqual(mock_run.call_count, 2)
-        mock_run.assert_has_calls([
-            call(
-                ["rtcwake", "-v", "-d", "rtc0", "-m", "disable"],
-                check=False
-            ),
-            call(["rtcwake", "-v", "-d", "rtc0", "-m", "off", "-s", "30"]),
-        ])
+        mock_run.assert_has_calls(
+            [
+                call(
+                    ["rtcwake", "-v", "-d", "rtc0", "-m", "disable"],
+                    check=False
+                ),
+                call(["rtcwake", "-v", "-d", "rtc0", "-m", "off", "-s", "30"]),
+            ]
+        )
 
 
 class CmdNumberTests(unittest.TestCase):

--- a/providers/base/tests/test_rtc_tests.py
+++ b/providers/base/tests/test_rtc_tests.py
@@ -55,12 +55,18 @@ class CmdListTests(unittest.TestCase):
 class CmdBatteryTests(unittest.TestCase):
     @patch("rtc_test.subprocess.run")
     def test_commands_has_called(self, mock_run: MagicMock):
-        mock_run.side_effect = [MagicMock(returncode=0), MagicMock(returncode=0)]
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(returncode=0),
+        ]
         args = SimpleNamespace(rtc="rtc0", seconds=30)
         self.assertEqual(rtc_test.cmd_battery(args), 0)
         self.assertEqual(mock_run.call_count, 2)
         mock_run.assert_has_calls([
-            call(["rtcwake", "-v", "-d", "rtc0", "-m", "disable"], check=False),
+            call(
+                ["rtcwake", "-v", "-d", "rtc0", "-m", "disable"],
+                check=False
+            ),
             call(["rtcwake", "-v", "-d", "rtc0", "-m", "off", "-s", "30"]),
         ])
 
@@ -89,11 +95,15 @@ class CmdReadTests(unittest.TestCase):
     @patch("rtc_test._can_read", return_value=True)
     def test_can_read(self, mock_can_read):
         self.assertEqual(rtc_test.cmd_read(SimpleNamespace(rtc="rtc0")), 0)
-        mock_can_read.assert_called_once_with("/sys/class/rtc/rtc0/since_epoch")
+        mock_can_read.assert_called_once_with(
+            "/sys/class/rtc/rtc0/since_epoch"
+        )
 
     @patch("rtc_test.subprocess.run")
     @patch("rtc_test._can_read", side_effect=[False, True])
-    def test_calls_hwclock_sync_when_unreadable(self, mock_can_read, mock_run: MagicMock):
+    def test_calls_hwclock_sync_when_unreadable(
+        self, mock_can_read, mock_run: MagicMock
+    ):
         mock_run.return_value = MagicMock(returncode=0)
         self.assertEqual(rtc_test.cmd_read(SimpleNamespace(rtc="rtc0")), 0)
         mock_run.assert_called_once_with(
@@ -102,13 +112,17 @@ class CmdReadTests(unittest.TestCase):
 
     @patch("rtc_test.subprocess.run")
     @patch("rtc_test._can_read", return_value=False)
-    def test_hwclock_command_itself_fails(self, mock_can_read, mock_run: MagicMock):
+    def test_hwclock_command_itself_fails(
+        self, mock_can_read, mock_run: MagicMock
+    ):
         mock_run.return_value = MagicMock(returncode=1)
         self.assertEqual(rtc_test.cmd_read(SimpleNamespace(rtc="rtc0")), 1)
 
     @patch("rtc_test.subprocess.run")
     @patch("rtc_test._can_read", side_effect=[False, False])
-    def test_still_unreadable_after_successful_sync(self, mock_can_read, mock_run: MagicMock):
+    def test_still_unreadable_after_successful_sync(
+        self, mock_can_read, mock_run: MagicMock
+    ):
         mock_run.return_value = MagicMock(returncode=0)
         self.assertEqual(rtc_test.cmd_read(SimpleNamespace(rtc="rtc0")), 1)
 
@@ -121,7 +135,9 @@ class CmdAlarmTests(unittest.TestCase):
 
     @patch("rtc_test.subprocess.run")
     @patch("rtc_test.os.path.isfile", return_value=True)
-    def test_success_calls_rtcwake_with_expected_args(self, mock_isfile, mock_run):
+    def test_success_calls_rtcwake_with_expected_args(
+        self, mock_isfile, mock_run
+    ):
         args = SimpleNamespace(rtc="rtc0", seconds=30, timeout=60)
         self.assertEqual(rtc_test.cmd_alarm(args), 0)
         mock_run.assert_called_once_with(

--- a/providers/base/units/rtc/jobs.pxu
+++ b/providers/base/units/rtc/jobs.pxu
@@ -68,7 +68,7 @@ category_id: rtc_category
 estimated_duration: 5
 command:
     rtc_path="/sys/class/rtc/{rtc}/since_epoch"
-    if ! rtc_time=$(cat "$rtc_path" 2>/dev/null); then
+    if ! cat "$rtc_path" >/dev/null; then
         echo "Warning: Unable to read $rtc_path."
         if ! hwclock --systohc --utc --rtc=/dev/{rtc}; then
             echo "Error: hwclock sync failed."

--- a/providers/base/units/rtc/jobs.pxu
+++ b/providers/base/units/rtc/jobs.pxu
@@ -70,11 +70,13 @@ command:
     rtc_path="/sys/class/rtc/{rtc}/since_epoch"
     if ! rtc_time=$(cat "$rtc_path" 2>/dev/null); then
         echo "Warning: Unable to read $rtc_path."
-        if hwclock --systohc --utc --rtc=/dev/{rtc}; then
-            if ! cat "$rtc_path" >/dev/null; then
-                echo "Error: RTC is still not readable after hwclock sync."
-                exit 1
-            fi
+        if ! hwclock --systohc --utc --rtc=/dev/{rtc}; then
+            echo "Error: hwclock sync failed."
+            exit 1
+        fi
+        if ! cat "$rtc_path" >/dev/null; then
+            echo "Error: RTC is still not readable after hwclock sync."
+            exit 1
         fi
     fi
 flags: also-after-suspend

--- a/providers/base/units/rtc/jobs.pxu
+++ b/providers/base/units/rtc/jobs.pxu
@@ -94,7 +94,11 @@ category_id: rtc_category
 estimated_duration: 40
 command: 
     if [ -f "/sys/class/rtc/{rtc}/wakealarm" ]; then 
-        rtcwake -d {rtc} -v -m on -s 30
+        timeout 60 rtcwake -d {rtc} -v -m on -s 30
+        if [ $? -eq 124 ]; then
+            echo "Error: rtcwake timed out!"
+            exit 1
+        fi
     else 
         echo "{rtc} does not support wakealarm"
         exit 1 

--- a/providers/base/units/rtc/jobs.pxu
+++ b/providers/base/units/rtc/jobs.pxu
@@ -59,8 +59,32 @@ command:
 unit: template
 template-resource: rtc_list
 template-unit: job
+id: rtc/rtc_read_{rtc}
+template-id: rtc/rtc_read_rtc
+_summary: Check that RTC {rtc} can be read
+plugin: shell
+user: root
+category_id: rtc_category
+estimated_duration: 5
+command:
+    rtc_path="/sys/class/rtc/{rtc}/since_epoch"
+    if ! rtc_time=$(cat "$rtc_path" 2>/dev/null); then
+        echo "Warning: Unable to read $rtc_path."
+        if hwclock --systohc --utc --rtc=/dev/{rtc}; then
+            if ! cat "$rtc_path" >/dev/null; then
+                echo "Error: RTC is still not readable after hwclock sync."
+                exit 1
+            fi
+        fi
+    fi
+flags: also-after-suspend
+
+unit: template
+template-resource: rtc_list
+template-unit: job
 id: rtc/rtc_alarm_{rtc}
 template-id: rtc/rtc_alarm_rtc
+depends: rtc/rtc_read_{rtc}
 _summary: Check that RTC alarm of {rtc} works
 plugin: shell
 user: root
@@ -80,6 +104,7 @@ template-resource: rtc_list
 template-unit: job
 id: rtc/rtc_clock_{rtc}
 template-id: rtc/rtc_clock_rtc
+depends: rtc/rtc_read_{rtc}
 _summary: Check that {rtc} clock is synchronized with system clock
 plugin: shell
 user: root
@@ -87,11 +112,7 @@ category_id: rtc_category
 estimated_duration: 5
 environ:
 command: 
-    rtc_path="/sys/class/rtc/{rtc}/since_epoch"
-    if ! rtc_time=$(cat "$rtc_path" 2>/dev/null); then
-        echo "FAILED to read RTC time from {rtc}" >&2
-        exit 1
-    fi
+    rtc_time=$(cat "/sys/class/rtc/{rtc}/since_epoch")
     sys_time=$(date +"%s")
     result=$(("$sys_time" - "$rtc_time"))
     if [[ "$result" -le "5" ]]; then

--- a/providers/base/units/rtc/jobs.pxu
+++ b/providers/base/units/rtc/jobs.pxu
@@ -95,9 +95,12 @@ estimated_duration: 40
 command: 
     if [ -f "/sys/class/rtc/{rtc}/wakealarm" ]; then 
         timeout 60 rtcwake -d {rtc} -v -m on -s 30
-        if [ $? -eq 124 ]; then
+        rtcwake_status=$?
+        if [ "$rtcwake_status" -eq 124 ]; then
             echo "Error: rtcwake timed out!"
             exit 1
+        elif [ "$rtcwake_status" -ne 0 ]; then
+            exit "$rtcwake_status"
         fi
     else 
         echo "{rtc} does not support wakealarm"

--- a/providers/base/units/rtc/jobs.pxu
+++ b/providers/base/units/rtc/jobs.pxu
@@ -7,9 +7,7 @@ _steps:
 _verification:
  RTC can wake up the system successfully.
 environ: RTC_DEVICE_FILE
-command:
- rtcwake -v -d "${RTC_DEVICE_FILE:-rtc0}" -m disable
- rtcwake -v -d "${RTC_DEVICE_FILE:-rtc0}" -m off -s 30
+command: rtc_test.py battery --rtc "${RTC_DEVICE_FILE:-rtc0}" --seconds 30
 plugin: user-interact
 user: root
 category_id: rtc_category
@@ -24,22 +22,9 @@ plugin: shell
 user: root
 estimated_duration: 1.0
 category_id: rtc_category
-command:
-    if [ -z "$TOTAL_RTC_NUM" ]; then
-        echo "TOTAL_RTC_NUM not defined, defaulting to 1"
-        TOTAL_RTC_NUM=1; 
-    fi
-    SYSFS_RTC_NUM=$(find /dev/ -name "rtc[0-9]" | wc -l)
-    echo "TOTAL_RTC_NUM: $TOTAL_RTC_NUM"
-    echo "Number of RTC devices found in sysfs: $SYSFS_RTC_NUM"
-    if [ "$SYSFS_RTC_NUM" != "$TOTAL_RTC_NUM" ]; then
-        echo "RTC number mismatch"
-        exit 1
-    else
-        echo "RTC number matched"
-    fi
+command: rtc_test.py number
 flags: also-after-suspend
-environ:  TOTAL_RTC_NUM
+environ: TOTAL_RTC_NUM
 
 id: rtc_list
 _summary: Generates a RTC list for the platform
@@ -49,12 +34,7 @@ plugin: resource
 user: root
 estimated_duration: 1.0
 category_id: rtc_category
-command:
-    rtcs=$(find /dev/ -name "rtc[0-9]"| awk -F "/" '{print $3}')
-    for c in ${rtcs}; do
-        echo "rtc: ${c}"
-        echo ""
-    done
+command: rtc_test.py list
 
 unit: template
 template-resource: rtc_list

--- a/providers/base/units/rtc/jobs.pxu
+++ b/providers/base/units/rtc/jobs.pxu
@@ -46,19 +46,7 @@ plugin: shell
 user: root
 category_id: rtc_category
 estimated_duration: 5
-command:
-    rtc_path="/sys/class/rtc/{rtc}/since_epoch"
-    if ! cat "$rtc_path" >/dev/null; then
-        echo "Warning: Unable to read $rtc_path."
-        if ! hwclock --systohc --utc --rtc=/dev/{rtc}; then
-            echo "Error: hwclock sync failed."
-            exit 1
-        fi
-        if ! cat "$rtc_path" >/dev/null; then
-            echo "Error: RTC is still not readable after hwclock sync."
-            exit 1
-        fi
-    fi
+command: rtc_test.py read --rtc {rtc}
 flags: also-after-suspend
 
 unit: template
@@ -72,20 +60,7 @@ plugin: shell
 user: root
 category_id: rtc_category
 estimated_duration: 40
-command: 
-    if [ -f "/sys/class/rtc/{rtc}/wakealarm" ]; then 
-        timeout 60 rtcwake -d {rtc} -v -m on -s 30
-        rtcwake_status=$?
-        if [ "$rtcwake_status" -eq 124 ]; then
-            echo "Error: rtcwake timed out!"
-            exit 1
-        elif [ "$rtcwake_status" -ne 0 ]; then
-            exit "$rtcwake_status"
-        fi
-    else 
-        echo "{rtc} does not support wakealarm"
-        exit 1 
-    fi
+command: rtc_test.py alarm --rtc {rtc} --seconds 30 --timeout 60
 flags: also-after-suspend
 
 unit: template
@@ -100,17 +75,5 @@ user: root
 category_id: rtc_category
 estimated_duration: 5
 environ:
-command: 
-    rtc_time=$(cat "/sys/class/rtc/{rtc}/since_epoch")
-    sys_time=$(date +"%s")
-    result=$(("$sys_time" - "$rtc_time"))
-    if [[ "$result" -le "5" ]]; then
-        echo "{rtc} Clock synchronized with System Clock"
-        echo "RTC clock= $rtc_time"
-    else
-        echo "{rtc} Clock not synchronized with System Clock"
-        echo "System clock= $sys_time"
-        echo "RTC clock= $rtc_time"
-        exit 1
-    fi
+command: rtc_test.py clock --rtc {rtc} --tolerance 5
 flags: also-after-suspend


### PR DESCRIPTION
## Description
- Check if RTCs are readable; if not, use `hwclock` to initialize time on RTCs that without a default time.
- Add `util-linux-extra` support for Ubuntu 24 and later versions.
- Set a timeout for the RTC alarm to prevent job hangs.

## Resolved issues
https://github.com/canonical/checkbox/issues/2748

## Documentation

## Tests
Submission: https://certification.canonical.com/submissions/status/402576
```
----------------------[ Starting new interactive session ]----------------------
Agent is using sideloaded providers
===========[ Bootstrap com.canonical.certification::rtc_list (1/1) ]============
--------------------------------------------------------------------------------
Outcome: job passed
-----------------------------[ Running job 1 / 5 ]------------------------------
[ RTC battery tracks the time and ensures the system can wake up from power off state. ]
ID: com.canonical.certification::rtc/battery
Category: Real Time Clock (RTC)
--------------------------------------------------------------------------------
Purpose:

RTC battery backup power can send system wakeup events.

Steps:

1. Start the test to power off the system (wakeup scheduled in 30s).

Pick an action
    => press ENTER to continue
  c => add a comment
  s => skip this job
  q => save the session and quit
[csq]: 
Connection lost!
[Errno 104] Connection reset by peer
Reconnecting ...
Reconnected (took: 63s)
----------------------[ Starting new interactive session ]----------------------
Agent is using sideloaded providers
[ RTC battery tracks the time and ensures the system can wake up from power off state. ]
ID: com.canonical.certification::rtc/battery
Category: Real Time Clock (RTC)
--------------------------------------------------------------------------------
Outcome: job passed
-----------------------------[ Running job 3 / 6 ]------------------------------
--------------------[ Check the number of RTC as expected. ]--------------------
ID: com.canonical.certification::rtc/rtc_number
Category: Real Time Clock (RTC)
--------------------------------------------------------------------------------
TOTAL_RTC_NUM not defined, defaulting to 1
TOTAL_RTC_NUM: 1
Number of RTC devices found in sysfs: 1
RTC number matched
--------------------------------------------------------------------------------
Outcome: job passed
-----------------------------[ Running job 4 / 6 ]------------------------------
----------------------[ Check that RTC rtc0 can be read ]-----------------------
ID: com.canonical.certification::rtc/rtc_read_rtc0
Category: Real Time Clock (RTC)
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
Outcome: job passed
-----------------------------[ Running job 5 / 6 ]------------------------------
---------------------[ Check that RTC alarm of rtc0 works ]---------------------
ID: com.canonical.certification::rtc/rtc_alarm_rtc0
Category: Real Time Clock (RTC)
--------------------------------------------------------------------------------
rtcwake: assuming RTC uses UTC ...
Using UTC time.
	delta   = 0
	tzone   = 0
	tzname  = UTC
	systime = 1789115411, (UTC) Fri Sep 11 08:30:11 2026
	rtctime = 1789115411, (UTC) Fri Sep 11 08:30:11 2026
alarm 0, sys_time 1789115411, rtc_time 1789115411, seconds 30
rtcwake: wakeup using rtc0 at Fri Sep 11 08:30:42 2026
suspend mode: on; reading rtc
... rtc0: 1a0
--------------------------------------------------------------------------------
Outcome: job passed
-----------------------------[ Running job 6 / 6 ]------------------------------
----------[ Check that rtc0 clock is synchronized with system clock ]-----------
ID: com.canonical.certification::rtc/rtc_clock_rtc0
Category: Real Time Clock (RTC)
--------------------------------------------------------------------------------
rtc0 Clock synchronized with System Clock
RTC clock= 1789115442
--------------------------------------------------------------------------------
Outcome: job passed
==================================[ Results ]===================================
Using side-loaded providers disabled the certification report
320kB [00:00, 33.8MB/s, file=python://stdout]                                                                                                                                                                                  
  job passed   : RTC battery tracks the time and ensures the system can wake up from power off state.
  job passed   : Check the number of RTC as expected.
  job passed   : Check that RTC rtc0 can be read
  job passed   : Check that RTC alarm of rtc0 works
  job passed   : Check that rtc0 clock is synchronized with system clock
```