### PR TITLE
update test plans to use template-id instead of regex (Infra)

### DIFF
--- a/providers/base/units/bluetooth/test-plan.pxu
+++ b/providers/base/units/bluetooth/test-plan.pxu
@@ -27,7 +27,7 @@ include:
     bluetooth/detect                               certification-status=blocker
     bluetooth/detect-output                        certification-status=blocker
     bluetooth/bluetooth_obex_send                  certification-status=blocker
-    bluetooth4/beacon_eddystone_url_.*             certification-status=blocker
+    bluetooth4/beacon_eddystone_url_interface      certification-status=blocker
 bootstrap_include:
     device
 
@@ -188,7 +188,7 @@ include:
     after-suspend-bluetooth/detect                         certification-status=blocker
     after-suspend-bluetooth/detect-output                  certification-status=blocker
     after-suspend-bluetooth/bluetooth_obex_send            certification-status=blocker
-    after-suspend-bluetooth4/beacon_eddystone_url_.*       certification-status=blocker
+    after-suspend-bluetooth4/beacon_eddystone_url_interface       certification-status=blocker
 bootstrap_include:
     device
 
@@ -212,5 +212,5 @@ nested_part:
     bluetooth-cert-automated
     after-suspend-bluetooth-cert-automated
 certification_status_overrides:
-    apply non-blocker to com.canonical.certification::bluetooth4/beacon_eddystone_url_.*
-    apply non-blocker to com.canonical.certification::after-suspend-bluetooth4/beacon_eddystone_url_.*
+    apply non-blocker to com.canonical.certification::bluetooth4/beacon_eddystone_url_interface
+    apply non-blocker to com.canonical.certification::after-suspend-bluetooth4/beacon_eddystone_url_interface

--- a/providers/base/units/bluetooth/test-plan.pxu
+++ b/providers/base/units/bluetooth/test-plan.pxu
@@ -213,4 +213,3 @@ nested_part:
     after-suspend-bluetooth-cert-automated
 certification_status_overrides:
     apply non-blocker to com.canonical.certification::bluetooth4/beacon_eddystone_url_interface
-    apply non-blocker to com.canonical.certification::after-suspend-bluetooth4/beacon_eddystone_url_interface

--- a/providers/base/units/camera/jobs.pxu
+++ b/providers/base/units/camera/jobs.pxu
@@ -134,6 +134,7 @@ template-unit: job
 plugin: attachment
 category_id: com.canonical.plainbox::camera
 id: camera/multiple-resolution-images-attachment_{name}
+template-id: camera/multiple-resolution-images-attachment_name
 flags: also-after-suspend
 _summary: Attach an image from the multiple resolution images test for {product_slug}
 estimated_duration: 1s
@@ -172,6 +173,7 @@ template-unit: job
 plugin: attachment
 category_id: com.canonical.plainbox::camera
 id: camera/camera-quality-image_{name}
+template-id: camera/camera-quality-image_name
 flags: also-after-suspend
 _summary: Attach the image used for the BRISQUE score for {product_slug}
 estimated_duration: 1s

--- a/providers/base/units/camera/test-plan.pxu
+++ b/providers/base/units/camera/test-plan.pxu
@@ -14,8 +14,8 @@ _name: Camera tests (Manual)
 _description:
  Camera tests (Manual)
 include:
- camera/still_.*                                   certification-status=blocker
- camera/display_.*                                 certification-status=blocker
+ camera/still_name                                 certification-status=blocker
+ camera/display_name                               certification-status=blocker
 bootstrap_include:
  device
 
@@ -24,8 +24,8 @@ unit: test plan
 _name: Camera tests after suspend (Manual)
 _description: Camera tests after suspend (Manual)
 include:
- after-suspend-camera/still_.*                     certification-status=blocker
- after-suspend-camera/display_.*                   certification-status=blocker
+ after-suspend-camera/still_name                   certification-status=blocker
+ after-suspend-camera/display_name                 certification-status=blocker
 bootstrap_include:
  device
 
@@ -44,11 +44,11 @@ unit: test plan
 _name: Camera tests (automated)
 _description: Camera tests (automated)
 include:
- camera/detect                                     certification-status=blocker
- camera/multiple-resolution-images_.*              certification-status=blocker
- camera/multiple-resolution-images-attachment_.*   certification-status=non-blocker
- camera/camera-quality_.*                          certification-status=non-blocker
- camera/camera-quality-image_.*                    certification-status=non-blocker
+ camera/detect                                       certification-status=blocker
+ camera/multiple-resolution-images_name              certification-status=blocker
+ camera/multiple-resolution-images-attachment_name   certification-status=non-blocker
+ camera/camera-quality_name                          certification-status=non-blocker
+ camera/camera-quality-image_name                    certification-status=non-blocker
 bootstrap_include:
  device
 
@@ -89,11 +89,11 @@ unit: test plan
 _name: Camera tests After Suspend (automated)
 _description: Camera tests After Suspend (automated)
 include:
- after-suspend-camera/detect                                     certification-status=blocker
- after-suspend-camera/multiple-resolution-images_.*              certification-status=blocker
- after-suspend-camera/multiple-resolution-images-attachment_.*   certification-status=non-blocker
- after-suspend-camera/camera-quality_.*                          certification-status=non-blocker
- after-suspend-camera/camera-quality-image_.*                    certification-status=non-blocker 
+ after-suspend-camera/detect                                       certification-status=blocker
+ after-suspend-camera/multiple-resolution-images_name              certification-status=blocker
+ after-suspend-camera/multiple-resolution-images-attachment_name   certification-status=non-blocker
+ after-suspend-camera/camera-quality_name                          certification-status=non-blocker
+ after-suspend-camera/camera-quality-image_name                    certification-status=non-blocker
 bootstrap_include:
  device
 
@@ -129,8 +129,8 @@ id: camera-base-26-04-manual
 unit: test plan
 _name: Camera for 26.04 (Manual)
 include:
-    camera/led_.*
-    after-suspend-camera/led_.*
+    camera/led_name
+    after-suspend-camera/led_name
 nested_part:
     submission-cert-full
     camera-cert-manual

--- a/providers/base/units/cpu/test-plan.pxu
+++ b/providers/base/units/cpu/test-plan.pxu
@@ -35,8 +35,8 @@ include:
     cpu/offlining_test                             certification-status=blocker
     cpu/topology                                   certification-status=blocker
     cpu/clocktest
-    cpu/armhf_vfp_support_.*
-    cpu/arm64_vfp_support_.*
+    cpu/armhf_vfp_support_platform
+    cpu/arm64_vfp_support_platform
 
 id: after-suspend-cpu-cert-automated
 unit: test plan

--- a/providers/base/units/disk/test-plan.pxu
+++ b/providers/base/units/disk/test-plan.pxu
@@ -20,12 +20,12 @@ _name: Disk tests (automated)
 _description: Disk tests (automated)
 include:
     disk/detect                                certification-status=blocker
-    disk/stats_.*
-    disk/read_performance_.*                   certification-status=blocker
-    disk/storage_device_.*                     certification-status=blocker
-    benchmarks/disk/hdparm-read_.*
-    benchmarks/disk/hdparm-cache-read_.*
-    disk/apste_support_on_.*
+    disk/stats_name
+    disk/read_performance_name                 certification-status=blocker
+    disk/storage_device_name                   certification-status=blocker
+    benchmarks/disk/hdparm-read_name
+    benchmarks/disk/hdparm-cache-read_name
+    disk/apste_support_on_name
     disk/check-software-raid
 bootstrap_include:
     device
@@ -36,12 +36,12 @@ _name: Disk tests after suspend (automated)
 _description: Disk tests after suspend (automated)
 include:
     after-suspend-disk/detect                                certification-status=blocker
-    after-suspend-disk/stats_.*
-    after-suspend-disk/read_performance_.*                   certification-status=blocker
-    after-suspend-disk/storage_device_.*                     certification-status=blocker
-    after-suspend-benchmarks/disk/hdparm-read_.*
-    after-suspend-benchmarks/disk/hdparm-cache-read_.*
-    after-suspend-disk/apste_support_on_.*
+    after-suspend-disk/stats_name
+    after-suspend-disk/read_performance_name                 certification-status=blocker
+    after-suspend-disk/storage_device_name                   certification-status=blocker
+    after-suspend-benchmarks/disk/hdparm-read_name
+    after-suspend-benchmarks/disk/hdparm-cache-read_name
+    after-suspend-disk/apste_support_on_name
 bootstrap_include:
     device
 

