### PR TITLE
Skip manual auto session (bugfix)

### DIFF
--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -23,54 +23,53 @@ functionality.
 import contextlib
 import gettext
 import ipaddress
+import itertools
 import json
 import logging
 import os
 import select
-import socket
-import time
 import signal
+import socket
 import sys
-import itertools
-
+import time
 from collections import namedtuple
 from contextlib import suppress
 from tempfile import SpooledTemporaryFile
 
-from plainbox.abc import IJobResult
-from plainbox.impl.color import Colorizer
-from plainbox.impl.config import Configuration
-from plainbox.impl.session.state import SessionMetaData
-from plainbox.impl.result_utils import pretty_skip_reason
-from plainbox.impl.session.resume import (
-    IncompatibleJobError,
-    CorruptedSessionError,
-)
-from plainbox.impl.session.remote_assistant import (
-    RemoteSessionAssistant,
-    RemoteSessionStates,
-)
-from plainbox.vendor import rpyc
+from tqdm import tqdm
+
+from checkbox_ng.launcher.run import NormalUI, ReRunJob
+from checkbox_ng.launcher.stages import MainLoopStage, ReportsStage
 from checkbox_ng.resume_menu import ResumeMenu
 from checkbox_ng.urwid_ui import (
-    TestPlanBrowser,
     CategoryBrowser,
+    InterruptDialogAnswer,
     ManifestBrowser,
     ReRunBrowser,
+    ResumeInstead,
+    TestPlanBrowser,
     interrupt_dialog,
     resume_dialog,
-    ResumeInstead,
-    InterruptDialogAnswer,
 )
 from checkbox_ng.utils import (
     generate_resume_candidate_description,
     newline_join,
     request_comment,
 )
-from checkbox_ng.launcher.run import NormalUI, ReRunJob
-from checkbox_ng.launcher.stages import MainLoopStage
-from checkbox_ng.launcher.stages import ReportsStage
-from tqdm import tqdm
+from plainbox.abc import IJobResult
+from plainbox.impl.color import Colorizer
+from plainbox.impl.config import Configuration
+from plainbox.impl.result_utils import pretty_skip_reason
+from plainbox.impl.session.remote_assistant import (
+    RemoteSessionAssistant,
+    RemoteSessionStates,
+)
+from plainbox.impl.session.resume import (
+    CorruptedSessionError,
+    IncompatibleJobError,
+)
+from plainbox.impl.session.state import SessionMetaData
+from plainbox.vendor import rpyc
 
 _ = gettext.gettext
 _logger = logging.getLogger("controller")
@@ -1051,7 +1050,9 @@ class RemoteController(ReportsStage, MainLoopStage):
             SimpleUI.horiz_line()
             next_job = False
             while next_job is False:
-                for interaction in self.sa.run_job(job["id"]):
+                for interaction in self.sa.run_job(
+                    job["id"], self.is_interactive
+                ):
                     # interaction is a netref, cache attributes here
                     kind = interaction.kind
                     message = interaction.message

--- a/checkbox-ng/checkbox_ng/launcher/controller.py
+++ b/checkbox-ng/checkbox_ng/launcher/controller.py
@@ -942,18 +942,28 @@ class RemoteController(ReportsStage, MainLoopStage):
                 self.finish_job()
                 break
 
+    def _pretty_skip_log(self, result):
+        if not result:
+            return
+        with suppress(ValueError, AttributeError):
+            # this only applies to automated skips on a recent enough
+            # checkbox agent
+            SimpleUI.yellow_text(pretty_skip_reason(result.skip_reason))
+        if (
+            result.outcome == IJobResult.OUTCOME_MANUAL_SKIP
+            and result.comments
+            and not self.is_interactive
+        ):
+            # Display manual skip in non interactive sessions because the
+            # comment is checkbox complaining about trying to run a manual
+            # test in a non-interactive session
+            SimpleUI.yellow_text(
+                "Job cannot be started because:\n- {}".format(result.comments)
+            )
+
     def finish_job(self, result=None, job_state=None):
         _logger.info("controller: Finishing job with a result: %s", result)
-        if result and hasattr(result, "skip_reason"):
-            skip_reason = result.skip_reason
-            try:
-                skip_reason_str = pretty_skip_reason(skip_reason)
-                SimpleUI.yellow_text(skip_reason_str)
-            except ValueError:
-                # unable to pretty print skip reason, it may be that the job
-                # wasnt skipped at all!
-                pass
-
+        self._pretty_skip_log(result)
         SimpleUI.horiz_line()
         job_result = self.sa.finish_job(result)
         print(_("Outcome") + ": " + SimpleUI.C.result(job_result))

