### PR TITLE
Wrap the resource job to preven any error be thrown (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
@@ -140,9 +140,9 @@ command:
 
 
 id: ce-oem-gpiod-gpio/check-simple-resource
-_summary: Check Generating libgpiod GPIO lines for simple GPIO tests
+_summary: Check libgpiod GPIO line resource generation for simple GPIO tests
 _purpose:
-    Check ce-oem-gpiod-gpio/simple-resource job executes successfully
+    Check that ce-oem-gpiod-gpio/simple-resource executes successfully.
 estimated_duration: 0.02
 category_id: com.canonical.certification::gpio
 plugin: shell

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/jobs.pxu
@@ -136,6 +136,32 @@ command:
             set -- "$@" --allow-named
             ;;
     esac
+    resource_wrapper.sh -- gpio_test_subprocess.py resource simple "$@" --format text
+
+
+id: ce-oem-gpiod-gpio/check-simple-resource
+_summary: Check Generating libgpiod GPIO lines for simple GPIO tests
+_purpose:
+    Check ce-oem-gpiod-gpio/simple-resource job executes successfully
+estimated_duration: 0.02
+category_id: com.canonical.certification::gpio
+plugin: shell
+user: root
+imports: from com.canonical.plainbox import manifest
+requires: manifest.has_gpiod_gpio == 'True'
+environ:
+    GPIOD_GPIO_IGNORE
+    GPIOD_GPIO_ALLOW_NAMED
+command:
+    set --
+    if [ -n "$GPIOD_GPIO_IGNORE" ]; then
+        set -- "$@" --ignore "$GPIOD_GPIO_IGNORE"
+    fi
+    case "$GPIOD_GPIO_ALLOW_NAMED" in
+        1|true|True|yes|Yes)
+            set -- "$@" --allow-named
+            ;;
+    esac
     gpio_test_subprocess.py resource simple "$@" --format text
 
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/test-plan.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/gpio/test-plan.pxu
@@ -23,9 +23,11 @@ bootstrap_include:
     ce-oem-gpiod-gpio/simple-resource
     ce-oem-gpiod-gpio/loopback-resource
 include:
+    check_gpio_loopback_pin_mapping_resource
     ce-oem-gpio/loopback-on-phycial-output-.*-input-.*
     ce-oem-gpio/check-slots
     ce-oem-gpio/node-export-test
+    ce-oem-gpiod-gpio/check-simple-resource
     ce-oem-gpiod-gpio/simple-input-GPIO_CHIP-GPIO_LINE
     ce-oem-gpiod-gpio/simple-output-GPIO_CHIP-GPIO_LINE
     ce-oem-gpiod-gpio/loopback-input-GPIO_INPUT_CHIP-GPIO_INPUT_LINE-output-GPIO_OUTPUT_CHIP-GPIO_OUTPUT_LINE


### PR DESCRIPTION
## Description

Prevent the error be thrown in resource job which causes.
Follow the way in this PR: https://github.com/canonical/checkbox/pull/2781

## Resolved issues

Before this PR, resource job failed like :
https://certification.canonical.com/hardware/202511-38135/submission/508224/test-results/fail/?term=simple

## Documentation

N/A

## Tests

Sideload Test: https://certification.canonical.com/hardware/202511-38135/submission/509202/test-results/?term=ce-oem-gpiod-gpio
- Resource jobs are always pass
- The check resource job grabs the real issue while we would like to test the case but not fulfill the prerequisites.
