### PR TITLE
Fix/xtest ta scope to snap (Bugfix)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/look_up_xtest.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/look_up_xtest.py
@@ -9,8 +9,18 @@ class ExtendSanpd(Snapd):
     def __init__(self, task_timeout=30, poll_interval=1, verbose=False):
         super().__init__(task_timeout, poll_interval, verbose)
 
-    def list_apps(self, snaps):
-        return self._get(self._apps, params=snaps)
+    def list_apps(self, snaps=None):
+        # Snapd._request() appends `params` verbatim as the query
+        # string (it is not a dict passed to e.g. requests), so it
+        # must be pre-formatted as "names=<snap>" here. Passing the
+        # bare snap name (the previous behaviour) built an invalid
+        # query string that snapd silently ignored, so /v2/apps
+        # returned every app on the system instead of just this
+        # snap's — look_up_app() would then happily match an "xtest"
+        # app belonging to a completely different snap (e.g. the
+        # board's gadget snap) instead of failing loudly.
+        params = "names={}".format(snaps) if snaps else None
+        return self._get(self._apps, params=params)
 
 
 def look_up_app(target_app, snap_name=None):

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
@@ -34,7 +34,10 @@ def _run_command(cmd, **kwargs):
 
 
 def launch_xtest(test_suite, test_id):
-    test_utility = look_up_app("xtest", os.environ.get("XTEST"))
+    # XTEST is a required environ for this job and always points to the
+    # xtest snap's own name, so it can be used directly as the snap name.
+    snap_name = os.environ["XTEST"]
+    test_utility = look_up_app("xtest", snap_name)
 
     print("Looking for PID of tee-supplicant..", flush=True)
     _run_command("pgrep tee-supplicant", check=True)
@@ -49,8 +52,6 @@ def launch_xtest(test_suite, test_id):
         )
         return 2
     elif optee_fw < "4.0":
-        # test_utility is returned as "<snap_name>.xtest"
-        snap_name = test_utility.rsplit(".", 1)[0]
         ta_path = find_ta_path(snap_name)
         install_ta(test_utility, ta_path)
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/optee_helper.py
@@ -49,7 +49,9 @@ def launch_xtest(test_suite, test_id):
         )
         return 2
     elif optee_fw < "4.0":