--- a/checkbox-ng/checkbox_ng/launcher/run.py
+++ b/checkbox-ng/checkbox_ng/launcher/run.py
@@ -220,8 +220,13 @@ class NormalUI(IJobRunnerUI):
             except ValueError:
                 pass  # unable to pretty print skip reason
         print(_("Job cannot be started because:"))
-        for inhibitor in job_state.readiness_inhibitor_list:
-            print(" - {}".format(self.C.YELLOW(inhibitor)))
+        if job_state.readiness_inhibitor_list:
+            for inhibitor in job_state.readiness_inhibitor_list:
+                print(" - {}".format(self.C.YELLOW(inhibitor)))
+        else:
+            # this is for tests that were skipped because interactive in a
+            # non-interactive session
+            print("-", self.C.RED(result.comments))
 
     def finished(self, job, job_state, result):
         self._print_result_outcome(result)

--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -136,6 +136,9 @@ class MainLoopStage(CheckboxUiStage):
                             " session"
                         ),
                     )
+                    result = result_builder.get_result()
+                    ui.job_cannot_start(job, job_state, result)
+                    ui.finished(job, job_state, result)
                     return result_builder
                 if job_state.can_start():
                     ui.notify_about_purpose(job)

--- a/checkbox-ng/checkbox_ng/launcher/stages.py
+++ b/checkbox-ng/checkbox_ng/launcher/stages.py
@@ -132,8 +132,8 @@ class MainLoopStage(CheckboxUiStage):
                     result_builder = JobResultBuilder(
                         outcome=IJobResult.OUTCOME_MANUAL_SKIP,
                         comments=_(
-                            "Trying to run interactive job in a silent"
-                            " session"
+                            "Unable to start interactive job in "
+                            "non-interactive session"
                         ),
                     )
                     result = result_builder.get_result()

--- a/checkbox-ng/plainbox/impl/session/assistant.py
+++ b/checkbox-ng/plainbox/impl/session/assistant.py
@@ -1172,7 +1172,11 @@ class SessionAssistant:
             JobState class for details.
         """
         UsageExpectation.of(self).enforce(self.get_job_state)
-        # XXX: job_state_map is a bit low level, can we avoid that?
+        UsageExpectation.of(self).allow(
+            self.get_job_state,
+            self.use_job_result,
+            "update the result of a job given its state",
+        )
         return self._context.state.job_state_map[job_id]
 
     @raises(KeyError, UnexpectedMethodCall)

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -592,7 +592,7 @@ class RemoteSessionAssistant:
 
             def cant_start_builder(*args, **kwargs):
                 comments = (
-                    "Unable to start interactive job in non-interactive"
+                    "Unable to start interactive job in non-interactive "
                     "session"
                 )
                 result_builder = JobResultBuilder(

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -592,7 +592,8 @@ class RemoteSessionAssistant:
 
             def cant_start_builder(*args, **kwargs):
                 comments = (
-                    "Unable to start inteactive job in non-interactive session"
+                    "Unable to start interactive job in non-interactive"
+                    "session"
                 )
                 result_builder = JobResultBuilder(
                     outcome=IJobResult.OUTCOME_MANUAL_SKIP,

--- a/checkbox-ng/plainbox/impl/session/remote_assistant.py
+++ b/checkbox-ng/plainbox/impl/session/remote_assistant.py
@@ -42,8 +42,10 @@ from plainbox.impl.providers.v1 import (
     reload_all_providers as reload_all_insecure_providers,
 )
 from plainbox.impl.result import JobResultBuilder, MemoryJobResult
-from plainbox.impl.result_utils import determine_outcome_and_skip_reason
-from plainbox.impl.result_utils import pretty_skip_reason
+from plainbox.impl.result_utils import (
+    determine_outcome_and_skip_reason,
+    pretty_skip_reason,
+)
 from plainbox.impl.secure.providers.v1 import (
     reload_all_providers as reload_all_secure_providers,
 )
@@ -195,7 +197,7 @@ class RemoteSessionAssistant:
     object but JSON encoded.
     """
 
-    REMOTE_API_VERSION = 15
+    REMOTE_API_VERSION = 16
 
     def __init__(self, cmd_callback):
         _logger.debug("__init__()")
@@ -548,7 +550,7 @@ class RemoteSessionAssistant:
     @allowed_when(
         RemoteSessionStates.SettingUp, RemoteSessionStates.TestsSelected
     )
