### PR TITLE
Add WOL test plan to 26.04 manual and update job dependencies (BugFix)

### DIFF
--- a/providers/base/units/ethernet/jobs.pxu
+++ b/providers/base/units/ethernet/jobs.pxu
@@ -240,6 +240,7 @@ template-resource: device
 template-filter: device.category == 'NETWORK' and device.mac != 'UNKNOWN'
 id: ethernet/wol_S5_{interface}
 template-id: ethernet/wol_S5_interface
+before: suspend/suspend_advanced_auto
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_ethernet_adapter == 'True'
@@ -297,6 +298,7 @@ template-resource: device
 template-filter: device.category == 'NETWORK' and device.mac != 'UNKNOWN' and device.interface != 'UNKNOWN'
 id: ethernet/wol_S3_{interface}
 template-id: ethernet/wol_S3_interface
+depends: suspend/suspend_advanced_auto
 _summary: Wake on LAN (WOL) test from S3 - {interface}
 _purpose:
  Check that another system can wake the System Under Test (SUT) up from S3 using the Ethernet port {interface}'s WOL function.

--- a/providers/base/units/ethernet/jobs.pxu
+++ b/providers/base/units/ethernet/jobs.pxu
@@ -244,7 +244,7 @@ before: suspend/suspend_advanced_auto
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_ethernet_adapter == 'True'
- manifest.has_ethernet_wake_on_lan_support== 'True'
+ manifest.has_ethernet_s5_wake_on_lan_support== 'True'
 _summary: Wake on LAN (WOL) test from S5 - {interface}
 _purpose:
  Check that another system can wake the System Under Test (SUT) from S5 using the Ethernet port {interface} WOL function.
@@ -286,7 +286,7 @@ plugin: user-interact-verify
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_ethernet_adapter == 'True'
- manifest.has_ethernet_wake_on_lan_support== 'True'
+ manifest.has_ethernet_s4_wake_on_lan_support== 'True'
 command: systemctl hibernate
 user: root
 category_id: com.canonical.plainbox::ethernet
@@ -315,7 +315,7 @@ plugin: user-interact-verify
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_ethernet_adapter == 'True'
- manifest.has_ethernet_wake_on_lan_support== 'True'
+ manifest.has_ethernet_s3_wake_on_lan_support== 'True'
 command: systemctl suspend
 user: root
 category_id: com.canonical.plainbox::ethernet
@@ -451,7 +451,7 @@ environ: SERVER_WAKE_ON_LAN WAKE_ON_LAN_DELAY WAKE_ON_LAN_RETRY PLAINBOX_SESSION
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_ethernet_adapter == 'True'
- manifest.has_ethernet_wake_on_lan_support == 'True'
+ manifest.has_ethernet_s3_wake_on_lan_support == 'True'
  manifest.wake_on_lan_server_running == 'True'
 command:
  set -e

--- a/providers/base/units/ethernet/manifest.pxu
+++ b/providers/base/units/ethernet/manifest.pxu
@@ -4,8 +4,18 @@ _name: An Ethernet Port
 value-type: bool
 
 unit: manifest entry
-id: has_ethernet_wake_on_lan_support
-_name: Wake-on-LAN support through Ethernet port
+id: has_ethernet_s3_wake_on_lan_support
+_name: S3 Wake-on-LAN support through Ethernet port
+value-type: bool
+
+unit: manifest entry
+id: has_ethernet_s4_wake_on_lan_support
+_name: S4 Wake-on-LAN support through Ethernet port
+value-type: bool
+
+unit: manifest entry
+id: has_ethernet_s5_wake_on_lan_support
+_name: S5 Wake-on-LAN support through Ethernet port
 value-type: bool
 
 unit: manifest entry

--- a/providers/base/units/ethernet/test-plan.pxu
+++ b/providers/base/units/ethernet/test-plan.pxu
@@ -186,6 +186,7 @@ nested_part:
     submission-cert-full
     ethernet-cert-manual
     after-suspend-ethernet-cert-manual
+    ethernet-wake-on-lan-cert-manual
     info-attachment-cert-full
 
 id: ethernet-base-26-04-automated

--- a/providers/certification-client/units/client-cert-desktop-24-04.pxu
+++ b/providers/certification-client/units/client-cert-desktop-24-04.pxu
@@ -146,7 +146,6 @@ nested_part:
     # with.
     power-automated
     tpm-cert-automated
-    ethernet-wake-on-lan-cert-auto
 bootstrap_include:
     device
     graphics_card


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
Transitions Wake-on-LAN (WOL) testing from automated to manual execution for 26.04 due to auto-detection limitations for supported network interfaces (e.g., handling fiber or unsupported controllers). 
Updates job dependencies and cleans up deprecated automated WOL test plans in 24.04.