--- a/providers/base/units/ethernet/test-plan.pxu
+++ b/providers/base/units/ethernet/test-plan.pxu
@@ -13,7 +13,7 @@ _name: Ethernet tests (manual)
 _description: Ethernet tests (manual)
 include:
     ethernet/detect                                certification-status=blocker
-    ethernet/hotplug-.*                            certification-status=blocker
+    ethernet/hotplug-interface                     certification-status=blocker
 bootstrap_include:
     device
 
@@ -23,7 +23,7 @@ _name: Ethernet tests after suspend (manual)
 _description: Ethernet tests after suspend
 include:
     after-suspend-ethernet/detect                  certification-status=blocker
-    after-suspend-ethernet/hotplug-.*              certification-status=blocker
+    after-suspend-ethernet/hotplug-interface       certification-status=blocker
 bootstrap_include:
     device
 

--- a/providers/base/units/info/test-plan.pxu
+++ b/providers/base/units/info/test-plan.pxu
@@ -36,7 +36,7 @@ include:
  efi_attachment
  info/buildstamp
  info/disk_partitions
- info/hdparm_.*.txt
+ info/hdparm_name.txt
  info/touchpad_driver
  installer_debug.gz
  kernel_cmdline_attachment

--- a/providers/base/units/input/test-plan.pxu
+++ b/providers/base/units/input/test-plan.pxu
@@ -14,20 +14,20 @@ _name: Input tests (Manual)
 _description:
  Input tests (Manual)
 include:
-    input/accelerometer                        certification-status=blocker
-    input/pointing_.*                          certification-status=blocker
-    input/clicking_.*                          certification-status=blocker
-    input/keyboard                             certification-status=blocker
+    input/accelerometer                                certification-status=blocker
+    input/pointing_product_slug_category___index__     certification-status=blocker
+    input/clicking_product_slug_category___index__     certification-status=blocker
+    input/keyboard                                     certification-status=blocker
 
 id: after-suspend-input-cert-manual
 unit: test plan
 _name: Input tests after suspend (Manual)
 _description: Input tests after suspend (Manual)
 include:
-    after-suspend-input/accelerometer          certification-status=blocker
-    after-suspend-input/pointing_.*            certification-status=blocker
-    after-suspend-input/clicking_.*            certification-status=blocker
-    after-suspend-input/keyboard               certification-status=blocker
+    after-suspend-input/accelerometer                                certification-status=blocker
+    after-suspend-input/pointing_product_slug_category___index__     certification-status=blocker
+    after-suspend-input/clicking_product_slug_category___index__     certification-status=blocker
+    after-suspend-input/keyboard                                     certification-status=blocker
 
 id: input-cert-automated
 unit: test plan
@@ -35,7 +35,7 @@ _name: Input tests (Automated)
 _description:
  Input tests (Automated)
 include:
- input/fixed_screen_orientation_on_.*       certification-status=non-blocker
+ input/fixed_screen_orientation_on_product___index__       certification-status=non-blocker
 bootstrap_include:
  dmi
 
@@ -45,7 +45,7 @@ _name: Input tests (Automated after suspend)
 _description:
  Input tests (Automated)
 include:
- after-suspend-input/fixed_screen_orientation_on_.*       certification-status=non-blocker
+ after-suspend-input/fixed_screen_orientation_on_product___index__       certification-status=non-blocker
 bootstrap_include:
  dmi
 

--- a/providers/base/units/led/test-plan.pxu
+++ b/providers/base/units/led/test-plan.pxu
@@ -19,7 +19,7 @@ _description:
     Notes: - led/power-blink-suspend and led/suspend are used later in the
              power management testplan just after a number of suspend tests.
 include:
-    camera/led_.*                      certification-status=blocker
+    camera/led_name                    certification-status=blocker
     led/caps-lock                      certification-status=blocker
     led/numeric-keypad                 certification-status=blocker
     led/power                          certification-status=blocker
@@ -35,7 +35,7 @@ unit: test plan
 _name: LED tests after suspend (Manual)
 _description: LED tests after suspend (Manual)
 include:
-    after-suspend-camera/led_.*        certification-status=blocker
+    after-suspend-camera/led_name      certification-status=blocker
     after-suspend-led/caps-lock        certification-status=blocker
     after-suspend-led/numeric-keypad   certification-status=blocker
     after-suspend-led/power            certification-status=blocker

