### PR TITLE
Avoid crashing on None time duration (bugfix)

### DIFF
--- a/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/checkbox.html
@@ -328,7 +328,7 @@
                                     {%- else %}
                                     <td style='width:10%'></td>
                                     {%- endif %}
-                                    <td style='width:10%'>{{ (job_state.result.execution_duration | default(0)) | round(1) }}s</td>
+                                    <td style='width:10%'>{{ (job_state.result.execution_duration | default(0, true)) | round(1) }}s</td>
                                     {%- if job_state.result.io_log_as_flat_text != "" %}
                                     <td style='width:10%'><a href="#{{ mainloop.index }}-{{ loop.index }}-log">I/O log</a></td>
                                     {%- else %}

--- a/checkbox-ng/plainbox/impl/providers/exporters/data/multi-page.html
+++ b/checkbox-ng/plainbox/impl/providers/exporters/data/multi-page.html
@@ -373,7 +373,7 @@
                     {%- else %}
                     <td style='width:10%'></td>
                     {%- endif %}
-                    <td style='width:10%'>{{ (job_state.result.execution_duration | default(0)) | round(1) }}s</td>
+                    <td style='width:10%'>{{ (job_state.result.execution_duration | default(0, true)) | round(1) }}s</td>
                     {%- if job_state.result.io_log_as_flat_text != "" %}
                     <td style='width:10%'><a href="#{{ managerloop.index }}-{{ mainloop.index }}-{{ loop.index }}-log">I/O log</a></td>
                     {%- else %}


### PR DESCRIPTION
## Description

If estimated duration is None, the html exporter crashs. This makes it so the default qualifiers no only removes empty values but also Nones (as undefines)

## Resolved issues

N/A

## Tests

Run the new Basic Manual... test plan. Before this bugfix when exporting the HTML the exporter crashes
After, it doesn't.
