### PR TITLE
Fix tests for CUDA > 13.3 (BugFix)

### DIFF
--- a/providers/gpgpu/bin/run_cuda_sample_set.py
+++ b/providers/gpgpu/bin/run_cuda_sample_set.py
@@ -73,12 +73,8 @@ def parse_args():
         missing_files=[
             # list of tuple with src, dest, and extension ?
             (
-                Path("Samples")
-                / "2_Concepts_and_Techniques"
-                / "EGLStream_CUDA_Interop",
-                Path("build")
-                / "Samples"
-                / "2_Concepts_and_Techniques"
+                Path("2_Concepts_and_Techniques") / "EGLStream_CUDA_Interop",
+                Path("2_Concepts_and_Techniques")
                 / "EGLStream_CUDA_Interop"
                 / "bin",
                 ".yuv",
@@ -107,8 +103,8 @@ def parse_args():
     libnvvm_parser.set_defaults(
         missing_files=[
             (
-                Path("Samples") / "7_libNVVM" / "ptxgen",
-                Path("build") / "Samples" / "7_libNVVM" / "ptxgen" / "bin",
+                Path("7_libNVVM") / "ptxgen",
+                Path("7_libNVVM") / "ptxgen" / "bin",
                 ".ll",
             )
         ]
@@ -121,13 +117,10 @@ def parse_args():
     platform_parser.set_defaults(
         missing_files=[
             (
-                Path("Samples")
-                / "8_Platform_Specific"
+                Path("8_Platform_Specific")
                 / "Tegra"
                 / "cudaNvSciBufMultiplanar",
-                Path("build")
-                / "Samples"
-                / "8_Platform_Specific"
+                Path("8_Platform_Specific")
                 / "Tegra"
                 / "cudaNvSciBufMultiplanar"
                 / "bin",
@@ -228,6 +221,13 @@ def copy_and_set_permissions(src, dst, file_extension):
             os.chmod(file_path, 0o644)
 
 
+def get_samples_dir_name(cuda_samples_version):
+    version = tuple(
+        int(component) for component in str(cuda_samples_version).split(".")
+    )
+    return "cpp" if version >= (13, 3) else "Samples"
+
+
 def clone_and_build(orig_dir, test_set, cuda_samples_version):
     """Function to clone the repository and build the correct subfolder
 
@@ -266,7 +266,7 @@ def clone_and_build(orig_dir, test_set, cuda_samples_version):
     )
 
     # Remove unnecessary folders
-    samples_dir = test_set_dir / "Samples"
+    samples_dir = test_set_dir / get_samples_dir_name(cuda_samples_version)
     for folder in samples_dir.glob("[0-9]_*/"):
         folder_number = folder.name.split("_")[0]
         if folder_number != test_set:
@@ -302,7 +302,7 @@ def clone_and_build(orig_dir, test_set, cuda_samples_version):
 
 
 # Function to run tests
-def run_tests(orig_dir, test_set, exclude_list):
+def run_tests(orig_dir, test_set, cuda_samples_version, exclude_list):
     """Run the test
 
     Args:
@@ -313,7 +313,8 @@ def run_tests(orig_dir, test_set, exclude_list):
     Returns:
         (int, int): total tests, skipped tests
     """
-    test_set_dir = Path(orig_dir) / test_set / "build" / "Samples"
+    samples_dir_name = get_samples_dir_name(cuda_samples_version)
+    test_set_dir = Path(orig_dir) / test_set / "build" / samples_dir_name
 
     executable_list = [
         exe
@@ -367,15 +368,23 @@ def main():
             cleanup_temporary_files(orig_dir, str(args.test_set))
         raise
 
+    samples_dir_name = get_samples_dir_name(args.cuda_samples_version)
+    source_dir = orig_dir / str(args.test_set) / samples_dir_name
+    build_dir = orig_dir / str(args.test_set) / "build" / samples_dir_name
     for src, dest, extension in args.missing_files:
         copy_and_set_permissions(
-            orig_dir / str(args.test_set) / src,
-            orig_dir / str(args.test_set) / dest,
+            source_dir / src,
+            build_dir / dest,
             extension,
         )
 
     try:
-        run_tests(orig_dir, str(args.test_set), args.cuda_ignore_tests)
+        run_tests(
+            orig_dir,
+            str(args.test_set),
+            args.cuda_samples_version,
+            args.cuda_ignore_tests,
+        )
 
     except subprocess.CalledProcessError:
         logging.error("Test failed")

--- a/providers/gpgpu/tests/test_run_cuda_sample_set.py
+++ b/providers/gpgpu/tests/test_run_cuda_sample_set.py
@@ -33,7 +33,7 @@ global clone_counter
 clone_counter = 0
 
 
-def dummy_clone(orig_dir, test_set):
+def dummy_clone(orig_dir, test_set, samples_dir_name="Samples"):
     global clone_counter
 
     def wrapper(*args, **kwargs) -> subprocess.CompletedProcess:
@@ -43,26 +43,28 @@ def dummy_clone(orig_dir, test_set):
         clone_counter = clone_counter + 1
         # Create a temporary directory to simulate the workspace
         test_set_dir_to_keep = (
-            orig_dir / test_set / "Samples" / "5_Domain_Specific"
+            orig_dir / test_set / samples_dir_name / "5_Domain_Specific"
         )
-        test_set_dir_to_keep_2 = orig_dir / test_set / "Samples" / "3_Dummy"
+        test_set_dir_to_keep_2 = (
+            orig_dir / test_set / samples_dir_name / "3_Dummy"
+        )
         test_set_dir_to_keep_5 = (
             orig_dir
             / test_set
-            / "Samples"
+            / samples_dir_name
             / "8_Platform_Specific"
             / "Tegra"
             / "cudaNvSciBufMultiplanar"
         )
 
         test_set_dir_to_keep_7 = (
-            orig_dir / test_set / "Samples" / "7_libNVVM" / "ptxgen"
+            orig_dir / test_set / samples_dir_name / "7_libNVVM" / "ptxgen"
         )
 
         test_set_dir_to_keep_4 = (
             orig_dir
             / test_set
-            / "Samples"
+            / samples_dir_name
             / "2_Concepts_and_Techniques"
             / "EGLStream_CUDA_Interop"
         )
@@ -70,13 +72,17 @@ def dummy_clone(orig_dir, test_set):
             orig_dir
             / test_set
             / "build"
-            / "Samples"
+            / samples_dir_name
             / "2_Concepts_and_Techniques"
             / "EGLStream_CUDA_Interop"
         )
 
-        test_set_dir_to_keep_3 = orig_dir / test_set / "Samples" / "Common"
-        test_set_dir_to_trash = orig_dir / test_set / "Samples" / "0_Utilities"
+        test_set_dir_to_keep_3 = (
+            orig_dir / test_set / samples_dir_name / "Common"
+        )
+        test_set_dir_to_trash = (
+            orig_dir / test_set / samples_dir_name / "0_Utilities"
+        )
 
         test_set_dir_to_keep.mkdir(parents=True, exist_ok=True)
         test_set_dir_to_keep_2.mkdir(parents=True, exist_ok=True)
@@ -130,6 +136,21 @@ class TestCudaSamples(unittest.TestCase):
             )
 
         run_cuda_sample_set.cleanup_temporary_files(".", str(test_set))
+
+        test_set = "5"
+        clone_counter = 0
+        cuda_samples_version = 13.3
+        mock_subprocess_run.side_effect = dummy_clone(
+            orig_dir, test_set, "cpp"
+        )
+        run_cuda_sample_set.clone_and_build(
+            orig_dir, test_set, cuda_samples_version
+        )
+        run_cuda_sample_set.cleanup_temporary_files(".", str(test_set))
+
+        cuda_samples_version = 12.8
+        clone_counter = 0
+        mock_subprocess_run.side_effect = dummy_clone(orig_dir, test_set)
         run_cuda_sample_set.clone_and_build(
             orig_dir, test_set, cuda_samples_version
         )
@@ -163,6 +184,14 @@ class TestCudaSamples(unittest.TestCase):
             orig_dir, test_set, cuda_samples_version
         )
         run_cuda_sample_set.cleanup_temporary_files(".", str(test_set))
+
+    def test_get_samples_dir_name(self):
+        self.assertEqual(
+            run_cuda_sample_set.get_samples_dir_name("13.2"), "Samples"
+        )
+        self.assertEqual(
+            run_cuda_sample_set.get_samples_dir_name("13.3"), "cpp"
+        )
 
     def test_remove_add_subdirectory_line(self):
         filepath = "test.txt"
@@ -200,7 +229,7 @@ class TestCudaSamples(unittest.TestCase):
             orig_dir
             / "3"
             / "build"
-            / "Samples"
+            / "cpp"
             / "5_Domain_Specific"
             / "truc"
             / "bin"
@@ -226,7 +255,9 @@ class TestCudaSamples(unittest.TestCase):
         os.chmod(str(Path(exe_dir / "test2")), 0o755)
         os.chmod(str(Path(exe_dir / "test1")), 0o755)
 
-        total, skipped = run_cuda_sample_set.run_tests("./", "3", ["test1"])
+        total, skipped = run_cuda_sample_set.run_tests(
+            "./", "3", "13.3", ["test1"]
+        )
         self.assertEqual(total, 3)
         self.assertEqual(skipped, 1)
         run_cuda_sample_set.cleanup_temporary_files("./", str(3))
@@ -255,7 +286,8 @@ class TestCudaSamples(unittest.TestCase):
             "File exist patched.", cmd=""
         ),
     )
-    def test_main(self, mock_run, mock_clone, mock_args):
+    @mock.patch("run_cuda_sample_set.copy_and_set_permissions")
+    def test_main(self, mock_copy, mock_run, mock_clone, mock_args):
         with self.assertRaises(FileExistsError):
             run_cuda_sample_set.main()
         mock_clone.side_effect = None


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

NVIDIA changed the path of their samples between 13.2 and 13.3. The changes made this path dynamically infered from the version, choosing between Samples/ and cpp/

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->
[SOMERVILLE-5258: [13.1 and 13.3] cuda-samples-2-conc failed to compileTriaged](https://warthogs.atlassian.net/browse/SOMERVILLE-5258?xpis=eyJicmlkZ2UiOiJzbWFydExpbmtzIiwiaWQiOiIxNzg4NTExMzg2MjMyIiwic291cmNlIjoiamlyYS1KU1cifQ%3D%3D)
 
[SOMERVILLE-5261: [13.1 only] cuda-samples-3-feat failed to compileTriaged](https://warthogs.atlassian.net/browse/SOMERVILLE-5261?xpis=eyJicmlkZ2UiOiJzbWFydExpbmtzIiwiaWQiOiIxNzg4NTExMzg2MjMyIiwic291cmNlIjoiamlyYS1KU1cifQ%3D%3D)


[SOMERVILLE-5262: [13.3 only] cuda-samples-7-nvvm failed to compileTriaged](https://warthogs.atlassian.net/browse/SOMERVILLE-5262?xpis=eyJicmlkZ2UiOiJzbWFydExpbmtzIiwiaWQiOiIxNzg4NTExMzg2MjMyIiwic291cmNlIjoiamlyYS1KU1cifQ%3D%3D)
 
[SOMERVILLE-5263: [13.3 only] cuda-samples-8-plat failed to compileTriaged](https://warthogs.atlassian.net/browse/SOMERVILLE-5263?xpis=eyJicmlkZ2UiOiJzbWFydExpbmtzIiwiaWQiOiIxNzg4NTExMzg2MjMyIiwic291cmNlIjoiamlyYS1KU1cifQ%3D%3D)

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