--- a/providers/base/units/mediacard/test-plan.pxu
+++ b/providers/base/units/mediacard/test-plan.pxu
@@ -29,7 +29,7 @@ _name: Mediacard tests (Automated)
 _description:
  Mediacard tests (Automated)
 include:
-    mediacard/storage-preinserted-.*
+    mediacard/storage-preinserted-symlink_uuid
 bootstrap_include:
     removable_partition
 
@@ -39,7 +39,7 @@ _name: Mediacard tests (Automated)
 _description:
  Mediacard tests (Automated)
 include:
-    after-suspend-mediacard/storage-preinserted-.*
+    after-suspend-mediacard/storage-preinserted-symlink_uuid
 bootstrap_include:
     removable_partition
 
@@ -131,4 +131,3 @@ include:
     after-suspend-mediacard/sdhc-storage-manual
     after-suspend-mediacard/sdxc-storage-manual
 nested_part:
-

--- a/providers/base/units/networking/test-plan.pxu
+++ b/providers/base/units/networking/test-plan.pxu
@@ -12,7 +12,7 @@ unit: test plan
 _name: Networking tests (manual)
 _description: Networking tests (manual)
 include:
-    networking/info_device.*                       certification-status=blocker
+    networking/info_device__index___interface      certification-status=blocker
     networking/airplane-mode                       certification-status=blocker
 bootstrap_include:
     device
@@ -23,8 +23,8 @@ unit: test plan
 _name: Networking tests after suspend (manual)
 _description: Manual tests for networking after suspend
 include:
-    after-suspend-networking/info_device.*         certification-status=blocker
-    after-suspend-networking/airplane-mode         certification-status=blocker
+    after-suspend-networking/info_device__index___interface      certification-status=blocker
+    after-suspend-networking/airplane-mode                       certification-status=blocker
 bootstrap_include:
     device
     executable

--- a/providers/base/units/optical/test-plan.pxu
+++ b/providers/base/units/optical/test-plan.pxu
@@ -36,7 +36,7 @@ _description:
  Optical drive tests (Automated)
 include:
  optical/detect                                 certification-status=blocker
- optical/read-automated_.*                      certification-status=blocker
+ optical/read-automated_name                    certification-status=blocker
 bootstrap_include:
     device
 
@@ -47,7 +47,7 @@ _description:
  Optical drive tests after suspend (Automated)
 include:
  after-suspend-optical/detect                    certification-status=blocker
- after-suspend-optical/read-automated_.*         certification-status=blocker
+ after-suspend-optical/read-automated_name       certification-status=blocker
 bootstrap_include:
     device
 

--- a/providers/base/units/snapd/test-plan.pxu
+++ b/providers/base/units/snapd/test-plan.pxu
@@ -67,7 +67,7 @@ include:
     snappy/snap-remove
     snappy/test-store-install-beta
     snappy/test-store-install-edge
-    snappy/test-store-config-.*
+    snappy/test-store-config-store
     snappy/test-system-confinement
     snappy/test-snaps-confinement
 nested_part:

--- a/providers/base/units/stress/test-plan.pxu
+++ b/providers/base/units/stress/test-plan.pxu
@@ -303,7 +303,7 @@ unit: test plan
 _name: Automated iperf3 tests
 _description: Automated iperf3 performance test
 include:
-    ethernet/iperf3_.*
+    ethernet/iperf3_interface
 bootstrap_include:
     device
 
@@ -346,4 +346,4 @@ certification_status_overrides:
     apply blocker to com.canonical.certification::(warm|cold)-.*-device-check
     apply blocker to com.canonical.certification::(warm|cold)-.*-service-check
     apply blocker to com.canonical.certification::(warm|cold)-.*-renderer-check
-    apply blocker to com.canonical.certification::ethernet/iperf3_.*
+    apply blocker to com.canonical.certification::ethernet/iperf3_interface

--- a/providers/base/units/touchpad/test-plan.pxu
+++ b/providers/base/units/touchpad/test-plan.pxu
@@ -40,7 +40,7 @@ _description:
  Touchpad tests (Automated)
 include:
  touchpad/detected-as-mouse                     certification-status=blocker
- touchpad/palm-rejection-firmware-labeling_.*   certification-status=non-blocker
+ touchpad/palm-rejection-firmware-labeling_product_slug   certification-status=non-blocker
 
 id: after-suspend-touchpad-cert-automated
 unit: test plan
