### PR TITLE
Make Checkbox immune to the OOM Killer (New)

### DIFF
--- a/checkbox-core-snap/series16/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series16/snap/snapcraft.yaml
@@ -64,7 +64,7 @@ apps:
     plugs: &standard [home, network-bind, hardware-observe, bluez, bluetooth-control,
       gpio, modem-manager, mount-observe, network-manager, pulseaudio, serial-port,
       system-observe, tpm, udisks2, account-control, accounts-service,
-      login-session-control, login-session-observe, checkbox-support]
+      login-session-control, login-session-observe, process-control, checkbox-support]
     environment:
       PYTHONPATH: $SNAP/lib/python3.5/site-packages/:$SNAP/lib64/python3.5/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH

--- a/checkbox-core-snap/series18/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series18/snap/snapcraft.yaml
@@ -68,7 +68,7 @@ apps:
     plugs: &standard [home, network-bind, hardware-observe, bluez, bluetooth-control,
       gpio, modem-manager, mount-observe, network-manager, pulseaudio, serial-port,
       system-observe, tpm, udisks2, account-control, accounts-service,
-      login-session-control, login-session-observe, checkbox-support]
+      login-session-control, login-session-observe, process-control, checkbox-support]
     environment:
       PYTHONPATH: $SNAP/lib/python3.6/site-packages/:$SNAP/lib64/python3.6/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH

--- a/checkbox-core-snap/series20/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series20/snap/snapcraft.yaml
@@ -68,7 +68,7 @@ apps:
     plugs: &standard [home, network-bind, hardware-observe, bluez, bluetooth-control,
       gpio, modem-manager, mount-observe, network-manager, pulseaudio, serial-port,
       system-observe, tpm, udisks2, account-control, accounts-service,
-      login-session-control, login-session-observe, checkbox-support]
+      login-session-control, login-session-observe, process-control, checkbox-support]
     environment:
       PYTHONPATH: $SNAP/lib/python3.8/site-packages/:$SNAP/lib64/python3.8/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH

--- a/checkbox-core-snap/series22/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series22/snap/snapcraft.yaml
@@ -72,7 +72,7 @@ apps:
     plugs: &standard [home, network-bind, hardware-observe, bluez, bluetooth-control,
       gpio, modem-manager, mount-observe, network-manager, pulseaudio, serial-port,
       system-observe, tpm, udisks2, account-control, accounts-service,
-      login-session-control, login-session-observe, checkbox-support]
+      login-session-control, login-session-observe, process-control, checkbox-support]
     environment:
       PYTHONPATH: $SNAP/lib/python3.10/site-packages/:$SNAP/lib64/python3.10/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH

--- a/checkbox-core-snap/series24/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series24/snap/snapcraft.yaml
@@ -72,7 +72,7 @@ apps:
     plugs: &standard [home, network-bind, hardware-observe, bluez, bluetooth-control,
       gpio, modem-manager, mount-observe, network-manager, pulseaudio, serial-port,
       system-observe, tpm, udisks2, account-control, accounts-service,
-      login-session-control, login-session-observe, checkbox-support]
+      login-session-control, login-session-observe, process-control, checkbox-support]
     environment:
       PYTHONPATH: $SNAP/lib/python3.12/site-packages/:$SNAP/lib64/python3.12/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH

--- a/checkbox-core-snap/series26/snap/snapcraft.yaml
+++ b/checkbox-core-snap/series26/snap/snapcraft.yaml
@@ -72,7 +72,7 @@ apps:
     plugs: &standard [home, network-bind, hardware-observe, bluez, bluetooth-control,
       gpio, modem-manager, mount-observe, network-manager, pulseaudio, serial-port,
       system-observe, tpm, udisks2, account-control, accounts-service,
-      login-session-control, login-session-observe, checkbox-support]
+      login-session-control, login-session-observe, process-control, checkbox-support]
     environment:
       PYTHONPATH: $SNAP/lib/python3.14/site-packages/:$SNAP/lib64/python3.14/site-packages/:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
       PATH: /snap/bin:$PATH

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -119,12 +119,42 @@ class UnifiedRunner(IJobRunner):
         self._stdin = stdin
         self._running_jobs_pid = None
         self._extra_env = extra_env
