### PR TITLE
Fix salvages skipped (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/result_utils.py
+++ b/checkbox-ng/plainbox/impl/result_utils.py
@@ -71,7 +71,7 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
     - If any dependency was manually skipped, outcome is OUTCOME_MANUAL_SKIP
     - Else if there are failed manifest expressions, outcome is
     OUTCOME_SKIPPED_MANIFEST
-    - Else if there are FAILED_DEP inhibitors, outcome is
+    - Else if there are FAILED_DEP/NOT_FAILED_DEP inhibitors, outcome is
     OUTCOME_SKIPPED_DEPENDENCY
     - Else if there are failed resource expressions, outcome is
     OUTCOME_SKIPPED_RESOURCE, except if `fail-on-resource` flag is used, in
@@ -106,7 +106,10 @@ def determine_outcome_and_skip_reason(job_state, job_state_map):
             has_failed_manifest = True
             skip_reason["related_manifests"] += inhibitor.related_manifests
 
-        elif inhibitor.cause == InhibitionCause.FAILED_DEP:
+        elif inhibitor.cause in [
+            InhibitionCause.FAILED_DEP,
+            InhibitionCause.NOT_FAILED_DEP,
+        ]:
             has_failed_dep = True
             # Check if the dependency was manually skipped
             if inhibitor.related_job:

--- a/checkbox-ng/plainbox/impl/test_result_utils.py
+++ b/checkbox-ng/plainbox/impl/test_result_utils.py
@@ -85,6 +85,29 @@ class DetermineOutcomeAndSkipReasonTests(unittest.TestCase):
         self.assertIn("job1", skip_reason["related_dependencies"])
         self.assertIn("job2", skip_reason["related_dependencies"])
 
+    def test_not_failed_deps(self):
+        """Test with NOT_FAILED_DEP inhibitor."""
+        job = Mock()
+        job.id = "job1"
+
+        inhibitor = Mock()
+        inhibitor.cause = InhibitionCause.NOT_FAILED_DEP
+        inhibitor.related_job = job
+
+        job_state = Mock()
+        job_state.readiness_inhibitor_list = [inhibitor]
+
+        job_state_map = {
+            "job1": Mock(result=Mock(outcome="fail")),
+        }
+
+        outcome, skip_reason = determine_outcome_and_skip_reason(
+            job_state, job_state_map
+        )
+
+        self.assertEqual(outcome, IJobResult.OUTCOME_SKIPPED_DEPENDENCY)
+        self.assertIn("job1", skip_reason["related_dependencies"])
+
     def test_failed_resource_inhibitor(self):
         """Test with a FAILED_RESOURCE inhibitor."""
         expr = Mock()

--- a/metabox/metabox/metabox-provider/units/salvages.yaml
+++ b/metabox/metabox/metabox-provider/units/salvages.yaml
@@ -1,0 +1,29 @@
+id: salvages_skipped_by_dependency
+plugin: shell
+command: true
+summary: This job should be skipped since the job it's salvaging is skipped by dependency
+salvages: skipped_by_dependency
+---
+id: salvages_skipped_by_requirement
+plugin: shell
+command: true
+summary: This job should be skipped since the job it's salvaging is skipped by requirement
+salvages: simple_skipped
+---
+id: salvages_skipped_by_manifest
+plugin: shell
+command: true
+summary: This job should be skipped since the job it's salvaging is skipped by requirement
+salvages: skipped_by_manifest
+---
+id: salvages_test_plan
+unit: test plan
+name: Salvages Test Plan
+description: Test plan used in salvages testing
+include:
+  - skipped_by_dependency
+  - simple_skipped
+  - skipped_by_manifest
+  - salvages_skipped_by_dependency
+  - salvages_skipped_by_requirement
+  - salvages_skipped_by_manifest

--- a/metabox/metabox/metabox-provider/units/salvages.yaml
+++ b/metabox/metabox/metabox-provider/units/salvages.yaml
@@ -13,7 +13,7 @@ salvages: simple_skipped
 id: salvages_skipped_by_manifest
 plugin: shell
 command: 'true'
-summary: This job should be skipped since the job it's salvaging is skipped by requirement
+summary: This job should be skipped since the job it's salvaging is skipped by manifest
 salvages: skipped_by_manifest
 ---
 id: salvages_test_plan

--- a/metabox/metabox/metabox-provider/units/salvages.yaml
+++ b/metabox/metabox/metabox-provider/units/salvages.yaml
@@ -1,18 +1,18 @@
 id: salvages_skipped_by_dependency
 plugin: shell
-command: true
+command: 'true'
 summary: This job should be skipped since the job it's salvaging is skipped by dependency
 salvages: skipped_by_dependency
 ---
 id: salvages_skipped_by_requirement
 plugin: shell
-command: true
+command: 'true'
 summary: This job should be skipped since the job it's salvaging is skipped by requirement
 salvages: simple_skipped
 ---
 id: salvages_skipped_by_manifest
 plugin: shell
-command: true
+command: 'true'
 summary: This job should be skipped since the job it's salvaging is skipped by requirement
 salvages: skipped_by_manifest
 ---

--- a/metabox/metabox/metabox-provider/units/salvages.yaml
+++ b/metabox/metabox/metabox-provider/units/salvages.yaml
@@ -2,19 +2,22 @@ id: salvages_skipped_by_dependency
 plugin: shell
 command: 'true'
 summary: This job should be skipped since the job it's salvaging is skipped by dependency
-salvages: skipped_by_dependency
+salvages:
+  - skipped_by_dependency
 ---
 id: salvages_skipped_by_requirement
 plugin: shell
 command: 'true'
 summary: This job should be skipped since the job it's salvaging is skipped by requirement
-salvages: simple_skipped
+salvages:
+  - simple_skipped
 ---
 id: salvages_skipped_by_manifest
 plugin: shell
 command: 'true'
 summary: This job should be skipped since the job it's salvaging is skipped by manifest
-salvages: skipped_by_manifest
+salvages:
+  - skipped_by_manifest
 ---
 id: salvages_test_plan
 unit: test plan

--- a/metabox/metabox/scenarios/basic/salvages.py
+++ b/metabox/metabox/scenarios/basic/salvages.py
@@ -1,0 +1,53 @@
+# This file is part of Checkbox.
+#
+# Copyright 2025 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+
+from metabox.core.scenario import Scenario
+from metabox.core.actions import AssertPrinted, Start
+from metabox.core.utils import tag
+
+
+@tag("salvages", "basic")
+class SalvagesSkipped(Scenario):
+    modes = ["remote", "local"]
+
+    launcher = textwrap.dedent("""
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::salvages_test_plan
+        forced = yes
+        [test selection]
+        forced = yes
+        [ui]
+        type = silent
+        [manifest]
+        2021.com.canonical.certification::skipping_test_manifest=False
+        """)
+    steps = [
+        Start(),
+        AssertPrinted("salvages_skipped_by_dependency"),
+        AssertPrinted("Job cannot be started because of failed dependency:"),
+        AssertPrinted("skipped_by_dependency"),
+        AssertPrinted("salvages_skipped_by_requirement"),
+        AssertPrinted("Job cannot be started because of failed dependency:"),
+        AssertPrinted("simple_skipped"),
+        AssertPrinted("salvages_skipped_by_manifest"),
+        AssertPrinted("Job cannot be started because of failed dependency:"),
+        AssertPrinted("skipped_by_manifest"),
+    ]


### PR DESCRIPTION

## Description

If a job (job 1) is used to salvage another job (job 2), but job 2 is
being skipped, Checkbox will crash.

This commit prevents this by setting the outcome of job 1 to
`OUTCOME_SKIPPED_DEPENDENCY`.

## Tests

- Add unit test to check `NOT_FAILED_DEP`
- Added a Metabox test
