### PR TITLE
Gate bluetooth-detect job on executables rather than packages (BugFix)

### DIFF
--- a/providers/base/units/bluetooth/jobs.pxu
+++ b/providers/base/units/bluetooth/jobs.pxu
@@ -31,7 +31,8 @@ id: bluetooth/detect-output
 flags: also-after-suspend
 estimated_duration: 1.2
 requires:
- package.name == 'bluez' or snap.name == 'bluez'
+ executable.name == 'hcitool'
+ executable.name == 'rfkill'
  device.category == 'BLUETOOTH'
 command:
  if rfkill list bluetooth | grep -q 'Hard blocked: yes'; then


### PR DESCRIPTION
## WARNING: This modifies com.canonical.certification::sru-server

## Description

This job is self contained, no external script, which makes it easy to define a more scoped list of dependencies. Also, moving to checkbox snaps and plz-run, it'll be more productive to gate on executables rather than packages (outside the confinement).

## Resolved issues

N/A

## Documentation

N/A

## Tests

Not really tested