-    def run_job(self, job_id):
+    def run_job(self, job_id, interactive_session):
         """
         Depending on the type of the job, run_job can yield different number
         of Interaction instances.
@@ -578,6 +580,24 @@ class RemoteSessionAssistant:
                 )
                 if skip_reason:
                     result_builder.skip_reason = skip_reason
+                return result_builder
+
+            self._be = BackgroundExecutor(self, job_id, cant_start_builder)
+            yield from self.interact(Interaction("skip", None, self._be))
+
+        if (
+            job.plugin in ["manual", "user-interact-verify", "user-interact"]
+            and not interactive_session
+        ):
+
+            def cant_start_builder(*args, **kwargs):
+                comments = (
+                    "Unable to start inteactive job in non-interactive session"
+                )
+                result_builder = JobResultBuilder(
+                    outcome=IJobResult.OUTCOME_MANUAL_SKIP,
+                    comments=comments,
+                )
                 return result_builder
 
             self._be = BackgroundExecutor(self, job_id, cant_start_builder)

--- a/metabox/metabox/metabox-provider/units/basic-jobs.yaml
+++ b/metabox/metabox/metabox-provider/units/basic-jobs.yaml
@@ -20,6 +20,33 @@ command: 'echo foo: $foo'
 environ:
   - foo
 ---
+id: basic/manual
+summary: A simple manual job
+purpose: |
+  This test checks that the manual plugin works fine
+steps: |
+  1. Add a comment
+  2. Set the result as passed
+verification: |
+  Check that in the report the result is passed and the comment is displayed
+plugin: manual
+estimated_duration: '30'
+---
+id: basic/user-interact-verify
+summary: A simple user interaction and verification job
+purpose: |
+  This test checks that the user-interact-verify plugin works fine
+steps: |
+  1. Read this description
+  2. Ensure that the command has not been started yet
+  3. Press the test button
+  4. Look at the output and determine the outcome of the test
+verification: |
+  The command should have printed "Please select 'pass'"
+plugin: user-interact-verify
+command: echo "Please select 'pass'"
+estimated_duration: '25'
+---
 id: config-environ-source
 flags:
   - simple

--- a/metabox/metabox/metabox-provider/units/basic-tps.yaml
+++ b/metabox/metabox/metabox-provider/units/basic-tps.yaml
@@ -27,6 +27,13 @@ include:
   - stub/user-interact-verify
 ---
 unit: test plan
+id: basic-manual-one-per-kind
+name: Basic Manual One Per Kind
+include:
+  - basic/manual
+  - basic/user-interact-verify
+---
+unit: test plan
 id: basic-session-resume-manual
 name: Basic Manual (for Session Resume Scenario)
 include:

--- a/metabox/metabox/scenarios/basic/manual_silent.py
+++ b/metabox/metabox/scenarios/basic/manual_silent.py
@@ -1,0 +1,46 @@
+# This file is part of Checkbox.
+#
+# Copyright 2026 Canonical Ltd.
+#
+# Checkbox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+#
+# Checkbox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Checkbox.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+
+from metabox.core.actions import Expect, Start
+from metabox.core.scenario import Scenario
+from metabox.core.utils import tag
+
+
+@tag("manual", "silent", "basic")
+class SilentManualJobsAreSkipped(Scenario):
+    modes = ["local", "remote"]
+
+    launcher = textwrap.dedent("""
+        [ui]
+        type = silent
+        [launcher]
+        launcher_version = 1
+        stock_reports = text
+        [test plan]
+        unit = 2021.com.canonical.certification::basic-manual-one-per-kind
+        forced = yes
+        [test selection]
+        forced = yes
+        """)
+    steps = [
+        Start(),
+        Expect("2021.com.canonical.certification::basic/manual"),
+        Expect("Outcome: job manually skipped"),
+        Expect("2021.com.canonical.certification::basic/user-interact-verify"),
+        Expect("Outcome: job manually skipped"),
+    ]


### PR DESCRIPTION
## Description

Both remote and local manual test skipping is broken. When the ui is set to silent (non interactive, nice name, no questions), manual tests and manual interactions are supposed to be skipped. This is not the case for manual tests in remote (which are executed normally) nor in local (where they crash Checkbox).

This pr fixes both issues and adds coverage of this scenario

## Resolved issues

Fixes: CHECKBOX-2313

## Documentation

N/A

## Tests

Added new metabox scenario