**Key Changes**

- Added ethernet-wake-on-lan-cert-manual to the ethernet-base-26-04-manual desktop test plan 
- Cleanup: Removed the typo test plan 'ethernet-wake-on-lan-cert-auto' from client-cert-desktop-24-04-automated.

- Job Modifications:
  - Added before: suspend/suspend_advanced_auto prerequisite to ethernet/wol_S5_interface jobs.
  - Added depends: ethernet/wol_S3_interface requirement for proper dependency sequencing.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->
https://warthogs.atlassian.net/browse/OEMQA-6863
## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->
N/A
## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
```
ubuntu@ubuntu:~$ checkbox-cli list-bootstrapped ethernet-base-26-04-manual
com.canonical.certification::miscellanea/device_check
com.canonical.certification::executable
com.canonical.certification::lsblk_attachment
com.canonical.certification::cpuinfo
com.canonical.certification::system_info_json
com.canonical.certification::info/kernel_config
com.canonical.certification::kernel_config_attachment
com.canonical.certification::modprobe_json
com.canonical.certification::dmi_present
com.canonical.certification::dmi_attachment
com.canonical.certification::efi
com.canonical.certification::lsb
com.canonical.certification::uname
com.canonical.certification::udev_attachment
com.canonical.certification::dmi
com.canonical.certification::requirements
com.canonical.certification::udev_json
com.canonical.certification::environment
com.canonical.certification::raw_devices_dmi_json
com.canonical.certification::dkms_info_json
com.canonical.certification::lspci_standard_config_json
com.canonical.certification::device
com.canonical.certification::snap
com.canonical.certification::meminfo
com.canonical.certification::package
com.canonical.certification::sysfs_attachment
com.canonical.certification::cdimage
com.canonical.certification::dpkg
com.canonical.certification::module
com.canonical.certification::kernel_cmdline_attachment
com.canonical.certification::miscellanea/submission-resources
com.canonical.certification::info/systemd-analyze
com.canonical.certification::info/systemd-analyze-critical-chain
com.canonical.certification::info/kernel-config-iommu-flag
com.canonical.plainbox::manifest
com.canonical.certification::ethernet/detect
com.canonical.certification::ethernet/hotplug-enx00e0fc682ebf
com.canonical.certification::sleep
com.canonical.certification::rtc
com.canonical.certification::lsusb_attachment
com.canonical.certification::ethernet/wol_S5_enx00e0fc682ebf
com.canonical.certification::suspend/suspend_advanced_auto
com.canonical.certification::after-suspend-ethernet/detect
com.canonical.certification::after-suspend-ethernet/hotplug-enx00e0fc682ebf
com.canonical.certification::ethernet/wol_S3_enx00e0fc682ebf
com.canonical.certification::acpi_sleep_attachment
com.canonical.certification::codecs_attachment
com.canonical.certification::cpuinfo_attachment
com.canonical.certification::dkms_info_attachment
com.canonical.certification::dmesg_attachment
com.canonical.certification::dmidecode_attachment
com.canonical.certification::dpkg_attachment
com.canonical.certification::efi_attachment
com.canonical.certification::info/buildstamp
com.canonical.certification::info/disk_partitions
com.canonical.certification::block_device
com.canonical.certification::info/hdparm_nvme0n1.txt
com.canonical.certification::info/touchpad_driver
com.canonical.certification::installer_debug.gz
com.canonical.certification::lsmod_attachment
com.canonical.certification::lspci_attachment
com.canonical.certification::lspci_standard_config_attachment
com.canonical.certification::lstopo_visual_attachment
com.canonical.certification::meminfo_attachment
com.canonical.certification::modinfo_attachment
com.canonical.certification::modprobe_attachment
com.canonical.certification::modules_attachment
com.canonical.certification::sysctl_attachment
com.canonical.certification::firmware/fwts_dump
com.canonical.certification::firmware/fwts_dump_acpi_attachment.gz
com.canonical.certification::info/secure-boot-check
```

09/02 
For @hanhsuan's suggestion
Granularly splits the Wake-on-LAN (WOL) manifest resource dependencies to independently check for S3, S4, and S5 power state support.

Removed Key:
- has_ethernet_wake_on_lan_support

Added/Updated Keys:
- has_ethernet_s3_wake_on_lan_support
- has_ethernet_s4_wake_on_lan_support
- has_ethernet_s5_wake_on_lan_support

<img width="942" height="343" alt="image" src="https://github.com/user-attachments/assets/14f8aee9-22f2-4688-bdb9-a44d353e3ef3" />