+        self._systemd_runner_prepared = False
+
+    def prepare_system_based_runner(self):
+        """
+        Patches to the system that only apply when using the systemd runner
+        """
+        if self._systemd_runner_prepared:
+            return
+        else:
+            # only apply the patches once
+            self._systemd_runner_prepared = True
+        if not os.geteuid():
+            # Be lenient here, the user may be experimenting and none of these
+            # are make or break, they are all QoL patches
+            return
+        try:
+            # Make Checkbox immune to the OOM Killer
+            # this is only applied when using the systemd based runner because
+            # the oom_score_adj is inherited by children (applying this to the
+            # subprocess based runner would make all tests immune to OOM as
+            # well)
+            with open("/proc/self/oom_score_adj", "w") as f:
+                f.write("-1000")
+        except PermissionError:
+            logger.warning(
+                "Unable to set OOMScoreAdjust, memory stress tests may crash "
+                "the Checkbox Agent"
+            )
 
     def run_job(
         self, job, job_state, environ=None, ui=None, as_systemd_unit=False
     ):
         logger.info(_("Running %r"), job)
         self._job_runner_ui_delegate.ui = ui
+        if as_systemd_unit:
+            self.prepare_system_based_runner()
 
         if isinstance(job, InvalidJob):
             self._job_runner_ui_delegate.on_begin("", dict())

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -121,7 +121,7 @@ class UnifiedRunner(IJobRunner):
         self._extra_env = extra_env
         self._systemd_runner_prepared = False
 
-    def prepare_system_based_runner(self):
+    def prepare_systemd_based_runner(self):
         """
         Patches to the system that only apply when using the systemd runner
         """
@@ -142,7 +142,7 @@ class UnifiedRunner(IJobRunner):
             # well)
             with open("/proc/self/oom_score_adj", "w") as f:
                 f.write("-1000")
-        except PermissionError:
+        except OSError:
             logger.warning(
                 "Unable to set OOMScoreAdjust, memory stress tests may crash "
                 "the Checkbox Agent"
@@ -154,7 +154,7 @@ class UnifiedRunner(IJobRunner):
         logger.info(_("Running %r"), job)
         self._job_runner_ui_delegate.ui = ui
         if as_systemd_unit:
-            self.prepare_system_based_runner()
+            self.prepare_systemd_based_runner()
 
         if isinstance(job, InvalidJob):
             self._job_runner_ui_delegate.on_begin("", dict())

--- a/checkbox-ng/plainbox/impl/execution.py
+++ b/checkbox-ng/plainbox/impl/execution.py
@@ -130,7 +130,7 @@ class UnifiedRunner(IJobRunner):
         else:
             # only apply the patches once
             self._systemd_runner_prepared = True
-        if not os.geteuid():
+        if os.geteuid() != 0:
             # Be lenient here, the user may be experimenting and none of these
             # are make or break, they are all QoL patches
             return

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -197,7 +197,7 @@ class SessionMetaData:
             "features", "systemd_based_job_runner"
         )
         if systemd_based_job_runner is None:
-            systemd_based_job_runner = os.getenv("SNAP")
+            systemd_based_job_runner = bool(os.getenv("SNAP"))
         if systemd_based_job_runner:
             if shutil.which("plz-run"):
                 logger.info("Using systemd-based runner")

--- a/checkbox-ng/plainbox/impl/session/state.py
+++ b/checkbox-ng/plainbox/impl/session/state.py
@@ -25,6 +25,7 @@ Session State Handling.
 import collections
 import json
 import logging
+import os
 import re
 import shutil
 from contextlib import suppress
@@ -46,7 +47,6 @@ from plainbox.impl.session.system_information import (
 )
 from plainbox.impl.unit.job import JobDefinition
 from plainbox.impl.unit.testplan import TestPlanUnitSupport
-from plainbox.impl.unit.unit import on_ubuntucore
 from plainbox.impl.unit.unit_with_id import UnitWithId
 from plainbox.suspend_consts import Suspend
 from plainbox.vendor import morris
@@ -197,19 +197,19 @@ class SessionMetaData:
             "features", "systemd_based_job_runner"
         )
         if systemd_based_job_runner is None:
-            systemd_based_job_runner = on_ubuntucore()
+            systemd_based_job_runner = os.getenv("SNAP")
         if systemd_based_job_runner:
             if shutil.which("plz-run"):
                 logger.info("Using systemd-based runner")
                 self._flags.add(self.FLAG_FEATURE_SYSTEMD_BASED_JOB_RUNNER)
             else:
                 logger.error(
-                    "Experimental systemd-based runner was requested but "
+                    "Systemd-based runner was requested but "
                     "required dependency plz-run is not installed"
                 )
-                logger.error("Falling back to shell based runner")
+                logger.error("Falling back to legacy shell based runner")
         else:
-            logger.info("Using subprocess-based runner")
+            logger.info("Using legacy subprocess-based runner")
 
     @property
     def flags(self):