-        ta_path = find_ta_path()
+        # test_utility is returned as "<snap_name>.xtest"
+        snap_name = test_utility.rsplit(".", 1)[0]
+        ta_path = find_ta_path(snap_name)
         install_ta(test_utility, ta_path)
 
     ret = _run_command(

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
@@ -18,17 +18,21 @@ def run_command(cmd, capture_output=True, text=True, check=True):
 def find_ta_path(snap_name):
     # TAs may also be bundled by other snaps (e.g. the board's gadget
     # snap), so only look inside the xtest snap's own directory to
-    # avoid picking up unrelated duplicates. Restrict the search to
-    # the snap's currently active revision (the "current" symlink
-    # snapd maintains) rather than the whole snap root: a stale
-    # optee_armtz left behind in an older, still-retained revision
-    # would otherwise be picked up too and falsely reported as a
-    # duplicate.
-    current_revision = os.path.join("/var/snap", snap_name, "current")
+    # avoid picking up unrelated duplicates. On real devices the TA
+    # lives directly under the snap's persistent common data dir, e.g.
+    # /var/snap/<snap_name>/common/lib/optee_armtz — a sibling of
+    # "current"/the numbered revision dirs, not nested under them — so
+    # the search root here is the whole snap dir, not ".../current".
+    # followlinks is left at its default (False): "current" (and any
+    # other numbered revision dir) is a symlink to a revision dir, so
+    # not following it avoids walking that same revision data twice
+    # (once under its real numbered name, once via "current") and
+    # falsely reporting duplicate TA sources.
+    snap_root = os.path.join("/var/snap", snap_name)
     print("Looking for TA path...", flush=True)
     ta_folders = [
         os.path.join(dirpath, "optee_armtz")
-        for dirpath, dirnames, _ in os.walk(current_revision)
+        for dirpath, dirnames, _ in os.walk(snap_root)
         if "optee_armtz" in dirnames
     ]
     if not ta_folders:

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
@@ -16,16 +16,21 @@ def run_command(cmd, capture_output=True, text=True, check=True):
         raise SystemExit("Error: {}".format(e))
 
 
-def find_ta_path():
-    dir = "/var/snap/**/optee_armtz"
+def find_ta_path(snap_name):
+    # TAs may also be bundled by other snaps (e.g. the board's gadget
+    # snap), so only look inside the xtest snap's own directory to
+    # avoid picking up unrelated duplicates.
+    dir = "/var/snap/{}/**/optee_armtz".format(snap_name)
     print("Looking for TA path...", flush=True)
     ta_folder = glob.glob(dir, recursive=True)
     if not ta_folder:
-        raise SystemError("Not able to find TA in the system!")
+        raise SystemError(
+            "Not able to find TA in the {} snap!".format(snap_name)
+        )
     elif len(ta_folder) > 1:
         raise SystemError(
-            "Found multiple TA sources."
-            "Please make sure only one exist in the system!"
+            "Found multiple TA sources in the {} snap."
+            "Please make sure only one exist in the system!".format(snap_name)
         )
     return ta_folder[0]
 
@@ -39,7 +44,9 @@ def install_ta(xtest, path):
 
 def main():
     xtest = look_up_app("xtest", os.environ.get("XTEST"))
-    ta_path = find_ta_path()
+    # xtest is returned as "<snap_name>.xtest"
+    snap_name = xtest.rsplit(".", 1)[0]
+    ta_path = find_ta_path(snap_name)
     install_ta(xtest, ta_path)
 
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
@@ -2,7 +2,6 @@
 
 from look_up_xtest import look_up_app
 from subprocess import run, CalledProcessError
-import glob
 import os
 
 
@@ -19,20 +18,29 @@ def run_command(cmd, capture_output=True, text=True, check=True):
 def find_ta_path(snap_name):
     # TAs may also be bundled by other snaps (e.g. the board's gadget
     # snap), so only look inside the xtest snap's own directory to
-    # avoid picking up unrelated duplicates.
-    dir = "/var/snap/{}/**/optee_armtz".format(snap_name)
+    # avoid picking up unrelated duplicates. Restrict the search to
+    # the snap's currently active revision (the "current" symlink
+    # snapd maintains) rather than the whole snap root: a stale
+    # optee_armtz left behind in an older, still-retained revision
+    # would otherwise be picked up too and falsely reported as a
+    # duplicate.
+    current_revision = os.path.join("/var/snap", snap_name, "current")
     print("Looking for TA path...", flush=True)
-    ta_folder = glob.glob(dir, recursive=True)
-    if not ta_folder:
+    ta_folders = [
+        os.path.join(dirpath, "optee_armtz")
+        for dirpath, dirnames, _ in os.walk(current_revision)
+        if "optee_armtz" in dirnames
+    ]
+    if not ta_folders:
         raise SystemError(
             "Not able to find TA in the {} snap!".format(snap_name)
         )
-    elif len(ta_folder) > 1:
+    elif len(ta_folders) > 1:
         raise SystemError(
             "Found multiple TA sources in the {} snap."
             "Please make sure only one exist in the system!".format(snap_name)
         )
-    return ta_folder[0]
+    return ta_folders[0]
 
 
 def install_ta(xtest, path):

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/xtest_install_ta.py
@@ -43,9 +43,10 @@ def install_ta(xtest, path):
 
 
 def main():
-    xtest = look_up_app("xtest", os.environ.get("XTEST"))
-    # xtest is returned as "<snap_name>.xtest"
-    snap_name = xtest.rsplit(".", 1)[0]
+    # XTEST is a required environ for this job and always points to the
+    # xtest snap's own name, so it can be used directly as the snap name.
+    snap_name = os.environ["XTEST"]
+    xtest = look_up_app("xtest", snap_name)
     ta_path = find_ta_path(snap_name)
     install_ta(xtest, ta_path)
 

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_look_up_xtest.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_look_up_xtest.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import patch
+
+import look_up_xtest
+
+
+class TestListApps(unittest.TestCase):
+
+    @patch.object(look_up_xtest.ExtendSanpd, "_get")
+    def test_builds_names_query_when_snap_given(self, mock_get):
+        look_up_xtest.ExtendSanpd().list_apps("hon-x-test")
+        mock_get.assert_called_once_with("/v2/apps", params="names=hon-x-test")
+
+    @patch.object(look_up_xtest.ExtendSanpd, "_get")
+    def test_no_params_when_snap_omitted(self, mock_get):
+        look_up_xtest.ExtendSanpd().list_apps()
+        mock_get.assert_called_once_with("/v2/apps", params=None)
+
+
+class TestLookUpApp(unittest.TestCase):
+
+    @patch.object(look_up_xtest.ExtendSanpd, "list_apps")
+    def test_scopes_lookup_to_requested_snap(self, mock_list_apps):
+        # Regression test: list_apps() must actually be called with
+        # the snap name so snapd only returns that snap's apps —
+        # otherwise an "xtest" app belonging to an unrelated snap
+        # (e.g. a board's gadget snap) could be matched instead.
+        mock_list_apps.return_value = {
+            "result": [{"snap": "hon-x-test", "name": "xtest"}]
+        }
+        result = look_up_xtest.look_up_app("xtest", "hon-x-test")
+        mock_list_apps.assert_called_once_with("hon-x-test")
+        self.assertEqual(result, "hon-x-test.xtest")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_xtest_install_ta.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_xtest_install_ta.py
@@ -6,30 +6,48 @@ import xtest_install_ta
 
 class TestFindTaPath(unittest.TestCase):
 
-    @patch("xtest_install_ta.glob.glob")
-    def test_ta_found(self, mock_glob):
-        mock_glob.return_value = [
-            "/var/snap/hon-x-test/common/lib/optee_armtz"
+    @patch("xtest_install_ta.os.walk")
+    def test_ta_found(self, mock_walk):
+        mock_walk.return_value = [
+            ("/var/snap/hon-x-test/current", ["common"], []),
+            ("/var/snap/hon-x-test/current/common", ["lib"], []),
+            (
+                "/var/snap/hon-x-test/current/common/lib",
+                ["optee_armtz"],
+                [],
+            ),
         ]
         path = xtest_install_ta.find_ta_path("hon-x-test")
-        self.assertEqual(path, "/var/snap/hon-x-test/common/lib/optee_armtz")
-        mock_glob.assert_called_once_with(
-            "/var/snap/hon-x-test/**/optee_armtz", recursive=True
+        self.assertEqual(
+            path,
+            "/var/snap/hon-x-test/current/common/lib/optee_armtz",
         )
+        mock_walk.assert_called_once_with("/var/snap/hon-x-test/current")
 
-    @patch("xtest_install_ta.glob.glob")
-    def test_ta_not_found(self, mock_glob):
-        mock_glob.return_value = []
+    @patch("xtest_install_ta.os.walk")
+    def test_ta_not_found(self, mock_walk):
+        mock_walk.return_value = [
+            ("/var/snap/hon-x-test/current", ["common"], []),
+            ("/var/snap/hon-x-test/current/common", [], []),
+        ]
         with self.assertRaises(SystemError):
             xtest_install_ta.find_ta_path("hon-x-test")
 
-    @patch("xtest_install_ta.glob.glob")
-    def test_multiple_ta_found_in_same_snap(self, mock_glob):
+    @patch("xtest_install_ta.os.walk")
+    def test_multiple_ta_found_in_same_snap(self, mock_walk):
         # Even scoped to a single snap, more than one match should
         # still be treated as ambiguous and fail loudly.
-        mock_glob.return_value = [
-            "/var/snap/hon-x-test/common/lib/optee_armtz",
-            "/var/snap/hon-x-test/x1/optee_armtz",
+        mock_walk.return_value = [
+            (
+                "/var/snap/hon-x-test/current/common/lib",
+                ["optee_armtz"],
+                [],
+            ),
+            (
+                "/var/snap/hon-x-test/current/x1",
+                ["optee_armtz"],
+                [],
+            ),
         ]
         with self.assertRaises(SystemError):
             xtest_install_ta.find_ta_path("hon-x-test")

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_xtest_install_ta.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_xtest_install_ta.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -6,29 +8,54 @@ import xtest_install_ta
 
 class TestFindTaPath(unittest.TestCase):
 
+    def test_finds_ta_directly_under_common_on_real_filesystem(self):
+        # Regression test: on real devices the TA lives directly under
+        # the snap's persistent common data dir, e.g.
+        # /var/snap/<snap_name>/common/lib/optee_armtz — a sibling of
+        # "current"/the numbered revision dirs, not nested under them.
+        # Exercised against a real filesystem (rather than a mocked
+        # os.walk) so a regression that goes back to searching only
+        # under ".../current" would actually be caught here.
+        with tempfile.TemporaryDirectory() as tmp:
+            snap_root = os.path.join(tmp, "hon-x-test")
+            ta_dir = os.path.join(snap_root, "common", "lib", "optee_armtz")
+            os.makedirs(ta_dir)
+            revision_dir = os.path.join(snap_root, "x1")
+            os.makedirs(revision_dir)
+            os.symlink(revision_dir, os.path.join(snap_root, "current"))
+
+            real_join = os.path.join
+
+            def fake_join(a, *rest):
+                # Redirect only find_ta_path()'s own "/var/snap" root
+                # onto our fixture; everything else joins normally.
+                if a == "/var/snap":
+                    return real_join(tmp, *rest)
+                return real_join(a, *rest)
+
+            with patch("xtest_install_ta.os.path.join", fake_join):
+                found = xtest_install_ta.find_ta_path("hon-x-test")
+            self.assertEqual(found, ta_dir)
+
     @patch("xtest_install_ta.os.walk")
     def test_ta_found(self, mock_walk):
         mock_walk.return_value = [
-            ("/var/snap/hon-x-test/current", ["common"], []),
-            ("/var/snap/hon-x-test/current/common", ["lib"], []),
-            (
-                "/var/snap/hon-x-test/current/common/lib",
-                ["optee_armtz"],
-                [],
-            ),
+            ("/var/snap/hon-x-test", ["common", "current", "x1"], []),
+            ("/var/snap/hon-x-test/common", ["lib"], []),
+            ("/var/snap/hon-x-test/common/lib", ["optee_armtz"], []),
         ]
         path = xtest_install_ta.find_ta_path("hon-x-test")
         self.assertEqual(
             path,
-            "/var/snap/hon-x-test/current/common/lib/optee_armtz",
+            "/var/snap/hon-x-test/common/lib/optee_armtz",
         )
-        mock_walk.assert_called_once_with("/var/snap/hon-x-test/current")
+        mock_walk.assert_called_once_with("/var/snap/hon-x-test")
 
     @patch("xtest_install_ta.os.walk")
     def test_ta_not_found(self, mock_walk):
         mock_walk.return_value = [
-            ("/var/snap/hon-x-test/current", ["common"], []),
-            ("/var/snap/hon-x-test/current/common", [], []),
+            ("/var/snap/hon-x-test", ["common"], []),
+            ("/var/snap/hon-x-test/common", [], []),
         ]
         with self.assertRaises(SystemError):
             xtest_install_ta.find_ta_path("hon-x-test")
@@ -39,12 +66,12 @@ class TestFindTaPath(unittest.TestCase):
         # still be treated as ambiguous and fail loudly.
         mock_walk.return_value = [
             (
-                "/var/snap/hon-x-test/current/common/lib",
+                "/var/snap/hon-x-test/common/lib",
                 ["optee_armtz"],
                 [],
             ),
             (
-                "/var/snap/hon-x-test/current/x1",
+                "/var/snap/hon-x-test/x1",
                 ["optee_armtz"],
                 [],
             ),

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_xtest_install_ta.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_xtest_install_ta.py
@@ -1,0 +1,61 @@
+import unittest
+from unittest.mock import patch
+
+import xtest_install_ta
+
+
+class TestFindTaPath(unittest.TestCase):
+
+    @patch("xtest_install_ta.glob.glob")
+    def test_ta_found(self, mock_glob):
+        mock_glob.return_value = [
+            "/var/snap/hon-x-test/common/lib/optee_armtz"
+        ]
+        path = xtest_install_ta.find_ta_path("hon-x-test")
+        self.assertEqual(path, "/var/snap/hon-x-test/common/lib/optee_armtz")
+        mock_glob.assert_called_once_with(
+            "/var/snap/hon-x-test/**/optee_armtz", recursive=True
+        )
+
+    @patch("xtest_install_ta.glob.glob")
+    def test_ta_not_found(self, mock_glob):
+        mock_glob.return_value = []
+        with self.assertRaises(SystemError):
+            xtest_install_ta.find_ta_path("hon-x-test")
+
+    @patch("xtest_install_ta.glob.glob")
+    def test_multiple_ta_found_in_same_snap(self, mock_glob):
+        # Even scoped to a single snap, more than one match should
+        # still be treated as ambiguous and fail loudly.
+        mock_glob.return_value = [
+            "/var/snap/hon-x-test/common/lib/optee_armtz",
+            "/var/snap/hon-x-test/x1/optee_armtz",
+        ]
+        with self.assertRaises(SystemError):
+            xtest_install_ta.find_ta_path("hon-x-test")
+
+
+class TestMain(unittest.TestCase):
+
+    @patch("xtest_install_ta.install_ta")
+    @patch("xtest_install_ta.find_ta_path")
+    @patch("xtest_install_ta.look_up_app")
+    def test_main_uses_snap_from_xtest_app(
+        self, mock_look_up_app, mock_find_ta_path, mock_install_ta
+    ):
+        mock_look_up_app.return_value = "hon-x-test.xtest"
+        mock_find_ta_path.return_value = (
+            "/var/snap/hon-x-test/common/lib/optee_armtz"
+        )
+
+        xtest_install_ta.main()
+
+        mock_find_ta_path.assert_called_once_with("hon-x-test")
+        mock_install_ta.assert_called_once_with(
+            "hon-x-test.xtest",
+            "/var/snap/hon-x-test/common/lib/optee_armtz",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_xtest_install_ta.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/tests/test_xtest_install_ta.py
@@ -37,10 +37,11 @@ class TestFindTaPath(unittest.TestCase):
 
 class TestMain(unittest.TestCase):
 
+    @patch.dict("xtest_install_ta.os.environ", {"XTEST": "hon-x-test"})
     @patch("xtest_install_ta.install_ta")
     @patch("xtest_install_ta.find_ta_path")
     @patch("xtest_install_ta.look_up_app")
-    def test_main_uses_snap_from_xtest_app(
+    def test_main_uses_snap_from_xtest_env(
         self, mock_look_up_app, mock_find_ta_path, mock_install_ta
     ):
         mock_look_up_app.return_value = "hon-x-test.xtest"
@@ -50,6 +51,7 @@ class TestMain(unittest.TestCase):
 
         xtest_install_ta.main()
 
+        mock_look_up_app.assert_called_once_with("xtest", "hon-x-test")
         mock_find_ta_path.assert_called_once_with("hon-x-test")
         mock_install_ta.assert_called_once_with(
             "hon-x-test.xtest",


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
This change fix the issue we enconter in shiner pdk platform. Since the gadget snap and x-test snap both include the TA file. And we should use the TA from test tool instead of the gadget. 
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests
sideload result
- https://certification.canonical.com/hardware/202501-36203/submission/509747/
- https://certification.canonical.com/hardware/202511-38134/submission/509905/test-results/
