### PR TITLE
Remove "hash" when calling clevis-encrypt (BugFix)

### DIFF
--- a/providers/tpm2/units/clevis.pxu
+++ b/providers/tpm2/units/clevis.pxu
@@ -60,7 +60,7 @@ command:
  echo "+ Generate a random string"
  rand=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c32768)
  echo "+ Encrypt and decrypt the string using the TPM"
- result=$(echo -n $rand | clevis-encrypt-tpm2 '{{"hash": "{pcr_bank}", "key":"rsa", "pcr_bank":"{pcr_bank}","pcr_ids":"0,1"}}' | clevis-decrypt-tpm2)
+ result=$(echo -n $rand | clevis-encrypt-tpm2 '{{"key":"rsa", "pcr_bank":"{pcr_bank}","pcr_ids":"0,1"}}' | clevis-decrypt-tpm2)
  echo "+ Compare with the original string"
  [[ $result == $rand ]]
 
@@ -96,6 +96,6 @@ command:
  echo "+ Generate a random string"
  rand=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c32768)
  echo "+ Encrypt and decrypt the string using the TPM"
- result=$(echo -n $rand | clevis-encrypt-tpm2 '{{"hash": "{pcr_bank}", "key":"ecc", "pcr_bank":"{pcr_bank}","pcr_ids":"0,1"}}' | clevis-decrypt-tpm2)
+ result=$(echo -n $rand | clevis-encrypt-tpm2 '{{"key":"ecc", "pcr_bank":"{pcr_bank}","pcr_ids":"0,1"}}' | clevis-decrypt-tpm2)
  echo "+ Compare with the original string"
  [[ $result == $rand ]]


### PR DESCRIPTION
 ## WARNING: This modifies com.canonical.certification::sru-server

## Description

Fixes #2820 

## Resolved issues

See #2820 for the details 

## Documentation

## Tests

Device with only sha384 PCR banks: https://certification.canonical.com/hardware/202607-39061/submission/509175/

Normal x86 laptop: https://certification.canonical.com/hardware/202601-38351/submission/509176/