@@ -49,7 +49,7 @@ _description:
  Touchpad tests after suspend (Automated)
 include:
  after-suspend-touchpad/detected-as-mouse                     certification-status=blocker
- after-suspend-touchpad/palm-rejection-firmware-labeling_.*   certification-status=non-blocker
+ after-suspend-touchpad/palm-rejection-firmware-labeling_product_slug   certification-status=non-blocker
 
 id: after-suspend-touchpad-cert-full
 unit: test plan

--- a/providers/base/units/touchscreen/test-plan.pxu
+++ b/providers/base/units/touchscreen/test-plan.pxu
@@ -118,8 +118,8 @@ nested_part:
     after-suspend-touchscreen-cert-manual
     info-attachment-cert-full
 certification_status_overrides:
-    apply blocker to com.canonical.certification::touchscreen/multitouch-rotate-.*
-    apply blocker to com.canonical.certification::after-suspend-touchscreen/multitouch-rotate-.*
+    apply blocker to com.canonical.certification::touchscreen/multitouch-rotate-product_slug
+    apply blocker to com.canonical.certification::after-suspend-touchscreen/multitouch-rotate-product_slug
 
 id: touchscreen-base-26-04-automated
 unit: test plan

--- a/providers/base/units/touchscreen/test-plan.pxu
+++ b/providers/base/units/touchscreen/test-plan.pxu
@@ -119,7 +119,6 @@ nested_part:
     info-attachment-cert-full
 certification_status_overrides:
     apply blocker to com.canonical.certification::touchscreen/multitouch-rotate-product_slug
-    apply blocker to com.canonical.certification::after-suspend-touchscreen/multitouch-rotate-product_slug
 
 id: touchscreen-base-26-04-automated
 unit: test plan

--- a/providers/base/units/usb/test-plan.pxu
+++ b/providers/base/units/usb/test-plan.pxu
@@ -33,7 +33,7 @@ _description:
 include:
  usb/detect                                 certification-status=blocker
  usb/storage-detect
- usb/storage-preinserted-.*
+ usb/storage-preinserted-symlink_uuid
 
 id: after-suspend-usb-cert-automated
 unit: test plan
@@ -43,7 +43,7 @@ _description:
 include:
  after-suspend-usb/detect                                 certification-status=blocker
  after-suspend-usb/storage-detect
- after-suspend-usb/storage-preinserted-.*
+ after-suspend-usb/storage-preinserted-symlink_uuid
 
 id: usb3-cert-full
 unit: test plan
@@ -411,9 +411,9 @@ nested_part:
     after-suspend-usb3-cert-automated
 certification_status_overrides:
     apply blocker to com.canonical.certification::usb/storage-detect
-    apply blocker to com.canonical.certification::usb/storage-preinserted-.*
+    apply blocker to com.canonical.certification::usb/storage-preinserted-symlink_uuid
     apply blocker to com.canonical.certification::after-suspend-usb/storage-detect
-    apply blocker to com.canonical.certification::after-suspend-usb/storage-preinserted-.*
+    apply blocker to com.canonical.certification::after-suspend-usb/storage-preinserted-symlink_uuid
 
 id: usb-c-base-26-04-manual
 unit: test plan

--- a/providers/base/units/usb/test-plan.pxu
+++ b/providers/base/units/usb/test-plan.pxu
@@ -413,7 +413,6 @@ certification_status_overrides:
     apply blocker to com.canonical.certification::usb/storage-detect
     apply blocker to com.canonical.certification::usb/storage-preinserted-symlink_uuid
     apply blocker to com.canonical.certification::after-suspend-usb/storage-detect
-    apply blocker to com.canonical.certification::after-suspend-usb/storage-preinserted-symlink_uuid
 
 id: usb-c-base-26-04-manual
 unit: test plan


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description
## WARNING: This modifies com.canonical.certification::sru-server
<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
Update test plans to use `template-id` instead of the previous format,
following up on #1137 and #1127.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->
https://warthogs.atlassian.net/browse/OEMQA-6553
## Documentation
N/A
<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
Iperf: https://certification.canonical.com/hardware/202511-38065/submission/509888/

Auto: https://certification.canonical.com/hardware/202511-38065/submission/509873/

Manual: https://certification.canonical.com/hardware/202511-38065/submission/509768/

09/10
remove redundant: https://certification.canonical.com/hardware/202511-38064/submission/510250/