### PR TITLE
Wrap ntpdate with plz-run in networking/ntp test (BugFix)

### DIFF
--- a/providers/base/bin/network_ntp_test.py
+++ b/providers/base/bin/network_ntp_test.py
@@ -104,7 +104,7 @@ def SyncTime(server):
     that syncs time faster than the slewed method that ntpdate uses by default,
     meaning we'll see something meaningful faster.
     """
-    cmd = "ntpdate -b " + server
+    cmd = "plz-run ntpdate -b " + server
     logging.debug("using %s" % server)
     sync = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)
     result = sync.communicate()


### PR DESCRIPTION
## Description

In Snap automated test, the `networking/ntp` test script calls host `ntpdate` (which wraps `ntpdig`). Because the subprocess inherits the Snap environment, `ntpdig` fails to locate its Python module, throwing error such as:
`ntpdig: can't find Python NTP library -- check PYTHONPATH.` `No module named 'ntp'`.

This PR prefixes the `ntpdate` command with `plz-run` to executes `ntpdate` command outside the Snap environment, clearing the conflicting Snap environment variables.

## Resolved issues

[OEMQA-6842](https://warthogs.atlassian.net/browse/OEMQA-6842)

## Documentation

N/A

## Tests

1. Run the `networking/ntp` test in Checkbox with Snap version.
2. Verify that `ntpdate` executes without throwing `PYTHONPATH` or `No module named 'ntp' errors`.
3. Confirm NTP synchronization test completes successfully.

[OEMQA-6842]: https://warthogs.atlassian.net/browse/OEMQA-6842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