### PR TITLE
Consolidate 26.04 power auto test plans and add amd_pmf (BugFix)

### DIFF
--- a/providers/base/units/power-management/test-plan.pxu
+++ b/providers/base/units/power-management/test-plan.pxu
@@ -157,19 +157,13 @@ nested_part:
     after-suspend-power-management-precheck-cert-manual
     info-attachment-cert-full
 
-id: power-management-precheck-base-26-04-automated
+id: power-management-base-26-04-automated
 unit: test plan
-_name: Power Management Precheck for 26.04 (Automated)
-_description: Automated tests for power-management-precheck
-include:
-nested_part:
-    power-management-precheck-cert-automated
-    after-suspend-power-management-precheck-cert-automated
-
-id: power-base-26-04-automated
-unit: test plan
-_name: Power for 26.04 (Automated)
-_description: Automated tests for power
+_name: Power Management for 26.04 (Automated)
+_description: Automated tests for power management
 include:
 nested_part:
     power-cert-automated
+    power-management-amd-specific-automated
+    power-management-precheck-cert-automated
+    after-suspend-power-management-precheck-cert-automated

--- a/providers/certification-client/units/client-cert-desktop-26-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-26-04.pxu
@@ -62,7 +62,6 @@ nested_part:
     networking-base-26-04-automated
     misc-client-base-26-04-automated
     acpi-base-26-04-automated
-    power-management-precheck-base-26-04-automated
     snappy-snap-base-26-04-automated
     cpu-base-26-04-automated
     memory-base-26-04-automated
@@ -90,7 +89,7 @@ nested_part:
     before-after-suspend-reference-base-26-04-automated
     firmware-fwupdmgr-base-26-04-automated
     optical-base-26-04-automated
-    power-base-26-04-automated
+    power-management-base-26-04-automated
     tpm-base-26-04-automated
 bootstrap_include:
     device

--- a/providers/certification-client/units/client-cert-iot-desktop-26-04.pxu
+++ b/providers/certification-client/units/client-cert-iot-desktop-26-04.pxu
@@ -107,7 +107,6 @@ nested_part:
     networking-base-26-04-automated
     misc-client-base-26-04-automated
     acpi-base-26-04-automated
-    power-management-precheck-base-26-04-automated
     snappy-snap-base-26-04-automated
     cpu-base-26-04-automated
     memory-base-26-04-automated
@@ -131,7 +130,7 @@ nested_part:
     usb-dwc3-base-26-04-automated
     before-after-suspend-reference-base-26-04-automated
     firmware-fwupdmgr-base-26-04-automated
-    power-base-26-04-automated
+    power-management-base-26-04-automated
     tpm-base-26-04-automated
     after-suspend-audio-automated
     after-suspend-bluez-automated

--- a/providers/certification-client/units/client-cert-iot-server-26-04.pxu
+++ b/providers/certification-client/units/client-cert-iot-server-26-04.pxu
@@ -117,7 +117,6 @@ nested_part:
     networking-base-26-04-automated
     misc-client-base-26-04-automated
     acpi-base-26-04-automated
-    power-management-precheck-base-26-04-automated
     snappy-snap-base-26-04-automated
     cpu-base-26-04-automated
     memory-base-26-04-automated
@@ -139,7 +138,7 @@ nested_part:
     usb-dwc3-base-26-04-automated
     before-after-suspend-reference-base-26-04-automated
     firmware-fwupdmgr-base-26-04-automated
-    power-base-26-04-automated
+    power-management-base-26-04-automated
     tpm-base-26-04-automated
     after-suspend-audio-automated
     after-suspend-bluez-automated

--- a/providers/certification-client/units/client-cert-iot-ubuntucore-26.pxu
+++ b/providers/certification-client/units/client-cert-iot-ubuntucore-26.pxu
@@ -159,7 +159,6 @@ nested_part:
   networking-base-26-04-automated
   misc-client-base-26-04-automated
   acpi-base-26-04-automated
-  power-management-precheck-base-26-04-automated
   snappy-snap-base-26-04-automated
   kernel-snap-automated
   ubuntucore-automated
@@ -181,7 +180,7 @@ nested_part:
   usb-c-base-26-04-automated
   usb-dwc3-base-26-04-automated
   before-after-suspend-reference-base-26-04-automated
-  power-base-26-04-automated
+  power-management-base-26-04-automated
   tpm-base-26-04-automated
   after-suspend-audio-automated
   after-suspend-bluez-automated


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
Refactors and updates the 26.04 power management automated test plans across platforms.

**Key Changes**

- Added amd_pmf test coverage to power-management-base-26-04-automated.

- Renamed power-base-26-04-automated to power-management-base-26-04-automated for consistency. 

- Removed power-management-precheck-base-26-04-automated and migrated its contents into the updated base plan.

- Verified 26.04.pxu test plans across Desktop, IoT (Ubuntu Core), and Server configurations.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->
https://warthogs.atlassian.net/browse/OEMQA-6862

## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
```
ubuntu@ubuntu:~$ checkbox-cli list-bootstrapped power-management-base-26-04-automated
Skipped file: /usr/share/checkbox-provider-base/units/camera/README.rst
com.canonical.certification::power-management/warm-reboot
com.canonical.certification::power-management/post-warm-reboot
com.canonical.certification::rtc
com.canonical.certification::power-management/cold-reboot
com.canonical.certification::power-management/post-cold-reboot
com.canonical.plainbox::manifest
com.canonical.certification::power-management/amd_pmf_detect
com.canonical.certification::sleep
com.canonical.certification::cpuinfo
com.canonical.certification::power-management/rtc
com.canonical.certification::power-management/tickless_idle
com.canonical.certification::suspend/suspend_advanced_auto
com.canonical.certification::after-suspend-power-management/amd_pmf_detect
com.canonical.certification::executable
com.canonical.certification::power-management/fwts_wakealarm
com.canonical.certification::power-management/fwts_wakealarm-log-attach
com.canonical.certification::after-suspend-power-management/rtc
com.canonical.certification::after-suspend-power-management/tickless_idle
com.canonical.certification::after-suspend-power-management/fwts_wakealarm
com.canonical.certification::after-suspend-power-management/fwts_wakealarm-log-attach
```

[desktop_after.txt](https://github.com/user-attachments/files/31678490/desktop_after.txt)
[desktop_before.txt](https://github.com/user-attachments/files/31678492/desktop_before.txt)
[iot_desktop_after.txt](https://github.com/user-attachments/files/31678493/iot_desktop_after.txt)
[iot_desktop_before.txt](https://github.com/user-attachments/files/31678494/iot_desktop_before.txt)
[iot_server_after.txt](https://github.com/user-attachments/files/31678495/iot_server_after.txt)
[iot_server_before.txt](https://github.com/user-attachments/files/31678497/iot_server_before.txt)
[iot_ubuntucore_after.txt](https://github.com/user-attachments/files/31678498/iot_ubuntucore_after.txt)
[iot_ubuntucore_before.txt](https://github.com/user-attachments/files/31678499/iot_ubuntucore_before.txt)