--- a/checkbox-ng/plainbox/impl/test_execution.py
+++ b/checkbox-ng/plainbox/impl/test_execution.py
@@ -23,6 +23,7 @@ from unittest import TestCase, mock
 
 from plainbox.impl.execution import (
     FakeJobRunner,
+    IJobResult,
     MountingStrategy,
     UnifiedRunner,
     add_to_environment,
@@ -30,7 +31,6 @@ from plainbox.impl.execution import (
     get_execution_command_subshell,
     get_execution_command_systemd_unit,
     get_execution_environment,
-    IJobResult,
 )
 from plainbox.impl.unit.job import InvalidJob
 
@@ -326,6 +326,57 @@ class UnifiedRunnerTests(TestCase):
                 self_mock, job_mock, {}, mock.Mock(), as_systemd_unit=True
             )
         self.assertEqual(str(e.exception), "systemd")
+
+    @mock.patch("os.geteuid")
+    def test_prepare_systemd_based_runner_already_prepared(self, mock_geteuid):
+        self_mock = mock.MagicMock()
+        self_mock._systemd_runner_prepared = True
+
+        UnifiedRunner.prepare_systemd_based_runner(self_mock)
+
+        self.assertFalse(mock_geteuid.called)
+
+    @mock.patch("builtins.open", new_callable=mock.mock_open)
+    @mock.patch("os.geteuid")
+    def test_prepare_systemd_based_runner_not_root(
+        self, mock_geteuid, mock_open
+    ):
+        self_mock = mock.MagicMock()
+        self_mock._systemd_runner_prepared = False
+        mock_geteuid.return_value = 1000
+
+        UnifiedRunner.prepare_systemd_based_runner(self_mock)
+
+        self.assertTrue(mock_geteuid.called)
+        self.assertFalse(mock_open.called)
+
+    @mock.patch("builtins.open", new_callable=mock.mock_open)
+    @mock.patch("os.geteuid")
+    def test_prepare_systemd_based_runner_writes_oom_score(
+        self, mock_geteuid, mock_open
+    ):
+        self_mock = mock.MagicMock()
+        self_mock._systemd_runner_prepared = False
+        mock_geteuid.return_value = 0
+
+        UnifiedRunner.prepare_systemd_based_runner(self_mock)
+
+        self.assertTrue(mock_open.called)
+
+    @mock.patch("plainbox.impl.execution.logger")
+    @mock.patch("plainbox.impl.execution.open")
+    @mock.patch("os.geteuid")
+    def test_prepare_systemd_based_runner_write_failure_warns(
+        self, mock_geteuid, mock_open, mock_logger
+    ):
+        self_mock = mock.MagicMock()
+        self_mock._systemd_runner_prepared = False
+        mock_geteuid.return_value = 0
+        mock_open.side_effect = OSError("Permission denied")
+
+        UnifiedRunner.prepare_systemd_based_runner(self_mock)
+
+        self.assertTrue(mock_logger.warning.called)
 
     @mock.patch("os.getcwd")
     def test_get_proper_job_cwd_preserve_cwd(self, os_cwd_mock):


### PR DESCRIPTION
## Description

Checkbox is used to run stress tests. One thing that can happen is that the system runs low on memory and the OOM Killer decides that Checkbox is a great target to take down to free up a bit of memory. This leads to the tester getting a weird job result (namely because the checkbox service is restarted and checkbox assumes that the machine went down during the test, so the test is marked as crashed).

This PR makes it so if the tester is using the new systemd based runner (as of this PR, default for all snaps!) and is root (so they aren't just debugging something locally), Checkbox makes itself immune to the OOM Killer. This change is transient (doesn't persist application restart) and doesn't cause any issue if done multiple times. 

As mentioned this also makes the systemd based runner default on snaps (as it is bundled in the snap). Debian will follow once I'm done pushing `plz-run` to all PPAs

## Resolved issues

Fixes: https://github.com/canonical/checkbox/issues/1391

> Note: without the new runner, this issue can't be solved as far as I understand. If the new process is a subprocess of checkbox and not another systemd unit, the new process will always inherit the oom score adjustment and there is no reasonable way to reset it because the new process may not have the permissions to write to /proc/self/oom_score_adj.
> Note2: The new runner also fixes checkbox going down when the stress test itself is killed because the new systemd unit is in a different cgroup (as it is not a subprocess) so the default behaviour of the OOM Killer to kill all units in the cgroup also doesn't kill Checkbox anymore

## Documentation

N/A

## Tests

Tested locally by causing an artificial oom kill of the stress test, note2 stands

It is really tricky to make the OOM Killer kill what you want so for the score itself we will have to just trust that the score mechanism works. 
