### PR TITLE
Add NVLink status check support script in checkbox support. (New)

### DIFF
--- a/checkbox-support/checkbox_support/scripts/nvlink_status.py
+++ b/checkbox-support/checkbox_support/scripts/nvlink_status.py
@@ -1,0 +1,137 @@
+"""
+Check the NVLink status of NVIDIA GPUs using ctypes bindings to libnvml.
+"""
+
+import argparse
+import ctypes
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+# NVML return codes
+# https://github.com/NVIDIA/nvidia-settings/blob/5b341a9e54f08ac324e148e1e7e102030e42b1c4/src/nvml.h#L1293
+NVML_SUCCESS = 0
+NVML_ERROR_NOT_SUPPORTED = 3
+
+# NVLink links are typically numbered 0-5 on modern GPUs
+NVLINK_MAX_LINKS = 6
+
+
+def check_nv_link_status(missing_lib_result: bool = False) -> bool:
+    """
+    Check NVLink status using ctypes binding to libnvml.
+
+    :param missing_lib_result: value to return when libnvidia-ml.so.1
+                                can't be loaded, i.e. there is no NVIDIA
+                                driver installed on the system.
+
+    :returns: True if NVLink is active/detected on any GPU,
+              False otherwise.
+    """
+    try:
+        # Try to load the NVIDIA Management Library
+        nvml = ctypes.CDLL("libnvidia-ml.so.1")
+    except OSError:
+        logger.info("libnvidia-ml.so.1 not found, assuming no NVLink")
+        return missing_lib_result
+
+    # Initialize NVML
+    nvmlInit = nvml.nvmlInit_v2
+    nvmlInit.restype = ctypes.c_int
+
+    # https://github.com/NVIDIA/nvidia-settings/blob/5b341a9e54f08ac324e148e1e7e102030e42b1c4/src/nvml.h#L3974-L4000
+    ret = nvmlInit()
+    if ret != NVML_SUCCESS:
+        logger.info("NVML initialization failed")
+        return False
+
+    try:
+        # Get device count
+        nvmlDeviceGetCount = nvml.nvmlDeviceGetCount_v2
+        nvmlDeviceGetCount.argtypes = [ctypes.POINTER(ctypes.c_uint)]
+        nvmlDeviceGetCount.restype = ctypes.c_int
+
+        device_count = ctypes.c_uint()
+        ret = nvmlDeviceGetCount(ctypes.byref(device_count))
+        if ret != NVML_SUCCESS:
+            return False
+
+        # Check each device for NVLink
+        # https://github.com/NVIDIA/nvidia-settings/blob/5b341a9e54f08ac324e148e1e7e102030e42b1c4/src/nvml.h#L4593-L4639
+        nvmlDeviceGetHandleByIndex = nvml.nvmlDeviceGetHandleByIndex_v2
+        nvmlDeviceGetHandleByIndex.argtypes = [
+            ctypes.c_uint,
+            ctypes.POINTER(ctypes.c_void_p),
+        ]
+        # https://github.com/NVIDIA/nvidia-settings/blob/5b341a9e54f08ac324e148e1e7e102030e42b1c4/src/nvml.h#L9486-L9504
+        nvmlDeviceGetHandleByIndex.restype = ctypes.c_int
+
+        nvmlDeviceGetNvLinkState = nvml.nvmlDeviceGetNvLinkState
+        nvmlDeviceGetNvLinkState.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint,
+            ctypes.POINTER(ctypes.c_uint),
+        ]
+        nvmlDeviceGetNvLinkState.restype = ctypes.c_int
+
+        for i in range(device_count.value):
+            handle = ctypes.c_void_p()
+            ret = nvmlDeviceGetHandleByIndex(i, ctypes.byref(handle))
+            if ret != NVML_SUCCESS:
+                continue
+
+            for link in range(NVLINK_MAX_LINKS):
+                state = ctypes.c_uint()
+                ret = nvmlDeviceGetNvLinkState(
+                    handle, link, ctypes.byref(state)
+                )
+                # Skip if not supported
+                if ret == NVML_ERROR_NOT_SUPPORTED:
+                    continue
+                # Check if link is active (state == 1)
+                if ret == NVML_SUCCESS and state.value == 1:
+                    return True
+
+        return False
+    finally:
+        # Shutdown NVML
+        nvml.nvmlShutdown()
+
+
+def _args_parsing(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--missing-lib-exit-code",
+        type=int,
+        choices=[0, 1],
+        default=1,
+        help=(
+            "Exit code to use when libnvidia-ml.so.1 can't be loaded, "
+            "i.e. there is no NVIDIA driver installed. "
+            "Defaults to 1 (same as 'NVLink not detected')."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = _args_parsing(argv)
+
+    # missing_lib_result is a bool, so map the requested exit code
+    # (0 or 1) to what check_nv_link_status should return in that case:
+    # exit code 0 means "NVLink detected" (True), exit code 1 means
+    # "NVLink not detected" (False).
+    missing_lib_result = args.missing_lib_exit_code == 0
+
+    if check_nv_link_status(missing_lib_result):
+        logger.info("NVLink detected")
+        return 0
+
+    logger.info("NVLink not detected")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/checkbox-support/checkbox_support/scripts/tests/test_nvlink_status.py
+++ b/checkbox-support/checkbox_support/scripts/tests/test_nvlink_status.py
@@ -1,0 +1,137 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from checkbox_support.scripts.nvlink_status import (
+    NVML_ERROR_NOT_SUPPORTED,
+    NVML_SUCCESS,
+    check_nv_link_status,
+    main,
+)
+
+
+def _make_nvml_mock(
+    device_count=1, link_states=None, init_ret=NVML_SUCCESS, count_ret=None
+):
+    """
+    Build a MagicMock standing in for the ctypes.CDLL("libnvidia-ml.so.1")
+    object, wiring up nvmlInit_v2/nvmlDeviceGetCount_v2/
+    nvmlDeviceGetHandleByIndex_v2/nvmlDeviceGetNvLinkState/nvmlShutdown.
+
+    :param device_count: number of devices nvmlDeviceGetCount_v2 reports
+
+    :param link_states: iterable of NVLink link states (0/1) returned in
+                         order for nvmlDeviceGetNvLinkState calls, or
+                         empty/None for "not supported"/no active links
+
+    :param init_ret: return code of nvmlInit_v2
+
+    :param count_ret: return code of nvmlDeviceGetCount_v2, defaults to
+                       NVML_SUCCESS
+    """
+    if count_ret is None:
+        count_ret = NVML_SUCCESS
+    link_states = list(link_states or [])
+
+    nvml = MagicMock()
+    nvml.nvmlInit_v2.return_value = init_ret
+
+    def fake_get_count(count_ptr):
+        count_ptr._obj.value = device_count
+        return count_ret
+
+    nvml.nvmlDeviceGetCount_v2.side_effect = fake_get_count
+
+    def fake_get_handle(index, handle_ptr):
+        handle_ptr._obj.value = 1
+        return NVML_SUCCESS
+
+    nvml.nvmlDeviceGetHandleByIndex_v2.side_effect = fake_get_handle
+
+    call_counter = {"n": 0}
+
+    def fake_get_nvlink_state(handle, link, state_ptr):
+        idx = call_counter["n"]
+        call_counter["n"] += 1
+        if idx >= len(link_states):
+            return NVML_ERROR_NOT_SUPPORTED
+        state_ptr._obj.value = link_states[idx]
+        return NVML_SUCCESS
+
+    nvml.nvmlDeviceGetNvLinkState.side_effect = fake_get_nvlink_state
+
+    return nvml
+
+
+class CheckNvLinkStatusTests(unittest.TestCase):
+    @patch("checkbox_support.scripts.nvlink_status.ctypes.CDLL")
+    def test_nvlink_detected(self, mock_cdll):
+        mock_cdll.return_value = _make_nvml_mock(link_states=[0, 1])
+        self.assertTrue(check_nv_link_status())
+
+    @patch("checkbox_support.scripts.nvlink_status.ctypes.CDLL")
+    def test_nvlink_not_detected(self, mock_cdll):
+        mock_cdll.return_value = _make_nvml_mock(link_states=[0, 0])
+        self.assertFalse(check_nv_link_status())
+
+    @patch("checkbox_support.scripts.nvlink_status.ctypes.CDLL")
+    def test_nvlink_not_supported(self, mock_cdll):
+        mock_cdll.return_value = _make_nvml_mock(link_states=[])
+        self.assertFalse(check_nv_link_status())
+
+    @patch("checkbox_support.scripts.nvlink_status.ctypes.CDLL")
+    def test_nvml_init_failed(self, mock_cdll):
+        mock_cdll.return_value = _make_nvml_mock(init_ret=1)
+        self.assertFalse(check_nv_link_status())
+
+    @patch("checkbox_support.scripts.nvlink_status.ctypes.CDLL")
+    def test_device_count_failed(self, mock_cdll):
+        mock_cdll.return_value = _make_nvml_mock(count_ret=1)
+        self.assertFalse(check_nv_link_status())
+
+    @patch("checkbox_support.scripts.nvlink_status.ctypes.CDLL")
+    def test_missing_lib_default_result(self, mock_cdll):
+        mock_cdll.side_effect = OSError("library not found")
+        self.assertFalse(check_nv_link_status())
+
+    @patch("checkbox_support.scripts.nvlink_status.ctypes.CDLL")
+    def test_missing_lib_custom_result(self, mock_cdll):
+        mock_cdll.side_effect = OSError("library not found")
+        self.assertTrue(check_nv_link_status(missing_lib_result=True))
+
+    @patch("checkbox_support.scripts.nvlink_status.ctypes.CDLL")
+    def test_shutdown_called(self, mock_cdll):
+        nvml_mock = _make_nvml_mock(link_states=[1])
+        mock_cdll.return_value = nvml_mock
+        check_nv_link_status()
+        nvml_mock.nvmlShutdown.assert_called_once()
+
+
+class MainTests(unittest.TestCase):
+    @patch("checkbox_support.scripts.nvlink_status.check_nv_link_status")
+    def test_exit_code_0_when_detected(self, mock_check):
+        mock_check.return_value = True
+        self.assertEqual(main([]), 0)
+
+    @patch("checkbox_support.scripts.nvlink_status.check_nv_link_status")
+    def test_exit_code_1_when_not_detected(self, mock_check):
+        mock_check.return_value = False
+        self.assertEqual(main([]), 1)
+
+    @patch("checkbox_support.scripts.nvlink_status.check_nv_link_status")
+    def test_missing_lib_exit_code_default(self, mock_check):
+        # default --missing-lib-exit-code is 1, so check_nv_link_status
+        # should be called with missing_lib_result=False
+        mock_check.return_value = False
+        main([])
+        mock_check.assert_called_once_with(False)
+
+    @patch("checkbox_support.scripts.nvlink_status.check_nv_link_status")
+    def test_missing_lib_exit_code_override(self, mock_check):
+        mock_check.return_value = True
+        result = main(["--missing-lib-exit-code", "0"])
+        mock_check.assert_called_once_with(True)
+        self.assertEqual(result, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/checkbox-support/pyproject.toml
+++ b/checkbox-support/pyproject.toml
@@ -64,6 +64,7 @@ noble_prod = [
   checkbox-support-parse = "checkbox_support.parsers:main"
   checkbox-support-image_checker = "checkbox_support.scripts.image_checker:main"
   checkbox-support-pipewire-utils = "checkbox_support.scripts.pipewire_utils:main"
+  checkbox-support-nvlink-status = "checkbox_support.scripts.nvlink_status:main"
 [project.entry-points."plainbox.parsers"]
   pactl-list="checkbox_support.parsers.pactl:parse_pactl_output"
   udevadm="checkbox_support.parsers.udevadm:parse_udevadm_output"

--- a/checkbox-support/setup.cfg
+++ b/checkbox-support/setup.cfg
@@ -34,3 +34,4 @@ console_scripts=
   checkbox-support-lsusb=checkbox_support.scripts.lsusb:main
   checkbox-support-parse=checkbox_support.parsers:main
   checkbox-support-pipewire-utils=checkbox_support.scripts.pipewire_utils:main
+  checkbox-support-nvlink-status=checkbox_support.scripts.nvlink_status:main


### PR DESCRIPTION
<!--
Example Title: Fixed bugged behaviour of checkbox load config (Bugfix)

A Traceability Marker is required as a suffix in the PR title to help understand the impact of your change at a glance.

Pick one of the following:
- Infra: Your change only includes documentation, comments, github actions or metabox
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility.
    - This includes any API change to checkbox-ng/checkbox-support
    - Changes to PXU grammar/field requirements
    - Breaking changes to dependencies in snaps (fwts upgrade for example)

If your change is to providers it can only be (Infra, BugFix or New).

If your change impacts the submission format in Checkbox test reports, ensure that `submission-schema/schema.json` is updated and relevant fields are documented.

Signed commits are required.
  - See CONTRIBUTING.md (https://github.com/canonical/checkbox/blob/main/CONTRIBUTING.md#signed-commits-required) for further instructions.
  - If you are posting your first pull request from a fork of the repository, a Checkbox maintainer (someone with contributor / maintainer / admin rights) will be required to enable CI checks in the repo to be executed.
    - This will be communicated with a comment to the PR of the form `/canonical/self-hosted-runners/run-workflows <SHA-for-HEAD-commit>`
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->
An increasing number of test conditions require checking the NVLink status. Therefore, it would be beneficial to create a dedicated utility script in the Checkbox support files that can be reused as needed.

Migrate to use this support script will be in another PR.
1.  test case: `graphics/nvlink-status-check`
2.  `prime_offload_tester.py`
3.  `base/bin/graphics_env.sh`

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
-->
https://github.com/canonical/checkbox/pull/431

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

## Tests

<!--
Please provide:

- The steps to follow so that the reviewer can test on their end
- A list of what tests were run and on what platform/configuration
- Checkbox submissions where applicable
-->
This code is mainly from the `prime_offload_tester.py` and could be tested by
```
python3 checkbox/checkbox-support/checkbox_support/scripts/nvlink_status.py
```