### PR TITLE
Move ce-oem monitor test plan from auto to manual (BugFix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/monitor/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/monitor/test-plan.pxu
@@ -8,7 +8,7 @@ nested_part:
 
 id: ce-oem-monitor-manual
 unit: test plan
-_name: Built-in monitor or panel auto tests
+_name: Built-in monitor or panel manual tests
 _description: Manual built-in monitor or panel tests
 bootstrap_include:
     ce-oem-monitor/backlight_panel_list

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/monitor/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/monitor/test-plan.pxu
@@ -4,12 +4,12 @@ _name: Monitor tests
 _description: Full built-in monitor or panel tests
 include:
 nested_part:
-    ce-oem-monitor-automated
+    ce-oem-monitor-manual
 
-id: ce-oem-monitor-automated
+id: ce-oem-monitor-manual
 unit: test plan
 _name: Built-in monitor or panel auto tests
-_description: Automated built-in monitor or panel tests
+_description: Manual built-in monitor or panel tests
 bootstrap_include:
     ce-oem-monitor/backlight_panel_list
 include:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
@@ -56,6 +56,7 @@ nested_part:
     ce-oem-cash-drawer-manual
     ce-oem-power-manual
     ce-oem-i2c-manual
+    ce-oem-monitor-manual
 certification_status_overrides:
     apply blocker to .*
 
@@ -109,7 +110,6 @@ nested_part:
     ce-oem-printer-automated
     ce-oem-credit-card-reader-automated
     ce-oem-nxp-ele-automated
-    ce-oem-monitor-automated
     ce-oem-ebbr-automated
     ce-oem-i2c-automated
 certification_status_overrides:


### PR DESCRIPTION
## Description

Modify the ce-oem monitor test plan from auto to manual

## Resolved issues

The ce-oem backlight case is `user-interactive` type, so it should be placed in manual test plan.

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

Sideload list-bootstrapped of : https://pastebin.canonical.com/p/tPNTCzsRXN/.
```bash
checkbox.checkbox-cli list-bootstrapped com.canonical.contrib::ce-oem-iot-desktop-26-04-manual
..
com.canonical.contrib::ce-oem-monitor/panel-brightness-amdgpu-bl1
..
```