### PR TITLE
Fix tpm2 pcrbanks resource failure (bugfix)

### DIFF
--- a/providers/tpm2/bin/tpm2_capabilities.py
+++ b/providers/tpm2/bin/tpm2_capabilities.py
@@ -87,13 +87,8 @@ def build_capabilities():
         "pcr_banks": set(),
     }
 
-    try:
-        algs_caps = subprocess.check_output(["tpm2_getcap", "algorithms"])
-        pcrs_caps = subprocess.check_output(["tpm2_getcap", "pcrs"])
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        raise SystemExit(
-            "Please make sure you have installed tpm-tools and tpm chip."
-        )
+    algs_caps = subprocess.check_output(["tpm2_getcap", "algorithms"])
+    pcrs_caps = subprocess.check_output(["tpm2_getcap", "pcrs"])
 
     algs_list = yaml.load(algs_caps, Loader=yaml.SafeLoader)
     pcrs_list = yaml.load(pcrs_caps, Loader=yaml.SafeLoader)
@@ -284,7 +279,15 @@ def parse_args(argv=None):
 
 def main(argv=None):
     args = parse_args(argv)
-    tpm2_cap = build_capabilities()
+    try:
+        tpm2_cap = build_capabilities()
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        if args.resource or args.resource_pcr_banks:
+            # resource job should only output `key: value` items and should
+            # never fail (other mechanisms are in place to make sure a failure
+            # in the TPM2 detection is raised when running Checkbox)
+            raise SystemExit()
+        raise SystemExit(exc)
 
     if args.resource:
         # print as resource unit

--- a/providers/tpm2/tests/test_tpm2_capabilities.py
+++ b/providers/tpm2/tests/test_tpm2_capabilities.py
@@ -112,14 +112,6 @@ class TestBuildCapabilities(unittest.TestCase):
         for variant in ("aes", "aes128", "aes192", "aes256"):
             self.assertNotIn(variant, caps["symmetric"])
 
-    @patch(
-        "tpm2_capabilities.subprocess.check_output",
-        side_effect=FileNotFoundError,
-    )
-    def test_missing_tpm2_tools_raises(self, _out):
-        with self.assertRaises(SystemExit):
-            tpm2_capabilities.build_capabilities()
-
 
 class TestParseArgs(unittest.TestCase):
     def test_resource_flag(self):
@@ -156,6 +148,14 @@ class TestParseArgs(unittest.TestCase):
 
 
 class TestMain(unittest.TestCase):
+    @patch(
+        "tpm2_capabilities.subprocess.check_output",
+        side_effect=FileNotFoundError,
+    )
+    def test_missing_tpm2_tools_raises(self, _out):
+        with self.assertRaises(SystemExit):
+            tpm2_capabilities.main()
+
     @patch(
         "tpm2_capabilities.subprocess.check_call",
         side_effect=_fake_check_call_all_ok,

--- a/providers/tpm2/units/clevis.pxu
+++ b/providers/tpm2/units/clevis.pxu
@@ -22,11 +22,16 @@ plugin: shell
 imports: from com.canonical.plainbox import manifest
 requires:
  manifest.has_tpm2_chip == 'True'
- executable.name == 'clevis-encrypt-tpm2'
 _summary: clevis encrypt/decrypt precheck
 depends: tpm2/detect
 flags: simple
-command: true
+command:
+  if ! command -v clevis-encrypt-tpm2 &> /dev/null; then
+      echo "Error: 'clevis-encrypt-tpm2' is not installed or not available in PATH." >&2
+      exit 1
+  fi
+  echo "'clevis-encrypt-tpm2' is available."
+  exit 0
 
 unit: template
 template-resource: tpm2_pcr_banks


### PR DESCRIPTION
## WARNING: This modifies com.canonical.certification::sru-server


## Description

The `tpm2_pcr_banks` resource job is used by a few `clevis-encrypt-tpm2/...` template units to determine what PCR bank(s)
to test.

It means `tpm2_pcr_banks` will be called regardless if the `has_tpm2` manifest entry is set to True or not (since it's called at bootstrapping time).

Instead of failing, this resource job (or, rather, its underlying Python script, `tpm2_capabilities.py`) should just print nothing, and delegate the failure to other jobs (like tpm2/detect, which is present
in the clevis-automated test plan).

Minor: make clevis-precheck job fail if tools are not available 

## Resolved issues

CHECKBOX-2325

## Documentation

See commit messages

## Tests

- unit tests
- tested locally (my desktop has TPM2 chip), running `clevis-automated` with all the right tools available result in a passed session with the right PCR banks recognized and templated jobs generated and run:

```
==================================[ Results ]===================================
 ☑ : Hardware Manifest
 ☑ : Check at least one TPM2 device is identified
 ☑ : clevis encrypt/decrypt precheck
 ☑ : Ensure TPM has required caps (sha256 PCR bank and hash) for clevis RSA
 ☑ : clevis encrypt/decrypt key rsa using sha256 PCR bank and hash
 ☑ : Ensure TPM has required caps (sha256 PCR bank and hash) for clevis ECC
 ☑ : clevis encrypt/decrypt key ecc using sha256 PCR bank and hash
```

- tested locally by removing the tools required for testing (tpm2-tools and clevis-tpm2). When running `clevis-automated`, `clevis-encrypt-tpm2/precheck` fails (as it should) but `tpm2_pcr_banks` simply returns nothing (since it's a resource job and it should only return `key: value` lines):

```json
        {
            "id": "clevis-encrypt-tpm2/precheck",
            "full_id": "com.canonical.certification::clevis-encrypt-tpm2/precheck",
            "name": "clevis encrypt/decrypt precheck",
            "certification_status": "blocker",
            "category": "TPM 2.0 (Trusted Platform Module)",
            "category_id": "com.canonical.certification::tpm2",
            "status": "fail",
            "outcome": "fail",
            "skip_reason": null,
            "comments": null,
            "io_log": "Error: 'clevis-encrypt-tpm2' is not installed or not available in PATH.\n",
            "type": "test",
            "project": "certification",
            "duration": 0.11055564880371094,
            "plugin": "shell",
            "template_id": null
        },
        {
            "id": "tpm2_pcr_banks",
            "full_id": "com.canonical.certification::tpm2_pcr_banks",
            "name": "Print each TPM2 PCR bank as a separate resource record",
            "certification_status": "non-blocker",
            "category": "TPM 2.0 (Trusted Platform Module)",
            "category_id": "com.canonical.certification::tpm2",
            "status": "pass",
            "outcome": "pass",
            "skip_reason": null,
            "comments": null,
            "io_log": "",
            "type": "test",
            "project": "certification",
            "duration": 1.8594224452972412,
            "plugin": "resource",
            "template_id": null
        },
```

