### PR TITLE
Adjust the setup order for OV5640 Camera (BugFix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/data/Genio-MIPI-Camera-TestScenario-TestSetup/genio_mipi_camera_test_setup_OV5640_CSI0.json
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/data/Genio-MIPI-Camera-TestScenario-TestSetup/genio_mipi_camera_test_setup_OV5640_CSI0.json
@@ -28,16 +28,16 @@
             ],
             "links": [
                 {
-                    "source_entity": "seninf-0",
-                    "source_pad_number": 1,
-                    "sink_entity": "1a092000.camsv2",
+                    "source_entity": "ov5640 7-003c",
+                    "source_pad_number": 0,
+                    "sink_entity": "seninf-0",
                     "sink_pad_number": 0,
                     "flags": 1
                 },
                 {
-                    "source_entity": "ov5640 7-003c",
-                    "source_pad_number": 0,
-                    "sink_entity": "seninf-0",
+                    "source_entity": "seninf-0",
+                    "source_pad_number": 1,
+                    "sink_entity": "1a092000.camsv2",
                     "sink_pad_number": 0,
                     "flags": 1
                 }

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/data/Genio-MIPI-Camera-TestScenario-TestSetup/genio_mipi_camera_test_setup_OV5640_dual.json
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/data/Genio-MIPI-Camera-TestScenario-TestSetup/genio_mipi_camera_test_setup_OV5640_dual.json
@@ -28,16 +28,16 @@
             ],
             "links": [
                 {
-                    "source_entity": "seninf-0",
-                    "source_pad_number": 1,
-                    "sink_entity": "1a092000.camsv2",
+                    "source_entity": "ov5640 7-003c",
+                    "source_pad_number": 0,
+                    "sink_entity": "seninf-0",
                     "sink_pad_number": 0,
                     "flags": 1
                 },
                 {
-                    "source_entity": "ov5640 7-003c",
-                    "source_pad_number": 0,
-                    "sink_entity": "seninf-0",
+                    "source_entity": "seninf-0",
+                    "source_pad_number": 1,
+                    "sink_entity": "1a092000.camsv2",
                     "sink_pad_number": 0,
                     "flags": 1
                 }
@@ -70,16 +70,16 @@
             ],
             "links": [
                 {
-                    "source_entity": "seninf-1",
-                    "source_pad_number": 1,
-                    "sink_entity": "1a093000.camsv3",
+                    "source_entity": "ov5640 8-003c",
+                    "source_pad_number": 0,
+                    "sink_entity": "seninf-1",
                     "sink_pad_number": 0,
                     "flags": 1
                 },
                 {
-                    "source_entity": "ov5640 8-003c",
-                    "source_pad_number": 0,
-                    "sink_entity": "seninf-1",
+                    "source_entity": "seninf-1",
+                    "source_pad_number": 1,
+                    "sink_entity": "1a093000.camsv3",
                     "sink_pad_number": 0,
                     "flags": 1
                 }


### PR DESCRIPTION
## Description

While testing the OV5640 MIPI camera, the setup order does matter. Wrong order will cause the `Unable to parse link: Invalid argument` error

Spec: https://genio.mediatek.com/doc/iot-yocto/latest/sw/yocto/app-dev/camera/camera-g720-evk-v4l2-yuv.html#multi-camera-support

## Resolved issues

Failed scenario due to wrong setup order: https://certification.canonical.com/hardware/202605-38736/submission/508225/test-results/fail/

## Documentation

N/A

## Tests

Sidelaod Test: https://certification.canonical.com/hardware/202605-38736/submission/508872/
