### PR TITLE
Add control-host WiFi AP test support (New)

### DIFF
--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/wifi_test.py
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/bin/wifi_test.py
@@ -9,6 +9,13 @@ For wifi-p2p:
     We are not able to validate the result even following the user
     manual of network-manager.
 
+The DUT-hosted AP can be validated by two kinds of peer:
+    ssh-host: a full Linux host reachable over SSH, on which nmcli is
+        used to join the AP.
+    control-host: a controllable WiFi peer reachable over its REST API
+        (``http://<host>:8000``), expected to be reachable via the lab
+        management network rather than through the WiFi link under test.
+
 Please refer to following for more details:
 [1] https://networkmanager.dev/docs/api/latest/nm-settings-nmcli.html
 [2] https://netplan.readthedocs.io/en/stable/netplan-yaml
@@ -17,19 +24,26 @@ Please refer to following for more details:
 """
 
 import argparse
+import json
+import logging
+import os
+import random
+import re
+import string
 import subprocess
 import sys
 import time
-import logging
-import re
-import random
-import string
+import urllib.error
+import urllib.request
 from contextlib import contextmanager
 
 # Configure logging
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
+
+CONTROL_HOST_REST_PORT = 8000
+CONTROL_HOST_REQUEST_TIMEOUT = 30
 
 
 class WiFiManager:
@@ -179,14 +193,14 @@ def run_command(command):
     return output
 
 
+def ping_cmd(ip):
+    return "ping {} -c 4".format(ip)
+
+
 def sshpass_cmd_gen(ip, user, pwd, cmd):
     return "sshpass -p {} ssh -o StrictHostKeyChecking=no {}@{} {}".format(
         pwd, user, ip, cmd
     )
-
-
-def ping_cmd(ip):
-    return "ping {} -c 4".format(ip)
 
 
 @contextmanager
@@ -259,7 +273,7 @@ def bring_up_conn_from_host(ip, user, pwd, up_host_conn):
             time.sleep(10)
 
 
-def ping_test(target_ip, host_net_info: dict):
+def ssh_host_ping_test(target_ip, host_net_info: dict):
     ip = host_net_info["ip"]
     user = host_net_info["user"]
     pwd = host_net_info["pwd"]
@@ -288,31 +302,178 @@ def ping_test(target_ip, host_net_info: dict):
     return 1
 
 
-def main():
+def run_ssh_host_test(args):
+    with WiFiManager(**vars(args)) as manager:
+        host_net_info = {
+            "ip": args.host_ip,
+            "user": args.host_user,
+            "pwd": args.host_pwd,
+        }
+        connect_info = {
+            "ssid": args.ssid,
+            "connect_cmd": manager.connect_dut_cmd(args.host_interface),
+            "delete_cmd": manager.del_cmd(),
+            "up_cmd": manager.up_cmd(),
+        }
+        with connect_dut_from_host_via_wifi(host_net_info, connect_info):
+            return ssh_host_ping_test(manager.get_ip_addr(), host_net_info)
+
+
+def control_host_request(host, path, method="GET", payload=None):
+    """Call the control host's REST API and return the decoded JSON body."""
+    url = "http://{}:{}{}".format(host, CONTROL_HOST_REST_PORT, path)
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Content-Type": "application/json"} if data else {}
+    request = urllib.request.Request(
+        url, data=data, headers=headers, method=method
+    )
+    try:
+        with urllib.request.urlopen(
+            request, timeout=CONTROL_HOST_REQUEST_TIMEOUT
+        ) as response:
+            body = response.read()
+            return json.loads(body) if body else {}
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", "replace")
+        raise SystemError(
+            "Control host API error on {}: HTTP {} {}".format(
+                path, e.code, detail
+            )
+        )
+    except urllib.error.URLError as e:
+        raise SystemError(
+            "Unable to reach control host at {}: {}".format(host, e.reason)
+        )
+
+
+def control_host_wifi_connect(host, ssid, password):
+    """
+    Ask the control host to join the DUT-hosted network and return the IP
+    address it was assigned.
+
+    The control host's ``client/connect`` call blocks until it has
+    associated, but the DHCP lease may still be in progress when it
+    returns, so the status is polled for a short while afterwards.
+    """
+    logging.info("Enabling control host WiFi radio")
+    control_host_request(host, "/api/v1/wifi/enable", "POST")
+
+    logging.info("Requesting control host to join SSID %s", ssid)
+    payload = {"ssid": ssid}
+    if password:
+        payload["password"] = password
+    control_host_request(host, "/api/v1/wifi/client/connect", "POST", payload)
+
+    for i in range(1, 6):
+        status = control_host_request(host, "/api/v1/wifi/status")
+        ip_address = (status.get("client") or {}).get("ip_address")
+        if ip_address:
+            logging.info("Control host client IP address is %s", ip_address)
+            return ip_address
+        time.sleep(5)
+    raise SystemError(
+        "Control host joined {} but reported no IP address".format(ssid)
+    )
+
+
+def control_host_wifi_disconnect(host):
+    logging.info("Disconnecting control host from the WiFi network")
+    control_host_request(host, "/api/v1/wifi/client/disconnect", "POST")
+
+
+def control_host_ping_test(target_ip):
+    logging.info("Pinging control host client %s...", target_ip)
+    try:
+        run_command(ping_cmd(target_ip))
+        logging.info("Ping to control host client passed.")
+        return 0
+    except subprocess.CalledProcessError as e:
+        logging.error("Ping to control host client failed: %s", e.output)
+        return 1
+
+
+def run_control_host_test(args):
+    manager_config = vars(args).copy()
+    manager_config["type"] = "wifi"
+    manager_config["mode"] = "ap"
+    with WiFiManager(**manager_config):
+        password = args.ssid_pwd if args.keymgmt else None
+        ip_address = control_host_wifi_connect(
+            args.control_host, args.ssid, password
+        )
+        try:
+            return control_host_ping_test(ip_address)
+        finally:
+            control_host_wifi_disconnect(args.control_host)
+
+
+def add_wifi_ap_args(parser):
+    parser.add_argument("--band", required=True, help="WiFi band to use")
+    parser.add_argument(
+        "--channel", required=True, type=int, help="WiFi channel to use"
+    )
+    parser.add_argument(
+        "--keymgmt", required=False, help="Key management method"
+    )
+    parser.add_argument(
+        "--group", required=False, help="Group key management method"
+    )
+    parser.add_argument(
+        "--ssid-pwd",
+        required=False,
+        default="insecure",
+        help="Password for SSID",
+    )
+
+
+def build_arg_parser():
     parser = argparse.ArgumentParser(description="WiFi test")
-    subparsers = parser.add_subparsers(
+    parser.add_argument(
+        "--interface", required=True, help="WiFi interface to use"
+    )
+    peer_subparsers = parser.add_subparsers(
+        dest="peer_mode",
+        required=True,
+        help="How the peer joining the DUT-hosted network is controlled",
+    )
+
+    ssh_host_parser = peer_subparsers.add_parser(
+        "ssh-host", help="Join the AP by SSHing into a peer host"
+    )
+    ssh_host_parser.add_argument(
+        "--host-ip",
+        required=True,
+        help="IP address of the Host device to connect to."
+        "The HOST is a device to access the DUT's AP.",
+    )
+    ssh_host_parser.add_argument(
+        "--host-user",
+        required=True,
+        help="Username of the Host device for SSH connection",
+    )
+    ssh_host_parser.add_argument(
+        "--host-pwd",
+        required=True,
+        help="Password of the Host device for SSH connection",
+    )
+    ssh_host_parser.add_argument(
+        "--host-interface",
+        required=True,
+        help="The wifi interface name of the Host device",
+    )
+    type_subparsers = ssh_host_parser.add_subparsers(
         dest="type",
         required=True,
         help="Type of connection. " 'Currentlly support "wifi" and "wifi-p2p"',
     )
-    # Subparser for 'wifi'
-    wifi_parser = subparsers.add_parser("wifi", help="WiFi configuration")
+    wifi_parser = type_subparsers.add_parser("wifi", help="WiFi configuration")
     wifi_parser.add_argument(
         "--mode",
         choices=["ap", "adhoc"],
         required=True,
         help="WiFi mode: ap or adhoc",
     )
-    wifi_parser.add_argument("--band", required=True, help="WiFi band to use")
-    wifi_parser.add_argument(
-        "--channel", required=True, type=int, help="WiFi channel to use"
-    )
-    wifi_parser.add_argument(
-        "--keymgmt", required=False, help="Key management method"
-    )
-    wifi_parser.add_argument(
-        "--group", required=False, help="Group key management method"
-    )
+    add_wifi_ap_args(wifi_parser)
     wifi_parser.add_argument(
         "--ssid",
         default="".join(
@@ -321,62 +482,42 @@ def main():
         required=False,
         help="SSID for AP mode",
     )
-    wifi_parser.add_argument(
-        "--ssid-pwd",
-        required=False,
-        default="insecure",
-        help="Password for SSID",
-    )
-
-    # Subparser for 'wifi-p2p'
-    wifi_p2p_parser = subparsers.add_parser(
+    wifi_p2p_parser = type_subparsers.add_parser(
         "wifi-p2p", help="WiFi P2P configuration"
     )
     wifi_p2p_parser.add_argument(
         "--peer", required=True, help="MAC address for P2P peer"
     )
-    parser.add_argument(
-        "--interface", required=True, help="WiFi interface to use"
+
+    control_host_parser = peer_subparsers.add_parser(
+        "control-host",
+        help="Join the AP via a control host's REST API",
     )
-    parser.add_argument(
-        "--host-ip",
-        required=True,
-        help="IP address of the Host device to connect to."
-        "The HOST is a device to access the DUT's AP.",
+    add_wifi_ap_args(control_host_parser)
+    control_host_parser.add_argument(
+        "--ssid", required=True, help="SSID for the DUT-hosted AP"
     )
-    parser.add_argument(
-        "--host-user",
+    control_host_parser.add_argument(
+        "--control-host",
         required=True,
-        help="Username of the Host device for SSH connection",
-    )
-    parser.add_argument(
-        "--host-pwd",
-        required=True,
-        help="Password of the Host device for SSH connection",
-    )
-    parser.add_argument(
-        "--host-interface",
-        required=True,
-        help="The wifi interface name of the Host device",
+        help="Control host IPaddress",
     )
 
+    return parser
+
+
+def main():
+    parser = build_arg_parser()
     args = parser.parse_args()
-    config = vars(args)
+
     try:
-        with WiFiManager(**config) as manager:
-            host_net_info = {
-                "ip": args.host_ip,
-                "user": args.host_user,
-                "pwd": args.host_pwd,
-            }
-            connect_info = {
-                "ssid": args.ssid,
-                "connect_cmd": manager.connect_dut_cmd(args.host_interface),
-                "delete_cmd": manager.del_cmd(),
-                "up_cmd": manager.up_cmd(),
-            }
-            with connect_dut_from_host_via_wifi(host_net_info, connect_info):
-                ret = ping_test(manager.get_ip_addr(), host_net_info)
+        if args.peer_mode == "ssh-host":
+            ret = run_ssh_host_test(args)
+        elif args.peer_mode == "control-host":
+            ret = run_control_host_test(args)
+        else:
+            logging.error("Unsupported peer mode: %s", args.peer_mode)
+            sys.exit(1)
         sys.exit(ret)
     except SystemError as e:
         logging.error(e)

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/wifi/README.md
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/wifi/README.md
@@ -51,3 +51,13 @@ and perform connecting AP and ping DUT automaticlly by using `sshpass` command.
 A template job for WPA AP mode automated test. It will depend on resource job `ce_oem_wifi_ap_mode` to generate the related jobs.\
 This job requires the checkbox environment variables `WIFI_AP_HOST_DEVICE_IP` `WIFI_AP_HOST_DEVICE_USER` `WIFI_AP_HOST_DEVICE_PWD` to allow auto login to HOST machine
 and perform connecting AP and ping DUT automaticlly by using `sshpass` command.
+
+## id: ce-oem-wireless/ap_open_{band}_ch{channel}_{group}_{interface}_control_host_automated
+A template job for open AP mode automated test using a control host. It will depend on resource job `ce_oem_wifi_ap_mode` to generate the related jobs.\
+This job requires the checkbox environment variable `CONTROL_HOST` to allow the control host to join the AP
+and perform connecting AP and ping the control host automaticlly by using its REST API.
+
+## id: ce-oem-wireless/ap_wpa_{key_mgmt}_{band}_ch{channel}_{group}_{interface}_control_host_automated
+A template job for WPA AP mode automated test using a control host. It will depend on resource job `ce_oem_wifi_ap_mode` to generate the related jobs.\
+This job requires the checkbox environment variable `CONTROL_HOST` to allow the control host to join the AP
+and perform connecting AP and ping the control host automaticlly by using its REST API.

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/wifi/manifest.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/wifi/manifest.pxu
@@ -2,3 +2,8 @@ unit: manifest entry
 id: has_wifi_ap_host
 _name: Does WiFi AP paring HOST machine available for testing WiFi AP mode?
 value-type: bool
+
+unit: manifest entry
+id: has_wifi_ap_control_host
+_name: Is a control host available to join the DUT-hosted WiFi AP under test?
+value-type: bool

--- a/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/wifi/wifi-ap.pxu
+++ b/contrib/checkbox-ce-oem/checkbox-provider-ce-oem/units/wifi/wifi-ap.pxu
@@ -46,7 +46,7 @@ estimated_duration: 120.0
 user: root
 flags: preserve-locale also-after-suspend
 command:
-   wifi_test.py --interface {interface} --host-ip "$WIFI_AP_HOST_DEVICE_IP" \
+   wifi_test.py --interface {interface} ssh-host --host-ip "$WIFI_AP_HOST_DEVICE_IP" \
    --host-user "$WIFI_AP_HOST_DEVICE_USER" --host-pwd "$WIFI_AP_HOST_DEVICE_PWD" \
    --host-interface "$WIFI_AP_HOST_DEVICE_INTERFACE" wifi --mode ap  --band {band} --channel {channel}
 
@@ -72,7 +72,60 @@ estimated_duration: 120.0
 user: root
 flags: preserve-locale also-after-suspend
 command:
-   wifi_test.py --interface {interface} --host-ip "$WIFI_AP_HOST_DEVICE_IP" \
+   wifi_test.py --interface {interface} ssh-host --host-ip "$WIFI_AP_HOST_DEVICE_IP" \
    --host-user "$WIFI_AP_HOST_DEVICE_USER" --host-pwd "$WIFI_AP_HOST_DEVICE_PWD" \
    --host-interface "$WIFI_AP_HOST_DEVICE_INTERFACE" wifi --mode ap  --band {band} \
    --channel {channel} --keymgmt {key_mgmt} --group {group}
+
+unit: template
+template-resource: ce_oem_wifi_ap_mode
+template-filter: ce_oem_wifi_ap_mode.key_mgmt == 'none'
+template-unit: job
+id: ce-oem-wireless/ap_open_{band}_ch{channel}_{group}_{interface}_control_host_automated
+category_id: com.canonical.certification::wifi_ap
+_summary: Create open 802.11{band} Wi-Fi AP on {interface} and check connection with a control host
+_description:
+   Create open 802.11{band} Wi-Fi AP on {interface} in channel{channel} group {group}
+   and check a control host can join it and reach the assigned IP address.
+plugin: shell
+environ: CONTROL_HOST
+imports:
+  from com.canonical.certification import net_if_management
+  from com.canonical.plainbox import manifest
+requires:
+  net_if_management.device == '{interface}'
+  net_if_management.master_mode_managed_by == 'NetworkManager'
+  manifest.has_wifi_ap_control_host == 'True'
+estimated_duration: 60.0
+user: root
+flags: preserve-locale also-after-suspend
+command:
+   wifi_test.py --interface {interface} control-host --band {band} --channel {channel} \
+   --ssid qa-test-ap-{interface}-{channel} --control-host "$CONTROL_HOST"
+
+unit: template
+template-resource: ce_oem_wifi_ap_mode
+template-filter: ce_oem_wifi_ap_mode.key_mgmt != 'none'
+template-unit: job
+id: ce-oem-wireless/ap_wpa_{key_mgmt}_{band}_ch{channel}_{group}_{interface}_control_host_automated
+category_id: com.canonical.certification::wifi_ap
+_summary: Create wpa 802.11{band} Wi-Fi AP on {interface} and check connection with a control host
+_description:
+   Create wpa 802.11{band} Wi-Fi AP on {interface} in channel{channel} group {group}
+   and check a control host can join it and reach the assigned IP address.
+plugin: shell
+environ: CONTROL_HOST
+imports:
+  from com.canonical.certification import net_if_management
+  from com.canonical.plainbox import manifest
+requires:
+  net_if_management.device == '{interface}'
+  net_if_management.master_mode_managed_by == 'NetworkManager'
+  manifest.has_wifi_ap_control_host == 'True'
+estimated_duration: 60.0
+user: root
+flags: preserve-locale also-after-suspend
+command:
+   wifi_test.py --interface {interface} control-host --band {band} --channel {channel} \
+   --keymgmt {key_mgmt} --group {group} --ssid qa-test-ap-{interface}-{channel} \
+   --control-host "$CONTROL_HOST"


### PR DESCRIPTION
## Description
Add a control-host peer mode to wifi_test.py for validating a DUT-hosted WiFi AP against a control host reachable over its REST API, alongside the existing SSH-host based flow. The existing "wifi"/"wifi-p2p" CLI schema is unchanged, so current SSH-host jobs keep working; "control-host" is a new sibling subcommand.

Add the ce_oem_wifi_ap_control_host manifest entry and add the the corresponding job units in wifi-ap.pxu.

## Resolved issues

https://warthogs.atlassian.net/browse/PECA-1881

## Documentation

Readme in the unit is updated

## Tests

- make sure you have a compatible control-host
- set CONTROL_HOST env var with the IP address of the control host
- set the manifest
- run the test 
